### PR TITLE
[WIP] Add metrics for total and available subnets for nodes

### DIFF
--- a/go-controller/pkg/metrics/master.go
+++ b/go-controller/pkg/metrics/master.go
@@ -83,6 +83,34 @@ var MetricMasterLeader = prometheus.NewGauge(prometheus.GaugeOpts{
 	Help:      "Identifies whether the instance of ovnkube-master is a leader(1) or not(0).",
 })
 
+var metricV4HostSubnetCount = prometheus.NewGauge(prometheus.GaugeOpts{
+	Namespace: MetricOvnkubeNamespace,
+	Subsystem: MetricOvnkubeSubsystemMaster,
+	Name:      "num_v4_host_subnets",
+	Help:      "The total number of v4 host subnets possible",
+})
+
+var metricV6HostSubnetCount = prometheus.NewGauge(prometheus.GaugeOpts{
+	Namespace: MetricOvnkubeNamespace,
+	Subsystem: MetricOvnkubeSubsystemMaster,
+	Name:      "num_v6_host_subnets",
+	Help:      "The total number of v6 host subnets possible",
+})
+
+var metricV4AllocatedHostSubnetCount = prometheus.NewGauge(prometheus.GaugeOpts{
+	Namespace: MetricOvnkubeNamespace,
+	Subsystem: MetricOvnkubeSubsystemMaster,
+	Name:      "allocated_v4_host_subnets",
+	Help:      "The total number of v4 host subnets currently allocated",
+})
+
+var metricV6AllocatedHostSubnetCount = prometheus.NewGauge(prometheus.GaugeOpts{
+	Namespace: MetricOvnkubeNamespace,
+	Subsystem: MetricOvnkubeSubsystemMaster,
+	Name:      "allocated_v6_host_subnets",
+	Help:      "The total number of v6 host subnets currently allocated",
+})
+
 var registerMasterMetricsOnce sync.Once
 var startE2ETimeStampUpdaterOnce sync.Once
 
@@ -203,4 +231,17 @@ func RecordPodCreated(pod *kapi.Pod) {
 		metricPodCreationLatency.Observe(creationLatency)
 		return
 	}
+}
+
+// RecordSubnetUsage records the number of subnets allocated for nodes
+func RecordSubnetUsage(v4SubnetsAllocated, v6SubnetsAllocated int) {
+	metricV4AllocatedHostSubnetCount.Set(float64(v4SubnetsAllocated))
+	metricV6AllocatedHostSubnetCount.Set(float64(v6SubnetsAllocated))
+}
+
+// RecordSubnetCount records the number of available subnets per configuration
+// for ovn-kubernetes
+func RecordSubnetCount(v4SubnetCount, v6SubnetCount int) {
+	metricV4HostSubnetCount.Set(float64(v4SubnetCount))
+	metricV6HostSubnetCount.Set(float64(v6SubnetCount))
 }

--- a/go-controller/pkg/metrics/master.go
+++ b/go-controller/pkg/metrics/master.go
@@ -176,6 +176,10 @@ func RegisterMasterMetrics(nbClient, sbClient goovn.Client) {
 			},
 			func() float64 { return 1 },
 		))
+		prometheus.MustRegister(metricV4HostSubnetCount)
+		prometheus.MustRegister(metricV6HostSubnetCount)
+		prometheus.MustRegister(metricV4AllocatedHostSubnetCount)
+		prometheus.MustRegister(metricV6AllocatedHostSubnetCount)
 	})
 }
 

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -186,6 +186,12 @@ type Controller struct {
 
 	// go-ovn southbound client interface
 	ovnSBClient goovn.Client
+
+	// v4HostSubnetsUsed keeps track of number of v4 subnets currently assigned to nodes
+	v4HostSubnetsUsed int
+
+	// v6HostSubnetsUsed keeps track of number of v6 subnets currently assigned to nodes
+	v6HostSubnetsUsed int
 }
 
 const (


### PR DESCRIPTION
This commit adds support for collecting metrics related to subnet
allocation for the node. In particular, metrics for total number
of v4 and v6 subnets allowed in the cluster and metrics for
number of v4 subnets and v6 subnets allocated to nodes are collected

Signed-off-by: Aniket Bhat <anbhat@redhat.com>

/assign
/hold