### PR TITLE
Bug 1947835: Fix service update for policy type assertion

### DIFF
--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -906,8 +906,8 @@ func (oc *Controller) handlePeerService(
 			},
 			UpdateFunc: func(oldObj, newObj interface{}) {
 				// If Service Is updated make sure same pods are still matched
-				oldSvc := oldObj.(kapi.Service)
-				newSvc := newObj.(kapi.Service)
+				oldSvc := oldObj.(*kapi.Service)
+				newSvc := newObj.(*kapi.Service)
 				if reflect.DeepEqual(newSvc.Spec.ExternalIPs, oldSvc.Spec.ExternalIPs) &&
 					reflect.DeepEqual(newSvc.Spec.ClusterIP, oldSvc.Spec.ClusterIP) &&
 					reflect.DeepEqual(newSvc.Spec.Type, oldSvc.Spec.Type) &&


### PR DESCRIPTION
4.7 back-port of:

-----------------

The updateFunc in handlePeerService when a service is updated casts the
previous / old objects to kapi.Service (instead of pointers). This
may result in a runtime.TypeAssertionError and a crash of kube master

Signed-off-by: Federico Paolinelli <fpaoline@redhat.com>

/assign @trozet @dcbw 

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->