### PR TITLE
Bug 1942604: Allow-from-router network policy support for ovn-kubernetes

### DIFF
--- a/contrib/kind.sh
+++ b/contrib/kind.sh
@@ -109,9 +109,11 @@ parse_args()
             -ov | --ovn-image )           	shift
                                           	OVN_IMAGE=$1
                                           	;;
-            --delete )                    	delete
-                                          	exit
-                                          	;;
+            -hns | --host-network-namespace )   OVN_HOST_NETWORK_NAMESPACE=$1
+                                                ;;
+            --delete )                          delete
+                                                exit
+                                                ;;
             -h | --help )                       usage
                                                 exit
                                                 ;;
@@ -139,6 +141,7 @@ print_params()
      echo "OVN_DISABLE_SNAT_MULTIPLE_GWS = $OVN_DISABLE_SNAT_MULTIPLE_GWS"
      echo "OVN_MULTICAST_ENABLE = $OVN_MULTICAST_ENABLE"
      echo "OVN_IMAGE = $OVN_IMAGE"
+     echo "OVN_HOST_NETWORK_NAMESPACE = $OVN_HOST_NETWORK_NAMESPACE"
      echo ""
 }
 
@@ -164,7 +167,6 @@ OVN_DISABLE_SNAT_MULTIPLE_GWS=${OVN_DISABLE_SNAT_MULTIPLE_GWS:-false}
 OVN_MULTICAST_ENABLE=${OVN_MULTICAST_ENABLE:-false}
 KIND_ALLOW_SYSTEM_WRITES=${KIND_ALLOW_SYSTEM_WRITES:-false}
 OVN_IMAGE=${OVN_IMAGE:-local}
-
 # Input not currently validated. Modify outside script at your own risk.
 # These are the same values defaulted to in KIND code (kind/default.go).
 # NOTE: KIND NET_CIDR_IPV6 default use a /64 but OVN have a /64 per host
@@ -182,6 +184,7 @@ if [ "$OVN_HA" == true ]; then
 else
   KIND_NUM_WORKER=${KIND_NUM_WORKER:-2}
 fi
+OVN_HOST_NETWORK_NAMESPACE=${OVN_HOST_NETWORK_NAMESPACE:-ovn-host-network}
 
 print_params
 

--- a/dist/images/daemonset.sh
+++ b/dist/images/daemonset.sh
@@ -39,6 +39,9 @@ OVN_HYBRID_OVERLAY_ENABLE=""
 OVN_DISABLE_SNAT_MULTIPLE_GWS=""
 OVN_MULTICAST_ENABLE=""
 OVN_EGRESSIP_ENABLE=
+OVN_V4_JOIN_SUBNET=""
+OVN_V6_JOIN_SUBNET=""
+OVN_HOST_NETWORK_NAMESPACE=""
 
 # Parse parameters given as arguments to this script.
 while [ "$1" != "" ]; do
@@ -146,6 +149,15 @@ while [ "$1" != "" ]; do
     ;;
   --egress-ip-enable)
     OVN_EGRESSIP_ENABLE=$VALUE
+    ;;
+  --v4-join-subnet)
+    OVN_V4_JOIN_SUBNET=$VALUE
+    ;;
+  --v6-join-subnet)
+    OVN_V6_JOIN_SUBNET=$VALUE
+    ;;
+  --host-network-namespace)
+    OVN_HOST_NETWORK_NAMESPACE=$VALUE
     ;;
   *)
     echo "WARNING: unknown parameter \"$PARAM\""
@@ -302,14 +314,16 @@ net_cidr=${OVN_NET_CIDR:-"10.128.0.0/14/23"}
 svc_cidr=${OVN_SVC_CIDR:-"172.30.0.0/16"}
 k8s_apiserver=${OVN_K8S_APISERVER:-"10.0.2.16:6443"}
 mtu=${OVN_MTU:-1400}
-
+host_network_namespace=${OVN_HOST_NETWORK_NAMESPACE:-ovn-host-network}
 echo "net_cidr: ${net_cidr}"
 echo "svc_cidr: ${svc_cidr}"
 echo "k8s_apiserver: ${k8s_apiserver}"
 echo "mtu: ${mtu}"
