### PR TITLE
Bug 1915027: Fix MCS-blocking iptables rules

### DIFF
--- a/go-controller/pkg/cni/OCP_HACKS.go
+++ b/go-controller/pkg/cni/OCP_HACKS.go
@@ -13,10 +13,10 @@ import (
 // OCP HACK: block access to MCS/metadata; https://github.com/openshift/ovn-kubernetes/pull/19
 var iptablesCommands = [][]string{
 	// Block MCS
-	{"-A", "OUTPUT", "-p", "tcp", "-m", "tcp", "--dport", "22623", "-j", "REJECT"},
-	{"-A", "OUTPUT", "-p", "tcp", "-m", "tcp", "--dport", "22624", "-j", "REJECT"},
-	{"-A", "FORWARD", "-p", "tcp", "-m", "tcp", "--dport", "22623", "-j", "REJECT"},
-	{"-A", "FORWARD", "-p", "tcp", "-m", "tcp", "--dport", "22624", "-j", "REJECT"},
+	{"-A", "OUTPUT", "-p", "tcp", "-m", "tcp", "--dport", "22623", "--syn", "-j", "REJECT"},
+	{"-A", "OUTPUT", "-p", "tcp", "-m", "tcp", "--dport", "22624", "--syn", "-j", "REJECT"},
+	{"-A", "FORWARD", "-p", "tcp", "-m", "tcp", "--dport", "22623", "--syn", "-j", "REJECT"},
+	{"-A", "FORWARD", "-p", "tcp", "-m", "tcp", "--dport", "22624", "--syn", "-j", "REJECT"},
 }
 
 var iptables4OnlyCommands = [][]string{

--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -473,12 +473,12 @@ func expectedIPTablesRules(gatewayIP string) map[string]util.FakeTable {
 
 	// OCP HACK: Block MCS Access. https://github.com/openshift/ovn-kubernetes/pull/170
 	table["filter"]["FORWARD"] = append(table["filter"]["FORWARD"],
-		"-p tcp -m tcp --dport 22624 -j REJECT",
-		"-p tcp -m tcp --dport 22623 -j REJECT",
+		"-p tcp -m tcp --dport 22624 --syn -j REJECT",
+		"-p tcp -m tcp --dport 22623 --syn -j REJECT",
 	)
 	table["filter"]["OUTPUT"] = append(table["filter"]["OUTPUT"],
-		"-p tcp -m tcp --dport 22624 -j REJECT",
-		"-p tcp -m tcp --dport 22623 -j REJECT",
+		"-p tcp -m tcp --dport 22624 --syn -j REJECT",
+		"-p tcp -m tcp --dport 22623 --syn -j REJECT",
 	)
 	// END OCP HACK
 


### PR DESCRIPTION
The MCS-blocking rules were too aggressive, and would block connections using 22623/22624 as a source port in some cases.

`--syn` means "SYN and not ACK", so this should make it only block attempts to establish connections to port 22623/4, and not any other traffic involving those ports.