### PR TITLE
Bug 1985512: Add v6 management interface address for host network policy

### DIFF
--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -753,8 +753,9 @@ func (oc *Controller) ensureNodeLogicalNetwork(node *kapi.Node, hostSubnets []*n
 	var hostNetworkPolicyIPs []net.IP
 	for _, hostSubnet := range hostSubnets {
 		gwIfAddr := util.GetNodeGatewayIfAddr(hostSubnet)
+		mgmtIfAddr := util.GetNodeManagementIfAddr(hostSubnet)
 		lrpArgs = append(lrpArgs, gwIfAddr.String())
-
+		hostNetworkPolicyIPs = append(hostNetworkPolicyIPs, mgmtIfAddr.IP)
 		if utilnet.IsIPv6CIDR(hostSubnet) {
 			v6Gateway = gwIfAddr.IP
 
@@ -763,8 +764,6 @@ func (oc *Controller) ensureNodeLogicalNetwork(node *kapi.Node, hostSubnets []*n
 			)
 		} else {
 			v4Gateway = gwIfAddr.IP
-			mgmtIfAddr := util.GetNodeManagementIfAddr(hostSubnet)
-			hostNetworkPolicyIPs = append(hostNetworkPolicyIPs, mgmtIfAddr.IP)
 			excludeIPs := mgmtIfAddr.IP.String()
 			if config.HybridOverlay.Enabled {
 				hybridOverlayIfAddr := util.GetNodeHybridOverlayIfAddr(hostSubnet)


### PR DESCRIPTION
This commit adds the previously missing v6 management interface
address to the host network policy address set.

Signed-off-by: Aniket Bhat <anbhat@redhat.com>
(cherry picked from commit 255118c1031e9518bd04b111767f5e3ba8af0c5f)

