### PR TITLE
Bug 1952262: Revert "removing the hybrid overlay externalGW code"

### DIFF
--- a/go-controller/hybrid-overlay/pkg/controller/master.go
+++ b/go-controller/hybrid-overlay/pkg/controller/master.go
@@ -4,9 +4,11 @@ import (
 	"fmt"
 	"net"
 	"sync"
+	"time"
 
 	goovn "github.com/ebay/go-ovn"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/hybrid-overlay/pkg/types"
+	hotypes "github.com/ovn-org/ovn-kubernetes/go-controller/hybrid-overlay/pkg/types"
 	houtil "github.com/ovn-org/ovn-kubernetes/go-controller/hybrid-overlay/pkg/util"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/informer"
@@ -16,7 +18,11 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 
 	kapi "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/labels"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 	utilnet "k8s.io/utils/net"
@@ -24,11 +30,13 @@ import (
 
 // MasterController is the master hybrid overlay controller
 type MasterController struct {
-	kube             kube.Interface
-	allocator        *subnetallocator.SubnetAllocator
-	nodeEventHandler informer.EventHandler
-	ovnNBClient      goovn.Client
-	ovnSBClient      goovn.Client
+	kube                  kube.Interface
+	allocator             *subnetallocator.SubnetAllocator
+	nodeEventHandler      informer.EventHandler
+	namespaceEventHandler informer.EventHandler
+	podEventHandler       informer.EventHandler
+	ovnNBClient           goovn.Client
+	ovnSBClient           goovn.Client
 }
 
 // NewMaster a new master controller that listens for node events
@@ -64,6 +72,36 @@ func NewMaster(kube kube.Interface,
 			return m.DeleteNode(node)
 		},
 		informer.ReceiveAllUpdates,
+	)
+
+	m.namespaceEventHandler = eventHandlerCreateFunction("namespace", namespaceInformer,
+		func(obj interface{}) error {
+			ns, ok := obj.(*kapi.Namespace)
+			if !ok {
+				return fmt.Errorf("object is not a namespace")
+			}
+			return m.AddNamespace(ns)
+		},
+		func(obj interface{}) error {
+			// discard deletes
+			return nil
+		},
+		nsHybridAnnotationChanged,
+	)
+
+	m.podEventHandler = eventHandlerCreateFunction("pod", podInformer,
+		func(obj interface{}) error {
+			pod, ok := obj.(*kapi.Pod)
+			if !ok {
+				return fmt.Errorf("object is not a pod")
+			}
+			return m.AddPod(pod)
+		},
+		func(obj interface{}) error {
+			// discard deletes
+			return nil
+		},
+		informer.DiscardAllUpdates,
 	)
 
 	// Add our hybrid overlay CIDRs to the subnetallocator
@@ -104,6 +142,22 @@ func (m *MasterController) Run(stopCh <-chan struct{}) {
 	go func() {
 		defer wg.Done()
 		err := m.nodeEventHandler.Run(informer.DefaultNodeInformerThreadiness, stopCh)
+		if err != nil {
+			klog.Error(err)
+		}
+	}()
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		err := m.namespaceEventHandler.Run(informer.DefaultInformerThreadiness, stopCh)
+		if err != nil {
+			klog.Error(err)
+		}
+	}()
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		err := m.podEventHandler.Run(informer.DefaultInformerThreadiness, stopCh)
 		if err != nil {
 			klog.Error(err)
 		}
@@ -381,4 +435,79 @@ func removeHybridLRPolicySharedGW(nodeName string) error {
 		}
 	}
 	return nil
