### PR TITLE
Bug 1962387: Update ACLs with dual stack address sets & cleanup old address sets

### DIFF
--- a/go-controller/pkg/ovn/address_set/address_set_cleanup.go
+++ b/go-controller/pkg/ovn/address_set/address_set_cleanup.go
@@ -1,0 +1,43 @@
+package addressset
+
+// NonDualStackAddressSetCleanup cleans addresses in old non dual stack format.
+// Assumes that for every address set <name>, if there exists an address set
+// of <name_[v4|v6]>, address set <name> is no longer used and removes it.
+// This method should only be called after ensuring address sets in old format
+// are no longer being referenced from any other object.
+func NonDualStackAddressSetCleanup() error {
+	// For each address set, track if it is in old non dual stack
+	// format and in new dual stack format
+	addressSets := map[string][2]bool{}
+	err := forEachAddressSet(func(name string) {
+		shortName := truncateSuffixFromAddressSet(name)
+		info, found := addressSets[shortName]
+		if !found {
+			info = [2]bool{false, false}
+		}
+		if shortName == name {
+			// This address set is in old non dual stack format
+			info[0] = true
+		} else {
+			// This address set is in new dual stack format
+			info[1] = true
+		}
+		addressSets[shortName] = info
+	})
+	if err != nil {
+		return err
+	}
+
+	for name, info := range addressSets {
+		// If we have an address set in both old and new formats,
+		// we can safely remove the old format.
+		if info[0] && info[1] {
+			err := destroyAddressSet(name)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}

--- a/go-controller/pkg/ovn/address_set/address_set_test.go
+++ b/go-controller/pkg/ovn/address_set/address_set_test.go
@@ -45,10 +45,13 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 		app.Flags = config.Flags
 
 		fexec = ovntest.NewFakeExec()
-		err := util.SetExec(fexec)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		asFactory = NewOvnAddressSetFactory()
+	})
+
+	ginkgo.JustBeforeEach(func() {
+		err := util.SetExec(fexec)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 
 	ginkgo.Context("when iterating address sets", func() {
@@ -569,6 +572,90 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 				err = as.DeleteIPs([]net.IP{net.ParseIP(addr1)})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
+				gomega.Expect(fexec.CalledMatchesExpected()).To(gomega.BeTrue(), fexec.ErrorDesc)
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+	})
+
+	ginkgo.Context("Dual Stack : when cleaning up old address sets", func() {
+		ginkgo.BeforeEach(func() {
+			fexec = ovntest.NewLooseCompareFakeExec()
+		})
+
+		ginkgo.It("destroys address sets in old non dual stack format", func() {
+			app.Action = func(ctx *cli.Context) error {
+				_, err := config.InitConfig(ctx, fexec, nil)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				namespaces := []testAddressSetName{
+					{
+						// to be removed as v4 address exists
+						namespace: "as1",
+					},
+					{
+						// to be removed as v6 address exists
+						namespace: "as2",
+					},
+					{
+						// to be removed as both v4 & v6 address exists
+						namespace: "as3",
+					},
+					{
+						// not to be removed, no v4 or v6 address exists
+						namespace: "as4",
+					},
+					{
+						// not to be removed, address in new dual stack format
+						namespace: "as1",
+						suffix2:   ipv4AddressSetSuffix,
+					},
+					{
+						// not to be removed, address in new dual stack format
+						namespace: "as2",
+						suffix2:   ipv6AddressSetSuffix,
+					},
+					{
+						// not to be removed, address in new dual stack format
+						namespace: "as3",
+						suffix2:   ipv4AddressSetSuffix,
+					},
+					{
+						// not to be removed, address in new dual stack format
+						namespace: "as3",
+						suffix2:   ipv6AddressSetSuffix,
+					},
+					{
+						// not to be removed, address in new dual stack format
+						namespace: "as5",
+						suffix2:   ipv4AddressSetSuffix,
+					},
+					{
+						// not to be removed, address in new dual stack format
+						namespace: "as5",
+						suffix2:   ipv6AddressSetSuffix,
+					},
+				}
+
+				var namespacesRes string
+				for _, n := range namespaces {
+					namespacesRes += fmt.Sprintf("name=%s\n", n.makeName())
+				}
+				fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+					Cmd:    "ovn-nbctl --timeout=15 --format=csv --data=bare --no-heading --columns=external_ids find address_set",
+					Output: namespacesRes,
+				})
+				fexec.AddFakeCmdsNoOutputNoError([]string{
+					"ovn-nbctl --timeout=15 --if-exists destroy address_set " + hashedAddressSet(namespaces[0].makeName()),
+					"ovn-nbctl --timeout=15 --if-exists destroy address_set " + hashedAddressSet(namespaces[1].makeName()),
+					"ovn-nbctl --timeout=15 --if-exists destroy address_set " + hashedAddressSet(namespaces[2].makeName()),
+				})
+
+				err = NonDualStackAddressSetCleanup()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				gomega.Expect(fexec.CalledMatchesExpected()).To(gomega.BeTrue(), fexec.ErrorDesc)
 				return nil
 			}

--- a/go-controller/pkg/ovn/gress_policy.go
+++ b/go-controller/pkg/ovn/gress_policy.go
@@ -225,48 +225,64 @@ func (gp *gressPolicy) getMatchFromIPBlock(lportMatch, l4Match string) []string 
 	return ipBlockMatches
 }
 
-// addNamespaceAddressSet adds a new namespace address set to the gress policy
-func (gp *gressPolicy) addNamespaceAddressSet(name, portGroupName string) {
+// addNamespaceAddressSet adds a namespace address set to the gress policy
+// and returns whether the address set was already in the policy or not.
+func (gp *gressPolicy) addNamespaceAddressSet(name string) bool {
 	v4HashName, v6HashName := addressset.MakeAddressSetHashNames(name)
 	v4HashName = "$" + v4HashName
 	v6HashName = "$" + v6HashName
 
 	if gp.peerV4AddressSets.Has(v4HashName) || gp.peerV6AddressSets.Has(v6HashName) {
-		return
+		return false
 	}
-	oldL3Match := gp.getL3MatchFromAddressSet()
 	if config.IPv4Mode {
 		gp.peerV4AddressSets.Insert(v4HashName)
 	}
 	if config.IPv6Mode {
 		gp.peerV6AddressSets.Insert(v6HashName)
 	}
-	gp.localPodUpdateACL(oldL3Match, gp.getL3MatchFromAddressSet(), portGroupName)
+
+	return true
+}
+
+func (gp *gressPolicy) addNamespaceAddressSets(namespaces []interface{}) {
+	if len(namespaces) <= 0 {
+		return
+	}
+	for _, nsInterface := range namespaces {
+		namespace, ok := nsInterface.(*v1.Namespace)
+		if !ok {
+			klog.Errorf("Spurious object in addNamespaceAddressSets: %v", nsInterface)
+			continue
+		}
+		gp.addNamespaceAddressSet(namespace.Name)
+	}
 }
 
 // delNamespaceAddressSet removes a namespace address set from the gress policy
-func (gp *gressPolicy) delNamespaceAddressSet(name, portGroupName string) {
+// and returns whether the address set was in the policy or not.
+func (gp *gressPolicy) delNamespaceAddressSet(name  string) bool {
 	v4HashName, v6HashName := addressset.MakeAddressSetHashNames(name)
 	v4HashName = "$" + v4HashName
 	v6HashName = "$" + v6HashName
 
 	if !gp.peerV4AddressSets.Has(v4HashName) && !gp.peerV6AddressSets.Has(v6HashName) {
-		return
+		return false
 	}
-	oldL3Match := gp.getL3MatchFromAddressSet()
 	if config.IPv4Mode {
 		gp.peerV4AddressSets.Delete(v4HashName)
 	}
 	if config.IPv6Mode {
 		gp.peerV6AddressSets.Delete(v6HashName)
 	}
-	gp.localPodUpdateACL(oldL3Match, gp.getL3MatchFromAddressSet(), portGroupName)
+
+	return true
 }
 
-// localPodAddACL adds an ACL that implements the gress policy's rules to the
+// localPodSetACL adds or updates an ACL that implements the gress policy's rules to the
 // given Port Group (which should contain all pod logical switch ports selected
 // by the parent NetworkPolicy)
-func (gp *gressPolicy) localPodAddACL(portGroupName, portGroupUUID string, aclLogging string) {
+func (gp *gressPolicy) localPodSetACL(portGroupName, portGroupUUID string, aclLogging string) {
 	l3Match := gp.getL3MatchFromAddressSet()
 	var lportMatch string
 	var cidrMatches []string
@@ -284,7 +300,7 @@ func (gp *gressPolicy) localPodAddACL(portGroupName, portGroupUUID string, aclLo
 			// Add ACL allow rule for IPBlock CIDR
 			cidrMatches = gp.getMatchFromIPBlock(lportMatch, l4Match)
 			for i, cidrMatch := range cidrMatches {
-				if err := gp.addACLAllow(cidrMatch, l4Match, portGroupUUID, i+1, aclLogging); err != nil {
+				if err := gp.addOrModifyACLAllow(cidrMatch, l4Match, portGroupUUID, i+1, aclLogging); err != nil {
 					klog.Warningf(err.Error())
 				}
 			}
@@ -292,7 +308,7 @@ func (gp *gressPolicy) localPodAddACL(portGroupName, portGroupUUID string, aclLo
 		// if there are pod/namespace selector, then allow packets from/to that address_set or
 		// if the NetworkPolicyPeer is empty, then allow from all sources or to all destinations.
 		if gp.sizeOfAddressSet() > 0 || len(gp.ipBlock) == 0 {
-			if err := gp.addACLAllow(match, l4Match, portGroupUUID, 0, aclLogging); err != nil {
+			if err := gp.addOrModifyACLAllow(match, l4Match, portGroupUUID, 0, aclLogging); err != nil {
 				klog.Warningf(err.Error())
 			}
 		}
@@ -307,21 +323,21 @@ func (gp *gressPolicy) localPodAddACL(portGroupName, portGroupUUID string, aclLo
 			// Add ACL allow rule for IPBlock CIDR
 			cidrMatches = gp.getMatchFromIPBlock(lportMatch, l4Match)
 			for i, cidrMatch := range cidrMatches {
-				if err := gp.addACLAllow(cidrMatch, l4Match, portGroupUUID, i+1, aclLogging); err != nil {
+				if err := gp.addOrModifyACLAllow(cidrMatch, l4Match, portGroupUUID, i+1, aclLogging); err != nil {
 					klog.Warningf(err.Error())
 				}
 			}
 		}
 		if gp.sizeOfAddressSet() > 0 || len(gp.ipBlock) == 0 {
-			if err := gp.addACLAllow(match, l4Match, portGroupUUID, 0, aclLogging); err != nil {
+			if err := gp.addOrModifyACLAllow(match, l4Match, portGroupUUID, 0, aclLogging); err != nil {
 				klog.Warningf(err.Error())
 			}
 		}
 	}
 }
 
-// addACLAllow adds an ACL with a given match to the given Port Group
-func (gp *gressPolicy) addACLAllow(match, l4Match, portGroupUUID string, ipBlockCidr int, aclLogging string) error {
+// addOrModifyACLAllow adds or modifies an ACL with a given match to the given Port Group
+func (gp *gressPolicy) addOrModifyACLAllow(match, l4Match, portGroupUUID string, ipBlockCidr int, aclLogging string) error {
 	var direction, action, aclName string
 	direction = types.DirectionToLPort
 	action = "allow-related"
@@ -342,12 +358,29 @@ func (gp *gressPolicy) addACLAllow(match, l4Match, portGroupUUID string, ipBlock
 	}
 
 	if uuid != "" {
+		// We already have an ACL. We will update it.
+		_, stderr, err = util.RunOVNNbctl("set", "acl", uuid,
+			match,
+			fmt.Sprintf("priority=%s", types.DefaultAllowPriority),
+			fmt.Sprintf("direction=%s", direction),
+			fmt.Sprintf("action=%s", action),
+			fmt.Sprintf("log=%t", aclLogging != ""),
+			fmt.Sprintf("severity=%s", getACLLoggingSeverity(aclLogging)),
+			fmt.Sprintf("meter=%s", types.OvnACLLoggingMeter),
+			fmt.Sprintf("name=%.63s", aclName),
+		)
+		if err != nil {
+			return fmt.Errorf("failed to modify the allow-from rule for "+
+				"namespace=%s, policy=%s, stderr: %q (%v)",
+				gp.policyNamespace, gp.policyName, stderr, err)
+		}
 		return nil
 	}
 
 	_, stderr, err = util.RunOVNNbctl("--id=@acl", "create",
 		"acl", fmt.Sprintf("priority=%s", types.DefaultAllowPriority),
-		fmt.Sprintf("direction=%s", direction), match,
+		fmt.Sprintf("direction=%s", direction), 
+		match,
 		fmt.Sprintf("action=%s", action),
 		fmt.Sprintf("log=%t", aclLogging != ""),
 		fmt.Sprintf("severity=%s", getACLLoggingSeverity(aclLogging)),
@@ -364,33 +397,6 @@ func (gp *gressPolicy) addACLAllow(match, l4Match, portGroupUUID string, ipBlock
 		return fmt.Errorf("failed to create the acl allow rule for "+
 			"namespace=%s, policy=%s, stderr: %q (%v)", gp.policyNamespace,
 			gp.policyName, stderr, err)
-	}
-
-	return nil
-}
-
-// modifyACLAllow updates an ACL with a new match
-func (gp *gressPolicy) modifyACLAllow(oldMatch, newMatch string) error {
-	uuid, stderr, err := util.RunOVNNbctl("--data=bare", "--no-heading",
-		"--columns=_uuid", "find", "ACL", oldMatch,
-		fmt.Sprintf("external-ids:namespace=%s", gp.policyNamespace),
-		fmt.Sprintf("external-ids:policy=%s", gp.policyName),
-		fmt.Sprintf("external-ids:%s_num=%d", gp.policyType, gp.idx),
-		fmt.Sprintf("external-ids:policy_type=%s", gp.policyType))
-	if err != nil {
-		return fmt.Errorf("find failed to get the allow rule for "+
-			"namespace=%s, policy=%s, stderr: %q (%v)",
-			gp.policyNamespace, gp.policyName, stderr, err)
-	}
-	if uuid == "" {
-		return nil
-	}
-
-	// We already have an ACL. We will update it.
-	if _, stderr, err = util.RunOVNNbctl("set", "acl", uuid, newMatch); err != nil {
-		return fmt.Errorf("failed to modify the allow-from rule for "+
-			"namespace=%s, policy=%s, stderr: %q (%v)",
-			gp.policyNamespace, gp.policyName, stderr, err)
 	}
 
 	return nil
@@ -420,34 +426,6 @@ func constructIPBlockStringsForACL(direction string, ipBlocks []*knet.IPBlock, l
 		matchStrings = append(matchStrings, matchStr)
 	}
 	return matchStrings
-}
-
-// localPodUpdateACL updates an existing ACL that implements the gress policy's rules
-func (gp *gressPolicy) localPodUpdateACL(oldl3Match, newl3Match, portGroupName string) {
-	var lportMatch string
-	if gp.policyType == knet.PolicyTypeIngress {
-		lportMatch = fmt.Sprintf("outport == @%s", portGroupName)
-	} else {
-		lportMatch = fmt.Sprintf("inport == @%s", portGroupName)
-	}
-	if len(gp.portPolicies) == 0 {
-		oldMatch := fmt.Sprintf("match=\"%s && %s\"", oldl3Match, lportMatch)
-		newMatch := fmt.Sprintf("match=\"%s && %s\"", newl3Match, lportMatch)
-		if err := gp.modifyACLAllow(oldMatch, newMatch); err != nil {
-			klog.Warningf(err.Error())
-		}
-	}
-	for _, port := range gp.portPolicies {
-		l4Match, err := port.getL4Match()
-		if err != nil {
-			continue
-		}
-		oldMatch := fmt.Sprintf("match=\"%s && %s && %s\"", oldl3Match, l4Match, lportMatch)
-		newMatch := fmt.Sprintf("match=\"%s && %s && %s\"", newl3Match, l4Match, lportMatch)
-		if err := gp.modifyACLAllow(oldMatch, newMatch); err != nil {
-			klog.Warningf(err.Error())
-		}
-	}
 }
 
 func (gp *gressPolicy) destroy() error {

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -400,6 +400,13 @@ func (oc *Controller) Run(wg *sync.WaitGroup, nodeName string) error {
 		}()
 	}
 
+	// Final step to cleanup after resource handlers have synced
+	err := oc.ovnTopologyCleanup()
+	if err != nil {
+		klog.Errorf("Failed to cleanup OVN topology to version %d: %v", ovntypes.OvnCurrentTopologyVersion, err)
+		return err
+	}
+
 	// Master is fully running and resource handlers have synced, update Topology version in OVN
 	stdout, stderr, err := util.RunOVNNbctl("set", "logical_router", ovntypes.OVNClusterRouter,
 		fmt.Sprintf("external_ids:k8s-ovn-topo-version=%d", ovntypes.OvnCurrentTopologyVersion))
@@ -420,6 +427,19 @@ func (oc *Controller) Run(wg *sync.WaitGroup, nodeName string) error {
 	}
 
 	return nil
+}
+
+func (oc *Controller) ovnTopologyCleanup() error {
+	ver, err := util.DetermineOVNTopoVersionFromOVN()
+	if err != nil {
+		return err
+	}
+
+	// Cleanup address sets in non dual stack formats in all versions known to possibly exist.
+	if err == nil && ver <= ovntypes.OvnPortBindingTopoVersion {
+		err = addressset.NonDualStackAddressSetCleanup()
+	}
+	return err
 }
 
 // syncPeriodic adds a goroutine that periodically does some work

--- a/go-controller/pkg/ovn/policy_test.go
+++ b/go-controller/pkg/ovn/policy_test.go
@@ -107,28 +107,54 @@ func (n kNetworkPolicy) addLocalPodCmds(fexec *ovntest.FakeExec, networkPolicy *
 	n.addDefaultDenyPGCmds(fexec, networkPolicy)
 }
 
-func (n kNetworkPolicy) addNamespaceSelectorCmds(fexec *ovntest.FakeExec, networkPolicy *knet.NetworkPolicy, findAgain bool) {
+func (n kNetworkPolicy) addNamespaceSelectorCmds(fexec *ovntest.FakeExec, networkPolicy *knet.NetworkPolicy, namespace string) {
+	as := []string{}
+	if namespace != "" {
+		as = append(as, namespace)
+	}
+
 	for i := range networkPolicy.Spec.Ingress {
+		ingressAsMatch := asMatch(append(as, getAddressSetName(networkPolicy.Namespace, networkPolicy.Name, knet.PolicyTypeIngress, i)))
 		fexec.AddFakeCmdsNoOutputNoError([]string{
 			fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find ACL external-ids:l4Match=\"None\" external-ids:ipblock_cidr=0 external-ids:namespace=%s external-ids:policy=%s external-ids:Ingress_num=%v external-ids:policy_type=Ingress", networkPolicy.Namespace, networkPolicy.Name, i),
-			"ovn-nbctl --timeout=15 --id=@acl create acl priority=" + types.DefaultAllowPriority + " direction=" + types.DirectionToLPort + " match=\"ip4.src == {$a3128014386057836746} && outport == @a14195333570786048679\" action=allow-related log=false severity=info meter=acl-logging name=" + networkPolicy.Namespace + "_" +networkPolicy.Name + "_"+ strconv.Itoa(i) + " external-ids:l4Match=\"None\" external-ids:ipblock_cidr=0 external-ids:namespace=namespace1 external-ids:policy=networkpolicy1 external-ids:Ingress_num=0 external-ids:policy_type=Ingress -- add port_group " + fakePgUUID + " acls @acl",
+			"ovn-nbctl --timeout=15 --id=@acl create acl priority=" + types.DefaultAllowPriority + " direction=" + types.DirectionToLPort + " match=\"ip4.src == {" + ingressAsMatch + "} && outport == @a14195333570786048679\" action=allow-related log=false severity=info meter=acl-logging name=" + networkPolicy.Namespace + "_" + networkPolicy.Name + "_" + strconv.Itoa(i) + " external-ids:l4Match=\"None\" external-ids:ipblock_cidr=0 external-ids:namespace=namespace1 external-ids:policy=networkpolicy1 external-ids:Ingress_num=0 external-ids:policy_type=Ingress -- add port_group " + fakePgUUID + " acls @acl",
 		})
-		if findAgain {
-			fexec.AddFakeCmdsNoOutputNoError([]string{
-				"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find ACL match=\"ip4.src == {$a3128014386057836746} && outport == @a14195333570786048679\" external-ids:namespace=namespace1 external-ids:policy=networkpolicy1 external-ids:Ingress_num=0 external-ids:policy_type=Ingress",
-			})
-		}
 	}
 	for i := range networkPolicy.Spec.Egress {
+		egressAsMatch := asMatch(append(as, getAddressSetName(networkPolicy.Namespace, networkPolicy.Name, knet.PolicyTypeEgress, i)))
 		fexec.AddFakeCmdsNoOutputNoError([]string{
 			fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find ACL external-ids:l4Match=\"None\" external-ids:ipblock_cidr=0 external-ids:namespace=%s external-ids:policy=%s external-ids:Egress_num=%v external-ids:policy_type=Egress", networkPolicy.Namespace, networkPolicy.Name, i),
-			"ovn-nbctl --timeout=15 --id=@acl create acl priority=" + types.DefaultAllowPriority + " direction=" + types.DirectionToLPort + " match=\"ip4.dst == {$a17928043879887565554} && inport == @a14195333570786048679\" action=allow-related log=false severity=info meter=acl-logging name=" + networkPolicy.Namespace + "_" +networkPolicy.Name + "_"+ strconv.Itoa(i) + " external-ids:l4Match=\"None\" external-ids:ipblock_cidr=0 external-ids:namespace=namespace1 external-ids:policy=networkpolicy1 external-ids:Egress_num=0 external-ids:policy_type=Egress -- add port_group " + fakePgUUID + " acls @acl",
+			"ovn-nbctl --timeout=15 --id=@acl create acl priority=" + types.DefaultAllowPriority + " direction=" + types.DirectionToLPort + " match=\"ip4.dst == {" + egressAsMatch + "} && inport == @a14195333570786048679\" action=allow-related log=false severity=info meter=acl-logging name=" + networkPolicy.Namespace + "_" + networkPolicy.Name + "_" + strconv.Itoa(i) + " external-ids:l4Match=\"None\" external-ids:ipblock_cidr=0 external-ids:namespace=namespace1 external-ids:policy=networkpolicy1 external-ids:Egress_num=0 external-ids:policy_type=Egress -- add port_group " + fakePgUUID + " acls @acl",
 		})
-		if findAgain {
-			fexec.AddFakeCmdsNoOutputNoError([]string{
-				"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find ACL match=\"ip4.dst == {$a17928043879887565554} && inport == @a14195333570786048679\" external-ids:namespace=namespace1 external-ids:policy=networkpolicy1 external-ids:Egress_num=0 external-ids:policy_type=Egress",
+	}
+}
+
+func (n kNetworkPolicy) addNamespaceSelectorCmdsExistingAcl(fexec *ovntest.FakeExec, networkPolicy *knet.NetworkPolicy, namespace string) {
+	for i := range networkPolicy.Spec.Ingress {
+		ingressAsMatch := asMatch([]string{
+			namespace,
+			getAddressSetName(networkPolicy.Namespace, networkPolicy.Name, knet.PolicyTypeIngress, i),
+		})
+		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+			Cmd: fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find ACL external-ids:l4Match=\"None\" external-ids:ipblock_cidr=0 external-ids:namespace=%s external-ids:policy=%s external-ids:Ingress_num=%v external-ids:policy_type=Ingress", networkPolicy.Namespace, networkPolicy.Name, i),
+			Output: fakeUUID,
+		})
+		fexec.AddFakeCmdsNoOutputNoError([]string{
+			"ovn-nbctl --timeout=15 set acl " + fakeUUID + " match=\"ip4.src == {" + ingressAsMatch + "} && outport == @a14195333570786048679\" priority=" + types.DefaultAllowPriority + " direction=" + types.DirectionToLPort + " action=allow-related log=false severity=info meter=acl-logging name=" + networkPolicy.Namespace + "_" + networkPolicy.Name + "_" + strconv.Itoa(i),
+		})
+	}
+	for i := range networkPolicy.Spec.Egress {
+		egressAsMatch := asMatch([]string{
+			namespace,
+			getAddressSetName(networkPolicy.Namespace, networkPolicy.Name, knet.PolicyTypeEgress, i),
+		})	
+		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+			Cmd: fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find ACL external-ids:l4Match=\"None\" external-ids:ipblock_cidr=0 external-ids:namespace=%s external-ids:policy=%s external-ids:Egress_num=%v external-ids:policy_type=Egress", networkPolicy.Namespace, networkPolicy.Name, i),
+			Output: fakeUUID,
 			})
-		}
+		fexec.AddFakeCmdsNoOutputNoError([]string{
+			"ovn-nbctl --timeout=15 set acl " + fakeUUID + " match=\"ip4.dst == {" + egressAsMatch + "} && inport == @a14195333570786048679\" priority=" + types.DefaultAllowPriority + " direction=" + types.DirectionToLPort + " action=allow-related log=false severity=info meter=acl-logging name=" + networkPolicy.Namespace + "_" + networkPolicy.Name + "_" + strconv.Itoa(i),
+		})
 	}
 }
 
@@ -542,7 +568,79 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 						},
 					})
 
-				npTest.addNamespaceSelectorCmds(fExec, networkPolicy, true)
+				npTest.addNamespaceSelectorCmds(fExec, networkPolicy, namespace2.Name)
+				npTest.addDefaultDenyPGCmds(fExec, networkPolicy)
+
+				fakeOvn.start(ctx,
+					&v1.NamespaceList{
+						Items: []v1.Namespace{
+							namespace1,
+							namespace2,
+						},
+					},
+					&knet.NetworkPolicyList{
+						Items: []knet.NetworkPolicy{
+							*networkPolicy,
+						},
+					},
+				)
+
+				fakeOvn.controller.WatchNamespaces()
+				fakeOvn.controller.WatchNetworkPolicy()
+
+				fakeOvn.asf.ExpectEmptyAddressSet(namespaceName1)
+				fakeOvn.asf.ExpectEmptyAddressSet(namespaceName2)
+
+				eventuallyExpectEmptyAddressSets(fakeOvn, networkPolicy)
+
+				_, err := fakeOvn.fakeClient.KubeClient.NetworkingV1().NetworkPolicies(networkPolicy.Namespace).Get(context.TODO(), networkPolicy.Name, metav1.GetOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Eventually(fExec.CalledMatchesExpected).Should(gomega.BeTrue(), fExec.ErrorDesc)
+
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+
+		ginkgo.It("reconciles an ingress networkPolicy updating an existing ACL", func() {
+			app.Action = func(ctx *cli.Context) error {
+
+				npTest := kNetworkPolicy{}
+
+				namespace1 := *newNamespace(namespaceName1)
+				namespace2 := *newNamespace(namespaceName2)
+				networkPolicy := newNetworkPolicy("networkpolicy1", namespace1.Name,
+					metav1.LabelSelector{},
+					[]knet.NetworkPolicyIngressRule{
+						{
+							From: []knet.NetworkPolicyPeer{
+								{
+									NamespaceSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"name": namespace2.Name,
+										},
+									},
+								},
+							},
+						},
+					},
+					[]knet.NetworkPolicyEgressRule{
+						{
+							To: []knet.NetworkPolicyPeer{
+								{
+									NamespaceSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"name": namespace2.Name,
+										},
+									},
+								},
+							},
+						},
+					})
+
+				npTest.addNamespaceSelectorCmdsExistingAcl(fExec, networkPolicy, namespace2.Name)
 				npTest.addDefaultDenyPGCmds(fExec, networkPolicy)
 
 				fakeOvn.start(ctx,
@@ -625,7 +723,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 					})
 
 				nPodTest.baseCmds(fExec)
-				npTest.addNamespaceSelectorCmds(fExec, networkPolicy, false)
+				npTest.addNamespaceSelectorCmds(fExec, networkPolicy, "")
 				npTest.addLocalPodCmds(fExec, networkPolicy)
 
 				fakeOvn.start(ctx,
@@ -722,7 +820,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 					})
 
 				nPodTest.baseCmds(fExec)
-				npTest.addNamespaceSelectorCmds(fExec, networkPolicy, false)
+				npTest.addNamespaceSelectorCmds(fExec, networkPolicy, "")
 				npTest.addDefaultDenyPGCmds(fExec, networkPolicy)
 
 				fakeOvn.start(ctx,
@@ -899,7 +997,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 					})
 
 				nPodTest.baseCmds(fExec)
-				npTest.addNamespaceSelectorCmds(fExec, networkPolicy, true)
+				npTest.addNamespaceSelectorCmds(fExec, networkPolicy, namespace2.Name)
 				npTest.addLocalPodCmds(fExec, networkPolicy)
 
 				fakeOvn.start(ctx,
@@ -930,16 +1028,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				gomega.Eventually(fExec.CalledMatchesExpected).Should(gomega.BeTrue(), fExec.ErrorDesc)
 				fakeOvn.asf.ExpectAddressSetWithIPs(namespaceName1, []string{nPodTest.podIP})
 
-				fExec.AddFakeCmd(&ovntest.ExpectedCmd{
-					Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find ACL match=\"ip4.src == {$a3128014386057836746, $a4615334824109672969} && outport == @a14195333570786048679\" external-ids:namespace=namespace1 external-ids:policy=networkpolicy1 external-ids:Ingress_num=0 external-ids:policy_type=Ingress",
-					Output: fakeUUID,
-				})
-				fExec.AddFakeCmdsNoOutputNoError([]string{
-					"ovn-nbctl --timeout=15 set acl " + fakeUUID + " match=\"ip4.src == {$a3128014386057836746} && outport == @a14195333570786048679\"",
-				})
-				fExec.AddFakeCmdsNoOutputNoError([]string{
-					"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find ACL match=\"ip4.dst == {$a17928043879887565554, $a4615334824109672969} && inport == @a14195333570786048679\" external-ids:namespace=namespace1 external-ids:policy=networkpolicy1 external-ids:Egress_num=0 external-ids:policy_type=Egress",
-				})
+				npTest.addNamespaceSelectorCmds(fExec, networkPolicy, "")
 
 				err = fakeOvn.fakeClient.KubeClient.CoreV1().Namespaces().Delete(context.TODO(), namespace2.Name, *metav1.NewDeleteOptions(0))
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -989,7 +1078,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 						},
 					})
 
