### PR TITLE
SDN-490: Porting clearance of NetworkUnavailable status from SDN to OVN

### DIFF
--- a/go-controller/pkg/cluster/master_test.go
+++ b/go-controller/pkg/cluster/master_test.go
@@ -5,7 +5,7 @@ import (
 	"net"
 
 	"github.com/urfave/cli"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kuberuntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
@@ -277,12 +277,25 @@ subnet=%s
 				"ovn-nbctl --timeout=15 -- --may-exist lsp-add " + masterName + " stor-" + masterName + " -- set logical_switch_port stor-" + masterName + " type=router options:router-port=rtos-" + masterName + " addresses=\"" + lrpMAC + "\"",
 			})
 
-			masterNode := v1.Node{ObjectMeta: metav1.ObjectMeta{
-				Name: masterName,
-				Annotations: map[string]string{
-					OvnHostSubnet: masterSubnet,
+			masterNode := v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: masterName,
+					Annotations: map[string]string{
+						OvnHostSubnet: masterSubnet,
+					},
 				},
-			}}
+				Status: v1.NodeStatus{
+					Conditions: []v1.NodeCondition{
+						v1.NodeCondition{
+							Type:               v1.NodeNetworkUnavailable,
+							Status:             v1.ConditionTrue,
+							Reason:             "NoRouteCreated",
+							Message:            "Node created without a route",
+							LastTransitionTime: metav1.Now(),
+						},
+					},
+				},
+			}
 			fakeClient := fake.NewSimpleClientset(&v1.NodeList{
 				Items: []v1.Node{masterNode},
 			})
@@ -310,6 +323,12 @@ subnet=%s
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(fexec.CalledMatchesExpected()).To(BeTrue())
+
+			node, err := fakeClient.CoreV1().Nodes().Get(masterNode.Name, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(node.Status.Conditions)).To(BeIdenticalTo(1))
+			Expect(node.Status.Conditions[0].Message).To(BeIdenticalTo("ovn-kube cleared kubelet-set NoRouteCreated"))
+
 			return nil
 		}
 

--- a/go-controller/pkg/kube/kube.go
+++ b/go-controller/pkg/kube/kube.go
@@ -17,6 +17,7 @@ import (
 type Interface interface {
 	SetAnnotationOnPod(pod *kapi.Pod, key, value string) error
 	SetAnnotationOnNode(node *kapi.Node, key, value string) error
+	SetUpdateStatusOnNode(*kapi.Node) error
 	GetAnnotationsOnPod(namespace, name string) (map[string]string, error)
 	GetPod(namespace, name string) (*kapi.Pod, error)
 	GetPods(namespace string) (*kapi.PodList, error)
@@ -51,6 +52,16 @@ func (k *Kube) SetAnnotationOnNode(node *kapi.Node, key, value string) error {
 	_, err := k.KClient.CoreV1().Nodes().Patch(node.Name, types.MergePatchType, []byte(patchData))
 	if err != nil {
 		logrus.Errorf("Error in setting annotation on node %s: %v", node.Name, err)
+	}
+	return err
+}
+
+// SetUpdateStatusOnNode takes the node object and sets the provided update status
+func (k *Kube) SetUpdateStatusOnNode(node *kapi.Node) error {
+	logrus.Infof("Updating status on node %s", node.Name)
+	_, err := k.KClient.CoreV1().Nodes().UpdateStatus(node)
+	if err != nil {
+		logrus.Errorf("Error in updating status on node %s: %v", node.Name, err)
 	}
 	return err
 }


### PR DESCRIPTION
Hi 

This is a port of the SDN code for removing the initial `NodeNetworkUnavailable` condition that k8s sets for GCE nodes. 

I am opening this PR as I happened to pick up this user story earlier today, prior to the planning, and implemented it quite quickly. Please have a look and discuss:

* If this is a necessary PR (I understood that @danwinship was not convinced that it was) 
* If this is the right repo, or if it should target upstream instead. 

/assign @danwinship @squeed 