+}
+
+// AddNamespace copies namespace annotations to all pods in the namespace
+func (m *MasterController) AddNamespace(ns *kapi.Namespace) error {
+	podLister := listers.NewPodLister(m.podEventHandler.GetIndexer())
+	pods, err := podLister.Pods(ns.Name).List(labels.Everything())
+	if err != nil {
+		return err
+	}
+	for _, pod := range pods {
+		if err := houtil.CopyNamespaceAnnotationsToPod(m.kube, ns, pod); err != nil {
+			klog.Errorf("Unable to copy hybrid-overlay namespace annotations to pod %s", pod.Name)
+		}
+	}
+	return nil
+}
+
+// waitForNamespace fetches a namespace from the cache, or waits until it's available
+func (m *MasterController) waitForNamespace(name string) (*kapi.Namespace, error) {
+	var namespaceBackoff = wait.Backoff{Duration: 1 * time.Second, Steps: 7, Factor: 1.5, Jitter: 0.1}
+	var namespace *kapi.Namespace
+	if err := wait.ExponentialBackoff(namespaceBackoff, func() (bool, error) {
+		var err error
+		namespaceLister := listers.NewNamespaceLister(m.namespaceEventHandler.GetIndexer())
+		namespace, err = namespaceLister.Get(name)
+		if err != nil {
+			if errors.IsNotFound(err) {
+				// Namespace not found; retry
+				return false, nil
+			}
+			klog.Warningf("Error getting namespace: %v", err)
+			return false, err
+		}
+		return true, nil
+	}); err != nil {
+		return nil, fmt.Errorf("failed to get namespace object: %v", err)
+	}
+	return namespace, nil
+}
+
+// AddPod ensures that hybrid overlay annotations are copied to a
+// pod when it's created. This allows the nodes to set up the appropriate
+// flows
+func (m *MasterController) AddPod(pod *kapi.Pod) error {
+	namespace, err := m.waitForNamespace(pod.Namespace)
+	if err != nil {
+		return err
+	}
+
+	namespaceExternalGw := namespace.Annotations[hotypes.HybridOverlayExternalGw]
+	namespaceVTEP := namespace.Annotations[hotypes.HybridOverlayVTEP]
+
+	podExternalGw := pod.Annotations[hotypes.HybridOverlayExternalGw]
+	podVTEP := pod.Annotations[hotypes.HybridOverlayVTEP]
+
+	if namespaceExternalGw != podExternalGw || namespaceVTEP != podVTEP {
+		// copy namespace annotations to the pod and return
+		return houtil.CopyNamespaceAnnotationsToPod(m.kube, namespace, pod)
+	}
+	return nil
+}
+
+// nsHybridAnnotationChanged returns true if any relevant NS attributes changed
+func nsHybridAnnotationChanged(old, new interface{}) bool {
+	oldNs := old.(*kapi.Namespace)
+	newNs := new.(*kapi.Namespace)
+
+	nsExGwOld := oldNs.GetAnnotations()[hotypes.HybridOverlayExternalGw]
+	nsVTEPOld := oldNs.GetAnnotations()[hotypes.HybridOverlayVTEP]
+	nsExGwNew := newNs.GetAnnotations()[hotypes.HybridOverlayExternalGw]
+	nsVTEPNew := newNs.GetAnnotations()[hotypes.HybridOverlayVTEP]
+	if nsExGwOld != nsExGwNew || nsVTEPOld != nsVTEPNew {
+		return true
+	}
+	return false
 }

--- a/go-controller/hybrid-overlay/pkg/controller/master_test.go
+++ b/go-controller/hybrid-overlay/pkg/controller/master_test.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"strings"
 	"sync"
 
