### PR TITLE
Bug 1921283: [4.5] Fix MCS-blocking iptables rules

### DIFF
--- a/go-controller/pkg/cni/helper_linux.go
+++ b/go-controller/pkg/cni/helper_linux.go
@@ -225,10 +225,10 @@ func setupSriovInterface(netns ns.NetNS, containerID, ifName string, ifInfo *Pod
 
 var iptablesCommands = [][]string{
 	// Block MCS
-	{"-A", "OUTPUT", "-p", "tcp", "-m", "tcp", "--dport", "22623", "-j", "REJECT"},
-	{"-A", "OUTPUT", "-p", "tcp", "-m", "tcp", "--dport", "22624", "-j", "REJECT"},
-	{"-A", "FORWARD", "-p", "tcp", "-m", "tcp", "--dport", "22623", "-j", "REJECT"},
-	{"-A", "FORWARD", "-p", "tcp", "-m", "tcp", "--dport", "22624", "-j", "REJECT"},
+	{"-A", "OUTPUT", "-p", "tcp", "-m", "tcp", "--dport", "22623", "--syn", "-j", "REJECT"},
+	{"-A", "OUTPUT", "-p", "tcp", "-m", "tcp", "--dport", "22624", "--syn", "-j", "REJECT"},
+	{"-A", "FORWARD", "-p", "tcp", "-m", "tcp", "--dport", "22623", "--syn", "-j", "REJECT"},
+	{"-A", "FORWARD", "-p", "tcp", "-m", "tcp", "--dport", "22624", "--syn", "-j", "REJECT"},
 
 	// Block cloud provider metadata IP except DNS
 	{"-A", "OUTPUT", "-p", "tcp", "-m", "tcp", "-d", "169.254.169.254", "!", "--dport", "53", "-j", "REJECT"},

--- a/go-controller/pkg/node/block_mcs.go
+++ b/go-controller/pkg/node/block_mcs.go
@@ -2,25 +2,21 @@
 
 package node
 
-func generateBlockMCSRules(rules *[]iptRule) {
-	*rules = append(*rules, iptRule{
-		table: "filter",
-		chain: "FORWARD",
-		args:  []string{"-p", "tcp", "-m", "tcp", "--dport", "22623", "-j", "REJECT"},
-	})
-	*rules = append(*rules, iptRule{
-		table: "filter",
-		chain: "FORWARD",
-		args:  []string{"-p", "tcp", "-m", "tcp", "--dport", "22624", "-j", "REJECT"},
-	})
-	*rules = append(*rules, iptRule{
-		table: "filter",
-		chain: "OUTPUT",
-		args:  []string{"-p", "tcp", "-m", "tcp", "--dport", "22623", "-j", "REJECT"},
-	})
-	*rules = append(*rules, iptRule{
-		table: "filter",
-		chain: "OUTPUT",
-		args:  []string{"-p", "tcp", "-m", "tcp", "--dport", "22624", "-j", "REJECT"},
-	})
+func generateBlockMCSRules() (addRules, delRules []iptRule) {
+	for _, chain := range []string{"FORWARD", "OUTPUT"} {
+		for _, port := range []string{"22623", "22624"} {
+			addRules = append(addRules, iptRule{
+				table:    "filter",
+				chain:    chain,
+				args:     []string{"-p", "tcp", "-m", "tcp", "--dport", port, "--syn", "-j", "REJECT"},
+			})
+			// Delete the old "--syn"-less rules on upgrade
+			delRules = append(delRules, iptRule{
+				table:    "filter",
+				chain:    chain,
+				args:     []string{"-p", "tcp", "-m", "tcp", "--dport", port, "-j", "REJECT"},
+			})
+		}
+	}
+	return
 }


### PR DESCRIPTION
backport of #400 to 4.5

This had to be rewritten to deal with code differences from 4.5 to master so it could use some extra sanity-checking