### PR TITLE
Create a podman image to use with CI so linter/utests can be run

### DIFF
--- a/Dockerfile.utest
+++ b/Dockerfile.utest
@@ -1,0 +1,14 @@
+FROM registry.centos.org/centos/centos:7
+
+# base: EPEL repo for extra tools
+RUN yum -y install epel-release
+
+# build: system utilities and libraries
+RUN yum update -y && \
+    yum -y install epel-release && \
+    yum -y groupinstall 'Development Tools' && \
+    yum -y install openssl-devel protobuf-compiler jq podman && \
+    yum -y install yamllint && \
+    yum -y install cmake elfutils-libelf-devel libcurl-devel binutils-devel elfutils-devel && \
+    yum clean all
+


### PR DESCRIPTION
For OpenShift CI, we need to create a custom image that has podman
installed in it to run the containerized linter, gofmt, and utests
There is no base image that will provide podman by default. So the
alternative is to create our own image and use it in the tests.

Signed-off-by: Aniket Bhat <anbhat@redhat.com>
