### PR TITLE
Install iptables wrappers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,6 +71,14 @@ COPY .git/refs/heads/ /root/.git/refs/heads/
 COPY dist/images/ovnkube.sh /root/
 COPY dist/images/ovn-debug.sh /root/
 
+# iptables wrappers
+COPY ./dist/images/iptables-scripts/iptables /usr/sbin/
+COPY ./dist/images/iptables-scripts/iptables-save /usr/sbin/
+COPY ./dist/images/iptables-scripts/iptables-restore /usr/sbin/
+COPY ./dist/images/iptables-scripts/ip6tables /usr/sbin/
+COPY ./dist/images/iptables-scripts/ip6tables-save /usr/sbin/
+COPY ./dist/images/iptables-scripts/ip6tables-restore /usr/sbin/
+COPY ./dist/images/iptables-scripts/iptables /usr/sbin/
 
 LABEL io.k8s.display-name="ovn kubernetes" \
       io.k8s.description="This is a component of OpenShift Container Platform that provides an overlay network using ovn." \

--- a/dist/images/iptables-scripts/ip6tables
+++ b/dist/images/iptables-scripts/ip6tables
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec chroot /host /usr/sbin/ip6tables "$@"

--- a/dist/images/iptables-scripts/ip6tables-restore
+++ b/dist/images/iptables-scripts/ip6tables-restore
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec chroot /host /usr/sbin/ip6tables-restore "$@"

--- a/dist/images/iptables-scripts/ip6tables-save
+++ b/dist/images/iptables-scripts/ip6tables-save
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec chroot /host /usr/sbin/ip6tables-save "$@"

--- a/dist/images/iptables-scripts/iptables
+++ b/dist/images/iptables-scripts/iptables
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec chroot /host /usr/sbin/iptables "$@"

--- a/dist/images/iptables-scripts/iptables-restore
+++ b/dist/images/iptables-scripts/iptables-restore
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec chroot /host /usr/sbin/iptables-restore "$@"

--- a/dist/images/iptables-scripts/iptables-save
+++ b/dist/images/iptables-scripts/iptables-save
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec chroot /host /usr/sbin/iptables-save "$@"


### PR DESCRIPTION
ovnkube creates iptables rules for nodeport ports, so it needs to use the right iptables binaries

see also https://github.com/openshift/cluster-network-operator/pull/197