### PR TITLE
[wip] cni: disallow overlapping sandbox operations

### DIFF
--- a/go-controller/pkg/cni/types.go
+++ b/go-controller/pkg/cni/types.go
@@ -2,6 +2,7 @@ package cni
 
 import (
 	"net/http"
+	"sync"
 
 	"github.com/containernetworking/cni/pkg/types/current"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/cni/types"
@@ -85,4 +86,9 @@ type Server struct {
 	requestFunc cniRequestFunc
 	rundir      string
 	kclient     kubernetes.Interface
+
+	// Pod list and lock to prevent overlapping ADD/DEL of same pod for
+	// different sandboxes. Map of "<namespace>/<name>" to sandbox ID
+	podsLock sync.Mutex
+	pods     map[string]string
 }


### PR DESCRIPTION
Seen in OpenShift CI while running Kube e2e tests:

```
I1102 04:32:21.153987    2365 cniserver.go:147] Waiting for ADD result for pod e2e-statefulset-9850/ss2-0
I1102 04:32:21.154009    2365 cni.go:147] [e2e-statefulset-9850/ss2-0] dispatching pod network request &{ADD e2e-statefulset-9850 ss2-0 481471f123841fdadc38b94994288fa8f7358e4af4eba91ebeb5d86382964706 /var/run/netns/77679d70-26e5-40ea-a567-52ae34ed8bae eth0 0xc001e43100}
I1102 04:32:22.501855    2365 cni.go:157] [e2e-statefulset-9850/ss2-0] CNI request &{ADD e2e-statefulset-9850 ss2-0 481471f123841fdadc38b94994288fa8f7358e4af4eba91ebeb5d86382964706 /var/run/netns/77679d70-26e5-40ea-a567-52ae34ed8bae eth0 0xc001e43100}, result "{\"Result\":{\"interfaces\":[{\"name\":\"481471f123841fd\",\"mac\":\"9a:2a:d9:50:d4:84\"},{\"name\":\"eth0\",\"mac\":\"0a:58:0a:81:02:43\",\"sandbox\":\"/var/run/netns/77679d70-26e5-40ea-a567-52ae34ed8bae\"}],\"ips\":[{\"version\":\"4\",\"interface\":1,\"address\":\"10.129.2.67/23\",\"gateway\":\"10.129.2.1\"}],\"dns\":{}},\"PodIFInfo\":null}", err <nil>
I1102 04:33:09.952174    2365 cniserver.go:147] Waiting for ADD result for pod e2e-statefulset-9850/ss2-0
I1102 04:33:09.952200    2365 cni.go:147] [e2e-statefulset-9850/ss2-0] dispatching pod network request &{ADD e2e-statefulset-9850 ss2-0 dddf4b94a831ae5867d739480a7ed17b88d4efae4f3c046ec5583c04d8b7eb67 /var/run/netns/103cafe5-813d-4b00-9657-09495b2dce10 eth0 0xc002885c00}
I1102 04:33:11.718732    2365 cni.go:157] [e2e-statefulset-9850/ss2-0] CNI request &{ADD e2e-statefulset-9850 ss2-0 dddf4b94a831ae5867d739480a7ed17b88d4efae4f3c046ec5583c04d8b7eb67 /var/run/netns/103cafe5-813d-4b00-9657-09495b2dce10 eth0 0xc002885c00}, result "{\"Result\":{\"interfaces\":[{\"name\":\"dddf4b94a831ae5\",\"mac\":\"ce:ca:62:23:67:c8\"},{\"name\":\"eth0\",\"mac\":\"0a:58:0a:81:02:5b\",\"sandbox\":\"/var/run/netns/103cafe5-813d-4b00-9657-09495b2dce10\"}],\"ips\":[{\"version\":\"4\",\"interface\":1,\"address\":\"10.129.2.91/23\",\"gateway\":\"10.129.2.1\"}],\"dns\":{}},\"PodIFInfo\":null}", err <nil>
I1102 04:33:12.201995    2365 cniserver.go:147] Waiting for DEL result for pod e2e-statefulset-9850/ss2-0
I1102 04:33:12.202019    2365 cni.go:147] [e2e-statefulset-9850/ss2-0] dispatching pod network request &{DEL e2e-statefulset-9850 ss2-0 481471f123841fdadc38b94994288fa8f7358e4af4eba91ebeb5d86382964706 /var/run/netns/77679d70-26e5-40ea-a567-52ae34ed8bae eth0 0xc0021f7000}
I1102 04:33:12.337285    2365 cni.go:157] [e2e-statefulset-9850/ss2-0] CNI request &{DEL e2e-statefulset-9850 ss2-0 481471f123841fdadc38b94994288fa8f7358e4af4eba91ebeb5d86382964706 /var/run/netns/77679d70-26e5-40ea-a567-52ae34ed8bae eth0 0xc0021f7000}, result "", err <nil>
I1102 04:34:28.766922    2365 cniserver.go:147] Waiting for DEL result for pod e2e-statefulset-9850/ss2-0
I1102 04:34:28.766947    2365 cni.go:147] [e2e-statefulset-9850/ss2-0] dispatching pod network request &{DEL e2e-statefulset-9850 ss2-0 dddf4b94a831ae5867d739480a7ed17b88d4efae4f3c046ec5583c04d8b7eb67 /var/run/netns/103cafe5-813d-4b00-9657-09495b2dce10 eth0 0xc001782b00}
I1102 04:34:29.273686    2365 cni.go:157] [e2e-statefulset-9850/ss2-0] CNI request &{DEL e2e-statefulset-9850 ss2-0 dddf4b94a831ae5867d739480a7ed17b88d4efae4f3c046ec5583c04d8b7eb67 /var/run/netns/103cafe5-813d-4b00-9657-09495b2dce10 eth0 0xc001782b00}, result "", err <nil>

Clearly trying to run ADD for the same pod twice, but for a different sandbox isn't
going to work very well since we track our OVN resources (like iface-id) on a per-
pod basis, not a per-sandbox one. Just don't allow this, and let the runtime
retry the request for the second sandbox after it's DEL-ed the first one.
```