### PR TITLE
Bug 1868501: Do not default HO cluster subnets

### DIFF
--- a/go-controller/hybrid-overlay/pkg/controller/node_linux_test.go
+++ b/go-controller/hybrid-overlay/pkg/controller/node_linux_test.go
@@ -317,7 +317,7 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 				// Assume fresh OVS bridge
 				Output: "",
 			})
-
+			config.HybridOverlay.RawClusterSubnets = "10.0.0.1/16/23"
 			_, err := config.InitConfig(ctx, fexec, nil)
 			Expect(err).NotTo(HaveOccurred())
 

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -93,9 +93,7 @@ var (
 	}
 
 	// HybridOverlay holds hybrid overlay feature config options.
-	HybridOverlay = HybridOverlayConfig{
-		RawClusterSubnets: "10.132.0.0/14/23",
-	}
+	HybridOverlay HybridOverlayConfig
 
 	// NbctlDaemon enables ovn-nbctl to run in daemon mode
 	NbctlDaemonMode bool
@@ -1040,12 +1038,14 @@ func buildHybridOverlayConfig(ctx *cli.Context, cli, file *config, allSubnets *c
 
 	if HybridOverlay.Enabled {
 		var err error
-		HybridOverlay.ClusterSubnets, err = ParseClusterSubnetEntries(HybridOverlay.RawClusterSubnets)
-		if err != nil {
-			return fmt.Errorf("hybrid overlay cluster subnet invalid: %v", err)
-		}
-		for _, subnet := range HybridOverlay.ClusterSubnets {
-			allSubnets.append(configSubnetHybrid, subnet.CIDR)
+		if len(HybridOverlay.RawClusterSubnets) > 0 {
+			HybridOverlay.ClusterSubnets, err = ParseClusterSubnetEntries(HybridOverlay.RawClusterSubnets)
+			if err != nil {
+				return fmt.Errorf("hybrid overlay cluster subnet invalid: %v", err)
+			}
+			for _, subnet := range HybridOverlay.ClusterSubnets {
+				allSubnets.append(configSubnetHybrid, subnet.CIDR)
+			}
 		}
 	}
 


### PR DESCRIPTION
The hybrid-overlay-cluster-subnets argument is not required to have a
value for hybrid overlay to work. It is only required when using Windows
nodes that are part of the cluster. It is not required when sending to
3rd party gateways. This patch removes the default subnet value for the
arg.

Signed-off-by: Tim Rozet <trozet@redhat.com>
(cherry picked from commit d117020089abafbc0ffa7b32a27e776efd18e963)
