### PR TITLE
[release-4.7] Bug 1970779: Remove getDefaultIfAddr and use getNetworkInterfaceIPAddresses

### DIFF
--- a/go-controller/pkg/node/gateway_init.go
+++ b/go-controller/pkg/node/gateway_init.go
@@ -178,11 +178,15 @@ func (n *OvnNode) initGateway(subnets []*net.IPNet, nodeAnnotator kube.Annotator
 		return err
 	}
 
-	v4IfAddr, v6IfAddr, err := getDefaultIfAddr(gatewayIntf)
-	if err == nil {
-		if err := util.SetNodePrimaryIfAddr(nodeAnnotator, v4IfAddr, v6IfAddr); err != nil {
-			klog.Errorf("Unable to set primary IP net label on node, err: %v", err)
-		}
+	ifAddrs, err := getNetworkInterfaceIPAddresses(gatewayIntf)
+	if err != nil {
+		return err
+	}
+
+	v4IfAddr, _ := util.MatchIPNetFamily(false, ifAddrs)
+	v6IfAddr, _ := util.MatchIPNetFamily(true, ifAddrs)
+	if err := util.SetNodePrimaryIfAddr(nodeAnnotator, v4IfAddr, v6IfAddr); err != nil {
+		klog.Errorf("Unable to set primary IP net label on node, err: %v", err)
 	}
 
 	var gw *gateway

--- a/go-controller/pkg/node/helper_linux.go
+++ b/go-controller/pkg/node/helper_linux.go
@@ -12,7 +12,6 @@ import (
 	"github.com/vishvananda/netlink"
 	kapi "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
-	utilnet "k8s.io/utils/net"
 )
 
 // getDefaultGatewayInterfaceDetails returns the interface name on
@@ -93,28 +92,6 @@ func getDefaultGatewayInterfaceByFamily(family int) (string, net.IP, error) {
 		}
 	}
 	return "", net.IP{}, fmt.Errorf("failed to get default gateway interface")
-}
-
-func getDefaultIfAddr(defaultGatewayIntf string) (*net.IPNet, *net.IPNet, error) {
-	var v4IfAddr, v6IfAddr *net.IPNet
-	primaryLink, err := netlink.LinkByName(defaultGatewayIntf)
-	if err != nil {
-		return nil, nil, fmt.Errorf("error: unable to get link for default interface: %s, err: %v", defaultGatewayIntf, err)
-	}
-	addrs, err := netlink.AddrList(primaryLink, netlink.FAMILY_ALL)
-	if err != nil {
-		return nil, nil, fmt.Errorf("error: unable to list addresses for default interface, err: %v", err)
-	}
-	for _, addr := range addrs {
-		if addr.IP.IsGlobalUnicast() {
-			if utilnet.IsIPv6(addr.IP) {
-				v6IfAddr = addr.IPNet
-			} else {
-				v4IfAddr = addr.IPNet
-			}
-		}
-	}
-	return v4IfAddr, v6IfAddr, nil
 }
 
 func getIntfName(gatewayIntf string) (string, error) {


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

As seen in the associated bug report: https://bugzilla.redhat.com/show_bug.cgi?id=1970779#c3 , there can be situations where the egress IP related code for finding the default IP address can sometimes pick up the virtual IPs on bare-metal clusters. Hence back-port the following commit which uses `getNetworkInterfaceIPAddresses` instead and has dedicated code to avoid that: https://github.com/openshift/ovn-kubernetes/blob/master/go-controller/pkg/util/net_linux.go#L370-L376

/assign @trozet 

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->