-				npTest.addNamespaceSelectorCmds(fExec, networkPolicy, true)
+				npTest.addNamespaceSelectorCmds(fExec, networkPolicy, namespace2.Name)
 				npTest.addDefaultDenyPGCmds(fExec, networkPolicy)
 
 				fakeOvn.start(ctx,
@@ -1013,16 +1102,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				gomega.Eventually(fExec.CalledMatchesExpected).Should(gomega.BeTrue(), fExec.ErrorDesc)
 
-				fExec.AddFakeCmd(&ovntest.ExpectedCmd{
-					Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find ACL match=\"ip4.src == {$a3128014386057836746, $a4615334824109672969} && outport == @a14195333570786048679\" external-ids:namespace=namespace1 external-ids:policy=networkpolicy1 external-ids:Ingress_num=0 external-ids:policy_type=Ingress",
-					Output: fakeUUID,
-				})
-				fExec.AddFakeCmdsNoOutputNoError([]string{
-					"ovn-nbctl --timeout=15 set acl " + fakeUUID + " match=\"ip4.src == {$a3128014386057836746} && outport == @a14195333570786048679\"",
-				})
-				fExec.AddFakeCmdsNoOutputNoError([]string{
-					"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find ACL match=\"ip4.dst == {$a17928043879887565554, $a4615334824109672969} && inport == @a14195333570786048679\" external-ids:namespace=namespace1 external-ids:policy=networkpolicy1 external-ids:Egress_num=0 external-ids:policy_type=Egress",
-				})
+				npTest.addNamespaceSelectorCmds(fExec, networkPolicy, "")
 
 				err = fakeOvn.fakeClient.KubeClient.CoreV1().Namespaces().Delete(context.TODO(), namespace2.Name, *metav1.NewDeleteOptions(0))
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -1081,7 +1161,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 					})
 
 				nPodTest.baseCmds(fExec)