@@ -10,6 +11,8 @@ import (
 	"github.com/urfave/cli/v2"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
 
@@ -376,6 +379,190 @@ var _ = Describe("Hybrid SDN Master Operations", func() {
 			}, 5).ShouldNot(HaveKey(hotypes.HybridOverlayDRMAC))
 
 			Eventually(fexec.CalledMatchesExpected, 2).Should(BeTrue(), fexec.ErrorDesc)
+			return nil
+		}
+
+		err := app.Run([]string{
+			app.Name,
+			"-loglevel=5",
+			"-enable-hybrid-overlay",
+			"-hybrid-overlay-cluster-subnets=" + hybridOverlayClusterCIDR,
+		})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("copies namespace annotations when a pod is added", func() {
+		app.Action = func(ctx *cli.Context) error {
+			const (
+				nsName     string = "nstest"
+				nsVTEP            = "1.1.1.1"
+				nsExGw            = "2.2.2.2"
+				nodeName   string = "node1"
+				nodeSubnet string = "10.1.2.0/24"
+				nodeHOIP   string = "10.1.2.3"
+				nodeHOMAC  string = "00:00:00:52:19:d2"
+				pod1Name   string = "pod1"
+				pod1IP     string = "1.2.3.5"
+				pod1CIDR   string = pod1IP + "/24"
+				pod1MAC    string = "aa:bb:cc:dd:ee:ff"
+			)
+
+			ns := &v1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					UID:  k8stypes.UID(nsName),
+					Name: nsName,
+					Annotations: map[string]string{
+						hotypes.HybridOverlayVTEP:       nsVTEP,
+						hotypes.HybridOverlayExternalGw: nsExGw,
+					},
+				},
+				Spec:   v1.NamespaceSpec{},
+				Status: v1.NamespaceStatus{},
+			}
+			fakeClient := fake.NewSimpleClientset([]runtime.Object{
+				ns,
+				createPod(nsName, pod1Name, nodeName, pod1CIDR, pod1MAC),
+				&v1.NodeList{Items: []v1.Node{newTestNode(nodeName, "linux", nodeSubnet, "", nodeHOMAC)}},
+			}...)
+
+			_, err := config.InitConfig(ctx, nil, nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			f := informers.NewSharedInformerFactory(fakeClient, informer.DefaultResyncInterval)
+			mockOVNNBClient := ovntest.NewMockOVNClient(goovn.DBNB)
+			mockOVNSBClient := ovntest.NewMockOVNClient(goovn.DBSB)
+			m, err := NewMaster(
+				&kube.Kube{KClient: fakeClient},
+				f.Core().V1().Nodes().Informer(),
+				f.Core().V1().Namespaces().Informer(),
+				f.Core().V1().Pods().Informer(),
+				mockOVNNBClient,
+				mockOVNSBClient,
+				informer.NewTestEventHandler,
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			populatePortAddresses(nodeName, nodeHOMAC, nodeHOIP, mockOVNNBClient)
+
+			f.Start(stopChan)
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				m.Run(stopChan)
+			}()
+			f.WaitForCacheSync(stopChan)
+
+			Eventually(func() error {
+				pod, err := fakeClient.CoreV1().Pods(nsName).Get(context.TODO(), pod1Name, metav1.GetOptions{})
+				if err != nil {
+					return err
+				}
+				if pod.Annotations[hotypes.HybridOverlayVTEP] != nsVTEP {
+					return fmt.Errorf("error with annotation %s. expected: %s, got: %s", hotypes.HybridOverlayVTEP, nsVTEP, pod.Annotations[hotypes.HybridOverlayVTEP])
+				}
+				if pod.Annotations[hotypes.HybridOverlayExternalGw] != nsExGw {
+					return fmt.Errorf("error with annotation %s. expected: %s, got: %s", hotypes.HybridOverlayVTEP, nsExGw, pod.Annotations[hotypes.HybridOverlayExternalGw])
+				}
+				return nil
+			}, 2).Should(Succeed())
+
+			return nil
+		}
+
+		err := app.Run([]string{
+			app.Name,
+			"-loglevel=5",
+			"-enable-hybrid-overlay",
+			"-hybrid-overlay-cluster-subnets=" + hybridOverlayClusterCIDR,
+		})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("update pod annotations when a namespace is updated", func() {
+		app.Action = func(ctx *cli.Context) error {
+			const (
+				nsName        string = "nstest"
+				nsVTEP        string = "1.1.1.1"
+				nsVTEPUpdated string = "3.3.3.3"
+				nsExGw        string = "2.2.2.2"
+				nsExGwUpdated string = "4.4.4.4"
+				nodeName      string = "node1"
+				nodeSubnet    string = "10.1.2.0/24"
+				nodeHOMAC     string = "00:00:00:52:19:d2"
+				nodeHOIP      string = "10.1.2.3"
+				pod1Name      string = "pod1"
+				pod1IP        string = "1.2.3.5"
+				pod1CIDR      string = pod1IP + "/24"
+				pod1MAC       string = "aa:bb:cc:dd:ee:ff"
+			)
+
+			ns := &v1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					UID:  k8stypes.UID(nsName),
+					Name: nsName,
+					Annotations: map[string]string{
+						hotypes.HybridOverlayVTEP:       nsVTEP,
+						hotypes.HybridOverlayExternalGw: nsExGw,
+					},
+				},
+				Spec:   v1.NamespaceSpec{},
+				Status: v1.NamespaceStatus{},
+			}
+			fakeClient := fake.NewSimpleClientset([]runtime.Object{
+				ns,
+				&v1.NodeList{Items: []v1.Node{newTestNode(nodeName, "linux", nodeSubnet, "", nodeHOMAC)}},
+				createPod(nsName, pod1Name, nodeName, pod1CIDR, pod1MAC),
+			}...)
+
+			addLinuxNodeCommands(fexec, nodeHOMAC, nodeName, nodeHOIP)
+			_, err := config.InitConfig(ctx, nil, nil)
+			Expect(err).NotTo(HaveOccurred())
+			f := informers.NewSharedInformerFactory(fakeClient, informer.DefaultResyncInterval)
+
+			k := &kube.Kube{KClient: fakeClient}
+			mockOVNNBClient := ovntest.NewMockOVNClient(goovn.DBNB)
+			mockOVNSBClient := ovntest.NewMockOVNClient(goovn.DBSB)
+			m, err := NewMaster(
+				k,
+				f.Core().V1().Nodes().Informer(),
+				f.Core().V1().Namespaces().Informer(),
+				f.Core().V1().Pods().Informer(),
+				mockOVNNBClient,
+				mockOVNSBClient,
+				informer.NewTestEventHandler,
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			f.Start(stopChan)
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				m.Run(stopChan)
+			}()
+			f.WaitForCacheSync(stopChan)
+
+			updatedNs, err := fakeClient.CoreV1().Namespaces().Get(context.TODO(), nsName, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			nsAnnotator := kube.NewNamespaceAnnotator(k, updatedNs)
+			nsAnnotator.Set(hotypes.HybridOverlayVTEP, nsVTEPUpdated)
+			nsAnnotator.Set(hotypes.HybridOverlayExternalGw, nsExGwUpdated)
+			err = nsAnnotator.Run()
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(func() error {
+				pod, err := fakeClient.CoreV1().Pods(nsName).Get(context.TODO(), pod1Name, metav1.GetOptions{})
+				if err != nil {
+					return err
+				}
+				if reflect.DeepEqual(pod.Annotations[hotypes.HybridOverlayVTEP], nsVTEP) {
+					return fmt.Errorf("error with annotation %s. expected: %s, got: %s", hotypes.HybridOverlayVTEP, nsVTEPUpdated, pod.Annotations[hotypes.HybridOverlayVTEP])
+				}
+				if reflect.DeepEqual(pod.Annotations[hotypes.HybridOverlayExternalGw], nsExGw) {
+					return fmt.Errorf("error with annotation %s. expected: %s, got: %s", hotypes.HybridOverlayExternalGw, nsExGwUpdated, pod.Annotations[hotypes.HybridOverlayExternalGw])
+				}
+				return nil
+			}, 2).Should(Succeed())
+
 			return nil
 		}
 

--- a/go-controller/hybrid-overlay/pkg/controller/node.go
+++ b/go-controller/hybrid-overlay/pkg/controller/node.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/hybrid-overlay/pkg/types"
+	hotypes "github.com/ovn-org/ovn-kubernetes/go-controller/hybrid-overlay/pkg/types"
 	houtil "github.com/ovn-org/ovn-kubernetes/go-controller/hybrid-overlay/pkg/util"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/informer"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
@@ -53,8 +54,12 @@ func podChanged(old, new interface{}) bool {
 
 	oldIPs, oldMAC, _ := getPodDetails(oldPod)
 	newIPs, newMAC, _ := getPodDetails(newPod)
+	oldExGw := oldPod.Annotations[hotypes.HybridOverlayExternalGw]
+	oldVTEP := oldPod.Annotations[hotypes.HybridOverlayVTEP]
+	newExGw := newPod.Annotations[hotypes.HybridOverlayExternalGw]
+	newVTEP := newPod.Annotations[hotypes.HybridOverlayVTEP]
 
-	if len(oldIPs) != len(newIPs) || !reflect.DeepEqual(oldMAC, newMAC) {
+	if len(oldIPs) != len(newIPs) || !reflect.DeepEqual(oldMAC, newMAC) || !reflect.DeepEqual(oldExGw, newExGw) || !reflect.DeepEqual(oldVTEP, newVTEP) {
 		return true
 	}
 	for i := range oldIPs {

--- a/go-controller/hybrid-overlay/pkg/types/types.go
+++ b/go-controller/hybrid-overlay/pkg/types/types.go
@@ -11,6 +11,10 @@ const (
 	HybridOverlayNodeSubnet = HybridOverlayAnnotationBase + "node-subnet"
 	// HybridOverlayDRMAC holds the MAC address of the Distributed Router/gateway
 	HybridOverlayDRMAC = HybridOverlayAnnotationBase + "distributed-router-gateway-mac"
+	// HybridOverlayExternalGw is a pod and namespace annotation. It holds the IP address of the external gateway to route default traffic
+	HybridOverlayExternalGw = HybridOverlayAnnotationBase + "external-gw"
+	// HybridOverlayVTEP is a pod and namespace annotation that holds the IP address of the VTEP
+	HybridOverlayVTEP = HybridOverlayAnnotationBase + "vtep"
 	// HybridOverlayVNI is the VNI for VXLAN tunnels between nodes/endpoints
 	HybridOverlayVNI = 4097
 )

--- a/go-controller/hybrid-overlay/pkg/util/util.go
+++ b/go-controller/hybrid-overlay/pkg/util/util.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/hybrid-overlay/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
 
 	kapi "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -78,4 +79,22 @@ func StartNodeWatch(h types.NodeHandler, wf *factory.WatchFactory) {
 			h.Delete(node)
 		},
 	}, nil)
+}
+
+// CopyNamespaceAnnotationsToPod copies annotations from a namespace to a pod
+func CopyNamespaceAnnotationsToPod(k kube.Interface, ns *kapi.Namespace, pod *kapi.Pod) error {
+	nsGw, nsGwExists := ns.Annotations[types.HybridOverlayExternalGw]
+	nsVTEP, nsVTEPExists := ns.Annotations[types.HybridOverlayVTEP]
+	annotator := kube.NewPodAnnotator(k, pod)
+	if nsGwExists {
+		if err := annotator.Set(types.HybridOverlayExternalGw, nsGw); err != nil {
+			return err
+		}
+	}
+	if nsVTEPExists {
+		if err := annotator.Set(types.HybridOverlayVTEP, nsVTEP); err != nil {
+			return err
+		}
+	}
+	return annotator.Run()
 }

--- a/go-controller/pkg/ovn/namespace.go
+++ b/go-controller/pkg/ovn/namespace.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	hotypes "github.com/ovn-org/ovn-kubernetes/go-controller/hybrid-overlay/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	addressset "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/address_set"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
@@ -196,6 +197,24 @@ func (oc *Controller) AddNamespace(ns *kapi.Namespace) {
 	defer nsInfo.Unlock()
 
 	var err error
+	annotation := ns.Annotations[hotypes.HybridOverlayExternalGw]
+	if annotation != "" {
+		parsedAnnotation := net.ParseIP(annotation)
+		if parsedAnnotation == nil {
+			klog.Errorf("Could not parse hybrid overlay external gw annotation")
+		} else {
+			nsInfo.hybridOverlayExternalGW = parsedAnnotation
+		}
+	}
+	annotation = ns.Annotations[hotypes.HybridOverlayVTEP]
+	if annotation != "" {
+		parsedAnnotation := net.ParseIP(annotation)
+		if parsedAnnotation == nil {
+			klog.Errorf("Could not parse hybrid overlay VTEP annotation")
+		} else {
+			nsInfo.hybridOverlayVTEP = parsedAnnotation
+		}
+	}
 	if annotation, ok := ns.Annotations[routingExternalGWsAnnotation]; ok {
 		nsInfo.routingExternalGWs.gws, err = parseRoutingExternalGWAnnotation(annotation)
 		if err != nil {
@@ -206,7 +225,7 @@ func (oc *Controller) AddNamespace(ns *kapi.Namespace) {
 		}
 	}
 
-	annotation := ns.Annotations[aclLoggingAnnotation]
+	annotation = ns.Annotations[aclLoggingAnnotation]
 	if annotation != "" {
 		if oc.aclLoggingCanEnable(annotation, nsInfo) {
 			klog.Infof("Namespace %s: ACL logging is set to deny=%s allow=%s", ns.Name, nsInfo.aclLogging.Deny, nsInfo.aclLogging.Allow)
@@ -291,6 +310,7 @@ func (oc *Controller) updateNamespace(old, newer *kapi.Namespace) {
 			}
 		}
 	}
+
 	aclAnnotation := newer.Annotations[aclLoggingAnnotation]
 	oldACLAnnotation := old.Annotations[aclLoggingAnnotation]
 	// support for ACL logging update, if new annotation is empty, make sure we propagate new setting
@@ -303,6 +323,29 @@ func (oc *Controller) updateNamespace(old, newer *kapi.Namespace) {
 			klog.Infof("Namespace %s: ACL logging setting updated to deny=%s allow=%s",
 				old.Name, nsInfo.aclLogging.Deny, nsInfo.aclLogging.Allow)
 		}
+	}
+
+	annotation := newer.Annotations[hotypes.HybridOverlayExternalGw]
+	if annotation != "" {
+		parsedAnnotation := net.ParseIP(annotation)
+		if parsedAnnotation == nil {
+			klog.Errorf("Could not parse hybrid overlay external gw annotation")
+		} else {
+			nsInfo.hybridOverlayExternalGW = parsedAnnotation
+		}
+	} else {
+		nsInfo.hybridOverlayExternalGW = nil
+	}
+	annotation = newer.Annotations[hotypes.HybridOverlayVTEP]
+	if annotation != "" {
+		parsedAnnotation := net.ParseIP(annotation)
+		if parsedAnnotation == nil {
+			klog.Errorf("Could not parse hybrid overlay VTEP annotation")
+		} else {
+			nsInfo.hybridOverlayVTEP = parsedAnnotation
+		}
+	} else {
+		nsInfo.hybridOverlayVTEP = nil
 	}
 	oc.multicastUpdateNamespace(newer, nsInfo)
 }

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -89,6 +89,9 @@ type namespaceInfo struct {
 	// defines the namespaces egressFirewall
 	egressFirewall *egressFirewall
 
+	hybridOverlayExternalGW net.IP
+	hybridOverlayVTEP       net.IP
+
 	// routingExternalGWs is a slice of net.IP containing the values parsed from
 	// annotation k8s.ovn.org/routing-external-gws
 	routingExternalGWs gatewayInfo

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -156,12 +156,28 @@ func (oc *Controller) addRoutesGatewayIP(pod *kapi.Pod, podAnnotation *util.PodA
 			}
 		}
 	}
