### PR TITLE
Dockerfile: yum '==' operator deprecated

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,8 +43,8 @@ RUN INSTALL_PKGS=" \
 	libreswan \
 	" && \
 	yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False $INSTALL_PKGS && \
-	yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False "openvswitch2.13 == $ovsver" "openvswitch2.13-devel == $ovsver" "python3-openvswitch2.13 == $ovsver" "openvswitch2.13-ipsec == $ovsver" && \
-	yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False "ovn2.13 == $ovnver" "ovn2.13-central == $ovnver" "ovn2.13-host == $ovnver" "ovn2.13-vtep == $ovnver" && \
+	yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False "openvswitch2.13 = $ovsver" "openvswitch2.13-devel = $ovsver" "python3-openvswitch2.13 = $ovsver" "openvswitch2.13-ipsec = $ovsver" && \
+	yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False "ovn2.13 = $ovnver" "ovn2.13-central = $ovnver" "ovn2.13-host = $ovnver" "ovn2.13-vtep = $ovnver" && \
 	yum clean all && rm -rf /var/cache/*
 
 RUN mkdir -p /var/run/openvswitch && \


### PR DESCRIPTION
CI gives warning:

'Using '==' operator in reldeps can result in an undefined behavior.
It is deprecated and the support will be dropped in future versions.
Use '=' operator instead.'

Signed-off-by: Mark Gray <mark.d.gray@redhat.com>