### PR TITLE
HACK: add ipv4 interfaces to pods that need them

### DIFF
--- a/go-controller/pkg/cni/cnishim.go
+++ b/go-controller/pkg/cni/cnishim.go
@@ -125,6 +125,11 @@ func (p *Plugin) CmdAdd(args *skel.CmdArgs) error {
 		}
 	}
 
+	err = maybeAddIPv4Hack(args, result)
+	if err != nil {
+		return fmt.Errorf("failed to add hack IPv4 interface: %v", err)
+	}
+
 	return types.PrintResult(result, conf.CNIVersion)
 }
 

--- a/go-controller/pkg/cni/ipv4_hack.go
+++ b/go-controller/pkg/cni/ipv4_hack.go
@@ -1,0 +1,105 @@
+package cni
+
+// cnishim hack to add an IPv4 interface to pods that need IPv4 access
+// in nominally single-stack IPv6 clusters on dual-stack cloud hosts
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"strings"
+
+	"github.com/containernetworking/cni/pkg/invoke"
+	"github.com/containernetworking/cni/pkg/skel"
+	"github.com/containernetworking/cni/pkg/types/current"
+)
+
+var ipv4HackPodsByPlatform = map[string]map[string][]string{
+	"aws": {
+		// Operators that need AWS API access, which is IPv4-only
+		"openshift-authentication-operator":   []string{"authentication-operator"},
+		"openshift-cloud-credential-operator": []string{"cloud-credential-operator"},
+		"openshift-image-registry":            []string{"cluster-image-registry-operator"},
+		"openshift-ingress-operator":          []string{"ingress-operator"},
+		"openshift-machine-api":               []string{"machine-api-controllers"},
+
+		// AWS upstream DNS servers are IPv4 only
+		"openshift-dns": []string{"dns-default"},
+
+		// Needs to talk to ingress, which is IPv4-only in AWS
+		"openshift-console": []string{"console"},
+	},
+	"azure": {
+		// Operators that need Azure API access, which is IPv4-only
+		"openshift-authentication-operator":   []string{"authentication-operator"},
+		"openshift-cloud-credential-operator": []string{"cloud-credential-operator"},
+		"openshift-image-registry":            []string{"cluster-image-registry-operator", "image-registry"},
+		"openshift-ingress-operator":          []string{"ingress-operator"},
+		"openshift-machine-api":               []string{"machine-api-controllers"},
+
+		// We currently get IPv4 nameservers but this can be fixed
+		// https://bugzilla.redhat.com/show_bug.cgi?id=1803832
+		"openshift-dns": []string{"dns-default"},
+	},
+}
+
+func maybeAddIPv4Hack(args *skel.CmdArgs, result *current.Result) error {
+	// Only need IPv4 hack on single-stack IPv6
+	if len(result.IPs) != 1 || result.IPs[0].Version != "6" {
+		return nil
+	}
+
+	// Find hack pods for cloud platform
+	bytes, err := ioutil.ReadFile("/proc/cmdline")
+	if err != nil {
+		return nil
+	}
+	var ipv4HackPods map[string][]string
+	for _, arg := range strings.Split(strings.TrimSpace(string(bytes)), " ") {
+		if strings.HasPrefix(arg, "ignition.platform.id=") {
+			id := strings.Split(arg, "=")
+			ipv4HackPods = ipv4HackPodsByPlatform[id[1]]
+			break
+		}
+	}
+	if ipv4HackPods == nil {
+		return nil
+	}
+
+	cniArgs := os.Getenv("CNI_ARGS")
+	mapArgs := make(map[string]string)
+	for _, arg := range strings.Split(cniArgs, ";") {
+		parts := strings.Split(arg, "=")
+		if len(parts) != 2 {
+			continue
+		}
+		mapArgs[strings.TrimSpace(parts[0])] = strings.TrimSpace(parts[1])
+	}
+	namespace := mapArgs["K8S_POD_NAMESPACE"]
+	name := mapArgs["K8S_POD_NAME"]
+	if namespace == "" || name == "" {
+		return nil
+	}
+
+	match := false
+	for _, prefix := range ipv4HackPods[namespace] {
+		if strings.HasPrefix(name, prefix) {
+			match = true
+			break
+		}
+	}
+	if !match {
+		return nil
+	}
+
+	v4Args := &invoke.Args{
+		Command:     "ADD",
+		ContainerID: args.ContainerID,
+		NetNS:       args.Netns,
+		IfName:      "eth4",
+		Path:        "/var/lib/cni/bin",
+	}
+	v4Config := []byte(`{"cniVersion": "0.3.0", "name": "ipv4-hack", "type": "bridge", "bridge": "ipv4-hack", "isDefaultGateway": true, "ipMasq": true, "ipam": { "type": "host-local", "subnet": "10.192.0.0/24" } }`)
+	os.Setenv("CNI_IFNAME", "eth4")
+	return invoke.ExecPluginWithoutResult(context.TODO(), "/var/lib/cni/bin/bridge", v4Config, v4Args, nil)
+}

