### PR TITLE
Bug 1801417: [4.3]Bump ovnkube to support OVN2.12

### DIFF
--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -65,9 +65,7 @@ ovn_log_northd=${OVN_LOG_NORTHD:-"-vconsole:info"}
 ovn_log_nb=${OVN_LOG_NB:-"-vconsole:info"}
 ovn_log_sb=${OVN_LOG_SB:-"-vconsole:info"}
 ovn_log_controller=${OVN_LOG_CONTROLLER:-"-vconsole:info"}
-ovn_log_nbctld=${OVN_LOG_NBCTLD:-"/var/log/openvswitch/ovn-nbctl.log"}
 
-logdir=/var/log/openvswitch
 ovnkubelogdir=/var/log/ovn-kubernetes
 
 # ovnkube.sh version (update when API between daemonset and script changes - v.x.y)
@@ -129,13 +127,36 @@ ovn_sb_port=${OVN_SB_PORT:-6642}
 ovn_hybrid_overlay_enable=${OVN_HYBRID_OVERLAY_ENABLE:-}
 ovn_hybrid_overlay_net_cidr=${OVN_HYBRID_OVERLAY_NET_CIDR:-}
 
+# Determine the ovn rundir.
+if [[ -f /usr/bin/ovn-appctl ]] ; then
+	# ovn-appctl is present. Use new ovn run dir path.
+	OVN_RUNDIR=/var/run/ovn
+	OVNCTL_PATH=/usr/share/ovn/scripts/ovn-ctl
+	OVN_LOGDIR=/var/log/ovn
+  OVN_ETCDIR=/etc/ovn
+else
+	# ovn-appctl is not present. Use openvswitch run dir path.
+	OVN_RUNDIR=/var/run/openvswitch
+	OVNCTL_PATH=/usr/share/openvswitch/scripts/ovn-ctl
+	OVN_LOGDIR=/var/log/openvswitch
+  OVN_ETCDIR=/etc/openvswitch
+fi
+
+OVS_RUNDIR=/var/run/openvswitch
+OVS_LOGDIR=/var/log/openvswitch
+
+ovn_log_nbctld=${OVN_LOG_NBCTLD:-"${OVN_LOGDIR}/ovn-nbctl.log"}
+
 # =========================================
 
 setup_ovs_permissions () {
   if [ ${ovs_user_id:-XX} != "XX" ]; then
       chown -R ${ovs_user_id} /etc/openvswitch
-      chown -R ${ovs_user_id} /var/run/openvswitch
-      chown -R ${ovs_user_id} /var/log/openvswitch
+      chown -R ${ovs_user_id} ${OVS_RUNDIR}
+      chown -R ${ovs_user_id} ${OVS_LOGDIR}
+      chown -R ${ovs_user_id} ${OVN_ETCDIR}
+      chown -R ${ovs_user_id} ${OVN_RUNDIR}
+      chown -R ${ovs_user_id} ${OVN_LOGDIR}
   fi
 }
 
