### PR TITLE
Bug 1915295: fix service controller repair loop race

### DIFF
--- a/go-controller/pkg/ovn/controller/services/service_tracker.go
+++ b/go-controller/pkg/ovn/controller/services/service_tracker.go
@@ -122,20 +122,6 @@ func (st *serviceTracker) getService(name, namespace string) sets.String {
 	return sets.NewString()
 }
 
-// getServiceVipsMap return a set with all the service VIPs in the format IP:Port/Protocol
-func (st *serviceTracker) getServiceVipsMap() sets.String {
-	st.Lock()
-	defer st.Unlock()
-
-	result := sets.NewString()
-	for _, vips := range st.virtualIPByService {
-		for key := range vips {
-			result.Insert(key)
-		}
-	}
-	return result
-}
-
 // updateKubernetesService adds or updates the tracker from a Kubernetes service
 // added for testing purposes
 func (st *serviceTracker) updateKubernetesService(service *v1.Service) {


### PR DESCRIPTION
The new service controller for endpoint slices has a repair
loop that runs once, during the controller startup process,
so we can delete out of sync data between OVN and Kubernetes,
specially to deal with upgrades and OVN new features.

The repair loop was using the controller service tracker as a
source of true, but this is racy because the service tracker
is updated just after the OVN Load Balancer has been configured,
so it can happen that the Service has an OVN loadbalancer, but
doesn´t exist on the service tracker. As a consequence the repair
loops things that is a stale loadbalancer and deletes it.

The repair loop must use the informer cache as source of true, also
it must run before starting the informers workers, so we avoid any
races.

Signed-off-by: Antonio Ojea <aojea@redhat.com>

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1915295

