### PR TITLE
Bug 1885517: Clean up old local gw mode external ports

### DIFF
--- a/go-controller/pkg/ovn/gateway_init.go
+++ b/go-controller/pkg/ovn/gateway_init.go
@@ -212,6 +212,10 @@ func gatewayInit(nodeName string, clusterIPSubnet []*net.IPNet, hostSubnets []*n
 			"stderr: %q, error: %v", externalSwitch, stdout, stderr, err)
 	}
 
+	// OCP HACK - clean up old local gateway port that might still be in DB
+	cleanOldLocalGWPort(nodeName)
+	// END OCP HACK
+
 	// Add external interface as a logical port to external_switch.
 	// This is a learning switch port with "unknown" address. The external
 	// world is accessed via this port.


### PR DESCRIPTION
When we upgrade from 4.5->4.6 we transition from the old local gateway
mode to the new. In this case, OVS is clean when 4.6 comes up, but OVN
DB still has a leftover "br-local" port that exists on the external
switch. ovn-controller will try to wire this port to br-int, creating
double patch ports between br-ex and br-int, thus causing a broadcast
storm.

This patch ensures we remove the old port from OVN NB DB, which
ovn-controller will then ensure is removed from the external switch.

Signed-off-by: Tim Rozet <trozet@redhat.com>

