### PR TITLE
Bug 1892472: Run linter, utests, and gofmt in container

### DIFF
--- a/go-controller/Makefile
+++ b/go-controller/Makefile
@@ -9,6 +9,18 @@ PKGS ?=
 GOPATH ?= $(shell go env GOPATH)
 TEST_REPORT_DIR?=$(CURDIR)/_artifacts
 export TEST_REPORT_DIR
+GO_DOCKER_IMG = quay.io/giantswarm/golang:1.15.7
+# CONTAINER_RUNNABLE determines if the tests can be run inside a container. It checks to see if
+# podman/docker is installed on the system and also confirms that it is not running in a CI environment by checking
+# that the GITHUB_ACTIONS environment variable is not set. NOTE: Running tests in a container inside of a CI environment
+# fails some of the tests needing mount options inspite of starting the container with the right linux capabilities.
+PODMAN ?= $(shell podman -v > /dev/null 2>&1; echo $$?)
+ifeq ($(PODMAN), 0)
+CONTAINER_RUNTIME=podman
+else
+CONTAINER_RUNTIME=docker
+endif
+CONTAINER_RUNNABLE ?= $(shell $(CONTAINER_RUNTIME) -v > /dev/null 2>&1 && ! printenv GITHUB_ACTIONS > /dev/null 2>&1; echo $$?)
 
 .PHONY: all build check test
 
@@ -19,15 +31,20 @@ export TEST_REPORT_DIR
 #       (disables compiler optimization and inlining to aid source debugging tools
 #        like delve)
 
-
 all build:
 	hack/build-go.sh cmd/ovnkube cmd/ovn-k8s-cni-overlay cmd/ovn-kube-util hybrid-overlay/cmd/hybrid-overlay-node cmd/ovndbchecker cmd/ovnkube-trace
 
 windows:
 	WINDOWS_BUILD="yes" hack/build-go.sh hybrid-overlay/cmd/hybrid-overlay-node
 
+# Note: `--security-opt label=disable` option is required on systems where SELinux is enabled for `podman` to successfully run the
+# tests in a container. Refer: https://www.projectatomic.io/blog/2016/03/dwalsh_selinux_containers/ for additional context
 check test:
+ifeq ($(CONTAINER_RUNNABLE), 0)
+	$(CONTAINER_RUNTIME) run --security-opt label=disable --cap-add=NET_ADMIN --cap-add=SYS_ADMIN -v $(shell dirname $(PWD)):/go/src/github.com/ovn-org/ovn-kubernetes -w /go/src/github.com/ovn-org/ovn-kubernetes/go-controller $(GO_DOCKER_IMG) sh -c "RACE=1 DOCKER_TEST=1 hack/test-go.sh ${PKGS}"
+else
 	RACE=1 hack/test-go.sh ${PKGS}
+endif
 
 codegen:
 	hack/update-codegen.sh
@@ -51,4 +68,8 @@ lint:
 	@GOPATH=${GOPATH} ./hack/lint.sh
 
 gofmt:
+ifeq ($(CONTAINER_RUNNABLE), 0)
+	$(CONTAINER_RUNTIME) run --security-opt label=disable -v $(shell dirname $(PWD)):/go/src/github.com/ovn-org/ovn-kubernetes -w /go/src/github.com/ovn-org/ovn-kubernetes/go-controller $(GO_DOCKER_IMG) hack/verify-gofmt.sh
+else
 	@./hack/verify-gofmt.sh
+endif

--- a/go-controller/hack/lint.sh
+++ b/go-controller/hack/lint.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
-GO111MODULE=on ${GOPATH}/bin/golangci-lint run \
-    --timeout=15m0s --verbose --print-resources-usage --modules-download-mode=vendor \
-    && echo "lint OK!"
+
+# pin golangci-lint version to 1.33.2
+VERSION=v1.33.2
+
+docker run --rm -v $(pwd):/app -w /app -e GO111MODULE=on golangci/golangci-lint:${VERSION} \
+	golangci-lint run --verbose --print-resources-usage \
+	--modules-download-mode=vendor --timeout=15m0s && \
+	echo "lint OK!"

--- a/go-controller/hack/test-go.sh
+++ b/go-controller/hack/test-go.sh
@@ -26,7 +26,7 @@ function testrun {
     if [ ! -z "${RACE:-}" ]; then
         args="-race "
     fi
-    if [[ "$USER" != root && " ${root_pkgs[@]} " =~ " $pkg " ]]; then
+    if [[ "$USER" != root && " ${root_pkgs[@]} " =~ " $pkg " && -z "${DOCKER_TEST:-}" ]]; then
         testfile=$(mktemp --tmpdir ovn-test.XXXXXXXX)
         echo "sudo required for ${pkg}, compiling test to ${testfile}"
         if [[ ! -z "${RACE:-}" && "${pkg}" != "github.com/ovn-org/ovn-kubernetes/go-controller/hybrid-overlay/pkg/controller" ]]; then


### PR DESCRIPTION
Cherry-pick changes from github.com/ovn-org/ovn-kubernetes#1935 and github.com/ovn-org/ovn-kubernetes#1976 for running lint, gofmt, and utest jobs in containers.

Signed-off-by: Aniket Bhat <anbhat@redhat.com>