### PR TITLE
Add missing python3-pyOpenSSL library

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN yum install -y  \
 	yum clean all
 
 RUN INSTALL_PKGS=" \
-	openssl firewalld-filesystem \
+	openssl python3-pyOpenSSL firewalld-filesystem \
 	libpcap iproute strace \
 	containernetworking-plugins \
 	tcpdump iputils \


### PR DESCRIPTION
This PR adds python3-pyOpenSSL to the Dockerfile, needed for ovn-detrace to
work with ssl endpoints.

