### PR TITLE
CARRY: hybrid-overlay: fix argument handling for Windows hybrid-overlay.exe

### DIFF
--- a/go-controller/hybrid-overlay/cmd/hybrid-overlay/hybrid-overlay.go
+++ b/go-controller/hybrid-overlay/cmd/hybrid-overlay/hybrid-overlay.go
@@ -30,7 +30,13 @@ func main() {
 				"to integrate with rest of the network. Requires the " +
 				"name of the node in the kubernetes cluster.",
 		}})...)
+	c.Flags = append(c.Flags, config.CommonFlags...)
+	c.Flags = append(c.Flags, config.CNIFlags...)
 	c.Flags = append(c.Flags, config.K8sFlags...)
+	c.Flags = append(c.Flags, config.OvnNBFlags...)
+	c.Flags = append(c.Flags, config.OvnSBFlags...)
+	c.Flags = append(c.Flags, config.OVNGatewayFlags...)
+	c.Flags = append(c.Flags, config.MasterHAFlags...)
 	c.Action = func(c *cli.Context) error {
 		if err := runHybridOverlay(c); err != nil {
 			panic(err.Error())

--- a/go-controller/pkg/cluster/node_test.go
+++ b/go-controller/pkg/cluster/node_test.go
@@ -59,7 +59,7 @@ var _ = Describe("Node Operations", func() {
 					"external_ids:ovn-encap-ip=%s "+
 					"external_ids:ovn-remote-probe-interval=%d "+
 					"external_ids:ovn-openflow-probe-interval=%d "+
-					"external_ids:hostname=\"%s\""
+					"external_ids:hostname=\"%s\"",
 					nodeIP, interval, ofintval, nodeName),
 			})
 


### PR DESCRIPTION
Prevents a "cluster subnet invalid" error on starting the Windows binary. Because of Tim's config defaults changes in https://github.com/ovn-org/ovn-kubernetes/pull/1044 the cluster subnets option will now be empty unless the config flags are added that fill in the defaults.

@JacobTanenbaum @aravindhp @ravisantoshgudimetla 