### PR TITLE
Bug 1937238: Refactor chain setup for NodePort and ExternalIP

### DIFF
--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -261,24 +261,8 @@ cookie=0x0, duration=8366.597s, table=1, n_packets=10641, n_bytes=10370087, prio
 		Eventually(fexec.CalledMatchesExpected, 5).Should(BeTrue(), fexec.ErrorDesc)
 
 		expectedTables := map[string]util.FakeTable{
-			"filter": {
-				"OUTPUT": []string{
-					"-j OVN-KUBE-EXTERNALIP",
-					"-j OVN-KUBE-NODEPORT",
-				},
-				"FORWARD": []string{
-					"-j OVN-KUBE-EXTERNALIP",
-					"-j OVN-KUBE-NODEPORT",
-				},
-				"OVN-KUBE-NODEPORT":   []string{},
-				"OVN-KUBE-EXTERNALIP": []string{},
-			},
 			"nat": {
 				"OUTPUT": []string{
-					"-j OVN-KUBE-EXTERNALIP",
-					"-j OVN-KUBE-NODEPORT",
-				},
-				"PREROUTING": []string{
 					"-j OVN-KUBE-EXTERNALIP",
 					"-j OVN-KUBE-NODEPORT",
 				},
@@ -291,8 +275,7 @@ cookie=0x0, duration=8366.597s, table=1, n_packets=10641, n_bytes=10370087, prio
 		Expect(err).NotTo(HaveOccurred())
 
 		expectedTables = map[string]util.FakeTable{
-			"filter": {},
-			"nat":    {},
+			"nat": {},
 		}
 		f6 := iptV6.(*util.FakeIPTables)
 		err = f6.MatchState(expectedTables)
@@ -446,21 +429,13 @@ func expectedIPTablesRules(gatewayIP string) map[string]util.FakeTable {
 				"-i " + localnetGatewayNextHopPort + " -m comment --comment from OVN to localhost -j ACCEPT",
 			},
 			"FORWARD": []string{
-				"-j OVN-KUBE-EXTERNALIP",
-				"-j OVN-KUBE-NODEPORT",
 				"-o " + localnetGatewayNextHopPort + " -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT",
 				"-i " + localnetGatewayNextHopPort + " -j ACCEPT",
 			},
-			"OVN-KUBE-NODEPORT":   []string{},
-			"OVN-KUBE-EXTERNALIP": []string{},
 		},
 		"nat": {
 			"POSTROUTING": []string{
 				"-s " + gatewayIP + " -j MASQUERADE",
-			},
-			"PREROUTING": []string{
-				"-j OVN-KUBE-EXTERNALIP",
-				"-j OVN-KUBE-NODEPORT",
 			},
 			"OUTPUT": []string{
 				"-j OVN-KUBE-EXTERNALIP",

--- a/go-controller/pkg/node/gateway_iptables.go
+++ b/go-controller/pkg/node/gateway_iptables.go
@@ -10,6 +10,7 @@ import (
 	"github.com/coreos/go-iptables/iptables"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	"github.com/pkg/errors"
 	kapi "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
 	utilnet "k8s.io/utils/net"
@@ -39,6 +40,7 @@ type iptRule struct {
 }
 
 func addIptRules(rules []iptRule) error {
+	var addErrors error
 	for _, r := range rules {
 		klog.V(5).Infof("Adding rule in table: %s, chain: %s with args: \"%s\" for protocol: %v ", r.table, r.chain, strings.Join(r.args, " "), r.protocol)
 		ipt, _ := util.GetIPTablesHelper(r.protocol)
@@ -50,24 +52,27 @@ func addIptRules(rules []iptRule) error {
 			err = ipt.Insert(r.table, r.chain, 1, r.args...)
 		}
 		if err != nil {
-			return fmt.Errorf("failed to add iptables %s/%s rule %q: %v",
+			addErrors = errors.Wrapf(addErrors, "failed to add iptables %s/%s rule %q: %v",
 				r.table, r.chain, strings.Join(r.args, " "), err)
 		}
 	}
-	return nil
+	return addErrors
 }
 
 func delIptRules(rules []iptRule) error {
+	var delErrors error
 	for _, r := range rules {
 		klog.V(5).Infof("Deleting rule in table: %s, chain: %s with args: \"%s\" for protocol: %v ", r.table, r.chain, strings.Join(r.args, " "), r.protocol)
 		ipt, _ := util.GetIPTablesHelper(r.protocol)
-		err := ipt.Delete(r.table, r.chain, r.args...)
-		if err != nil {
-			return fmt.Errorf("failed to delete iptables %s/%s rule %q: %v",
-				r.table, r.chain, strings.Join(r.args, " "), err)
+		if exists, err := ipt.Exists(r.table, r.chain, r.args...); err == nil && exists {
+			err := ipt.Delete(r.table, r.chain, r.args...)
+			if err != nil {
+				delErrors = errors.Wrapf(delErrors, "failed to delete iptables %s/%s rule %q: %v",
+					r.table, r.chain, strings.Join(r.args, " "), err)
+			}
 		}
 	}
-	return nil
+	return delErrors
 }
 
 func getSharedGatewayInitRules(chain string, proto iptables.Protocol) []iptRule {
@@ -75,24 +80,6 @@ func getSharedGatewayInitRules(chain string, proto iptables.Protocol) []iptRule 
 		{
 			table:    "nat",
 			chain:    "OUTPUT",
-			args:     []string{"-j", chain},
-			protocol: proto,
-		},
-		{
-			table:    "nat",
-			chain:    "PREROUTING",
-			args:     []string{"-j", chain},
-			protocol: proto,
-		},
-		{
-			table:    "filter",
-			chain:    "OUTPUT",
-			args:     []string{"-j", chain},
-			protocol: proto,
-		},
-		{
-			table:    "filter",
-			chain:    "FORWARD",
 			args:     []string{"-j", chain},
 			protocol: proto,
 		},
@@ -113,6 +100,34 @@ func getLocalGatewayInitRules(chain string, proto iptables.Protocol) []iptRule {
 			args:     []string{"-j", chain},
 			protocol: proto,
 		},
+	}
+}
+
+func getLegacyLocalGatewayInitRules(chain string, proto iptables.Protocol) []iptRule {
+	return []iptRule{
+		{
+			table:    "filter",
+			chain:    "FORWARD",
+			args:     []string{"-j", chain},
+			protocol: proto,
+		},
+	}
+}
+
+func getLegacySharedGatewayInitRules(chain string, proto iptables.Protocol) []iptRule {
+	return []iptRule{
+		{
+			table:    "nat",
+			chain:    "PREROUTING",
+			args:     []string{"-j", chain},
+			protocol: proto,
+		},
+		{
+			table:    "filter",
+			chain:    "OUTPUT",
+			args:     []string{"-j", chain},
+			protocol: proto,
+		},
 		{
 			table:    "filter",
 			chain:    "FORWARD",
@@ -129,7 +144,7 @@ func getNodePortIPTRules(svcPort kapi.ServicePort, nodeIP *net.IPNet, targetIP s
 	} else {
 		protocol = iptables.ProtocolIPv4
 	}
-	var natArgs, filterArgs []string
+	var natArgs []string
 	if nodeIP != nil {
 		natArgs = []string{
 			"-p", string(svcPort.Protocol),
@@ -138,23 +153,12 @@ func getNodePortIPTRules(svcPort kapi.ServicePort, nodeIP *net.IPNet, targetIP s
 			"-j", "DNAT",
 			"--to-destination", util.JoinHostPortInt32(targetIP, targetPort),
 		}
-		filterArgs = []string{
-			"-p", string(svcPort.Protocol),
-			"-d", nodeIP.IP.String(),
-			"--dport", fmt.Sprintf("%d", svcPort.NodePort),
-			"-j", "ACCEPT",
-		}
 	} else {
 		natArgs = []string{
 			"-p", string(svcPort.Protocol),
 			"--dport", fmt.Sprintf("%d", svcPort.NodePort),
 			"-j", "DNAT",
 			"--to-destination", util.JoinHostPortInt32(targetIP, targetPort),
-		}
-		filterArgs = []string{
-			"-p", string(svcPort.Protocol),
-			"--dport", fmt.Sprintf("%d", svcPort.NodePort),
-			"-j", "ACCEPT",
 		}
 	}
 
@@ -163,12 +167,6 @@ func getNodePortIPTRules(svcPort kapi.ServicePort, nodeIP *net.IPNet, targetIP s
 			table:    "nat",
 			chain:    iptableNodePortChain,
 			args:     natArgs,
-			protocol: protocol,
-		},
-		{
-			table:    "filter",
-			chain:    iptableNodePortChain,
-			args:     filterArgs,
 			protocol: protocol,
 		},
 	}
@@ -191,17 +189,6 @@ func getExternalIPTRules(svcPort kapi.ServicePort, externalIP, dstIP string) []i
 				"--dport", fmt.Sprintf("%v", svcPort.Port),
 				"-j", "DNAT",
 				"--to-destination", util.JoinHostPortInt32(dstIP, svcPort.Port),
-			},
-			protocol: protocol,
-		},
-		{
-			table: "filter",
-			chain: iptableExternalIPChain,
-			args: []string{
-				"-p", string(svcPort.Protocol),
-				"-d", externalIP,
-				"--dport", fmt.Sprintf("%v", svcPort.Port),
-				"-j", "ACCEPT",
 			},
 			protocol: protocol,
 		},
@@ -267,7 +254,7 @@ func initLocalGatewayNATRules(ifname string, cidr *net.IPNet) error {
 	return addIptRules(getLocalGatewayNATRules(ifname, cidr))
 }
 
-func initGatewayIPTables(genGatewayChainRules func(chain string, proto iptables.Protocol) []iptRule) error {
+func handleGatewayIPTables(iptCallback func(rules []iptRule) error, genGatewayChainRules func(chain string, proto iptables.Protocol) []iptRule) error {
 	rules := make([]iptRule, 0)
 	for _, chain := range []string{iptableNodePortChain, iptableExternalIPChain} {
 		for _, proto := range clusterIPTablesProtocols() {
@@ -278,27 +265,30 @@ func initGatewayIPTables(genGatewayChainRules func(chain string, proto iptables.
 			if err := ipt.NewChain("nat", chain); err != nil {
 				klog.V(5).Infof("Chain: \"%s\" in table: \"%s\" already exists, skipping creation", "nat", chain)
 			}
-			if err := ipt.NewChain("filter", chain); err != nil {
-				klog.V(5).Infof("Chain: \"%s\" in table: \"%s\" already exists, skipping creation", "filter", chain)
-			}
 			rules = append(rules, genGatewayChainRules(chain, proto)...)
 		}
 	}
-	if err := addIptRules(rules); err != nil {
-		return fmt.Errorf("failed to add iptables rules %v: %v", rules, err)
+	if err := iptCallback(rules); err != nil {
+		return fmt.Errorf("failed to handle iptables rules %v: %v", rules, err)
 	}
 	return nil
 }
 
 func initSharedGatewayIPTables() error {
-	if err := initGatewayIPTables(getSharedGatewayInitRules); err != nil {
+	if err := handleGatewayIPTables(addIptRules, getSharedGatewayInitRules); err != nil {
+		return err
+	}
+	if err := handleGatewayIPTables(delIptRules, getLegacySharedGatewayInitRules); err != nil {
 		return err
 	}
 	return nil
 }
 
 func initLocalGatewayIPTables() error {
-	if err := initGatewayIPTables(getLocalGatewayInitRules); err != nil {
+	if err := handleGatewayIPTables(addIptRules, getLocalGatewayInitRules); err != nil {
+		return err
+	}
+	if err := handleGatewayIPTables(delIptRules, getLegacyLocalGatewayInitRules); err != nil {
 		return err
 	}
 	return nil
@@ -313,9 +303,7 @@ func cleanupSharedGatewayIPTChains() {
 				return
 			}
 			_ = ipt.ClearChain("nat", chain)
-			_ = ipt.ClearChain("filter", chain)
 			_ = ipt.DeleteChain("nat", chain)
-			_ = ipt.DeleteChain("filter", chain)
 		}
 	}
 }

--- a/go-controller/pkg/node/gateway_localnet.go
+++ b/go-controller/pkg/node/gateway_localnet.go
@@ -366,7 +366,6 @@ func (l *localPortWatcher) SyncServices(serviceInterface []interface{}) {
 	}
 	for _, chain := range []string{iptableNodePortChain, iptableExternalIPChain} {
 		recreateIPTRules("nat", chain, keepIPTRules)
-		recreateIPTRules("filter", chain, keepIPTRules)
 	}
 	removeStaleRoutes(keepRoutes)
 }
@@ -419,15 +418,6 @@ func getLoadBalancerIPTRules(svc *kapi.Service, svcPort kapi.ServicePort, gatewa
 				"-d", ing.IP,
 				"-p", string(svcPort.Protocol), "--dport", ingPort,
 				"-j", "DNAT", "--to-destination", util.JoinHostPortInt32(gatewayIP, targetPort),
-			},
-		})
-		rules = append(rules, iptRule{
-			table: "filter",
-			chain: iptableNodePortChain,
-			args: []string{
-				"-d", ing.IP,
-				"-p", string(svcPort.Protocol), "--dport", ingPort,
-				"-j", "ACCEPT",
 			},
 		})
 	}

--- a/go-controller/pkg/node/gateway_localnet_linux_test.go
+++ b/go-controller/pkg/node/gateway_localnet_linux_test.go
@@ -36,8 +36,7 @@ func getFakeLocalAddrs() map[string]net.IPNet {
 
 func initFakeNodePortWatcher(fakeOvnNode *FakeOVNNode, iptV4, iptV6 util.IPTablesHelper) *localPortWatcher {
 	initIPTable := map[string]util.FakeTable{
-		"filter": {},
-		"nat":    {},
+		"nat": {},
 	}
 
 	f4 := iptV4.(*util.FakeIPTables)
@@ -145,14 +144,6 @@ var _ = Describe("Node Operations", func() {
 				startLocalPortWatcher(fNPW, fakeOvnNode.watcher)
 
 				expectedTables := map[string]util.FakeTable{
-					"filter": {
-						"FORWARD": []string{
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-						},
-						"OVN-KUBE-NODEPORT":   []string{},
-						"OVN-KUBE-EXTERNALIP": []string{},
-					},
 					"nat": {
 						"PREROUTING": []string{
 							"-j OVN-KUBE-EXTERNALIP",
@@ -171,8 +162,7 @@ var _ = Describe("Node Operations", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				expectedTables = map[string]util.FakeTable{
-					"filter": {},
-					"nat":    {},
+					"nat": {},
 				}
 				f6 := iptV6.(*util.FakeIPTables)
 				err = f6.MatchState(expectedTables)
@@ -234,12 +224,6 @@ var _ = Describe("Node Operations", func() {
 				addIptRules(fakeRules)
 
 				expectedTables := map[string]util.FakeTable{
-					"filter": {
-						"OVN-KUBE-EXTERNALIP": []string{
-							fmt.Sprintf("-p UDP -d 10.10.10.10 --dport 27000 -j ACCEPT"),
-							fmt.Sprintf("-p %s -d %s --dport %v -j ACCEPT", service.Spec.Ports[0].Protocol, externalIP, service.Spec.Ports[0].Port),
-						},
-					},
 					"nat": {
 						"OVN-KUBE-EXTERNALIP": []string{
 							fmt.Sprintf("-p UDP -d 10.10.10.10 --dport 27000 -j DNAT --to-destination 172.32.0.12:27000"),
@@ -263,16 +247,6 @@ var _ = Describe("Node Operations", func() {
 				Expect(fakeOvnNode.fakeExec.CalledMatchesExpected()).To(BeTrue(), fExec.ErrorDesc)
 
 				expectedTables = map[string]util.FakeTable{
-					"filter": {
-						"FORWARD": []string{
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-						},
-						"OVN-KUBE-NODEPORT": []string{},
-						"OVN-KUBE-EXTERNALIP": []string{
-							fmt.Sprintf("-p %s -d %s --dport %v -j ACCEPT", service.Spec.Ports[0].Protocol, externalIP, service.Spec.Ports[0].Port),
-						},
-					},
 					"nat": {
 						"PREROUTING": []string{
 							"-j OVN-KUBE-EXTERNALIP",
@@ -324,8 +298,7 @@ var _ = Describe("Node Operations", func() {
 				fNPW.addService(&service)
 
 				expectedTables := map[string]util.FakeTable{
-					"filter": {},
-					"nat":    {},
+					"nat": {},
 				}
 
 				f4 := iptV4.(*util.FakeIPTables)
@@ -360,8 +333,7 @@ var _ = Describe("Node Operations", func() {
 				fNPW.addService(&service)
 
 				expectedTables := map[string]util.FakeTable{
-					"filter": {},
-					"nat":    {},
+					"nat": {},
 				}
 
 				f4 := iptV4.(*util.FakeIPTables)
@@ -396,11 +368,6 @@ var _ = Describe("Node Operations", func() {
 				fNPW.addService(&service)
 
 				expectedTables := map[string]util.FakeTable{
-					"filter": {
-						"OVN-KUBE-EXTERNALIP": []string{
-							fmt.Sprintf("-p %s -d %s --dport %v -j ACCEPT", service.Spec.Ports[0].Protocol, externalIP, service.Spec.Ports[0].Port),
-						},
-					},
 					"nat": {
 						"OVN-KUBE-EXTERNALIP": []string{
 							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, externalIP, service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
@@ -436,11 +403,6 @@ var _ = Describe("Node Operations", func() {
 				fNPW.addService(&service)
 
 				expectedTables := map[string]util.FakeTable{
-					"filter": {
-						"OVN-KUBE-NODEPORT": []string{
-							fmt.Sprintf("-p %s --dport %v -j ACCEPT", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort),
-						},
-					},
 					"nat": {
 						"OVN-KUBE-NODEPORT": []string{
 							fmt.Sprintf("-p %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
@@ -478,11 +440,6 @@ var _ = Describe("Node Operations", func() {
 				fNPW.addService(&service)
 
 				expectedTables4 := map[string]util.FakeTable{
-					"filter": {
-						"OVN-KUBE-NODEPORT": []string{
-							fmt.Sprintf("-p %s --dport %v -j ACCEPT", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort),
-						},
-					},
 					"nat": {
 						"OVN-KUBE-NODEPORT": []string{
 							fmt.Sprintf("-p %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, service.Spec.ClusterIPs[0], service.Spec.Ports[0].Port),
@@ -495,11 +452,6 @@ var _ = Describe("Node Operations", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				expectedTables6 := map[string]util.FakeTable{
-					"filter": {
-						"OVN-KUBE-NODEPORT": []string{
-							fmt.Sprintf("-p %s --dport %v -j ACCEPT", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort),
-						},
-					},
 					"nat": {
 						"OVN-KUBE-NODEPORT": []string{
 							fmt.Sprintf("-p %s --dport %v -j DNAT --to-destination [%s]:%v", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, service.Spec.ClusterIPs[1], service.Spec.Ports[0].Port),
@@ -540,8 +492,7 @@ var _ = Describe("Node Operations", func() {
 				fNPW.deleteService(&service)
 
 				expectedTables := map[string]util.FakeTable{
-					"filter": {},
-					"nat":    {},
+					"nat": {},
 				}
 
 				f4 := iptV4.(*util.FakeIPTables)
@@ -576,8 +527,7 @@ var _ = Describe("Node Operations", func() {
 				fNPW.deleteService(&service)
 
 				expectedTables := map[string]util.FakeTable{
-					"filter": {},
-					"nat":    {},
+					"nat": {},
 				}
 
 				f4 := iptV4.(*util.FakeIPTables)
@@ -612,8 +562,7 @@ var _ = Describe("Node Operations", func() {
 				fNPW.deleteService(&service)
 
 				expectedTables := map[string]util.FakeTable{
-					"filter": {},
-					"nat":    {},
+					"nat": {},
 				}
 
 				f4 := iptV4.(*util.FakeIPTables)
@@ -648,8 +597,7 @@ var _ = Describe("Node Operations", func() {
 				fNPW.deleteService(&service)
 
 				expectedTables := map[string]util.FakeTable{
-					"filter": {},
-					"nat":    {},
+					"nat": {},
 				}
 
 				f4 := iptV4.(*util.FakeIPTables)
@@ -687,11 +635,6 @@ var _ = Describe("Node Operations", func() {
 				fNPW.addService(&service)
 
 				expectedTables := map[string]util.FakeTable{
-					"filter": {
-						"OVN-KUBE-EXTERNALIP": []string{
-							fmt.Sprintf("-p %s -d %s --dport %v -j ACCEPT", service.Spec.Ports[0].Protocol, externalIP, service.Spec.Ports[0].Port),
-						},
-					},
 					"nat": {
 						"OVN-KUBE-EXTERNALIP": []string{
 							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, externalIP, service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
@@ -706,9 +649,6 @@ var _ = Describe("Node Operations", func() {
 				fNPW.deleteService(&service)
 
 				expectedTables = map[string]util.FakeTable{
-					"filter": {
-						"OVN-KUBE-EXTERNALIP": []string{},
-					},
 					"nat": {
 						"OVN-KUBE-EXTERNALIP": []string{},
 					},
@@ -742,11 +682,6 @@ var _ = Describe("Node Operations", func() {
 				fNPW.addService(&service)
 
 				expectedTables := map[string]util.FakeTable{
-					"filter": {
-						"OVN-KUBE-NODEPORT": []string{
-							fmt.Sprintf("-p %s --dport %v -j ACCEPT", service.Spec.Ports[0].Protocol, nodePort),
-						},
-					},
 					"nat": {
 						"OVN-KUBE-NODEPORT": []string{
 							fmt.Sprintf("-p %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, nodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
@@ -761,9 +696,6 @@ var _ = Describe("Node Operations", func() {
 				fNPW.deleteService(&service)
 
 				expectedTables = map[string]util.FakeTable{
-					"filter": {
-						"OVN-KUBE-NODEPORT": []string{},
-					},
 					"nat": {
 						"OVN-KUBE-NODEPORT": []string{},
 					},

--- a/go-controller/pkg/node/gateway_shared_intf_linux.go
+++ b/go-controller/pkg/node/gateway_shared_intf_linux.go
@@ -124,6 +124,5 @@ func syncSharedGatewayIptRules(services []interface{}, nodeIP *net.IPNet) {
 	}
 	for _, chain := range []string{iptableNodePortChain, iptableExternalIPChain} {
 		recreateIPTRules("nat", chain, keepIPTRules)
-		recreateIPTRules("filter", chain, keepIPTRules)
 	}
 }

--- a/go-controller/pkg/node/management-port_linux_test.go
+++ b/go-controller/pkg/node/management-port_linux_test.go
@@ -203,7 +203,6 @@ func testManagementPort(ctx *cli.Context, fexec *ovntest.FakeExec, testNS ns.Net
 
 	for _, cfg := range configs {
 		expectedTables := map[string]util.FakeTable{
-			"filter": {},
 			"nat": {
 				"POSTROUTING": []string{
 					"-o " + mgtPort + " -j OVN-KUBE-SNAT-MGMTPORT",

--- a/go-controller/pkg/util/iptables.go
+++ b/go-controller/pkg/util/iptables.go
@@ -93,7 +93,6 @@ func newFakeWithProtocol(protocol iptables.Protocol) *FakeIPTables {
 		tables: make(map[string]*FakeTable),
 	}
 	// Prepopulate some common tables
-	ipt.tables["filter"] = newFakeTable()
 	ipt.tables["nat"] = newFakeTable()
 	return ipt
 }


### PR DESCRIPTION
Our iptables rules for NodePort and ExternalIP services were setting
up rules in filter FORWARD, which is a table used for routing packets
which don't have the node IP as neither source nore destination IP.

This is not needed for NodePort and ExternalIP. For NodePort services we
currently DNAT directly to the gatewayIP/clusterIP when a packet hits
a node, and this happens on every node, which thus, does not warrant
setting up filter FORWARD rules. In no case will node port packets
just be forwarded to another node.

For ExternalIP there is one case where routing external IP packets to
another node does occur, but we use routing table rules to do this. Which
means the filter FORWARD rules are not needed in that case either.

The problem with having NodePort and ExternalIP iptables rules in filter
FORWARD is that: every packet on the cluster going from one node to another
will be looked up in those chains. They will never match, but the lookup
can be exteremely costly on cluster with a lot of NodePort services defined,
see: https://bugzilla.redhat.com/show_bug.cgi?id=1923157

Also, remove NAT PREROUTING in shared gateway mode, since we configure OVS
flows on the shared gateway bridge to steer traffic into OVN thus rendering
the iptables rules superflous.

Signed-off-by: Alexander Constantinescu <aconstan@redhat.com>

Delete stale iptables jump rules for updates

On updates we need to remove the legacy jump rules for each
mode. This will handle that. Unfortunately there's no generic
way to do so depending on the services that we find, so we
still need them hard-coded. For posteriority's sake we should
really always have them, since we don't release ovn-kubernetes
and we never know when someone deploying ovn-kubernetes reaches
N+2 and can remove these.

/assign @trozet 

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->