### PR TITLE
hybrid-overlay-node: Windows service enablement

### DIFF
--- a/go-controller/go.mod
+++ b/go-controller/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/stretchr/testify v1.4.0
 	github.com/urfave/cli/v2 v2.2.0
 	github.com/vishvananda/netlink v0.0.0-20200625175047-bca67dfc8220
+	golang.org/x/sys v0.0.0-20200121082415-34d275377bf9
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0 // indirect
 	gopkg.in/fsnotify/fsnotify.v1 v1.4.7
 	gopkg.in/gcfg.v1 v1.2.3

--- a/go-controller/go.sum
+++ b/go-controller/go.sum
@@ -20,6 +20,7 @@ github.com/Microsoft/hcsshim v0.8.6 h1:ZfF0+zZeYdzMIVMZHKtDKJvLHj76XCuVae/jNkjj0
 github.com/Microsoft/hcsshim v0.8.6/go.mod h1:Op3hHsoHPAvb6lceZHDtd9OkTew38wNoXnJs8iY7rUg=
 github.com/Microsoft/hcsshim v0.8.10-0.20200606013352-27a858bf1651 h1:GxW+YVOC3reTHwPmunbeG1TXRB/OGNIMvo0WTLzsD6c=
 github.com/Microsoft/hcsshim v0.8.10-0.20200606013352-27a858bf1651/go.mod h1:ay/0dTb7NsG8QMDfsRfLHgZo/6xAJShLe1+ePPflihk=
+github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46 h1:lsxEuwrXEAokXB9qhlbKWPpo3KMLZQ5WB5WLQRW1uq0=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/PuerkitoBio/purell v1.0.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20160726150825-5bd2802263f2/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
@@ -76,6 +77,7 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
@@ -110,6 +112,7 @@ github.com/godbus/dbus/v5 v5.0.3/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5x
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.3.1 h1:DqDEcV5aeaTmdFBePNpYsp3FlcVH/2ISVVM9Qf8PSls=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
+github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191027212112-611e8accdfc9 h1:uHTyIjqVhYRhLbJ8nIiOJHkEZZ+5YoOsAbD3sk82NiE=
@@ -123,6 +126,7 @@ github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
+github.com/google/btree v1.0.0 h1:0udJVsspx3VBr5FwtLhQQtuAsVc79tTq0ocGIPAU6qo=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=

