### PR TITLE
Bug 1820737: scale: Enable parallel pod creation

### DIFF
--- a/go-controller/pkg/factory/factory.go
+++ b/go-controller/pkg/factory/factory.go
@@ -411,7 +411,7 @@ const (
 	resyncInterval        = 12 * time.Hour
 	handlerAlive   uint32 = 0
 	handlerDead    uint32 = 1
-	numEventQueues int    = 10
+	numEventQueues int    = 15
 )
 
 var (
@@ -436,7 +436,7 @@ func NewWatchFactory(c kubernetes.Interface, stopChan chan struct{}) (*WatchFact
 	}
 	var err error
 	// Create shared informers we know we'll use
-	wf.informers[podType], err = newInformer(podType, wf.iFactory.Core().V1().Pods().Informer())
+	wf.informers[podType], err = newQueuedInformer(podType, wf.iFactory.Core().V1().Pods().Informer(), stopChan)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This commit enables creating queued informers for pod events and
increases the number of event queues for handling events to 15.
At scale, the pod informer gets events more rapidly, but the handling
of these events is rather serialized. This will allow for multiple pod
events to be handled in parallel for a given namespace.

Scale tests were ran with this change.
At higher node scale (n > 150), the event handlers start contending if the numEventQueues is > 25.

Signed-off-by: Aniket Bhat anbhat@redhat.com