### PR TITLE
Wrap IPv6 address in [] before adding port

### DIFF
--- a/go-controller/pkg/cluster/gateway_localnet.go
+++ b/go-controller/pkg/cluster/gateway_localnet.go
@@ -4,6 +4,7 @@ package cluster
 
 import (
 	"fmt"
+	"net"
 	"reflect"
 	"strings"
 	"time"
@@ -202,7 +203,7 @@ func localnetIptRules(svc *kapi.Service) []iptRule {
 		}
 
 		nodePort := fmt.Sprintf("%d", svcPort.NodePort)
-		destination := strings.Split(localnetGatewayIP, "/")[0] + ":" + nodePort
+		destination := net.JoinHostPort(strings.Split(localnetGatewayIP, "/")[0], nodePort)
 
 		rules = append(rules, iptRule{
 			table: "nat",


### PR DESCRIPTION
This code assumed an IPv4 address.  When the IP address is IPv6, we
must wrap it with square brackets to differentiate the address from
the : that separates the address from the port number.

This is the openshift equivalent of https://github.com/ovn-org/ovn-kubernetes/pull/901