### PR TITLE
Bug 1946899: master: enable logical datapath groups for OVN >= 20.12

### DIFF
--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -211,6 +211,31 @@ func (oc *Controller) upgradeOVNTopology(existingNodes *kapi.NodeList) error {
 	return nil
 }
 
+// enableOVNLogicalDataPathGroups sets an OVN flag to enable logical datapath
+// groups on OVN 20.12 and later. The option is ignored if OVN doesn't
+// understand it. Logical datapath groups reduce the size of the southbound
+// database in large clusters. ovn-controllers should be upgraded to a version
+// that supports them before the option is turned on by the master.
+func (oc *Controller) enableOVNLogicalDatapathGroups() error {
+	options, err := oc.ovnNBClient.NBGlobalGetOptions()
+	if err != nil {
+		klog.Errorf("Failed to get NB global options: %v", err)
+		return err
+	}
+	options["use_logical_dp_groups"] = "true"
+	cmd, err := oc.ovnNBClient.NBGlobalSetOptions(options)
+	if err != nil {
+		klog.Errorf("Failed to set NB global option to enable logical datapath groups: %v", err)
+		return err
+	}
+	if err := cmd.Execute(); err != nil {
+		klog.Errorf("Failed to enable logical datapath groups: %v", err)
+		return err
+	}
+
+	return nil
+}
+
 // StartClusterMaster runs a subnet IPAM and a controller that watches arrival/departure
 // of nodes in the cluster
 // On an addition to the cluster (node create), a new subnet is created for it that will translate
@@ -238,6 +263,11 @@ func (oc *Controller) StartClusterMaster(masterNodeName string) error {
 		// set aside the first two IPs for the nextHop on the host and for distributed gateway port
 		_ = oc.nodeLocalNatIPv6Allocator.Allocate(net.ParseIP(types.V6NodeLocalNATSubnetNextHop))
 		_ = oc.nodeLocalNatIPv6Allocator.Allocate(net.ParseIP(types.V6NodeLocalDistributedGWPortIP))
+	}
+
+	// Enable logical datapath groups for OVN 20.12 and later
+	if err := oc.enableOVNLogicalDatapathGroups(); err != nil {
+		return err
 	}
 
 	existingNodes, err := oc.kube.GetNodes()


### PR DESCRIPTION
Since the CNO patch is already on 4.7, this back-port should work

------

Logical datapath groups reduce the size of the southbound
database in large clusters. The option is ignored if unsupported
by ovn-northd. ovn-controllers should be upgraded to a version
that supports this option before it is turned on.

Signed-off-by: Dan Williams <dcbw@redhat.com>

/assign @dcbw 

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->