### PR TITLE
cni: update MCS-blocking code to do both IPv4 and IPv6

### DIFF
--- a/go-controller/pkg/cni/helper_linux.go
+++ b/go-controller/pkg/cni/helper_linux.go
@@ -294,8 +294,7 @@ func (pr *PodRequest) ConfigureInterface(namespace string, podName string, ifInf
 	}
 
 	if ifInfo.Ingress > 0 || ifInfo.Egress > 0 {
-		var l netlink.Link
-		l, err = netlink.LinkByName(hostIface.Name)
+		l, err := netlink.LinkByName(hostIface.Name)
 		if err != nil {
 			return nil, fmt.Errorf("failed to find host veth interface %s: %v", hostIface.Name, err)
 		}

--- a/go-controller/pkg/cni/iptables_blocking.go
+++ b/go-controller/pkg/cni/iptables_blocking.go
@@ -1,0 +1,65 @@
+// +build linux
+
+package cni
+
+import (
+	"fmt"
+	"os/exec"
+
+	"github.com/containernetworking/plugins/pkg/ns"
+	utilnet "k8s.io/utils/net"
+)
+
+var iptablesCommands = [][]string{
+	// Block MCS
+	{"-A", "OUTPUT", "-p", "tcp", "-m", "tcp", "--dport", "22623", "-j", "REJECT"},
+	{"-A", "OUTPUT", "-p", "tcp", "-m", "tcp", "--dport", "22624", "-j", "REJECT"},
+	{"-A", "FORWARD", "-p", "tcp", "-m", "tcp", "--dport", "22623", "-j", "REJECT"},
+	{"-A", "FORWARD", "-p", "tcp", "-m", "tcp", "--dport", "22624", "-j", "REJECT"},
+}
+
+var iptables4OnlyCommands = [][]string{
+	// Block cloud provider metadata IP except DNS
+	{"-A", "OUTPUT", "-p", "tcp", "-m", "tcp", "-d", "169.254.169.254", "!", "--dport", "53", "-j", "REJECT"},
+	{"-A", "OUTPUT", "-p", "udp", "-m", "udp", "-d", "169.254.169.254", "!", "--dport", "53", "-j", "REJECT"},
+	{"-A", "FORWARD", "-p", "tcp", "-m", "tcp", "-d", "169.254.169.254", "!", "--dport", "53", "-j", "REJECT"},
+	{"-A", "FORWARD", "-p", "udp", "-m", "udp", "-d", "169.254.169.254", "!", "--dport", "53", "-j", "REJECT"},
+}
+
+func setupIPTablesBlocks(netns ns.NetNS, ifInfo *PodInterfaceInfo) error {
+	return netns.Do(func(hostNS ns.NetNS) error {
+		var hasIPv4, hasIPv6 bool
+		for _, ip := range ifInfo.IPs {
+			if utilnet.IsIPv6CIDR(ip) {
+				hasIPv6 = true
+			} else {
+				hasIPv4 = true
+			}
+		}
+
+		for _, args := range iptablesCommands {
+			if hasIPv4 {
+				out, err := exec.Command("iptables", args...).CombinedOutput()
+				if err != nil {
+					return fmt.Errorf("could not set up pod iptables rules: %s", string(out))
+				}
+			}
+			if hasIPv6 {
+				out, err := exec.Command("ip6tables", args...).CombinedOutput()
+				if err != nil {
+					return fmt.Errorf("could not set up pod iptables rules: %s", string(out))
+				}
+			}
+		}
+		if hasIPv4 {
+			for _, args := range iptables4OnlyCommands {
+				out, err := exec.Command("iptables", args...).CombinedOutput()
+				if err != nil {
+					return fmt.Errorf("could not set up pod iptables rules: %s", string(out))
+				}
+			}
+		}
+
+		return nil
+	})
+}


### PR DESCRIPTION
noticed by @celebdor 
/assign @dcbw 

Also fixed failure-to-do-MCS-blocking to be a fatal pod error rather than just a warning. And for the same reason, I made the IPv4 and IPv6 sections conditional on whether we are using IPv4/IPv6, since you don't want to block IPv4-only pods because we couldn't create ip6tables rules.