### PR TITLE
Bug 1899266: Fixes ICMPv6 flooding behavior

### DIFF
--- a/go-controller/pkg/node/gateway_localnet.go
+++ b/go-controller/pkg/node/gateway_localnet.go
@@ -482,14 +482,17 @@ func addDefaultConntrackRulesLocal(nodeName, gwBridge, gwIntf string, stopChan c
 
 	if config.IPv6Mode {
 		// REMOVEME(trozet) when https://bugzilla.kernel.org/show_bug.cgi?id=11797 is resolved
-		// must flood icmpv6 traffic as it fails to create a CT entry
-		_, stderr, err = util.RunOVSOfctl("add-flow", gwBridge,
-			fmt.Sprintf("cookie=%s, priority=1, table=1,icmp6 actions=FLOOD", defaultOpenFlowCookie))
-		if err != nil {
-			return fmt.Errorf("failed to add openflow flow to %s, stderr: %q, "+
-				"error: %v", gwBridge, stderr, err)
+		// must flood icmpv6 Route Advertisement and Neighbor Advertisement traffic as it fails to create a CT entry
+		for _, icmpType := range []int{134, 136} {
+			_, stderr, err = util.RunOVSOfctl("add-flow", gwBridge,
+				fmt.Sprintf("cookie=%s, priority=14, table=1,icmp6,icmpv6_type=%d actions=FLOOD",
+					defaultOpenFlowCookie, icmpType))
+			if err != nil {
+				return fmt.Errorf("failed to add openflow flow to %s, stderr: %q, "+
+					"error: %v", gwBridge, stderr, err)
+			}
+			nFlows++
 		}
-		nFlows++
 	}
 
 	// table 1, all other connections go to host


### PR DESCRIPTION
Our flows for flooding icmpv6 to both OVN and the host were too generic.
This caused ICMPv6 echo requests to be sent to both, resulting in a
duplicate ack and other issues. This patch changes the flows for icmpv6
to be more specific and target only flooding for Neighbor Advertisements
and Route Advertisements. This will allow OVN to receive only the
packets it needs for peering/discovery, while all other ICMPv6 will go to
the host only.

Signed-off-by: Tim Rozet <trozet@redhat.com>
(cherry picked from commit 1206bc2ba30d35a9c896b3cddf6f2f8fd6694583)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->