-				npTest.addNamespaceSelectorCmds(fExec, networkPolicy, false)
+				npTest.addNamespaceSelectorCmds(fExec, networkPolicy, "")
 				npTest.addLocalPodCmds(fExec, networkPolicy)
 
 				fakeOvn.start(ctx,
@@ -1184,7 +1264,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 					})
 
 				nPodTest.baseCmds(fExec)
-				npTest.addNamespaceSelectorCmds(fExec, networkPolicy, false)
+				npTest.addNamespaceSelectorCmds(fExec, networkPolicy, "")
 				npTest.addDefaultDenyPGCmds(fExec, networkPolicy)
 
 				fakeOvn.start(ctx,
@@ -1290,7 +1370,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 					})
 
 				nPodTest.baseCmds(fExec)
-				npTest.addNamespaceSelectorCmds(fExec, networkPolicy, false)
+				npTest.addNamespaceSelectorCmds(fExec, networkPolicy, "")
 				npTest.addDefaultDenyPGCmds(fExec, networkPolicy)
 
 				fakeOvn.start(ctx,
@@ -1388,7 +1468,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 					})
 
 				nPodTest.baseCmds(fExec)
-				npTest.addNamespaceSelectorCmds(fExec, networkPolicy, false)
+				npTest.addNamespaceSelectorCmds(fExec, networkPolicy, "")
 				npTest.addLocalPodCmds(fExec, networkPolicy)
 
 				fakeOvn.start(ctx,
@@ -1452,18 +1532,17 @@ func asMatch(addressSets []string) string {
 func addExpectedGressCmds(fExec *ovntest.FakeExec, gp *gressPolicy, pgName string, oldAS, newAS []string) []string {
 	const uuid string = "94407fe0-2c15-4a63-baea-ab4af0ea5bb8"
 
-	oldMatch := asMatch(oldAS)
 	newMatch := asMatch(newAS)
 
 	gpDirection := string(knet.PolicyTypeIngress)
 	fExec.AddFakeCmd(&ovntest.ExpectedCmd{
-		Cmd: fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find ACL match=\"ip4.src == {%s} && outport == @%s\" external-ids:namespace=%s external-ids:policy=%s external-ids:%s_num=%d external-ids:policy_type=%s",
-			oldMatch, pgName, gp.policyNamespace, gp.policyName, gpDirection, gp.idx, gpDirection),
+		Cmd: fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find ACL external-ids:l4Match=\"None\" external-ids:ipblock_cidr=0 external-ids:namespace=%s external-ids:policy=%s external-ids:%s_num=%d external-ids:policy_type=%s",
+			gp.policyNamespace, gp.policyName, gpDirection, gp.idx, gpDirection),
 		Output: uuid,
 	})
 	fExec.AddFakeCmdsNoOutputNoError([]string{
-		fmt.Sprintf("ovn-nbctl --timeout=15 set acl %s match=\"ip4.src == {%s} && outport == @%s\"",
-			uuid, newMatch, pgName),
+		fmt.Sprintf("ovn-nbctl --timeout=15 set acl %s match=\"ip4.src == {%s} && outport == @%s\" priority=1001 direction=to-lport action=allow-related log=true severity=info meter=acl-logging name=%s",
+			uuid, newMatch, pgName, gp.policyNamespace + "_" + gp.policyName + "_"+ strconv.Itoa(gp.idx)),
 	})
 	return newAS
 }
