### PR TITLE
using to launch cluster-bot with more debugging

### DIFF
--- a/go-controller/pkg/ovn/common.go
+++ b/go-controller/pkg/ovn/common.go
@@ -86,7 +86,7 @@ func removeFromAddressSet(hashName string, address string) {
 
 func createAddressSet(name string, hashName string,
 	addresses []string) {
-	klog.V(5).Infof("createAddressSet with %s and %s", name, addresses)
+	klog.V(2).Infof("createAddressSet with %s and %s", name, addresses)
 	addressSet, stderr, err := util.RunOVNNbctl("--data=bare",
 		"--no-heading", "--columns=_uuid", "find", "address_set",
 		fmt.Sprintf("name=%s", hashName))
@@ -139,7 +139,7 @@ func createAddressSet(name string, hashName string,
 }
 
 func deleteAddressSet(hashName string) {
-	klog.V(5).Infof("deleteAddressSet %s", hashName)
+	klog.V(2).Infof("deleteAddressSet %s", hashName)
 
 	_, stderr, err := util.RunOVNNbctl("--if-exists", "destroy",
 		"address_set", hashName)

--- a/go-controller/pkg/ovn/common.go
+++ b/go-controller/pkg/ovn/common.go
@@ -86,7 +86,7 @@ func removeFromAddressSet(hashName string, address string) {
 
 func createAddressSet(name string, hashName string,
 	addresses []string) {
-	klog.V(2).Infof("createAddressSet with %s and %s", name, addresses)
+	klog.V(2).Infof("createAddressSet with %s (%s) and %s", name, hashName, addresses)
 	addressSet, stderr, err := util.RunOVNNbctl("--data=bare",
 		"--no-heading", "--columns=_uuid", "find", "address_set",
 		fmt.Sprintf("name=%s", hashName))

--- a/go-controller/pkg/ovn/namespace.go
+++ b/go-controller/pkg/ovn/namespace.go
@@ -133,7 +133,7 @@ func (oc *Controller) multicastDeleteNamespace(ns *kapi.Namespace, nsInfo *names
 
 // AddNamespace creates corresponding addressset in ovn db
 func (oc *Controller) AddNamespace(ns *kapi.Namespace) {
-	klog.V(5).Infof("Adding namespace: %s", ns.Name)
+	klog.V(2).Infof("Adding namespace: %s", ns.Name)
 	nsInfo := oc.createNamespaceLocked(ns.Name)
 	defer nsInfo.Unlock()
 
@@ -211,7 +211,7 @@ func (oc *Controller) updateNamespace(old, newer *kapi.Namespace) {
 }
 
 func (oc *Controller) deleteNamespace(ns *kapi.Namespace) {
-	klog.V(5).Infof("Deleting namespace: %s", ns.Name)
+	klog.V(2).Infof("Deleting namespace: %s", ns.Name)
 
 	nsInfo := oc.deleteNamespaceLocked(ns.Name)
 	if nsInfo == nil {


### PR DESCRIPTION
Temporarily increase addressSet debugging level to help debug stress Test

it is very hard to debug the ovn networking stress tests with the current level of debugging.
All the runs in the ovn-controller seem to have the same parsing error where it seems an
addressSet is being used before it is actually created

try to confirm this

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->