### PR TITLE
Bug 1918442: Fix idling and rejects for 4.7

### DIFF
--- a/go-controller/pkg/ovn/controller/services/services_controller.go
+++ b/go-controller/pkg/ovn/controller/services/services_controller.go
@@ -311,7 +311,7 @@ func (c *Controller) syncServices(key string) error {
 			if err != nil {
 				klog.Errorf("Error trying to get ACL for Service %s/%s: %v", name, namespace, err)
 			}
-			// if there is no ACL and there is no endpoints we add a new ACL
+			// if there is no ACL and there are no endpoints we add a new ACL
 			// if there is an ACL and we have endpoints we have to remove the ACL
 			// if there is no ACL and we have endpoints we don´t need to do anything
 			if len(eps) == 0 && len(aclID) == 0 {
@@ -320,14 +320,16 @@ func (c *Controller) syncServices(key string) error {
 				if err != nil {
 					klog.Errorf("Error trying to add ACL for Service %s/%s: %v", name, namespace, err)
 				}
-			} else if len(aclID) > 0 {
+			} else if len(eps) > 0 && len(aclID) > 0 {
 				// remove acl
 				err = acl.RemoveACLFromPortGroup(aclID, c.clusterPortGroupUUID)
 				if err != nil {
 					klog.Errorf("Error trying to remove ACL for Service %s/%s: %v", name, namespace, err)
 				}
+			} else {
+				klog.Infof("ACL: %s already created for Service : %s/%s", aclID, namespace, name)
 			}
-			// end of reject ACL code
+			// end of reject ACL code for Service IP
 
 			// Node Port
 			if svcPort.NodePort != 0 {

--- a/go-controller/pkg/ovn/controller/services/services_controller_test.go
+++ b/go-controller/pkg/ovn/controller/services/services_controller_test.go
@@ -60,7 +60,7 @@ func TestSyncServices(t *testing.T) {
 		ovnCmd        []ovntest.ExpectedCmd
 	}{
 		{
-			name: "delete OVN LoadBalancer from deleted Single Stack Service",
+			name: "delete endpoint slice with no service",
 			slice: &discovery.EndpointSlice{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      serviceName + "ab23",
@@ -79,13 +79,13 @@ func TestSyncServices(t *testing.T) {
 					Output: loadbalancerTCP,
 				},
 				{
-					Cmd:    "ovn-nbctl --timeout=15 --if-exists remove load_balancer " + loadbalancerTCP + " vips \"192.168.1.1:80\"",
+					Cmd:    `ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find acl name=a08ea426-2288-11eb-a30b-a8a1590cda29-192.168.1.1\:80`,
 					Output: "",
 				},
 			},
 		},
 		{
-			name: "create OVN LoadBalancer from Single Stack Service without endpoints",
+			name: "create service from Single Stack Service without endpoints",
 			slice: &discovery.EndpointSlice{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      serviceName + "ab23",
@@ -115,10 +115,6 @@ func TestSyncServices(t *testing.T) {
 				{
 					Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:k8s-cluster-lb-tcp=yes",
 					Output: loadbalancerTCP,
-				},
-				{
-					Cmd:    `ovn-nbctl --timeout=15 set load_balancer ` + loadbalancerTCP + ` vips:"192.168.1.1:80"=""`,
-					Output: "",
 				},
 				{
 					Cmd:    `ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find acl name=a08ea426-2288-11eb-a30b-a8a1590cda29-192.168.1.1\:80`,
@@ -162,10 +158,6 @@ func TestSyncServices(t *testing.T) {
 				{
 					Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:k8s-cluster-lb-tcp=yes",
 					Output: loadbalancerTCP,
-				},
-				{
-					Cmd:    `ovn-nbctl --timeout=15 set load_balancer ` + loadbalancerTCP + ` vips:"192.168.1.1:80"=""`,
-					Output: "",
 				},
 				{
 					Cmd:    `ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find acl name=a08ea426-2288-11eb-a30b-a8a1590cda29-192.168.1.1\:80`,
@@ -448,6 +440,99 @@ func TestUpdateServicePorts(t *testing.T) {
 	if !controller.serviceTracker.hasServiceVIP(serviceName, ns, "192.168.1.1:8888", v1.ProtocolTCP) {
 		t.Fatalf("Service with port 8888 should exist")
 	}
+}
+
+// A service created has no VIP entry and reject acl is created
+func TestServiceCreateReject(t *testing.T) {
+	// Expected OVN commands
+	fexec := ovntest.NewFakeExec()
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:k8s-cluster-lb-tcp=yes",
+		Output: loadbalancerTCP,
+	})
+	// Find if ACL exists
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    `ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find acl name=a08ea426-2288-11eb-a30b-a8a1590cda29-192.168.1.1\:80`,
+		Output: "",
+	})
+	// Create ACL
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    `ovn-nbctl --timeout=15 --id=@reject-acl create acl direction=from-lport priority=1000 match="ip4.dst==192.168.1.1 && tcp && tcp.dst==80" action=reject name=a08ea426-2288-11eb-a30b-a8a1590cda29-192.168.1.1\:80 -- add port_group 58a1ef18-3649-11eb-bd94-a8a1590cda29 acls @reject-acl`,
+		Output: "",
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:k8s-cluster-lb-tcp=yes",
+		Output: loadbalancerTCP,
+	})
+	// Endpoints got added, create LB entry
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    `ovn-nbctl --timeout=15 set load_balancer a08ea426-2288-11eb-a30b-a8a1590cda29 vips:"192.168.1.1:80"="10.0.0.2:3456"`,
+		Output: loadbalancerTCP,
+	})
+	// Find existing ACL
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    `ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find acl name=a08ea426-2288-11eb-a30b-a8a1590cda29-192.168.1.1\:80`,
+		Output: "1234",
+	})
+	// Remove ACL
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    `ovn-nbctl --timeout=15 -- --if-exists remove port_group 58a1ef18-3649-11eb-bd94-a8a1590cda29 acls 1234`,
+		Output: "",
+	})
+
+	err := util.SetExec(fexec)
+	if err != nil {
+		t.Errorf("fexec error: %v", err)
+	}
+
+	ns := "testns"
+	serviceName := "foo"
+	service := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: ns},
+		Spec: v1.ServiceSpec{
+			Type:       v1.ServiceTypeClusterIP,
+			ClusterIP:  "192.168.1.1",
+			ClusterIPs: []string{"192.168.1.1"},
+			Selector:   map[string]string{"foo": "bar"},
+			Ports: []v1.ServicePort{{
+				Port:       80,
+				Protocol:   v1.ProtocolTCP,
+				TargetPort: intstr.FromInt(3456),
+			}},
+		},
+	}
+	slice := &discovery.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      serviceName + "ab23",
+			Namespace: ns,
+			Labels:    map[string]string{discovery.LabelServiceName: serviceName},
+		},
+		Ports: []discovery.EndpointPort{
+			{
+				Name:     utilpointer.StringPtr("tcp-example"),
+				Protocol: protoPtr(v1.ProtocolTCP),
+				Port:     utilpointer.Int32Ptr(int32(3456)),
+			},
+		},
+		AddressType: discovery.AddressTypeIPv4,
+		Endpoints: []discovery.Endpoint{
+			{
+				Conditions: discovery.EndpointConditions{
+					Ready: utilpointer.BoolPtr(true),
+				},
+				Addresses: []string{"10.0.0.2"},
+				Topology:  map[string]string{"kubernetes.io/hostname": "node-1"},
+			},
+		},
+	}
+	controller := newController()
+	// Process the first service, should not create VIP in LB and create reject ACL instead
+	controller.serviceStore.Add(service)
+	controller.syncServices(ns + "/" + serviceName)
+
+	// Now add endpoints and ensure ACL is removed and LB VIP gets created
+	controller.endpointSliceStore.Add(slice)
+	controller.syncServices(ns + "/" + serviceName)
 }
 
 // protoPtr takes a Protocol and returns a pointer to it.


### PR DESCRIPTION
Temporary fix idling and reject with the new service controller.
In 4.8 we leverage OVN for doing that, in 4.7 we use ACLs