### PR TITLE
Bug 1875282: [release-4.4] Bump OVS and OVN

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,8 +39,8 @@ RUN INSTALL_PKGS=" \
 	tcpdump \
 	" && \
 	yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False $INSTALL_PKGS && \
-	yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False "openvswitch2.13 >= 2.13.0-29.el7fdp" openvswitch2.13-devel && \
-	yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False "ovn2.13 >= 2.13.0-31" ovn2.13-central ovn2.13-host ovn2.13-vtep && \
+	yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False "openvswitch2.13 >= 2.13.0-44.el7fdp" openvswitch2.13-devel && \
+	yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False "ovn2.13 >= 20.06.2-3" ovn2.13-central ovn2.13-host ovn2.13-vtep && \
 	yum clean all && rm -rf /var/cache/*
 
 RUN mkdir -p /var/run/openvswitch && \


### PR DESCRIPTION
Release-4.4 back-port of https://github.com/openshift/ovn-kubernetes/pull/271 needed for fixing errors in ovn-controller such as:

```
2020-09-03T06:28:52Z|00209|ovsdb_idl|WARN|transaction error: {"details":"inconsistent data","error":"ovsdb error"}
```

/hold 

because it needs to go in after: https://github.com/openshift/cluster-network-operator/pull/781 so that we make sure that we can upgrade the OVN NB/SB DB

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->