### PR TITLE
Bug 1951064: master: cancel leader election on exit

### DIFF
--- a/go-controller/cmd/ovnkube/ovnkube.go
+++ b/go-controller/cmd/ovnkube/ovnkube.go
@@ -248,7 +248,7 @@ func runOvnKube(ctx *cli.Context) error {
 		metrics.RegisterMasterMetrics(ovnNBClient, ovnSBClient)
 
 		ovnController := ovn.NewOvnController(ovnClientset, masterWatchFactory, stopChan, nil, ovnNBClient, ovnSBClient, util.EventRecorder(ovnClientset.KubeClient))
-		if err := ovnController.Start(master, wg); err != nil {
+		if err := ovnController.Start(master, wg, ctx.Context); err != nil {
 			return err
 		}
 	}

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -58,7 +58,7 @@ func (_ ovnkubeMasterLeaderMetricsProvider) NewLeaderMetric() leaderelection.Swi
 }
 
 // Start waits until this process is the leader before starting master functions
-func (oc *Controller) Start(nodeName string, wg *sync.WaitGroup) error {
+func (oc *Controller) Start(nodeName string, wg *sync.WaitGroup, ctx context.Context) error {
 	// Set up leader election process first
 	rl, err := resourcelock.New(
 		resourcelock.ConfigMapsResourceLock,
@@ -73,10 +73,11 @@ func (oc *Controller) Start(nodeName string, wg *sync.WaitGroup) error {
 	}
 
 	lec := leaderelection.LeaderElectionConfig{
-		Lock:          rl,
-		LeaseDuration: time.Duration(config.MasterHA.ElectionLeaseDuration) * time.Second,
-		RenewDeadline: time.Duration(config.MasterHA.ElectionRenewDeadline) * time.Second,
-		RetryPeriod:   time.Duration(config.MasterHA.ElectionRetryPeriod) * time.Second,
+		Lock:            rl,
+		LeaseDuration:   time.Duration(config.MasterHA.ElectionLeaseDuration) * time.Second,
+		RenewDeadline:   time.Duration(config.MasterHA.ElectionRenewDeadline) * time.Second,
+		RetryPeriod:     time.Duration(config.MasterHA.ElectionRetryPeriod) * time.Second,
+		ReleaseOnCancel: true,
 		Callbacks: leaderelection.LeaderCallbacks{
 			OnStartedLeading: func(ctx context.Context) {
 				klog.Infof("Won leader election; in active mode")
@@ -119,7 +120,12 @@ func (oc *Controller) Start(nodeName string, wg *sync.WaitGroup) error {
 		return err
 	}
 
-	go leaderElector.Run(context.Background())
+	wg.Add(1)
+	go func() {
+		leaderElector.Run(ctx)
+		klog.Infof("Stopped leader election")
+		wg.Done()
+	}()
 
 	return nil
 }


### PR DESCRIPTION
When the master is terminated instead of just exiting, give leader
election a chance to release the leader lock so another ovnkube
master can grab it while this instance is down.

Signed-off-by: Dan Williams <dcbw@redhat.com>
(cherry picked from commit 9c1d0c193d736d2d8180e5b0e5dc3c87f0b9ff03)

