### PR TITLE
Bug 1956980: [release-4.7] fix ForEachAddressSet() as it is not calling the callback functions

### DIFF
--- a/go-controller/pkg/ovn/address_set/address_set.go
+++ b/go-controller/pkg/ovn/address_set/address_set.go
@@ -83,11 +83,7 @@ func (asf *ovnAddressSetFactory) ForEachAddressSet(iteratorFn AddressSetIterFunc
 
 	processedAddressSets := sets.String{}
 	for _, line := range strings.Split(output, "\n") {
-		parts := strings.Split(line, ",")
-		if len(parts) != 2 {
-			continue
-		}
-		for _, externalID := range strings.Fields(parts[1]) {
+		for _, externalID := range strings.Split(line, ",") {
 			if !strings.HasPrefix(externalID, "name=") {
 				continue
 			}

--- a/go-controller/pkg/ovn/address_set/address_set_test.go
+++ b/go-controller/pkg/ovn/address_set/address_set_test.go
@@ -74,9 +74,13 @@ var _ = Describe("OVN Address Set operations", func() {
 				}
 
 				var namespacesRes string
-				for _, n := range namespaces {
+				for i, n := range namespaces {
 					name := n.makeName()
-					namespacesRes += fmt.Sprintf("%s,name=%s\n", hashedAddressSet(name), name)
+					if i%2 == 0 {
+						namespacesRes += fmt.Sprintf("keyA=valA,name=%s\n", name)
+					} else {
+						namespacesRes += fmt.Sprintf("name=%s,keyB=valB\n", name)
+					}
 				}
 				fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 					Cmd:    "ovn-nbctl --timeout=15 --format=csv --data=bare --no-heading --columns=external_ids find address_set",


### PR DESCRIPTION
we have,
external_ids        : {name=kube-system_v4}
external_ids        : {name=default_v4}
external_ids        : {name=default.access-web.egress.3_v4}
external_ids        : {name=kube-public_v4}
external_ids        : {name=ovn-kubernetes_v4}
external_ids        : {name=default.access-web.ingress.0_v4}
external_ids        : {name=kube-node-lease_v4}
external_ids        : {name=default.access-mysql.ingress.0_v4}
external_ids        : {name=default.access-web.egress.0_v4}

so, there is only one part of key=value in `external_ids` and this
results in ForEachAddressSet() not calling the iterator function.

Signed-off-by: Girish Moodalbail <gmoodalbail@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->