### PR TITLE
Bug 1880591: Fixes race during 4.5->4.6 upgrade with ovn node and master

### DIFF
--- a/go-controller/pkg/node/OCP_HACKS.go
+++ b/go-controller/pkg/node/OCP_HACKS.go
@@ -65,6 +65,7 @@ func (n *OvnNode) initSharedGatewayNoBridge(subnets []*net.IPNet, gwNextHops []n
 	err = util.SetL3GatewayConfig(nodeAnnotator, &util.L3GatewayConfig{
 		ChassisID:      chassisID,
 		Mode:           config.GatewayModeLocal,
+		InterfaceID:    "br-local" + "_" + n.name,
 		IPAddresses:    ips,
 		MACAddress:     util.IPAddrToHWAddr(ips[0].IP),
 		NextHops:       gwNextHops,


### PR DESCRIPTION
When an ovnkube-node upgrades, it annotates its gateway config onto the
kubernets node object. When ovnkube-master sees this node add/update
event it then will try to sync its gateway configuration in OVN. In
ovnkube-master 4.6, if we see a node that is in a 4.5 state, but its pod
is a 4.6 ovnkube-pod we will ignore doing any OVN gateway config on it.
However, this patch addresses a case where 4.6 ovnkube-node upgraded,
started, and annotated its node, before ovnkube-master pod was upgraded
to 4.6. In that case the old 4.5 ovnkube-master code will try to create
a gateway interface, for the updated node, and we were never setting
that interface ID. Thus, OVN would get a new port with an empty name in
addition to its already configured br-local port and not know which one
to use. If it picks the "new port" then kapi access will stop working.

This patch works around this potential race by setting the node
annotation to the old interface value in 4.6 ovnkube-node so that if we
hit this race, the old ovnkube-master code will not create an empty
additional port in OVN.

Signed-off-by: Tim Rozet <trozet@redhat.com>

