### PR TITLE
[release 4.4] bug 1829442: Remove errors based on passing nil elements to MarshalPodAnnotations()

### DIFF
--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -331,10 +331,16 @@ func (oc *Controller) addLogicalPort(pod *kapi.Pod) error {
 		if err != nil {
 			return err
 		}
+
+		var gwIPs []net.IP
+		if gwIP != nil {
+			gwIPs = []net.IP{gwIP}
+		}
+
 		marshalledAnnotation, err := util.MarshalPodAnnotation(&util.PodAnnotation{
 			IPs:      []*net.IPNet{podCIDR},
 			MAC:      podMac,
-			Gateways: []net.IP{gwIP},
+			Gateways: gwIPs,
 			Routes:   routes,
 		})
 		if err != nil {
@@ -342,7 +348,7 @@ func (oc *Controller) addLogicalPort(pod *kapi.Pod) error {
 		}
 
 		klog.V(5).Infof("Annotation values: ip=%s ; mac=%s ; gw=%s\nAnnotation=%s",
-			podCIDR, podMac, gwIP, marshalledAnnotation)
+			podCIDR, podMac, gwIPs, marshalledAnnotation)
 		if err = oc.kube.SetAnnotationsOnPod(pod, marshalledAnnotation); err != nil {
 			return fmt.Errorf("failed to set annotation on pod %s: %v", pod.Name, err)
 		}

--- a/go-controller/pkg/util/pod_annotation.go
+++ b/go-controller/pkg/util/pod_annotation.go
@@ -182,7 +182,7 @@ func UnmarshalPodAnnotation(annotations map[string]string) (*PodAnnotation, erro
 	}
 	for _, gwstr := range a.Gateways {
 		gw := net.ParseIP(gwstr)
-		if err != nil {
+		if gw == nil {
 			return nil, fmt.Errorf("failed to parse pod gateway %q", gwstr)
 		}
 		podAnnotation.Gateways = append(podAnnotation.Gateways, gw)


### PR DESCRIPTION
cherry pick of upstream: b5fb5b
master PR: https://github.com/openshift/ovn-kubernetes/pull/156
Upstream PR: https://github.com/ovn-org/ovn-kubernetes/pull/1319

Currently passing nil elements to MarshalPodAnnotations will cause "<nil>"
to be added to the json fields where they are not appropriate.

This PR removes one specific example of attempting to pass a nil element
to MarshalPodAnnotations() and fixes an error in UnmarshalPodAnnotations()
which incorrectly handled a call to net.ParseIP() in which was expecting
an error in the case of an invalid IP address but in the docs returns nil
on invalid IP. This exposes the error of attempting to unmarshal an
invaild gatewayIP and add a test case to verify the error returned.

Signed-off-by: Jacob Tanenbaum <jtanenba@redhat.com>