### PR TITLE
bug 1748162: - [GCP]Failed to install cluster with OVN network type

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,7 @@ RUN INSTALL_PKGS=" \
 	openvswitch2.11 openvswitch2.11-devel \
 	openvswitch2.11-ovn-common openvswitch2.11-ovn-central \
 	openvswitch2.11-ovn-host openvswitch2.11-ovn-vtep \
+	libibverbs \
 	containernetworking-plugins \
 	" && \
 	yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False $INSTALL_PKGS && \


### PR DESCRIPTION
Comment #11 redirects this to a vsphere bug
OVN as network type to install cluster on vsphere.

cannot load glue library: libibverbs.so.1

https://bugzilla.redhat.com/show_bug.cgi?id=1748162

Signed-off-by: Phil Cameron <pcameron@redhat.com>