### PR TITLE
Add windows nodes to ovn's node watcher

### DIFF
--- a/go-controller/cmd/ovnkube/ovnkube.go
+++ b/go-controller/cmd/ovnkube/ovnkube.go
@@ -24,8 +24,6 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 
-	"k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kexec "k8s.io/utils/exec"
 )
 
@@ -244,22 +242,17 @@ func runOvnKube(ctx *cli.Context) error {
 
 		ovn.RegisterMetrics()
 
-		var nodeSelector *metav1.LabelSelector
 		var hybridOverlayClusterSubnets []config.CIDRNetworkEntry
 		if enableHybridOverlay {
 			hybridOverlayClusterSubnets, err = hocontroller.GetHybridOverlayClusterSubnets(ctx)
 			if err != nil {
 				return err
 			}
-
-			nodeSelector = &metav1.LabelSelector{
-				MatchLabels: map[string]string{v1.LabelOSStable: "linux"},
-			}
 		}
 
 		// run the HA master controller to init the master
 		ovnHAController := ovn.NewHAMasterController(clientset, factory, master, stopChan,
-			hybridOverlayClusterSubnets, nodeSelector)
+			hybridOverlayClusterSubnets, nil)
 		if err := ovnHAController.StartHAMasterController(); err != nil {
 			return err
 		}

--- a/go-controller/cmd/ovnkube/ovnkube.go
+++ b/go-controller/cmd/ovnkube/ovnkube.go
@@ -252,7 +252,7 @@ func runOvnKube(ctx *cli.Context) error {
 
 		// run the HA master controller to init the master
 		ovnHAController := ovn.NewHAMasterController(clientset, factory, master, stopChan,
-			hybridOverlayClusterSubnets, nil)
+			hybridOverlayClusterSubnets)
 		if err := ovnHAController.StartHAMasterController(); err != nil {
 			return err
 		}

--- a/go-controller/pkg/ovn/ha_master.go
+++ b/go-controller/pkg/ovn/ha_master.go
@@ -39,14 +39,12 @@ type HAMasterController struct {
 	isLeader        bool
 	leaderElector   *leaderelection.LeaderElector
 	stopChan        chan struct{}
-	nodeSelector    *metav1.LabelSelector
 }
 
 // NewHAMasterController creates a new HA Master controller
 func NewHAMasterController(kubeClient kubernetes.Interface, wf *factory.WatchFactory,
 	nodeName string, stopChan chan struct{},
-	hybridOverlayClusterSubnets []config.CIDRNetworkEntry,
-	nodeSelector *metav1.LabelSelector) *HAMasterController {
+	hybridOverlayClusterSubnets []config.CIDRNetworkEntry) *HAMasterController {
 	ovnController := NewOvnController(kubeClient, wf, hybridOverlayClusterSubnets)
 	return &HAMasterController{
 		kubeClient:      kubeClient,
@@ -56,7 +54,6 @@ func NewHAMasterController(kubeClient kubernetes.Interface, wf *factory.WatchFac
 		isLeader:        false,
 		leaderElector:   nil,
 		stopChan:        stopChan,
-		nodeSelector:    nodeSelector,
 	}
 }
 
@@ -206,7 +203,7 @@ func (hacontroller *HAMasterController) ConfigureAsActive(masterNodeName string)
 		return err
 	}
 
-	return hacontroller.ovnController.Run(hacontroller.nodeSelector, hacontroller.stopChan)
+	return hacontroller.ovnController.Run(hacontroller.stopChan)
 }
 
 //updateOvnDbEndpoints Updates the ovnkube-db endpoints. Should be called

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -248,7 +248,7 @@ var _ = Describe("Master Operations", func() {
 			err = clusterController.StartClusterMaster("master")
 			Expect(err).NotTo(HaveOccurred())
 
-			err = clusterController.WatchNodes(nil)
+			err = clusterController.WatchNodes()
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(fexec.CalledMatchesExpected()).To(BeTrue(), fexec.ErrorDesc)
@@ -322,7 +322,7 @@ var _ = Describe("Master Operations", func() {
 			err = clusterController.StartClusterMaster("master")
 			Expect(err).NotTo(HaveOccurred())
 
-			err = clusterController.WatchNodes(nil)
+			err = clusterController.WatchNodes()
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(fexec.CalledMatchesExpected()).To(BeTrue(), fexec.ErrorDesc)
@@ -483,7 +483,7 @@ subnet=%s
 			clusterController.UDPLoadBalancerUUID = udpLBUUID
 
 			// Let the real code run and ensure OVN database sync
-			err = clusterController.WatchNodes(nil)
+			err = clusterController.WatchNodes()
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(fexec.CalledMatchesExpected()).To(BeTrue(), fexec.ErrorDesc)
@@ -719,7 +719,7 @@ var _ = Describe("Gateway Init Operations", func() {
 			clusterController.UDPLoadBalancerUUID = udpLBUUID
 
 			// Let the real code run and ensure OVN database sync
-			err = clusterController.WatchNodes(nil)
+			err = clusterController.WatchNodes()
 			Expect(err).NotTo(HaveOccurred())
 
 			_, subnet, err := net.ParseCIDR(nodeSubnet)
@@ -944,7 +944,7 @@ var _ = Describe("Gateway Init Operations", func() {
 			clusterController.UDPLoadBalancerUUID = udpLBUUID
 
 			// Let the real code run and ensure OVN database sync
-			err = clusterController.WatchNodes(nil)
+			err = clusterController.WatchNodes()
 			Expect(err).NotTo(HaveOccurred())
 
 			_, subnet, err := net.ParseCIDR(nodeSubnet)


### PR DESCRIPTION
Currently the ovn controller treats pods on windows and linux nodes the same. By adding a windows node cache the logic can be implemented to treat them differently. 

fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1789881
upstream PR: https://github.com/ovn-org/ovn-kubernetes/pull/1015