### PR TITLE
Bug 1956955: Reduces number of OVN operations in services #2201

### DIFF
--- a/go-controller/pkg/ovn/controller/services/repair_test.go
+++ b/go-controller/pkg/ovn/controller/services/repair_test.go
@@ -15,12 +15,18 @@ import (
 )
 
 const (
-	tcpLBUUID    string = "1a3dfc82-2749-4931-9190-c30e7c0ecea3"
-	udpLBUUID    string = "6d3142fc-53e8-4ac1-88e6-46094a5a9957"
-	sctpLBUUID   string = "0514c521-a120-4756-aec6-883fe5db7139"
-	grTcpLBUUID  string = "001c2ec6-2f32-11eb-9bc2-a8a1590cda29"
-	grUdpLBUUID  string = "05c55ae6-2f32-11eb-822e-a8a1590cda29"
-	grSctpLBUUID string = "0ac92874-2f32-11eb-8ca0-a8a1590cda29"
+	tcpLBUUID        string = "1a3dfc82-2749-4931-9190-c30e7c0ecea3"
+	udpLBUUID        string = "6d3142fc-53e8-4ac1-88e6-46094a5a9957"
+	sctpLBUUID       string = "0514c521-a120-4756-aec6-883fe5db7139"
+	grTcpLBUUID      string = "001c2ec6-2f32-11eb-9bc2-a8a1590cda29"
+	grUdpLBUUID      string = "05c55ae6-2f32-11eb-822e-a8a1590cda29"
+	grSctpLBUUID     string = "0ac92874-2f32-11eb-8ca0-a8a1590cda29"
+	workerTCPLBUUID  string = "2095292c-adb4-11eb-8529-0242ac130003"
+	workerUDPLBUUID  string = "2b662964-adb4-11eb-8529-0242ac130003"
+	workerSCTPLBUUID string = "50738e40-adb4-11eb-8529-0242ac130003"
+	idlingTCPLB      string = "a64d5efe-adb4-11eb-8529-0242ac130003"
+	idlingUDPLB      string = "bd58fa04-adb4-11eb-8529-0242ac130003"
+	idlingSCTPLB     string = "c90b1940-adb4-11eb-8529-0242ac130003"
 )
 
 func newServiceInformer() coreinformers.ServiceInformer {
@@ -48,6 +54,14 @@ func TestRepair_Empty(t *testing.T) {
 		Output: "",
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading get load_balancer " + workerSCTPLBUUID + " vips",
+		Output: "",
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading get load_balancer " + idlingSCTPLB + " vips",
+		Output: "",
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading get load_balancer " + tcpLBUUID + " vips",
 		Output: "",
 	})
@@ -56,11 +70,27 @@ func TestRepair_Empty(t *testing.T) {
 		Output: "",
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading get load_balancer " + workerTCPLBUUID + " vips",
+		Output: "",
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading get load_balancer " + idlingTCPLB + " vips",
+		Output: "",
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading get load_balancer " + udpLBUUID + " vips",
 		Output: "",
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading get load_balancer " + grUdpLBUUID + " vips",
+		Output: "",
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading get load_balancer " + workerUDPLBUUID + " vips",
+		Output: "",
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading get load_balancer " + idlingUDPLB + " vips",
 		Output: "",
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
@@ -96,6 +126,14 @@ func TestRepair_OVNStaleData(t *testing.T) {
 		Output: "",
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading get load_balancer " + workerSCTPLBUUID + " vips",
+		Output: "",
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading get load_balancer " + idlingSCTPLB + " vips",
+		Output: "",
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading get load_balancer " + tcpLBUUID + " vips",
 		Output: "",
 	})
