### PR TITLE
[release-4.7] Bug 1991445: Bump OVN to 20.12.0-140.el8fdp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN yum install -y  \
 	yum clean all
 
 ARG ovsver=2.13.0-79.el8fdp
-ARG ovnver=20.12.0-24.el8fdp
+ARG ovnver=20.12.0-140.el8fdp
 
 RUN INSTALL_PKGS=" \
 	openssl python3-pyOpenSSL firewalld-filesystem \


### PR DESCRIPTION
Manual cherry-pick of https://github.com/openshift/ovn-kubernetes/pull/591 because automatic cherry-pick failed due to DockerFile conflicts.