### PR TITLE
Fix order of pods, namespaces, services and endpoints

### DIFF
--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -167,8 +167,8 @@ func (oc *Controller) Run(stopChan chan struct{}) error {
 		return err
 	}
 
-	for _, f := range []func() error{oc.WatchPods, oc.WatchServices, oc.WatchEndpoints,
-		oc.WatchNamespaces, oc.WatchNetworkPolicy} {
+	for _, f := range []func() error{oc.WatchPods, oc.WatchNamespaces, oc.WatchServices,
+		oc.WatchEndpoints, oc.WatchNetworkPolicy} {
 		if err := f(); err != nil {
 			return err
 		}


### PR DESCRIPTION
On a restart of ovnkube master due to leader election change
(normal) and perhaps loading and processing all the existing pods.

E0609 18:43:27.194389       1 ovn.go:396] timeout waiting for namespace event

Occured. We process services and endpoints before namespaces, which is
the wrong order because pods (which are first) depend on Namespaces.
So if there are a lot of services & endpoints their initial processing
will block the namespaces which will block and fail pods.

SDN-1037 - Processing services and endpoints incorrectly happens before namespaces.
https://issues.redhat.com/browse/SDN-1037

Signed-off-by: Phil Cameron <pcameron@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->