@@ -104,11 +142,27 @@ func TestRepair_OVNStaleData(t *testing.T) {
 		Output: "",
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading get load_balancer " + workerTCPLBUUID + " vips",
+		Output: "",
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading get load_balancer " + idlingTCPLB + " vips",
+		Output: "",
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading get load_balancer " + udpLBUUID + " vips",
 		Output: `{"10.96.0.10:53"="10.244.2.3:53,10.244.2.5:53", "10.96.0.10:9153"="10.244.2.3:9153,10.244.2.5:9153", "10.96.0.1:443"="172.19.0.3:6443"}`,
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading get load_balancer " + grUdpLBUUID + " vips",
+		Output: "",
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading get load_balancer " + workerUDPLBUUID + " vips",
+		Output: "",
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading get load_balancer " + idlingUDPLB + " vips",
 		Output: "",
 	})
 	// The repair loop must delete the remaining entries in OVN
@@ -165,6 +219,14 @@ func TestRepair_OVNSynced(t *testing.T) {
 		Output: "",
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading get load_balancer " + workerSCTPLBUUID + " vips",
+		Output: "",
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading get load_balancer " + idlingSCTPLB + " vips",
+		Output: "",
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading get load_balancer " + tcpLBUUID + " vips",
 		Output: `{"10.96.0.10:80"="10.0.0.2:3456,10.0.0.3:3456", "[fd00:10:96::1]:80"="[2001:db8::1]:3456,[2001:db8::2]:3456"}`,
 	})
@@ -173,11 +235,27 @@ func TestRepair_OVNSynced(t *testing.T) {
 		Output: "",
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading get load_balancer " + workerTCPLBUUID + " vips",
+		Output: "",
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading get load_balancer " + idlingTCPLB + " vips",
+		Output: "",
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading get load_balancer " + udpLBUUID + " vips",
 		Output: "",
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading get load_balancer " + grUdpLBUUID + " vips",
+		Output: "",
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading get load_balancer " + workerUDPLBUUID + " vips",
+		Output: "",
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading get load_balancer " + idlingUDPLB + " vips",
 		Output: "",
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
@@ -219,6 +297,14 @@ func TestRepair_OVNMissingService(t *testing.T) {
 		Output: "",
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading get load_balancer " + workerSCTPLBUUID + " vips",
+		Output: "",
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading get load_balancer " + idlingSCTPLB + " vips",
+		Output: "",
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading get load_balancer " + tcpLBUUID + " vips",
 		Output: `{"10.96.0.10:80"="10.0.0.2:3456,10.0.0.3:3456"}`,
 	})
@@ -227,11 +313,27 @@ func TestRepair_OVNMissingService(t *testing.T) {
 		Output: "",
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading get load_balancer " + workerTCPLBUUID + " vips",
+		Output: "",
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading get load_balancer " + idlingTCPLB + " vips",
+		Output: "",
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading get load_balancer " + udpLBUUID + " vips",
 		Output: "",
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading get load_balancer " + grUdpLBUUID + " vips",
+		Output: "",
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading get load_balancer " + workerUDPLBUUID + " vips",
+		Output: "",
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading get load_balancer " + idlingUDPLB + " vips",
 		Output: "",
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
@@ -273,12 +375,36 @@ func initializeClusterIPLBs(fexec *ovntest.FakeExec) {
 		Output: grSctpLBUUID,
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:k8s-worker-lb-sctp=gateway1",
+		Output: workerSCTPLBUUID,
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:TCP_lb_gateway_router=gateway1",
 		Output: grTcpLBUUID,
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:k8s-worker-lb-tcp=gateway1",
+		Output: workerTCPLBUUID,
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:UDP_lb_gateway_router=gateway1",
 		Output: grUdpLBUUID,
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:k8s-worker-lb-udp=gateway1",
+		Output: workerUDPLBUUID,
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:k8s-idling-lb-sctp=yes",
+		Output: idlingSCTPLB,
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:k8s-idling-lb-tcp=yes",
+		Output: idlingTCPLB,
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:k8s-idling-lb-udp=yes",
+		Output: idlingUDPLB,
 	})
 }
 

