### PR TITLE
Bug 1943310: [4.7] Enable DB memory trimming on compaction

### DIFF
--- a/go-controller/cmd/ovndbchecker/ovndbchecker.go
+++ b/go-controller/cmd/ovndbchecker/ovndbchecker.go
@@ -182,6 +182,10 @@ func runOvnKubeDBChecker(ctx *cli.Context) error {
 		return err
 	}
 
+	if err = ovndbmanager.EnableDBMemTrimming(); err != nil {
+		return err
+	}
+
 	stopChan := make(chan struct{})
 	ovndbmanager.RunDBChecker(
 		&kube.Kube{


### PR DESCRIPTION
Will periodically release memory back to the OS.

Cherry-pick of https://github.com/ovn-org/ovn-kubernetes/pull/1920 that was pulled into 4.8 as part of https://github.com/openshift/ovn-kubernetes/pull/438

@trozet 