### PR TITLE
[WIP] Fix cni add 

### DIFF
--- a/go-controller/pkg/cni/cniserver_test.go
+++ b/go-controller/pkg/cni/cniserver_test.go
@@ -51,7 +51,7 @@ func clientDoCNI(t *testing.T, client *http.Client, req *Request) ([]byte, int) 
 
 var expectedResult cnitypes.Result
 
-func serverHandleCNI(request *PodRequest, podLister corev1listers.PodLister) ([]byte, error) {
+func serverHandleCNI(request *PodRequest, podLister corev1listers.PodLister, useOVSExternalIDs bool) ([]byte, error) {
 	if request.Command == CNIAdd {
 		return json.Marshal(&expectedResult)
 	} else if request.Command == CNIDel || request.Command == CNIUpdate || request.Command == CNICheck {
@@ -88,7 +88,7 @@ func TestCNIServer(t *testing.T) {
 		t.Fatalf("failed to create watch factory: %v", err)
 	}
 
-	s := NewCNIServer(tmpDir, wf)
+	s := NewCNIServer(tmpDir, false, wf)
 	if err := s.Start(serverHandleCNI); err != nil {
 		t.Fatalf("error starting CNI server: %v", err)
 	}
@@ -283,8 +283,8 @@ func TestCNIServerCancelAdd(t *testing.T) {
 
 	started := make(chan bool)
 
-	s := NewCNIServer(tmpDir, wf)
-	if err := s.Start(func(request *PodRequest, podLister corev1listers.PodLister) ([]byte, error) {
+	s := NewCNIServer(tmpDir, false, wf)
+	if err := s.Start(func(request *PodRequest, podLister corev1listers.PodLister, useOVSExternalIDs bool) ([]byte, error) {
 		// Let the testcase know it can now delete the pod
 		close(started)
 		// Wait for the testcase to cancel us

--- a/go-controller/pkg/cni/helper_linux.go
+++ b/go-controller/pkg/cni/helper_linux.go
@@ -384,8 +384,12 @@ func (pr *PodRequest) ConfigureInterface(namespace string, podName string, ifInf
 		return nil, err
 	}
 
-	if err = waitForPodFlows(pr.ctx, ifInfo.MAC.String(), ifInfo.IPs, hostIface.Name, ifaceID, ofPort); err != nil {
-		return nil, fmt.Errorf("error while waiting on flows for pod: %v", err)
+	if err = waitForPodInterface(pr.ctx, ifInfo.MAC.String(), ifInfo.IPs, hostIface.Name, ifaceID, ofPort, ifInfo.CheckExtIDs); err != nil {
+		if ifInfo.CheckExtIDs {
+			return nil, fmt.Errorf("error while waiting on OVS.Interface.external-ids:ovn-installed for pod: %v", err)
+		} else {
+			return nil, fmt.Errorf("error while waiting on flows for pod: %v", err)
+		}
 	}
 
 	return []*current.Interface{hostIface, contIface}, nil

--- a/go-controller/pkg/cni/types.go
+++ b/go-controller/pkg/cni/types.go
@@ -22,9 +22,10 @@ const serverSocketPath string = serverRunDir + "/" + serverSocketName
 type PodInterfaceInfo struct {
 	util.PodAnnotation
 
-	MTU     int   `json:"mtu"`
-	Ingress int64 `json:"ingress"`
-	Egress  int64 `json:"egress"`
+	MTU         int   `json:"mtu"`
+	Ingress     int64 `json:"ingress"`
+	Egress      int64 `json:"egress"`
+	CheckExtIDs bool  `json:"check-external-ids"`
 }
 
 // Explicit type for CNI commands the server handles
@@ -88,15 +89,18 @@ type PodRequest struct {
 	cancel context.CancelFunc
 }
 
-type cniRequestFunc func(request *PodRequest, podLister corev1listers.PodLister) ([]byte, error)
+type cniRequestFunc func(request *PodRequest, podLister corev1listers.PodLister, useOVSExternalIDs bool) ([]byte, error)
 
 // Server object that listens for JSON-marshaled Request objects
 // on a private root-only Unix domain socket.
 type Server struct {
 	http.Server
-	requestFunc cniRequestFunc
-	rundir      string
-	podLister   corev1listers.PodLister
+	requestFunc       cniRequestFunc
+	rundir            string
+	useOVSExternalIDs bool
+	podLister         corev1listers.PodLister
+	// serveMutex handles in flight changes to Server config
+	servMutex sync.RWMutex
 
 	// runningSandboxAdds is a map of sandbox ID to PodRequest for any CNIAdd operation
 	runningSandboxAddsLock sync.Mutex

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -1125,6 +1125,10 @@ func buildGatewayConfig(ctx *cli.Context, cli, file *config, allSubnets *configS
 		}
 	}
 
+	// HACK force shared gw mode
+	Gateway.Mode = GatewayModeShared
+	Gateway.DisableSNATMultipleGWs = true
+
 	if Gateway.Mode != GatewayModeShared && Gateway.VLANID != 0 {
 		return fmt.Errorf("gateway VLAN ID option: %d is supported only in shared gateway mode", Gateway.VLANID)
 	}

--- a/go-controller/pkg/types/const.go
+++ b/go-controller/pkg/types/const.go
@@ -102,7 +102,8 @@ const (
 	OvnSingleJoinSwitchTopoVersion = 1
 	OvnNamespacedDenyPGTopoVersion = 2
 	OvnHostToSvcOFTopoVersion      = 3
-	OvnCurrentTopologyVersion      = OvnHostToSvcOFTopoVersion
+	OvnPortBindingTopoVersion      = 4
+	OvnCurrentTopologyVersion      = OvnPortBindingTopoVersion
 
 	// OVN-K8S annotation constants
 	OvnK8sPrefix   = "k8s.ovn.org"


### PR DESCRIPTION
We are seeing on some platforms the following test fails:
ns/e2e-statefulset-1794 pod/ss-0 node/ip-10-0-168-201.us-east-2.compute.internal - 26.40 seconds after deletion - reason/FailedCreatePodSandBox Failed to create pod sandbox: rpc error: code = Unknown desc = failed to create pod network sandbox k8s_ss-0_e2e-statefulset-1794_1e8fc57d-c08b-48a3-9f03-bbfddb0c435c_0(e641a4f9828234a0d345063c7dc18acddfbfe3150b89006f9c308d78ce58ad29): [e2e-statefulset-1794/ss-0:ovn-kubernetes]: error adding container to network "ovn-kubernetes": CNI request failed with status 400: '[e2e-statefulset-1794/ss-0 e641a4f9828234a0d345063c7dc18acddfbfe3150b89006f9c308d78ce58ad29] [e2e-statefulset-1794/ss-0 e641a4f9828234a0d345063c7dc18acddfbfe3150b89006f9c308d78ce58ad29] failed to configure pod interface: error while waiting on flows for pod: timed out waiting for OVS flows

This fails this test:
https://github.com/kubernetes/kubernetes/blob/master/test/e2e/apps/statefulset.go#L731

This is probably due to ovnkube-master lagging to update the LSP, and CNI add has already found a previous annotation and is waiting for flows on an outdated IP.