--- a/go-controller/pkg/ovn/controller/services/service_tracker_test.go
+++ b/go-controller/pkg/ovn/controller/services/service_tracker_test.go
@@ -45,7 +45,7 @@ func Test_serviceTracker_updateService(t *testing.T) {
 
 	st := newServiceTracker()
 	for _, tt := range tests {
-		st.updateService(tt.name, tt.namespace, tt.vip, tt.proto)
+		st.updateService(tt.name, tt.namespace, tt.vip, tt.proto, "")
 		if !st.hasService(tt.name, tt.namespace) {
 			t.Fatalf("Error: service %s %s not updated", tt.name, tt.namespace)
 		}

--- a/go-controller/pkg/ovn/controller/services/services_controller.go
+++ b/go-controller/pkg/ovn/controller/services/services_controller.go
@@ -343,7 +343,7 @@ func (c *Controller) syncServices(key string) error {
 			// Reconcile OVN, update the load balancer with current endpoints
 
 			var currentLB string
-			// If any of the lbEps contain the a host IP we add to worker/GR LB separately, and not to cluster LB
+			// If any of the lbEps contain a host IP we add to worker/GR LB separately, and not to cluster LB
 			if hasHostEndpoints(eps.IPs) && config.Gateway.Mode == config.GatewayModeShared {
 				currentLB = loadbalancer.NodeLoadBalancer
 				if err := createPerNodeVIPs([]string{ip}, svcPort.Protocol, svcPort.Port, eps.IPs, eps.Port); err != nil {

--- a/go-controller/pkg/ovn/controller/services/services_controller.go
+++ b/go-controller/pkg/ovn/controller/services/services_controller.go
@@ -291,6 +291,15 @@ func (c *Controller) syncServices(key string) error {
 				"Error trying to delete the OVN LoadBalancer while setting up Idling for Service %s/%s: %v", name, namespace, err)
 			return err
 		}
+		// at this point we have processed all vips we've found in the service
+		// so the remaining ones that we had in the vipsTracked variable should be deleted
+		// We remove them from OVN and from the tracker
+		err = deleteVIPsFromAllOVNBalancers(vipsTracked, name, namespace)
+		if err != nil {
+			c.eventRecorder.Eventf(service, v1.EventTypeWarning, "FailedToDeleteOVNLoadBalancer",
+				"Error trying to delete the OVN LoadBalancer for Service %s/%s: %v", name, namespace, err)
+			return err
+		}
 		// Delete the Service VIP from the Service Tracker
 		c.serviceTracker.deleteServiceVIPs(name, namespace, vipsTracked)
 		return nil

--- a/go-controller/pkg/ovn/controller/services/services_controller_test.go
+++ b/go-controller/pkg/ovn/controller/services/services_controller_test.go
@@ -178,15 +178,8 @@ func TestSyncServices(t *testing.T) {
 					Output: idlingloadbalancerTCP,
 				},
 				{
-					Cmd:    "ovn-nbctl --timeout=15 --if-exists remove load_balancer a08ea426-2288-11eb-a30b-a8a1590cda30 vips \"192.168.1.1:80\"",
-					Output: "",
-				},
-				{
-					Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:k8s-idling-lb-tcp=yes",
-					Output: idlingloadbalancerTCP,
-				},
-				{
-					Cmd:    "ovn-nbctl --timeout=15 --if-exists remove load_balancer a08ea426-2288-11eb-a30b-a8a1590cda30 vips \"5.5.5.5:32766\"",
+					Cmd: `ovn-nbctl --timeout=15 --if-exists remove load_balancer a08ea426-2288-11eb-a30b-a8a1590cda30 vips "192.168.1.1:80"` +
+						` -- --if-exists remove load_balancer a08ea426-2288-11eb-a30b-a8a1590cda30 vips "5.5.5.5:32766"`,
 					Output: "",
 				},
 				{
@@ -456,11 +449,11 @@ func TestUpdateServicePorts(t *testing.T) {
 		Output: "load_balancer_1",
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-		Cmd:    `ovn-nbctl --timeout=15 --if-exists remove load_balancer load_balancer_1 vips "192.168.1.1:80"`,
+		Cmd:    `ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:TCP_lb_gateway_router=GR_2`,
 		Output: "",
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-		Cmd:    `ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:TCP_lb_gateway_router=GR_2`,
+		Cmd:    `ovn-nbctl --timeout=15 --if-exists remove load_balancer load_balancer_1 vips "192.168.1.1:80"`,
 		Output: "",
 	})
 	// update service starts here
@@ -490,11 +483,11 @@ func TestUpdateServicePorts(t *testing.T) {
 		Output: "load_balancer_1",
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-		Cmd:    `ovn-nbctl --timeout=15 --if-exists remove load_balancer load_balancer_1 vips "192.168.1.1:8888"`,
+		Cmd:    `ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:TCP_lb_gateway_router=GR_2`,
 		Output: "",
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-		Cmd:    `ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:TCP_lb_gateway_router=GR_2`,
+		Cmd:    `ovn-nbctl --timeout=15 --if-exists remove load_balancer load_balancer_1 vips "192.168.1.1:8888"`,
 		Output: "",
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
@@ -507,10 +500,6 @@ func TestUpdateServicePorts(t *testing.T) {
 	})
 	// Remove the old ServicePort
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-		Cmd:    `ovn-nbctl --timeout=15 --if-exists remove load_balancer a08ea426-2288-11eb-a30b-a8a1590cda29 vips "192.168.1.1:80"`,
-		Output: "",
-	})
-	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 		Cmd:    fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:TCP_lb_gateway_router=%s", gatewayRouter1),
 		Output: "load_balancer_1",
 	})
