### PR TITLE
Fix broken unit-tests and make gofmt happy

### DIFF
--- a/go-controller/pkg/cni/OCP_HACKS.go
+++ b/go-controller/pkg/cni/OCP_HACKS.go
@@ -68,6 +68,7 @@ func setupIPTablesBlocks(netns ns.NetNS, ifInfo *PodInterfaceInfo) error {
 		return nil
 	})
 }
+
 // END OCP HACK
 
 // OCP HACK: wait for OVN to fully process the new pod
@@ -97,4 +98,5 @@ func waitForBrIntFlows(ip string) error {
 		return strings.Contains(stdout, ip), nil
 	})
 }
+
 // END OCP HACK

--- a/go-controller/pkg/node/OCP_HACKS.go
+++ b/go-controller/pkg/node/OCP_HACKS.go
@@ -33,6 +33,7 @@ func generateBlockMCSRules(rules *[]iptRule) {
 		args:  []string{"-p", "tcp", "-m", "tcp", "--dport", "22624", "-j", "REJECT"},
 	})
 }
+
 // END OCP HACK
 
 // OCP HACK: Fix Azure/GCP LoadBalancers. https://github.com/openshift/ovn-kubernetes/pull/112
@@ -64,4 +65,5 @@ func getLoadBalancerIPTRules(svc *kapi.Service, svcPort kapi.ServicePort, gatewa
 	}
 	return rules
 }
+
 // END OCP HACK

--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -484,8 +484,6 @@ var _ = Describe("Gateway Init Operations", func() {
 				"-p tcp -m tcp --dport 22623 -j REJECT",
 			)
 			// END OCP HACK
-
-			Expect(ipt.MatchState(expectedTables)).NotTo(HaveOccurred())
 			f4 := iptV4.(*util.FakeIPTables)
 			err = f4.MatchState(expectedTables)
 			Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
The downstream merge broke the unit-test compilation for one of the tests.
This fixes the unit-test file and makes gofmt happy.

Signed-off-by: Aniket Bhat <anbhat@redhat.com>