@@ -1514,70 +1593,80 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Low-Level Operations", func() {
 		six := fmt.Sprintf("testing.policy.ingress.6")
 
 		cur := addExpectedGressCmds(fExec, gp, pgName, []string{asName}, []string{asName, one})
-		gp.addNamespaceAddressSet(one, pgName)
+		gomega.Expect(gp.addNamespaceAddressSet(one)).To(gomega.BeTrue())
+		gp.localPodSetACL(pgName, pgUUID, defaultACLLoggingSeverity)
 		gomega.Expect(fExec.CalledMatchesExpected()).To(gomega.BeTrue(), fExec.ErrorDesc)
 
 		cur = addExpectedGressCmds(fExec, gp, pgName, cur, []string{asName, one, two})
-		gp.addNamespaceAddressSet(two, pgName)
+		gomega.Expect(gp.addNamespaceAddressSet(two)).To(gomega.BeTrue())
+		gp.localPodSetACL(pgName, pgUUID, defaultACLLoggingSeverity)
 		gomega.Expect(fExec.CalledMatchesExpected()).To(gomega.BeTrue(), fExec.ErrorDesc)
 
 		// address sets should be alphabetized
 		cur = addExpectedGressCmds(fExec, gp, pgName, cur, []string{asName, one, two, three})
