### PR TITLE
[master] Bump OVN to 20.09.0-7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,11 +32,8 @@ RUN yum install -y  \
 	selinux-policy && \
 	yum clean all
 
-#======== 4.6.0-0.nightly-2020-09-25-070943 Version ========
-# ovn2.13-20.06.2-11.el8fdp.x86_64
-# openvswitch2.13-2.13.0-57.el8fdp
 ARG ovsver=2.13.0-57.el8fdp
-ARG ovnver=20.06.2-11.el8fdp
+ARG ovnver=20.09.0-7.el8fdn
 
 RUN INSTALL_PKGS=" \
 	openssl firewalld-filesystem \

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,12 @@ RUN yum install -y  \
 	selinux-policy && \
 	yum clean all
 
+#======== 4.6.0-0.nightly-2020-09-25-070943 Version ========
+# ovn2.13-20.06.2-11.el8fdp.x86_64
+# openvswitch2.13-2.13.0-57.el8fdp
+ARG ovsver=2.13.0-57.el8fdp
+ARG ovnver=20.06.2-11.el8fdp
+
 RUN INSTALL_PKGS=" \
 	openssl firewalld-filesystem \
 	libpcap iproute strace \
@@ -39,11 +45,8 @@ RUN INSTALL_PKGS=" \
 	tcpdump iputils \
 	" && \
 	yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False $INSTALL_PKGS && \
-	#======== 4.6.0-0.nightly-2020-09-25-070943 Version ========
-	# ovn2.13-20.06.2-11.el8fdp.x86_64
-	# openvswitch2.13-2.13.0-57.el8fdp
-	yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False "openvswitch2.13 == 2.13.0-57.el8fdp" "openvswitch2.13-devel == 2.13.0-57.el8fdp" "python3-openvswitch2.13 == 2.13.0-57.el8fdp" && \
-	yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False "ovn2.13 == 20.06.2-11.el8fdp" "ovn2.13-central == 20.06.2-11.el8fdp" "ovn2.13-host == 20.06.2-11.el8fdp" "ovn2.13-vtep == 20.06.2-11.el8fdp" && \
+	yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False "openvswitch2.13 == $ovsver" "openvswitch2.13-devel == $ovsver" "python3-openvswitch2.13 == $ovsver" && \
+	yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False "ovn2.13 == $ovnver" "ovn2.13-central == $ovnver" "ovn2.13-host == $ovnver" "ovn2.13-vtep == $ovnver" && \
 	yum clean all && rm -rf /var/cache/*
 
 RUN mkdir -p /var/run/openvswitch && \


### PR DESCRIPTION
We have good signal for this build in 4.6 via https://github.com/openshift/ovn-kubernetes/pull/324 so we're pretty sure this OVN is solid.

@trozet