### PR TITLE
[wip] cni: cancel pod sandbox add requests if the pod's UID changes

### DIFF
--- a/go-controller/pkg/cni/cni.go
+++ b/go-controller/pkg/cni/cni.go
@@ -97,10 +97,11 @@ func (pr *PodRequest) cmdAdd(podLister corev1listers.PodLister, useOVSExternalID
 	}
 	// Get the IP address and MAC address of the pod
 	// for Smart-Nic, ensure connection-details is present
-	annotations, err := GetPodAnnotations(pr.ctx, podLister, kclient, namespace, podName, annotCondFn)
+	podUID, annotations, err := GetPodAnnotations(pr.ctx, podLister, kclient, namespace, podName, annotCondFn)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get pod annotation: %v", err)
 	}
+	pr.PodUID = podUID
 
 	podInterfaceInfo, err := PodAnnotation2PodInfo(annotations, useOVSExternalIDs, pr.IsSmartNIC)
 	if err != nil {
@@ -149,10 +150,11 @@ func (pr *PodRequest) cmdCheck(podLister corev1listers.PodLister, useOVSExternal
 	if pr.IsSmartNIC {
 		annotCondFn = isSmartNICReady
 	}
-	annotations, err := GetPodAnnotations(pr.ctx, podLister, kclient, pr.PodNamespace, pr.PodName, annotCondFn)
+	podUID, annotations, err := GetPodAnnotations(pr.ctx, podLister, kclient, pr.PodNamespace, pr.PodName, annotCondFn)
 	if err != nil {
 		return nil, err
 	}
+	pr.PodUID = podUID
 
 	if pr.CNIConf.PrevResult != nil {
 		result, err := current.NewResultFromResult(pr.CNIConf.PrevResult)
@@ -176,7 +178,8 @@ func (pr *PodRequest) cmdCheck(podLister corev1listers.PodLister, useOVSExternal
 		}
 		for _, ip := range result.IPs {
 			if err = waitForPodInterface(pr.ctx, result.Interfaces[*ip.Interface].Mac, []*net.IPNet{&ip.Address},
-				hostIfaceName, ifaceID, ofPort, useOVSExternalIDs); err != nil {
+				hostIfaceName, ifaceID, ofPort, useOVSExternalIDs, podLister, kclient, pr.PodNamespace, pr.PodName,
+				pr.PodUID); err != nil {
 				return nil, fmt.Errorf("error while waiting on OVN pod interface: %s ip: %v, error: %v", ifaceID, ip, err)
 			}
 		}
@@ -231,7 +234,7 @@ func HandleCNIRequest(request *PodRequest, podLister corev1listers.PodLister, us
 
 // getCNIResult get result from pod interface info.
 func (pr *PodRequest) getCNIResult(podInterfaceInfo *PodInterfaceInfo) (*current.Result, error) {
-	interfacesArray, err := pr.ConfigureInterface(pr.PodNamespace, pr.PodName, podInterfaceInfo)
+	interfacesArray, err := pr.ConfigureInterface(podInterfaceInfo)
 	if err != nil {
 		return nil, fmt.Errorf("failed to configure pod interface: %v", err)
 	}

--- a/go-controller/pkg/cni/cniserver_test.go
+++ b/go-controller/pkg/cni/cniserver_test.go
@@ -4,7 +4,6 @@ package cni
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -19,9 +18,6 @@ import (
 
 	cnitypes "github.com/containernetworking/cni/pkg/types"
 	cni020 "github.com/containernetworking/cni/pkg/types/020"
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/fake"
 	corev1listers "k8s.io/client-go/listers/core/v1"
 	utiltesting "k8s.io/client-go/util/testing"
@@ -246,98 +242,5 @@ func TestCNIServer(t *testing.T) {
 				t.Fatalf("[%s] unexpected error message '%v'", tc.name, string(body))
 			}
 		}
-	}
-}
-
-func newObjectMeta(name, namespace string) metav1.ObjectMeta {
-	return metav1.ObjectMeta{
-		Name:      name,
-		UID:       types.UID(name),
-		Namespace: namespace,
-	}
-}
-
-func TestCNIServerCancelAdd(t *testing.T) {
-	tmpDir, err := utiltesting.MkTmpdir("cniserver")
-	if err != nil {
-		t.Fatalf("failed to create temp directory: %v", err)
-	}
-	defer os.RemoveAll(tmpDir)
-	socketPath := filepath.Join(tmpDir, serverSocketName)
-
-	fakeClient := fake.NewSimpleClientset(
-		&v1.NamespaceList{
-			Items: []v1.Namespace{{ObjectMeta: newObjectMeta(name, name)}},
-		},
-		&v1.PodList{
-			Items: []v1.Pod{
-				{
-					ObjectMeta: newObjectMeta(name, namespace),
-					Spec:       v1.PodSpec{NodeName: nodeName},
-				},
-			},
-		},
-	)
-
-	fakeClientset := &util.OVNClientset{KubeClient: fakeClient}
-	wf, err := factory.NewNodeWatchFactory(fakeClientset, nodeName)
-	if err != nil {
-		t.Fatalf("failed to create watch factory: %v", err)
-	}
-
-	started := make(chan bool)
-
-	s, err := NewCNIServer(tmpDir, false, wf, fakeClient)
-	if err != nil {
-		t.Fatalf("error Creating CNI server: %v", err)
-	}
-	if err := s.Start(func(request *PodRequest, podLister corev1listers.PodLister, useOVSExternalIDs bool,
-		kclient kubernetes.Interface) ([]byte, error) {
-		// Let the testcase know it can now delete the pod
-		close(started)
-		// Wait for the testcase to cancel us
-		<-request.ctx.Done()
-		return nil, fmt.Errorf("pod operation canceled")
-	}); err != nil {
-		t.Fatalf("error starting CNI server: %v", err)
-	}
-
-	client := &http.Client{
-		Transport: &http.Transport{
-			Dial: func(proto, addr string) (net.Conn, error) {
-				return net.Dial("unix", socketPath)
-			},
-		},
-	}
-
-	request := &Request{
-		Env: map[string]string{
-			"CNI_COMMAND":     string(CNIAdd),
-			"CNI_CONTAINERID": sandboxID,
-			"CNI_NETNS":       "/some/path",
-			"CNI_ARGS":        makeCNIArgs(namespace, name),
-		},
-		Config: []byte("{\"cniVersion\": \"0.1.0\",\"name\": \"ovnkube\",\"type\": \"ovnkube\"}"),
-	}
-
-	var code int
-	var body []byte
-	done := make(chan bool)
-	go func() {
-		body, code = clientDoCNI(t, client, request)
-		close(done)
-	}()
-	<-started
-	err = fakeClient.CoreV1().Pods(namespace).Delete(context.TODO(), name, *metav1.NewDeleteOptions(0))
-	if err != nil {
-		t.Fatalf("[ADD] failed to delete pod: %v", err)
-	}
-	<-done
-
-	if code != http.StatusBadRequest {
-		t.Fatalf("[ADD] expected status %v but got %v", http.StatusBadRequest, code)
-	}
-	if !strings.Contains(string(body), "pod operation canceled") {
-		t.Fatalf("[ADD] unexpected error message '%v'", string(body))
 	}
 }

--- a/go-controller/pkg/cni/cnishim.go
+++ b/go-controller/pkg/cni/cnishim.go
@@ -24,10 +24,12 @@ import (
 	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/vishvananda/netlink"
 	lumberjack "gopkg.in/natefinch/lumberjack.v2"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 
 	ovntypes "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/cni/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 )
 
 // Plugin is the structure to hold the endpoint information and the corresponding
@@ -133,6 +135,19 @@ func (p *Plugin) postMetrics(startTime time.Time, cmd command, err error) {
 	})
 }
 
+func newClientset(kubeconfig string) (*kubernetes.Clientset, error) {
+	if kubeconfig == "" {
+		return nil, nil
+	}
+	kclient, err := util.NewKubernetesClientset(&config.KubernetesConfig{
+		Kubeconfig: kubeconfig,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create kubernetes client from %s: %v", kubeconfig, err)
+	}
+	return kclient, nil
+}
+
 // CmdAdd is the callback for 'add' cni calls from skel
 func (p *Plugin) CmdAdd(args *skel.CmdArgs) error {
 	var err error
@@ -149,6 +164,12 @@ func (p *Plugin) CmdAdd(args *skel.CmdArgs) error {
 		return err
 	}
 	setupLogging(conf)
+
+	kclient, errK := newClientset(conf.Kubeconfig)
+	if errK != nil {
+		err = errK
+		return err
+	}
 
 	req := newCNIRequest(args)
 
@@ -170,7 +191,7 @@ func (p *Plugin) CmdAdd(args *skel.CmdArgs) error {
 	if response.Result != nil {
 		result = response.Result
 	} else {
-		pr, _ := cniRequestToPodRequest(req)
+		pr, _ := cniRequestToPodRequest(req, nil, kclient)
 		result, err = pr.getCNIResult(response.PodIFInfo)
 		if err != nil {
 			err = fmt.Errorf("failed to get CNI Result from pod interface info %v: %v", response.PodIFInfo, err)

--- a/go-controller/pkg/cni/helper_linux.go
+++ b/go-controller/pkg/cni/helper_linux.go
@@ -12,6 +12,8 @@ import (
 	"strconv"
 	"strings"
 
+	"k8s.io/client-go/kubernetes"
+	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/klog/v2"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
@@ -251,8 +253,9 @@ func setupSriovInterface(netns ns.NetNS, containerID, ifName string, ifInfo *Pod
 }
 
 // ConfigureOVS performs OVS configurations in order to set up Pod networking
-func ConfigureOVS(ctx context.Context, namespace string, podName string, hostIfaceName string,
-	ifInfo *PodInterfaceInfo, sandboxID string) error {
+func ConfigureOVS(ctx context.Context, namespace, podName, hostIfaceName string,
+	ifInfo *PodInterfaceInfo, sandboxID string, podLister corev1listers.PodLister,
+	kclient kubernetes.Interface, initialPodUID string) error {
 	klog.Infof("ConfigureOVS: namespace: %s, podName: %s", namespace, podName)
 	ifaceID := fmt.Sprintf("%s_%s", namespace, podName)
 
@@ -307,7 +310,9 @@ func ConfigureOVS(ctx context.Context, namespace string, podName string, hostIfa
 		return err
 	}
 
-	if err = waitForPodInterface(ctx, ifInfo.MAC.String(), ifInfo.IPs, hostIfaceName, ifaceID, ofPort, ifInfo.CheckExtIDs); err != nil {
+	if err = waitForPodInterface(ctx, ifInfo.MAC.String(), ifInfo.IPs, hostIfaceName,
+		ifaceID, ofPort, ifInfo.CheckExtIDs, podLister, kclient, namespace, podName,
+		initialPodUID); err != nil {
 		if ifInfo.CheckExtIDs {
 			return fmt.Errorf("error while waiting on OVS.Interface.external-ids:ovn-installed for pod: %v", err)
 		} else {
@@ -318,7 +323,7 @@ func ConfigureOVS(ctx context.Context, namespace string, podName string, hostIfa
 }
 
 // ConfigureInterface sets up the container interface
-func (pr *PodRequest) ConfigureInterface(namespace string, podName string, ifInfo *PodInterfaceInfo) ([]*current.Interface, error) {
+func (pr *PodRequest) ConfigureInterface(ifInfo *PodInterfaceInfo) ([]*current.Interface, error) {
 	netns, err := ns.GetNS(pr.Netns)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open netns %q: %v", pr.Netns, err)
@@ -344,7 +349,8 @@ func (pr *PodRequest) ConfigureInterface(namespace string, podName string, ifInf
 	}
 
 	if !ifInfo.IsSmartNic {
-		err = ConfigureOVS(pr.ctx, namespace, podName, hostIface.Name, ifInfo, pr.SandboxID)
+		err = ConfigureOVS(pr.ctx, pr.PodNamespace, pr.PodName, hostIface.Name, ifInfo, pr.SandboxID,
+			pr.podLister, pr.kclient, pr.PodUID)
 		if err != nil {
 			return nil, err
 		}

--- a/go-controller/pkg/cni/types.go
+++ b/go-controller/pkg/cni/types.go
@@ -3,7 +3,6 @@ package cni
 import (
 	"context"
 	"net/http"
-	"sync"
 	"time"
 
 	"github.com/containernetworking/cni/pkg/types/current"
@@ -76,6 +75,8 @@ type PodRequest struct {
 	PodNamespace string
 	// kubernetes pod name
 	PodName string
+	// kubernetes pod UID
+	PodUID string
 	// kubernetes container ID
 	SandboxID string
 	// kernel network namespace path
@@ -92,6 +93,9 @@ type PodRequest struct {
 	cancel context.CancelFunc
 	// Interface to pod is a Smart-NIC interface
 	IsSmartNIC bool
+
+	podLister corev1listers.PodLister
+	kclient   kubernetes.Interface
 }
 
 type cniRequestFunc func(request *PodRequest, podLister corev1listers.PodLister, useOVSExternalIDs bool, kclient kubernetes.Interface) ([]byte, error)
@@ -105,10 +109,6 @@ type Server struct {
 	useOVSExternalIDs int32
 	kclient           kubernetes.Interface
 	podLister         corev1listers.PodLister
-
-	// runningSandboxAdds is a map of sandbox ID to PodRequest for any CNIAdd operation
-	runningSandboxAddsLock sync.Mutex
-	runningSandboxAdds     map[string]*PodRequest
 
 	// CNI Server mode
 	mode string

--- a/go-controller/pkg/cni/types/types.go
+++ b/go-controller/pkg/cni/types/types.go
@@ -23,6 +23,9 @@ type NetConf struct {
 	// LogFileMaxAge represents the maximum number
 	// of days to retain old log files
 	LogFileMaxAge int `json:"logfile-maxage"`
+
+	// Kubeconfig is the path to a kubeconfig
+	Kubeconfig string `json:"kubeconfig,omitempty"`
 }
 
 // NetworkSelectionElement represents one element of the JSON format

--- a/go-controller/pkg/cni/utils.go
+++ b/go-controller/pkg/cni/utils.go
@@ -42,43 +42,55 @@ func isSmartNICReady(podAnnotation map[string]string) bool {
 	return false
 }
 
-// getPod returns a pod from the informer cache or (if that fails) the apiserver
+// getPod tries to read a Pod object from the informer cache, or if the pod
+// doesn't exist there, the apiserver. If neither a list or a kube client is
+// given, returns no pod and no error
 func getPod(podLister corev1listers.PodLister, kclient kubernetes.Interface, namespace, name string) (*kapi.Pod, error) {
-	pod, err := podLister.Pods(namespace).Get(name)
-	if apierrors.IsNotFound(err) {
+	var pod *kapi.Pod
+	var err error
+
+	if podLister != nil {
+		pod, err = podLister.Pods(namespace).Get(name)
+		if err != nil && !apierrors.IsNotFound(err) {
+			return nil, err
+		}
+		// drop through
+	}
+
+	if kclient != nil {
 		// If the pod wasn't in our local cache, ask for it directly
 		pod, err = kclient.CoreV1().Pods(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 	}
+
 	return pod, err
 }
 
-// GetPodAnnotations obtains the pod annotation from the cache
-func GetPodAnnotations(ctx context.Context, podLister corev1listers.PodLister, kclient kubernetes.Interface, namespace, name string, annotCond podAnnotWaitCond) (map[string]string, error) {
+// GetPodAnnotations obtains the pod UID and annotation from the cache or apiserver
+func GetPodAnnotations(ctx context.Context, podLister corev1listers.PodLister, kclient kubernetes.Interface, namespace, name string, annotCond podAnnotWaitCond) (string, map[string]string, error) {
 	var notFoundCount uint
 
 	timeout := time.After(30 * time.Second)
 	for {
 		select {
 		case <-ctx.Done():
-			return nil, fmt.Errorf("canceled waiting for annotations")
+			return "", nil, fmt.Errorf("canceled waiting for annotations")
 		case <-timeout:
-			return nil, fmt.Errorf("timed out waiting for annotations")
+			return "", nil, fmt.Errorf("timed out waiting for annotations")
 		default:
 			pod, err := getPod(podLister, kclient, namespace, name)
 			if err != nil {
 				if !apierrors.IsNotFound(err) {
-					return nil, fmt.Errorf("failed to get pod for annotations: %v", err)
+					return "", nil, fmt.Errorf("failed to get pod for annotations: %v", err)
 				}
 				// Allow up to 1 second for pod to be found
 				notFoundCount++
 				if notFoundCount >= 5 {
-					return nil, fmt.Errorf("timed out waiting for pod after 1s: %v", err)
+					return "", nil, fmt.Errorf("timed out waiting for pod after 1s: %v", err)
 				}
 				// drop through to try again
 			} else if pod != nil {
-				annotations := pod.ObjectMeta.Annotations
-				if annotCond(annotations) {
-					return annotations, nil
+				if annotCond(pod.Annotations) {
+					return string(pod.UID), pod.Annotations, nil
 				}
 			}
 

--- a/go-controller/pkg/cni/utils_test.go
+++ b/go-controller/pkg/cni/utils_test.go
@@ -101,7 +101,7 @@ var _ = Describe("CNI Utils tests", func() {
 		It("Returns Pod annotation if annotation condition is met", func() {
 			podAnnot := map[string]string{"foo": "bar"}
 			pod.Annotations = podAnnot
-			ctx, cancelFunc := context.WithTimeout(context.Background(), 20*time.Millisecond)
+			ctx, cancelFunc := context.WithTimeout(context.Background(), 1*time.Second)
 			defer cancelFunc()
 
 			cond := func(podAnnotation map[string]string) bool {
@@ -113,9 +113,10 @@ var _ = Describe("CNI Utils tests", func() {
 
 			fakeClient := newFakeKubeClientWithPod(pod)
 			podNamespaceLister.On("Get", mock.AnythingOfType("string")).Return(pod, nil)
-			annot, err := GetPodAnnotations(ctx, &podLister, fakeClient, "some-ns", "some-pod", cond)
+			uid, annot, err := GetPodAnnotations(ctx, &podLister, fakeClient, "some-ns", "some-pod", cond)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(annot).To(Equal(podAnnot))
+			Expect(uid).To(Equal(string(pod.UID)))
 		})
 
 		It("Returns with Error if context is canceled", func() {
@@ -132,7 +133,7 @@ var _ = Describe("CNI Utils tests", func() {
 
 			fakeClient := newFakeKubeClientWithPod(pod)
 			podNamespaceLister.On("Get", mock.AnythingOfType("string")).Return(pod, nil)
-			_, err := GetPodAnnotations(ctx, &podLister, fakeClient, "some-ns", "some-pod", cond)
+			_, _, err := GetPodAnnotations(ctx, &podLister, fakeClient, "some-ns", "some-pod", cond)
 			Expect(err).To(HaveOccurred())
 		})
 
@@ -151,7 +152,7 @@ var _ = Describe("CNI Utils tests", func() {
 
 			fakeClient := newFakeKubeClientWithPod(pod)
 			podNamespaceLister.On("Get", mock.AnythingOfType("string")).Return(pod, nil)
-			_, err := GetPodAnnotations(ctx, &podLister, fakeClient, "some-ns", "some-pod", cond)
+			_, _, err := GetPodAnnotations(ctx, &podLister, fakeClient, "some-ns", "some-pod", cond)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -165,7 +166,7 @@ var _ = Describe("CNI Utils tests", func() {
 
 			fakeClient := newFakeKubeClientWithPod(pod)
 			podNamespaceLister.On("Get", mock.AnythingOfType("string")).Return(nil, fmt.Errorf("failed to list pods"))
-			_, err := GetPodAnnotations(ctx, &podLister, fakeClient, "some-ns", "some-pod", cond)
+			_, _, err := GetPodAnnotations(ctx, &podLister, fakeClient, "some-ns", "some-pod", cond)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("failed to list pods"))
 		})
@@ -185,7 +186,7 @@ var _ = Describe("CNI Utils tests", func() {
 
 			fakeClient := newFakeKubeClientWithPod(pod)
 			podNamespaceLister.On("Get", mock.AnythingOfType("string")).Return(nil, errors.NewNotFound(v1.Resource("pod"), name))
-			_, err := GetPodAnnotations(ctx, &podLister, fakeClient, "some-ns", "some-pod", cond)
+			_, _, err := GetPodAnnotations(ctx, &podLister, fakeClient, "some-ns", "some-pod", cond)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -199,7 +200,7 @@ var _ = Describe("CNI Utils tests", func() {
 
 			fakeClient := fake.NewSimpleClientset(&v1.PodList{Items: []v1.Pod{}})
 			podNamespaceLister.On("Get", mock.AnythingOfType("string")).Return(nil, errors.NewNotFound(v1.Resource("pod"), name))
-			_, err := GetPodAnnotations(ctx, &podLister, fakeClient, "some-ns", "some-pod", cond)
+			_, _, err := GetPodAnnotations(ctx, &podLister, fakeClient, "some-ns", "some-pod", cond)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("timed out waiting for pod after 1s"))
 		})

--- a/go-controller/pkg/config/cni.go
+++ b/go-controller/pkg/config/cni.go
@@ -26,6 +26,7 @@ func WriteCNIConfig() error {
 		LogFileMaxSize:    Logging.LogFileMaxSize,
 		LogFileMaxBackups: Logging.LogFileMaxBackups,
 		LogFileMaxAge:     Logging.LogFileMaxAge,
+		Kubeconfig:        Kubernetes.Kubeconfig,
 	}
 
 	bytes, err := json.Marshal(netConf)


### PR DESCRIPTION
If the the pod's UID changes that means the pod was deleted
and re-created. There's no point in continuing this sandbox
request as kubelet will just be tearing it down soon anyway.