### PR TITLE
Bug 1917609: Fixes deleting exgw pod

### DIFF
--- a/go-controller/pkg/ovn/egressgw.go
+++ b/go-controller/pkg/ovn/egressgw.go
@@ -133,12 +133,12 @@ func (oc *Controller) deletePodExternalGW(pod *kapi.Pod) {
 	klog.Infof("Deleting routes for external gateway pod: %s, for namespace(s) %s", pod.Name,
 		podRoutingNamespaceAnno)
 	for _, namespace := range strings.Split(podRoutingNamespaceAnno, ",") {
-		oc.deletePodGWRoutesForNamespace(pod.Name, namespace, pod.Spec.NodeName)
+		oc.deletePodGWRoutesForNamespace(pod.Name, namespace)
 	}
 }
 
 // deletePodGwRoutesForNamespace handles deleting all routes in a namespace for a specific pod GW
-func (oc *Controller) deletePodGWRoutesForNamespace(pod, namespace, node string) {
+func (oc *Controller) deletePodGWRoutesForNamespace(pod, namespace string) {
 	nsInfo := oc.getNamespaceLocked(namespace)
 	if nsInfo == nil {
 		return
@@ -163,11 +163,7 @@ func (oc *Controller) deletePodGWRoutesForNamespace(pod, namespace, node string)
 				continue
 			}
 			mask := GetIPFullMask(podIP)
-			// TODO (trozet): use the go bindings here and batch commands
-			if err := oc.delHybridRoutePolicyForPod(net.ParseIP(podIP), node); err != nil {
-				klog.Error(err)
-			}
-
+			node := strings.TrimPrefix(gr, "GR_")
 			_, stderr, err := util.RunOVNNbctl("--", "--if-exists", "--policy=src-ip",
 				"lr-route-del", gr, podIP+mask, gwIP.String())
 			if err != nil {
@@ -180,6 +176,12 @@ func (oc *Controller) deletePodGWRoutesForNamespace(pod, namespace, node string)
 				// clean up if there are no more routes for this podIP
 				if entry := nsInfo.podExternalRoutes[podIP]; len(entry) == 0 {
 					delete(nsInfo.podExternalRoutes, podIP)
+					// TODO (trozet): use the go bindings here and batch commands
+					// delete the ovn_cluster_router policy if the pod has no more exgws to revert back to normal
+					// default gw behavior
+					if err := oc.delHybridRoutePolicyForPod(net.ParseIP(podIP), node); err != nil {
+						klog.Error(err)
+					}
 				}
 			}
 		}


### PR DESCRIPTION
The ovn_cluster_router policy was being removed for a pod anytime an
exgw was deleted. This is incorrect, because a pod may have more than
one exgw configured. The policy should only be removed for a pod if it
no longer has any exgws configured.

Additionally, the policy was being removed for potentially the wrong
node. This patch corrects the node to be the one where the affected pod
lives.

Signed-off-by: Tim Rozet <trozet@redhat.com>
(cherry picked from commit a843da3d15ecfaef857e07cc2c977fc2d94e3a96)

