### PR TITLE
Bump OVN to ovn2.13-20.12.0-25.el8fdp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN yum install -y  \
 	yum clean all
 
 ARG ovsver=2.13.0-79.el8fdp
-ARG ovnver=20.12.0-24.el8fdp
+ARG ovnver=20.12.0-25.el8fdp
 
 RUN INSTALL_PKGS=" \
 	openssl python3-pyOpenSSL firewalld-filesystem \


### PR DESCRIPTION
Includes a required fix for force_snat_ip=router_ip for upcoming shared
gw.

Signed-off-by: Tim Rozet <trozet@redhat.com>

