### PR TITLE
Bug 1859883: Fix ovnkube-node aggressive memory allocation to prevent …

### DIFF
--- a/go-controller/pkg/cni/OCP_HACKS.go
+++ b/go-controller/pkg/cni/OCP_HACKS.go
@@ -86,13 +86,13 @@ func ofctlExec(args ...string) (string, error) {
 	klog.V(5).Infof("exec: ovs-ofctl %s", cmdStr)
 
 	err := cmd.Run()
-	stdoutStr := string(stdout.Bytes())
-	stderrStr := string(stderr.Bytes())
 	if err != nil {
-		klog.V(5).Infof("exec: stderr: %q", stderrStr)
-		return "", fmt.Errorf("failed to run 'ovs-ofctl %s': %v\n  %q", cmdStr, err, string(stderr.Bytes()))
+		stderrStr := string(stderr.Bytes())
+		klog.Errorf("exec: ovs-ofctl %s : stderr: %q",cmdStr, stderrStr)
+		return "", fmt.Errorf("failed to run 'ovs-ofctl %s': %v\n  %q", cmdStr, err, stderrStr)
 	}
-	klog.V(5).Infof("exec: stdout: %q", stdoutStr)
+	stdoutStr := string(stdout.Bytes())
+	klog.V(5).Infof("exec: ovs-ofctl %s: stdout: %q", cmdStr, stdoutStr)
 
 	trimmed := strings.TrimSpace(stdoutStr)
 	// If output is a single line, strip the trailing newline
@@ -104,9 +104,9 @@ func ofctlExec(args ...string) (string, error) {
 
 func waitForPodFlows(mac string) error {
 	return wait.PollImmediate(200*time.Millisecond, 20*time.Second, func() (bool, error) {
-		//Query the flows by mac address and count the number of flows.
+		// Query the flows by mac address
 		query := fmt.Sprintf("table=9,dl_src=%s",mac)
-		//ovs-ofctl dumps error on stderr, so stdout will only dump flow data if matches the query.
+		// ovs-ofctl dumps error on stderr, so stdout will only dump flow data if matches the query.
 		stdout, err := ofctlExec("dump-flows", "br-int", query)
 		if err != nil {
 			return false, nil

--- a/go-controller/pkg/cni/helper_linux.go
+++ b/go-controller/pkg/cni/helper_linux.go
@@ -314,7 +314,7 @@ func (pr *PodRequest) ConfigureInterface(namespace string, podName string, ifInf
 	}
 
 	// OCP HACK: wait for OVN to fully process the new pod
-	if err = waitForBrIntFlows(ifInfo.IPs[0].IP.String()); err != nil {
+	if err = waitForPodFlows(ifInfo.MAC.String()); err != nil {
 		return nil, fmt.Errorf("timed out dumping br-int flow entries for sandbox: %v", err)
 	}
 	// END OCP HACK


### PR DESCRIPTION
…memory bloating

**- What this PR does and why is it needed**
    During the pod creation, ovnkube-node dump all the flows from br-int and grep
    for the ip address of the pod to verify that pod related flows are programmed.
    This can cause aggressive and big memory allocation to store the string output
    from ovs-ofctl command.
    This patch optimized the ovs-ofctl dump-flow query to dump flows only related
    to the pods. This will avoid dumping the massive string output and prevent
    memory bloating.

Signed-off-by: Anil Vishnoi <avishnoi@redhat.com>

