### PR TITLE
[wip] master: cancel leader election on exit

### DIFF
--- a/go-controller/cmd/ovnkube/ovnkube.go
+++ b/go-controller/cmd/ovnkube/ovnkube.go
@@ -248,7 +248,7 @@ func runOvnKube(ctx *cli.Context) error {
 		metrics.RegisterMasterMetrics(ovnNBClient, ovnSBClient)
 
 		ovnController := ovn.NewOvnController(ovnClientset, masterWatchFactory, stopChan, nil, ovnNBClient, ovnSBClient, util.EventRecorder(ovnClientset.KubeClient))
-		if err := ovnController.Start(master, wg); err != nil {
+		if err := ovnController.Start(master, wg, ctx.Context); err != nil {
 			return err
 		}
 	}

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -56,7 +56,7 @@ func (_ ovnkubeMasterLeaderMetricsProvider) NewLeaderMetric() leaderelection.Swi
 }
 
 // Start waits until this process is the leader before starting master functions
-func (oc *Controller) Start(nodeName string, wg *sync.WaitGroup) error {
+func (oc *Controller) Start(nodeName string, wg *sync.WaitGroup, ctx context.Context) error {
 	// Set up leader election process first
 	rl, err := resourcelock.New(
 		resourcelock.ConfigMapsResourceLock,
@@ -71,10 +71,11 @@ func (oc *Controller) Start(nodeName string, wg *sync.WaitGroup) error {
 	}
 
 	lec := leaderelection.LeaderElectionConfig{
-		Lock:          rl,
-		LeaseDuration: time.Duration(config.MasterHA.ElectionLeaseDuration) * time.Second,
-		RenewDeadline: time.Duration(config.MasterHA.ElectionRenewDeadline) * time.Second,
-		RetryPeriod:   time.Duration(config.MasterHA.ElectionRetryPeriod) * time.Second,
+		Lock:            rl,
+		LeaseDuration:   time.Duration(config.MasterHA.ElectionLeaseDuration) * time.Second,
+		RenewDeadline:   time.Duration(config.MasterHA.ElectionRenewDeadline) * time.Second,
+		RetryPeriod:     time.Duration(config.MasterHA.ElectionRetryPeriod) * time.Second,
+		ReleaseOnCancel: true,
 		Callbacks: leaderelection.LeaderCallbacks{
 			OnStartedLeading: func(ctx context.Context) {
 				klog.Infof("Won leader election; in active mode")
@@ -117,7 +118,12 @@ func (oc *Controller) Start(nodeName string, wg *sync.WaitGroup) error {
 		return err
 	}
 
-	go leaderElector.Run(context.Background())
+	wg.Add(1)
+	go func() {
+		leaderElector.Run(ctx)
+		klog.Infof("Leader election terminated")
+		wg.Done()
+	}()
 
 	return nil
 }

--- a/go-controller/vendor/k8s.io/client-go/tools/leaderelection/leaderelection.go
+++ b/go-controller/vendor/k8s.io/client-go/tools/leaderelection/leaderelection.go
@@ -290,6 +290,7 @@ func (le *LeaderElector) release() bool {
 	if !le.IsLeader() {
 		return true
 	}
+	klog.Infof("###### releasing cm %+v %s", le.config.Lock, le.config.Lock.Describe())
 	now := metav1.Now()
 	leaderElectionRecord := rl.LeaderElectionRecord{
 		LeaderTransitions:    le.observedRecord.LeaderTransitions,

--- a/go-controller/vendor/k8s.io/client-go/tools/leaderelection/resourcelock/configmaplock.go
+++ b/go-controller/vendor/k8s.io/client-go/tools/leaderelection/resourcelock/configmaplock.go
@@ -113,7 +113,12 @@ func (cml *ConfigMapLock) RecordEvent(s string) {
 // Describe is used to convert details on current resource lock
 // into a string
 func (cml *ConfigMapLock) Describe() string {
-	return fmt.Sprintf("%v/%v", cml.ConfigMapMeta.Namespace, cml.ConfigMapMeta.Name)
+	var ns, name string
+	if cml.cm != nil {
+		ns = cml.cm.Namespace
+		name = cml.cm.Name
+	}
+	return fmt.Sprintf("[%v/%v %v/%v]", cml.ConfigMapMeta.Namespace, cml.ConfigMapMeta.Name, ns, name)
 }
 
 // Identity returns the Identity of the lock


### PR DESCRIPTION
When the master is terminated instead of just exiting, give leader
election a chance to release the leader lock so another ovnkube
master can grab it while this instance is down.

@trozet 