### PR TITLE
Bug 1970068: Fixes getNodeIPs assuming dualstack

### DIFF
--- a/go-controller/pkg/ovn/controller/services/services_controller_test.go
+++ b/go-controller/pkg/ovn/controller/services/services_controller_test.go
@@ -58,8 +58,10 @@ func TestSyncServices(t *testing.T) {
 	ns := "testns"
 	serviceName := "foo"
 	config.Kubernetes.OVNEmptyLbEvents = true
+	config.IPv4Mode = true
 	defer func() {
 		config.Kubernetes.OVNEmptyLbEvents = false
+		config.IPv4Mode = false
 	}()
 
 	tests := []struct {
@@ -217,14 +219,6 @@ func TestSyncServices(t *testing.T) {
 				{
 					Cmd:    "ovn-nbctl --timeout=15 set load_balancer load_balancer_1 vips:\"5.5.5.5:32766\"=\"\"",
 					Output: "",
-				},
-				{
-					Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=name find logical_router options:chassis!=null",
-					Output: gatewayRouter1,
-				},
-				{
-					Cmd:    `ovn-nbctl --timeout=15 get logical_router 2e290f10-3652-11eb-839b-a8a1590cda29 external_ids:physical_ips`,
-					Output: "5.5.5.5",
 				},
 			},
 		},

--- a/go-controller/pkg/ovn/controller/services/utils.go
+++ b/go-controller/pkg/ovn/controller/services/utils.go
@@ -338,8 +338,8 @@ func getNodeIPs(isIPv6 bool) ([]string, error) {
 		}
 		physicalIPs, err = util.MatchAllIPStringFamily(isIPv6, physicalIPs)
 		if err != nil {
-			klog.Errorf("Failed to find node ips for gateway: %s that match IP family, error: %v",
-				gatewayRouter, err)
+			klog.Errorf("Failed to find node ips for gateway: %s that match IP family, IPv6: %t, error: %v",
+				gatewayRouter, isIPv6, err)
 			continue
 		}
 		nodeIPs = append(nodeIPs, physicalIPs...)
@@ -350,6 +350,7 @@ func getNodeIPs(isIPv6 bool) ([]string, error) {
 // collectServiceVIPs collects all the vips associated to a given service
 // and returns them as a set.
 func collectServiceVIPs(service *v1.Service) sets.String {
+	isV6Families := getIPFamiliesEnabled()
 	res := sets.NewString()
 	for _, ip := range util.GetClusterIPs(service) {
 		for _, svcPort := range service.Spec.Ports {
@@ -361,10 +362,11 @@ func collectServiceVIPs(service *v1.Service) sets.String {
 	for _, svcPort := range service.Spec.Ports {
 		// Node Port
 		if svcPort.NodePort != 0 {
-			for _, isIPv6 := range []bool{false, true} {
+			for _, isIPv6 := range isV6Families {
 				nodeIPs, err := getNodeIPs(isIPv6)
 				if err != nil {
 					klog.Error(err)
+					continue
 				}
 				for _, ip := range nodeIPs {
 					vip := util.JoinHostPortInt32(ip, svcPort.NodePort)
@@ -406,4 +408,17 @@ func svcNeedsIdling(annotations map[string]string) bool {
 		}
 	}
 	return false
+}
+
+// get IPFamiliesEnabled returns a slice representing which ip families
+// are enabled, with false representing ipv4, and true for ipv6
+func getIPFamiliesEnabled() []bool {
+	isV6Families := make([]bool, 0, 2)
+	if config.IPv4Mode {
+		isV6Families = append(isV6Families, false)
+	}
+	if config.IPv6Mode {
+		isV6Families = append(isV6Families, true)
+	}
+	return isV6Families
 }


### PR DESCRIPTION
The function was assuming dualstack, which was causing "Failed to find
node ips for gateway" error to appear over 14k times in our scale
test runs downstream.

Signed-off-by: Tim Rozet <trozet@redhat.com>

