### PR TITLE
Dockerfile: bump OVN to 20.09.0-21

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN yum install -y  \
 	yum clean all
 
 ARG ovsver=2.13.0-72.el8fdp
-ARG ovnver=20.09.0-20.el8fdn
+ARG ovnver=20.09.0-21.el8fdn
 
 RUN INSTALL_PKGS=" \
 	openssl python3-pyOpenSSL firewalld-filesystem \


### PR DESCRIPTION
Only change is a fix to LB VIP selection in ovn-northd that was
broken in -14 and later.

@trozet 