### PR TITLE
[WIP Do not merge] Extra logging for testing CI job

### DIFF
--- a/go-controller/pkg/node/gateway_localnet.go
+++ b/go-controller/pkg/node/gateway_localnet.go
@@ -85,6 +85,7 @@ func delIptRules(ipt util.IPTablesHelper, rules []iptRule) {
 				strings.Join(r.args, " "), err)
 		}
 	}
+	klog.Infof("deleted iptables rules")
 }
 
 func generateGatewayNATRules(ifname string, ip net.IP) []iptRule {


### PR DESCRIPTION
**- What this PR does and why is it needed**
In order to find cause for kubelet livelock issue (which was observed in ovn CI jobs), I create this PR so that I can have more clue in CI job artifacts.

**- Special notes for reviewers**
This patch is used to trigger ovn tests.
From my interaction with cluster-bot, with openshift/origin PR alone, ovn tests are not run.
ovn tests were where Casey reported livelock scenario.

**- Description for the changelog**
One line change in go-controller/pkg/node/gateway_localnet.go is introduced for debugging livelock problem in ovn tests.