### PR TITLE
[release-4.7] Bug 1959737: Fix: egress IP route health check detection state on restart

### DIFF
--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -879,12 +879,16 @@ func (oc *Controller) WatchEgressNodes() {
 				klog.Error(err)
 			}
 			nodeLabels := node.GetLabels()
-			if _, hasEgressLabel := nodeLabels[nodeEgressLabel]; hasEgressLabel && oc.isEgressNodeReady(node) && oc.isEgressNodeReachable(node) {
+			if _, hasEgressLabel := nodeLabels[nodeEgressLabel]; hasEgressLabel {
 				oc.setNodeEgressAssignable(node.Name, true)
-				oc.setNodeEgressReady(node.Name, true)
-				oc.setNodeEgressReachable(node.Name, true)
-				if err := oc.addEgressNode(node); err != nil {
-					klog.Error(err)
+				if oc.isEgressNodeReady(node) {
+					oc.setNodeEgressReady(node.Name, true)
+					if oc.isEgressNodeReachable(node) {
+						oc.setNodeEgressReachable(node.Name, true)
+						if err := oc.addEgressNode(node); err != nil {
+							klog.Error(err)
+						}
+					}
 				}
 			}
 		},


### PR DESCRIPTION
Egress IP initializes a "watcher" which health checks connectivity to egress
nodes every 5 seconds. This is done in its sync function. However, due to a
bug in the state initialization in WatchEgressNodes we don't set the
different egress node fields correctly in our ADD func which screws up the health
check detection mechanism upon a ovnkube-master restart.

Essentially it does like this:

1) egress setup is made
2) there's a problem with connectivity to the egress node(s)
3) ovnkube-master is restarted

Once step 3) is made: it is expected that ovnkube-master will perform
health checks continously and detect when the connectivity in step 2) is
back up. However because of this problem that is not the case and even
if further connectivity is successful, we never flag the node as such in
our internal data.

Signed-off-by: Alexander Constantinescu <aconstan@redhat.com>

/assign @dcbw 

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->