### PR TITLE
[WIP] DNM Fixes race in gateway start up -local gw

### DIFF
--- a/go-controller/pkg/node/OCP_HACKS.go
+++ b/go-controller/pkg/node/OCP_HACKS.go
@@ -43,23 +43,23 @@ func generateBlockMCSRules(rules *[]iptRule, protocol iptables.Protocol) {
 
 // initSharedGatewayNoBridge is used in order to run local gateway mode without moving the NIC to an ovs bridge
 // https://github.com/openshift/ovn-kubernetes/pull/281
-func initSharedGatewayNoBridge(nodeName string, subnets []*net.IPNet, gwNextHops []net.IP, nodeAnnotator kube.Annotator) (postWaitFunc, error) {
+func initSharedGatewayNoBridge(nodeName string, subnets []*net.IPNet, gwNextHops []net.IP, nodeAnnotator kube.Annotator) error {
 	err := setupLocalNodeAccessBridge(nodeName, subnets)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	chassisID, err := util.GetNodeChassisID()
 	if err != nil {
-		return nil, err
+		return err
 	}
 	// get the real default interface
 	defaultGatewayIntf, _, err := getDefaultGatewayInterfaceDetails()
 	if err != nil {
-		return nil, err
+		return err
 	}
 	ips, err := getNetworkInterfaceIPAddresses(defaultGatewayIntf)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get interface details for %s (%v)",
+		return fmt.Errorf("failed to get interface details for %s (%v)",
 			defaultGatewayIntf, err)
 	}
 	err = util.SetL3GatewayConfig(nodeAnnotator, &util.L3GatewayConfig{
@@ -71,8 +71,7 @@ func initSharedGatewayNoBridge(nodeName string, subnets []*net.IPNet, gwNextHops
 		NodePortEnable: config.Gateway.NodeportEnable,
 	})
 	if err != nil {
-		return nil, err
-	} else {
-		return func() error { return nil }, nil
+		return err
 	}
+	return nil
 }

--- a/go-controller/pkg/node/gateway.go
+++ b/go-controller/pkg/node/gateway.go
@@ -9,7 +9,8 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/informer"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
-	util "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+
 	kapi "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
 )
@@ -20,7 +21,6 @@ import (
 // are kept in sync
 type Gateway interface {
 	informer.ServiceAndEndpointsEventHandler
-	Init() error
 	Run(<-chan struct{}, *sync.WaitGroup)
 }
 
@@ -34,7 +34,6 @@ type gateway struct {
 	// localPortWatcher is used in Local GW mode to handle iptables rules and routes for services
 	localPortWatcher informer.ServiceEventHandler
 	openflowManager  *openflowManager
-	initFunc         func() error
 }
 
 func (g *gateway) AddService(svc *kapi.Service) {
@@ -113,10 +112,6 @@ func (g *gateway) DeleteEndpoints(ep *kapi.Endpoints) {
 	if g.loadBalancerHealthChecker != nil {
 		g.loadBalancerHealthChecker.AddEndpoints(ep)
 	}
-}
-
-func (g *gateway) Init() error {
-	return g.initFunc()
 }
 
 func (g *gateway) Run(stopChan <-chan struct{}, wg *sync.WaitGroup) {

--- a/go-controller/pkg/node/gateway_init.go
+++ b/go-controller/pkg/node/gateway_init.go
@@ -212,9 +212,7 @@ func (n *OvnNode) initGateway(subnets []*net.IPNet, nodeAnnotator kube.Annotator
 	// as that option does not add default SNAT rules on the GR and the gatewayReady function checks
 	// those default NAT rules are present
 	if !config.Gateway.DisableSNATMultipleGWs && config.Gateway.Mode != config.GatewayModeLocal {
-		waiter.AddWait(gatewayReady, gw.Init)
-	} else {
-		waiter.AddWait(func() (bool, error) { return true, nil }, gw.Init)
+		waiter.AddWait(gatewayReady, func() error { return nil })
 	}
 
 	n.gateway = gw

--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -234,8 +234,6 @@ cookie=0x0, duration=8366.597s, table=1, n_packets=10641, n_bytes=10370087, prio
 			gatewayNextHops, gatewayIntf, err := getGatewayNextHops()
 			sharedGw, err := newSharedGateway(nodeName, ovntest.MustParseIPNets(nodeSubnet), gatewayNextHops, gatewayIntf, nodeAnnotator)
 			Expect(err).NotTo(HaveOccurred())
-			err = sharedGw.Init()
-			Expect(err).NotTo(HaveOccurred())
 			startGateway(sharedGw, wf)
 			// check if IP addresses have been assigned to localnetGatewayNextHopPort interface
 			link, err := netlink.LinkByName(localnetGatewayNextHopPort)

--- a/go-controller/pkg/node/gateway_localnet.go
+++ b/go-controller/pkg/node/gateway_localnet.go
@@ -55,9 +55,7 @@ func newLocalGateway(nodeName string, hostSubnets []*net.IPNet, gwNextHops []net
 	// Do not configure OVS bridge for local gateway mode with a gateway iface of none
 	// For SDN->OVN migration, see https://github.com/openshift/ovn-kubernetes/pull/281
 	if gwIntf == "none" {
-		var err error
-		gw.initFunc, err = initSharedGatewayNoBridge(nodeName, hostSubnets, gwNextHops, nodeAnnotator)
-		if err != nil {
+		if err := initSharedGatewayNoBridge(nodeName, hostSubnets, gwNextHops, nodeAnnotator); err != nil {
 			return nil, err
 		}
 		// END OCP HACK
@@ -67,12 +65,10 @@ func newLocalGateway(nodeName string, hostSubnets []*net.IPNet, gwNextHops []net
 		if err != nil {
 			return nil, err
 		}
-
-		gw.initFunc = func() error {
-			klog.Info("Creating Local Gateway Openflow Manager")
-			var err error
-			gw.openflowManager, err = newLocalGatewayOpenflowManager(nodeName, macAddress.String(), bridgeName, uplinkName)
-			return err
+		klog.Info("Creating Local Gateway Openflow Manager")
+		gw.openflowManager, err = newLocalGatewayOpenflowManager(nodeName, macAddress.String(), bridgeName, uplinkName)
+		if err != nil {
+			return nil, err
 		}
 	}
 

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -523,25 +523,18 @@ func newSharedGateway(nodeName string, subnets []*net.IPNet, gwNextHops []net.IP
 		return nil, err
 	}
 
-	gw.initFunc = func() error {
-		// Program cluster.GatewayIntf to let non-pod traffic to go to host
-		// stack
-		klog.Info("Creating Shared Gateway Openflow Manager")
-		var err error
+	klog.Info("Creating Shared Gateway Openflow Manager")
+	gw.openflowManager, err = newSharedGatewayOpenFlowManager(nodeName, macAddress.String(), bridgeName, uplinkName)
+	if err != nil {
+		return nil, err
+	}
 
-		gw.openflowManager, err = newSharedGatewayOpenFlowManager(nodeName, macAddress.String(), bridgeName, uplinkName)
+	if config.Gateway.NodeportEnable {
+		klog.Info("Creating Shared Gateway Node Port Watcher")
+		gw.nodePortWatcher, err = newNodePortWatcher(nodeName, bridgeName, uplinkName, ips[0])
 		if err != nil {
-			return err
+			return nil, err
 		}
-
-		if config.Gateway.NodeportEnable {
-			klog.Info("Creating Shared Gateway Node Port Watcher")
-			gw.nodePortWatcher, err = newNodePortWatcher(nodeName, bridgeName, uplinkName, ips[0])
-			if err != nil {
-				return err
-			}
-		}
-		return nil
 	}
 
 	klog.Info("Shared Gateway Creation Complete")


### PR DESCRIPTION
There is a race between when service handlers are added for the gateway
and when the gateway Init function gets executed. The Init function will
wait until the gateway is ready, while the service handler is already
added and may miss events. This causes shared gateway bridge to miss
flows for services.

We really dont need to wait to setup the shared bridge, so there's no
need to have an Init function. This patch moves the gateway init to
happen before the handlers are added, and removes the Init function.

Signed-off-by: Tim Rozet <trozet@redhat.com>

