### PR TITLE
Bug 1950159: Fix linter errors in OCP Hacks

### DIFF
--- a/go-controller/pkg/node/OCP_HACKS.go
+++ b/go-controller/pkg/node/OCP_HACKS.go
@@ -35,7 +35,7 @@ func generateBlockMCSRules(rules *[]iptRule, protocol iptables.Protocol) {
 		}
 	}
 
-	delIptRules(delRules)
+	_ = delIptRules(delRules)
 }
 
 // initSharedGatewayNoBridge is used in order to run local gateway mode without moving the NIC to an ovs bridge


### PR DESCRIPTION
Fix lint issues with the downstream OCP hack.

Signed-off-by: Aniket Bhat <anbhat@redhat.com>
