### PR TITLE
Bug 1991793: [4.9] bump OVN to ovn21.09-21.09.0-12.el8fdp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN yum install -y  \
 	yum clean all
 
 ARG ovsver=2.15.0-28.el8fdp
-ARG ovnver=21.09.0-10.el8fdp
+ARG ovnver=21.09.0-12.el8fdp
 
 RUN INSTALL_PKGS=" \
 	openssl python3-pyOpenSSL firewalld-filesystem \


### PR DESCRIPTION
@abhat @alexanderConstantinescu @trozet 

Relevant changes include:

- [controller: Improve ct zone handling](http://patchwork.ozlabs.org/project/ovn/list/?series=256319&archive=both&state=*
) series which reduces the amount of work ovn-controller does when processing ct_zone changes.
- [northd: do not configure ECMP routes with wrong next-hop](https://github.com/ovn-org/ovn/commit/9cd64780d89c4acd2ae0c12693be66962ada97cd) for [rhbz#1978796](https://bugzilla.redhat.com/show_bug.cgi?id=1978796)
- [ofctrl: Add memory usage statistics](https://github.com/ovn-org/ovn/commit/7670db7ae137e97509f73cc48a5d792a1801a5bf)

Going to fail until mirrors sync and the -12 RPM becomes available in a few hours.