### PR TITLE
Bug 1986573: Declare a maximum line length for batching

### DIFF
--- a/go-controller/pkg/util/ovs.go
+++ b/go-controller/pkg/util/ovs.go
@@ -906,7 +906,11 @@ func (t *NBTxn) AddOrCommit(args []string) (string, string, error) {
 		len(t.txnArgs), incomingLength, buffer)
 
 	// case where we are going to exceed max arguments
-	if len(t.args)+len(t.txnArgs)+incomingLength+buffer > maxArgs {
+	// also check entire line length is going be over 100k
+	// maximum bash command seems to be a combination of max args and length of each argument
+	// maximum length is PAGE_SIZE * 32 which we can assume to be 4k page, and equals 131072
+	if len(t.args)+len(t.txnArgs)+incomingLength+buffer > maxArgs || len(strings.Join(t.args, " "))+
+		len(strings.Join(t.txnArgs, " "))+len(strings.Join(args, " ")) > 100000 {
 		klog.Info("Requested transaction add is too large, committing...")
 		if stdout, stderr, err := t.Commit(); err != nil {
 			return stdout, stderr, err


### PR DESCRIPTION
There are still bash errors for "too many args" which stem not from the
number of arguments but a combination of number of args and total length
of the args. This sets the maximum line length to 100k, which is less
than the default maximum of 130k (to be safe).

Signed-off-by: Tim Rozet <trozet@redhat.com>
(cherry picked from commit 0f80eea1cd94bde568daa659869f7194baf03d9b)

This is the last fix that went in for batching commands that did not make it into 4.8.