### PR TITLE
Bug 1908472: [4.6] Increase QPS and Burst setting

### DIFF
--- a/go-controller/pkg/util/kube.go
+++ b/go-controller/pkg/util/kube.go
@@ -59,6 +59,8 @@ func NewClientsets(conf *config.KubernetesConfig) (*kubernetes.Clientset, *egres
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}
+	kconfig.QPS = 25
+	kconfig.Burst = 25
 
 	crdClientset, err := apiextensionsclientset.NewForConfig(kconfig)
 	if err != nil {


### PR DESCRIPTION
Our client will under high load exceed the default QPS (query per second)
and Burst setting when communicating with the API server, which will cause
the client request to get throttled by the API server. These default
values are currently 5 and 10 respectively. Scalability testing has shown that
25 and 25 are values which lead to reasonable pod ready latency times
under high load.

Signed-off-by: Alexander Constantinescu <aconstan@redhat.com>

@alexanderConstantinescu @trozet