### PR TITLE
Bug 1946696: iptables: add filter on node local traffic

### DIFF
--- a/go-controller/pkg/node/gateway_localnet.go
+++ b/go-controller/pkg/node/gateway_localnet.go
@@ -215,7 +215,7 @@ func (l *localPortWatcher) addService(svc *kapi.Service) error {
 
 			if port.NodePort > 0 {
 				if gatewayIP != "" {
-					iptRules = append(iptRules, getNodePortIPTRules(port, nil, ip, port.Port)...)
+					iptRules = append(iptRules, getNodePortIPTRules(port, ip, port.Port)...)
 					klog.V(5).Infof("Will add iptables rule for NodePort: %v and "+
 						"protocol: %v", port.NodePort, port.Protocol)
 				} else {
@@ -283,7 +283,7 @@ func (l *localPortWatcher) deleteService(svc *kapi.Service) error {
 			iptRules = append(iptRules, getLoadBalancerIPTRules(svc, port, ip, port.Port)...)
 			if port.NodePort > 0 {
 				if gatewayIP != "" {
-					iptRules = append(iptRules, getNodePortIPTRules(port, nil, ip, port.Port)...)
+					iptRules = append(iptRules, getNodePortIPTRules(port, ip, port.Port)...)
 					klog.V(5).Infof("Will delete iptables rule for NodePort: %v and "+
 						"protocol: %v", port.NodePort, port.Protocol)
 				}
@@ -359,7 +359,7 @@ func (l *localPortWatcher) SyncServices(serviceInterface []interface{}) {
 				gatewayIP = l.gatewayIPv6
 			}
 			if gatewayIP != "" {
-				keepIPTRules = append(keepIPTRules, getGatewayIPTRules(svc, gatewayIP, nil)...)
+				keepIPTRules = append(keepIPTRules, getGatewayIPTRules(svc, gatewayIP)...)
 			}
 			keepRoutes = append(keepRoutes, svc.Spec.ExternalIPs...)
 		}

--- a/go-controller/pkg/node/gateway_localnet_linux_test.go
+++ b/go-controller/pkg/node/gateway_localnet_linux_test.go
@@ -405,7 +405,7 @@ var _ = Describe("Node Operations", func() {
 				expectedTables := map[string]util.FakeTable{
 					"nat": {
 						"OVN-KUBE-NODEPORT": []string{
-							fmt.Sprintf("-p %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
+							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
 						},
 					},
 				}
@@ -442,7 +442,7 @@ var _ = Describe("Node Operations", func() {
 				expectedTables4 := map[string]util.FakeTable{
 					"nat": {
 						"OVN-KUBE-NODEPORT": []string{
-							fmt.Sprintf("-p %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, service.Spec.ClusterIPs[0], service.Spec.Ports[0].Port),
+							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, service.Spec.ClusterIPs[0], service.Spec.Ports[0].Port),
 						},
 					},
 				}
@@ -454,7 +454,7 @@ var _ = Describe("Node Operations", func() {
 				expectedTables6 := map[string]util.FakeTable{
 					"nat": {
 						"OVN-KUBE-NODEPORT": []string{
-							fmt.Sprintf("-p %s --dport %v -j DNAT --to-destination [%s]:%v", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, service.Spec.ClusterIPs[1], service.Spec.Ports[0].Port),
+							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination [%s]:%v", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, service.Spec.ClusterIPs[1], service.Spec.Ports[0].Port),
 						},
 					},
 				}
@@ -684,7 +684,7 @@ var _ = Describe("Node Operations", func() {
 				expectedTables := map[string]util.FakeTable{
 					"nat": {
 						"OVN-KUBE-NODEPORT": []string{
-							fmt.Sprintf("-p %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, nodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
+							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, nodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
 						},
 					},
 				}

--- a/go-controller/pkg/node/gateway_shared_intf_linux.go
+++ b/go-controller/pkg/node/gateway_shared_intf_linux.go
@@ -93,21 +93,21 @@ func setupLocalNodeAccessBridge(nodeName string, subnets []*net.IPNet) error {
 	return nil
 }
 
-func addSharedGatewayIptRules(service *kapi.Service, nodeIP *net.IPNet) {
-	rules := getGatewayIPTRules(service, "", nodeIP)
+func addSharedGatewayIptRules(service *kapi.Service) {
+	rules := getGatewayIPTRules(service, "")
 	if err := addIptRules(rules); err != nil {
 		klog.Errorf("Failed to add iptables rules for service %s/%s: %v", service.Namespace, service.Name, err)
 	}
 }
 
-func delSharedGatewayIptRules(service *kapi.Service, nodeIP *net.IPNet) {
-	rules := getGatewayIPTRules(service, "", nodeIP)
+func delSharedGatewayIptRules(service *kapi.Service) {
+	rules := getGatewayIPTRules(service, "")
 	if err := delIptRules(rules); err != nil {
 		klog.Errorf("Failed to delete iptables rules for service %s/%s: %v", service.Namespace, service.Name, err)
 	}
 }
 
-func syncSharedGatewayIptRules(services []interface{}, nodeIP *net.IPNet) {
+func syncSharedGatewayIptRules(services []interface{}) {
 	keepIPTRules := []iptRule{}
 	for _, service := range services {
 		svc, ok := service.(*kapi.Service)
@@ -115,7 +115,7 @@ func syncSharedGatewayIptRules(services []interface{}, nodeIP *net.IPNet) {
 			klog.Errorf("Spurious object in syncSharedGatewayIptRules: %v", service)
 			continue
 		}
-		keepIPTRules = append(keepIPTRules, getGatewayIPTRules(svc, "", nodeIP)...)
+		keepIPTRules = append(keepIPTRules, getGatewayIPTRules(svc, "")...)
 	}
 	for _, chain := range []string{iptableNodePortChain, iptableExternalIPChain} {
 		recreateIPTRules("nat", chain, keepIPTRules)


### PR DESCRIPTION
Back-port PR to 4.7

This patch simplifies ovnkube-node to remove the notion of node IP.
This notion only existed for the iptables rules to be configured
correctly. By utilizing `--dst-type LOCAL` we however don't need
that anymore and can simplify our logic.

Signed-off-by: Alexander Constantinescu <aconstan@redhat.com>

/assign @trozet 

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->