### PR TITLE
Bug 1827391: hybrid-overlay: fix podChanged() return values

### DIFF
--- a/go-controller/hybrid-overlay/pkg/controller/node_linux.go
+++ b/go-controller/hybrid-overlay/pkg/controller/node_linux.go
@@ -99,14 +99,14 @@ func podChanged(pod1 *kapi.Pod, pod2 *kapi.Pod, nodeName string) bool {
 	podIPs2, mac2, _ := getPodDetails(pod2, nodeName)
 
 	if len(podIPs1) != len(podIPs2) || !reflect.DeepEqual(mac1, mac2) {
-		return false
+		return true
 	}
 	for i := range podIPs1 {
 		if podIPs1[i].String() != podIPs2[i].String() {
-			return false
+			return true
 		}
 	}
-	return true
+	return false
 }
 
 func (n *NodeController) syncPods(pods []interface{}) {


### PR DESCRIPTION
cherry pick of https://github.com/ovn-org/ovn-kubernetes/pull/1286
along with https://github.com/openshift/cluster-network-operator/pull/604 restores communication over the hybrid overlay network for an openshift cluster 

It was returning exactly the opposite of what it was supposed to.

Fixes: 0303efa4de5a13

Signed-off-by: Dan Williams <dcbw@redhat.com>