### PR TITLE
[WIP] Add a cluster-wide group with node ls-to-cluster-router ports.

### DIFF
--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -41,7 +41,10 @@ import (
 )
 
 const (
-	egressfirewallCRD = "egressfirewalls.k8s.ovn.org"
+	egressfirewallCRD                string        = "egressfirewalls.k8s.ovn.org"
+	clusterPortGroupName             string        = "clusterPortGroup"
+	clusterRtrPortGroupName          string        = "clusterRtrPortGroup"
+	egressFirewallDNSDefaultDuration time.Duration = 30 * time.Minute
 )
 
 // ServiceVIPKey is used for looking up service namespace information for a
@@ -151,6 +154,10 @@ type Controller struct {
 
 	// An address set factory that creates address sets
 	addressSetFactory AddressSetFactory
+
+	// Port group for all node logical switch ports connected to the cluster
+	// logical router
+	clusterRtrPortGroupUUID string
 
 	// Port group for ingress deny rule
 	portGroupIngressDeny string


### PR DESCRIPTION
Commit 40a90f06644a removed the multicast deny port group and used
instead the cluster port group.  However, this breaks pod-to-pod
multicast when pods reside on different nodes.  That is because OVN ACLs
are applied on all logical switch ports, including logical switch ports
connected to router ports.

Hence, an ACL of the form "if ip.mcast then deny" applied on the
clusterPortGroup will drop all multicast traffic that would normally be
routed by the cluster router even when multicast is allowed for a
namespace.

Instead, add a new (smaller) cluster wide group that only contains the
node logical switch ports connected to the cluster router.  This allows us
to define two allow ACLs for multicast traffic from/to node switches to/from
cluster router, therefore not breaking the namespace multicast allow policy
if pods reside on different nodes.

Fixes: 40a90f06644a ("Migrate default deny multicast policy to port-group")
Signed-off-by: Dumitru Ceara <dceara@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->