### PR TITLE
Bug 1958958: NewAddressSet: return nil in case of error

### DIFF
--- a/go-controller/pkg/ovn/address_set/address_set.go
+++ b/go-controller/pkg/ovn/address_set/address_set.go
@@ -67,7 +67,11 @@ var _ AddressSetFactory = &ovnAddressSetFactory{}
 
 // NewAddressSet returns a new address set object
 func (asf *ovnAddressSetFactory) NewAddressSet(name string, ips []net.IP) (AddressSet, error) {
-	return newOvnAddressSets(name, ips)
+	res, err := newOvnAddressSets(name, ips)
+	if err != nil {
+		return nil, err
+	}
+	return res, nil
 }
 
 // ForEachAddressSet will pass the unhashed address set name, namespace name


### PR DESCRIPTION
newOvnAddressSets returns a concrete type, that gets assigned to an
interface. This makes the interface not being nil (even if the backing
value is).  In particular, having
nsInfo.addressSet, err = oc.createNamespaceAddrSetAllPods(ns)
called twice would result in having the interface not being nil but the
value behind it being nil and it will make sequent use of
nsInfo.addressSet refer to a nil value.