### PR TITLE
Bug 1882092: Pin 4.5 OVN to 4.4.24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,13 +40,11 @@ RUN INSTALL_PKGS=" \
 	" && \
 	yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False $INSTALL_PKGS && \
 	yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False "openvswitch2.13 >= 2.13.0-29.el7fdp" openvswitch2.13-devel && \
-	# OVN-Kubernetes 4.5.7 comes shipped with these OVN versions. Since we can't support SB/NB DB upgrades for now, pin the version so that we don't block 4.5.8 upgrades 
-	#======== 4.5.7 ========
-	#ovn2.13-2.13.0-39.el7fdp.x86_64
-	#ovn2.13-central-2.13.0-39.el7fdp.x86_64
-	#ovn2.13-host-2.13.0-39.el7fdp.x86_64
-	#ovn2.13-vtep-2.13.0-39.el7fdp.x86_64
-	yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False "ovn2.13 == 2.13.0-39.el7fdp" "ovn2.13-central == 2.13.0-39.el7fdp" "ovn2.13-host == 2.13.0-39.el7fdp" "ovn2.13-vtep == 2.13.0-39.el7fdp" && \
+	# OVN-Kubernetes 4.4.24 comes shipped with these OVN versions.
+	#======== 4.4.24 version ========
+	# ovn2.13-20.06.2-4.el7fdp.x86_64
+	# We need to pin to the 4.4.24 version
+	yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False "ovn2.13 == 20.06.2-4.el7fdp" "ovn2.13-central == 20.06.2-4.el7fdp" "ovn2.13-host == 20.06.2-4.el7fdp" "ovn2.13-vtep == 20.06.2-4.el7fdp" && \
 	yum clean all && rm -rf /var/cache/*
 
 RUN mkdir -p /var/run/openvswitch && \


### PR DESCRIPTION
https://github.com/openshift/ovn-kubernetes/pull/283 pins OVN to 20.06.2-4.el7fdp so we pin 4.5 to the same version

/assign @dcbw @trozet 

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->