### PR TITLE
Bug 1749403: add iptables rules for Azure, etc, loadbalancers

### DIFF
--- a/go-controller/pkg/cluster/gateway_init.go
+++ b/go-controller/pkg/cluster/gateway_init.go
@@ -19,7 +19,7 @@ func bridgedGatewayNodeSetup(nodeName, bridgeInterface string) (string, string, 
 		return "", "", err
 	}
 	stdout, stderr, err := util.RunOVSVsctl("set", "bridge",
-		bridgeInterface, "other-config:hwaddr="+macAddress.String())
+		bridgeInterface, "other-config:hwaddr="+macAddress)
 	if err != nil {
 		return "", "", fmt.Errorf("Failed to set bridge, stdout: %q, stderr: %q, "+
 			"error: %v", stdout, stderr, err)
@@ -35,7 +35,7 @@ func bridgedGatewayNodeSetup(nodeName, bridgeInterface string) (string, string, 
 	}
 
 	ifaceID := bridgeInterface + "_" + nodeName
-	return ifaceID, macAddress.String(), nil
+	return ifaceID, macAddress, nil
 }
 
 // getIPv4Address returns the ipv4 address for the network interface 'iface'.

--- a/go-controller/pkg/cluster/gateway_init_linux_test.go
+++ b/go-controller/pkg/cluster/gateway_init_linux_test.go
@@ -567,7 +567,9 @@ GR_openshift-master-node chassis=6a47b33b-89d3-4d65-ac31-b19b549326c7 lb_force_s
 
 			ipt, err := util.NewFakeWithProtocol(iptables.ProtocolIPv4)
 			Expect(err).NotTo(HaveOccurred())
-			err = initLocalnetGatewayInternal(nodeName, []string{clusterCIDR}, nodeSubnet, ipt, wf)
+			util.SetIPTablesHelper(iptables.ProtocolIPv4, ipt)
+
+			err = initLocalnetGateway(nodeName, []string{clusterCIDR}, nodeSubnet, wf)
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(fexec.CalledMatchesExpected()).To(BeTrue())

