### PR TITLE
Bug 1814712: Removing node bring up debug log level

### DIFF
--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -158,10 +158,6 @@ func NewOvnController(kubeClient kubernetes.Interface, wf *factory.WatchFactory,
 
 // Run starts the actual watching.
 func (oc *Controller) Run(stopChan chan struct{}) error {
-	// Setting debug log level during node bring up to expose bring up process.
-	// Log level is returned to configured value when bring up is complete.
-	logrus.SetLevel(5)
-
 	startOvnUpdater()
 
 	// WatchNodes must be started first so that its initial Add will


### PR DESCRIPTION
This is apparently not needed as it's been removed in release-4.5 and master, and upstreams. So let's just remove it. 