### PR TITLE
Bug 1830370: build: require OVN >= 2.13.0-21 for rhbz#1819785 and rhbz#1827403

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,11 +36,11 @@ RUN INSTALL_PKGS=" \
 	PyYAML openssl firewalld-filesystem \
 	libpcap iproute strace \
 	openvswitch2.13 openvswitch2.13-devel \
-	ovn2.13 ovn2.13-central ovn2.13-host ovn2.13-vtep \
 	containernetworking-plugins yum-utils \
 	tcpdump \
 	" && \
 	yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False $INSTALL_PKGS && \
+	yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False "ovn2.13 >= 2.13.0-21" ovn2.13-central ovn2.13-host ovn2.13-vtep && \
 	yum clean all && rm -rf /var/cache/*
 
 RUN mkdir -p /var/run/openvswitch && \


### PR DESCRIPTION
`HAProxy Router performance is off with OVNKubernetes as SDN on OCP 4.3.9 deployed on AWS`
https://bugzilla.redhat.com/show_bug.cgi?id=1819785 [ovn]
https://bugzilla.redhat.com/show_bug.cgi?id=1830370 [ocp]

`ovn-northd: Optimize flows for LB Hairpin traffic.`
https://bugzilla.redhat.com/show_bug.cgi?id=1827403