### PR TITLE
[release-4.6] Bug 1966280: Adds reconciliation for hanging pod adds

### DIFF
--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -32,6 +32,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
+	utilwait "k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/cache"
@@ -188,6 +189,15 @@ type Controller struct {
 
 	// go-ovn southbound client interface
 	ovnSBClient goovn.Client
+
+	// Map of pods that need to be retried, and the timestamp of when they last failed
+	retryPods     map[types.UID]retryEntry
+	retryPodsLock sync.Mutex
+}
+
+type retryEntry struct {
+	pod       *kapi.Pod
+	timeStamp time.Time
 }
 
 const (
@@ -257,6 +267,7 @@ func NewOvnController(kubeClient kubernetes.Interface, egressIPClient egressipap
 		serviceVIPToNameLock:     sync.Mutex{},
 		serviceLBMap:             make(map[string]map[string]*loadBalancerConf),
 		serviceLBLock:            sync.Mutex{},
+		retryPods:                make(map[types.UID]retryEntry),
 		recorder:                 recorder,
 		ovnNBClient:              ovnNBClient,
 		ovnSBClient:              ovnSBClient,
@@ -495,66 +506,117 @@ func (oc *Controller) recordPodEvent(addErr error, pod *kapi.Pod) {
 	}
 }
 
+// iterateRetryPods checks if any outstanding pods have been waiting for 60 seconds of last known failure
+// then tries to re-add them if so
+func (oc *Controller) iterateRetryPods() {
+	oc.retryPodsLock.Lock()
+	defer oc.retryPodsLock.Unlock()
+	now := time.Now()
+	for uid, podEntry := range oc.retryPods {
+		pod := podEntry.pod
+		podTimer := podEntry.timeStamp.Add(time.Minute)
+		if now.After(podTimer) {
+			podDesc := fmt.Sprintf("[%s/%s/%s]", pod.UID, pod.Namespace, pod.Name)
+			klog.Infof("%s retry pod setup", podDesc)
+
+			if oc.ensurePod(nil, pod, true) {
+				klog.Infof("%s pod setup successful", podDesc)
+				delete(oc.retryPods, uid)
+			} else {
+				klog.Infof("%s setup retry failed; will try again later", podDesc)
+				oc.retryPods[uid] = retryEntry{pod, time.Now()}
+			}
+		}
+	}
+}
+
+// checkAndDeleteRetryPod deletes a specific entry from the map, if it existed, returns true
+func (oc *Controller) checkAndDeleteRetryPod(uid types.UID) bool {
+	oc.retryPodsLock.Lock()
+	defer oc.retryPodsLock.Unlock()
+	if _, ok := oc.retryPods[uid]; ok {
+		delete(oc.retryPods, uid)
+		return true
+	}
+	return false
+}
+
+// addRetryPod tracks a failed pod to retry later
+func (oc *Controller) addRetryPod(pod *kapi.Pod) {
+	oc.retryPodsLock.Lock()
+	defer oc.retryPodsLock.Unlock()
+	oc.retryPods[pod.UID] = retryEntry{pod, time.Now()}
+}
+
+func exGatewayAnnotationsChanged(oldPod, newPod *kapi.Pod) bool {
+	return oldPod.Annotations[routingNamespaceAnnotation] != newPod.Annotations[routingNamespaceAnnotation] ||
+		oldPod.Annotations[routingNetworkAnnotation] != newPod.Annotations[routingNetworkAnnotation]
+}
+
+// ensurePod tries to set up a pod. It returns success or failure; failure
+// indicates the pod should be retried later.
+func (oc *Controller) ensurePod(oldPod, pod *kapi.Pod, addPort bool) bool {
+	// Try unscheduled pods later
+	if !podScheduled(pod) {
+		return false
+	}
+
+	if podWantsNetwork(pod) && addPort {
+		if err := oc.addLogicalPort(pod); err != nil {
+			klog.Errorf(err.Error())
+			oc.recordPodEvent(err, pod)
+			return false
+		}
+	} else {
+		if oldPod != nil && exGatewayAnnotationsChanged(oldPod, pod) {
+			// No matter if a pod is ovn networked, or host networked, we still need to check for exgw
+			// annotations. If the pod is ovn networked and is in update reschedule, addLogicalPort will take
+			// care of updating the exgw updates
+			oc.deletePodExternalGW(oldPod)
+		}
+		if err := oc.addPodExternalGW(pod); err != nil {
+			klog.Errorf(err.Error())
+			oc.recordPodEvent(err, pod)
+			return false
+		}
+	}
+
+	return true
+}
+
 // WatchPods starts the watching of Pod resource and calls back the appropriate handler logic
 func (oc *Controller) WatchPods() {
-	var retryPods sync.Map
+	go func() {
+		// track the retryPods map and every 30 seconds check if any pods need to be retried
+		utilwait.Until(oc.iterateRetryPods, 30*time.Second, oc.stopChan)
+	}()
 
 	start := time.Now()
 	oc.watchFactory.AddPodHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			pod := obj.(*kapi.Pod)
-			if !podWantsNetwork(pod) {
-				// host network pod is able to serve as external gw for other pods
-				if err := oc.addPodExternalGW(pod); err != nil {
-					klog.Errorf(err.Error())
-				}
-				return
-			}
-			if podScheduled(pod) {
-				if err := oc.addLogicalPort(pod); err != nil {
-					klog.Errorf(err.Error())
-					oc.recordPodEvent(err, pod)
-					retryPods.Store(pod.UID, true)
-				}
-			} else {
-				// Handle unscheduled pods later in UpdateFunc
-				retryPods.Store(pod.UID, true)
+			if !oc.ensurePod(nil, pod, true) {
+				oc.addRetryPod(pod)
 			}
 		},
 		UpdateFunc: func(old, newer interface{}) {
 			oldPod := old.(*kapi.Pod)
 			pod := newer.(*kapi.Pod)
-
-			_, retry := retryPods.Load(pod.UID)
-			if podScheduled(pod) && retry && podWantsNetwork(pod) {
-				if err := oc.addLogicalPort(pod); err != nil {
-					klog.Errorf(err.Error())
-					oc.recordPodEvent(err, pod)
-				} else {
-					retryPods.Delete(pod.UID)
-				}
-			} else {
-				// No matter if a pod is ovn networked, or host networked, we still need to check for exgw
-				// annotations. If the pod is ovn networked and is in update reschedule, addLogicalPort will take
-				// care of updating the exgw updates
-				if oldPod.Annotations[routingNamespaceAnnotation] != pod.Annotations[routingNamespaceAnnotation] ||
-					oldPod.Annotations[routingNetworkAnnotation] != pod.Annotations[routingNetworkAnnotation] {
-					oc.deletePodExternalGW(oldPod)
-					if err := oc.addPodExternalGW(pod); err != nil {
-						klog.Errorf(err.Error())
-					}
-				}
+			if !oc.ensurePod(oldPod, pod, oc.checkAndDeleteRetryPod(pod.UID)) {
+				// add back the failed pod
+				oc.addRetryPod(pod)
+				return
 			}
 		},
 		DeleteFunc: func(obj interface{}) {
 			pod := obj.(*kapi.Pod)
+			oc.checkAndDeleteRetryPod(pod.UID)
 			if !podWantsNetwork(pod) {
 				oc.deletePodExternalGW(pod)
 				return
 			}
 			// deleteLogicalPort will take care of removing exgw for ovn networked pods
 			oc.deleteLogicalPort(pod)
-			retryPods.Delete(pod.UID)
 		},
 	}, oc.syncPods)
 	klog.Infof("Bootstrapping existing pods and cleaning stale pods took %v", time.Since(start))


### PR DESCRIPTION

**FYI: this was a "semi-smooth" back-port (i.e: I had to resolve some conflicts). Please pay special attention to that when reviewing.** 

----------------------

If a pod add fails in ovnkube-master, and there is no subsequent update
event for the pod we never try to add it again and CNI will just
continuously fail. A prime example of this is if a pod is added for a
node, who has not yet registered with ovnkube-master by setting its L3
gateway config.

This patch adds a goroutine which will run and check to see if there are
any pods that need retry who have been sitting for longer than a minute.
If such pods exist, the goroutine will attempt to addLogicalPort for
them.

Signed-off-by: Tim Rozet <trozet@redhat.com>
Co-Authored-by: Dan Williams <dcbw@redhat.com>

/assign @dcbw @trozet 



<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->