### PR TITLE
Bug 1952819: Bump the go-ovn version to f0122836cc35fcadf72de8698b26157c5a42a9f8

### DIFF
--- a/go-controller/go.mod
+++ b/go-controller/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/containernetworking/cni v0.8.0
 	github.com/containernetworking/plugins v0.8.7
 	github.com/coreos/go-iptables v0.4.5
-	github.com/ebay/go-ovn v0.1.1-0.20210225191205-f6ee8f3f087c
+	github.com/ebay/go-ovn v0.1.1-0.20210505151822-f0122836cc35
 	github.com/ebay/libovsdb v0.2.1-0.20200719163122-3332afaeb27c
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/gorilla/mux v1.8.0

--- a/go-controller/go.sum
+++ b/go-controller/go.sum
@@ -140,6 +140,8 @@ github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/ebay/go-ovn v0.1.1-0.20210225191205-f6ee8f3f087c h1:ZhauuMfb01gW+x/QwV4vRQnBn8b5BX10r2fvC2FhvFs=
 github.com/ebay/go-ovn v0.1.1-0.20210225191205-f6ee8f3f087c/go.mod h1:Du3Zt/R+DqyqtY5aNTd2gB9bg/igI1RR4fUj6AjmkjI=
+github.com/ebay/go-ovn v0.1.1-0.20210505151822-f0122836cc35 h1:7QLMkuQBRBjK21hcJdHDBxSh68dJeeEUXYeBtoUijbU=
+github.com/ebay/go-ovn v0.1.1-0.20210505151822-f0122836cc35/go.mod h1:Du3Zt/R+DqyqtY5aNTd2gB9bg/igI1RR4fUj6AjmkjI=
 github.com/ebay/libovsdb v0.0.0-20190718202342-e49b8c4e1142/go.mod h1:TPIbkgdnu8IfDA510pGDS3zYGmnvrPttnge3uhBQf/0=
 github.com/ebay/libovsdb v0.2.1-0.20200719163122-3332afaeb27c h1:YSECgIEwf07ycYVwVM8KXCgkpXajecPqRyAuyFELZxA=
 github.com/ebay/libovsdb v0.2.1-0.20200719163122-3332afaeb27c/go.mod h1:ZW5Fi5OPYcMy3EI20lW62TKBMHSlaDPlTqC3Gm4ev9Q=

