### PR TITLE
Bug 1810814: CARRY: ovn: fix cloud load balancer rules for IPv6

### DIFF
--- a/go-controller/pkg/cluster/gateway_localnet.go
+++ b/go-controller/pkg/cluster/gateway_localnet.go
@@ -241,13 +241,15 @@ func localnetIptRules(svc *kapi.Service) []iptRule {
 		}
 
 		nodePort := fmt.Sprintf("%d", svcPort.NodePort)
-		destination := strings.Split(localnetGatewayIP(), "/")[0] + ":" + nodePort
+		destination := net.JoinHostPort(strings.Split(localnetGatewayIP(), "/")[0], nodePort)
 
 		rules = append(rules, iptRule{
 			table: "nat",
 			chain: iptableNodePortChain,
-			args: []string{"-p", string(protocol), "--dport", nodePort, "-j", "DNAT", "--to-destination",
-				net.JoinHostPort(strings.Split(localnetGatewayIP(), "/")[0], nodePort)},
+			args: []string{
+				"-p", string(protocol), "--dport", nodePort,
+				"-j", "DNAT", "--to-destination", destination,
+			},
 		})
 		rules = append(rules, iptRule{
 			table: "filter",


### PR DESCRIPTION
We have a local hack to make load balancers on Azure work (#23) which was never upstreamed because I didn't know how to implement it for shared gateway mode. We should fix that. But anyway, the code needs a fix for IPv6.

/assign @dcbw 
/cc @ironcladlou 