--- a/go-controller/vendor/github.com/containernetworking/cni/pkg/invoke/args.go
+++ b/go-controller/vendor/github.com/containernetworking/cni/pkg/invoke/args.go
@@ -1,0 +1,128 @@
+// Copyright 2015 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package invoke
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+type CNIArgs interface {
+	// For use with os/exec; i.e., return nil to inherit the
+	// environment from this process
+	// For use in delegation; inherit the environment from this
+	// process and allow overrides
+	AsEnv() []string
+}
+
+type inherited struct{}
+
+var inheritArgsFromEnv inherited
+
+func (_ *inherited) AsEnv() []string {
+	return nil
+}
+
+func ArgsFromEnv() CNIArgs {
+	return &inheritArgsFromEnv
+}
+
+type Args struct {
+	Command       string
+	ContainerID   string
+	NetNS         string
+	PluginArgs    [][2]string
+	PluginArgsStr string
+	IfName        string
+	Path          string
+}
+
+// Args implements the CNIArgs interface
+var _ CNIArgs = &Args{}
+
+func (args *Args) AsEnv() []string {
+	env := os.Environ()
+	pluginArgsStr := args.PluginArgsStr
+	if pluginArgsStr == "" {
+		pluginArgsStr = stringify(args.PluginArgs)
+	}
+
+	// Duplicated values which come first will be overrided, so we must put the
+	// custom values in the end to avoid being overrided by the process environments.
+	env = append(env,
+		"CNI_COMMAND="+args.Command,
+		"CNI_CONTAINERID="+args.ContainerID,
+		"CNI_NETNS="+args.NetNS,
+		"CNI_ARGS="+pluginArgsStr,
+		"CNI_IFNAME="+args.IfName,
+		"CNI_PATH="+args.Path,
+	)
+	return dedupEnv(env)
+}
+
+// taken from rkt/networking/net_plugin.go
+func stringify(pluginArgs [][2]string) string {
+	entries := make([]string, len(pluginArgs))
+
+	for i, kv := range pluginArgs {
+		entries[i] = strings.Join(kv[:], "=")
+	}
+
+	return strings.Join(entries, ";")
+}
+
+// DelegateArgs implements the CNIArgs interface
+// used for delegation to inherit from environments
+// and allow some overrides like CNI_COMMAND
+var _ CNIArgs = &DelegateArgs{}
+
+type DelegateArgs struct {
+	Command string
+}
+
+func (d *DelegateArgs) AsEnv() []string {
+	env := os.Environ()
+
+	// The custom values should come in the end to override the existing
+	// process environment of the same key.
+	env = append(env,
+		"CNI_COMMAND="+d.Command,
+	)
+	return dedupEnv(env)
+}
+
+// dedupEnv returns a copy of env with any duplicates removed, in favor of later values.
+// Items not of the normal environment "key=value" form are preserved unchanged.
+func dedupEnv(env []string) []string {
+	out := make([]string, 0, len(env))
+	envMap := map[string]string{}
+
+	for _, kv := range env {
+		// find the first "=" in environment, if not, just keep it
+		eq := strings.Index(kv, "=")
+		if eq < 0 {
+			out = append(out, kv)
+			continue
+		}
+		envMap[kv[:eq]] = kv[eq+1:]
+	}
+
+	for k, v := range envMap {
+		out = append(out, fmt.Sprintf("%s=%s", k, v))
+	}
+
+	return out
+}

