### PR TITLE
Bug 1962392: CARRY: fix missed learn for hybrid exgw

### DIFF
--- a/go-controller/hybrid-overlay/pkg/controller/node_linux.go
+++ b/go-controller/hybrid-overlay/pkg/controller/node_linux.go
@@ -610,7 +610,7 @@ func (n *NodeController) syncFlows() {
 			// and we accidentally pick up the old vtep flow and cache it. This should only ever happen on a pod update
 			// with an NS annotation VTEP change. We only need to ignore it for one iteration of sync.
 			if cacheEntry.ignoreLearn {
-				klog.V(5).Infof("Ignoring learned flow to add to hybrid cache for this iteration: %s", line)
+				klog.Infof("Ignoring learned flow to add to hybrid cache for this iteration: %s", line)
 				cacheEntry.ignoreLearn = false
 				cacheEntry.learnedFlow = ""
 				continue
@@ -635,6 +635,13 @@ func (n *NodeController) syncFlows() {
 	_, _, err = util.ReplaceOFFlows(extBridgeName, flows)
 	if err != nil {
 		klog.Errorf("Failed to add flows, error: %v, flows: %s", err, flows)
+		return
+	}
+
+	// handle resetting ignore learn as we may not have encountered some pods while
+	// iterating through the flows in OVS
+	for _, entry := range n.flowCache {
+		entry.ignoreLearn = false
 	}
 }
 


### PR DESCRIPTION
We are intentionally ignoring learn when something critical to the learn
flow changes like pod ip, mac, exgw annotations. However, once we sync
flows we should reset the pod to learn the flow on the next sync.
However, we were only resetting pods for which we found flows already in
OVS. This fixes that by restting ignoreLearn for all pods as long as we
have a successful sync.

Signed-off-by: Tim Rozet <trozet@redhat.com>