-		gp.addNamespaceAddressSet(three, pgName)
+		gomega.Expect(gp.addNamespaceAddressSet(three)).To(gomega.BeTrue())
+		gp.localPodSetACL(pgName, pgUUID, defaultACLLoggingSeverity)
 		gomega.Expect(fExec.CalledMatchesExpected()).To(gomega.BeTrue(), fExec.ErrorDesc)
 
 		// re-adding an existing set is a no-op
-		gp.addNamespaceAddressSet(one, pgName)
-		gomega.Expect(fExec.CalledMatchesExpected()).To(gomega.BeTrue(), fExec.ErrorDesc)
+		gp.addNamespaceAddressSet(one)
+		gomega.Expect(gp.addNamespaceAddressSet(three)).To(gomega.BeFalse())
 
 		cur = addExpectedGressCmds(fExec, gp, pgName, cur, []string{asName, one, two, three, four})
-		gp.addNamespaceAddressSet(four, pgName)
+		gomega.Expect(gp.addNamespaceAddressSet(four)).To(gomega.BeTrue())
+		gp.localPodSetACL(pgName, pgUUID, defaultACLLoggingSeverity)
 		gomega.Expect(fExec.CalledMatchesExpected()).To(gomega.BeTrue(), fExec.ErrorDesc)
 
 		// now delete a set
 		cur = addExpectedGressCmds(fExec, gp, pgName, cur, []string{asName, two, three, four})