--- a/go-controller/vendor/github.com/containernetworking/cni/pkg/invoke/delegate.go
+++ b/go-controller/vendor/github.com/containernetworking/cni/pkg/invoke/delegate.go
@@ -1,0 +1,80 @@
+// Copyright 2016 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package invoke
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+
+	"github.com/containernetworking/cni/pkg/types"
+)
+
+func delegateCommon(delegatePlugin string, exec Exec) (string, Exec, error) {
+	if exec == nil {
+		exec = defaultExec
+	}
+
+	paths := filepath.SplitList(os.Getenv("CNI_PATH"))
+	pluginPath, err := exec.FindInPath(delegatePlugin, paths)
+	if err != nil {
+		return "", nil, err
+	}
+
+	return pluginPath, exec, nil
+}
+
+// DelegateAdd calls the given delegate plugin with the CNI ADD action and
+// JSON configuration
+func DelegateAdd(ctx context.Context, delegatePlugin string, netconf []byte, exec Exec) (types.Result, error) {
+	pluginPath, realExec, err := delegateCommon(delegatePlugin, exec)
+	if err != nil {
+		return nil, err
+	}
+
+	// DelegateAdd will override the original "CNI_COMMAND" env from process with ADD
+	return ExecPluginWithResult(ctx, pluginPath, netconf, delegateArgs("ADD"), realExec)
+}
+
+// DelegateCheck calls the given delegate plugin with the CNI CHECK action and
+// JSON configuration
+func DelegateCheck(ctx context.Context, delegatePlugin string, netconf []byte, exec Exec) error {
+	pluginPath, realExec, err := delegateCommon(delegatePlugin, exec)
+	if err != nil {
+		return err
+	}
+
+	// DelegateCheck will override the original CNI_COMMAND env from process with CHECK
+	return ExecPluginWithoutResult(ctx, pluginPath, netconf, delegateArgs("CHECK"), realExec)
+}
+
+// DelegateDel calls the given delegate plugin with the CNI DEL action and
+// JSON configuration
+func DelegateDel(ctx context.Context, delegatePlugin string, netconf []byte, exec Exec) error {
+	pluginPath, realExec, err := delegateCommon(delegatePlugin, exec)
+	if err != nil {
+		return err
+	}
+
+	// DelegateDel will override the original CNI_COMMAND env from process with DEL
+	return ExecPluginWithoutResult(ctx, pluginPath, netconf, delegateArgs("DEL"), realExec)
+}
+
+// return CNIArgs used by delegation
+func delegateArgs(action string) *DelegateArgs {
+	return &DelegateArgs{
+		Command: action,
+	}
+}

