### PR TITLE
Bug 1961506: Detect if OVS supports check pkt length

### DIFF
--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -121,6 +121,10 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 			Output: systemID,
 		})
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+			Cmd:    "ovs-appctl --timeout=15 dpif/show-dp-features breth0",
+			Output: "Check pkt length action: Yes",
+		})
+		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 			Cmd:    "ovs-vsctl --timeout=15 get Interface patch-breth0_node1-to-br-int ofport",
 			Output: "5",
 		})


### PR DESCRIPTION
In older kernels like RHEL 7, OVS does not support chk pkt length in
kernel datapath. This will cause all packets hitting these flows to go
to userspace, which is the majority of OVN destined ingress traffic into
the node. This will result in severe performance degradation. To avoid
this, detect and disable using these flows if the kernel datapath does
not support the action.

Note this will result in these nodes not being able to handle packets
larger than pod MTU and send ICMP frag needed, but the trade off vs.
performance impact is worth it.

Signed-off-by: Tim Rozet <trozet@redhat.com>
(cherry picked from commit 7e832266167b518fdb9f6eba63623e7753e753f5)
