### PR TITLE
Bug 1954773: adding cli flag for egressfirewall and removing CRD watcher

### DIFF
--- a/contrib/kind.sh
+++ b/contrib/kind.sh
@@ -478,6 +478,7 @@ create_ovn_kube_manifests() {
     --ovn-loglevel-controller="${OVN_LOG_LEVEL_CONTROLLER}" \
     --ovn-loglevel-nbctld="${OVN_LOG_LEVEL_NBCTLD}" \
     --egress-ip-enable=true \
+    --egress-firewall-enable=true \
     --v4-join-subnet="${JOIN_SUBNET_IPV4}" \
     --v6-join-subnet="${JOIN_SUBNET_IPV6}"
   popd

--- a/dist/images/daemonset.sh
+++ b/dist/images/daemonset.sh
@@ -40,6 +40,7 @@ OVN_DISABLE_SNAT_MULTIPLE_GWS=""
 OVN_EMPTY_LB_EVENTS=""
 OVN_MULTICAST_ENABLE=""
 OVN_EGRESSIP_ENABLE=
+OVN_EGRESSFIREWALL_ENABLE=
 OVN_V4_JOIN_SUBNET=""
 OVN_V6_JOIN_SUBNET=""
 OVN_NETFLOW_TARGETS=""
@@ -157,6 +158,9 @@ while [ "$1" != "" ]; do
   --egress-ip-enable)
     OVN_EGRESSIP_ENABLE=$VALUE
     ;;
+  --egress-firewall-enable)
+    OVN_EGRESSFIREWALL_ENABLE=$VALUE
+    ;;
   --v4-join-subnet)
     OVN_V4_JOIN_SUBNET=$VALUE
     ;;
@@ -230,6 +234,8 @@ ovn_hybrid_overlay_enable=${OVN_HYBRID_OVERLAY_ENABLE}
 echo "ovn_hybrid_overlay_enable: ${ovn_hybrid_overlay_enable}"
 ovn_egress_ip_enable=${OVN_EGRESSIP_ENABLE}
 echo "ovn_egress_ip_enable: ${ovn_egress_ip_enable}"
+ovn_egress_firewall_enable=${OVN_EGRESSFIREWALL_ENABLE}
+echo "ovn_egress_firewall_enable: ${ovn_egress_firewall_enable}"
 ovn_hybrid_overlay_net_cidr=${OVN_HYBRID_OVERLAY_NET_CIDR}
 echo "ovn_hybrid_overlay_net_cidr: ${ovn_hybrid_overlay_net_cidr}"
 ovn_disable_snat_multiple_gws=${OVN_DISABLE_SNAT_MULTIPLE_GWS}
@@ -338,6 +344,7 @@ ovn_image=${image} \
   ovn_v6_join_subnet=${ovn_v6_join_subnet} \
   ovn_multicast_enable=${ovn_multicast_enable} \
   ovn_egress_ip_enable=${ovn_egress_ip_enable} \
+  ovn_egress_firewall_enable=${ovn_egress_firewall_enable} \
   ovn_ssl_en=${ovn_ssl_en} \
   ovn_master_count=${ovn_master_count} \
   ovn_gateway_mode=${ovn_gateway_mode} \

--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -68,6 +68,7 @@ fi
 # OVN_SSL_ENABLE - use SSL transport to NB/SB db and northd (default: no)
 # OVN_REMOTE_PROBE_INTERVAL - ovn remote probe interval in ms (default 100000)
 # OVN_EGRESSIP_ENABLE - enable egress IP for ovn-kubernetes
+# OVN_EGRESSFIREWALL_ENABLE - enable egressFirewall for ovn-kubernetes
 # OVN_UNPRIVILEGED_MODE - execute CNI ovs/netns commands from host (default no)
 # OVNKUBE_NODE_MODE - ovnkube node mode of operation, one of: full, smart-nic, smart-nic-host (default: full)
 # OVN_ENCAP_IP - encap IP to be used for OVN traffic on the node. mandatory in case ovnkube-node-mode=="smart-nic"
@@ -194,6 +195,8 @@ ovn_remote_probe_interval=${OVN_REMOTE_PROBE_INTERVAL:-100000}
 ovn_multicast_enable=${OVN_MULTICAST_ENABLE:-}
 #OVN_EGRESSIP_ENABLE - enable egress IP for ovn-kubernetes
 ovn_egressip_enable=${OVN_EGRESSIP_ENABLE:-false}
+#OVN_EGRESSFIREWALL_ENABLE - enable egressFirewall for ovn-kubernetes
+ovn_egressfirewall_enable=${OVN_EGRESSFIREWALL_ENABLE:-false}
 ovn_acl_logging_rate_limit=${OVN_ACL_LOGGING_RATE_LIMIT:-"20"}
 ovn_netflow_targets=${OVN_NETFLOW_TARGETS:-}
 ovn_sflow_targets=${OVN_SFLOW_TARGETS:-}
