### PR TITLE
Do not install arch-specific dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN yum install -y  \
 	yum clean all
 
 RUN INSTALL_PKGS=" \
-	PyYAML bind-utils openssl numactl-libs firewalld-filesystem \
+	PyYAML bind-utils openssl firewalld-filesystem \
 	libpcap  hostname iproute strace socat \
 	openvswitch2.11 openvswitch2.11-devel \
 	openvswitch2.11-ovn-common openvswitch2.11-ovn-central \


### PR DESCRIPTION
numactl-libs is not built on s390x in RHEL 7.  It will be pulled in as a requirement of openvswitch2.11 on those architectures on which it is required.