--- a/go-controller/vendor/github.com/ebay/go-ovn/common.go
+++ b/go-controller/vendor/github.com/ebay/go-ovn/common.go
@@ -43,6 +43,7 @@ const (
 	TableMeterBand                string = "Meter_Band"
 	TableLogicalRouterPort        string = "Logical_Router_Port"
 	TableLogicalRouterStaticRoute string = "Logical_Router_Static_Route"
+	TableLogicalRouterPolicy      string = "Logical_Router_Policy"
 	TableNAT                      string = "NAT"
 	TableDHCPOptions              string = "DHCP_Options"
 	TableConnection               string = "Connection"
@@ -66,6 +67,7 @@ var NBTablesOrder = []string{
 	TableMeterBand,
 	TableLogicalRouterPort,
 	TableLogicalRouterStaticRoute,
+	TableLogicalRouterPolicy,
 	TableLogicalSwitchPort,
 	TableNAT,
 	TableConnection,

--- a/go-controller/vendor/github.com/ebay/go-ovn/logical_router.go
+++ b/go-controller/vendor/github.com/ebay/go-ovn/logical_router.go
@@ -32,6 +32,7 @@ type LogicalRouter struct {
 	StaticRoutes []string
 	NAT          []string
 	LoadBalancer []string
+	Policies     []string
 
 	Options    map[interface{}]interface{}
 	ExternalID map[interface{}]interface{}
@@ -156,6 +157,15 @@ func (odbi *ovndb) rowToLogicalRouter(uuid string) *LogicalRouter {
 			lr.NAT = []string{nats.(libovsdb.UUID).GoUUID}
 		case libovsdb.OvsSet:
 			lr.NAT = odbi.ConvertGoSetToStringArray(nats.(libovsdb.OvsSet))
+		}
+	}
+
+	if policies, ok := cacheLogicalRouter.Fields["policies"]; ok {
+		switch policies.(type) {
+		case libovsdb.UUID:
+			lr.Policies = []string{policies.(libovsdb.UUID).GoUUID}
+		case libovsdb.OvsSet:
+			lr.Policies = odbi.ConvertGoSetToStringArray(policies.(libovsdb.OvsSet))
 		}
 	}
 

--- a/go-controller/vendor/github.com/ebay/go-ovn/logical_router_policy.go
+++ b/go-controller/vendor/github.com/ebay/go-ovn/logical_router_policy.go
@@ -1,0 +1,297 @@
+/**
+ * Copyright (c) 2021 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package goovn
+
+import (
+	"fmt"
+
+	"github.com/ebay/libovsdb"
+)
+
+// LogicalRouterPolicy ovnnb item
+type LogicalRouterPolicy struct {
+	UUID       string
+	Priority   int
+	Match      string
+	Action     string
+	Nexthop    *string
+	NextHops   []string
+	Options    map[interface{}]interface{}
+	ExternalID map[interface{}]interface{}
+}
+
+func (odbi *ovndb) lrpolicyAddImp(lr string, priority int, match string, action string, nexthop *string, nexthops []string, options map[string]string, external_ids map[string]string) (*OvnCommand, error) {
+	namedUUID, err := newRowUUID()
+	if err != nil {
+		return nil, err
+	}
+
+	row := make(OVNRow)
+	row["priority"] = priority
+	row["match"] = match
+	row["action"] = action
+
+	if nexthop != nil {
+		row["nexthop"] = *nexthop
+	}
+	if nexthops != nil {
+		nexthopsSet, err := libovsdb.NewOvsSet(nexthops)
+		if err != nil {
+			return nil, err
+		}
+		row["nexthops"] = nexthopsSet
+	}
+	if options != nil {
+		optionsMap, err := libovsdb.NewOvsMap(options)
+		if err != nil {
+			return nil, err
+		}
+		row["options"] = optionsMap
+	}
+	if external_ids != nil {
+		oMap, err := libovsdb.NewOvsMap(external_ids)
+		if err != nil {
+			return nil, err
+		}
+		row["external_ids"] = oMap
+	}
+
+	if uuid := odbi.getRowUUID(TableLogicalRouterPolicy, row); len(uuid) > 0 {
+		return nil, ErrorExist
+	}
+
+	insertOp := libovsdb.Operation{
+		Op:       opInsert,
+		Table:    TableLogicalRouterPolicy,
+		Row:      row,
+		UUIDName: namedUUID,
+	}
+
+	mutateUUID := []libovsdb.UUID{stringToGoUUID(namedUUID)}
+	mutateSet, err := libovsdb.NewOvsSet(mutateUUID)
+	if err != nil {
+		return nil, err
+	}
+	mutation := libovsdb.NewMutation("policies", opInsert, mutateSet)
+	condition := libovsdb.NewCondition("name", "==", lr)
+
+	mutateOp := libovsdb.Operation{
+		Op:        opMutate,
+		Table:     TableLogicalRouter,
+		Mutations: []interface{}{mutation},
+		Where:     []interface{}{condition},
+	}
+	operations := []libovsdb.Operation{insertOp, mutateOp}
+	return &OvnCommand{operations, odbi, make([][]map[string]interface{}, len(operations))}, nil
+}
+
+func (odbi *ovndb) lrpolicyDelImp(lr string, priority int, match *string) (*OvnCommand, error) {
+	if lr == "" {
+		return nil, fmt.Errorf("lr (logical router name) is required")
+	}
+
+	row := make(OVNRow)
+	row["name"] = lr
+	lruuid := odbi.getRowUUID(TableLogicalRouter, row)
+	if len(lruuid) == 0 {
+		return nil, ErrorNotFound
+	}
+
+	var mutateSet *libovsdb.OvsSet
+	var err error
+
+	if match != nil {
+		// delete all with same priority and match
+		row := make(OVNRow)
+		row["prority"] = priority
+		row["match"] = *match
+		lrpolicyuuids := odbi.getRowUUIDs(TableLogicalRouterPolicy, row)
+		if len(lrpolicyuuids) == 0 {
+			return nil, ErrorNotFound
+		}
+		delUUIDs := make([]libovsdb.UUID, len(lrpolicyuuids))
+		for i, uuid := range lrpolicyuuids {
+			delUUIDs[i] = stringToGoUUID(uuid)
+		}
+		mutateSet, err = libovsdb.NewOvsSet(delUUIDs)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		row := make(OVNRow)
+		row["prority"] = priority
+		lrpolicyuuids := odbi.getRowUUIDs(TableLogicalRouterPolicy, row)
+		if len(lrpolicyuuids) == 0 {
+			return nil, ErrorNotFound
+		}
+		delUUIDs := make([]libovsdb.UUID, len(lrpolicyuuids))
+		for i, uuid := range lrpolicyuuids {
+			delUUIDs[i] = stringToGoUUID(uuid)
+		}
+		mutateSet, err = libovsdb.NewOvsSet(delUUIDs)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	mutation := libovsdb.NewMutation("policies", opDelete, mutateSet)
+	// mutate  lrouter for the corresponding policies
+	mucondition := libovsdb.NewCondition("name", "==", lr)
+	mutateOp := libovsdb.Operation{
+		Op:        opMutate,
+		Table:     TableLogicalRouter,
+		Mutations: []interface{}{mutation},
+		Where:     []interface{}{mucondition},
+	}
+	operations := []libovsdb.Operation{mutateOp}
+	return &OvnCommand{operations, odbi, make([][]map[string]interface{}, len(operations))}, nil
+}
+
+func (odbi *ovndb) lrpolicyDelByUUIDImp(lr string, uuid string) (*OvnCommand, error) {
+	if lr == "" {
+		return nil, fmt.Errorf("lr (logical router name) is required")
+	}
+	row := make(OVNRow)
+	row["name"] = lr
+	lruuid := odbi.getRowUUID(TableLogicalRouter, row)
+	if len(lruuid) == 0 {
+		return nil, ErrorNotFound
+	}
+	// delete with specified uuid
+	mutateSet, err := libovsdb.NewOvsSet([]libovsdb.UUID{stringToGoUUID(uuid)})
+	if err != nil {
+		return nil, err
+	}
+	mutation := libovsdb.NewMutation("policies", opDelete, mutateSet)
+	// mutate  lrouter for the corresponding policies
+	mucondition := libovsdb.NewCondition("name", "==", lr)
+	mutateOp := libovsdb.Operation{
+		Op:        opMutate,
+		Table:     TableLogicalRouter,
+		Mutations: []interface{}{mutation},
+		Where:     []interface{}{mucondition},
+	}
+	operations := []libovsdb.Operation{mutateOp}
+	return &OvnCommand{operations, odbi, make([][]map[string]interface{}, len(operations))}, nil
+}
+
+func (odbi *ovndb) lrpolicyDelAllImp(lr string) (*OvnCommand, error) {
+	if lr == "" {
+		return nil, fmt.Errorf("lr (logical router name) is required")
+	}
+
+	row := make(OVNRow)
+	row["name"] = lr
+	lruuid := odbi.getRowUUID(TableLogicalRouter, row)
+	if len(lruuid) == 0 {
+		return nil, ErrorNotFound
+	}
+
+	// delete everything
+	row = make(OVNRow)
+	lrpolicyuuids := odbi.getRowUUIDs(TableLogicalRouterPolicy, row)
+	if len(lrpolicyuuids) == 0 {
+		return nil, ErrorNotFound
+	}
+	delUUIDs := make([]libovsdb.UUID, len(lrpolicyuuids))
+	for i, uuid := range lrpolicyuuids {
+		delUUIDs[i] = stringToGoUUID(uuid)
+	}
+	mutateSet, err := libovsdb.NewOvsSet(delUUIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	mutation := libovsdb.NewMutation("policies", opDelete, mutateSet)
+	// mutate  lrouter for the corresponding policies
+	mucondition := libovsdb.NewCondition("name", "==", lr)
+	mutateOp := libovsdb.Operation{
+		Op:        opMutate,
+		Table:     TableLogicalRouter,
+		Mutations: []interface{}{mutation},
+		Where:     []interface{}{mucondition},
+	}
+	operations := []libovsdb.Operation{mutateOp}
+	return &OvnCommand{operations, odbi, make([][]map[string]interface{}, len(operations))}, nil
+}
+
+func (odbi *ovndb) rowToLogicalRouterPolicy(uuid string) *LogicalRouterPolicy {
+	cacheLogicalRouterPolicy, ok := odbi.cache[TableLogicalRouterPolicy][uuid]
+	if !ok {
+		return nil
+	}
+	lrpolicy := &LogicalRouterPolicy{
+		UUID:       uuid,
+		Priority:   cacheLogicalRouterPolicy.Fields["priority"].(int),
+		Match:      cacheLogicalRouterPolicy.Fields["match"].(string),
+		Action:     cacheLogicalRouterPolicy.Fields["action"].(string),
+		Options:    cacheLogicalRouterPolicy.Fields["options"].(libovsdb.OvsMap).GoMap,
+		ExternalID: cacheLogicalRouterPolicy.Fields["external_ids"].(libovsdb.OvsMap).GoMap,
+	}
+
+	if nexthop, ok := cacheLogicalRouterPolicy.Fields["nexthop"]; ok {
+		lrpolicy.Nexthop = odbi.optionalStringFieldToPointer(nexthop)
+	}
+
+	for _, n := range cacheLogicalRouterPolicy.Fields["nexthops"].(libovsdb.OvsSet).GoSet {
+		lrpolicy.NextHops = append(lrpolicy.NextHops, n.(string))
+	}
+	return lrpolicy
+}
+
+func (odbi *ovndb) lrPolicyListImp(lr string) ([]*LogicalRouterPolicy, error) {
+	odbi.cachemutex.RLock()
+	defer odbi.cachemutex.RUnlock()
+	cacheLogicalRouter, ok := odbi.cache[TableLogicalRouter]
+	if !ok {
+		return nil, ErrorNotFound
+	}
+	for _, drows := range cacheLogicalRouter {
+		if rlr, ok := drows.Fields["name"].(string); ok && rlr == lr {
+			policies := drows.Fields["policies"]
+			if policies != nil {
+				switch policies.(type) {
+				case libovsdb.OvsSet:
+					if sr, ok := policies.(libovsdb.OvsSet); ok {
+						listLRPolicy := make([]*LogicalRouterPolicy, 0, len(sr.GoSet))
+						for _, s := range sr.GoSet {
+							if sruid, ok := s.(libovsdb.UUID); ok {
+								policy := odbi.rowToLogicalRouterPolicy(sruid.GoUUID)
+								listLRPolicy = append(listLRPolicy, policy)
+							}
+						}
+						return listLRPolicy, nil
+					} else {
+						return nil, fmt.Errorf("type libovsdb.OvsSet casting failed")
+					}
+				case libovsdb.UUID:
+					if policyuuid, ok := policies.(libovsdb.UUID); ok {
+						policy := odbi.rowToLogicalRouterPolicy(policyuuid.GoUUID)
+						return []*LogicalRouterPolicy{policy}, nil
+					} else {
+						return nil, fmt.Errorf("type libovsdb.UUID casting failed")
+					}
+				default:
+					return nil, fmt.Errorf("unsupported type found in ovsdb rows")
+				}
+			}
+			return []*LogicalRouterPolicy{}, nil
+		}
+	}
+
+	return nil, ErrorNotFound
+}

--- a/go-controller/vendor/github.com/ebay/go-ovn/logical_switch_port.go
+++ b/go-controller/vendor/github.com/ebay/go-ovn/logical_switch_port.go
@@ -149,6 +149,20 @@ func (odbi *ovndb) lspSetPortSecurityImp(lsp string, security ...string) (*OvnCo
 	return &OvnCommand{operations, odbi, make([][]map[string]interface{}, len(operations))}, nil
 }
 
+func (odbi *ovndb) lspSetTypeImp(lsp string, portType string) (*OvnCommand, error) {
+	row := make(OVNRow)
+	row["type"] = portType
+	condition := libovsdb.NewCondition("name", "==", lsp)
+	updateOp := libovsdb.Operation{
+		Op:    opUpdate,
+		Table: TableLogicalSwitchPort,
+		Row:   row,
+		Where: []interface{}{condition},
+	}
+	operations := []libovsdb.Operation{updateOp}
+	return &OvnCommand{operations, odbi, make([][]map[string]interface{}, len(operations))}, nil
+}
+
 func (odbi *ovndb) lspSetDHCPv4OptionsImp(lsp string, uuid string) (*OvnCommand, error) {
 	row := make(OVNRow)
 	row["dhcpv4_options"] = stringToGoUUID(uuid)

--- a/go-controller/vendor/github.com/ebay/go-ovn/ovnnotify.go
+++ b/go-controller/vendor/github.com/ebay/go-ovn/ovnnotify.go
@@ -25,6 +25,8 @@ type ovnNotifier struct {
 }
 
 func (notify ovnNotifier) Update(context interface{}, tableUpdates libovsdb.TableUpdates) {
+	notify.odbi.cachemutex.Lock()
+	defer notify.odbi.cachemutex.Unlock()
 	notify.odbi.populateCache(tableUpdates)
 }
 func (notify ovnNotifier) Locked([]interface{}) {

--- a/go-controller/vendor/github.com/ebay/go-ovn/test_common.go
+++ b/go-controller/vendor/github.com/ebay/go-ovn/test_common.go
@@ -61,6 +61,18 @@ const (
 	PG_TEST_ID_2         = "169.254.1.1"
 	PG_TEST_KEY_3        = "foo1"
 	PG_TEST_ID_3         = "bar1"
+	ACL_NAME_1           = "aclName1"
+	ACL_NAME_2           = "aclName2"
+	ACL_NAME_3           = "aclName3"
+	ACL_NAME_4           = "aclName4"
+	ACL_NAME_5           = "aclName5"
+	SEVERITY_INFO        = "info"
+	SEVERITY_ALERT       = "alert"
+	SEVERITY_WARNING     = "warning"
+	METER1               = "testMeter1"
+	METER2               = "testMeter2"
+	METER3               = "testMeter3"
+	NONEXISTENT_UUID     = "53be5050-87b2-49d4-9c74-bf645653a524"
 )
 
 var (

--- a/go-controller/vendor/modules.txt
+++ b/go-controller/vendor/modules.txt
@@ -59,7 +59,7 @@ github.com/davecgh/go-spew/spew
 # github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96
 github.com/docker/spdystream
 github.com/docker/spdystream/spdy
-# github.com/ebay/go-ovn v0.1.1-0.20210225191205-f6ee8f3f087c
+# github.com/ebay/go-ovn v0.1.1-0.20210505151822-f0122836cc35
 github.com/ebay/go-ovn
 # github.com/ebay/libovsdb v0.2.1-0.20200719163122-3332afaeb27c
 github.com/ebay/libovsdb


### PR DESCRIPTION
It includes https://github.com/eBay/go-ovn/pull/148, which ensures no
missed deletion events during a reconnection.

This was missed in https://github.com/openshift/ovn-kubernetes/pull/528