### PR TITLE
    WIP test PR only

### DIFF
--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -510,6 +510,16 @@ var _ = Describe("Gateway Init Operations", func() {
 	})
 
 	AfterEach(func() {
+		var err error
+		err = testNS.Do(func(ns.NetNS) error {
+			defer GinkgoRecover()
+
+			ovntest.DelLink("br-local")
+			ovntest.DelLink(localnetGatewayNextHopPort)
+
+			return nil
+		})
+		Expect(err).NotTo(HaveOccurred())
 		Expect(testNS.Close()).To(Succeed())
 	})
 

--- a/go-controller/pkg/node/gateway_localnet.go
+++ b/go-controller/pkg/node/gateway_localnet.go
@@ -35,6 +35,7 @@ const (
 	// fixed MAC address for the br-nexthop interface. the last 4 hex bytes
 	// translates to the br-nexthop's IP address
 	localnetGatewayNextHopMac = "00:00:a9:fe:21:01"
+	localnetGatewayMac        = "00:00:a9:fe:21:02"
 	// Routing table for ExternalIP communication
 	localnetGatewayExternalIDTable = "6"
 )
@@ -122,11 +123,13 @@ func (n *OvnNode) initLocalnetGateway(hostSubnets []*net.IPNet, nodeAnnotator ku
 		return err
 	}
 
+	gwMacAddress, _ := net.ParseMAC(localnetGatewayMac)
+
 	err = util.SetL3GatewayConfig(nodeAnnotator, &util.L3GatewayConfig{
 		Mode:           config.GatewayModeLocal,
 		ChassisID:      chassisID,
 		InterfaceID:    ifaceID,
-		MACAddress:     macAddress,
+		MACAddress:     gwMacAddress,
 		IPAddresses:    gatewayIfAddrs,
 		NextHops:       nextHops,
 		NodePortEnable: config.Gateway.NodeportEnable,

--- a/go-controller/pkg/util/net_linux.go
+++ b/go-controller/pkg/util/net_linux.go
@@ -160,6 +160,15 @@ func LinkAddrFlush(link netlink.Link) error {
 	return nil
 }
 
+// LinkSetHardwareAddr sets hardware addresses on the given link
+func LinkSetHardwareAddr(link netlink.Link, macAddress net.HardwareAddr) error {
+	err := netLinkOps.LinkSetHardwareAddr(link, macAddress)
+	if err != nil {
+		return fmt.Errorf("failed to add address %s on link %s: %v", macAddress.String(), link.Attrs().Name, err)
+	}
+	return nil
+}
+
 // LinkAddrExist returns true if the given address is present on the link
 func LinkAddrExist(link netlink.Link, address *net.IPNet) (bool, error) {
 	addrs, err := netLinkOps.AddrList(link, getFamily(address.IP))


### PR DESCRIPTION
    Using br-local with NORMAL action wasn't working because both ports have the same MACUsing.
    This PR sets the annotation so that the OVN GR will use a different MAC address

Signed-off-by: Michael Cambria <mcambria@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->