### PR TITLE
Bug 1962819: CNI cmdCheck: treat ingress_policing_rate=0 as not found

### DIFF
--- a/go-controller/pkg/cni/bandwidth_test.go
+++ b/go-controller/pkg/cni/bandwidth_test.go
@@ -2,8 +2,9 @@ package cni
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/mock"
 	"testing"
+
+	"github.com/stretchr/testify/mock"
 
 	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
 	mock_k8s_io_utils_exec "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/mocks/k8s.io/utils/exec"
@@ -245,94 +246,55 @@ func TestSetPodBandwidth(t *testing.T) {
 	}
 }
 
-func TestGetPodBandwidth(t *testing.T) {
+func TestGetIngressPodBandwidth(t *testing.T) {
 	mockKexecIface := new(mock_k8s_io_utils_exec.Interface)
 	mockCmd := new(mock_k8s_io_utils_exec.Cmd)
 
 	tests := []struct {
 		desc                string
 		expectedErr         bool
+		expectedNotFound    bool
 		onRetArgsKexecIface []ovntest.TestifyMockHelper
 		onRetArgsCmdList    []ovntest.TestifyMockHelper
 		runnerInstance      kexec.Interface
-		egressBPS           int64
-		igressBPS           int64
+		bps                 int64
 	}{
 		{
-			desc: "Positive test code path when ingressBPS and egressBPS are correctly set",
+			desc: "Positive test code path when ingressBPS is correctly set",
 			onRetArgsKexecIface: []ovntest.TestifyMockHelper{
-				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
 				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
 				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
 			},
 			onRetArgsCmdList: []ovntest.TestifyMockHelper{
 				{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{[]byte{1}, nil}},
 				{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{[]byte("\"10000000\""), nil}},
-				{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{[]byte("10000"), nil}},
 			},
 			runnerInstance: mockKexecIface,
-			igressBPS:      10000000,
-			egressBPS:      10000000,
+			bps:            10000000,
 		},
 		{
-			desc: "Positive test code path when ingressBPS and egressBPS are not set",
+			desc: "Positive test code path when ingressBPS is not set",
 			onRetArgsKexecIface: []ovntest.TestifyMockHelper{
-				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
 				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
 			},
 			onRetArgsCmdList: []ovntest.TestifyMockHelper{
 				{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{nil, nil}},
-				{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{[]byte("0"), nil}},
 			},
-			runnerInstance: mockKexecIface,
-			igressBPS:      -1,
-			egressBPS:      0,
+			runnerInstance:   mockKexecIface,
+			expectedNotFound: true,
 		},
 		{
-			desc: "Positive test code path when ingressBPS is not set (no port) and egressBPS is set",
+			desc: "Positive test code path when ingressBPS is not set (no max-rate)",
 			onRetArgsKexecIface: []ovntest.TestifyMockHelper{
-				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
-				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
-			},
-			onRetArgsCmdList: []ovntest.TestifyMockHelper{
-				{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{nil, nil}},
-				{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{[]byte("10000"), nil}},
-			},
-			runnerInstance: mockKexecIface,
-			igressBPS:      -1,
-			egressBPS:      10000000,
-		},
-		{
-			desc: "Positive test code path when ingressBPS is not set (no max-rate) and egressBPS is set",
-			onRetArgsKexecIface: []ovntest.TestifyMockHelper{
-				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
 				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
 				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
 			},
 			onRetArgsCmdList: []ovntest.TestifyMockHelper{
 				{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{[]byte{1}, nil}},
 				{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{nil, nil}},
-				{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{[]byte("10000"), nil}},
 			},
-			runnerInstance: mockKexecIface,
-			igressBPS:      -1,
-			egressBPS:      10000000,
-		},
-		{
-			desc: "Positive test code path when ingressBPS is set but egressBPS isn't",
-			onRetArgsKexecIface: []ovntest.TestifyMockHelper{
-				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
-				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
-				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
-			},
-			onRetArgsCmdList: []ovntest.TestifyMockHelper{
-				{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{[]byte{1}, nil}},
-				{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{[]byte("\"10000000\""), nil}},
-				{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{nil, nil}},
-			},
-			runnerInstance: mockKexecIface,
-			igressBPS:      10000000,
-			egressBPS:      -1,
+			runnerInstance:   mockKexecIface,
+			expectedNotFound: true,
 		},
 		{
 			desc:        "Negative test code path when ovsGet 'port' returns error",
@@ -371,32 +333,105 @@ func TestGetPodBandwidth(t *testing.T) {
 			},
 			runnerInstance: mockKexecIface,
 		},
+	}
+	for i, tc := range tests {
+		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
+			if tc.onRetArgsKexecIface != nil {
+				for _, item := range tc.onRetArgsKexecIface {
+					ifaceCall := mockKexecIface.On(item.OnCallMethodName)
+					for _, arg := range item.OnCallMethodArgType {
+						ifaceCall.Arguments = append(ifaceCall.Arguments, mock.AnythingOfType(arg))
+					}
+					for _, ret := range item.RetArgList {
+						ifaceCall.ReturnArguments = append(ifaceCall.ReturnArguments, ret)
+					}
+					ifaceCall.Once()
+				}
+			}
+
+			if tc.onRetArgsCmdList != nil {
+				for _, item := range tc.onRetArgsCmdList {
+					mockCall := mockCmd.On(item.OnCallMethodName)
+					for _, arg := range item.OnCallMethodArgType {
+						mockCall.Arguments = append(mockCall.Arguments, mock.AnythingOfType(arg))
+					}
+					for _, ret := range item.RetArgList {
+						mockCall.ReturnArguments = append(mockCall.ReturnArguments, ret)
+					}
+					mockCall.Once()
+				}
+			}
+			// note runner is defined in pkg/cni/ovs.go file
+			runner = tc.runnerInstance
+			bandwidth, e := getOvsPortBandwidth("ifname", Ingress)
+			switch {
+			case tc.expectedErr:
+				assert.Error(t, e)
+			case tc.expectedNotFound:
+				assert.Equal(t, e, BandwidthNotFound)
+			default:
+				assert.Nil(t, e)
+				assert.Equal(t, bandwidth, tc.bps)
+			}
+			mockCmd.AssertExpectations(t)
+			mockKexecIface.AssertExpectations(t)
+		})
+	}
+}
+
+func TestGetEgressPodBandwidth(t *testing.T) {
+	mockKexecIface := new(mock_k8s_io_utils_exec.Interface)
+	mockCmd := new(mock_k8s_io_utils_exec.Cmd)
+
+	tests := []struct {
+		desc                string
+		expectedErr         bool
+		expectedNotFound    bool
+		onRetArgsKexecIface []ovntest.TestifyMockHelper
+		onRetArgsCmdList    []ovntest.TestifyMockHelper
+		runnerInstance      kexec.Interface
+		bps                 int64
+	}{
 		{
-			desc:        "Negative test code path when ovsGet 'interface' returns error",
-			expectedErr: true,
+			desc: "Positive test code path when egressBPS is correctly set",
 			onRetArgsKexecIface: []ovntest.TestifyMockHelper{
-				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
-				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
 				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
 			},
 			onRetArgsCmdList: []ovntest.TestifyMockHelper{
-				{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{[]byte{1}, nil}},
-				{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{[]byte("\"10000000\""), nil}},
-				{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{nil, fmt.Errorf("mock: failed to run ovsSet")}},
+				{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{[]byte("10000"), nil}},
 			},
 			runnerInstance: mockKexecIface,
+			bps:            10000000,
+		},
+		{
+			desc: "Positive test code path when egressBPS is not set (no ingress_policing_rate)",
+			onRetArgsKexecIface: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
+			},
+			onRetArgsCmdList: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{nil, nil}},
+			},
+			runnerInstance:   mockKexecIface,
+			expectedNotFound: true,
+		},
+		{
+			desc: "Positive test code path when egressBPS is not set",
+			onRetArgsKexecIface: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
+			},
+			onRetArgsCmdList: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{[]byte("0"), nil}},
+			},
+			runnerInstance:   mockKexecIface,
+			expectedNotFound: true,
 		},
 		{
 			desc:        "Negative test code path when ovsGet 'interface' returns error",
 			expectedErr: true,
 			onRetArgsKexecIface: []ovntest.TestifyMockHelper{
 				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
-				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
-				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
 			},
 			onRetArgsCmdList: []ovntest.TestifyMockHelper{
-				{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{[]byte{1}, nil}},
-				{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{[]byte("\"10000000\""), nil}},
 				{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{nil, fmt.Errorf("mock: failed to run ovsSet")}},
 			},
 			runnerInstance: mockKexecIface,
@@ -406,12 +441,8 @@ func TestGetPodBandwidth(t *testing.T) {
 			expectedErr: true,
 			onRetArgsKexecIface: []ovntest.TestifyMockHelper{
 				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
-				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
-				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
 			},
 			onRetArgsCmdList: []ovntest.TestifyMockHelper{
-				{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{[]byte{1}, nil}},
-				{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{[]byte("\"10000000\""), nil}},
 				{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{[]byte("test"), nil}},
 			},
 			runnerInstance: mockKexecIface,
@@ -446,14 +477,15 @@ func TestGetPodBandwidth(t *testing.T) {
 			}
 			// note runner is defined in pkg/cni/ovs.go file
 			runner = tc.runnerInstance
-			igress, egress, e := getPodBandwidth("ifname")
-
-			if tc.expectedErr {
+			bandwidth, e := getOvsPortBandwidth("ifname", Egress)
+			switch {
+			case tc.expectedErr:
 				assert.Error(t, e)
-			} else {
+			case tc.expectedNotFound:
+				assert.Equal(t, e, BandwidthNotFound)
+			default:
 				assert.Nil(t, e)
-				assert.Equal(t, igress, tc.igressBPS)
-				assert.Equal(t, egress, tc.egressBPS)
+				assert.Equal(t, bandwidth, tc.bps)
 			}
 			mockCmd.AssertExpectations(t)
 			mockKexecIface.AssertExpectations(t)

--- a/go-controller/pkg/cni/utils.go
+++ b/go-controller/pkg/cni/utils.go
@@ -1,0 +1,32 @@
+package cni
+
+import (
+	"errors"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+)
+
+// PodAnnotation2PodInfo creates PodInterfaceInfo from Pod annotations and additional attributes
+func PodAnnotation2PodInfo(podAnnotation map[string]string) (*PodInterfaceInfo, error) {
+	podAnnotSt, err := util.UnmarshalPodAnnotation(podAnnotation)
+	if err != nil {
+		return nil, err
+	}
+	ingress, err := extractPodBandwidth(podAnnotation, Ingress)
+	if err != nil && !errors.Is(err, BandwidthNotFound) {
+		return nil, err
+	}
+	egress, err := extractPodBandwidth(podAnnotation, Egress)
+	if err != nil && !errors.Is(err, BandwidthNotFound) {
+		return nil, err
+	}
+
+	podInterfaceInfo := &PodInterfaceInfo{
+		PodAnnotation: *podAnnotSt,
+		MTU:           config.Default.MTU,
+		Ingress:       ingress,
+		Egress:        egress,
+	}
+	return podInterfaceInfo, nil
+}


### PR DESCRIPTION
When the cni is not chained with multus, the container runtime invokes
the check command. The check command checks the bandwith requirements
annotated on the pod, vs what's being configured in ovs. Ovs sets
ingress_policing_rate=0 by default, so the check always fails.

Here, when ingress_policing_rate is 0, we treat it as not found.

Manual cherry pick of https://github.com/openshift/ovn-kubernetes/pull/522