### PR TITLE
Bug 1945725: Revert the ovn change to avoid a crash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN yum install -y  \
 	yum clean all
 
 ARG ovsver=2.13.0-72.el8fdp
-ARG ovnver=20.09.0-7.el8fdn
+ARG ovnver=20.06.2-11.el8fdp
 
 RUN INSTALL_PKGS=" \
 	openssl firewalld-filesystem \


### PR DESCRIPTION
We bumped the ovn version to 20.09.0-7.el8fdn to try to fix Bug 1933752 (https://bugzilla.redhat.com/show_bug.cgi?id=1933752) where we would log messages when some NetworkPolicies were used.  However, other NetworkPolicies can cause that version to crash.

So, until we work out how we want to fix the problem, it is safer to revert the change.
