### PR TITLE
Create separate image for Windows binary artifacts

### DIFF
--- a/Dockerfile.artifacts
+++ b/Dockerfile.artifacts
@@ -1,0 +1,22 @@
+# This Dockerfile builds an image containing the Windows ovn binaries
+# layered on top of the Linux ovn-kubernetes image.
+FROM openshift/origin-release:golang-1.12 AS builder
+
+WORKDIR /go-controller
+COPY go-controller/ .
+
+# build the binaries
+RUN CGO_ENABLED=0 make windows
+
+FROM openshift/origin-ovn-kubernetes
+
+COPY --from=builder /go-controller/_output/go/bin/windows/ovnkube.exe /usr/share/openshift/windows/
+COPY --from=builder /go-controller/_output/go/bin/windows/hybrid-overlay.exe /usr/share/openshift/windows/
+COPY --from=builder /go-controller/_output/go/bin/windows/ovn-k8s-cni-overlay.exe /usr/share/openshift/windows/
+
+LABEL io.k8s.display-name="ovn kubernetes" \
+      io.k8s.description="This is a component of OpenShift Container Platform that provides an overlay network using ovn." \
+      summary="This is a component of OpenShift Container Platform that provides an overlay network using ovn." \
+      io.openshift.tags="openshift" \
+      maintainer="Phil Cameron <pcameron@redhat.com>"
+

--- a/go-controller/hack/build-go.sh
+++ b/go-controller/hack/build-go.sh
@@ -35,11 +35,11 @@ build_windows_binaries() {
     set -x
     for bin in "$@"; do
         binbase=$(basename ${bin})
-        GOOS=windows go build -v \
+        GOOS=windows GOARCH=amd64 go build -v \
             -mod vendor \
             -gcflags "${GCFLAGS}" \
             -ldflags "-B ${BUILDID}" \
-            -o "${OVN_KUBE_OUTPUT_BINPATH_WINDOWS}/${binbase}"\
+            -o "${OVN_KUBE_OUTPUT_BINPATH_WINDOWS}/${binbase}.exe"\
             "./${bin}"
     done
 }


### PR DESCRIPTION
This would have to be paired with a new container request and PR to ocp-build-data (which I can also provide).  How these binaries would be extracted and distributed to users would be up to ART.

CC: @dcbw 