@@ -231,7 +252,7 @@ get_ovn_db_vars () {
 # This checks if OVS is up and running
 ovs_ready () {
   for daemon in `echo ovsdb-server ovs-vswitchd` ; do
-    pidfile=/var/run/openvswitch/${daemon}.pid
+    pidfile=${OVS_RUNDIR}/${daemon}.pid
     if [[ -f ${pidfile} ]] ; then
       check_health $daemon $(cat $pidfile)
       if [[ $? == 0 ]] ; then
@@ -248,7 +269,15 @@ ovs_ready () {
 # or by using `ovs-appctl` utility for the processes that support it.
 # $1 is the name of the process
 process_ready () {
-  pidfile=/var/run/openvswitch/${1}.pid
+  case ${1} in
+    "ovsdb-server"|"ovs-vswitchd")
+    pidfile=${OVS_RUNDIR}/${1}.pid
+    ;;
+    *)
+    pidfile=${OVN_RUNDIR}/${1}.pid
+    ;;
+  esac
+
   if [[ -f ${pidfile} ]] ; then
     check_health $1 $(cat $pidfile)
     if [[ $? == 0 ]] ; then
@@ -263,7 +292,15 @@ process_ready () {
 # $1 is the name of the process
 # $2 is the pid of an another process to kill before exiting
 process_healthy () {
-  pid=$(cat /var/run/openvswitch/${1}.pid)
+  case ${1} in
+    "ovsdb-server"|"ovs-vswitchd")
+    pid=$(cat ${OVS_RUNDIR}/${1}.pid)
+    ;;
+    *)
+    pid=$(cat ${OVN_RUNDIR}/${1}.pid)
+    ;;
+  esac
+
   while true; do
     check_health $1 ${pid}
     if [[ $? != 0 ]] ; then
@@ -285,10 +322,10 @@ check_health () {
     "ovnkube"|"ovnkube-master")
     ;;
     "ovnnb_db"|"ovnsb_db")
-    ctl_file=/var/run/openvswitch/${1}.ctl
+    ctl_file=${OVN_RUNDIR}/${1}.ctl
     ;;
     "ovn-northd"|"ovn-controller"|"ovsdb-server"|"ovs-vswitchd"|"ovn-nbctl")
-    ctl_file=/var/run/openvswitch/${1}.${2}.ctl
+    ctl_file=${OVN_RUNDIR}/${1}.${2}.ctl
     ;;
     *)
     echo "Unknown service ${1} specified. Exiting.. "