--- a/go-controller/pkg/cluster/gateway_localnet.go
+++ b/go-controller/pkg/cluster/gateway_localnet.go
@@ -108,15 +108,11 @@ func localnetGatewayNAT(ipt util.IPTablesHelper, ifname, ip string) error {
 
 func initLocalnetGateway(nodeName string, clusterIPSubnet []string,
 	subnet string, wf *factory.WatchFactory) error {
-	ipt, err := iptables.NewWithProtocol(iptables.ProtocolIPv4)
+	ipt, err := util.GetIPTablesHelper(iptables.ProtocolIPv4)
 	if err != nil {
 		return fmt.Errorf("failed to initialize iptables: %v", err)
 	}
-	return initLocalnetGatewayInternal(nodeName, clusterIPSubnet, subnet, ipt, wf)
-}
 
-func initLocalnetGatewayInternal(nodeName string, clusterIPSubnet []string,
-	subnet string, ipt util.IPTablesHelper, wf *factory.WatchFactory) error {
 	// Create a localnet OVS bridge.
 	localnetBridgeName := "br-local"
 	_, stderr, err := util.RunOVSVsctl("--may-exist", "add-br",
@@ -190,7 +186,7 @@ func localnetAddService(svc *kapi.Service) error {
 	if !util.ServiceTypeHasNodePort(svc) {
 		return nil
 	}
-	ipt, err := iptables.NewWithProtocol(iptables.ProtocolIPv4)
+	ipt, err := util.GetIPTablesHelper(iptables.ProtocolIPv4)
 	if err != nil {
 		return fmt.Errorf("failed to initialize iptables: %v", err)
 	}
@@ -223,7 +219,7 @@ func localnetDeleteService(svc *kapi.Service) error {
 	if !util.ServiceTypeHasNodePort(svc) {
 		return nil
 	}
-	ipt, err := iptables.NewWithProtocol(iptables.ProtocolIPv4)
+	ipt, err := util.GetIPTablesHelper(iptables.ProtocolIPv4)
 	if err != nil {
 		return fmt.Errorf("failed to initialize iptables: %v", err)
 	}

--- a/go-controller/pkg/ovn/management-port.go
+++ b/go-controller/pkg/ovn/management-port.go
@@ -3,9 +3,6 @@ package ovn
 import (
 	"fmt"
 	"net"
-	"os"
-	"runtime"
-	"strconv"
 	"strings"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
@@ -13,194 +10,11 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-const (
-	windowsOS = "windows"
-)
-
-func configureManagementPortWindows(clusterSubnet []string, routerIP,
-	interfaceName, interfaceIP string) error {
-	// Up the interface.
-	_, _, err := util.RunPowershell("Enable-NetAdapter", "-IncludeHidden", interfaceName)
-	if err != nil {
-		return err
-	}
-
-	//check if interface already exists
-	ifAlias := fmt.Sprintf("-InterfaceAlias %s", interfaceName)
-	_, _, err = util.RunPowershell("Get-NetIPAddress", ifAlias)
-	if err == nil {
-		//The interface already exists, we should delete the routes and IP
-		logrus.Debugf("Interface %s exists, removing.", interfaceName)
-		_, _, err = util.RunPowershell("Remove-NetIPAddress", ifAlias, "-Confirm:$false")
-		if err != nil {
-			return err
-		}
-	}
-
-	// Assign IP address to the internal interface.
-	portIP, interfaceIPNet, err := net.ParseCIDR(interfaceIP)
-	if err != nil {
-		return fmt.Errorf("Failed to parse interfaceIP %v : %v", interfaceIP, err)
-	}
-	portPrefix, _ := interfaceIPNet.Mask.Size()
-	_, _, err = util.RunPowershell("New-NetIPAddress",
-		fmt.Sprintf("-IPAddress %s", portIP),
-		fmt.Sprintf("-PrefixLength %d", portPrefix),
-		ifAlias)
-	if err != nil {
-		return err
-	}
-
-	// Set MTU for the interface
-	_, _, err = util.RunNetsh("interface", "ipv4", "set", "subinterface",
-		interfaceName, fmt.Sprintf("mtu=%d", config.Default.MTU),
-		"store=persistent")
-	if err != nil {
-		return err
-	}
-
-	// Retrieve the interface index
-	stdout, stderr, err := util.RunPowershell("$(Get-NetAdapter", "-IncludeHidden", "|", "Where",
-		"{", "$_.Name", "-Match", fmt.Sprintf("\"%s\"", interfaceName), "}).ifIndex")
-	if err != nil {
-		logrus.Errorf("Failed to fetch interface index, stderr: %q, error: %v", stderr, err)
-		return err
-	}
-	if _, err := strconv.Atoi(stdout); err != nil {
-		logrus.Errorf("Failed to parse interface index %q: %v", stdout, err)
-		return err
-	}
-	interfaceIndex := stdout
-
-	for _, subnet := range clusterSubnet {
-		subnetIP, subnetIPNet, err := net.ParseCIDR(subnet)
-		if err != nil {
-			return fmt.Errorf("failed to parse clusterSubnet %v : %v", subnet, err)
-		}
-		// Checking if the route already exists, in which case it will not be created again
-		stdout, stderr, err = util.RunRoute("print", "-4", subnetIP.String())
-		if err != nil {
-			logrus.Debugf("Failed to run route print, stderr: %q, error: %v", stderr, err)
-		}
-
-		if strings.Contains(stdout, subnetIP.String()) {
-			logrus.Debugf("Route was found, skipping route add")
-		} else {
-			// Windows route command requires the mask to be specified in the IP format
-			subnetMask := net.IP(subnetIPNet.Mask).String()
-			// Create a route for the entire subnet.
-			_, stderr, err = util.RunRoute("-p", "add",
-				subnetIP.String(), "mask", subnetMask,
-				routerIP, "METRIC", "2", "IF", interfaceIndex)
-			if err != nil {
-				logrus.Errorf("failed to run route add, stderr: %q, error: %v", stderr, err)
-				return err
-			}
-		}
-	}
-
-	clusterServiceIP, clusterServiceIPNet, err := net.ParseCIDR(config.Kubernetes.ServiceCIDR)
-	if err != nil {
-		return fmt.Errorf("Failed to parse clusterServicesSubnet %v : %v", config.Kubernetes.ServiceCIDR, err)
-	}
-	// Checking if the route already exists, in which case it will not be created again
-	stdout, stderr, err = util.RunRoute("print", "-4", clusterServiceIP.String())
-	if err != nil {
-		logrus.Debugf("Failed to run route print, stderr: %q, error: %v", stderr, err)
-	}
-
-	if strings.Contains(stdout, clusterServiceIP.String()) {
-		logrus.Debugf("Route was found, skipping route add")
-	} else {
-		// Windows route command requires the mask to be specified in the IP format
-		clusterServiceMask := net.IP(clusterServiceIPNet.Mask).String()
-		// Create a route for the entire subnet.
-		_, stderr, err = util.RunRoute("-p", "add",
-			clusterServiceIP.String(), "mask", clusterServiceMask,
-			routerIP, "METRIC", "2", "IF", interfaceIndex)
-		if err != nil {
-			logrus.Errorf("failed to run route add, stderr: %q, error: %v", stderr, err)
-			return err
-		}
-	}
-
-	return nil
-}
-
-func configureManagementPort(clusterSubnet []string, routerIP, routerMac,
-	interfaceName, interfaceIP string) error {
-	if runtime.GOOS == windowsOS {
-		// Return here for Windows, the commands for enabling the interface, setting the IP and adding the
-		// route will be done in the above function
-		return configureManagementPortWindows(clusterSubnet, routerIP, interfaceName, interfaceIP)
-	}
-
-	// Up the interface.
-	_, _, err := util.RunIP("link", "set", interfaceName, "up")
-	if err != nil {
-		return err
-	}
-
-	// The interface may already exist, in which case delete the routes and IP.
-	_, _, err = util.RunIP("addr", "flush", "dev", interfaceName)
-	if err != nil {
-		return err
-	}
-
-	// Assign IP address to the internal interface.
-	_, _, err = util.RunIP("addr", "add", interfaceIP, "dev", interfaceName)
-	if err != nil {
-		return err
-	}
-
-	for _, subnet := range clusterSubnet {
-		// Flush the route for the entire subnet (in case it was added before).
-		_, _, err = util.RunIP("route", "flush", subnet)
-		if err != nil {
-			return err
-		}
-
-		// Create a route for the entire subnet.
-		_, _, err = util.RunIP("route", "add", subnet, "via", routerIP)
-		if err != nil {
-			return err
-		}
-	}
-
-	// Flush the route for the services subnet (in case it was added before).
-	_, _, err = util.RunIP("route", "flush", config.Kubernetes.ServiceCIDR)
-	if err != nil {
-		return err
-	}
-
-	// Create a route for the services subnet.
-	_, _, err = util.RunIP("route", "add", config.Kubernetes.ServiceCIDR, "via", routerIP)
-	if err != nil {
-		return err
-	}
-
-	// Add a neighbour entry on the K8s node to map routerIP with routerMAC. This is
-	// required because in certain cases ARP requests from the K8s Node to the routerIP
-	// arrives on OVN Logical Router pipeline with ARP source protocol address set to
-	// K8s Node IP. OVN Logical Router pipeline drops such packets since it expects
-	// source protocol address to be in the Logical Switch's subnet.
-	_, _, err = util.RunIP("neigh", "add", routerIP, "dev", interfaceName, "lladdr", routerMac)
-	if err != nil && os.IsNotExist(err) {
-		return err
-	}
-
-	return nil
-}
-
-// CreateManagementPort creates a management port attached to the node switch
-// that lets the node access its pods via their private IP address. This is used
-// for health checking and other management tasks.
-func CreateManagementPort(nodeName, localSubnet string, clusterSubnet []string) error {
-
+func createManagementPortGeneric(nodeName, localSubnet string, clusterSubnet []string) (string, string, string, string, error) {
 	// Determine the IP of the node switch's logical router port on the cluster router
 	ip, subnet, err := net.ParseCIDR(localSubnet)
 	if err != nil {
-		return fmt.Errorf("Failed to parse local subnet %s: %v", localSubnet, err)
+		return "", "", "", "", fmt.Errorf("Failed to parse local subnet %s: %v", localSubnet, err)
 	}
 	ip = util.NextIP(ip)
 	routerIP := ip.String()
@@ -220,7 +34,7 @@ func CreateManagementPort(nodeName, localSubnet string, clusterSubnet []string) 
 	stdout, stderr, err := util.RunOVSVsctl("--", "--may-exist", "add-br", "br-int")
 	if err != nil {
 		logrus.Errorf("Failed to create br-int, stdout: %q, stderr: %q, error: %v", stdout, stderr, err)
-		return err
+		return "", "", "", "", err
 	}
 
 	// Create a OVS internal interface.
@@ -232,12 +46,12 @@ func CreateManagementPort(nodeName, localSubnet string, clusterSubnet []string) 
 		"external-ids:iface-id=k8s-"+nodeName)
 	if err != nil {
 		logrus.Errorf("Failed to add port to br-int, stdout: %q, stderr: %q, error: %v", stdout, stderr, err)
-		return err
+		return "", "", "", "", err
 	}
 	macAddress, err := util.GetOVSPortMACAddress(interfaceName)
 	if err != nil {
 		logrus.Errorf("Failed to get management port MAC address: %v", err)
-		return err
+		return "", "", "", "", err
 	}
 
 	// Create this node's management logical port on the node switch
@@ -248,15 +62,15 @@ func CreateManagementPort(nodeName, localSubnet string, clusterSubnet []string) 
 	stdout, stderr, err = util.RunOVNNbctl("--", "--may-exist", "lsp-add", nodeName, "k8s-"+nodeName, "--", "lsp-set-addresses", "k8s-"+nodeName, macAddress+" "+portIP)
 	if err != nil {
 		logrus.Errorf("Failed to add logical port to switch, stdout: %q, stderr: %q, error: %v", stdout, stderr, err)
-		return err
+		return "", "", "", "", err
 	}
 	// switch-to-router ports only have MAC address and nothing else.
 	routerMac, stderr, err := util.RunOVNNbctl("lsp-get-addresses", "stor-"+nodeName)
 	if err != nil {
 		logrus.Errorf("Failed to retrieve the MAC address of the logical port, stderr: %q, error: %v",
 			stderr, err)
-		return err
+		return "", "", "", "", err
 	}
-	err = configureManagementPort(clusterSubnet, routerIP, routerMac, interfaceName, portIPMask)
-	return err
+
+	return interfaceName, portIPMask, routerIP, routerMac, nil
 }

--- a/go-controller/pkg/ovn/management-port.go
+++ b/go-controller/pkg/ovn/management-port.go
@@ -234,20 +234,10 @@ func CreateManagementPort(nodeName, localSubnet string, clusterSubnet []string) 
 		logrus.Errorf("Failed to add port to br-int, stdout: %q, stderr: %q, error: %v", stdout, stderr, err)
 		return err
 	}
-	macAddress, stderr, err := util.RunOVSVsctl("--if-exists", "get", "interface", interfaceName, "mac_in_use")
+	macAddress, err := util.GetOVSPortMACAddress(interfaceName)
 	if err != nil {
-		logrus.Errorf("Failed to get mac address of %v, stderr: %q, error: %v", interfaceName, stderr, err)
+		logrus.Errorf("Failed to get management port MAC address: %v", err)
 		return err
-	}
-	if macAddress == "[]" {
-		return fmt.Errorf("Failed to get mac address of %v", interfaceName)
-	}
-
-	if runtime.GOOS == windowsOS && macAddress == "00:00:00:00:00:00" {
-		macAddress, err = util.FetchIfMacWindows(interfaceName)
-		if err != nil {
-			return err
-		}
 	}
 
 	// Create this node's management logical port on the node switch

--- a/go-controller/pkg/ovn/management-port_linux.go
+++ b/go-controller/pkg/ovn/management-port_linux.go
@@ -1,0 +1,77 @@
+// +build linux
+
+package ovn
+
+import (
+	"os"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+)
+
+// CreateManagementPort creates a management port attached to the node switch
+// that lets the node access its pods via their private IP address. This is used
+// for health checking and other management tasks.
+func CreateManagementPort(nodeName, localSubnet string, clusterSubnet []string) error {
+	interfaceName, interfaceIP, routerIP, routerMAC, err :=
+		createManagementPortGeneric(nodeName, localSubnet, clusterSubnet)
+	if err != nil {
+		return err
+	}
+
+	// Up the interface.
+	_, _, err = util.RunIP("link", "set", interfaceName, "up")
+	if err != nil {
+		return err
+	}
+
+	// The interface may already exist, in which case delete the routes and IP.
+	_, _, err = util.RunIP("addr", "flush", "dev", interfaceName)
+	if err != nil {
+		return err
+	}
+
+	// Assign IP address to the internal interface.
+	_, _, err = util.RunIP("addr", "add", interfaceIP, "dev", interfaceName)
+	if err != nil {
+		return err
+	}
+
+	for _, subnet := range clusterSubnet {
+		// Flush the route for the entire subnet (in case it was added before).
+		_, _, err = util.RunIP("route", "flush", subnet)
+		if err != nil {
+			return err
+		}
+
+		// Create a route for the entire subnet.
+		_, _, err = util.RunIP("route", "add", subnet, "via", routerIP)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Flush the route for the services subnet (in case it was added before).
+	_, _, err = util.RunIP("route", "flush", config.Kubernetes.ServiceCIDR)
+	if err != nil {
+		return err
+	}
+
+	// Create a route for the services subnet.
+	_, _, err = util.RunIP("route", "add", config.Kubernetes.ServiceCIDR, "via", routerIP)
+	if err != nil {
+		return err
+	}
+
+	// Add a neighbour entry on the K8s node to map routerIP with routerMAC. This is
+	// required because in certain cases ARP requests from the K8s Node to the routerIP
+	// arrives on OVN Logical Router pipeline with ARP source protocol address set to
+	// K8s Node IP. OVN Logical Router pipeline drops such packets since it expects
+	// source protocol address to be in the Logical Switch's subnet.
+	_, _, err = util.RunIP("neigh", "add", routerIP, "dev", interfaceName, "lladdr", routerMAC)
+	if err != nil && os.IsNotExist(err) {
+		return err
+	}
+
+	return nil
+}

--- a/go-controller/pkg/ovn/management-port_linux_test.go
+++ b/go-controller/pkg/ovn/management-port_linux_test.go
@@ -1,10 +1,11 @@
+// +build linux
+
 package ovn
 
 import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"runtime"
 
 	"github.com/urfave/cli"
 
@@ -69,6 +70,8 @@ var _ = Describe("Management Port Operations", func() {
 			)
 
 			fexec := ovntest.NewFakeExec()
+
+			// generic setup
 			fexec.AddFakeCmdsNoOutputNoError([]string{
 				"ovs-vsctl --timeout=15 -- --may-exist add-br br-int",
 				"ovs-vsctl --timeout=15 -- --may-exist add-port br-int " + mgtPort + " -- set interface " + mgtPort + " type=internal mtu_request=" + mtu + " external-ids:iface-id=" + mgtPort,
@@ -85,39 +88,17 @@ var _ = Describe("Management Port Operations", func() {
 				Output: lrpMAC,
 			})
 
-			if runtime.GOOS == windowsOS {
-				const ifindex string = "10"
-				fexec.AddFakeCmdsNoOutputNoError([]string{
-					"powershell Enable-NetAdapter " + mgtPort,
-					"powershell Get-NetIPAddress -InterfaceAlias " + mgtPort,
-					"powershell Remove-NetIPAddress -InterfaceAlias " + mgtPort + " -Confirm:$false",
-					"powershell New-NetIPAddress -IPAddress " + mgtPortIP + " -PrefixLength " + mgtPortPrefix + " -InterfaceAlias " + mgtPort,
-					"netsh interface ipv4 set subinterface " + mgtPort + " mtu=" + mtu + " store=persistent",
-				})
-				fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-					Cmd:    "powershell $(Get-NetAdapter | Where { $_.Name -Match \"" + mgtPort + "\" }).ifIndex",
-					Output: ifindex,
-				})
-				fexec.AddFakeCmdsNoOutputNoError([]string{
-					// Don't print route output; test that network is not yet found
-					"route print -4 " + clusterIPNet,
-					"route -p add " + clusterIPNet + " mask 255.255.0.0 " + gwIP + " METRIC 2 IF " + ifindex,
-					// Don't print route output; test that network is not yet found
-					"route print -4 " + serviceIPNet,
-					"route -p add " + serviceIPNet + " mask 255.255.0.0 " + gwIP + " METRIC 2 IF " + ifindex,
-				})
-			} else {
-				fexec.AddFakeCmdsNoOutputNoError([]string{
-					"ip link set " + mgtPort + " up",
-					"ip addr flush dev " + mgtPort,
-					"ip addr add " + mgtPortCIDR + " dev " + mgtPort,
-					"ip route flush " + clusterCIDR,
-					"ip route add " + clusterCIDR + " via " + gwIP,
-					"ip route flush " + serviceCIDR,
-					"ip route add " + serviceCIDR + " via " + gwIP,
-					"ip neigh add " + gwIP + " dev " + mgtPort + " lladdr " + lrpMAC,
-				})
-			}
+			// linux-specific setup
+			fexec.AddFakeCmdsNoOutputNoError([]string{
+				"ip link set " + mgtPort + " up",
+				"ip addr flush dev " + mgtPort,
+				"ip addr add " + mgtPortCIDR + " dev " + mgtPort,
+				"ip route flush " + clusterCIDR,
+				"ip route add " + clusterCIDR + " via " + gwIP,
+				"ip route flush " + serviceCIDR,
+				"ip route add " + serviceCIDR + " via " + gwIP,
+				"ip neigh add " + gwIP + " dev " + mgtPort + " lladdr " + lrpMAC,
+			})
 
 			err := util.SetExec(fexec)
 			Expect(err).NotTo(HaveOccurred())

--- a/go-controller/pkg/ovn/management-port_windows.go
+++ b/go-controller/pkg/ovn/management-port_windows.go
@@ -1,0 +1,134 @@
+// +build windows
+
+package ovn
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	"github.com/sirupsen/logrus"
+)
+
+// CreateManagementPort creates a management port attached to the node switch
+// that lets the node access its pods via their private IP address. This is used
+// for health checking and other management tasks.
+func CreateManagementPort(nodeName, localSubnet string, clusterSubnet []string) error {
+	interfaceName, interfaceIP, routerIP, _, err :=
+		createManagementPortGeneric(nodeName, localSubnet, clusterSubnet)
+	if err != nil {
+		return err
+	}
+
+	// Up the interface.
+	_, _, err = util.RunPowershell("Enable-NetAdapter", "-IncludeHidden", interfaceName)
+	if err != nil {
+		return err
+	}
+
+	//check if interface already exists
+	ifAlias := fmt.Sprintf("-InterfaceAlias %s", interfaceName)
+	_, _, err = util.RunPowershell("Get-NetIPAddress", ifAlias)
+	if err == nil {
+		//The interface already exists, we should delete the routes and IP
+		logrus.Debugf("Interface %s exists, removing.", interfaceName)
+		_, _, err = util.RunPowershell("Remove-NetIPAddress", ifAlias, "-Confirm:$false")
+		if err != nil {
+			return err
+		}
+	}
+
+	// Assign IP address to the internal interface.
+	portIP, interfaceIPNet, err := net.ParseCIDR(interfaceIP)
+	if err != nil {
+		return fmt.Errorf("Failed to parse interfaceIP %v : %v", interfaceIP, err)
+	}
+	portPrefix, _ := interfaceIPNet.Mask.Size()
+	_, _, err = util.RunPowershell("New-NetIPAddress",
+		fmt.Sprintf("-IPAddress %s", portIP),
+		fmt.Sprintf("-PrefixLength %d", portPrefix),
+		ifAlias)
+	if err != nil {
+		return err
+	}
+
+	// Set MTU for the interface
+	_, _, err = util.RunNetsh("interface", "ipv4", "set", "subinterface",
+		interfaceName, fmt.Sprintf("mtu=%d", config.Default.MTU),
+		"store=persistent")
+	if err != nil {
+		return err
+	}
+
+	// Retrieve the interface index
+	stdout, stderr, err := util.RunPowershell("$(Get-NetAdapter", "-IncludeHidden", "|", "Where",
+		"{", "$_.Name", "-Match", fmt.Sprintf("\"%s\"", interfaceName), "}).ifIndex")
+	if err != nil {
+		logrus.Errorf("Failed to fetch interface index, stderr: %q, error: %v", stderr, err)
+		return err
+	}
+	if _, err = strconv.Atoi(stdout); err != nil {
+		logrus.Errorf("Failed to parse interface index %q: %v", stdout, err)
+		return err
+	}
+	interfaceIndex := stdout
+
+	for _, subnet := range clusterSubnet {
+		var subnetIP net.IP
+		var subnetIPNet *net.IPNet
+		subnetIP, subnetIPNet, err = net.ParseCIDR(subnet)
+		if err != nil {
+			return fmt.Errorf("failed to parse clusterSubnet %v : %v", subnet, err)
+		}
+		// Checking if the route already exists, in which case it will not be created again
+		stdout, stderr, err = util.RunRoute("print", "-4", subnetIP.String())
+		if err != nil {
+			logrus.Debugf("Failed to run route print, stderr: %q, error: %v", stderr, err)
+		}
+
+		if strings.Contains(stdout, subnetIP.String()) {
+			logrus.Debugf("Route was found, skipping route add")
+		} else {
+			// Windows route command requires the mask to be specified in the IP format
+			subnetMask := net.IP(subnetIPNet.Mask).String()
+			// Create a route for the entire subnet.
+			_, stderr, err = util.RunRoute("-p", "add",
+				subnetIP.String(), "mask", subnetMask,
+				routerIP, "METRIC", "2", "IF", interfaceIndex)
+			if err != nil {
+				logrus.Errorf("failed to run route add, stderr: %q, error: %v", stderr, err)
+				return err
+			}
+		}
+	}
+
+	clusterServiceIP, clusterServiceIPNet, err := net.ParseCIDR(config.Kubernetes.ServiceCIDR)
+	if err != nil {
+		return fmt.Errorf("Failed to parse clusterServicesSubnet %v : %v", config.Kubernetes.ServiceCIDR, err)
+	}
+	// Checking if the route already exists, in which case it will not be created again
+	stdout, stderr, err = util.RunRoute("print", "-4", clusterServiceIP.String())
+	if err != nil {
+		logrus.Debugf("Failed to run route print, stderr: %q, error: %v", stderr, err)
+	}
+
+	if strings.Contains(stdout, clusterServiceIP.String()) {
+		logrus.Debugf("Route was found, skipping route add")
+	} else {
+		// Windows route command requires the mask to be specified in the IP format
+		clusterServiceMask := net.IP(clusterServiceIPNet.Mask).String()
+		// Create a route for the entire subnet.
+		_, stderr, err = util.RunRoute("-p", "add",
+			clusterServiceIP.String(), "mask", clusterServiceMask,
+			routerIP, "METRIC", "2", "IF", interfaceIndex)
+		if err != nil {
+			logrus.Errorf("failed to run route add, stderr: %q, error: %v", stderr, err)
+			return err
+		}
+	}
+
+	return nil
+}

--- a/go-controller/pkg/ovn/management-port_windows_test.go
+++ b/go-controller/pkg/ovn/management-port_windows_test.go
@@ -1,0 +1,127 @@
+// +build windows
+
+package ovn
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/urfave/cli"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var tmpDir string
+
+var _ = AfterSuite(func() {
+	err := os.RemoveAll(tmpDir)
+	Expect(err).NotTo(HaveOccurred())
+})
+
+func createTempFile(name string) (string, error) {
+	fname := filepath.Join(tmpDir, name)
+	if err := ioutil.WriteFile(fname, []byte{0x20}, 0644); err != nil {
+		return "", err
+	}
+	return fname, nil
+}
+
+var _ = Describe("Management Port Operations", func() {
+	var tmpErr error
+	var app *cli.App
+
+	tmpDir, tmpErr = ioutil.TempDir("", "clusternodetest_certdir")
+	if tmpErr != nil {
+		GinkgoT().Errorf("failed to create tempdir: %v", tmpErr)
+	}
+
+	BeforeEach(func() {
+		// Restore global default values before each testcase
+		config.RestoreDefaultConfig()
+
+		app = cli.NewApp()
+		app.Name = "test"
+		app.Flags = config.Flags
+	})
+
+	It("sets up the management port", func() {
+		app.Action = func(ctx *cli.Context) error {
+			const (
+				nodeName      string = "node1"
+				nodeSubnet    string = "10.1.1.0/24"
+				mgtPortMAC    string = "00:00:00:55:66:77"
+				mgtPort       string = "k8s-" + nodeName
+				mgtPortIP     string = "10.1.1.2"
+				mgtPortPrefix string = "24"
+				clusterIPNet  string = "10.1.0.0"
+				clusterCIDR   string = clusterIPNet + "/16"
+				serviceIPNet  string = "172.16.1.0"
+				mtu           string = "1400"
+				gwIP          string = "10.1.1.1"
+				lrpMAC        string = "00:00:00:00:00:03"
+				ifindex       string = "10"
+			)
+
+			fexec := ovntest.NewFakeExec()
+
+			// generic setup
+			fexec.AddFakeCmdsNoOutputNoError([]string{
+				"ovs-vsctl --timeout=15 -- --may-exist add-br br-int",
+				"ovs-vsctl --timeout=15 -- --may-exist add-port br-int " + mgtPort + " -- set interface " + mgtPort + " type=internal mtu_request=" + mtu + " external-ids:iface-id=" + mgtPort,
+			})
+			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+				Cmd:    "ovs-vsctl --timeout=15 --if-exists get interface " + mgtPort + " mac_in_use",
+				Output: mgtPortMAC,
+			})
+			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+				Cmd: "ovn-nbctl --timeout=15 -- --may-exist lsp-add " + nodeName + " " + mgtPort + " -- lsp-set-addresses " + mgtPort + " " + mgtPortMAC + " " + mgtPortIP + " -- --if-exists remove logical_switch " + nodeName + " other-config exclude_ips",
+			})
+			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+				Cmd:    "ovn-nbctl --timeout=15 lsp-get-addresses stor-" + nodeName,
+				Output: lrpMAC,
+			})
+
+			// windows-specific setup
+			fexec.AddFakeCmdsNoOutputNoError([]string{
+				"powershell Enable-NetAdapter " + mgtPort,
+				"powershell Get-NetIPAddress -InterfaceAlias " + mgtPort,
+				"powershell Remove-NetIPAddress -InterfaceAlias " + mgtPort + " -Confirm:$false",
+				"powershell New-NetIPAddress -IPAddress " + mgtPortIP + " -PrefixLength " + mgtPortPrefix + " -InterfaceAlias " + mgtPort,
+				"netsh interface ipv4 set subinterface " + mgtPort + " mtu=" + mtu + " store=persistent",
+			})
+			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+				Cmd:    "powershell $(Get-NetAdapter | Where { $_.Name -Match \"" + mgtPort + "\" }).ifIndex",
+				Output: ifindex,
+			})
+			fexec.AddFakeCmdsNoOutputNoError([]string{
+				// Don't print route output; test that network is not yet found
+				"route print -4 " + clusterIPNet,
+				"route -p add " + clusterIPNet + " mask 255.255.0.0 " + gwIP + " METRIC 2 IF " + ifindex,
+				// Don't print route output; test that network is not yet found
+				"route print -4 " + serviceIPNet,
+				"route -p add " + serviceIPNet + " mask 255.255.0.0 " + gwIP + " METRIC 2 IF " + ifindex,
+			})
+
+			err := util.SetExec(fexec)
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = config.InitConfig(ctx, fexec, nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			err = CreateManagementPort(nodeName, nodeSubnet, []string{clusterCIDR})
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(fexec.CalledMatchesExpected()).To(BeTrue())
+			return nil
+		}
+
+		err := app.Run([]string{app.Name})
+		Expect(err).NotTo(HaveOccurred())
+	})
+})

