### PR TITLE
Updating ose-ovn-kubernetes builder & base images to be consistent with ART

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@
 # are built in this Dockerfile and included in the image (instead of the rpm)
 #
 
-FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.6 AS builder
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.7 AS builder
 
 WORKDIR /go/src/github.com/openshift/ovn-kubernetes
 COPY . .
@@ -18,9 +18,9 @@ COPY . .
 RUN cd go-controller; CGO_ENABLED=0 make
 RUN cd go-controller; CGO_ENABLED=0 make windows
 
-FROM registry.svc.ci.openshift.org/ocp/4.6:cli AS cli
+FROM registry.svc.ci.openshift.org/ocp/4.7:cli AS cli
 
-FROM registry.svc.ci.openshift.org/ocp/4.6:base
+FROM registry.svc.ci.openshift.org/ocp/4.7:base
 
 USER root
 


### PR DESCRIPTION
Updating ose-ovn-kubernetes builder & base images to be consistent with ART
Reconciling with https://github.com/openshift/ocp-build-data/tree/f66c03011773dc3755ad874fc691be612914d65f/images/ose-ovn-kubernetes.yml

If you have any questions about this pull request, please reach out to `@art-team` in the `#aos-art` coreos slack channel.

Depends on https://github.com/openshift/images/pull/44 . Allow it to merge and then run `/test all` on this PR.