### PR TITLE
[DNM] Hack: fall back to a direct retrieval of annotations on failure

### DIFF
--- a/go-controller/pkg/cni/cni.go
+++ b/go-controller/pkg/cni/cni.go
@@ -97,7 +97,7 @@ func (pr *PodRequest) cmdAdd(podLister corev1listers.PodLister, useOVSExternalID
 	}
 	// Get the IP address and MAC address of the pod
 	// for Smart-Nic, ensure connection-details is present
-	annotations, err := GetPodAnnotations(pr.ctx, podLister, namespace, podName, annotCondFn)
+	annotations, err := GetPodAnnotationsFallback(pr.ctx, podLister, namespace, podName, annotCondFn, kclient)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get pod annotation: %v", err)
 	}


### PR DESCRIPTION
There seems to be a problem where the Pod informer is somehow behind when starting up during upgrades. So, try and fall back.

As a debugging measure, dump stack when fallback succeeds.

/cc @trozet 