### PR TITLE
Bug 1986443: Fix pod handler race downstream

### DIFF
--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -448,7 +448,7 @@ func (oc *Controller) iterateRetryPods(updateAll bool) {
 		}
 		pod := podEntry.pod
 		if !util.PodScheduled(pod) {
-			return
+			continue
 		}
 		podTimer := podEntry.timeStamp.Add(time.Minute)
 		if updateAll || now.After(podTimer) {


### PR DESCRIPTION
Fixes another case where update pod and adding pods to retry could race. Also a trivial fix to skipping the pod when it is not scheduled.