### PR TITLE
[DNM]: Consider changed configuration when kicking out raft members

### DIFF
--- a/dist/templates/ovnkube-db.yaml.j2
+++ b/dist/templates/ovnkube-db.yaml.j2
@@ -48,6 +48,7 @@ spec:
   template:
     metadata:
       labels:
+        app: ovnkube-db
         name: ovnkube-db
         component: network
         type: infra

--- a/go-controller/pkg/ovndbmanager/ovndbmanager.go
+++ b/go-controller/pkg/ovndbmanager/ovndbmanager.go
@@ -10,27 +10,29 @@ import (
 	"sync"
 	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/klog"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 )
 
-func RunDBChecker(stopCh <-chan struct{}) {
+func RunDBChecker(kclient kube.Interface, stopCh <-chan struct{}) {
 	defer utilruntime.HandleCrash()
 	klog.Info("Starting DB Checker to ensure cluster membership and DB consistency")
 	wg := &sync.WaitGroup{}
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		ensureOvnDBState(util.OvnNbdbLocation, stopCh)
+		ensureOvnDBState(util.OvnNbdbLocation, kclient, stopCh)
 	}()
 
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		ensureOvnDBState(util.OvnSbdbLocation, stopCh)
+		ensureOvnDBState(util.OvnSbdbLocation, kclient, stopCh)
 	}()
 	<-stopCh
 	klog.Info("Shutting down db checker")
@@ -38,7 +40,7 @@ func RunDBChecker(stopCh <-chan struct{}) {
 	klog.Info("Shut down db checker")
 }
 
-func ensureOvnDBState(db string, stopCh <-chan struct{}) {
+func ensureOvnDBState(db string, kclient kube.Interface, stopCh <-chan struct{}) {
 	ticker := time.NewTicker(60 * time.Second)
 	klog.Infof("Starting ensure routine for Raft db: %s", db)
 	_, _, err := util.RunOVSDBTool("db-is-standalone", db)
@@ -62,7 +64,7 @@ func ensureOvnDBState(db string, stopCh <-chan struct{}) {
 		case <-ticker.C:
 			klog.V(5).Infof("Ensure routines for Raft db: %s kicked off by ticker", db)
 			ensureLocalRaftServerID(db)
-			ensureClusterRaftMembership(db)
+			ensureClusterRaftMembership(db, kclient)
 			ensureDBHealth(db)
 		case <-stopCh:
 			ticker.Stop()
@@ -128,7 +130,7 @@ func ensureLocalRaftServerID(db string) {
 }
 
 // ensureClusterRaftMembership ensures there are no unknown members in the current Raft cluster
-func ensureClusterRaftMembership(db string) {
+func ensureClusterRaftMembership(db string, kclient kube.Interface) {
 	var knownMembers, knownServers []string
 
 	var dbName string
@@ -159,6 +161,15 @@ func ensureClusterRaftMembership(db string) {
 	r, _ := regexp.Compile(`([a-z0-9]{4}) at ((ssl|tcp):\[?[a-z0-9.:]+\]?)`)
 	members := r.FindAllStringSubmatch(out, -1)
 	kickedMembersCount := 0
+	dbAppLabel := map[string]string{"app": "ovnkube-db"}
+	dbPods, err := kclient.GetPods(config.Kubernetes.OVNConfigNamespace,
+		metav1.LabelSelector{
+			MatchLabels: dbAppLabel,
+		})
+	if err != nil {
+		klog.Warningf("Unable to get db pod list from kubeclient: %v", err)
+		return
+	}
 	for _, member := range members {
 		if len(member) < 3 {
 			klog.Warningf("Unable to find parse member: %s", member)
@@ -174,6 +185,16 @@ func ensureClusterRaftMembership(db string) {
 			if knownServer == matchedServer[1] {
 				memberFound = true
 				break
+			}
+		}
+		if !memberFound {
+			for _, dbPod := range dbPods.Items {
+				for _, ip := range dbPod.Status.PodIPs {
+					if ip.IP == matchedServer[1] {
+						memberFound = true
+						break
+					}
+				}
 			}
 		}
 		if !memberFound && (len(members)-kickedMembersCount) > 3 {

--- a/go-controller/pkg/ovndbmanager/ovndbmanager.go
+++ b/go-controller/pkg/ovndbmanager/ovndbmanager.go
@@ -189,9 +189,13 @@ func ensureClusterRaftMembership(db string, kclient kube.Interface) {
 		}
 		if !memberFound {
 			for _, dbPod := range dbPods.Items {
+				klog.Infof("Checking for matching IP: %s for pod: %s - %v", matchedServer[1],
+					dbPod.Name, dbPod.Status.PodIPs)
 				for _, ip := range dbPod.Status.PodIPs {
 					if ip.IP == matchedServer[1] {
 						memberFound = true
+						klog.Infof("Matching IP: %s found pod: %s - %s", matchedServer[1],
+							dbPod.Name, ip.IP)
 						break
 					}
 				}

--- a/go-controller/pkg/ovndbmanager/ovndbmanager.go
+++ b/go-controller/pkg/ovndbmanager/ovndbmanager.go
@@ -161,7 +161,7 @@ func ensureClusterRaftMembership(db string, kclient kube.Interface) {
 	r, _ := regexp.Compile(`([a-z0-9]{4}) at ((ssl|tcp):\[?[a-z0-9.:]+\]?)`)
 	members := r.FindAllStringSubmatch(out, -1)
 	kickedMembersCount := 0
-	dbAppLabel := map[string]string{"app": "ovnkube-db"}
+	dbAppLabel := map[string]string{"db-pod": "true"}
 	dbPods, err := kclient.GetPods(config.Kubernetes.OVNConfigNamespace,
 		metav1.LabelSelector{
 			MatchLabels: dbAppLabel,


### PR DESCRIPTION
In certain use-cases such as master replacement, we have seen
that the configuration of the db/master pods that holds the addresses
of the raft members isn't updated by the time the new master joins the
raft cluster. When this happens the db pods carrying the old address
configuration for nbdb and sbdb would kick the newly joined master out.
This commit addresses this issue by additionally checking existing master
pods' IPs against the server id list for determining whether a given
server id should be booted out of the raft cluster.

Signed-off-by: Aniket Bhat <anbhat@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->