### PR TITLE
Bug 1953169: endpoint slice controller doesn't handle services target port correctly

### DIFF
--- a/go-controller/pkg/util/kube.go
+++ b/go-controller/pkg/util/kube.go
@@ -308,19 +308,10 @@ func GetLbEndpoints(slices []*discovery.EndpointSlice, svcPort kapi.ServicePort,
 		// build the list of endpoints in the slice
 		for _, port := range slice.Ports {
 			// If Service port name set it must match the name field in the endpoint
+			// If Service port name is not set we just use the endpoint port
 			if svcPort.Name != "" && svcPort.Name != *port.Name {
 				klog.V(5).Infof("Slice %s with different Port name, requested: %s received: %s",
 					slice.Name, svcPort.Name, *port.Name)
-				continue
-			}
-
-			// Get the targeted port
-			tgtPort := int32(svcPort.TargetPort.IntValue())
-			// If this is a string, it will return 0
-			// it has to match the port name
-			// otherwise, it has to match the port number
-			if (tgtPort == 0 && svcPort.TargetPort.String() != *port.Name) ||
-				(tgtPort > 0 && tgtPort != *port.Port) {
 				continue
 			}
 


### PR DESCRIPTION
Service targetPort is a selector for the endpoints/endpointslices
controller to create the endpoints based on that container port name.
It is not meant to be used in the Service implementation.
The relation is ServicePort.Name - EndpointPort.Name, however,
ServicePort.Name is only required for multiple ports and it may be empty.
If the endpoint matches the service and there is no name,
that means that is a single port service and there is only one endpoint.