@@ -519,11 +508,9 @@ func TestUpdateServicePorts(t *testing.T) {
 		Output: "node_load_balancer_1",
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-		Cmd:    `ovn-nbctl --timeout=15 --if-exists remove load_balancer load_balancer_1 vips "192.168.1.1:80"`,
-		Output: "",
-	})
-	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-		Cmd:    `ovn-nbctl --timeout=15 --if-exists remove load_balancer node_load_balancer_1 vips "192.168.1.1:80"`,
+		Cmd: `ovn-nbctl --timeout=15 --if-exists remove load_balancer a08ea426-2288-11eb-a30b-a8a1590cda29 vips "192.168.1.1:80"` +
+			` -- --if-exists remove load_balancer load_balancer_1 vips "192.168.1.1:80"` +
+			` -- --if-exists remove load_balancer node_load_balancer_1 vips "192.168.1.1:80"`,
 		Output: "",
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
@@ -643,14 +630,6 @@ func TestUpdateServiceEndpointsToHost(t *testing.T) {
 		Output: "load_balancer_worker_1",
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-		Cmd:    `ovn-nbctl --timeout=15 --if-exists remove load_balancer load_balancer_1 vips "192.168.1.1:80"`,
-		Output: "",
-	})
-	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-		Cmd:    `ovn-nbctl --timeout=15 --if-exists remove load_balancer load_balancer_worker_1 vips "192.168.1.1:80"`,
-		Output: "",
-	})
-	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 		Cmd:    `ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:TCP_lb_gateway_router=GR_2`,
 		Output: "load_balancer_2",
 	})
