### PR TITLE
Dynamic HA - `--no-leader-only` for ovn commands

### DIFF
--- a/dist/images/Dockerfile
+++ b/dist/images/Dockerfile
@@ -62,6 +62,7 @@ COPY ovn-k8s-cni-overlay /usr/libexec/cni/ovn-k8s-cni-overlay
 # variables to direct operation and configure ovn
 COPY ovnkube.sh /root/
 COPY ovn-debug.sh /root/
+COPY ovnkube-helper.sh /root/
 # override the rpm's ovn_k8s.conf with this local copy
 COPY ovn_k8s.conf /etc/openvswitch/ovn_k8s.conf
 

--- a/dist/images/Dockerfile.fedora
+++ b/dist/images/Dockerfile.fedora
@@ -38,7 +38,7 @@ COPY git_info /root
 # variables to direct operation and configure ovn
 COPY ovnkube.sh /root/
 COPY ovn-debug.sh /root/
-
+COPY ovnkube-helper.sh /root/
 # iptables wrappers
 COPY ./iptables-scripts/iptables /usr/sbin/
 COPY ./iptables-scripts/iptables-save /usr/sbin/

--- a/dist/images/Dockerfile.ubuntu
+++ b/dist/images/Dockerfile.ubuntu
@@ -39,6 +39,7 @@ COPY ovn-k8s-cni-overlay /usr/libexec/cni/ovn-k8s-cni-overlay
 # variables to direct operation and configure ovn
 COPY ovnkube.sh /root/
 COPY ovn-debug.sh /root/
+COPY ovnkube-helper.sh /root/
 # override the pkg's ovn_k8s.conf with this local copy
 COPY ovn_k8s.conf /etc/openvswitch/ovn_k8s.conf
 

--- a/dist/images/ovnkube-helper.sh
+++ b/dist/images/ovnkube-helper.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+function watch_core_dns_ep () {
+  set +ex
+  local print_count=0
+  local print_interval=30
+  local watch_interval=5
+  while true; do
+    is_dns_up=$(kubectl get ep dns-default -n openshift-dns -o jsonpath='{.subsets[0].addresses[0].ip}' 2>/dev/null)
+    if [[ -n "${is_dns_up}" ]]; then
+      break
+    fi
+    if [[ $(($print_count % $print_interval)) == 0 ]]; then
+      echo "[$(date +%Y-%m-%dT%H:%M:%SZ)][watch_core_dns_ep] waiting for CoreDNS to start..."
+    fi
+    print_count=$(($print_count+$watch_interval))
+    sleep $watch_interval
+  done
+
+  echo "[$(date +%Y-%m-%dT%H:%M:%SZ)][watch_core_dns_ep] CoreDNS is up, replacing inherited nameserver entry from host with CoreDNS service IP in /etc/resolv.conf"
+  core_dns_svc_ip=$(kubectl get svc dns-default -n openshift-dns -o jsonpath='{.spec.clusterIP}' 2>/dev/null)
+
+  sed -e "s/nameserver.*/nameserver $core_dns_svc_ip/g" /etc/resolv.conf > resolv.tmp
+  cp -f resolv.tmp /etc/resolv.conf
+  rm resolv.tmp
+
+  # Perform DNS resolution against the DNS resolver first and /etc/hosts second
+  sed -i 's/hosts:      files dns myhostname/hosts:      dns files myhostname/g' /etc/nsswitch.conf
+}
+

--- a/go-controller/pkg/util/ovs.go
+++ b/go-controller/pkg/util/ovs.go
@@ -312,9 +312,10 @@ func getNbctlArgsAndEnv(timeout int, args ...string) ([]string, []string) {
 			fmt.Sprintf("--private-key=%s", config.OvnNorth.PrivKey),
 			fmt.Sprintf("--certificate=%s", config.OvnNorth.Cert),
 			fmt.Sprintf("--bootstrap-ca-cert=%s", config.OvnNorth.CACert),
-			fmt.Sprintf("--db=%s", config.OvnNorth.GetURL()))
+			fmt.Sprintf("--db=%s", config.OvnNorth.GetURL()),
+			"--no-leader-only")
 	} else if config.OvnNorth.Scheme == config.OvnDBSchemeTCP {
-		cmdArgs = append(cmdArgs, fmt.Sprintf("--db=%s", config.OvnNorth.GetURL()))
+		cmdArgs = append(cmdArgs, fmt.Sprintf("--db=%s", config.OvnNorth.GetURL()), "--no-leader-only")
 	}
 	cmdArgs = append(cmdArgs, fmt.Sprintf("--timeout=%d", timeout))
 	cmdArgs = append(cmdArgs, args...)
@@ -362,10 +363,12 @@ func RunOVNSbctlWithTimeout(timeout int, args ...string) (string, string,
 			fmt.Sprintf("--certificate=%s", config.OvnSouth.Cert),
 			fmt.Sprintf("--bootstrap-ca-cert=%s", config.OvnSouth.CACert),
 			fmt.Sprintf("--db=%s", config.OvnSouth.GetURL()),
+			"--no-leader-only",
 		}
 	} else if config.OvnSouth.Scheme == config.OvnDBSchemeTCP {
 		cmdArgs = []string{
 			fmt.Sprintf("--db=%s", config.OvnSouth.GetURL()),
+			"--no-leader-only",
 		}
 	}
 


### PR DESCRIPTION
This is a complementary PR to 

https://github.com/openshift/cluster-network-operator/pull/447

Please see that one for a explanation on why this change is needed