--- a/go-controller/hybrid-overlay/cmd/hybrid-overlay-node/init_others.go
+++ b/go-controller/hybrid-overlay/cmd/hybrid-overlay-node/init_others.go
@@ -1,0 +1,21 @@
+// +build !windows
+
+/*
+Copyright 2018 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+// initForOS performs non-Windows specific app initialization
+func initForOS(service bool) error {
+	return nil
+}

--- a/go-controller/hybrid-overlay/cmd/hybrid-overlay-node/init_windows.go
+++ b/go-controller/hybrid-overlay/cmd/hybrid-overlay-node/init_windows.go
@@ -1,0 +1,30 @@
+// +build windows
+
+/*
+Copyright 2018 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"github.com/ovn-org/ovn-kubernetes/go-controller/hybrid-overlay/pkg/windows/service"
+	"k8s.io/klog"
+)
+
+// initForOS performs Windows specific app initialization
+func initForOS(windowsService bool) error {
+	if windowsService {
+		klog.Infof("Initializing Windows service")
+		return service.InitService(appName)
+	}
+	return nil
+}

--- a/go-controller/hybrid-overlay/pkg/windows/service/service.go
+++ b/go-controller/hybrid-overlay/pkg/windows/service/service.go
@@ -1,0 +1,102 @@
+// +build windows
+
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Based on https://github.com/kubernetes/kubernetes/blob/master/pkg/windows/service/service.go
+The reason for making a copy is that packages in kubernetes/kubernetes
+are not setup to be imported as modules without vendoring and pinning the sub
+components using the "require" directive. If more packages need to be imported
+then we can revisit importing this module too.
+*/
+
+package service
+
+import (
+	"os"
+	"time"
+
+	"k8s.io/klog"
+
+	"golang.org/x/sys/windows"
+	"golang.org/x/sys/windows/svc"
+)
+
+type handler struct {
+	fromsvc chan error
+}
+
+// InitService is the entry point for running the daemon as a Windows
+// service. It returns an indication of whether it is running as a service;
+// and an error.
+func InitService(serviceName string) error {
+	h := &handler{
+		fromsvc: make(chan error),
+	}
+
+	var err error
+	go func() {
+		err = svc.Run(serviceName, h)
+		h.fromsvc <- err
+	}()
+
+	// Wait for the first signal from the service handler.
+	err = <-h.fromsvc
+	if err != nil {
+		return err
+	}
+	klog.Infof("Running %s as a Windows service!", serviceName)
+	return nil
+}
+
+func (h *handler) Execute(_ []string, r <-chan svc.ChangeRequest, s chan<- svc.Status) (bool, uint32) {
+	s <- svc.Status{State: svc.StartPending, Accepts: 0}
+	// Unblock initService()
+	h.fromsvc <- nil
+
+	s <- svc.Status{State: svc.Running, Accepts: svc.AcceptStop | svc.AcceptShutdown | svc.Accepted(windows.SERVICE_ACCEPT_PARAMCHANGE)}
+	klog.Infof("Service running")
+Loop:
+	for {
+		select {
+		case c := <-r:
+			switch c.Cmd {
+			case svc.Cmd(windows.SERVICE_CONTROL_PARAMCHANGE):
+				s <- c.CurrentStatus
+			case svc.Interrogate:
+				s <- c.CurrentStatus
+			case svc.Stop, svc.Shutdown:
+				klog.Infof("Service stopping")
+				// Free up the control handler and let us terminate as gracefully as possible.
+				// If that takes too long, the service controller will kill the remaining threads.
+				// As per https://docs.microsoft.com/en-us/windows/desktop/services/service-control-handler-function
+				s <- svc.Status{State: svc.StopPending}
+
+				// We need to exit our process, so atleast the service manager will think that we gracefully exited.
+				// At the time of writing this comment this is needed for applications like hybrid-overlay-node that do not
+				// use signals.
+				go func() {
+					// Ensure the SCM was notified (The operation above (send to s) was received and communicated to the
+					// service control manager - so it doesn't look like the service crashes)
+					time.Sleep(1 * time.Second)
+					os.Exit(0)
+				}()
+				break Loop
+			}
+		}
+	}
+
+	return false, 0
+}

