### PR TITLE
Bug 1870867: Fix br-local duplicate MAC

### DIFF
--- a/go-controller/pkg/node/gateway_localnet.go
+++ b/go-controller/pkg/node/gateway_localnet.go
@@ -37,6 +37,7 @@ const (
 	// translates to the br-nexthop's IP address
 	localnetGatewayNextHopMac = "00:00:a9:fe:21:01"
 	iptableNodePortChain      = "OVN-KUBE-NODEPORT"
+	localnetGatewayMac        = "00:00:a9:fe:21:02"
 )
 
 type iptRule struct {
@@ -185,11 +186,13 @@ func initLocalnetGateway(nodeName string, subnet *net.IPNet, wf *factory.WatchFa
 		return err
 	}
 
+	gwMacAddress, _ := net.ParseMAC(localnetGatewayMac)
+
 	err = util.SetL3GatewayConfig(nodeAnnotator, &util.L3GatewayConfig{
 		Mode:           config.GatewayModeLocal,
 		ChassisID:      chassisID,
 		InterfaceID:    ifaceID,
-		MACAddress:     macAddress,
+		MACAddress:     gwMacAddress,
 		IPAddresses:    []*net.IPNet{gatewayIPCIDR},
 		NextHops:       []net.IP{gatewayNextHop},
 		NodePortEnable: config.Gateway.NodeportEnable,


### PR DESCRIPTION
Using br-local with NORMAL action wasn't working because both ports have the same MACUsing.
    This PR sets the annotation so that the OVN GR will use a different MAC address