@@ -893,6 +896,11 @@ ovn-master() {
   if [[ ${ovn_egressip_enable} == "true" ]]; then
       egressip_enabled_flag="--enable-egress-ip"
   fi
+  egressfirewall_enabled_flag=
+  if [[ ${ovn_egressfirewall_enable} == "true" ]]; then
+	  egressfirewall_enabled_flag="--enable-egress-firewall"
+  fi
+  echo "egressfirewall_enabled_flag=${egressfirewall_enabled_flag}"
 
   ovnkube_master_metrics_bind_address="${metrics_endpoint_ip}:9409"
 
@@ -918,6 +926,7 @@ ovn-master() {
     ${multicast_enabled_flag} \
     ${ovn_acl_logging_rate_limit_flag} \
     ${egressip_enabled_flag} \
+    ${egressfirewall_enabled_flag} \
     --metrics-bind-address ${ovnkube_master_metrics_bind_address} \
     --host-network-namespace ${ovn_host_network_namespace} &
 

--- a/dist/templates/ovnkube-master.yaml.j2
+++ b/dist/templates/ovnkube-master.yaml.j2
@@ -240,6 +240,8 @@ spec:
           value: "{{ ovn_hybrid_overlay_enable }}"
         - name: OVN_EGRESSIP_ENABLE
           value: "{{ ovn_egress_ip_enable }}"
+        - name: OVN_EGRESSFIREWALL_ENABLE
+          value: "{{ ovn_egress_firewall_enable }}"
         - name: OVN_HYBRID_OVERLAY_NET_CIDR
           value: "{{ ovn_hybrid_overlay_net_cidr }}"
         - name: OVN_DISABLE_SNAT_MULTIPLE_GWS

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -249,7 +249,8 @@ type KubernetesConfig struct {
 
 // OVNKubernetesFeatureConfig holds OVN-Kubernetes feature enhancement config file parameters and command-line overrides
 type OVNKubernetesFeatureConfig struct {
-	EnableEgressIP bool `gcfg:"enable-egress-ip"`
+	EnableEgressIP       bool `gcfg:"enable-egress-ip"`
+	EnableEgressFirewall bool `gcfg:"enable-egress-firewall"`
 }
 
 // GatewayMode holds the node gateway mode
@@ -692,6 +693,12 @@ var OVNK8sFeatureFlags = []cli.Flag{
 		Usage:       "Configure to use EgressIP CRD feature with ovn-kubernetes.",
 		Destination: &cliConfig.OVNKubernetesFeature.EnableEgressIP,
 		Value:       OVNKubernetesFeature.EnableEgressIP,
+	},
+	&cli.BoolFlag{
+		Name:        "enable-egress-firewall",
+		Usage:       "Configure to use EgressFirewall CRD feature with ovn-kubernetes.",
+		Destination: &cliConfig.OVNKubernetesFeature.EnableEgressFirewall,
+		Value:       OVNKubernetesFeature.EnableEgressFirewall,
 	},
 }
 

--- a/go-controller/pkg/factory/factory.go
+++ b/go-controller/pkg/factory/factory.go
@@ -201,7 +201,6 @@ func NewMasterWatchFactory(ovnClientset *util.OVNClientset) (*WatchFactory, erro
 func NewNodeWatchFactory(ovnClientset *util.OVNClientset, nodeName string) (*WatchFactory, error) {
 	wf := &WatchFactory{
 		iFactory:    informerfactory.NewSharedInformerFactory(ovnClientset.KubeClient, resyncInterval),
-		eipFactory:  egressipinformerfactory.NewSharedInformerFactory(ovnClientset.EgressIPClient, resyncInterval),
 		efClientset: ovnClientset.EgressFirewallClient,
 		crdFactory:  apiextensionsinformerfactory.NewSharedInformerFactory(ovnClientset.APIExtensionsClient, resyncInterval),
 		informers:   make(map[reflect.Type]*informer),

--- a/go-controller/pkg/factory/factory.go
+++ b/go-controller/pkg/factory/factory.go
@@ -17,9 +17,6 @@ import (
 	egressipapi "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressip/v1"
 	egressipscheme "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressip/v1/apis/clientset/versioned/scheme"
 	egressipinformerfactory "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressip/v1/apis/informers/externalversions"
-	apiextensionsapi "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
-	apiextensionsscheme "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/scheme"
-	apiextensionsinformerfactory "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions"
 
 	kapi "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
@@ -46,7 +43,6 @@ type WatchFactory struct {
 	eipFactory  egressipinformerfactory.SharedInformerFactory
 	efFactory   egressfirewallinformerfactory.SharedInformerFactory
 	efClientset egressfirewallclientset.Interface
-	crdFactory  apiextensionsinformerfactory.SharedInformerFactory
 	informers   map[reflect.Type]*informer
 
 	stopChan               chan struct{}
@@ -77,7 +73,6 @@ var (
 	namespaceType      reflect.Type = reflect.TypeOf(&kapi.Namespace{})
 	nodeType           reflect.Type = reflect.TypeOf(&kapi.Node{})
 	egressFirewallType reflect.Type = reflect.TypeOf(&egressfirewallapi.EgressFirewall{})
-	crdType            reflect.Type = reflect.TypeOf(&apiextensionsapi.CustomResourceDefinition{})
 	egressIPType       reflect.Type = reflect.TypeOf(&egressipapi.EgressIP{})
 )
 
@@ -93,16 +88,11 @@ func NewMasterWatchFactory(ovnClientset *util.OVNClientset) (*WatchFactory, erro
 		iFactory:    informerfactory.NewSharedInformerFactory(ovnClientset.KubeClient, resyncInterval),
 		eipFactory:  egressipinformerfactory.NewSharedInformerFactory(ovnClientset.EgressIPClient, resyncInterval),
 		efClientset: ovnClientset.EgressFirewallClient,
-		crdFactory:  apiextensionsinformerfactory.NewSharedInformerFactory(ovnClientset.APIExtensionsClient, resyncInterval),
 		informers:   make(map[reflect.Type]*informer),
 		stopChan:    make(chan struct{}),
 	}
 	var err error
 
-	err = apiextensionsapi.AddToScheme(apiextensionsscheme.Scheme)
-	if err != nil {
-		return nil, err
-	}
 	err = egressipapi.AddToScheme(egressipscheme.Scheme)
 	if err != nil {
 		return nil, err
@@ -153,21 +143,11 @@ func NewMasterWatchFactory(ovnClientset *util.OVNClientset) (*WatchFactory, erro
 	if err != nil {
 		return nil, err
 	}
-	wf.informers[crdType], err = newInformer(crdType, wf.crdFactory.Apiextensions().V1beta1().CustomResourceDefinitions().Informer())
-	if err != nil {
-		return nil, err
-	}
 	wf.informers[nodeType], err = newQueuedInformer(nodeType, wf.iFactory.Core().V1().Nodes().Informer(), wf.stopChan)
 	if err != nil {
 		return nil, err
 	}
 
-	wf.crdFactory.Start(wf.stopChan)
-	for oType, synced := range wf.crdFactory.WaitForCacheSync(wf.stopChan) {
-		if !synced {
-			return nil, fmt.Errorf("error in syncing cache for %v informer", oType)
-		}
-	}
 	wf.iFactory.Start(wf.stopChan)
 	for oType, synced := range wf.iFactory.WaitForCacheSync(wf.stopChan) {
 		if !synced {
@@ -202,7 +182,6 @@ func NewNodeWatchFactory(ovnClientset *util.OVNClientset, nodeName string) (*Wat
 	wf := &WatchFactory{
 		iFactory:    informerfactory.NewSharedInformerFactory(ovnClientset.KubeClient, resyncInterval),
 		efClientset: ovnClientset.EgressFirewallClient,
-		crdFactory:  apiextensionsinformerfactory.NewSharedInformerFactory(ovnClientset.APIExtensionsClient, resyncInterval),
 		informers:   make(map[reflect.Type]*informer),
 		stopChan:    make(chan struct{}),
 	}
@@ -451,16 +430,6 @@ func (wf *WatchFactory) AddEgressFirewallHandler(handlerFuncs cache.ResourceEven
 // RemoveEgressFirewallHandler removes an EgressFirewall object event handler function
 func (wf *WatchFactory) RemoveEgressFirewallHandler(handler *Handler) {
 	wf.removeHandler(egressFirewallType, handler)
-}
-
-// AddCRDHandler adds a handler function that will be executed on CRD obje changes
-func (wf *WatchFactory) AddCRDHandler(handlerFuncs cache.ResourceEventHandler, processExisting func([]interface{})) *Handler {
-	return wf.addHandler(crdType, "", nil, handlerFuncs, processExisting)
-}
-
-// RemoveCRDHandler removes a CRD object event handler function
-func (wf *WatchFactory) RemoveCRDHandler(handler *Handler) {
-	wf.removeHandler(crdType, handler)
 }
 
 // AddEgressIPHandler adds a handler function that will be executed on EgressIP object changes

--- a/go-controller/pkg/factory/factory_test.go
+++ b/go-controller/pkg/factory/factory_test.go
@@ -484,6 +484,17 @@ var _ = Describe("Watch Factory Operations", func() {
 			testExisting(egressIPType)
 		})
 	})
+	Context("when EgressFirewall is disabled", func() {
+		testExisting := func(objType reflect.Type) {
+			wf, err = NewMasterWatchFactory(ovnClientset)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(wf.informers).NotTo(HaveKey(objType))
+		}
+		It("does not contain EgressFirewall informer", func() {
+			config.OVNKubernetesFeature.EnableEgressFirewall = false
+			testExisting(egressFirewallType)
+		})
+	})
 
 	addFilteredHandler := func(wf *WatchFactory, objType reflect.Type, namespace string, sel labels.Selector, funcs cache.ResourceEventHandlerFuncs) (*Handler, *handlerCalls) {
 		calls := handlerCalls{}

--- a/go-controller/pkg/factory/factory_test.go
+++ b/go-controller/pkg/factory/factory_test.go
@@ -22,9 +22,6 @@ import (
 	egressfirewallfake "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressfirewall/v1/apis/clientset/versioned/fake"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 
-	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
-	apiextensionsfake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
-
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	egressip "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressip/v1"
 	egressipfake "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressip/v1/apis/clientset/versioned/fake"
@@ -138,18 +135,6 @@ func newEgressIP(name, namespace string) *egressip.EgressIP {
 
 }
 
-func newCRD(name, namespace string) *apiextensions.CustomResourceDefinition {
-	return &apiextensions.CustomResourceDefinition{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
-			UID:  types.UID(name),
-			Labels: map[string]string{
-				"name": name,
-			},
-		},
-	}
-}
-
 func objSetup(c *fake.Clientset, objType string, listFn func(core.Action) (bool, runtime.Object, error)) *watch.FakeWatcher {
 	w := watch.NewFake()
 	c.AddWatchReactor(objType, core.DefaultWatchReactor(w, nil))
@@ -158,13 +143,6 @@ func objSetup(c *fake.Clientset, objType string, listFn func(core.Action) (bool,
 }
 
 func egressFirewallObjSetup(c *egressfirewallfake.Clientset, objType string, listFn func(core.Action) (bool, runtime.Object, error)) *watch.FakeWatcher {
-	w := watch.NewFake()
-	c.AddWatchReactor(objType, core.DefaultWatchReactor(w, nil))
-	c.AddReactor("list", objType, listFn)
-	return w
-}
-
-func crdObjSetup(c *apiextensionsfake.Clientset, objType string, listFn func(core.Action) (bool, runtime.Object, error)) *watch.FakeWatcher {
 	w := watch.NewFake()
 	c.AddWatchReactor(objType, core.DefaultWatchReactor(w, nil))
 	c.AddReactor("list", objType, listFn)
@@ -202,10 +180,9 @@ var _ = Describe("Watch Factory Operations", func() {
 		fakeClient                                *fake.Clientset
 		egressIPFakeClient                        *egressipfake.Clientset
 		egressFirewallFakeClient                  *egressfirewallfake.Clientset
-		crdFakeClient                             *apiextensionsfake.Clientset
 		podWatch, namespaceWatch, nodeWatch       *watch.FakeWatcher
 		policyWatch, endpointsWatch, serviceWatch *watch.FakeWatcher
-		egressFirewallWatch, crdWatch             *watch.FakeWatcher
+		egressFirewallWatch                       *watch.FakeWatcher
 		egressIPWatch                             *watch.FakeWatcher
 		pods                                      []*v1.Pod
 		namespaces                                []*v1.Namespace
@@ -216,7 +193,6 @@ var _ = Describe("Watch Factory Operations", func() {
 		egressIPs                                 []*egressip.EgressIP
 		wf                                        *WatchFactory
 		egressFirewalls                           []*egressfirewall.EgressFirewall
-		crds                                      []*apiextensions.CustomResourceDefinition
 		err                                       error
 	)
 
@@ -228,14 +204,12 @@ var _ = Describe("Watch Factory Operations", func() {
 
 		fakeClient = &fake.Clientset{}
 		egressFirewallFakeClient = &egressfirewallfake.Clientset{}
-		crdFakeClient = &apiextensionsfake.Clientset{}
 		egressIPFakeClient = &egressipfake.Clientset{}
 
 		ovnClientset = &util.OVNClientset{
 			KubeClient:           fakeClient,
 			EgressIPClient:       egressIPFakeClient,
 			EgressFirewallClient: egressFirewallFakeClient,
-			APIExtensionsClient:  crdFakeClient,
 		}
 
 		pods = make([]*v1.Pod, 0)
@@ -296,15 +270,6 @@ var _ = Describe("Watch Factory Operations", func() {
 		egressFirewallWatch = egressFirewallObjSetup(egressFirewallFakeClient, "egressfirewalls", func(core.Action) (bool, runtime.Object, error) {
 			obj := &egressfirewall.EgressFirewallList{}
 			for _, p := range egressFirewalls {
-				obj.Items = append(obj.Items, *p)
-			}
-			return true, obj, nil
-		})
-
-		crds = make([]*apiextensions.CustomResourceDefinition, 0)
-		crdWatch = crdObjSetup(crdFakeClient, "customresourcedefinitions", func(core.Action) (bool, runtime.Object, error) {
-			obj := &apiextensions.CustomResourceDefinitionList{}
-			for _, p := range crds {
 				obj.Items = append(obj.Items, *p)
 			}
 			return true, obj, nil
@@ -376,10 +341,6 @@ var _ = Describe("Watch Factory Operations", func() {
 		It("is called for each existing egressFirewall", func() {
 			egressFirewalls = append(egressFirewalls, newEgressFirewall("myEgressFirewall", "default"))
 			testExisting(egressFirewallType, "", nil)
-		})
-		It("is called for each existing CRDS", func() {
-			crds = append(crds, newCRD("myCRD", ""))
-			testExisting(crdType, "", nil)
 		})
 		It("is called for each existing egressIP", func() {
 			egressIPs = append(egressIPs, newEgressIP("myEgressIP", "default"))
@@ -460,11 +421,6 @@ var _ = Describe("Watch Factory Operations", func() {
 			egressFirewalls = append(egressFirewalls, newEgressFirewall("myFirewall", "default"))
 			egressFirewalls = append(egressFirewalls, newEgressFirewall("myFirewall1", "default"))
 			testExisting(egressFirewallType)
-		})
-		It("calls ADD for each existing CRD", func() {
-			crds = append(crds, newCRD("crd1", ""))
-			crds = append(crds, newCRD("crd2", ""))
-			testExisting(crdType)
 		})
 		It("calls ADD for each existing egressIP", func() {
 			egressIPs = append(egressIPs, newEgressIP("myEgressIP", "default"))
@@ -1087,40 +1043,6 @@ var _ = Describe("Watch Factory Operations", func() {
 		Eventually(c.getDeleted, 2).Should(Equal(1))
 
 		wf.RemoveEgressFirewallHandler(h)
-	})
-	It("responds to crd add/update/delete events", func() {
-		wf, err = NewMasterWatchFactory(ovnClientset)
-		Expect(err).NotTo(HaveOccurred())
-
-		added := newCRD("crd1", "")
-		h, c := addHandler(wf, crdType, cache.ResourceEventHandlerFuncs{
-			AddFunc: func(obj interface{}) {
-				crd := obj.(*apiextensions.CustomResourceDefinition)
-				Expect(reflect.DeepEqual(crd, added)).To(BeTrue())
-			},
-			UpdateFunc: func(old, new interface{}) {
-				newcrd := new.(*apiextensions.CustomResourceDefinition)
-				Expect(reflect.DeepEqual(newcrd, added)).To(BeTrue())
-				Expect(newcrd.Spec.Group).To(Equal("my-test"))
-			},
-			DeleteFunc: func(obj interface{}) {
-				crd := obj.(*apiextensions.CustomResourceDefinition)
-				Expect(reflect.DeepEqual(crd, added)).To(BeTrue())
-			},
-		})
-
-		crds = append(crds, added)
-		crdWatch.Add(added)
-		Eventually(c.getAdded, 2).Should(Equal(1))
-		added.Spec.Group = "my-test"
-		crdWatch.Modify(added)
-		Eventually(c.getUpdated, 2).Should(Equal(1))
-		crds = crds[:0]
-		crdWatch.Delete(added)
-		Eventually(c.getDeleted, 2).Should(Equal(1))
-
-		wf.RemoveCRDHandler(h)
-
 	})
 	It("responds to egressIP add/update/delete events", func() {
 		wf, err = NewMasterWatchFactory(ovnClientset)

--- a/go-controller/pkg/factory/handler.go
+++ b/go-controller/pkg/factory/handler.go
@@ -13,7 +13,6 @@ import (
 	egressfirewalllister "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressfirewall/v1/apis/listers/egressfirewall/v1"
 
 	egressiplister "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressip/v1/apis/listers/egressip/v1"
-	apiextensionslister "k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/v1beta1"
 
 	listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
@@ -297,8 +296,6 @@ func newInformerLister(oType reflect.Type, sharedInformer cache.SharedIndexInfor
 		return nil, nil
 	case egressFirewallType:
 		return egressfirewalllister.NewEgressFirewallLister(sharedInformer.GetIndexer()), nil
-	case crdType:
-		return apiextensionslister.NewCustomResourceDefinitionLister(sharedInformer.GetIndexer()), nil
 	case egressIPType:
 		return egressiplister.NewEgressIPLister(sharedInformer.GetIndexer()), nil
 	}

--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -28,7 +28,6 @@ import (
 
 	egressfirewallfake "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressfirewall/v1/apis/clientset/versioned/fake"
 	egressipfake "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressip/v1/apis/clientset/versioned/fake"
-	apiextensionsfake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -157,12 +156,10 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 			Items: []v1.Node{existingNode},
 		})
 		egressFirewallFakeClient := &egressfirewallfake.Clientset{}
-		crdFakeClient := &apiextensionsfake.Clientset{}
 		egressIPFakeClient := &egressipfake.Clientset{}
 		fakeClient := &util.OVNClientset{
 			KubeClient:           kubeFakeClient,
 			EgressFirewallClient: egressFirewallFakeClient,
-			APIExtensionsClient:  crdFakeClient,
 		}
 
 		stop := make(chan struct{})

--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -161,7 +161,6 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 		egressIPFakeClient := &egressipfake.Clientset{}
 		fakeClient := &util.OVNClientset{
 			KubeClient:           kubeFakeClient,
-			EgressIPClient:       egressIPFakeClient,
 			EgressFirewallClient: egressFirewallFakeClient,
 			APIExtensionsClient:  crdFakeClient,
 		}

--- a/go-controller/pkg/node/ovn_test.go
+++ b/go-controller/pkg/node/ovn_test.go
@@ -13,7 +13,6 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/record"
 
-	egressipfake "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressip/v1/apis/clientset/versioned/fake"
 	apiextensionsfake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
 )
 
@@ -50,7 +49,6 @@ func (o *FakeOVNNode) start(ctx *cli.Context, objects ...runtime.Object) {
 
 	o.fakeClient = &util.OVNClientset{
 		KubeClient:          fake.NewSimpleClientset(v1Objects...),
-		EgressIPClient:      egressipfake.NewSimpleClientset(),
 		APIExtensionsClient: apiextensionsfake.NewSimpleClientset(),
 	}
 	o.init()

--- a/go-controller/pkg/node/ovn_test.go
+++ b/go-controller/pkg/node/ovn_test.go
@@ -12,8 +12,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/record"
-
-	apiextensionsfake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
 )
 
 var fakeNodeName = "node"
@@ -48,8 +46,7 @@ func (o *FakeOVNNode) start(ctx *cli.Context, objects ...runtime.Object) {
 	Expect(err).NotTo(HaveOccurred())
 
 	o.fakeClient = &util.OVNClientset{
-		KubeClient:          fake.NewSimpleClientset(v1Objects...),
-		APIExtensionsClient: apiextensionsfake.NewSimpleClientset(),
+		KubeClient: fake.NewSimpleClientset(v1Objects...),
 	}
 	o.init()
 }

--- a/go-controller/pkg/ovn/egressfirewall_test.go
+++ b/go-controller/pkg/ovn/egressfirewall_test.go
@@ -48,9 +48,10 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations for local gateway mode", 
 	)
 
 	ginkgo.BeforeEach(func() {
-		// Restore global default values before each 99999e
+		// Restore global default values before each testcase
 		config.PrepareTestConfig()
 		config.Gateway.Mode = config.GatewayModeLocal
+		config.OVNKubernetesFeature.EnableEgressFirewall = true
 
 		app = cli.NewApp()
 		app.Name = "test"
@@ -422,9 +423,10 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations for shared gateway mode",
 	)
 
 	ginkgo.BeforeEach(func() {
-		// Restore global default values before each 99999e
+		// Restore global default values before each test
 		config.PrepareTestConfig()
 		config.Gateway.Mode = config.GatewayModeShared
+		config.OVNKubernetesFeature.EnableEgressFirewall = true
 
 		app = cli.NewApp()
 		app.Name = "test"

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/urfave/cli/v2"
 	kapi "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
-	apiextensionsfake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes/fake"
@@ -1208,13 +1207,11 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 				Items: []v1.Node{testNode},
 			})
 			egressFirewallFakeClient := &egressfirewallfake.Clientset{}
-			crdFakeClient := &apiextensionsfake.Clientset{}
 			egressIPFakeClient := &egressipfake.Clientset{}
 			fakeClient := &util.OVNClientset{
 				KubeClient:           kubeFakeClient,
 				EgressIPClient:       egressIPFakeClient,
 				EgressFirewallClient: egressFirewallFakeClient,
-				APIExtensionsClient:  crdFakeClient,
 			}
 
 			fexec := ovntest.NewLooseCompareFakeExec()
@@ -1516,13 +1513,11 @@ func TestController_allocateNodeSubnets(t *testing.T) {
 			defer close(stopChan)
 			kubeFakeClient := fake.NewSimpleClientset()
 			egressFirewallFakeClient := &egressfirewallfake.Clientset{}
-			crdFakeClient := &apiextensionsfake.Clientset{}
 			egressIPFakeClient := &egressipfake.Clientset{}
 			fakeClient := &util.OVNClientset{
 				KubeClient:           kubeFakeClient,
 				EgressIPClient:       egressIPFakeClient,
 				EgressFirewallClient: egressFirewallFakeClient,
-				APIExtensionsClient:  crdFakeClient,
 			}
 			f, err := factory.NewMasterWatchFactory(fakeClient)
 			clusterController := NewOvnController(fakeClient, f, stopChan,

--- a/go-controller/pkg/ovn/namespace_test.go
+++ b/go-controller/pkg/ovn/namespace_test.go
@@ -17,7 +17,6 @@ import (
 
 	kapi "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
-	apiextensionsfake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/fake"
@@ -202,13 +201,11 @@ var _ = ginkgo.Describe("OVN Namespace Operations", func() {
 					},
 				)
 				egressFirewallFakeClient := &egressfirewallfake.Clientset{}
-				crdFakeClient := &apiextensionsfake.Clientset{}
 				egressIPFakeClient := &egressipfake.Clientset{}
 				fakeClient := &util.OVNClientset{
 					KubeClient:           kubeFakeClient,
 					EgressIPClient:       egressIPFakeClient,
 					EgressFirewallClient: egressFirewallFakeClient,
-					APIExtensionsClient:  crdFakeClient,
 				}
 
 				_, err := fakeClient.KubeClient.CoreV1().Nodes().Create(context.TODO(), &testNode, metav1.CreateOptions{})

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -28,7 +28,6 @@ import (
 
 	egressfirewall "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressfirewall/v1"
 
-	apiextension "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	utilnet "k8s.io/utils/net"
 
 	kapi "k8s.io/api/core/v1"
@@ -664,44 +663,6 @@ func (oc *Controller) WatchNetworkPolicy() {
 		},
 	}, oc.syncNetworkPolicies)
 	klog.Infof("Bootstrapping existing policies and cleaning stale policies took %v", time.Since(start))
-}
-
-// WatchCRD starts the watching of the CRD resource and calls back to the
-// appropriate handler logic
-func (oc *Controller) WatchCRD() {
-	oc.watchFactory.AddCRDHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
-			crd := obj.(*apiextension.CustomResourceDefinition)
-			klog.Infof("Adding CRD %s to cluster", crd.Name)
-			if crd.Name == egressfirewallCRD {
-				err := oc.watchFactory.InitializeEgressFirewallWatchFactory()
-				if err != nil {
-					klog.Errorf("Error Creating EgressFirewallWatchFactory: %v", err)
-					return
-				}
-
-				oc.egressFirewallDNS, err = NewEgressDNS(oc.addressSetFactory, oc.stopChan)
-				if err != nil {
-					klog.Errorf("Error Creating EgressFirewallDNS: %v", err)
-					return
-				}
-				oc.egressFirewallDNS.Run(egressFirewallDNSDefaultDuration)
-				oc.egressFirewallHandler = oc.WatchEgressFirewall()
-			}
-		},
-		UpdateFunc: func(old, newer interface{}) {
-		},
-		DeleteFunc: func(obj interface{}) {
-			crd := obj.(*apiextension.CustomResourceDefinition)
-			klog.Infof("Deleting CRD %s from cluster", crd.Name)
-			if crd.Name == egressfirewallCRD {
-				oc.egressFirewallDNS.Shutdown()
-				oc.watchFactory.RemoveEgressFirewallHandler(oc.egressFirewallHandler)
-				oc.egressFirewallHandler = nil
-				oc.watchFactory.ShutdownEgressFirewallWatchFactory()
-			}
-		},
-	}, nil)
 }
 
 // WatchEgressFirewall starts the watching of egressfirewall resource and calls

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -49,7 +49,6 @@ import (
 )
 
 const (
-	egressfirewallCRD                string        = "egressfirewalls.k8s.ovn.org"
 	clusterPortGroupName             string        = "clusterPortGroup"
 	clusterRtrPortGroupName          string        = "clusterRtrPortGroup"
 	egressFirewallDNSDefaultDuration time.Duration = 30 * time.Minute
@@ -362,11 +361,21 @@ func (oc *Controller) Run(wg *sync.WaitGroup, nodeName string) error {
 	}
 
 	oc.WatchNetworkPolicy()
-	oc.WatchCRD()
 
 	if config.OVNKubernetesFeature.EnableEgressIP {
 		oc.WatchEgressNodes()
 		oc.WatchEgressIP()
+	}
+
+	if config.OVNKubernetesFeature.EnableEgressFirewall {
+		var err error
+		oc.egressFirewallDNS, err = NewEgressDNS(oc.addressSetFactory, oc.stopChan)
+		if err != nil {
+			return err
+		}
+		oc.egressFirewallDNS.Run(egressFirewallDNSDefaultDuration)
+		oc.egressFirewallHandler = oc.WatchEgressFirewall()
+
 	}
 
 	klog.Infof("Completing all the Watchers took %v", time.Since(start))

--- a/go-controller/pkg/ovn/ovn_test.go
+++ b/go-controller/pkg/ovn/ovn_test.go
@@ -87,7 +87,6 @@ func (o *FakeOVN) restart() {
 
 func (o *FakeOVN) shutdown() {
 	close(o.stopChan)
-	o.watcher.ShutdownEgressFirewallWatchFactory()
 	o.watcher.Shutdown()
 	err := o.controller.ovnNBClient.Close()
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -99,7 +98,6 @@ func (o *FakeOVN) init() {
 	var err error
 	o.stopChan = make(chan struct{})
 	o.watcher, err = factory.NewMasterWatchFactory(o.fakeClient)
-	o.watcher.InitializeEgressFirewallWatchFactory()
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	o.ovnNBClient = ovntest.NewMockOVNClient(goovn.DBNB)
 	o.ovnSBClient = ovntest.NewMockOVNClient(goovn.DBSB)

--- a/go-controller/pkg/ovn/ovn_test.go
+++ b/go-controller/pkg/ovn/ovn_test.go
@@ -18,7 +18,6 @@ import (
 	egressfirewallfake "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressfirewall/v1/apis/clientset/versioned/fake"
 	egressip "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressip/v1"
 	egressipfake "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressip/v1/apis/clientset/versioned/fake"
-	apiextensionsfake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
 )
 
 const (
@@ -75,7 +74,6 @@ func (o *FakeOVN) start(ctx *cli.Context, objects ...runtime.Object) {
 		KubeClient:           fake.NewSimpleClientset(v1Objects...),
 		EgressIPClient:       egressipfake.NewSimpleClientset(egressIPObjects...),
 		EgressFirewallClient: egressfirewallfake.NewSimpleClientset(egressFirewallObjects...),
-		APIExtensionsClient:  apiextensionsfake.NewSimpleClientset(),
 	}
 	o.init()
 }

--- a/go-controller/pkg/util/kube.go
+++ b/go-controller/pkg/util/kube.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	kapi "k8s.io/api/core/v1"
+	discovery "k8s.io/api/discovery/v1beta1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -23,8 +24,6 @@ import (
 
 	egressfirewallclientset "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressfirewall/v1/apis/clientset/versioned"
 	egressipclientset "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressip/v1/apis/clientset/versioned"
-	discovery "k8s.io/api/discovery/v1beta1"
-	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/cni/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
@@ -35,7 +34,6 @@ type OVNClientset struct {
 	KubeClient           kubernetes.Interface
 	EgressIPClient       egressipclientset.Interface
 	EgressFirewallClient egressfirewallclientset.Interface
-	APIExtensionsClient  apiextensionsclientset.Interface
 }
 
 func adjustCommit() string {
@@ -123,10 +121,6 @@ func NewOVNClientset(conf *config.KubernetesConfig) (*OVNClientset, error) {
 	if err != nil {
 		return nil, fmt.Errorf("unable to create kubernetes rest config, err: %v", err)
 	}
-	crdClientset, err := apiextensionsclientset.NewForConfig(kconfig)
-	if err != nil {
-		return nil, err
-	}
 	egressFirewallClientset, err := egressfirewallclientset.NewForConfig(kconfig)
 	if err != nil {
 		return nil, err
@@ -139,7 +133,6 @@ func NewOVNClientset(conf *config.KubernetesConfig) (*OVNClientset, error) {
 		KubeClient:           kclientset,
 		EgressIPClient:       egressIPClientset,
 		EgressFirewallClient: egressFirewallClientset,
-		APIExtensionsClient:  crdClientset,
 	}, nil
 }
 


### PR DESCRIPTION
cherry-picked three commits from upstream ovn-kube to apply cleanly and solve the problem 

[c37c866f78765dfe15fb06943ead64d0723fedba](https://github.com/ovn-org/ovn-kubernetes/commit/c37c866f78765dfe15fb06943ead64d0723fedba) -  change the egressFirewall to use a cli flag instead of dynamically turn
    on from watching CRDs

[2e870eb23259c71216bb56895d63394d84166527](https://github.com/ovn-org/ovn-kubernetes/commit/2e870eb23259c71216bb56895d63394d84166527) - Remove node-side egress IP clients to help everything apply cleanly

[f9af29bbd67dda81d7091c9651cef0cb3b1ff895](https://github.com/ovn-org/ovn-kubernetes/commit/f9af29bbd67dda81d7091c9651cef0cb3b1ff895) - remove the CRD watch and related bits as they are no longer needed

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->