### PR TITLE
Fix hardcoded namespace in ovnkube.sh

### DIFF
--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -149,7 +149,7 @@ wait_for_event () {
 ready_to_start_node () {
 
   # See if ep is available ...
-  ovn_master_host=$(kubectl --server=${K8S_APISERVER} --token=${k8s_token} --certificate-authority=${K8S_CACERT} get ep -n ovn-kubernetes ovnkube-master 2>/dev/null | grep 6642 | sed 's/:/ /' | awk '/ovnkube-master/{ print $2 }')
+  ovn_master_host=$(kubectl --server=${K8S_APISERVER} --token=${k8s_token} --certificate-authority=${K8S_CACERT} get ep -n openshift-ovn-kubernetes ovnkube-master 2>/dev/null | grep 6642 | sed 's/:/ /' | awk '/ovnkube-master/{ print $2 }')
   if [[ ${ovn_master_host} == "" ]] ; then
     # ... if not (we may be on the master) see if northd is up
     get_master_ovn_vars


### PR DESCRIPTION
`ovnkube.sh` hardcodes the namespace to look for the `ovnkube-master` service in, causing the nodes to never come up in a cluster-network-operator-managed cluster.

Upstream we should probably fix it so that this comes from an environment variable rather than being hardcoded, so that we don't need to carry a patch.