### PR TITLE
Undo the hack for CNO common name

### DIFF
--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -1432,8 +1432,6 @@ func buildOvnAuth(exec kexec.Interface, northbound bool, cliAuth, confAuth *OvnA
 		return nil, err
 	}
 
-	// REMOVEME after https://github.com/openshift/cluster-network-operator/pull/640 merges
-	auth.CertCommonName = "ovn"
 	switch {
 	case auth.Scheme == OvnDBSchemeSSL:
 		if auth.PrivKey == "" || auth.Cert == "" || auth.CACert == "" || auth.CertCommonName == "" {


### PR DESCRIPTION
We added a hack in the downstream code to set the common name of the certs
to let CI pass. This PR removes that hack. 

Signed-off-by: Aniket Bhat <anbhat@redhat.com>