@@ -659,11 +638,10 @@ func TestUpdateServiceEndpointsToHost(t *testing.T) {
 		Output: "load_balancer_worker_2",
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-		Cmd:    `ovn-nbctl --timeout=15 --if-exists remove load_balancer load_balancer_2 vips "192.168.1.1:80"`,
-		Output: "",
-	})
-	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-		Cmd:    `ovn-nbctl --timeout=15 --if-exists remove load_balancer load_balancer_worker_2 vips "192.168.1.1:80"`,
+		Cmd: `ovn-nbctl --timeout=15 --if-exists remove load_balancer load_balancer_1 vips "192.168.1.1:80"` +
+			` -- --if-exists remove load_balancer load_balancer_worker_1 vips "192.168.1.1:80"` +
+			` -- --if-exists remove load_balancer load_balancer_2 vips "192.168.1.1:80"` +
+			` -- --if-exists remove load_balancer load_balancer_worker_2 vips "192.168.1.1:80"`,
 		Output: "",
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
@@ -845,14 +823,6 @@ func TestUpdateServiceEndpointsLessRemoveOps(t *testing.T) {
 		Output: "load_balancer_worker_1",
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-		Cmd:    `ovn-nbctl --timeout=15 --if-exists remove load_balancer load_balancer_1 vips "192.168.1.1:80"`,
-		Output: "",
-	})
-	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-		Cmd:    `ovn-nbctl --timeout=15 --if-exists remove load_balancer load_balancer_worker_1 vips "192.168.1.1:80"`,
-		Output: "",
-	})
-	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 		Cmd:    `ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:TCP_lb_gateway_router=GR_2`,
 		Output: "load_balancer_2",
 	})