--- a/go-controller/vendor/github.com/containernetworking/cni/pkg/invoke/exec.go
+++ b/go-controller/vendor/github.com/containernetworking/cni/pkg/invoke/exec.go
@@ -1,0 +1,144 @@
+// Copyright 2015 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package invoke
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/containernetworking/cni/pkg/types"
+	"github.com/containernetworking/cni/pkg/version"
+)
+
+// Exec is an interface encapsulates all operations that deal with finding
+// and executing a CNI plugin. Tests may provide a fake implementation
+// to avoid writing fake plugins to temporary directories during the test.
+type Exec interface {
+	ExecPlugin(ctx context.Context, pluginPath string, stdinData []byte, environ []string) ([]byte, error)
+	FindInPath(plugin string, paths []string) (string, error)
+	Decode(jsonBytes []byte) (version.PluginInfo, error)
+}
+
+// For example, a testcase could pass an instance of the following fakeExec
+// object to ExecPluginWithResult() to verify the incoming stdin and environment
+// and provide a tailored response:
+//
+//import (
+//	"encoding/json"
+//	"path"
+//	"strings"
+//)
+//
+//type fakeExec struct {
+//	version.PluginDecoder
+//}
+//
+//func (f *fakeExec) ExecPlugin(pluginPath string, stdinData []byte, environ []string) ([]byte, error) {
+//	net := &types.NetConf{}
+//	err := json.Unmarshal(stdinData, net)
+//	if err != nil {
+//		return nil, fmt.Errorf("failed to unmarshal configuration: %v", err)
+//	}
+//	pluginName := path.Base(pluginPath)
+//	if pluginName != net.Type {
+//		return nil, fmt.Errorf("plugin name %q did not match config type %q", pluginName, net.Type)
+//	}
+//	for _, e := range environ {
+//		// Check environment for forced failure request
+//		parts := strings.Split(e, "=")
+//		if len(parts) > 0 && parts[0] == "FAIL" {
+//			return nil, fmt.Errorf("failed to execute plugin %s", pluginName)
+//		}
+//	}
+//	return []byte("{\"CNIVersion\":\"0.4.0\"}"), nil
+//}
+//
+//func (f *fakeExec) FindInPath(plugin string, paths []string) (string, error) {
+//	if len(paths) > 0 {
+//		return path.Join(paths[0], plugin), nil
+//	}
+//	return "", fmt.Errorf("failed to find plugin %s in paths %v", plugin, paths)
+//}
+
+func ExecPluginWithResult(ctx context.Context, pluginPath string, netconf []byte, args CNIArgs, exec Exec) (types.Result, error) {
+	if exec == nil {
+		exec = defaultExec
+	}
+
+	stdoutBytes, err := exec.ExecPlugin(ctx, pluginPath, netconf, args.AsEnv())
+	if err != nil {
+		return nil, err
+	}
+
+	// Plugin must return result in same version as specified in netconf
+	versionDecoder := &version.ConfigDecoder{}
+	confVersion, err := versionDecoder.Decode(netconf)
+	if err != nil {
+		return nil, err
+	}
+
+	return version.NewResult(confVersion, stdoutBytes)
+}
+
+func ExecPluginWithoutResult(ctx context.Context, pluginPath string, netconf []byte, args CNIArgs, exec Exec) error {
+	if exec == nil {
+		exec = defaultExec
+	}
+	_, err := exec.ExecPlugin(ctx, pluginPath, netconf, args.AsEnv())
+	return err
+}
+
+// GetVersionInfo returns the version information available about the plugin.
+// For recent-enough plugins, it uses the information returned by the VERSION
+// command.  For older plugins which do not recognize that command, it reports
+// version 0.1.0
+func GetVersionInfo(ctx context.Context, pluginPath string, exec Exec) (version.PluginInfo, error) {
+	if exec == nil {
+		exec = defaultExec
+	}
+	args := &Args{
+		Command: "VERSION",
+
+		// set fake values required by plugins built against an older version of skel
+		NetNS:  "dummy",
+		IfName: "dummy",
+		Path:   "dummy",
+	}
+	stdin := []byte(fmt.Sprintf(`{"cniVersion":%q}`, version.Current()))
+	stdoutBytes, err := exec.ExecPlugin(ctx, pluginPath, stdin, args.AsEnv())
+	if err != nil {
+		if err.Error() == "unknown CNI_COMMAND: VERSION" {
+			return version.PluginSupports("0.1.0"), nil
+		}
+		return nil, err
+	}
+
+	return exec.Decode(stdoutBytes)
+}
+
+// DefaultExec is an object that implements the Exec interface which looks
+// for and executes plugins from disk.
+type DefaultExec struct {
+	*RawExec
+	version.PluginDecoder
+}
+
+// DefaultExec implements the Exec interface
+var _ Exec = &DefaultExec{}
+
+var defaultExec = &DefaultExec{
+	RawExec: &RawExec{Stderr: os.Stderr},
+}

--- a/go-controller/vendor/github.com/containernetworking/cni/pkg/invoke/find.go
+++ b/go-controller/vendor/github.com/containernetworking/cni/pkg/invoke/find.go
@@ -1,0 +1,43 @@
+// Copyright 2015 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package invoke
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// FindInPath returns the full path of the plugin by searching in the provided path
+func FindInPath(plugin string, paths []string) (string, error) {
+	if plugin == "" {
+		return "", fmt.Errorf("no plugin name provided")
+	}
+
+	if len(paths) == 0 {
+		return "", fmt.Errorf("no paths provided")
+	}
+
+	for _, path := range paths {
+		for _, fe := range ExecutableFileExtensions {
+			fullpath := filepath.Join(path, plugin) + fe
+			if fi, err := os.Stat(fullpath); err == nil && fi.Mode().IsRegular() {
+				return fullpath, nil
+			}
+		}
+	}
+
+	return "", fmt.Errorf("failed to find plugin %q in path %s", plugin, paths)
+}

