### PR TITLE
Build the windows binary as part of the container ovn-kubernetes container build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ COPY go-controller/ .
 
 # build the binaries
 RUN CGO_ENABLED=0 make
+RUN CGO_ENABLED=0 make windows
 
 FROM openshift/origin-cli AS cli
 
@@ -50,6 +51,7 @@ RUN mkdir -p /var/run/openvswitch && \
 COPY --from=builder /go-controller/_output/go/bin/ovnkube /usr/bin/
 COPY --from=builder /go-controller/_output/go/bin/ovn-kube-util /usr/bin/
 COPY --from=builder /go-controller/_output/go/bin/ovn-k8s-cni-overlay /usr/libexec/cni/ovn-k8s-cni-overlay
+COPY --from=builder /go-controller/_output/go/bin/windows/hybrid-overlay /root/windows/
 
 COPY --from=cli /usr/bin/oc /usr/bin
 RUN ln -s /usr/bin/oc /usr/bin/kubectl


### PR DESCRIPTION
Adding the windows binary to the container build will allow the windows binary to be built in a way that can be released 

Jira Card: https://issues.redhat.com/browse/SDN-702
Signed-off-by: Jacob Tanenbaum <jtanenba@redhat.com>