--- a/go-controller/pkg/util/iptables.go
+++ b/go-controller/pkg/util/iptables.go
@@ -27,9 +27,24 @@ type IPTablesHelper interface {
 	Delete(string, string, ...string) error
 }
 
-// NewWithProtocol creates a new IPTablesHelper wrapping "live" go-iptables
-func NewWithProtocol(proto iptables.Protocol) (IPTablesHelper, error) {
-	return iptables.NewWithProtocol(proto)
+var helpers = make(map[iptables.Protocol]IPTablesHelper)
+
+// SetIPTablesHelper sets the IPTablesHelper to be used
+func SetIPTablesHelper(proto iptables.Protocol, ipt IPTablesHelper) {
+	helpers[proto] = ipt
+}
+
+// GetIPTablesHelper returns an IPTablesHelper. If SetIPTablesHelper has not yet been
+// called, it will create a new IPTablesHelper wrapping "live" go-iptables
+func GetIPTablesHelper(proto iptables.Protocol) (IPTablesHelper, error) {
+	if helpers[proto] == nil {
+		ipt, err := iptables.NewWithProtocol(proto)
+		if err != nil {
+			return nil, err
+		}
+		SetIPTablesHelper(proto, ipt)
+	}
+	return helpers[proto], nil
 }
 
 // FakeTable represents a mock iptables table and can be used for

--- a/go-controller/pkg/util/util.go
+++ b/go-controller/pkg/util/util.go
@@ -2,8 +2,6 @@ package util
 
 import (
 	"fmt"
-	"os/exec"
-	"strings"
 
 	"github.com/urfave/cli"
 )
@@ -15,21 +13,6 @@ func StringArg(context *cli.Context, name string) (string, error) {
 		return "", fmt.Errorf("argument --%s should be non-null", name)
 	}
 	return val, nil
-}
-
-// FetchIfMacWindows gets the mac of the interfaceName via powershell commands
-// There is a known issue with OVS not correctly picking up the
-// physical network interface MAC address.
-func FetchIfMacWindows(interfaceName string) (string, error) {
-	stdoutStderr, err := exec.Command("powershell", "$(Get-NetAdapter", "-IncludeHidden",
-		"-InterfaceAlias", fmt.Sprintf("\"%s\"", interfaceName), ").MacAddress").CombinedOutput()
-	if err != nil {
-		return "", fmt.Errorf("Failed to get mac address of ovn-k8s-master, stderr: %q, error: %v", fmt.Sprintf("%s", stdoutStderr), err)
-	}
-	// Windows returns it in 00-00-00-00-00-00 format, we want ':' instead of '-'
-	macAddress := strings.Replace(strings.TrimSpace(fmt.Sprintf("%s", stdoutStderr)), "-", ":", -1)
-
-	return strings.ToLower(macAddress), nil
 }
 
 // GetK8sMgmtIntfName returns the correct length interface name to be used


### PR DESCRIPTION
Certain CloudProviders (eg, Azure) assume that they can redirect loadbalancer traffic directly to a node with no rewriting, and the node will accept the packets. This works with kube-proxy because of a rule that was intended just as a shortcut to avoid sending local traffic to the load-balancer unnecessarily. Make it work with ovn-kubernetes too.

This was easier to fix for local gateway only than it would be to fix for everything, so I only fixed it for local gateway here. We need to fix this correctly upstream still.

This PR also pulls in the fixes to make HostPorts work and a random iptables-rules cleanup fix because it simplifies my new code. Only the last commit is new.