-		gp.delNamespaceAddressSet(one, pgName)
+		gomega.Expect(gp.delNamespaceAddressSet(one)).To(gomega.BeTrue())
+		gp.localPodSetACL(pgName, pgUUID, defaultACLLoggingSeverity)
 		gomega.Expect(fExec.CalledMatchesExpected()).To(gomega.BeTrue(), fExec.ErrorDesc)
 
 		// deleting again is a no-op
-		gp.delNamespaceAddressSet(one, pgName)
+		gomega.Expect(gp.delNamespaceAddressSet(one)).To(gomega.BeFalse())
 		gomega.Expect(fExec.CalledMatchesExpected()).To(gomega.BeTrue(), fExec.ErrorDesc)
 
 		// add and delete some more...
 		cur = addExpectedGressCmds(fExec, gp, pgName, cur, []string{asName, two, three, four, five})
-		gp.addNamespaceAddressSet(five, pgName)
+		gomega.Expect(gp.addNamespaceAddressSet(five)).To(gomega.BeTrue())
+		gp.localPodSetACL(pgName, pgUUID, defaultACLLoggingSeverity)
 		gomega.Expect(fExec.CalledMatchesExpected()).To(gomega.BeTrue(), fExec.ErrorDesc)
 
 		cur = addExpectedGressCmds(fExec, gp, pgName, cur, []string{asName, two, four, five})