@@ -329,15 +366,15 @@ display_file () {
 display () {
   echo "==================== display for ${ovn_pod_host}  =================== "
   date
-  display_file "nb-ovsdb" /var/run/openvswitch/ovnnb_db.pid ${logdir}/ovsdb-server-nb.log
-  display_file "sb-ovsdb" /var/run/openvswitch/ovnsb_db.pid ${logdir}/ovsdb-server-sb.log
-  display_file "run-ovn-northd" /var/run/openvswitch/ovn-northd.pid ${logdir}/ovn-northd.log
-  display_file "ovn-master" /var/run/openvswitch/ovnkube-master.pid ${ovnkubelogdir}/ovnkube-master.log
-  display_file "ovs-vswitchd" /var/run/openvswitch/ovs-vswitchd.pid ${logdir}/ovs-vswitchd.log
-  display_file "ovsdb-server" /var/run/openvswitch/ovsdb-server.pid ${logdir}/ovsdb-server.log
-  display_file "ovn-controller" /var/run/openvswitch/ovn-controller.pid ${logdir}/ovn-controller.log
-  display_file "ovnkube" /var/run/openvswitch/ovnkube.pid ${ovnkubelogdir}/ovnkube.log
-  display_file "run-nbctld" /var/run/openvswitch/ovn-nbctl.pid ${logdir}/ovn-nbctl.log
+  display_file "nb-ovsdb" ${OVN_RUNDIR}/ovnnb_db.pid ${OVN_LOGDIR}/ovsdb-server-nb.log
+  display_file "sb-ovsdb" ${OVN_RUNDIR}/ovnsb_db.pid ${OVN_LOGDIR}/ovsdb-server-sb.log
+  display_file "run-ovn-northd" ${OVN_RUNDIR}/ovn-northd.pid ${OVN_LOGDIR}/ovn-northd.log
+  display_file "ovn-master" ${OVN_RUNDIR}/ovnkube-master.pid ${ovnkubelogdir}/ovnkube-master.log
+  display_file "ovs-vswitchd" ${OVS_RUNDIR}/ovs-vswitchd.pid ${OVS_LOGDIR}/ovs-vswitchd.log
+  display_file "ovsdb-server" ${OVS_RUNDIR}/ovsdb-server.pid ${OVS_LOGDIR}/ovsdb-server.log
+  display_file "ovn-controller" ${OVN_RUNDIR}/ovn-controller.pid ${OVN_LOGDIR}/ovn-controller.log
+  display_file "ovnkube" ${OVN_RUNDIR}/ovnkube.pid ${ovnkubelogdir}/ovnkube.log
+  display_file "run-nbctld" ${OVN_RUNDIR}/ovn-nbctl.pid ${OVN_LOGDIR}/ovn-nbctl.log
 }
 
 setup_cni () {
@@ -440,8 +477,8 @@ ovs-server () {
       exit 1
     fi
   done
-  rm -f /var/run/openvswitch/ovs-vswitchd.pid
-  rm -f /var/run/openvswitch/ovsdb-server.pid
+  rm -f ${OVS_RUNDIR}/ovs-vswitchd.pid
+  rm -f ${OVS_RUNDIR}/ovsdb-server.pid
 
   # launch OVS
   function quit {
@@ -474,7 +511,7 @@ ovs-server () {
   # Ensure GENEVE's UDP port isn't firewalled
   /usr/share/openvswitch/scripts/ovs-ctl --protocol=udp --dport=6081 enable-protocol
 
-  tail --follow=name /var/log/openvswitch/ovs-vswitchd.log /var/log/openvswitch/ovsdb-server.log &
+  tail --follow=name ${OVS_LOGDIR}/ovs-vswitchd.log ${OVS_LOGDIR}/ovsdb-server.log &
   ovs_tail_pid=$!
   sleep 10
   while true; do
@@ -491,7 +528,7 @@ cleanup-ovs-server () {
   echo "=============== time: $(date +%d-%m-%H:%M:%S:%N) cleanup-ovs-server (wait for ovn-node to exit) ======="
   retries=0
   while [[ ${retries} -lt 80 ]]; do
-    if [[ ! -e /var/run/openvswitch/ovnkube.pid ]] ; then
+    if [[ ! -e ${OVN_RUNDIR}/ovnkube.pid ]] ; then
       break
     fi
     echo "=============== time: $(date +%d-%m-%H:%M:%S:%N) cleanup-ovs-server ovn-node still running, wait) ======="
@@ -534,7 +571,7 @@ EOF
 nb-ovsdb () {
   trap 'kill $(jobs -p); exit 0' TERM
   check_ovn_daemonset_version "3"
-  rm -f /var/run/openvswitch/ovnnb_db.pid
+  rm -f ${OVN_RUNDIR}/ovnnb_db.pid
 
   # Make sure /var/lib/openvswitch exists
   mkdir -p /var/lib/openvswitch
@@ -543,7 +580,7 @@ nb-ovsdb () {
 
   echo "=============== run nb_ovsdb ========== MASTER ONLY"
   run_as_ovs_user_if_needed \
-      /usr/share/openvswitch/scripts/ovn-ctl run_nb_ovsdb --no-monitor \
+      ${OVNCTL_PATH} run_nb_ovsdb --no-monitor \
       --ovn-nb-log="${ovn_log_nb}" &
 
   wait_for_event attempts=3 process_ready ovnnb_db
@@ -553,7 +590,7 @@ nb-ovsdb () {
   ovn_db_host=$(getent ahosts $(hostname) | head -1 | awk '{ print $1 }')
   ovn-nbctl set-connection ptcp:${ovn_nb_port}:${ovn_db_host} -- set connection . inactivity_probe=0
 
-  tail --follow=name /var/log/openvswitch/ovsdb-server-nb.log &
+  tail --follow=name ${OVN_LOGDIR}/ovsdb-server-nb.log &
   ovn_tail_pid=$!
 
   process_healthy ovnnb_db ${ovn_tail_pid}
@@ -564,7 +601,7 @@ nb-ovsdb () {
 sb-ovsdb () {
   trap 'kill $(jobs -p); exit 0' TERM
   check_ovn_daemonset_version "3"
-  rm -f /var/run/openvswitch/ovnsb_db.pid
+  rm -f ${OVN_RUNDIR}/ovnsb_db.pid
 
   # Make sure /var/lib/openvswitch exists
   mkdir -p /var/lib/openvswitch
@@ -573,7 +610,7 @@ sb-ovsdb () {
 
   echo "=============== run sb_ovsdb ========== MASTER ONLY"
   run_as_ovs_user_if_needed \
-      /usr/share/openvswitch/scripts/ovn-ctl run_sb_ovsdb --no-monitor     \
+      ${OVNCTL_PATH} run_sb_ovsdb --no-monitor     \
       --ovn-sb-log="${ovn_log_sb}" &
 
   wait_for_event attempts=3 process_ready ovnsb_db
@@ -586,7 +623,7 @@ sb-ovsdb () {
   # create the ovnkube_db endpoint for other pods to query the OVN DB IP
   set_ovnkube_db_ep
 
-  tail --follow=name /var/log/openvswitch/ovsdb-server-sb.log &
+  tail --follow=name ${OVN_LOGDIR}/ovsdb-server-sb.log &
   ovn_tail_pid=$!
 
   process_healthy ovnsb_db ${ovn_tail_pid}
@@ -597,8 +634,8 @@ sb-ovsdb () {
 # v3 - Runs northd on master. Does not run nb_ovsdb, and sb_ovsdb
 run-ovn-northd () {
   check_ovn_daemonset_version "3"
-  rm -f /var/run/openvswitch/ovn-northd.pid
-  rm -f /var/run/openvswitch/ovn-northd.*.ctl
+  rm -f ${OVN_RUNDIR}/ovn-northd.pid
+  rm -f ${OVN_RUNDIR}/ovn-northd.*.ctl
 
   # Make sure /var/lib/openvswitch exists
   mkdir -p /var/lib/openvswitch
@@ -619,7 +656,7 @@ run-ovn-northd () {
   ovn_nbdb_i=$(echo ${ovn_nbdb} | sed 's;//;;')
   ovn_sbdb_i=$(echo ${ovn_sbdb} | sed 's;//;;')
   run_as_ovs_user_if_needed \
-      /usr/share/openvswitch/scripts/ovn-ctl start_northd \
+      ${OVNCTL_PATH} start_northd \
       --no-monitor --ovn-manage-ovsdb=no \
       --ovn-northd-nb-db=${ovn_nbdb_i} --ovn-northd-sb-db=${ovn_sbdb_i} \
       --ovn-northd-log="${ovn_log_northd}" \
@@ -629,7 +666,7 @@ run-ovn-northd () {
   echo "=============== run_ovn_northd ========== RUNNING"
   sleep 1
 
-  tail --follow=name /var/log/openvswitch/ovn-northd.log &
+  tail --follow=name ${OVN_LOGDIR}/ovn-northd.log &
   ovn_tail_pid=$!
 
 
@@ -651,7 +688,7 @@ iptables-rules () {
 ovn-master () {
   trap 'kill $(jobs -p); exit 0' TERM
   check_ovn_daemonset_version "3"
-  rm -f /var/run/openvswitch/ovnkube-master.pid
+  rm -f ${OVN_RUNDIR}/ovnkube-master.pid
 
   echo "=============== ovn-master (wait for ready_to_start_node) ========== MASTER ONLY"
   wait_for_event ready_to_start_node
@@ -686,7 +723,7 @@ ovn-master () {
     --nbctl-daemon-mode \
     --loglevel=${ovnkube_loglevel} \
     ${hybrid_overlay_flags} \
-    --pidfile /var/run/openvswitch/ovnkube-master.pid \
+    --pidfile ${OVN_RUNDIR}/ovnkube-master.pid \
     --logfile /var/log/ovn-kubernetes/ovnkube-master.log \
     --metrics-bind-address "0.0.0.0:9102" &
   echo "=============== ovn-master ========== running"
@@ -703,7 +740,7 @@ ovn-master () {
 # ovn-controller - all nodes
 ovn-controller () {
   check_ovn_daemonset_version "3"
-  rm -f /var/run/openvswitch/ovn-controller.pid
+  rm -f ${OVN_RUNDIR}/ovn-controller.pid
 
   echo "=============== ovn-controller - (wait for ovs)"
   wait_for_event ovs_ready
@@ -716,10 +753,10 @@ ovn-controller () {
 
   echo "=============== ovn-controller  start_controller"
   rm -f /var/run/ovn-kubernetes/cni/*
-  rm -f /var/run/openvswitch/ovn-controller.*.ctl
+  rm -f ${OVN_RUNDIR}/ovn-controller.*.ctl
 
   run_as_ovs_user_if_needed \
-      /usr/share/openvswitch/scripts/ovn-ctl --no-monitor start_controller \
+      ${OVNCTL_PATH} --no-monitor start_controller \
                --ovn-controller-log="${ovn_log_controller}" \
                ${ovn_controller_opts}
 
@@ -727,7 +764,7 @@ ovn-controller () {
   echo "=============== ovn-controller ========== running"
 
   sleep 4
-  tail --follow=name /var/log/openvswitch/ovn-controller.log &
+  tail --follow=name ${OVN_LOGDIR}/ovn-controller.log &
   controller_tail_pid=$!
 
   process_healthy ovn-controller ${controller_tail_pid}
@@ -740,7 +777,7 @@ ovn-controller () {
 ovn-node () {
   trap 'kill $(jobs -p) ; rm -f /etc/cni/net.d/10-ovn-kubernetes.conf ; exit 0' TERM
   check_ovn_daemonset_version "3"
-  rm -f /var/run/openvswitch/ovnkube.pid
+  rm -f ${OVN_RUNDIR}/ovnkube.pid
 
   echo "=============== ovn-node - (wait for ovs)"
   wait_for_event ovs_ready
@@ -768,7 +805,7 @@ ovn-node () {
       --loglevel=${ovnkube_loglevel} \
       ${hybrid_overlay_flags} \
       --gateway-mode=${ovn_gateway_mode} ${ovn_gateway_opts}  \
-      --pidfile /var/run/openvswitch/ovnkube.pid \
+      --pidfile ${OVN_RUNDIR}/ovnkube.pid \
       --logfile /var/log/ovn-kubernetes/ovnkube.log \
       --metrics-bind-address "0.0.0.0:9101" &
 
@@ -813,8 +850,8 @@ cleanup-ovn-node () {
 # v3 - Runs ovn-nbctl in daemon mode
 run-nbctld () {
   check_ovn_daemonset_version "3"
-  rm -f /var/run/openvswitch/ovn-nbctl.pid
-  rm -f /var/run/openvswitch/ovn-nbctl.*.ctl
+  rm -f ${OVN_RUNDIR}/ovn-nbctl.pid
+  rm -f ${OVN_RUNDIR}/ovn-nbctl.*.ctl
 
   echo "=============== run-nbctld - (wait for ready_to_start_node)"
   wait_for_event ready_to_start_node
@@ -828,7 +865,7 @@ run-nbctld () {
   wait_for_event attempts=3 process_ready ovn-nbctl
   echo "=============== run_ovn_nbctl ========== RUNNING"
 
-  tail --follow=name /var/log/openvswitch/ovn-nbctl.log &
+  tail --follow=name ${OVN_LOGDIR}/ovn-nbctl.log &
   nbctl_tail_pid=$!
 
   process_healthy ovn-nbctl ${nbctl_tail_pid}

--- a/dist/templates/ovnkube-db-vip.yaml.j2
+++ b/dist/templates/ovnkube-db-vip.yaml.j2
@@ -71,10 +71,15 @@ spec:
 
         volumeMounts:
         # ovn db is stored in the pod in /etc/openvswitch
+        # (or in /etc/ovn if OVN from new repository is used)
         # and on the host in /var/lib/openvswitch/
         - mountPath: /etc/openvswitch/
           name: host-var-lib-ovs
+        - mountPath: /etc/ovn/
+          name: host-var-lib-ovs
         - mountPath: /var/log/openvswitch/
+          name: host-var-log-ovs
+        - mountPath: /var/log/ovn/
           name: host-var-log-ovs
         - mountPath: /etc/corosync
           name: host-etc-corosync

--- a/dist/templates/ovnkube-db.yaml.j2
+++ b/dist/templates/ovnkube-db.yaml.j2
@@ -56,10 +56,15 @@ spec:
 
         volumeMounts:
         # ovn db is stored in the pod in /etc/openvswitch
+        # (or in /etc/ovn if OVN from new repository is used)
         # and on the host in /var/lib/openvswitch/
         - mountPath: /etc/openvswitch/
           name: host-var-lib-ovs
+        - mountPath: /etc/ovn/
+          name: host-var-lib-ovs
         - mountPath: /var/log/openvswitch/
+          name: host-var-log-ovs
+        - mountPath: /var/log/ovn/
           name: host-var-log-ovs
 
         resources:
@@ -108,10 +113,15 @@ spec:
 
         volumeMounts:
         # ovn db is stored in the pod in /etc/openvswitch
+        # (or in /etc/ovn if OVN from new repository is used)
         # and on the host in /var/lib/openvswitch/
         - mountPath: /etc/openvswitch/
           name: host-var-lib-ovs
+        - mountPath: /etc/ovn/
+          name: host-var-lib-ovs
         - mountPath: /var/log/openvswitch/
+          name: host-var-log-ovs
+        - mountPath: /var/log/ovn/
           name: host-var-log-ovs
 
         resources:

--- a/dist/templates/ovnkube-master.yaml.j2
+++ b/dist/templates/ovnkube-master.yaml.j2
@@ -59,7 +59,11 @@ spec:
           readOnly: true
         - mountPath: /var/log/openvswitch/
           name: host-var-log-ovs
+        - mountPath: /var/log/ovn/
+          name: host-var-log-ovs
         - mountPath: /var/run/openvswitch/
+          name: host-var-run-ovs
+        - mountPath: /var/run/ovn/
           name: host-var-run-ovs
 
         resources:
@@ -120,7 +124,11 @@ spec:
         volumeMounts:
         - mountPath: /var/log/openvswitch/
           name: host-var-log-ovs
+        - mountPath: /var/log/ovn/
+          name: host-var-log-ovs
         - mountPath: /var/run/openvswitch/
+          name: host-var-run-ovs
+        - mountPath: /var/run/ovn/
           name: host-var-run-ovs
 
         resources:
@@ -166,6 +174,8 @@ spec:
         - mountPath: /var/log/ovn-kubernetes/
           name: host-var-log-ovnkube
         - mountPath: /var/run/openvswitch/
+          name: host-var-run-ovs
+        - mountPath: /var/run/ovn/
           name: host-var-run-ovs
 
         resources:

--- a/dist/templates/ovnkube-node.yaml.j2
+++ b/dist/templates/ovnkube-node.yaml.j2
@@ -106,7 +106,11 @@ spec:
           readOnly: true
         - mountPath: /var/log/openvswitch/
           name: host-var-log-ovs
+        - mountPath: /var/log/ovn/
+          name: host-var-log-ovs
         - mountPath: /var/run/openvswitch/
+          name: host-var-run-ovs
+        - mountPath: /var/run/ovn/
           name: host-var-run-ovs
 
         resources:
@@ -173,6 +177,8 @@ spec:
         - mountPath: /var/log/ovn-kubernetes/
           name: host-var-log-ovnkube
         - mountPath: /var/run/openvswitch/
+          name: host-var-run-ovs
+        - mountPath: /var/run/ovn/
           name: host-var-run-ovs
         # We mount our socket here
         - mountPath: /var/run/ovn-kubernetes

--- a/go-controller/pkg/cluster/node.go
+++ b/go-controller/pkg/cluster/node.go
@@ -26,7 +26,7 @@ import (
 type postReadyFn func() error
 
 func isOVNControllerReady(name string) (bool, error) {
-	const runDir string = "/var/run/openvswitch/"
+	runDir := util.GetOvnRunDir()
 
 	pid, err := ioutil.ReadFile(runDir + "ovn-controller.pid")
 	if err != nil {

--- a/go-controller/pkg/util/ovs.go
+++ b/go-controller/pkg/util/ovs.go
@@ -28,6 +28,7 @@ const (
 	ovsAppctlCommand  = "ovs-appctl"
 	ovnNbctlCommand   = "ovn-nbctl"
 	ovnSbctlCommand   = "ovn-sbctl"
+	ovnAppctlCommand  = "ovn-appctl"
 	ipCommand         = "ip"
 	powershellCommand = "powershell"
 	netshCommand      = "netsh"
@@ -39,9 +40,9 @@ const (
 )
 
 const (
-	nbdbCtlSockPath   = "/var/run/openvswitch/ovnnb_db.ctl"
-	sbdbCtlSockPath   = "/var/run/openvswitch/ovnsb_db.ctl"
-	northdCtlSockPath = "/var/run/openvswitch/ovn-northd.ctl"
+	nbdbCtlSock   = "ovnnb_db.ctl"
+	sbdbCtlSock   = "ovnsb_db.ctl"
+	northdCtlSock = "ovn-northd.ctl"
 )
 
 func runningPlatform() (string, error) {
@@ -87,9 +88,11 @@ type execHelper struct {
 	ofctlPath      string
 	vsctlPath      string
 	appctlPath     string
+	ovnappctlPath  string
 	nbctlPath      string
 	sbctlPath      string
 	ovnctlPath     string
+	ovnRunDir      string
 	ipPath         string
 	powershellPath string
 	netshPath      string
@@ -119,6 +122,21 @@ func SetExec(exec kexec.Interface) error {
 		return err
 	}
 
+	runner.ovnappctlPath, err = exec.LookPath(ovnAppctlCommand)
+	if err != nil {
+		// If ovn-appctl command is not available then fall back to
+		// ovs-appctl. It also means OVN is using the rundir of
+		// openvswitch.
+		runner.ovnappctlPath = runner.appctlPath
+		runner.ovnctlPath = "/usr/share/openvswitch/scripts/ovn-ctl"
+		runner.ovnRunDir = "/var/run/openvswitch/"
+	} else {
+		// If ovn-appctl command is available, it means OVN
+		// has its own separate rundir, logdir, sharedir.
+		runner.ovnctlPath = "/usr/share/ovn/scripts/ovn-ctl"
+		runner.ovnRunDir = "/var/run/ovn/"
+	}
+
 	runner.nbctlPath, err = exec.LookPath(ovnNbctlCommand)
 	if err != nil {
 		return err
@@ -127,7 +145,6 @@ func SetExec(exec kexec.Interface) error {
 	if err != nil {
 		return err
 	}
-	runner.ovnctlPath = "/usr/share/openvswitch/scripts/ovn-ctl"
 
 	return nil
 }
@@ -276,10 +293,10 @@ func getNbctlArgsAndEnv(timeout int, args ...string) ([]string, []string) {
 		// ovn-nbctl running in the background and afterward uses the daemon to execute
 		// operations. The client needs to use the control socket and set the path to the
 		// control socket in environment variable OVN_NB_DAEMON
-		pid, err := ioutil.ReadFile("/var/run/openvswitch/ovn-nbctl.pid")
+		pid, err := ioutil.ReadFile(runner.ovnRunDir + "ovn-nbctl.pid")
 		if err == nil {
 			envVars = append(envVars,
-				fmt.Sprintf("OVN_NB_DAEMON=/var/run/openvswitch/ovn-nbctl.%s.ctl",
+				fmt.Sprintf("OVN_NB_DAEMON=%sovn-nbctl.%s.ctl", runner.ovnRunDir,
 					strings.Trim(string(pid), " \n")))
 			logrus.Debugf("using ovn-nbctl daemon mode at %s", envVars)
 			cmdArgs = append(cmdArgs, fmt.Sprintf("--timeout=%d", timeout))
@@ -374,7 +391,7 @@ func RunOVNNBAppCtl(args ...string) (string, string, error) {
 	var cmdArgs []string
 	cmdArgs = []string{
 		"-t",
-		nbdbCtlSockPath,
+		runner.ovnRunDir + nbdbCtlSock,
 	}
 	cmdArgs = append(cmdArgs, args...)
 	stdout, stderr, err := runOVNretry(runner.appctlPath, nil, cmdArgs...)
@@ -386,7 +403,7 @@ func RunOVNSBAppCtl(args ...string) (string, string, error) {
 	var cmdArgs []string
 	cmdArgs = []string{
 		"-t",
-		sbdbCtlSockPath,
+		runner.ovnRunDir + sbdbCtlSock,
 	}
 	cmdArgs = append(cmdArgs, args...)
 	stdout, stderr, err := runOVNretry(runner.appctlPath, nil, cmdArgs...)
@@ -398,7 +415,7 @@ func RunOVNNorthAppCtl(args ...string) (string, string, error) {
 	var cmdArgs []string
 	cmdArgs = []string{
 		"-t",
-		northdCtlSockPath,
+		runner.ovnRunDir + northdCtlSock,
 	}
 	cmdArgs = append(cmdArgs, args...)
 	stdout, stderr, err := runOVNretry(runner.appctlPath, nil, cmdArgs...)
@@ -442,4 +459,22 @@ func RawExec(cmdPath string, args ...string) (string, string, error) {
 	}
 	stdout, stderr, err := run(cmdPath, args...)
 	return strings.TrimSpace(stdout.String()), stderr.String(), err
+}
+
+// AddNormalActionOFFlow replaces flows in the bridge with a NORMAL action flow
+func AddNormalActionOFFlow(bridgeName string) (string, string, error) {
+	args := []string{"-O", "OpenFlow13", "replace-flows", bridgeName, "-"}
+
+	stdin := &bytes.Buffer{}
+	stdin.Write([]byte("table=0,priority=0,actions=NORMAL\n"))
+
+	cmd := runner.exec.Command(runner.ofctlPath, args...)
+	cmd.SetStdin(stdin)
+	stdout, stderr, err := runCmd(cmd, runner.ofctlPath, args...)
+	return strings.Trim(stdout.String(), "\" \n"), stderr.String(), err
+}
+
+// GetOvnRunDir returns the OVN's rundir.
+func GetOvnRunDir() string {
+	return runner.ovnRunDir
 }


### PR DESCRIPTION
This is ovn-org/ovn-kubernetes/pull/926
It adds the code needed to support both ovn2.11 and ovn2.12

This is part of backport of ovn2.12 support to OCP-4.3

SDN-643

Support latest OVN

OVN post split from OVS (post 2.12) has changed the paths for the
runtime directory, log dir and db dir.
The default runtime dir is now - /var/run/ovn
The default log dir is now - /var/log/ovn
And the default db dir is - /etc/ovn

In order to support latest OVN version, this patch checks for the
presence of the file - /usr/bin/ovn-appctl. If this utility is
present, it means the deployment has latest OVN with new dir paths
and uses the new dirs. Else, the old openvswitch dir paths are used.

Signed-off-by: Numan Siddique <numans@ovn.org>
Signed-off-by: Phil Cameron <pcameron@redhat.com>