### PR TITLE
Remove unused packages from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,9 +33,9 @@ RUN yum install -y  \
 	yum clean all
 
 RUN INSTALL_PKGS=" \
-	PyYAML openssl firewalld-filesystem \
+	openssl firewalld-filesystem \
 	libpcap iproute strace \
-	containernetworking-plugins yum-utils \
+	containernetworking-plugins \
 	tcpdump \
 	" && \
 	yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False $INSTALL_PKGS && \


### PR DESCRIPTION
**- What this PR does and why is it needed**
This makes the Dockerfile compatible with RHEL 8 by not requiring unused
and obsolete packages.

**- Special notes for reviewers**
PyYAML should no longer be required as of commit f2dbc63c5efbb23743a31c1a46db589d9a5bb6dd.
yum-utils should no longer be required as of commit 2d4733b352265106fab7bfd6d5087b29a57f09d1.


**- How to verify it**
Image should build and pass CI as before.

**- Description for the changelog**
Remove unused packages from Dockerfile