### PR TITLE
Dockerfile: bump OVN to 20.09.0-23

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN yum install -y  \
 	yum clean all
 
 ARG ovsver=2.13.0-72.el8fdp
-ARG ovnver=20.09.0-21.el8fdn
+ARG ovnver=20.09.0-23.el8fdn
 
 RUN INSTALL_PKGS=" \
 	openssl python3-pyOpenSSL firewalld-filesystem \


### PR DESCRIPTION
OVN implements the option to reject packets destined to LoadBalancers
without endpoints, simplifying OVN-Kubernetes, since it doesn´t have to
handle the reject traffic with ACLs

Signed-off-by: Antonio Ojea <aojea@redhat.com>
