### PR TITLE
Bug 1956270: service controller should not use the target-port

### DIFF
--- a/go-controller/pkg/ovn/controller/services/utils.go
+++ b/go-controller/pkg/ovn/controller/services/utils.go
@@ -38,19 +38,10 @@ func getLbEndpoints(slices []*discovery.EndpointSlice, svcPort v1.ServicePort, f
 		// build the list of endpoints in the slice
 		for _, port := range slice.Ports {
 			// If Service port name set it must match the name field in the endpoint
+			// If Service port name is not set we just use the endpoint port
 			if svcPort.Name != "" && svcPort.Name != *port.Name {
 				klog.V(5).Infof("Slice %s with different Port name, requested: %s received: %s",
 					slice.Name, svcPort.Name, *port.Name)
-				continue
-			}
-
-			// Get the targeted port
-			tgtPort := int32(svcPort.TargetPort.IntValue())
-			// If this is a string, it will return 0
-			// it has to match the port name
-			// otherwise, it has to match the port number
-			if (tgtPort == 0 && svcPort.TargetPort.String() != *port.Name) ||
-				(tgtPort > 0 && tgtPort != *port.Port) {
 				continue
 			}
 

--- a/go-controller/pkg/ovn/controller/services/utils_test.go
+++ b/go-controller/pkg/ovn/controller/services/utils_test.go
@@ -76,7 +76,7 @@ func Test_getLbEndpoints(t *testing.T) {
 			want: []string{"10.0.0.2:80"},
 		},
 		{
-			name: "slices with different ports",
+			name: "slices with different port name",
 			args: args{
 				slices: []*discovery.EndpointSlice{
 					{
@@ -87,7 +87,7 @@ func Test_getLbEndpoints(t *testing.T) {
 						},
 						Ports: []discovery.EndpointPort{
 							{
-								Name:     utilpointer.StringPtr("tcp-example"),
+								Name:     utilpointer.StringPtr("tcp-example-wrong"),
 								Protocol: protoPtr(v1.ProtocolTCP),
 								Port:     utilpointer.Int32Ptr(int32(8080)),
 							},
@@ -111,6 +111,41 @@ func Test_getLbEndpoints(t *testing.T) {
 				family: v1.IPv4Protocol,
 			},
 			want: []string{},
+		},
+		{
+			name: "slices and service without port name",
+			args: args{
+				slices: []*discovery.EndpointSlice{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab23",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Protocol: protoPtr(v1.ProtocolTCP),
+								Port:     utilpointer.Int32Ptr(int32(8080)),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv4,
+						Endpoints: []discovery.Endpoint{
+							{
+								Conditions: discovery.EndpointConditions{
+									Ready: utilpointer.BoolPtr(true),
+								},
+								Addresses: []string{"10.0.0.2"},
+							},
+						},
+					},
+				},
+				svcPort: v1.ServicePort{
+					TargetPort: intstr.FromInt(80),
+					Protocol:   v1.ProtocolTCP,
+				},
+				family: v1.IPv4Protocol,
+			},
+			want: []string{"10.0.0.2:8080"},
 		},
 		{
 			name: "slices with different IP family",


### PR DESCRIPTION
Cherry-pick from https://github.com/openshift/ovn-kubernetes/pull/515

Service targetPort is a selector for the endpoints/endpointslices
controller to create the endpoints based on that container port name.
It is not meant to be used in the Service implementation.
The relation is ServicePort.Name - EndpointPort.Name, however,
ServicePort.Name is only required for multiple ports and it may be empty.
If the endpoint matches the service and there is no name,
that means that is a single port service and there is only one endpoint.

Signed-off-by: Antonio Ojea <aojea@redhat.com>