+echo "host_network_namespace: ${host_network_namespace}"
 
 net_cidr=${net_cidr} svc_cidr=${svc_cidr} \
   mtu_value=${mtu} k8s_apiserver=${k8s_apiserver} \
+  host_network_namespace=${host_network_namespace}	\
   j2 ../templates/ovn-setup.yaml.j2 -o ../yaml/ovn-setup.yaml
 
 cp ../templates/ovnkube-monitor.yaml.j2 ../yaml/ovnkube-monitor.yaml

--- a/dist/images/daemonset.sh
+++ b/dist/images/daemonset.sh
@@ -39,8 +39,6 @@ OVN_HYBRID_OVERLAY_ENABLE=""
 OVN_DISABLE_SNAT_MULTIPLE_GWS=""
 OVN_MULTICAST_ENABLE=""
 OVN_EGRESSIP_ENABLE=
-OVN_V4_JOIN_SUBNET=""
-OVN_V6_JOIN_SUBNET=""
 OVN_HOST_NETWORK_NAMESPACE=""
 
 # Parse parameters given as arguments to this script.
@@ -149,12 +147,6 @@ while [ "$1" != "" ]; do
     ;;
   --egress-ip-enable)
     OVN_EGRESSIP_ENABLE=$VALUE
-    ;;
-  --v4-join-subnet)
-    OVN_V4_JOIN_SUBNET=$VALUE
-    ;;
-  --v6-join-subnet)
-    OVN_V6_JOIN_SUBNET=$VALUE
     ;;
   --host-network-namespace)
     OVN_HOST_NETWORK_NAMESPACE=$VALUE

--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -68,6 +68,7 @@ fi
 # OVN_REMOTE_PROBE_INTERVAL - ovn remote probe interval in ms (default 100000)
 # OVN_EGRESSIP_ENABLE - enable egress IP for ovn-kubernetes
 # OVN_UNPRIVILEGED_MODE - execute CNI ovs/netns commands from host (default no)
+# OVN_HOST_NETWORK_NAMESPACE - namespace to classify host network traffic for applying network policies
 
 # The argument to the command is the operation to be performed
 # ovn-master ovn-controller ovn-node display display_env ovn_debug
@@ -152,6 +153,8 @@ svc_cidr=${OVN_SVC_CIDR:-172.30.0.0/16}
 mtu=${OVN_MTU:-1400}
 
 ovn_kubernetes_namespace=${OVN_KUBERNETES_NAMESPACE:-ovn-kubernetes}
+# namespace used for classifying host network traffic
+ovn_host_network_namespace=${OVN_HOST_NETWORK_NAMESPACE:-ovn-host-network}
 
 # host on which ovnkube-db POD is running and this POD contains both
 # OVN NB and SB DB running in their own container.
