### PR TITLE
Revert "cluster.go: Disable Southbound DB conditional monitoring."

### DIFF
--- a/go-controller/pkg/cluster/cluster.go
+++ b/go-controller/pkg/cluster/cluster.go
@@ -57,7 +57,6 @@ func setupOVNNode(node *kapi.Node) error {
 		fmt.Sprintf("external_ids:ovn-openflow-probe-interval=%d",
 			config.Default.OpenFlowProbe),
 		fmt.Sprintf("external_ids:hostname=\"%s\"", nodeName),
-		"external_ids:ovn-monitor-all=true",
 	)
 	if err != nil {
 		return fmt.Errorf("error setting OVS external IDs: %v\n  %q", err, stderr)

--- a/go-controller/pkg/cluster/node_test.go
+++ b/go-controller/pkg/cluster/node_test.go
@@ -59,8 +59,7 @@ var _ = Describe("Node Operations", func() {
 					"external_ids:ovn-encap-ip=%s "+
 					"external_ids:ovn-remote-probe-interval=%d "+
 					"external_ids:ovn-openflow-probe-interval=%d "+
-					"external_ids:hostname=\"%s\" "+
-					"external_ids:ovn-monitor-all=true",
+					"external_ids:hostname=\"%s\"",
 					nodeIP, interval, ofintval, nodeName),
 			})
 
@@ -113,8 +112,7 @@ var _ = Describe("Node Operations", func() {
 					"external_ids:ovn-encap-ip=%s "+
 					"external_ids:ovn-remote-probe-interval=%d "+
 					"external_ids:ovn-openflow-probe-interval=%d "+
-					"external_ids:hostname=\"%s\" "+
-					"external_ids:ovn-monitor-all=true",
+					"external_ids:hostname=\"%s\"",
 					nodeIP, interval, ofintval, nodeName),
 			})
 			fexec.AddFakeCmd(&ovntest.ExpectedCmd{


### PR DESCRIPTION
This reverts commit 799df52e72d24d77d5531e0961609ae9e43ca8b6.