-		gp.delNamespaceAddressSet(three, pgName)
+		gomega.Expect(gp.delNamespaceAddressSet(three)).To(gomega.BeTrue())
+		gp.localPodSetACL(pgName, pgUUID, defaultACLLoggingSeverity)
 		gomega.Expect(fExec.CalledMatchesExpected()).To(gomega.BeTrue(), fExec.ErrorDesc)
 
 		// deleting again is no-op
-		gp.delNamespaceAddressSet(one, pgName)
-		gomega.Expect(fExec.CalledMatchesExpected()).To(gomega.BeTrue(), fExec.ErrorDesc)
+		gomega.Expect(gp.delNamespaceAddressSet(one)).To(gomega.BeFalse())
 
 		cur = addExpectedGressCmds(fExec, gp, pgName, cur, []string{asName, two, four, five, six})
-		gp.addNamespaceAddressSet(six, pgName)
+		gomega.Expect(gp.addNamespaceAddressSet(six)).To(gomega.BeTrue())
+		gp.localPodSetACL(pgName, pgUUID, defaultACLLoggingSeverity)
 		gomega.Expect(fExec.CalledMatchesExpected()).To(gomega.BeTrue(), fExec.ErrorDesc)
 
 		cur = addExpectedGressCmds(fExec, gp, pgName, cur, []string{asName, four, five, six})