--- a/go-controller/vendor/github.com/containernetworking/cni/pkg/invoke/os_unix.go
+++ b/go-controller/vendor/github.com/containernetworking/cni/pkg/invoke/os_unix.go
@@ -1,0 +1,20 @@
+// Copyright 2016 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build darwin dragonfly freebsd linux netbsd openbsd solaris
+
+package invoke
+
+// Valid file extensions for plugin executables.
+var ExecutableFileExtensions = []string{""}

--- a/go-controller/vendor/github.com/containernetworking/cni/pkg/invoke/os_windows.go
+++ b/go-controller/vendor/github.com/containernetworking/cni/pkg/invoke/os_windows.go
@@ -1,0 +1,18 @@
+// Copyright 2016 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package invoke
+
+// Valid file extensions for plugin executables.
+var ExecutableFileExtensions = []string{".exe", ""}

--- a/go-controller/vendor/github.com/containernetworking/cni/pkg/invoke/raw_exec.go
+++ b/go-controller/vendor/github.com/containernetworking/cni/pkg/invoke/raw_exec.go
@@ -1,0 +1,62 @@
+// Copyright 2016 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package invoke
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os/exec"
+
+	"github.com/containernetworking/cni/pkg/types"
+)
+
+type RawExec struct {
+	Stderr io.Writer
+}
+
+func (e *RawExec) ExecPlugin(ctx context.Context, pluginPath string, stdinData []byte, environ []string) ([]byte, error) {
+	stdout := &bytes.Buffer{}
+	c := exec.CommandContext(ctx, pluginPath)
+	c.Env = environ
+	c.Stdin = bytes.NewBuffer(stdinData)
+	c.Stdout = stdout
+	c.Stderr = e.Stderr
+	if err := c.Run(); err != nil {
+		return nil, pluginErr(err, stdout.Bytes())
+	}
+
+	return stdout.Bytes(), nil
+}
+
+func pluginErr(err error, output []byte) error {
+	if _, ok := err.(*exec.ExitError); ok {
+		emsg := types.Error{}
+		if len(output) == 0 {
+			emsg.Msg = "netplugin failed with no error message"
+		} else if perr := json.Unmarshal(output, &emsg); perr != nil {
+			emsg.Msg = fmt.Sprintf("netplugin failed but error parsing its diagnostic message %q: %v", string(output), perr)
+		}
+		return &emsg
+	}
+
+	return err
+}
+
+func (e *RawExec) FindInPath(plugin string, paths []string) (string, error) {
+	return FindInPath(plugin, paths)
+}

--- a/go-controller/vendor/modules.txt
+++ b/go-controller/vendor/modules.txt
@@ -34,6 +34,7 @@ github.com/bhendo/go-powershell/utils
 # github.com/cespare/xxhash/v2 v2.1.0
 github.com/cespare/xxhash/v2
 # github.com/containernetworking/cni v0.7.1
+github.com/containernetworking/cni/pkg/invoke
 github.com/containernetworking/cni/pkg/skel
 github.com/containernetworking/cni/pkg/types
 github.com/containernetworking/cni/pkg/version


### PR DESCRIPTION
This is a hack we originally did for IPv6 on AWS on 4.3, where lots of pods needed IPv4 access in order to make anything work. We were hoping to not need it for Azure, but at least for the moment DNS is broken without it. We may be able to kill it in the future. Note that it completely no-ops unless you're in a single-stack IPv6 cluster.

I left in the AWS hack list in case we need it again in the future...

Note that we do not plan to ever support single-stack IPv6 for customers on cloud platforms so the hardcoded IP range doesn't really matter.

/assign @dcbw 
/cc @russellb 
