### PR TITLE
Bug 1950434: [4.6] pods: bind pod logical switch ports to the node's chassis with requested-chassis

### DIFF
--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -288,12 +288,30 @@ func (oc *Controller) addLogicalPort(pod *kapi.Pod) (err error) {
 	if lsp == nil {
 		cmd, err = oc.ovnNBClient.LSPAdd(logicalSwitch, portName)
 		if err != nil {
-			return fmt.Errorf("unable to create the LSPAdd command for port: %s from the nbdb", portName)
+			return fmt.Errorf("unable to create the LSPAdd command for port: %s from the nbdb: %v", portName, err)
 		}
 		cmds = append(cmds, cmd)
 	} else {
 		klog.Infof("LSP already exists for port: %s", portName)
 	}
+
+	// Bind the port to the node's chassis; prevents ping-ponging between
+	// chassis if ovnkube-node isn't running correctly and hasn't cleared
+	// out iface-id for an old instance of this pod, and the pod got
+	// rescheduled.
+	opts, err := oc.ovnNBClient.LSPGetOptions(portName)
+	if err != nil && err != goovn.ErrorNotFound {
+		klog.Warningf("Failed to get options for port %s: %v", portName, err)
+	}
+	if opts == nil {
+		opts = make(map[string]string)
+	}
+	opts["requested-chassis"] = pod.Spec.NodeName
+	cmd, err = oc.ovnNBClient.LSPSetOptions(portName, opts)
+	if err != nil {
+		return fmt.Errorf("unable to create the LSPSetOptions command for port: %s from the nbdb: %v", portName, err)
+	}
+	cmds = append(cmds, cmd)
 
 	annotation, err := util.UnmarshalPodAnnotation(pod.Annotations)
 

--- a/go-controller/pkg/testing/mock_lsp.go
+++ b/go-controller/pkg/testing/mock_lsp.go
@@ -120,12 +120,39 @@ func (mock *MockOVNClient) LSPGetDHCPv6Options(lsp string) (*goovn.DHCPOptions, 
 
 // Set options in LSP
 func (mock *MockOVNClient) LSPSetOptions(lsp string, options map[string]string) (*goovn.OvnCommand, error) {
-	return nil, fmt.Errorf("method %s is not implemented yet", functionName())
+	return &goovn.OvnCommand{
+		Exe: &MockExecution{
+			handler: mock,
+			op:      OpUpdate,
+			table:   LogicalSwitchPortType,
+			objName: lsp,
+			objUpdate: UpdateCache{
+				FieldType:  LogicalSwitchPortOptions,
+				FieldValue: options,
+			},
+		},
+	}, nil
 }
 
 // Get Options for LSP
 func (mock *MockOVNClient) LSPGetOptions(lsp string) (map[string]string, error) {
-	return nil, fmt.Errorf("method %s is not implemented yet", functionName())
+	lspRet, err := mock.LSPGet(lsp)
+	if err != nil {
+		return nil, err
+	}
+	if lspRet != nil {
+		return nil, fmt.Errorf("no lsp found with name: %s", lsp)
+	}
+	opts := make(map[string]string)
+	for k, v := range lspRet.Options {
+		key, keyOk := k.(string)
+		value, valueOk := v.(string)
+		if !keyOk || !valueOk {
+			continue
+		}
+		opts[key] = value
+	}
+	return opts, nil
 }
 
 // Set dynamic addresses in LSP
@@ -238,6 +265,17 @@ func (mock *MockOVNClient) updateLSPCache(lspName string, update UpdateCache, mo
 				extMap[k] = v
 			}
 			lsp.ExternalID = extMap
+		} else {
+			return fmt.Errorf("type assertion failed for LSP field: %s", update.FieldType)
+		}
+	case LogicalSwitchPortOptions:
+		klog.V(5).Infof("Setting options for LSP %s", lspName)
+		if opts, ok := update.FieldValue.(map[string]string); ok {
+			optMap := make(map[interface{}]interface{})
+			for k, v := range opts {
+				optMap[k] = v
+			}
+			lsp.Options = optMap
 		} else {
 			return fmt.Errorf("type assertion failed for LSP field: %s", update.FieldType)
 		}


### PR DESCRIPTION
To prevent port binding ping-pongs between ovn-controllers, if an
ovnkube-node isn't running or hasn't been able to clear the iface-id
for an old instance of a pod, but the pod has been rescheduled,
request the chassis the pod has been scheduled on.

4.6 backport of https://github.com/openshift/ovn-kubernetes/pull/500