### PR TITLE
[wip]: Make pod event handling parallel

### DIFF
--- a/go-controller/pkg/cluster/node.go
+++ b/go-controller/pkg/cluster/node.go
@@ -195,8 +195,13 @@ func (cluster *OvnClusterController) StartClusterNode(name string) error {
 		}
 	}
 
+	kclient, ok := cluster.Kube.(*kube.Kube)
+	if !ok {
+		return fmt.Errorf("Cannot get kubeclient for starting CNI server")
+	}
+
 	// start the cni server
-	cniServer := cni.NewCNIServer("")
+	cniServer := cni.NewCNIServer("", kclient.KClient)
 	err = cniServer.Start(cni.HandleCNIRequest)
 
 	return err

--- a/go-controller/pkg/cni/cniserver.go
+++ b/go-controller/pkg/cni/cniserver.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
@@ -44,7 +45,7 @@ import (
 var registerMetricsOnce sync.Once
 
 // NewCNIServer creates and returns a new Server object which will listen on a socket in the given path
-func NewCNIServer(rundir string) *Server {
+func NewCNIServer(rundir string, kclient kubernetes.Interface) *Server {
 	registerMetricsOnce.Do(func() {
 		prometheus.MustRegister(metricCNIRequestDuration)
 	})
@@ -58,7 +59,8 @@ func NewCNIServer(rundir string) *Server {
 		Server: http.Server{
 			Handler: router,
 		},
-		rundir: rundir,
+		rundir:  rundir,
+		kclient: kclient,
 	}
 	router.NotFoundHandler = http.HandlerFunc(http.NotFound)
 	router.HandleFunc("/", s.handleCNIRequest).Methods("POST")
@@ -163,7 +165,7 @@ func (s *Server) handleCNIRequest(w http.ResponseWriter, r *http.Request) {
 	}
 
 	klog.Infof("Waiting for %s result for pod %s/%s", req.Command, req.PodNamespace, req.PodName)
-	result, err := s.requestFunc(req)
+	result, err := s.requestFunc(req, s.kclient)
 	hasErr := "false"
 	if err != nil {
 		hasErr = "true"

--- a/go-controller/pkg/cni/types.go
+++ b/go-controller/pkg/cni/types.go
@@ -6,6 +6,7 @@ import (
 	"github.com/containernetworking/cni/pkg/types/current"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/cni/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	"k8s.io/client-go/kubernetes"
 )
 
 // serverRunDir is the default directory for CNIServer runtime files
@@ -69,7 +70,7 @@ type PodRequest struct {
 	CNIConf *types.NetConf
 }
 
-type cniRequestFunc func(request *PodRequest) ([]byte, error)
+type cniRequestFunc func(request *PodRequest, kclient kubernetes.Interface) ([]byte, error)
 
 // Server object that listens for JSON-marshaled Request objects
 // on a private root-only Unix domain socket.
@@ -77,4 +78,5 @@ type Server struct {
 	http.Server
 	requestFunc cniRequestFunc
 	rundir      string
+	kclient     kubernetes.Interface
 }

--- a/go-controller/pkg/factory/factory.go
+++ b/go-controller/pkg/factory/factory.go
@@ -435,7 +435,7 @@ func NewWatchFactory(c kubernetes.Interface, stopChan chan struct{}) (*WatchFact
 	}
 	var err error
 	// Create shared informers we know we'll use
-	wf.informers[podType], err = newInformer(podType, wf.iFactory.Core().V1().Pods().Informer())
+	wf.informers[podType], err = newQueuedInformer(podType, wf.iFactory.Core().V1().Pods().Informer(), stopChan)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Let pod event handling be parallel to use multiple informer queues for scalability.