### PR TITLE
correct the directory placement of windows binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,8 @@ RUN INSTALL_PKGS=" \
 RUN mkdir -p /var/run/openvswitch && \
     mkdir -p /etc/cni/net.d && \
     mkdir -p /opt/cni/bin && \
-    mkdir -p /usr/libexec/cni/
+    mkdir -p /usr/libexec/cni/ && \
+    mkdir -p /root/windows/
 
 COPY --from=builder /go-controller/_output/go/bin/ovnkube /usr/bin/
 COPY --from=builder /go-controller/_output/go/bin/ovn-kube-util /usr/bin/


### PR DESCRIPTION
Currently the windows binary does not get placed in the ovn-kubernetes image because the
dockerfile does not create the directory for it to be copied to.

Signed-off-by: Jacob Tanenbaum <jtanenba@redhat.com>