### PR TITLE
Bug 1959200: Adds back checking OF flows for CNI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN yum install -y  \
 	yum clean all
 
 ARG ovsver=2.15.0-9.el8fdp
-ARG ovnver=20.12.0-25.el8fdp
+ARG ovnver=20.12.0-140.el8fdp
 
 RUN INSTALL_PKGS=" \
 	openssl python3-pyOpenSSL firewalld-filesystem \

--- a/go-controller/pkg/cni/cni.go
+++ b/go-controller/pkg/cni/cni.go
@@ -97,7 +97,7 @@ func (pr *PodRequest) cmdAdd(podLister corev1listers.PodLister, useOVSExternalID
 	}
 	// Get the IP address and MAC address of the pod
 	// for Smart-Nic, ensure connection-details is present
-	annotations, err := GetPodAnnotations(pr.ctx, podLister, namespace, podName, annotCondFn)
+	annotations, err := GetPodAnnotations(pr.ctx, podLister, kclient, namespace, podName, annotCondFn)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get pod annotation: %v", err)
 	}
@@ -137,7 +137,7 @@ func (pr *PodRequest) cmdDel() ([]byte, error) {
 	return []byte{}, nil
 }
 
-func (pr *PodRequest) cmdCheck(podLister corev1listers.PodLister, useOVSExternalIDs bool) ([]byte, error) {
+func (pr *PodRequest) cmdCheck(podLister corev1listers.PodLister, useOVSExternalIDs bool, kclient kubernetes.Interface) ([]byte, error) {
 	namespace := pr.PodNamespace
 	podName := pr.PodName
 	if namespace == "" || podName == "" {
@@ -149,7 +149,7 @@ func (pr *PodRequest) cmdCheck(podLister corev1listers.PodLister, useOVSExternal
 	if pr.IsSmartNIC {
 		annotCondFn = isSmartNICReady
 	}
-	annotations, err := GetPodAnnotations(pr.ctx, podLister, pr.PodNamespace, pr.PodName, annotCondFn)
+	annotations, err := GetPodAnnotations(pr.ctx, podLister, kclient, pr.PodNamespace, pr.PodName, annotCondFn)
 	if err != nil {
 		return nil, err
 	}
@@ -217,7 +217,7 @@ func HandleCNIRequest(request *PodRequest, podLister corev1listers.PodLister, us
 	case CNIDel:
 		result, err = request.cmdDel()
 	case CNICheck:
-		result, err = request.cmdCheck(podLister, useOVSExternalIDs)
+		result, err = request.cmdCheck(podLister, useOVSExternalIDs, kclient)
 	default:
 	}
 	klog.Infof("%s %s finished CNI request %+v, result %q, err %v", request, request.Command, request, string(result), err)

--- a/go-controller/pkg/cni/cniserver.go
+++ b/go-controller/pkg/cni/cniserver.go
@@ -21,6 +21,7 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/metrics"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 )
 
 // *** The Server is PRIVATE API between OVN components and may be
@@ -93,6 +94,13 @@ func NewCNIServer(rundir string, useOVSExternalIDs bool, factory factory.NodeWat
 	}).Methods("POST")
 
 	factory.AddPodHandler(cache.ResourceEventHandlerFuncs{
+		UpdateFunc: func(oldObj, newObj interface{}) {
+			newPod := newObj.(*kapi.Pod)
+			annot, err := util.UnmarshalPodAnnotation(newPod.Annotations)
+			if err == nil {
+				s.cancelOldPodAdds(newPod, annot.MAC.String())
+			}
+		},
 		DeleteFunc: func(obj interface{}) {
 			pod := obj.(*kapi.Pod)
 			s.cancelOldestPodAdd(pod)
@@ -100,6 +108,22 @@ func NewCNIServer(rundir string, useOVSExternalIDs bool, factory factory.NodeWat
 	}, nil)
 
 	return s, nil
+}
+
+// cancelOldPodAdds cancels and outstanding pod add requests that do not match
+// the given MAC address.
+func (s *Server) cancelOldPodAdds(pod *kapi.Pod, podMAC string) {
+	s.runningSandboxAddsLock.Lock()
+	defer s.runningSandboxAddsLock.Unlock()
+
+	for _, req := range s.runningSandboxAdds {
+		// Cancel any match pod request that has a MAC set, that doesn't
+		// match the given MAC
+		if req.PodNamespace == pod.Namespace && req.PodName == pod.Name && req.MAC != "" && req.MAC != podMAC {
+			req.cancel()
+			klog.Infof("%s canceled sandbox ADD request; expected MAC %s", req, podMAC)
+		}
+	}
 }
 
 // cancelOldestPodAdd requests that the earliest outstanding add operation for a given

--- a/go-controller/pkg/cni/types.go
+++ b/go-controller/pkg/cni/types.go
@@ -92,6 +92,8 @@ type PodRequest struct {
 	cancel context.CancelFunc
 	// Interface to pod is a Smart-NIC interface
 	IsSmartNIC bool
+	// MAC address
+	MAC string
 }
 
 type cniRequestFunc func(request *PodRequest, podLister corev1listers.PodLister, useOVSExternalIDs bool, kclient kubernetes.Interface) ([]byte, error)

--- a/go-controller/pkg/cni/utils.go
+++ b/go-controller/pkg/cni/utils.go
@@ -8,6 +8,11 @@ import (
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+
+	kapi "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 	corev1listers "k8s.io/client-go/listers/core/v1"
 )
 
@@ -37,8 +42,20 @@ func isSmartNICReady(podAnnotation map[string]string) bool {
 	return false
 }
 
+// getPod returns a pod from the informer cache or (if that fails) the apiserver
+func getPod(podLister corev1listers.PodLister, kclient kubernetes.Interface, namespace, name string) (*kapi.Pod, error) {
+	pod, err := podLister.Pods(namespace).Get(name)
+	if apierrors.IsNotFound(err) {
+		// If the pod wasn't in our local cache, ask for it directly
+		pod, err = kclient.CoreV1().Pods(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	}
+	return pod, err
+}
+
 // GetPodAnnotations obtains the pod annotation from the cache
-func GetPodAnnotations(ctx context.Context, podLister corev1listers.PodLister, namespace, name string, annotCond podAnnotWaitCond) (map[string]string, error) {
+func GetPodAnnotations(ctx context.Context, podLister corev1listers.PodLister, kclient kubernetes.Interface, namespace, name string, annotCond podAnnotWaitCond) (map[string]string, error) {
+	var notFoundCount uint
+
 	timeout := time.After(30 * time.Second)
 	for {
 		select {
@@ -47,14 +64,24 @@ func GetPodAnnotations(ctx context.Context, podLister corev1listers.PodLister, n
 		case <-timeout:
 			return nil, fmt.Errorf("timed out waiting for annotations")
 		default:
-			pod, err := podLister.Pods(namespace).Get(name)
+			pod, err := getPod(podLister, kclient, namespace, name)
 			if err != nil {
-				return nil, fmt.Errorf("failed to get annotations: %v", err)
+				if !apierrors.IsNotFound(err) {
+					return nil, fmt.Errorf("failed to get pod for annotations: %v", err)
+				}
+				// Allow up to 1 second for pod to be found
+				notFoundCount++
+				if notFoundCount >= 5 {
+					return nil, fmt.Errorf("timed out waiting for pod after 1s: %v", err)
+				}
+				// drop through to try again
+			} else if pod != nil {
+				annotations := pod.ObjectMeta.Annotations
+				if annotCond(annotations) {
+					return annotations, nil
+				}
 			}
-			annotations := pod.ObjectMeta.Annotations
-			if annotCond(annotations) {
-				return annotations, nil
-			}
+
 			// try again later
 			time.Sleep(200 * time.Millisecond)
 		}


### PR DESCRIPTION
We see at scale that this can happen:
1. CNI delete
2. OVN is so busy it takes 30 seconds to remove the old logical port
3. CNI ADD within 30 seconds
4. ovn-controller sees old logical switchport, binds and considers new
   pod up, but no traffic works
5. sometime later OVN gets updated, and ovn-controller updates the pod
   with the new flows and traffic finally works

To solve this problem we need to have a minimal check to ensure the
right flows are present for the pod before we check if ovn_installed is
true. This change adds back the checks for mac address and of port
number.

(cherry picked from commit 22bed6a10c669142fb13e612a8fe17cf8b895fd6)

4.8 backport of https://github.com/ovn-org/ovn-kubernetes/pull/2220

@trozet 