-		gp.delNamespaceAddressSet(two, pgName)
+		gomega.Expect(gp.delNamespaceAddressSet(two)).To(gomega.BeTrue())
+		gp.localPodSetACL(pgName, pgUUID, defaultACLLoggingSeverity)
 		gomega.Expect(fExec.CalledMatchesExpected()).To(gomega.BeTrue(), fExec.ErrorDesc)
 
 		cur = addExpectedGressCmds(fExec, gp, pgName, cur, []string{asName, four, six})
-		gp.delNamespaceAddressSet(five, pgName)
+		gomega.Expect(gp.delNamespaceAddressSet(five)).To(gomega.BeTrue())
+		gp.localPodSetACL(pgName, pgUUID, defaultACLLoggingSeverity)
 		gomega.Expect(fExec.CalledMatchesExpected()).To(gomega.BeTrue(), fExec.ErrorDesc)
 
 		cur = addExpectedGressCmds(fExec, gp, pgName, cur, []string{asName, four})
-		gp.delNamespaceAddressSet(six, pgName)
+		gomega.Expect(gp.delNamespaceAddressSet(six)).To(gomega.BeTrue())
+		gp.localPodSetACL(pgName, pgUUID, defaultACLLoggingSeverity)
 		gomega.Expect(fExec.CalledMatchesExpected()).To(gomega.BeTrue(), fExec.ErrorDesc)
 
 		cur = addExpectedGressCmds(fExec, gp, pgName, cur, []string{asName})
-		gp.delNamespaceAddressSet(four, pgName)
+		gomega.Expect(gp.delNamespaceAddressSet(four)).To(gomega.BeTrue())
+		gp.localPodSetACL(pgName, pgUUID, defaultACLLoggingSeverity)
 		gomega.Expect(fExec.CalledMatchesExpected()).To(gomega.BeTrue(), fExec.ErrorDesc)
 
 		// deleting again is no-op
-		gp.delNamespaceAddressSet(four, pgName)
-		gomega.Expect(fExec.CalledMatchesExpected()).To(gomega.BeTrue(), fExec.ErrorDesc)
+		gomega.Expect(gp.delNamespaceAddressSet(four)).To(gomega.BeFalse())
 	})
 })


### PR DESCRIPTION
There might be existing policy ACLs referencing address sets with the
pre-dual stack support naming convention. Update ACLs on startup to be
sure that the correct address sets with dual stack naming convention
are referenced. Cleanup old address sets after resource handlers have sync'ed.

fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1962387
