### PR TITLE
Bug 1959597: upgrade ovs to version 2.15 to support column diffs.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN yum install -y  \
 	selinux-policy && \
 	yum clean all
 
-ARG ovsver=2.13.0-79.el8fdp
+ARG ovsver=2.15.0-15.el8fdp
 ARG ovnver=20.12.0-24.el8fdp
 
 RUN INSTALL_PKGS=" \
@@ -44,7 +44,7 @@ RUN INSTALL_PKGS=" \
 	ethtool conntrack-tools \
 	" && \
 	yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False $INSTALL_PKGS && \
-	yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False "openvswitch2.13 = $ovsver" "openvswitch2.13-devel = $ovsver" "python3-openvswitch2.13 = $ovsver" "openvswitch2.13-ipsec = $ovsver" && \
+	yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False "openvswitch2.15 = $ovsver" "openvswitch2.15-devel = $ovsver" "python3-openvswitch2.15 = $ovsver" "openvswitch2.15-ipsec = $ovsver" && \
 	yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False "ovn2.13 = $ovnver" "ovn2.13-central = $ovnver" "ovn2.13-host = $ovnver" "ovn2.13-vtep = $ovnver" && \
 	yum clean all && rm -rf /var/cache/*
 


### PR DESCRIPTION
Update 4.7 release to use OVS 2.15 so we can enable column diff feature starting from release 4.8
Note: after this commit is merged we no longer can downgrade to older releases.
New ovsdb-server will be able to read old database format, but older ovsdb-server will fail to read database created by this new OVS version.

changes in ovs2.15: https://github.com/openvswitch/ovs/blob/0b3ff31d35f56c9401d868613581b4d35bb42724/NEWS#L17
package details : https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1584628
