### PR TITLE
Bug 1908921: ovn/node: use node name as chassis hostname

### DIFF
--- a/go-controller/pkg/node/node.go
+++ b/go-controller/pkg/node/node.go
@@ -47,11 +47,6 @@ func NewNode(kubeClient kubernetes.Interface, wf *factory.WatchFactory, name str
 func setupOVNNode(node *kapi.Node) error {
 	var err error
 
-	nodeName, err := util.GetNodeHostname(node)
-	if err != nil {
-		return fmt.Errorf("failed to obtain hostname from node %q: %v", node.Name, err)
-	}
-
 	nodeIP := config.Default.EncapIP
 	if nodeIP == "" {
 		nodeIP, err = util.GetNodeIP(node)
@@ -73,7 +68,7 @@ func setupOVNNode(node *kapi.Node) error {
 			config.Default.InactivityProbe),
 		fmt.Sprintf("external_ids:ovn-openflow-probe-interval=%d",
 			config.Default.OpenFlowProbe),
-		fmt.Sprintf("external_ids:hostname=\"%s\"", nodeName),
+		fmt.Sprintf("external_ids:hostname=\"%s\"", node.Name),
 		"external_ids:ovn-monitor-all=true",
 	)
 	if err != nil {

--- a/go-controller/pkg/node/node_test.go
+++ b/go-controller/pkg/node/node_test.go
@@ -9,6 +9,7 @@ import (
 	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 	kapi "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -35,12 +36,11 @@ var _ = Describe("Node Operations", func() {
 				ofintval int    = 180
 			)
 			node := kapi.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: nodeName,
+				},
 				Status: kapi.NodeStatus{
 					Addresses: []kapi.NodeAddress{
-						{
-							Type:    kapi.NodeHostName,
-							Address: nodeName,
-						},
 						{
 							Type:    kapi.NodeExternalIP,
 							Address: nodeIP,
@@ -89,12 +89,11 @@ var _ = Describe("Node Operations", func() {
 				encapUUID   string = "e4437094-0094-4223-9f14-995d98d5fff8"
 			)
 			node := kapi.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: nodeName,
+				},
 				Status: kapi.NodeStatus{
 					Addresses: []kapi.NodeAddress{
-						{
-							Type:    kapi.NodeHostName,
-							Address: nodeName,
-						},
 						{
 							Type:    kapi.NodeExternalIP,
 							Address: nodeIP,

--- a/go-controller/pkg/util/kube.go
+++ b/go-controller/pkg/util/kube.go
@@ -99,27 +99,6 @@ func GetNodeIP(node *kapi.Node) (string, error) {
 		kapi.NodeInternalIP, kapi.NodeExternalIP)
 }
 
-// GetNodeHostame extracts the hostname from the node status in the API
-func GetNodeHostname(node *kapi.Node) (string, error) {
-	for _, addr := range node.Status.Addresses {
-		if addr.Type == kapi.NodeHostName {
-			return addr.Address, nil
-		}
-	}
-	for _, addr := range node.Status.Addresses {
-		if addr.Type == kapi.NodeExternalDNS {
-			return addr.Address, nil
-		}
-	}
-	for _, addr := range node.Status.Addresses {
-		if addr.Type == kapi.NodeInternalDNS {
-			return addr.Address, nil
-		}
-	}
-	return "", fmt.Errorf("%s doesn't have an address with type %s, %s or %s", node.GetName(),
-		kapi.NodeHostName, kapi.NodeExternalDNS, kapi.NodeInternalDNS)
-}
-
 const (
 	// DefNetworkAnnotation is the pod annotation for the cluster-wide default network
 	DefNetworkAnnotation = "v1.multus-cni.io/default-network"


### PR DESCRIPTION
Backport of https://github.com/ovn-org/ovn-kubernetes/pull/1653

In some cloud environments the Kube node name is a short name, while
the node's "hostname" is an FQDN. eg:

node.Name: ci-op-h2qtbcsi-99b10-qhxj2-worker-d-6wxxl
hostname:  ci-op-h2qtbcsi-99b10-qhxj2-worker-d-6wxxl.c.openshift-gce-devel-ci.internal

syncNodesPeriodic() assumed they were going to be the same, which
resulted in deleting all chassis records from the SBDB every five
minutes, because ovnkube-node was setting the node's FQDN as the

@trozet @fepan @fedepaol 