@@ -861,11 +831,10 @@ func TestUpdateServiceEndpointsLessRemoveOps(t *testing.T) {
 		Output: "load_balancer_worker_2",
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-		Cmd:    `ovn-nbctl --timeout=15 --if-exists remove load_balancer load_balancer_2 vips "192.168.1.1:80"`,
-		Output: "",
-	})
-	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-		Cmd:    `ovn-nbctl --timeout=15 --if-exists remove load_balancer load_balancer_worker_2 vips "192.168.1.1:80"`,
+		Cmd: `ovn-nbctl --timeout=15 --if-exists remove load_balancer load_balancer_1 vips "192.168.1.1:80"` +
+			` -- --if-exists remove load_balancer load_balancer_worker_1 vips "192.168.1.1:80"` +
+			` -- --if-exists remove load_balancer load_balancer_2 vips "192.168.1.1:80"` +
+			` -- --if-exists remove load_balancer load_balancer_worker_2 vips "192.168.1.1:80"`,
 		Output: "",
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{

--- a/go-controller/pkg/ovn/controller/services/utils.go
+++ b/go-controller/pkg/ovn/controller/services/utils.go
@@ -43,24 +43,32 @@ func deleteVIPsFromNonIdlingOVNBalancers(vips sets.String, name, namespace strin
 		return errors.Wrapf(err, "failed to retrieve OVN gateway routers")
 	}
 
-	// Obtain the VIPs associated to the Service from the Service Tracker
+	vipsPerProtocol := map[v1.Protocol]sets.String{}
+	lbsPerProtocol := map[v1.Protocol]sets.String{}
+	foundProtocols := map[v1.Protocol]struct{}{}
+
+	// Get load balancers for each Node
 	for vipKey := range vips {
 		// the VIP is stored with the format IP:Port/Protocol
 		vip, proto := splitVirtualIPKey(vipKey)
-		// ClusterIP use a global load balancer per protocol
+		foundProtocols[proto] = struct{}{}
+		if _, ok := vipsPerProtocol[proto]; !ok {
+			vipsPerProtocol[proto] = sets.NewString(vip)
+		} else {
+			vipsPerProtocol[proto].Insert(vip)
+		}
+		klog.Infof("Deleting VIP: %s from idling OVN LoadBalancer for service %s on namespace %s",
+			vip, name, namespace)
+		if _, ok := lbsPerProtocol[proto]; ok {
+			// already got the load balancers for this protocol, don't do it again
+			continue
+		}
 		lbID, err := loadbalancer.GetOVNKubeLoadBalancer(proto)
 		if err != nil {
 			klog.Errorf("Error getting OVN LoadBalancer for protocol %s", proto)
 			return err
 		}
-		// Delete the Service VIP from OVN
-		klog.Infof("Deleting service %s on namespace %s from OVN", name, namespace)
-		if err := loadbalancer.DeleteLoadBalancerVIP(lbID, vip); err != nil {
-			klog.Errorf("Error deleting VIP %s on OVN LoadBalancer %s", vip, lbID)
-			return err
-		}
-
-		// Configure the NodePort in each Node Gateway Router
+		lbsPerProtocol[proto] = sets.NewString(lbID)
 		for _, gatewayRouter := range gatewayRouters {
 			gatewayLB, err := gateway.GetGatewayLoadBalancer(gatewayRouter, proto)
 			if err != nil {
@@ -69,20 +77,21 @@ func deleteVIPsFromNonIdlingOVNBalancers(vips sets.String, name, namespace strin
 				// TODO: why continue? should we error and requeue and retry?
 				continue
 			}
+			lbsPerProtocol[proto].Insert(gatewayLB)
 			workerNode := util.GetWorkerFromGatewayRouter(gatewayRouter)
 			workerLB, err := loadbalancer.GetWorkerLoadBalancer(workerNode, proto)
 			if err != nil {
 				klog.Errorf("Worker switch %s does not have load balancer (%v)", workerNode, err)
 				continue
 			}
-			// Delete the Service VIP from OVN
-			klog.Infof("Deleting service %s on namespace %s from OVN", name, namespace)
-			for _, lb := range []string{gatewayLB, workerLB} {
-				if err := loadbalancer.DeleteLoadBalancerVIP(lb, vip); err != nil {
-					klog.Errorf("Error deleting VIP %s on OVN LoadBalancer %s", vip, lbID)
-					return err
-				}
-			}
+			lbsPerProtocol[proto].Insert(workerLB)
+		}
+	}
+
+	for proto := range foundProtocols {
+		if err := loadbalancer.DeleteLoadBalancerVIPs(lbsPerProtocol[proto].List(), vipsPerProtocol[proto].List()); err != nil {
+			klog.Errorf("Error deleting VIP %v on OVN LoadBalancer %v", vipsPerProtocol[proto].List(), lbsPerProtocol[proto].List())
+			return err
 		}
 	}
 	return nil
@@ -94,19 +103,37 @@ func deleteVIPsFromIdlingBalancer(vipProtocols sets.String, name, namespace stri
 		return nil
 	}
 
+	vipsPerProtocol := map[v1.Protocol]sets.String{}
+	lbsPerProtocol := map[v1.Protocol]sets.String{}
+	foundProtocols := map[v1.Protocol]struct{}{}
+
 	// Obtain the VIPs associated to the Service
 	for vipKey := range vipProtocols {
 		// the VIP is stored with the format IP:Port/Protocol
 		vip, proto := splitVirtualIPKey(vipKey)
+		if _, ok := vipsPerProtocol[proto]; !ok {
+			vipsPerProtocol[proto] = sets.NewString(vip)
+		} else {
+			vipsPerProtocol[proto].Insert(vip)
+		}
+		foundProtocols[proto] = struct{}{}
 		klog.Infof("Deleting VIP: %s from idling OVN LoadBalancer for service %s on namespace %s",
 			vip, name, namespace)
+		if _, ok := lbsPerProtocol[proto]; ok {
+			// lb already found for this protocol, don't do it again
+			continue
+		}
 		lbID, err := loadbalancer.GetOVNKubeIdlingLoadBalancer(proto)
 		if err != nil {
 			klog.Errorf("Error getting OVN idling LoadBalancer for protocol %s %v", proto, err)
 			return err
 		}
-		if err := loadbalancer.DeleteLoadBalancerVIP(lbID, vip); err != nil {
-			klog.Errorf("Error deleting VIP %s on idling OVN LoadBalancer %s %v", vip, lbID, err)
+		lbsPerProtocol[proto] = sets.NewString(lbID)
+	}
+	for proto := range foundProtocols {
+		if err := loadbalancer.DeleteLoadBalancerVIPs(lbsPerProtocol[proto].List(), vipsPerProtocol[proto].List()); err != nil {
+			klog.Errorf("Error deleting VIPs %v on idling OVN LoadBalancer %s %v",
+				vipsPerProtocol[proto].List(), lbsPerProtocol[proto].List(), err)
 			return err
 		}
 	}
@@ -231,7 +258,6 @@ func createPerNodePhysicalVIPs(isIPv6 bool, protocol v1.Protocol, sourcePort int
 }
 
 // deleteNodeVIPs removes load balancers on a per node basis for GR and worker switch LBs
-// if empty svcIP is provided, then the physical IPs will be used for the node
 func deleteNodeVIPs(svcIPs []string, protocol v1.Protocol, sourcePort int32) error {
 	klog.V(5).Infof("Searching to remove Gateway VIPs - %s, %d", protocol, sourcePort)
 	gatewayRouters, _, err := gateway.GetOvnGateways()
@@ -239,21 +265,12 @@ func deleteNodeVIPs(svcIPs []string, protocol v1.Protocol, sourcePort int32) err
 		klog.Errorf("Error while searching for gateways: %v", err)
 		return err
 	}
-
+	var loadBalancers []string
 	for _, gatewayRouter := range gatewayRouters {
-		var loadBalancers []string
 		gatewayLB, err := gateway.GetGatewayLoadBalancer(gatewayRouter, protocol)
 		if err != nil {
 			klog.Errorf("Gateway router %s does not have load balancer (%v)", gatewayRouter, err)
 			continue
-		}
-		ips := svcIPs
-		if len(ips) == 0 {
-			ips, err = gateway.GetGatewayPhysicalIPs(gatewayRouter)
-			if err != nil {
-				klog.Errorf("Gateway router %s does not have physical ip (%v)", gatewayRouter, err)
-				continue
-			}
 		}
 		loadBalancers = append(loadBalancers, gatewayLB)
 		if config.Gateway.Mode == config.GatewayModeShared {
@@ -265,16 +282,15 @@ func deleteNodeVIPs(svcIPs []string, protocol v1.Protocol, sourcePort int32) err
 			}
 			loadBalancers = append(loadBalancers, workerLB)
 		}
-		for _, loadBalancer := range loadBalancers {
-			for _, ip := range ips {
-				// With the physical_ip:sourcePort as the VIP, delete an entry in 'load_balancer'.
-				vip := util.JoinHostPortInt32(ip, sourcePort)
-				klog.V(5).Infof("Removing gateway VIP: %s from load balancer: %s", vip, loadBalancer)
-				if err := loadbalancer.DeleteLoadBalancerVIP(loadBalancer, vip); err != nil {
-					return err
-				}
-			}
-		}
+	}
+	vips := make([]string, 0, len(svcIPs))
+	for _, ip := range svcIPs {
+		vips = append(vips, util.JoinHostPortInt32(ip, sourcePort))
+	}
+
+	klog.V(5).Infof("Removing gateway VIPs: %v from load balancers: %v", vips, loadBalancers)
+	if err := loadbalancer.DeleteLoadBalancerVIPs(loadBalancers, vips); err != nil {
+		return err
 	}
 	return nil
 }

--- a/go-controller/pkg/ovn/controller/services/utils_test.go
+++ b/go-controller/pkg/ovn/controller/services/utils_test.go
@@ -65,10 +65,6 @@ func Test_deleteVIPsFromOVN(t *testing.T) {
 						Output: loadbalancerTCP,
 					},
 					{
-						Cmd:    `ovn-nbctl --timeout=15 --if-exists remove load_balancer a08ea426-2288-11eb-a30b-a8a1590cda29 vips "10.0.0.1:80"`,
-						Output: "",
-					},
-					{
 						Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:TCP_lb_gateway_router=2e290f10-3652-11eb-839b-a8a1590cda29",
 						Output: "loadbalancer1",
 					},
@@ -77,11 +73,9 @@ func Test_deleteVIPsFromOVN(t *testing.T) {
 						Output: "workerlb",
 					},
 					{
-						Cmd:    `ovn-nbctl --timeout=15 --if-exists remove load_balancer loadbalancer1 vips "10.0.0.1:80"`,
-						Output: "",
-					},
-					{
-						Cmd:    `ovn-nbctl --timeout=15 --if-exists remove load_balancer workerlb vips "10.0.0.1:80"`,
+						Cmd: `ovn-nbctl --timeout=15 --if-exists remove load_balancer a08ea426-2288-11eb-a30b-a8a1590cda29 vips "10.0.0.1:80"` +
+							` -- --if-exists remove load_balancer loadbalancer1 vips "10.0.0.1:80"` +
+							` -- --if-exists remove load_balancer workerlb vips "10.0.0.1:80"`,
 						Output: "",
 					},
 					{

--- a/go-controller/pkg/ovn/controller/services/utils_test.go
+++ b/go-controller/pkg/ovn/controller/services/utils_test.go
@@ -31,14 +31,9 @@ func Test_deleteVIPsFromOVN(t *testing.T) {
 		{
 			name: "empty",
 			args: args{
-				vips: sets.NewString(),
-				svc:  &v1.Service{},
-				ovnCmd: []ovntest.ExpectedCmd{
-					{
-						Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=name find logical_router options:chassis!=null",
-						Output: gatewayRouter1,
-					},
-				},
+				vips:   sets.NewString(),
+				svc:    &v1.Service{},
+				ovnCmd: []ovntest.ExpectedCmd{},
 			},
 			wantErr: false,
 		},
@@ -106,7 +101,7 @@ func Test_deleteVIPsFromOVN(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			st := newServiceTracker()
 			if len(tt.args.svc.Spec.ClusterIP) > 0 {
-				st.updateKubernetesService(tt.args.svc)
+				st.updateKubernetesService(tt.args.svc, "")
 			}
 			// Expected OVN commands
 			fexec := ovntest.NewFakeExec()
@@ -121,7 +116,6 @@ func Test_deleteVIPsFromOVN(t *testing.T) {
 			if err := deleteVIPsFromAllOVNBalancers(tt.args.vips, tt.args.svc.Name, tt.args.svc.Namespace); (err != nil) != tt.wantErr {
 				t.Errorf("deleteVIPsFromOVN() error = %v, wantErr %v", err, tt.wantErr)
 			}
-
 			if !fexec.CalledMatchesExpected() {
 				t.Error(fexec.ErrorDesc())
 			}

--- a/go-controller/pkg/ovn/loadbalancer/loadbalancer.go
+++ b/go-controller/pkg/ovn/loadbalancer/loadbalancer.go
@@ -15,6 +15,13 @@ import (
 	"k8s.io/klog/v2"
 )
 
+const (
+	// used to indicate if the service is running on node load balancers
+	NodeLoadBalancer = "NodeLoadBalancer"
+	// used to indicate if the service is running on idling load balancers
+	IdlingLoadBalancer = "IdlingLoadBalancer"
+)
+
 type NotFoundError struct {
 	What string
 }
@@ -30,7 +37,7 @@ func GetOVNKubeLoadBalancer(protocol kapi.Protocol) (string, error) {
 	return getLoadBalancerByProtocolType(protocol, types.ClusterLBPrefix)
 }
 
-// GetOVNKubeLoadBalancer returns the LoadBalancer matching the protocol
+// GetOVNKubeIdlingLoadBalancer returns the LoadBalancer matching the protocol
 func GetOVNKubeIdlingLoadBalancer(protocol kapi.Protocol) (string, error) {
 	return getLoadBalancerByProtocolType(protocol, types.ClusterIdlingLBPrefix)
 }


### PR DESCRIPTION
Changes-Include:
- Implement a services cache to avoid calling remove vip so many times in OVN for different load balancers which may not have the vip on them.
- Fixes leaving around unidling VIPs in OVN accidentally.
- Fixes initial sync of ovnkube-master starting, where it would not repair/resync certain services. This would result in some services not working across the cluster on ovnkube-master restart.
- Batches OVN service transactions: Large scale service operations result in many ovn-nbctl commands. This is addressed by batching as many as possible into a single nbctl transaction.