--- a/go-controller/vendor/golang.org/x/sys/windows/svc/event.go
+++ b/go-controller/vendor/golang.org/x/sys/windows/svc/event.go
@@ -1,0 +1,48 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build windows
+
+package svc
+
+import (
+	"errors"
+
+	"golang.org/x/sys/windows"
+)
+
+// event represents auto-reset, initially non-signaled Windows event.
+// It is used to communicate between go and asm parts of this package.
+type event struct {
+	h windows.Handle
+}
+
+func newEvent() (*event, error) {
+	h, err := windows.CreateEvent(nil, 0, 0, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &event{h: h}, nil
+}
+
+func (e *event) Close() error {
+	return windows.CloseHandle(e.h)
+}
+
+func (e *event) Set() error {
+	return windows.SetEvent(e.h)
+}
+
+func (e *event) Wait() error {
+	s, err := windows.WaitForSingleObject(e.h, windows.INFINITE)
+	switch s {
+	case windows.WAIT_OBJECT_0:
+		break
+	case windows.WAIT_FAILED:
+		return err
+	default:
+		return errors.New("unexpected result from WaitForSingleObject")
+	}
+	return nil
+}

--- a/go-controller/vendor/golang.org/x/sys/windows/svc/go12.c
+++ b/go-controller/vendor/golang.org/x/sys/windows/svc/go12.c
@@ -1,0 +1,24 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build windows
+// +build !go1.3
+
+// copied from pkg/runtime
+typedef	unsigned int	uint32;
+typedef	unsigned long long int	uint64;
+#ifdef _64BIT
+typedef	uint64		uintptr;
+#else
+typedef	uint32		uintptr;
+#endif
+
+// from sys_386.s or sys_amd64.s
+void ·servicemain(void);
+
+void
+·getServiceMain(uintptr *r)
+{
+	*r = (uintptr)·servicemain;
+}

--- a/go-controller/vendor/golang.org/x/sys/windows/svc/go12.go
+++ b/go-controller/vendor/golang.org/x/sys/windows/svc/go12.go
@@ -1,0 +1,11 @@
+// Copyright 2014 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build windows
+// +build !go1.3
+
+package svc
+
+// from go12.c
+func getServiceMain(r *uintptr)

--- a/go-controller/vendor/golang.org/x/sys/windows/svc/go13.go
+++ b/go-controller/vendor/golang.org/x/sys/windows/svc/go13.go
@@ -1,0 +1,31 @@
+// Copyright 2014 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build windows
+// +build go1.3
+
+package svc
+
+import "unsafe"
+
+const ptrSize = 4 << (^uintptr(0) >> 63) // unsafe.Sizeof(uintptr(0)) but an ideal const
+
+// Should be a built-in for unsafe.Pointer?
+func add(p unsafe.Pointer, x uintptr) unsafe.Pointer {
+	return unsafe.Pointer(uintptr(p) + x)
+}
+
+// funcPC returns the entry PC of the function f.
+// It assumes that f is a func value. Otherwise the behavior is undefined.
+func funcPC(f interface{}) uintptr {
+	return **(**uintptr)(add(unsafe.Pointer(&f), ptrSize))
+}
+
+// from sys_386.s and sys_amd64.s
+func servicectlhandler(ctl uint32) uintptr
+func servicemain(argc uint32, argv **uint16)
+
+func getServiceMain(r *uintptr) {
+	*r = funcPC(servicemain)
+}

--- a/go-controller/vendor/golang.org/x/sys/windows/svc/security.go
+++ b/go-controller/vendor/golang.org/x/sys/windows/svc/security.go
@@ -1,0 +1,62 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build windows
+
+package svc
+
+import (
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+func allocSid(subAuth0 uint32) (*windows.SID, error) {
+	var sid *windows.SID
+	err := windows.AllocateAndInitializeSid(&windows.SECURITY_NT_AUTHORITY,
+		1, subAuth0, 0, 0, 0, 0, 0, 0, 0, &sid)
+	if err != nil {
+		return nil, err
+	}
+	return sid, nil
+}
+
+// IsAnInteractiveSession determines if calling process is running interactively.
+// It queries the process token for membership in the Interactive group.
+// http://stackoverflow.com/questions/2668851/how-do-i-detect-that-my-application-is-running-as-service-or-in-an-interactive-s
+func IsAnInteractiveSession() (bool, error) {
+	interSid, err := allocSid(windows.SECURITY_INTERACTIVE_RID)
+	if err != nil {
+		return false, err
+	}
+	defer windows.FreeSid(interSid)
+
+	serviceSid, err := allocSid(windows.SECURITY_SERVICE_RID)
+	if err != nil {
+		return false, err
+	}
+	defer windows.FreeSid(serviceSid)
+
+	t, err := windows.OpenCurrentProcessToken()
+	if err != nil {
+		return false, err
+	}
+	defer t.Close()
+
+	gs, err := t.GetTokenGroups()
+	if err != nil {
+		return false, err
+	}
+	p := unsafe.Pointer(&gs.Groups[0])
+	groups := (*[2 << 20]windows.SIDAndAttributes)(p)[:gs.GroupCount]
+	for _, g := range groups {
+		if windows.EqualSid(g.Sid, interSid) {
+			return true, nil
+		}
+		if windows.EqualSid(g.Sid, serviceSid) {
+			return false, nil
+		}
+	}
+	return false, nil
+}

--- a/go-controller/vendor/golang.org/x/sys/windows/svc/service.go
+++ b/go-controller/vendor/golang.org/x/sys/windows/svc/service.go
@@ -1,0 +1,364 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build windows
+
+// Package svc provides everything required to build Windows service.
+//
+package svc
+
+import (
+	"errors"
+	"runtime"
+	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+// State describes service execution state (Stopped, Running and so on).
+type State uint32
+
+const (
+	Stopped         = State(windows.SERVICE_STOPPED)
+	StartPending    = State(windows.SERVICE_START_PENDING)
+	StopPending     = State(windows.SERVICE_STOP_PENDING)
+	Running         = State(windows.SERVICE_RUNNING)
+	ContinuePending = State(windows.SERVICE_CONTINUE_PENDING)
+	PausePending    = State(windows.SERVICE_PAUSE_PENDING)
+	Paused          = State(windows.SERVICE_PAUSED)
+)
+
+// Cmd represents service state change request. It is sent to a service
+// by the service manager, and should be actioned upon by the service.
+type Cmd uint32
+
+const (
+	Stop                  = Cmd(windows.SERVICE_CONTROL_STOP)
+	Pause                 = Cmd(windows.SERVICE_CONTROL_PAUSE)
+	Continue              = Cmd(windows.SERVICE_CONTROL_CONTINUE)
+	Interrogate           = Cmd(windows.SERVICE_CONTROL_INTERROGATE)
+	Shutdown              = Cmd(windows.SERVICE_CONTROL_SHUTDOWN)
+	ParamChange           = Cmd(windows.SERVICE_CONTROL_PARAMCHANGE)
+	NetBindAdd            = Cmd(windows.SERVICE_CONTROL_NETBINDADD)
+	NetBindRemove         = Cmd(windows.SERVICE_CONTROL_NETBINDREMOVE)
+	NetBindEnable         = Cmd(windows.SERVICE_CONTROL_NETBINDENABLE)
+	NetBindDisable        = Cmd(windows.SERVICE_CONTROL_NETBINDDISABLE)
+	DeviceEvent           = Cmd(windows.SERVICE_CONTROL_DEVICEEVENT)
+	HardwareProfileChange = Cmd(windows.SERVICE_CONTROL_HARDWAREPROFILECHANGE)
+	PowerEvent            = Cmd(windows.SERVICE_CONTROL_POWEREVENT)
+	SessionChange         = Cmd(windows.SERVICE_CONTROL_SESSIONCHANGE)
+)
+
+// Accepted is used to describe commands accepted by the service.
+// Note that Interrogate is always accepted.
+type Accepted uint32
+
+const (
+	AcceptStop                  = Accepted(windows.SERVICE_ACCEPT_STOP)
+	AcceptShutdown              = Accepted(windows.SERVICE_ACCEPT_SHUTDOWN)
+	AcceptPauseAndContinue      = Accepted(windows.SERVICE_ACCEPT_PAUSE_CONTINUE)
+	AcceptParamChange           = Accepted(windows.SERVICE_ACCEPT_PARAMCHANGE)
+	AcceptNetBindChange         = Accepted(windows.SERVICE_ACCEPT_NETBINDCHANGE)
+	AcceptHardwareProfileChange = Accepted(windows.SERVICE_ACCEPT_HARDWAREPROFILECHANGE)
+	AcceptPowerEvent            = Accepted(windows.SERVICE_ACCEPT_POWEREVENT)
+	AcceptSessionChange         = Accepted(windows.SERVICE_ACCEPT_SESSIONCHANGE)
+)
+
+// Status combines State and Accepted commands to fully describe running service.
+type Status struct {
+	State      State
+	Accepts    Accepted
+	CheckPoint uint32 // used to report progress during a lengthy operation
+	WaitHint   uint32 // estimated time required for a pending operation, in milliseconds
+	ProcessId  uint32 // if the service is running, the process identifier of it, and otherwise zero
+}
+
+// ChangeRequest is sent to the service Handler to request service status change.
+type ChangeRequest struct {
+	Cmd           Cmd
+	EventType     uint32
+	EventData     uintptr
+	CurrentStatus Status
+	Context       uintptr
+}
+
+// Handler is the interface that must be implemented to build Windows service.
+type Handler interface {
+
+	// Execute will be called by the package code at the start of
+	// the service, and the service will exit once Execute completes.
+	// Inside Execute you must read service change requests from r and
+	// act accordingly. You must keep service control manager up to date
+	// about state of your service by writing into s as required.
+	// args contains service name followed by argument strings passed
+	// to the service.
+	// You can provide service exit code in exitCode return parameter,
+	// with 0 being "no error". You can also indicate if exit code,
+	// if any, is service specific or not by using svcSpecificEC
+	// parameter.
+	Execute(args []string, r <-chan ChangeRequest, s chan<- Status) (svcSpecificEC bool, exitCode uint32)
+}
+
+var (
+	// These are used by asm code.
+	goWaitsH                       uintptr
+	cWaitsH                        uintptr
+	ssHandle                       uintptr
+	sName                          *uint16
+	sArgc                          uintptr
+	sArgv                          **uint16
+	ctlHandlerExProc               uintptr
+	cSetEvent                      uintptr
+	cWaitForSingleObject           uintptr
+	cRegisterServiceCtrlHandlerExW uintptr
+)
+
+func init() {
+	k := windows.NewLazySystemDLL("kernel32.dll")
+	cSetEvent = k.NewProc("SetEvent").Addr()
+	cWaitForSingleObject = k.NewProc("WaitForSingleObject").Addr()
+	a := windows.NewLazySystemDLL("advapi32.dll")
+	cRegisterServiceCtrlHandlerExW = a.NewProc("RegisterServiceCtrlHandlerExW").Addr()
+}
+
+type ctlEvent struct {
+	cmd       Cmd
+	eventType uint32
+	eventData uintptr
+	context   uintptr
+	errno     uint32
+}
+
+// service provides access to windows service api.
+type service struct {
+	name    string
+	h       windows.Handle
+	cWaits  *event
+	goWaits *event
+	c       chan ctlEvent
+	handler Handler
+}
+
+func newService(name string, handler Handler) (*service, error) {
+	var s service
+	var err error
+	s.name = name
+	s.c = make(chan ctlEvent)
+	s.handler = handler
+	s.cWaits, err = newEvent()
+	if err != nil {
+		return nil, err
+	}
+	s.goWaits, err = newEvent()
+	if err != nil {
+		s.cWaits.Close()
+		return nil, err
+	}
+	return &s, nil
+}
+
+func (s *service) close() error {
+	s.cWaits.Close()
+	s.goWaits.Close()
+	return nil
+}
+
+type exitCode struct {
+	isSvcSpecific bool
+	errno         uint32
+}
+
+func (s *service) updateStatus(status *Status, ec *exitCode) error {
+	if s.h == 0 {
+		return errors.New("updateStatus with no service status handle")
+	}
+	var t windows.SERVICE_STATUS
+	t.ServiceType = windows.SERVICE_WIN32_OWN_PROCESS
+	t.CurrentState = uint32(status.State)
+	if status.Accepts&AcceptStop != 0 {
+		t.ControlsAccepted |= windows.SERVICE_ACCEPT_STOP
+	}
+	if status.Accepts&AcceptShutdown != 0 {
+		t.ControlsAccepted |= windows.SERVICE_ACCEPT_SHUTDOWN
+	}
+	if status.Accepts&AcceptPauseAndContinue != 0 {
+		t.ControlsAccepted |= windows.SERVICE_ACCEPT_PAUSE_CONTINUE
+	}
+	if status.Accepts&AcceptParamChange != 0 {
+		t.ControlsAccepted |= windows.SERVICE_ACCEPT_PARAMCHANGE
+	}
+	if status.Accepts&AcceptNetBindChange != 0 {
+		t.ControlsAccepted |= windows.SERVICE_ACCEPT_NETBINDCHANGE
+	}
+	if status.Accepts&AcceptHardwareProfileChange != 0 {
+		t.ControlsAccepted |= windows.SERVICE_ACCEPT_HARDWAREPROFILECHANGE
+	}
+	if status.Accepts&AcceptPowerEvent != 0 {
+		t.ControlsAccepted |= windows.SERVICE_ACCEPT_POWEREVENT
+	}
+	if status.Accepts&AcceptSessionChange != 0 {
+		t.ControlsAccepted |= windows.SERVICE_ACCEPT_SESSIONCHANGE
+	}
+	if ec.errno == 0 {
+		t.Win32ExitCode = windows.NO_ERROR
+		t.ServiceSpecificExitCode = windows.NO_ERROR
+	} else if ec.isSvcSpecific {
+		t.Win32ExitCode = uint32(windows.ERROR_SERVICE_SPECIFIC_ERROR)
+		t.ServiceSpecificExitCode = ec.errno
+	} else {
+		t.Win32ExitCode = ec.errno
+		t.ServiceSpecificExitCode = windows.NO_ERROR
+	}
+	t.CheckPoint = status.CheckPoint
+	t.WaitHint = status.WaitHint
+	return windows.SetServiceStatus(s.h, &t)
+}
+
+const (
+	sysErrSetServiceStatusFailed = uint32(syscall.APPLICATION_ERROR) + iota
+	sysErrNewThreadInCallback
+)
+
+func (s *service) run() {
+	s.goWaits.Wait()
+	s.h = windows.Handle(ssHandle)
+	argv := (*[100]*int16)(unsafe.Pointer(sArgv))[:sArgc]
+	args := make([]string, len(argv))
+	for i, a := range argv {
+		args[i] = syscall.UTF16ToString((*[1 << 20]uint16)(unsafe.Pointer(a))[:])
+	}
+
+	cmdsToHandler := make(chan ChangeRequest)
+	changesFromHandler := make(chan Status)
+	exitFromHandler := make(chan exitCode)
+
+	go func() {
+		ss, errno := s.handler.Execute(args, cmdsToHandler, changesFromHandler)
+		exitFromHandler <- exitCode{ss, errno}
+	}()
+
+	ec := exitCode{isSvcSpecific: true, errno: 0}
+	outcr := ChangeRequest{
+		CurrentStatus: Status{State: Stopped},
+	}
+	var outch chan ChangeRequest
+	inch := s.c
+loop:
+	for {
+		select {
+		case r := <-inch:
+			if r.errno != 0 {
+				ec.errno = r.errno
+				break loop
+			}
+			inch = nil
+			outch = cmdsToHandler
+			outcr.Cmd = r.cmd
+			outcr.EventType = r.eventType
+			outcr.EventData = r.eventData
+			outcr.Context = r.context
+		case outch <- outcr:
+			inch = s.c
+			outch = nil
+		case c := <-changesFromHandler:
+			err := s.updateStatus(&c, &ec)
+			if err != nil {
+				// best suitable error number
+				ec.errno = sysErrSetServiceStatusFailed
+				if err2, ok := err.(syscall.Errno); ok {
+					ec.errno = uint32(err2)
+				}
+				break loop
+			}
+			outcr.CurrentStatus = c
+		case ec = <-exitFromHandler:
+			break loop
+		}
+	}
+
+	s.updateStatus(&Status{State: Stopped}, &ec)
+	s.cWaits.Set()
+}
+
+func newCallback(fn interface{}) (cb uintptr, err error) {
+	defer func() {
+		r := recover()
+		if r == nil {
+			return
+		}
+		cb = 0
+		switch v := r.(type) {
+		case string:
+			err = errors.New(v)
+		case error:
+			err = v
+		default:
+			err = errors.New("unexpected panic in syscall.NewCallback")
+		}
+	}()
+	return syscall.NewCallback(fn), nil
+}
+
+// BUG(brainman): There is no mechanism to run multiple services
+// inside one single executable. Perhaps, it can be overcome by
+// using RegisterServiceCtrlHandlerEx Windows api.
+
+// Run executes service name by calling appropriate handler function.
+func Run(name string, handler Handler) error {
+	runtime.LockOSThread()
+
+	tid := windows.GetCurrentThreadId()
+
+	s, err := newService(name, handler)
+	if err != nil {
+		return err
+	}
+
+	ctlHandler := func(ctl, evtype, evdata, context uintptr) uintptr {
+		e := ctlEvent{cmd: Cmd(ctl), eventType: uint32(evtype), eventData: evdata, context: context}
+		// We assume that this callback function is running on
+		// the same thread as Run. Nowhere in MS documentation
+		// I could find statement to guarantee that. So putting
+		// check here to verify, otherwise things will go bad
+		// quickly, if ignored.
+		i := windows.GetCurrentThreadId()
+		if i != tid {
+			e.errno = sysErrNewThreadInCallback
+		}
+		s.c <- e
+		// Always return NO_ERROR (0) for now.
+		return windows.NO_ERROR
+	}
+
+	var svcmain uintptr
+	getServiceMain(&svcmain)
+	t := []windows.SERVICE_TABLE_ENTRY{
+		{ServiceName: syscall.StringToUTF16Ptr(s.name), ServiceProc: svcmain},
+		{ServiceName: nil, ServiceProc: 0},
+	}
+
+	goWaitsH = uintptr(s.goWaits.h)
+	cWaitsH = uintptr(s.cWaits.h)
+	sName = t[0].ServiceName
+	ctlHandlerExProc, err = newCallback(ctlHandler)
+	if err != nil {
+		return err
+	}
+
+	go s.run()
+
+	err = windows.StartServiceCtrlDispatcher(&t[0])
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// StatusHandle returns service status handle. It is safe to call this function
+// from inside the Handler.Execute because then it is guaranteed to be set.
+// This code will have to change once multiple services are possible per process.
+func StatusHandle() windows.Handle {
+	return windows.Handle(ssHandle)
+}

--- a/go-controller/vendor/golang.org/x/sys/windows/svc/sys_386.s
+++ b/go-controller/vendor/golang.org/x/sys/windows/svc/sys_386.s
@@ -1,0 +1,69 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build windows
+
+// func servicemain(argc uint32, argv **uint16)
+TEXT ·servicemain(SB),7,$0
+	MOVL	argc+0(FP), AX
+	MOVL	AX, ·sArgc(SB)
+	MOVL	argv+4(FP), AX
+	MOVL	AX, ·sArgv(SB)
+
+	PUSHL	BP
+	PUSHL	BX
+	PUSHL	SI
+	PUSHL	DI
+
+	SUBL	$12, SP
+
+	MOVL	·sName(SB), AX
+	MOVL	AX, (SP)
+	MOVL	$·servicectlhandler(SB), AX
+	MOVL	AX, 4(SP)
+	// Set context to 123456 to test issue #25660.
+	MOVL	$123456, 8(SP)
+	MOVL	·cRegisterServiceCtrlHandlerExW(SB), AX
+	MOVL	SP, BP
+	CALL	AX
+	MOVL	BP, SP
+	CMPL	AX, $0
+	JE	exit
+	MOVL	AX, ·ssHandle(SB)
+
+	MOVL	·goWaitsH(SB), AX
+	MOVL	AX, (SP)
+	MOVL	·cSetEvent(SB), AX
+	MOVL	SP, BP
+	CALL	AX
+	MOVL	BP, SP
+
+	MOVL	·cWaitsH(SB), AX
+	MOVL	AX, (SP)
+	MOVL	$-1, AX
+	MOVL	AX, 4(SP)
+	MOVL	·cWaitForSingleObject(SB), AX
+	MOVL	SP, BP
+	CALL	AX
+	MOVL	BP, SP
+
+exit:
+	ADDL	$12, SP
+
+	POPL	DI
+	POPL	SI
+	POPL	BX
+	POPL	BP
+
+	MOVL	0(SP), CX
+	ADDL	$12, SP
+	JMP	CX
+
+// I do not know why, but this seems to be the only way to call
+// ctlHandlerProc on Windows 7.
+
+// func servicectlhandler(ctl uint32, evtype uint32, evdata uintptr, context uintptr) uintptr {
+TEXT ·servicectlhandler(SB),7,$0
+	MOVL	·ctlHandlerExProc(SB), CX
+	JMP	CX

--- a/go-controller/vendor/golang.org/x/sys/windows/svc/sys_amd64.s
+++ b/go-controller/vendor/golang.org/x/sys/windows/svc/sys_amd64.s
@@ -1,0 +1,44 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build windows
+
+// func servicemain(argc uint32, argv **uint16)
+TEXT ·servicemain(SB),7,$0
+	MOVL	CX, ·sArgc(SB)
+	MOVQ	DX, ·sArgv(SB)
+
+	SUBQ	$32, SP		// stack for the first 4 syscall params
+
+	MOVQ	·sName(SB), CX
+	MOVQ	$·servicectlhandler(SB), DX
+	// BUG(pastarmovj): Figure out a way to pass in context in R8.
+	// Set context to 123456 to test issue #25660.
+	MOVQ	$123456, R8
+	MOVQ	·cRegisterServiceCtrlHandlerExW(SB), AX
+	CALL	AX
+	CMPQ	AX, $0
+	JE	exit
+	MOVQ	AX, ·ssHandle(SB)
+
+	MOVQ	·goWaitsH(SB), CX
+	MOVQ	·cSetEvent(SB), AX
+	CALL	AX
+
+	MOVQ	·cWaitsH(SB), CX
+	MOVQ	$4294967295, DX
+	MOVQ	·cWaitForSingleObject(SB), AX
+	CALL	AX
+
+exit:
+	ADDQ	$32, SP
+	RET
+
+// I do not know why, but this seems to be the only way to call
+// ctlHandlerProc on Windows 7.
+
+// func ·servicectlhandler(ctl uint32, evtype uint32, evdata uintptr, context uintptr) uintptr {
+TEXT ·servicectlhandler(SB),7,$0
+	MOVQ	·ctlHandlerExProc(SB), AX
+	JMP	AX

--- a/go-controller/vendor/golang.org/x/sys/windows/svc/sys_arm.s
+++ b/go-controller/vendor/golang.org/x/sys/windows/svc/sys_arm.s
@@ -1,0 +1,38 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build windows
+
+#include "textflag.h"
+
+// func servicemain(argc uint32, argv **uint16)
+TEXT ·servicemain(SB),NOSPLIT|NOFRAME,$0
+	MOVM.DB.W [R4, R14], (R13)	// push {r4, lr}
+	MOVW    R13, R4
+	BIC     $0x7, R13		// alignment for ABI
+
+	MOVW	R0, ·sArgc(SB)
+	MOVW	R1, ·sArgv(SB)
+
+	MOVW	·sName(SB), R0
+	MOVW	·ctlHandlerExProc(SB), R1
+	MOVW	$0, R2
+	MOVW	·cRegisterServiceCtrlHandlerExW(SB), R3
+	BL      (R3)
+	CMP     $0, R0
+	BEQ     exit
+	MOVW	R0, ·ssHandle(SB)
+
+	MOVW	·goWaitsH(SB), R0
+	MOVW	·cSetEvent(SB), R1
+	BL      (R1)
+
+	MOVW	·cWaitsH(SB), R0
+	MOVW	$-1, R1
+	MOVW	·cWaitForSingleObject(SB), R2
+	BL      (R2)
+
+exit:
+	MOVW	R4, R13			// free extra stack space
+	MOVM.IA.W (R13), [R4, R15]	// pop {r4, pc}

--- a/go-controller/vendor/modules.txt
+++ b/go-controller/vendor/modules.txt
@@ -219,6 +219,7 @@ golang.org/x/oauth2/internal
 golang.org/x/sys/unix
 golang.org/x/sys/windows
 golang.org/x/sys/windows/registry
+golang.org/x/sys/windows/svc
 # golang.org/x/text v0.3.2
 golang.org/x/text/encoding
 golang.org/x/text/encoding/charmap


### PR DESCRIPTION
This PR introduces running hybrid overlay as a service
on Windows. This is achieved by adding a --windows-service
flag to enable running it as a Windows service. This flag
is ignored on Linux. This approach is based on kube-proxy
and kubelet services.

Upstream PR: ovn-org/ovn-kubernetes#1514

Signed-off-by: mansikulkarni96 <mankulka@redhat.com>

Co-authored-by: aravindhp <aravindh@redhat.com>