### PR TITLE
ovn: retry pod setup in update if it fails during add

### DIFF
--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -26,8 +26,10 @@ func (oc *Controller) syncPods(pods []interface{}) {
 			logrus.Errorf("Spurious object in syncPods: %v", podInterface)
 			continue
 		}
-		logicalPort := podLogicalPortName(pod)
-		expectedLogicalPorts[logicalPort] = true
+		if podScheduledAndNetworked(pod) {
+			logicalPort := podLogicalPortName(pod)
+			expectedLogicalPorts[logicalPort] = true
+		}
 	}
 
 	// get the list of logical ports from OVN
@@ -229,18 +231,17 @@ func (oc *Controller) waitForNodeLogicalSwitch(nodeName string) error {
 	return nil
 }
 
-func (oc *Controller) addLogicalPort(pod *kapi.Pod) {
+func (oc *Controller) addLogicalPort(pod *kapi.Pod) error {
 	var out, stderr string
 	var err error
 	if pod.Spec.HostNetwork {
-		return
+		return nil
 	}
 
 	logicalSwitch := pod.Spec.NodeName
 	if logicalSwitch == "" {
-		logrus.Errorf("Failed to find the logical switch for pod %s/%s",
+		return fmt.Errorf("Failed to find the logical switch for pod %s/%s",
 			pod.Namespace, pod.Name)
-		return
 	}
 
 	// Keep track of how long syncs take.
@@ -250,7 +251,7 @@ func (oc *Controller) addLogicalPort(pod *kapi.Pod) {
 	}()
 
 	if err = oc.waitForNodeLogicalSwitch(pod.Spec.NodeName); err != nil {
-		return
+		return err
 	}
 
 	portName := podLogicalPortName(pod)
@@ -270,10 +271,9 @@ func (oc *Controller) addLogicalPort(pod *kapi.Pod) {
 			"external-ids:pod=true", "--", "--if-exists",
 			"clear", "logical_switch_port", portName, "dynamic_addresses")
 		if err != nil {
-			logrus.Errorf("Failed to add logical port to switch "+
+			return fmt.Errorf("Failed to add logical port to switch "+
 				"stdout: %q, stderr: %q (%v)",
 				out, stderr, err)
-			return
 		}
 	} else {
 		out, stderr, err = util.RunOVNNbctl("--wait=sb", "--",
@@ -285,20 +285,17 @@ func (oc *Controller) addLogicalPort(pod *kapi.Pod) {
 			"external-ids:logical_switch="+logicalSwitch,
 			"external-ids:pod=true")
 		if err != nil {
-			logrus.Errorf("Error while creating logical port %s "+
+			return fmt.Errorf("Error while creating logical port %s "+
 				"stdout: %q, stderr: %q (%v)",
 				portName, out, stderr, err)
-			return
 		}
-
 	}
 
 	oc.logicalPortCache[portName] = logicalSwitch
 
 	gatewayIP, err := oc.getGatewayFromSwitch(logicalSwitch)
 	if err != nil {
-		logrus.Errorf("Error obtaining gateway address for switch %s", logicalSwitch)
-		return
+		return fmt.Errorf("Error obtaining gateway address for switch %s", logicalSwitch)
 	}
 
 	var podMac net.HardwareAddr
@@ -310,17 +307,14 @@ func (oc *Controller) addLogicalPort(pod *kapi.Pod) {
 			break
 		}
 		if err != nil {
-			logrus.Errorf("Error while obtaining addresses for %s - %v", portName,
-				err)
-			return
+			return fmt.Errorf("Error while obtaining addresses for %s - %v", portName, err)
 		}
 		time.Sleep(time.Second)
 		count--
 	}
 	if count == 0 {
-		logrus.Errorf("Error while obtaining addresses for %s "+
+		return fmt.Errorf("Error while obtaining addresses for %s "+
 			"stdout: %q, stderr: %q, (%v)", portName, out, stderr, err)
-		return
 	}
 
 	podCIDR := &net.IPNet{IP: podIP, Mask: gatewayIP.Mask}
@@ -329,9 +323,8 @@ func (oc *Controller) addLogicalPort(pod *kapi.Pod) {
 	out, stderr, err = util.RunOVNNbctl("lsp-set-port-security", portName,
 		fmt.Sprintf("%s %s", podMac, podCIDR))
 	if err != nil {
-		logrus.Errorf("error while setting port security for logical port %s "+
+		return fmt.Errorf("error while setting port security for logical port %s "+
 			"stdout: %q, stderr: %q (%v)", portName, out, stderr, err)
-		return
 	}
 
 	routes := []util.PodRoute{}
@@ -355,17 +348,16 @@ func (oc *Controller) addLogicalPort(pod *kapi.Pod) {
 		Routes: routes,
 	})
 	if err != nil {
-		logrus.Errorf("error creating pod network annotation: %v", err)
-		return
+		return fmt.Errorf("error creating pod network annotation: %v", err)
 	}
+
+	oc.addPodToNamespace(pod.Namespace, podIP, portName)
 
 	logrus.Debugf("Annotation values: ip=%s ; mac=%s ; gw=%s\nAnnotation=%s",
 		podCIDR, podMac, gatewayIP, annotation)
-	err = oc.kube.SetAnnotationOnPod(pod, "ovn", marshalledAnnotation)
-	if err != nil {
-		logrus.Errorf("Failed to set annotation on pod %s - %v", pod.Name, err)
+	if err = oc.kube.SetAnnotationOnPod(pod, "ovn", marshalledAnnotation); err != nil {
+		return fmt.Errorf("Failed to set annotation on pod %s - %v", pod.Name, err)
 	}
-	oc.addPodToNamespace(pod.Namespace, podIP, portName)
 
-	return
+	return nil
 }


### PR DESCRIPTION
If a failure occurred during a pod Add the error would be logged
but setup would never be retried because the pod would remain
scheduled. Instead, use the 'ovn' annotation as a marker of
whether the pod has been set up or not. Since setting the annotation
should be the last thing we do, we can mostly use this as an
indicator of setup success.

Signed-off-by: Dan Williams <dcbw@redhat.com>