+	// DUALSTACK FIXME: hybridOverlayExternalGW is not Dualstack
+	var hybridOverlayExternalGW net.IP
+	if config.HybridOverlay.Enabled {
+		hybridOverlayExternalGW, err = oc.getHybridOverlayExternalGwAnnotation(pod.Namespace)
+		if err != nil {
+			return err
+		}
+	}
 
 	for _, podIfAddr := range podAnnotation.IPs {
 		isIPv6 := utilnet.IsIPv6CIDR(podIfAddr)
 		nodeSubnet, err := util.MatchIPNetFamily(isIPv6, nodeSubnets)
 		if err != nil {
 			return err
+		}
+		// DUALSTACK FIXME: hybridOverlayExternalGW is not Dualstack
+		// When oc.getHybridOverlayExternalGwAnnotation() supports dualstack, return error if no match.
+		// If external gateway mode is configured, need to use it for all outgoing traffic, so don't want
+		// to fall back to the default gateway here
+		if hybridOverlayExternalGW != nil && utilnet.IsIPv6(hybridOverlayExternalGW) != isIPv6 {
+			klog.Warningf("Pod %s/%s has no external gateway for %s", pod.Namespace, pod.Name, util.IPFamilyName(isIPv6))
+			continue
 		}
 
 		gatewayIPnet := util.GetNodeGatewayIfAddr(nodeSubnet)
@@ -173,7 +189,7 @@ func (oc *Controller) addRoutesGatewayIP(pod *kapi.Pod, podAnnotation *util.PodA
 		var gatewayIP net.IP
 		hasRoutingExternalGWs := len(oc.getRoutingExternalGWs(pod.Namespace).gws) > 0
 		hasPodRoutingGWs := len(oc.getRoutingPodGWs(pod.Namespace)) > 0
-		if otherDefaultRoute || (hasRoutingExternalGWs && hasPodRoutingGWs) {
+		if otherDefaultRoute || (hybridOverlayExternalGW != nil && !hasRoutingExternalGWs && !hasPodRoutingGWs) {
 			for _, clusterSubnet := range config.Default.ClusterSubnets {
 				if isIPv6 == utilnet.IsIPv6CIDR(clusterSubnet.CIDR) {
 					podAnnotation.Routes = append(podAnnotation.Routes, util.PodRoute{
@@ -189,6 +205,9 @@ func (oc *Controller) addRoutesGatewayIP(pod *kapi.Pod, podAnnotation *util.PodA
 						NextHop: gatewayIPnet.IP,
 					})
 				}
+			}
+			if hybridOverlayExternalGW != nil {
+				gatewayIP = util.GetNodeHybridOverlayIfAddr(nodeSubnet).IP
 			}
 		} else {
 			gatewayIP = gatewayIPnet.IP
@@ -247,6 +266,15 @@ func (oc *Controller) getRoutingPodGWs(ns string) map[string]gatewayInfo {
 		res[k] = item
 	}
 	return res
+}
+
+func (oc *Controller) getHybridOverlayExternalGwAnnotation(ns string) (net.IP, error) {
+	nsInfo, err := oc.waitForNamespaceLocked(ns)
+	if err != nil {
+		return nil, err
+	}
+	defer nsInfo.Unlock()
+	return nsInfo.hybridOverlayExternalGW, nil
 }
 
 func (oc *Controller) addLogicalPort(pod *kapi.Pod) (err error) {


### PR DESCRIPTION
This reverts commit b77e0e3027d905089daa50bcd2731e9b4498079e and pulls back in external gateway support via hybrid overlay.