### PR TITLE
Bug 1907328: add iproute-tc package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ ARG ovnver=20.09.0-21.el8fdn
 
 RUN INSTALL_PKGS=" \
 	openssl python3-pyOpenSSL firewalld-filesystem \
-	libpcap iproute strace \
+	libpcap iproute iproute-tc strace \
 	containernetworking-plugins \
 	tcpdump iputils \
 	libreswan \


### PR DESCRIPTION
iproute-tc provides tc binary for OVS HW offload debugging

Signed-off-by: Zenghui Shi <zshi@redhat.com>