### PR TITLE
[WIP] Declare a maximum line length for batching

### DIFF
--- a/go-controller/pkg/util/ovs.go
+++ b/go-controller/pkg/util/ovs.go
@@ -905,7 +905,11 @@ func (t *NBTxn) AddOrCommit(args []string) (string, string, error) {
 		len(t.txnArgs), incomingLength, buffer)
 
 	// case where we are going to exceed max arguments
-	if len(t.args)+len(t.txnArgs)+incomingLength+buffer > maxArgs {
+	// also check entire line length is going be over 100k
+	// maximum bash command seems to be a combination of max args and length of each argument
+	// maximum length is PAGE_SIZE * 32 which we can assume to be 4k page, and equals 131072
+	if len(t.args)+len(t.txnArgs)+incomingLength+buffer > maxArgs || len(strings.Join(t.args, " "))+
+		len(strings.Join(t.txnArgs, " "))+len(strings.Join(args, " ")) > 100000 {
 		klog.Info("Requested transaction add is too large, committing...")
 		if stdout, stderr, err := t.Commit(); err != nil {
 			return stdout, stderr, err


### PR DESCRIPTION
There are still bash errors for "too many args" which stem not from the
number of arguments but a combination of number of args and total length
of the args. This sets the maximum line length to 100k, which is less
than the default maximum of 130k (to be safe).

Signed-off-by: Tim Rozet <trozet@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->