### PR TITLE
Bug 1880591: Allow local no bridge

### DIFF
--- a/go-controller/pkg/node/OCP_HACKS.go
+++ b/go-controller/pkg/node/OCP_HACKS.go
@@ -3,10 +3,17 @@
 package node
 
 import (
+	"fmt"
+	"net"
+
 	"github.com/coreos/go-iptables/iptables"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 )
 
-// OCP HACK: Block MCS Access. https://github.com/openshift/ovn-kubernetes/pull/170
+// Block MCS Access. https://github.com/openshift/ovn-kubernetes/pull/170
 func generateBlockMCSRules(rules *[]iptRule, protocol iptables.Protocol) {
 	*rules = append(*rules, iptRule{
 		table:    "filter",
@@ -34,4 +41,38 @@ func generateBlockMCSRules(rules *[]iptRule, protocol iptables.Protocol) {
 	})
 }
 
-// END OCP HACK
+// initSharedGatewayNoBridge is used in order to run local gateway mode without moving the NIC to an ovs bridge
+// https://github.com/openshift/ovn-kubernetes/pull/281
+func (n *OvnNode) initSharedGatewayNoBridge(subnets []*net.IPNet, gwNextHops []net.IP, nodeAnnotator kube.Annotator) (postWaitFunc, error) {
+	err := setupLocalNodeAccessBridge(n.name, subnets)
+	if err != nil {
+		return nil, err
+	}
+	chassisID, err := util.GetNodeChassisID()
+	if err != nil {
+		return nil, err
+	}
+	// get the real default interface
+	defaultGatewayIntf, _, err := getDefaultGatewayInterfaceDetails()
+	if err != nil {
+		return nil, err
+	}
+	ips, err := getNetworkInterfaceIPAddresses(defaultGatewayIntf)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get interface details for %s (%v)",
+			defaultGatewayIntf, err)
+	}
+	err = util.SetL3GatewayConfig(nodeAnnotator, &util.L3GatewayConfig{
+		ChassisID:      chassisID,
+		Mode:           config.GatewayModeLocal,
+		IPAddresses:    ips,
+		MACAddress:     util.IPAddrToHWAddr(ips[0].IP),
+		NextHops:       gwNextHops,
+		NodePortEnable: config.Gateway.NodeportEnable,
+	})
+	if err != nil {
+		return nil, err
+	} else {
+		return func() error { return nil }, nil
+	}
+}

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -522,7 +522,13 @@ func (n *OvnNode) initSharedGateway(subnets []*net.IPNet, gwNextHops []net.IP, g
 	var brCreated bool
 	var err error
 
-	if bridgeName, _, err = util.RunOVSVsctl("--", "port-to-br", gwIntf); err == nil {
+	// OCP HACK
+	// Do not configure OVS bridge for local gateway mode with a gateway iface of none
+	// For 4.5->4.6 migration, see 	https://github.com/openshift/ovn-kubernetes/pull/281
+	if gwIntf == "none" {
+		return n.initSharedGatewayNoBridge(subnets, gwNextHops, nodeAnnotator)
+		// END OCP HACK
+	} else if bridgeName, _, err = util.RunOVSVsctl("--", "port-to-br", gwIntf); err == nil {
 		// This is an OVS bridge's internal port
 		uplinkName, err = util.GetNicName(bridgeName)
 		if err != nil {

--- a/go-controller/pkg/ovn/OCP_HACKS.go
+++ b/go-controller/pkg/ovn/OCP_HACKS.go
@@ -1,0 +1,97 @@
+package ovn
+
+import (
+	"fmt"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	kapi "k8s.io/api/core/v1"
+	"strings"
+)
+
+// isGatewayInterfaceNone is used to determine if this is a local gateway mode with a "none" gateway interface
+// this indicates if we are in an upgrade mode from 4.5->4.6 where the GR would not exist.
+// See https://github.com/openshift/ovn-kubernetes/pull/281
+func isGatewayInterfaceNone() bool {
+	return config.Gateway.Interface == "none"
+}
+
+// createNodePortLoadBalancers is just a copy of the current node balancer code that will not be invoked during
+// local gateway mode + gateway-interface of "none". So we need to still create them ourselves on for the node
+// switches (since they will not be created on the GR)
+// See https://github.com/openshift/ovn-kubernetes/pull/281
+func createNodePortLoadBalancers(gatewayRouter, nodeName string, sctpSupport bool) error {
+	// Create 3 load-balancers for north-south traffic for each gateway
+	// router: UDP, TCP, SCTP
+	k8sNSLbTCP, k8sNSLbUDP, k8sNSLbSCTP, err := getGatewayLoadBalancers(gatewayRouter)
+	if err != nil {
+		return err
+	}
+	protoLBMap := map[kapi.Protocol]string{
+		kapi.ProtocolTCP:  k8sNSLbTCP,
+		kapi.ProtocolUDP:  k8sNSLbUDP,
+		kapi.ProtocolSCTP: k8sNSLbSCTP,
+	}
+	enabledProtos := []kapi.Protocol{kapi.ProtocolTCP, kapi.ProtocolUDP}
+	if sctpSupport {
+		enabledProtos = append(enabledProtos, kapi.ProtocolSCTP)
+	}
+	var stdout, stderr string
+	for _, proto := range enabledProtos {
+		if protoLBMap[proto] == "" {
+			protoLBMap[proto], stderr, err = util.RunOVNNbctl("--", "create",
+				"load_balancer",
+				fmt.Sprintf("external_ids:%s_lb_gateway_router=%s", proto, gatewayRouter),
+				fmt.Sprintf("protocol=%s", strings.ToLower(string(proto))))
+			if err != nil {
+				return fmt.Errorf("failed to create load balancer for gateway router %s for protocol %s: "+
+					"stderr: %q, error: %v", gatewayRouter, proto, stderr, err)
+			}
+		}
+	}
+
+	// Local gateway mode does not use GR for ingress node port traffic, it uses mp0 instead
+	if config.Gateway.Mode != config.GatewayModeLocal {
+		// Add north-south load-balancers to the gateway router.
+		lbString := fmt.Sprintf("%s,%s", protoLBMap[kapi.ProtocolTCP], protoLBMap[kapi.ProtocolUDP])
+		if sctpSupport {
+			lbString = lbString + "," + protoLBMap[kapi.ProtocolSCTP]
+		}
+		stdout, stderr, err = util.RunOVNNbctl("set", "logical_router", gatewayRouter, "load_balancer="+lbString)
+		if err != nil {
+			return fmt.Errorf("failed to set north-south load-balancers to the "+
+				"gateway router %s, stdout: %q, stderr: %q, error: %v",
+				gatewayRouter, stdout, stderr, err)
+		}
+	}
+	// Also add north-south load-balancers to local switches for pod -> nodePort traffic
+	stdout, stderr, err = util.RunOVNNbctl("get", "logical_switch", nodeName, "load_balancer")
+	if err != nil {
+		return fmt.Errorf("failed to get load-balancers on the node switch %s, stdout: %q, "+
+			"stderr: %q, error: %v", nodeName, stdout, stderr, err)
+	}
+	for _, proto := range enabledProtos {
+		if !strings.Contains(stdout, protoLBMap[proto]) {
+			stdout, stderr, err = util.RunOVNNbctl("ls-lb-add", nodeName, protoLBMap[proto])
+			if err != nil {
+				return fmt.Errorf("failed to add north-south load-balancer %s to the "+
+					"node switch %s, stdout: %q, stderr: %q, error: %v",
+					protoLBMap[proto], nodeName, stdout, stderr, err)
+			}
+		}
+	}
+	return nil
+}
+
+// gatewayInitMinimal sets up the minimal configuration needed for N/S traffic to work in Local gateway mode. In this
+// case we do not need any GR or join switch, just nodePort load balancers on the node switch
+// See https://github.com/openshift/ovn-kubernetes/pull/281
+func gatewayInitMinimal(nodeName string, l3GatewayConfig *util.L3GatewayConfig, sctpSupport bool) error {
+	gatewayRouter := gwRouterPrefix + nodeName
+	if l3GatewayConfig.NodePortEnable {
+		err := createNodePortLoadBalancers(gatewayRouter, nodeName, sctpSupport)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
For OCP we upgrade CNO before MCO. This means that ovn-k8s will get upgraded first when 4.5->4.6 upgrade happens and will try to create a bridge for local gateway mode now. We have to have an intermediate step where we do not create a shared gateway bridge until after the node reboots with ovs-configuration. Therefore this downstream only patch allows us to launch local gateway mode with no shared gateway bridge, and it should still function during upgrade.