### PR TITLE
[WIP] Directly load balance traffic to cloud load balancers

### DIFF
--- a/go-controller/pkg/ovn/endpoints.go
+++ b/go-controller/pkg/ovn/endpoints.go
@@ -106,6 +106,15 @@ func (ovn *Controller) AddEndpoints(ep *kapi.Endpoints) error {
 					}
 				}
 			}
+			// Cloud load balancers: directly load balance that traffic from pods
+			for _, ing := range svc.Status.LoadBalancer.Ingress {
+				if ing.IP == "" {
+					continue
+				}
+				if err = ovn.createLoadBalancerVIPs(loadBalancer, []string{ing.IP}, svcPort.Port, lbEps.IPs, lbEps.Port); err != nil {
+					klog.Errorf("Error in creating Ingress LB IP for svc %s, target port: %d - %v\n", svc.Name, lbEps.Port, err)
+				}
+			}
 		}
 	}
 	return nil
@@ -196,6 +205,27 @@ func (ovn *Controller) deleteEndpoints(ep *kapi.Endpoints) error {
 		if err != nil {
 			klog.Errorf("Error in deleting endpoints for lb %s: %v", lb, err)
 		}
+
+		// Cloud load balancers: directly reject traffic from pods
+		for _, ing := range svc.Status.LoadBalancer.Ingress {
+			if ing.IP == "" {
+				continue
+			}
+			if ovn.svcQualifiesForReject(svc) {
+				aclUUID, err := ovn.createLoadBalancerRejectACL(lb, ing.IP, svcPort.Port, svcPort.Protocol)
+				if err != nil {
+					klog.Errorf("Failed to create reject ACL for Ingress IP: %s, load balancer: %s, error: %v",
+						ing.IP, lb, err)
+				} else {
+					klog.Infof("Reject ACL created for Ingress IP: %s, load balancer: %s, %s", ing.IP, lb, aclUUID)
+				}
+			}
+			err := ovn.configureLoadBalancer(lb, ing.IP, svcPort.Port, nil)
+			if err != nil {
+				klog.Errorf("Error in deleting endpoints for lb %s: %v", lb, err)
+			}
+		}
+
 		vip := util.JoinHostPortInt32(svc.Spec.ClusterIP, svcPort.Port)
 		ovn.removeServiceEndpoints(lb, vip)
 

--- a/go-controller/pkg/ovn/service.go
+++ b/go-controller/pkg/ovn/service.go
@@ -108,6 +108,18 @@ func (ovn *Controller) syncServices(services []interface{}) {
 					svcRejectACLs[name] = make(map[string]bool)
 				}
 				svcRejectACLs[name][lb] = hasEndpoints
+
+				// Cloud load balancers: directly load balance that traffic from pods
+				for _, ing := range service.Status.LoadBalancer.Ingress {
+					if ing.IP == "" {
+						continue
+					}
+					name := ovn.generateACLName(lb, ing.IP, svcPort.Port)
+					if _, ok := svcRejectACLs[name]; !ok {
+						svcRejectACLs[name] = make(map[string]bool)
+					}
+					svcRejectACLs[name][lb] = hasEndpoints
+				}
 			}
 			for _, extIP := range service.Spec.ExternalIPs {
 				key := util.JoinHostPortInt32(extIP, svcPort.Port)
@@ -349,7 +361,24 @@ func (ovn *Controller) createService(service *kapi.Service) error {
 					if err != nil {
 						return fmt.Errorf("failed to create service ACL: %v", err)
 					}
-					klog.Infof("Service Reject ACL created for cluster IP: %s", aclUUID)
+
+					klog.Infof("Service Reject ACL created for ClusterIP service: %s, namespace: %s, via: "+
+						"%s:%s:%d, ACL UUID: %s", service.Name, service.Namespace, svcPort.Protocol,
+						service.Spec.ClusterIP, svcPort.Port, aclUUID)
+					// Cloud load balancers: directly reject traffic from pods
+					for _, ing := range service.Status.LoadBalancer.Ingress {
+						if ing.IP == "" {
+							continue
+						}
+						aclUUID, err := ovn.createLoadBalancerRejectACL(loadBalancer, ing.IP, svcPort.Port, svcPort.Protocol)
+						if err != nil {
+							klog.Errorf("Failed to create reject ACL for Ingress IP: %s, load balancer: %s, error: %v",
+								ing.IP, loadBalancer, err)
+						} else {
+							klog.Infof("Reject ACL created for Ingress IP: %s, load balancer: %s, %s", ing.IP,
+								loadBalancer, aclUUID)
+						}
+					}
 				}
 				if len(service.Spec.ExternalIPs) > 0 {
 					gateways, _, err := ovn.getOvnGateways()
@@ -387,8 +416,10 @@ func (ovn *Controller) updateService(oldSvc, newSvc *kapi.Service) error {
 	if reflect.DeepEqual(newSvc.Spec.Ports, oldSvc.Spec.Ports) &&
 		reflect.DeepEqual(newSvc.Spec.ExternalIPs, oldSvc.Spec.ExternalIPs) &&
 		reflect.DeepEqual(newSvc.Spec.ClusterIP, oldSvc.Spec.ClusterIP) &&
-		reflect.DeepEqual(newSvc.Spec.Type, oldSvc.Spec.Type) {
-		klog.V(5).Infof("Skipping service update for: %s as change does not apply to any of .Spec.Ports, .Spec.ExternalIP, .Spec.ClusterIP, .Spec.Type", newSvc.Name)
+		reflect.DeepEqual(newSvc.Spec.Type, oldSvc.Spec.Type) &&
+		reflect.DeepEqual(newSvc.Status.LoadBalancer.Ingress, oldSvc.Status.LoadBalancer.Ingress) {
+		klog.V(5).Infof("Skipping service update for: %s as change does not apply to any of .Spec.Ports, "+
+			".Spec.ExternalIP, .Spec.ClusterIP, .Spec.Type, .Status.LoadBalancer.Ingress", newSvc.Name)
 		return nil
 	}
 
@@ -429,6 +460,16 @@ func (ovn *Controller) deleteService(service *kapi.Service) {
 			vip := util.JoinHostPortInt32(service.Spec.ClusterIP, svcPort.Port)
 			if err := ovn.deleteLoadBalancerVIP(loadBalancer, vip); err != nil {
 				klog.Error(err)
+			}
+			// Cloud load balancers
+			for _, ing := range service.Status.LoadBalancer.Ingress {
+				if ing.IP == "" {
+					continue
+				}
+				ingressVIP := util.JoinHostPortInt32(ing.IP, svcPort.Port)
+				if err := ovn.deleteLoadBalancerVIP(loadBalancer, ingressVIP); err != nil {
+					klog.Error(err)
+				}
 			}
 			if err := ovn.deleteExternalVIPs(service, svcPort); err != nil {
 				klog.Error(err)


### PR DESCRIPTION
Cloud load balancers like Azure and GCP deliver external packets
directly to the hosts without changing the destination IP address.
Therefore we have special iptables rules for handling those packets.
However for traffic sourced from within the cluster (an ovn networked
pod), the current behavior sends the packet out of OVN externally
(either via mp0 in local gw mode, or br-ex in shared gw mode) only to be
circulated back into OVN to be load balanced.

Rather than doing this unnecessary traffic forwarding, make OVN handle
the load balancing directly for the egress pod traffic destined to the
load balancer service.

Signed-off-by: Tim Rozet <trozet@redhat.com>