@@ -475,6 +478,7 @@ display_env() {
   echo OVNKUBE_LOGLEVEL ${ovnkube_loglevel}
   echo OVN_DAEMONSET_VERSION ${ovn_daemonset_version}
   echo ovnkube.sh version ${ovnkube_version}
+  echo OVN_HOST_NETWORK_NAMESPACE ${ovn_host_network_namespace}
 }
 
 ovn_debug() {
@@ -865,7 +869,8 @@ ovn-master() {
     ${ovn_master_ssl_opts} \
     ${multicast_enabled_flag} \
     ${egressip_enabled_flag} \
-    --metrics-bind-address "0.0.0.0:9409" &
+    --metrics-bind-address "0.0.0.0:9409" \
+    --host-network-namespace ${ovn_host_network_namespace} &
   echo "=============== ovn-master ========== running"
   wait_for_event attempts=3 process_ready ovnkube-master
 
@@ -1006,7 +1011,8 @@ ovn-node() {
     ${multicast_enabled_flag} \
     ${egressip_enabled_flag} \
     --ovn-metrics-bind-address "0.0.0.0:9476" \
-    --metrics-bind-address "0.0.0.0:9410" &
+    --metrics-bind-address "0.0.0.0:9410" \
+    --host-network-namespace ${ovn_host_network_namespace} &
 
   wait_for_event attempts=3 process_ready ovnkube
   setup_cni

--- a/dist/templates/ovn-setup.yaml.j2
+++ b/dist/templates/ovn-setup.yaml.j2
@@ -108,3 +108,18 @@ data:
   svc_cidr:      "{{ svc_cidr }}"
   k8s_apiserver: "{{ k8s_apiserver }}"
   mtu:           "{{ mtu_value }}"
+  host_network_namespace: "{{ host_network_namespace }}"
+
+
+---
+# ovn-host-network-namespace.yaml
+#
+# Create the namespace for classifying host network traffic.
+#
+# This provisioning is done as part of installation after the cluster is
+# up and before the ovn daemonsets are created.
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "{{ host_network_namespace }}"

--- a/dist/templates/ovnkube-master.yaml.j2
+++ b/dist/templates/ovnkube-master.yaml.j2
@@ -246,6 +246,11 @@ spec:
           value: "{{ ovn_gateway_mode }}"
         - name: OVN_MULTICAST_ENABLE
           value: "{{ ovn_multicast_enable }}"
+        - name: OVN_HOST_NETWORK_NAMESPACE
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: host_network_namespace
       # end of container
 
       volumes:

--- a/dist/templates/ovnkube-node.yaml.j2
+++ b/dist/templates/ovnkube-node.yaml.j2
@@ -205,6 +205,11 @@ spec:
           value: "{{ ovn_multicast_enable }}"
         - name: OVN_UNPRIVILEGED_MODE
           value: "{{ ovn_unprivileged_mode }}"
+        - name: OVN_HOST_NETWORK_NAMESPACE
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: host_network_namespace
 
         lifecycle:
           preStop:

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -89,9 +89,10 @@ var (
 
 	// Kubernetes holds Kubernetes-related parsed config file parameters and command-line overrides
 	Kubernetes = KubernetesConfig{
-		APIServer:          DefaultAPIServer,
-		RawServiceCIDRs:    "172.16.1.0/24",
-		OVNConfigNamespace: "ovn-kubernetes",
+		APIServer:            DefaultAPIServer,
+		RawServiceCIDRs:      "172.16.1.0/24",
+		OVNConfigNamespace:   "ovn-kubernetes",
+		HostNetworkNamespace: "ovn-host-network",
 	}
 
 	// OVNKubernetesFeatureConfig holds OVN-Kubernetes feature enhancement config file parameters and command-line overrides
@@ -215,6 +216,7 @@ type KubernetesConfig struct {
 	PodIP                 string `gcfg:"pod-ip"` // UNUSED
 	RawNoHostSubnetNodes  string `gcfg:"no-hostsubnet-nodes"`
 	NoHostSubnetNodes     *metav1.LabelSelector
+	HostNetworkNamespace  string `gcfg:"host-network-namespace"`
 }
 
 // OVNKubernetesFeatureConfig holds OVN-Kubernetes feature enhancement config file parameters and command-line overrides
@@ -694,6 +696,12 @@ var K8sFlags = []cli.Flag{
 		Usage:       "Specify a label for nodes that will manage their own hostsubnets",
 		Destination: &cliConfig.Kubernetes.RawNoHostSubnetNodes,
 	},
+	&cli.StringFlag{
+		Name:        "host-network-namespace",
+		Usage:       "specify a namespace which will be used to classify host network traffic for network policy",
+		Destination: &cliConfig.Kubernetes.HostNetworkNamespace,
+		Value:       Kubernetes.HostNetworkNamespace,
+	},
 }
 
 // OvnNBFlags capture OVN northbound database options
@@ -978,10 +986,11 @@ func buildKubernetesConfig(exec kexec.Interface, cli, file *config, saPath strin
 
 	envConfig := savedKubernetes
 	envVarsMap := map[string]string{
-		"Kubeconfig": "KUBECONFIG",
-		"CACert":     "K8S_CACERT",
-		"APIServer":  "K8S_APISERVER",
-		"Token":      "K8S_TOKEN",
+		"Kubeconfig":           "KUBECONFIG",
+		"CACert":               "K8S_CACERT",
+		"APIServer":            "K8S_APISERVER",
+		"Token":                "K8S_TOKEN",
+		"HostNetworkNamespace": "OVN_HOST_NETWORK_NAMESPACE",
 	}
 	for k, v := range envVarsMap {
 		if x, exists := os.LookupEnv(v); exists && len(x) > 0 {

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -92,7 +92,7 @@ var (
 		APIServer:            DefaultAPIServer,
 		RawServiceCIDRs:      "172.16.1.0/24",
 		OVNConfigNamespace:   "ovn-kubernetes",
-		HostNetworkNamespace: "ovn-host-network",
+		HostNetworkNamespace: "",
 	}
 
 	// OVNKubernetesFeatureConfig holds OVN-Kubernetes feature enhancement config file parameters and command-line overrides

--- a/go-controller/pkg/node/OCP_HACKS.go
+++ b/go-controller/pkg/node/OCP_HACKS.go
@@ -35,7 +35,7 @@ func generateBlockMCSRules(rules *[]iptRule, protocol iptables.Protocol) {
 		}
 	}
 
-	delIptRules(delRules)
+	_ = delIptRules(delRules)
 }
 
 // initSharedGatewayNoBridge is used in order to run local gateway mode without moving the NIC to an ovs bridge

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -567,9 +567,10 @@ func (oc *Controller) syncGatewayLogicalNetwork(node *kapi.Node, l3GatewayConfig
 	return err
 }
 
-func (oc *Controller) ensureNodeLogicalNetwork(nodeName string, hostSubnets []*net.IPNet) error {
+func (oc *Controller) ensureNodeLogicalNetwork(node *kapi.Node, hostSubnets []*net.IPNet) error {
 	// logical router port MAC is based on IPv4 subnet if there is one, else IPv6
 	var nodeLRPMAC net.HardwareAddr
+	nodeName := node.Name
 	for _, hostSubnet := range hostSubnets {
 		gwIfAddr := util.GetNodeGatewayIfAddr(hostSubnet)
 		nodeLRPMAC = util.IPAddrToHWAddr(gwIfAddr.IP)
@@ -591,6 +592,7 @@ func (oc *Controller) ensureNodeLogicalNetwork(nodeName string, hostSubnets []*n
 	}
 
 	var v4Gateway net.IP
+	var hostNetworkPolicyIPs []net.IP
 	for _, hostSubnet := range hostSubnets {
 		gwIfAddr := util.GetNodeGatewayIfAddr(hostSubnet)
 		lrpArgs = append(lrpArgs, gwIfAddr.String())
@@ -601,8 +603,8 @@ func (oc *Controller) ensureNodeLogicalNetwork(nodeName string, hostSubnets []*n
 			)
 		} else {
 			v4Gateway = gwIfAddr.IP
-
 			mgmtIfAddr := util.GetNodeManagementIfAddr(hostSubnet)
+			hostNetworkPolicyIPs = append(hostNetworkPolicyIPs, mgmtIfAddr.IP)
 			excludeIPs := mgmtIfAddr.IP.String()
 			if config.HybridOverlay.Enabled {
 				hybridOverlayIfAddr := util.GetNodeHybridOverlayIfAddr(hostSubnet)
@@ -629,7 +631,34 @@ func (oc *Controller) ensureNodeLogicalNetwork(nodeName string, hostSubnets []*n
 		return err
 	}
 
-	// If supported, enable IGMP snooping and querier on the node.
+	// add the host network IPs for this node to host network namespace's address set
+	if err = func() error {
+		hostNetworkNamespace := config.Kubernetes.HostNetworkNamespace
+		if hostNetworkNamespace != "" {
+			nsInfo, err := oc.waitForNamespaceLocked(hostNetworkNamespace)
+			if err != nil {
+				klog.Errorf("Failed to get namespace %s (%v)",
+					hostNetworkNamespace, err)
+				return err
+			}
+			defer nsInfo.Unlock()
+			if nsInfo.addressSet == nil {
+				nsInfo.addressSet, err = oc.createNamespaceAddrSetAllPods(hostNetworkNamespace)
+				if err != nil {
+					return fmt.Errorf("cannot create address set for namespace: %s,"+
+						"error: %v", hostNetworkNamespace, err)
+				}
+			}
+			if err = nsInfo.addressSet.AddIPs(hostNetworkPolicyIPs); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		return err
+	}
+
+	// If supported, enable IGMP/MLD snooping and querier on the node.
 	if oc.multicastSupport {
 		stdout, stderr, err = util.RunOVNNbctl("set", "logical_switch",
 			nodeName, "other-config:mcast_snoop=\"true\"")
@@ -744,7 +773,7 @@ func (oc *Controller) addNode(node *kapi.Node) ([]*net.IPNet, error) {
 	hostSubnets, _ := util.ParseNodeHostSubnetAnnotation(node)
 	if hostSubnets != nil {
 		// Node already has subnet assigned; ensure its logical network is set up
-		return hostSubnets, oc.ensureNodeLogicalNetwork(node.Name, hostSubnets)
+		return hostSubnets, oc.ensureNodeLogicalNetwork(node, hostSubnets)
 	}
 
 	// Node doesn't have a subnet assigned; reserve a new one for it
@@ -764,7 +793,7 @@ func (oc *Controller) addNode(node *kapi.Node) ([]*net.IPNet, error) {
 	}()
 
 	// Ensure that the node's logical network has been created
-	err = oc.ensureNodeLogicalNetwork(node.Name, hostSubnets)
+	err = oc.ensureNodeLogicalNetwork(node, hostSubnets)
 	if err != nil {
 		return nil, err
 	}

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -42,10 +42,9 @@ import (
 )
 
 const (
-	egressfirewallCRD                string        = "egressfirewalls.k8s.ovn.org"
-	clusterPortGroupName             string        = "clusterPortGroup"
-	clusterRtrPortGroupName          string        = "clusterRtrPortGroup"
-	egressFirewallDNSDefaultDuration time.Duration = 30 * time.Minute
+	egressfirewallCRD       string = "egressfirewalls.k8s.ovn.org"
+	clusterPortGroupName    string = "clusterPortGroup"
+	clusterRtrPortGroupName string = "clusterRtrPortGroup"
 )
 
 // ServiceVIPKey is used for looking up service namespace information for a

--- a/go-controller/pkg/ovn/ovn_test.go
+++ b/go-controller/pkg/ovn/ovn_test.go
@@ -94,6 +94,7 @@ func (o *FakeOVN) init() {
 
 	o.stopChan = make(chan struct{})
 	o.watcher, err = factory.NewWatchFactory(o.fakeClient, o.fakeEgressIPClient, o.fakeEgressClient, o.fakeCRDClient)
+	Expect(err).NotTo(HaveOccurred())
 	if o.fakeEgressClient != nil {
 		o.watcher.InitializeEgressFirewallWatchFactory()
 	}

--- a/go-controller/pkg/util/util.go
+++ b/go-controller/pkg/util/util.go
@@ -40,6 +40,27 @@ const (
 	V4NodeLocalNatSubnetPrefix     = 20
 	V4NodeLocalNatSubnetNextHop    = "169.254.0.1"
 	V4NodeLocalDistributedGwPortIP = "169.254.0.2"
+	OVNClusterRouter               = "ovn_cluster_router"
+	GWRouterPrefix                 = "GR_"
+	OVNJoinSwitch                  = "join"
+	JoinSwitchToGWRouterPrefix     = "jtor-"
+	GWRouterToJoinSwitchPrefix     = "rtoj-"
+	ExternalSwitchPrefix           = "ext_"
+	GWRouterToExtSwitchPrefix      = "rtoe-"
+	EXTSwitchToGWRouterPrefix      = "etor-"
+	// LoadBalancer External Names
+	ClusterLBTCP          = "k8s-cluster-lb-tcp"
+	ClusterLBUDP          = "k8s-cluster-lb-udp"
+	ClusterLBSCTP         = "k8s-cluster-lb-sctp"
+	ClusterLBPrefix       = "k8s-cluster-lb"
+	ClusterIdlingLBPrefix = "k8s-idling-lb"
+	WorkerLBPrefix        = "k8s-worker-lb"
+	WorkerLBTCP           = WorkerLBPrefix + "-tcp"
+	WorkerLBUDP           = WorkerLBPrefix + "-udp"
+	WorkerLBSCTP          = WorkerLBPrefix + "-sctp"
+	GatewayLBTCP          = "TCP_lb_gateway_router"
+	GatewayLBUDP          = "UDP_lb_gateway_router"
+	GatewayLBSCTP         = "SCTP_lb_gateway_router"
 )
 
 // StringArg gets the named command-line argument or returns an error if it is empty


### PR DESCRIPTION
This PR cherry-picks commits needed for supporting allow-from-router feature to apply network policy to router endpoints when the endpoint publishing strategy is HostNetwork.