### PR TITLE
Bug 1956955: Batching: Fixes finding maximum bash arguments

### DIFF
--- a/go-controller/pkg/util/ovs.go
+++ b/go-controller/pkg/util/ovs.go
@@ -103,11 +103,17 @@ func findMaxArgsUsable(estimatedMax int) int {
 	for i := range args {
 		args[i] = "a"
 	}
-	if estimatedMax <= minOSArgs {
-		return minOSArgs
+
+	for estimatedMax > minOSArgs {
+		if _, err := exec.Command("/bin/true", args...).Output(); err == nil {
+			break
+		}
+		estimatedMax = int(float64(estimatedMax) * backoff)
+		args = args[:estimatedMax]
 	}
-	if _, err := exec.Command("/bin/true", args...).Output(); err != nil {
-		return findMaxArgsUsable(int(float64(estimatedMax) * backoff))
+
+	if estimatedMax < minOSArgs {
+		estimatedMax = minOSArgs
 	}
 	return estimatedMax
 }

--- a/go-controller/pkg/util/ovs_unit_test.go
+++ b/go-controller/pkg/util/ovs_unit_test.go
@@ -1993,3 +1993,42 @@ func TestDetectSCTPSupport(t *testing.T) {
 		})
 	}
 }
+
+func TestFindMaxArgsUsable(t *testing.T) {
+	tests := []struct {
+		desc            string
+		initialMaxWorks bool
+		maxArgs         int
+	}{
+		{
+			desc:            "positive test: small value should be usable",
+			initialMaxWorks: true,
+			maxArgs:         minOSArgs + 10,
+		},
+		{
+			desc:            "negative test: value smaller than minimum should result in minimum",
+			initialMaxWorks: false,
+			maxArgs:         minOSArgs - 10,
+		},
+		{
+			desc:            "negative test: giant initial value should not be usable and return a smaller int",
+			initialMaxWorks: false,
+			maxArgs:         10000000,
+		},
+	}
+
+	for i, tc := range tests {
+		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
+
+			val := findMaxArgsUsable(tc.maxArgs)
+
+			if tc.initialMaxWorks {
+				assert.EqualValues(t, val, tc.maxArgs, "max args should equal found value")
+			} else if tc.maxArgs < minOSArgs {
+				assert.EqualValues(t, val, minOSArgs)
+			} else {
+				assert.Less(t, val, tc.maxArgs, "value should be less than max args")
+			}
+		})
+	}
+}


### PR DESCRIPTION
It turns out what the system reports for maximum arguments may not be
the real amount of arguments that are usable in a shell. Different
kernels calculate it differently, but the gist is that the only reliable
way to know is to test for it. This patch does an initial search based
on the given max args in the kernel to find the actual usable amount.

The search is only done one time during initialization, so it shouldn't
impact performance.

Signed-off-by: Tim Rozet <trozet@redhat.com>

