### PR TITLE
Bug 1885605: backport br-ex extra port

### DIFF
--- a/go-controller/pkg/node/gateway_localnet.go
+++ b/go-controller/pkg/node/gateway_localnet.go
@@ -353,7 +353,7 @@ func getLoadBalancerIPTRules(svc *kapi.Service, svcPort kapi.ServicePort, gatewa
 // -- to also connection track the outbound north-south traffic through l3 gateway so that
 //    the return traffic can be steered back to OVN logical topology
 // -- to also handle unDNAT return traffic back out of the host
-func addDefaultConntrackRulesLocal(nodeName, gwBridge, gwIntf string, stopChan chan struct{}) error {
+func addDefaultConntrackRulesLocal(nodeName, macAddress, gwBridge, gwIntf string, stopChan chan struct{}) error {
 	// the name of the patch port created by ovn-controller is of the form
 	// patch-<logical_port_name_of_localnet_port>-to-br-int
 	localnetLpName := gwBridge + "_" + nodeName
@@ -374,13 +374,22 @@ func addDefaultConntrackRulesLocal(nodeName, gwBridge, gwIntf string, stopChan c
 			gwIntf, stderr, err)
 	}
 
-	// replace the left over OpenFlow flows with the FLOOD action flow
-	_, stderr, err = util.AddOFFlowWithSpecificAction(gwBridge, util.FloodAction)
+	// replace the left over OpenFlow flows with the Normal action flow
+	_, stderr, err = util.AddOFFlowWithSpecificAction(gwBridge, util.NormalAction)
 	if err != nil {
 		return fmt.Errorf("failed to replace-flows on bridge %q stderr:%s (%v)", gwBridge, stderr, err)
 	}
 
 	nFlows := 0
+	// table 0, we check to see if this dest mac is the shared mac, if so flood to both ports (non-IP traffic)
+	_, stderr, err = util.RunOVSOfctl("add-flow", gwBridge,
+		fmt.Sprintf("cookie=%s, priority=10, table=0, in_port=%s, dl_dst=%s, actions=output:%s,output:LOCAL",
+			defaultOpenFlowCookie, ofportPhys, macAddress, ofportPatch))
+	if err != nil {
+		return fmt.Errorf("failed to add openflow flow to %s, stderr: %q, error: %v", gwBridge, stderr, err)
+	}
+	nFlows++
+
 	if config.IPv4Mode {
 		// table 0, packets coming from pods headed externally. Commit connections
 		// so that reverse direction goes back to the pods.
@@ -470,14 +479,13 @@ func addDefaultConntrackRulesLocal(nodeName, gwBridge, gwIntf string, stopChan c
 		}
 		mask, _ := cidr.Mask.Size()
 		_, stderr, err = util.RunOVSOfctl("add-flow", gwBridge,
-			fmt.Sprintf("cookie=%s, priority=3, table=1, %s, %s_dst=%s/%d, actions=output:%s",
+			fmt.Sprintf("cookie=%s, priority=15, table=1, %s, %s_dst=%s/%d, actions=output:%s",
 				defaultOpenFlowCookie, ipPrefix, ipPrefix, cidr.IP, mask, ofportPatch))
 		if err != nil {
 			return fmt.Errorf("failed to add openflow flow to %s, stderr: %q, "+
 				"error: %v", gwBridge, stderr, err)
 		}
 		nFlows++
-
 	}
 
 	if config.IPv6Mode {
@@ -492,9 +500,18 @@ func addDefaultConntrackRulesLocal(nodeName, gwBridge, gwIntf string, stopChan c
 		nFlows++
 	}
 
-	// table 1, all other connections go to host
+	// table 1, we check to see if this dest mac is the shared mac, if so send to host
 	_, stderr, err = util.RunOVSOfctl("add-flow", gwBridge,
-		fmt.Sprintf("cookie=%s, priority=0, table=1, actions=LOCAL", defaultOpenFlowCookie))
+		fmt.Sprintf("cookie=%s, priority=10, table=1, dl_dst=%s, actions=output:LOCAL",
+			defaultOpenFlowCookie, macAddress))
+	if err != nil {
+		return fmt.Errorf("failed to add openflow flow to %s, stderr: %q, error: %v", gwBridge, stderr, err)
+	}
+	nFlows++
+
+	// table 1, all other connections do normal processing
+	_, stderr, err = util.RunOVSOfctl("add-flow", gwBridge,
+		fmt.Sprintf("cookie=%s, priority=0, table=1, actions=NORMAL", defaultOpenFlowCookie))
 	if err != nil {
 		return fmt.Errorf("failed to add openflow flow to %s, stderr: %q, "+
 			"error: %v", gwBridge, stderr, err)

--- a/go-controller/pkg/node/gateway_localnet.go
+++ b/go-controller/pkg/node/gateway_localnet.go
@@ -375,7 +375,7 @@ func addDefaultConntrackRulesLocal(nodeName, gwBridge, gwIntf string, stopChan c
 	}
 
 	// replace the left over OpenFlow flows with the FLOOD action flow
-	_, stderr, err = util.AddFloodActionOFFlow(gwBridge)
+	_, stderr, err = util.AddOFFlowWithSpecificAction(gwBridge, util.FloodAction)
 	if err != nil {
 		return fmt.Errorf("failed to replace-flows on bridge %q stderr:%s (%v)", gwBridge, stderr, err)
 	}

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -419,7 +419,7 @@ func addDefaultConntrackRules(nodeName, gwBridge, gwIntf string, stopChan chan s
 	}
 
 	// replace the left over OpenFlow flows with the FLOOD action flow
-	_, stderr, err = util.AddFloodActionOFFlow(gwBridge)
+	_, stderr, err = util.AddOFFlowWithSpecificAction(gwBridge, util.FloodAction)
 	if err != nil {
 		return fmt.Errorf("failed to replace-flows on bridge %q stderr:%s (%v)", gwBridge, stderr, err)
 	}
@@ -648,7 +648,7 @@ func cleanupSharedGateway() error {
 		return nil
 	}
 
-	_, stderr, err = util.AddFloodActionOFFlow(bridgeName)
+	_, stderr, err = util.AddOFFlowWithSpecificAction(bridgeName, util.NormalAction)
 	if err != nil {
 		return fmt.Errorf("failed to replace-flows on bridge %q stderr:%s (%v)", bridgeName, stderr, err)
 	}

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -593,7 +593,7 @@ func (n *OvnNode) initSharedGateway(subnets []*net.IPNet, gwNextHops []net.IP, g
 	return func() error {
 		if config.Gateway.NodeportEnable {
 			if config.Gateway.Mode == config.GatewayModeLocal {
-				if err := addDefaultConntrackRulesLocal(n.name, bridgeName, uplinkName, n.stopChan); err != nil {
+				if err := addDefaultConntrackRulesLocal(n.name, macAddress.String(), bridgeName, uplinkName, n.stopChan); err != nil {
 					return err
 				}
 			} else {

--- a/go-controller/pkg/util/ovs.go
+++ b/go-controller/pkg/util/ovs.go
@@ -51,6 +51,8 @@ const (
 	sbdbCtlSock     = "ovnsb_db.ctl"
 	OvnNbdbLocation = "/etc/ovn/ovnnb_db.db"
 	OvnSbdbLocation = "/etc/ovn/ovnsb_db.db"
+	FloodAction     = "FLOOD"
+	NormalAction    = "NORMAL"
 )
 
 var (
@@ -654,12 +656,12 @@ func RunRoute(args ...string) (string, string, error) {
 	return strings.TrimSpace(stdout.String()), stderr.String(), err
 }
 
-// AddFloodActionOFFlow replaces flows in the bridge with a FLOOD action flow
-func AddFloodActionOFFlow(bridgeName string) (string, string, error) {
+// AddOFFlowWithSpecificAction replaces flows in the bridge with a FLOOD action flow
+func AddOFFlowWithSpecificAction(bridgeName, action string) (string, string, error) {
 	args := []string{"-O", "OpenFlow13", "replace-flows", bridgeName, "-"}
 
 	stdin := &bytes.Buffer{}
-	stdin.Write([]byte("table=0,priority=0,actions=FLOOD\n"))
+	stdin.Write([]byte(fmt.Sprintf("table=0,priority=0,actions=%s\n", action)))
 
 	cmd := runner.exec.Command(runner.ofctlPath, args...)
 	cmd.SetStdin(stdin)

--- a/go-controller/pkg/util/ovs_unit_test.go
+++ b/go-controller/pkg/util/ovs_unit_test.go
@@ -2110,7 +2110,7 @@ func TestRunIP(t *testing.T) {
 	}
 }
 
-func TestAddFloodActionOFFlow(t *testing.T) {
+func TestAddOFFlowWithSpecificAction(t *testing.T) {
 	mockKexecIface := new(mock_k8s_io_utils_exec.Interface)
 	mockCmd := new(mock_k8s_io_utils_exec.Cmd)
 	mockExecRunner := new(mocks.ExecRunner)
@@ -2169,7 +2169,7 @@ func TestAddFloodActionOFFlow(t *testing.T) {
 			}
 			mockCall.Once()
 
-			_, _, e := AddFloodActionOFFlow("somename")
+			_, _, e := AddOFFlowWithSpecificAction("somename", "someaction")
 
 			if tc.expectedErr != nil {
 				assert.Error(t, e)


### PR DESCRIPTION
    Changes local gateway flows to NORMAL action
    
    Following the changes for shared gw mode from:
    https://github.com/ovn-org/ovn-kubernetes/pull/1774
    
    This behavior will allow NORMAL action for all packets not destined to
    the shared gw mac, thus allowing an non-ovn port to be attached to the
    shared gw bridge and function normally.
    
    Signed-off-by: Tim Rozet <trozet@redhat.com>
    (cherry picked from commit e4adba4a84716b757b7f0540ff002c5e605c9fbd)
