### PR TITLE
Bug 1903408: Merge externalTrafficPolicy ONLY

### DIFF
--- a/docs/design/external_traffic_policy.md
+++ b/docs/design/external_traffic_policy.md
@@ -1,0 +1,128 @@
+# K8's Services' ExternalTraffic Policy Implementation
+
+## Background 
+
+For [Kubernetes Services](https://kubernetes.io/docs/concepts/services-networking/service/) of type Nodeport or
+Loadbalancer a user can set the `service.spec.externalTrafficPolicy` field to either `cluster` or `local` to denote 
+whether or not external traffic is routed to cluster-wide or node-local endpoints. The default value for the 
+`externalTrafficPolicy` field is `cluster`. In this configuration in ingress traffic is equally disributed across all
+backends and the original client IP address is lost due to SNAT. If set to `local` then the client 
+source IP is propagated through the service and to the destination, while service traffic arriving at nodes without 
+local endpoints is dropped. 
+
+## Implementing `externalTrafficPolicy` In OVN-Kubernetes 
+
+To properly implement this feature for all relevant traffic flows, required changing how OVN, Iptables rules, and 
+Physical OVS flows are updated and managed in OVN-Kubernetes
+
+## New OVN Loabalancer 
+
+For services with `externalTrafficPolicy:local` traffic destined for a cluster networked pods will hit the new OVN 
+loadbalancer which resembles the following 
+
+```
+_uuid               : 8d317d7f-6818-4374-8dfa-fcf8685504b5
+external_ids        : {TCP_lb_gateway_router=GR_ovn-control-plane_local}
+health_check        : []
+ip_port_mappings    : {}
+name                : ""
+options             : {skip_snat="true"}
+protocol            : tcp
+selection_fields    : []
+vips                : {}
+```
+
+This new loabalancer contains the `_local` postfix along with the `skip_snat="true"` option and is applied to the
+GatewayRouters and Worker switches. It is needed to override the `lb_force_snat_ip=router_ip` option that is on all the Gateway Routers, which allows ingress traffic to arrive at OVN managed endpoints with the original client IP. All Vips 
+for services with `externalTrafficPolicy:local` will reside on this loadbalancer. 
+
+## Handling Flows between the overlay and underlay
+
+In this section I will explain some relevant traffic flows when a service's `externalTrafficPolicy` is `local`.  For 
+these examples we will be using a Nodeport service, but the flow is generally the same for ExternalIP and Loadbalancer 
+type services. 
+
+## Ingress Traffic 
+
+This section will cover the networking entities hit when traffic ingresses a cluster via a service to either host
+networked pods or cluster networked pods
+
+### External Source -> Service -> OVN pod
+
+This case is the same as normal shared gateway traffic ingress, meaning the externally sourced traffic is routed into 
+OVN via flows on breth0, except in this case the new local load balancer is hit on the GR, which ensures the ip of the 
+client is preserved  by the time it gets to the destination Pod. 
+
+```text
+          host (ovn-worker, 172.18.0.3) 
+           |
+eth0--->|breth0| -----> 172.18.0.3 OVN GR 100.64.0.4 --> join switch --> ovn_cluster_router --> 10.244.1.3 pod
+
+```
+
+### External Source -> Service -> Host Networked pod 
+
+This Scenario is a bit different, specifically traffic now needs to be directed from an external source to service and 
+then to the host itself(a host networked pod)
+
+In this flow, rather than going from breth0 into OVN we shortcircuit the path with physical flows on breth0 
+
+```text
+          host (ovn-worker, 172.18.0.3) 
+           ^
+           ^
+           |
+eth0--->|breth0| ---- 172.18.0.3 OVN GR 100.64.0.4 -- join switch -- ovn_cluster_router -- 10.244.1.3 pod
+
+```
+
+1. Match on the incoming traffic via it's nodePort, DNAT directly to the host networked endpoint, and send to `table=6` 
+
+```
+cookie=0x790ba3355d0c209b, duration=153.288s, table=0, n_packets=18, n_bytes=1468, idle_age=100, priority=100,tcp,in_port=1,tp_dst=<nodePort> actions=ct(commit,table=6,zone=64003,nat(dst=<nodeIP>:<targetIP>))
+```
+
+2. Send out the LOCAL ovs port on breth0, and traffic is delivered to host netwoked pod 
+
+```
+cookie=0x790ba3355d0c209b, duration=113.033s, table=6, n_packets=18, n_bytes=1468, priority=100 actions=LOCAL
+```
+
+3. Return traffic from the host networked pod to external source is matched in `table=7` based on the src_ip of the return 
+traffic being equal to `<targetIP>`, and un-Nat back to `<nodeIP>:<NodePort>`
+
+```
+ cookie=0x790ba3355d0c209b, duration=501.037s, table=0, n_packets=12, n_bytes=1259, idle_age=448, priority=100,tcp,in_port=LOCAL,tp_src=<targetIP> actions=ct(commit,table=7,zone=64003,nat)
+```
+
+4. Send the traffic back out breth0 back to the external source in `table=7`
+
+```
+cookie=0x790ba3355d0c209b, duration=501.037s, table=7, n_packets=12, n_bytes=1259, idle_age=448, priority=100 actions=output:1
+```
+
+## Host Traffic 
+
+This section will cover the networking entities hit when traffic travels from a cluster host via a service to either host
+networked pods or cluster networked pods
+
+### Host -> Service -> OVN Pod
+
+This case is similar to normal host -> Service -> OVN Pod except the SRC address of the Traffic will be that of the 
+management port `ovn-k8s-mp0` rather than the main address attatched to `eth0` on the host. 
+
+### Host -> Service -> Host 
+
+Again when the backend is a host networked pod we shortcircuit OVN to avoid SNAT and use iptables rules on the host
+to DNAT directly to the correct host endpoint.
+
+```
+-A OVN-KUBE-NODEPORT -p tcp -m addrtype --dst-type LOCAL -m tcp --dport 32126 -j DNAT --to-destination <nodeIP>:<targetIP>
+```
+
+## Intra Cluster traffic 
+
+For all service traffic that stays in the overlay the flows will remain the same for `externaltrafficpolicy:local`.  
+
+## Sources 
+- https://www.asykim.com/blog/deep-dive-into-kubernetes-external-traffic-policies

--- a/go-controller/pkg/factory/types.go
+++ b/go-controller/pkg/factory/types.go
@@ -42,6 +42,9 @@ type NodeWatchFactory interface {
 
 	NodeInformer() cache.SharedIndexInformer
 	LocalPodInformer() cache.SharedIndexInformer
+
+	GetService(namespace, name string) (*kapi.Service, error)
+	GetEndpoint(namespace, name string) (*kapi.Endpoints, error)
 }
 
 type Shutdownable interface {

--- a/go-controller/pkg/node/gateway.go
+++ b/go-controller/pkg/node/gateway.go
@@ -34,7 +34,7 @@ type gateway struct {
 	// portClaimWatcher is for reserving ports for virtual IPs allocated by the cluster on the host
 	portClaimWatcher informer.ServiceEventHandler
 	// nodePortWatcher is used in Shared GW mode to handle nodePort flows in shared OVS bridge
-	nodePortWatcher informer.ServiceEventHandler
+	nodePortWatcher informer.ServiceAndEndpointsEventHandler
 	// localPortWatcher is used in Local GW mode to handle iptables rules and routes for services
 	localPortWatcher informer.ServiceEventHandler
 	openflowManager  *openflowManager
@@ -107,17 +107,26 @@ func (g *gateway) AddEndpoints(ep *kapi.Endpoints) {
 	if g.loadBalancerHealthChecker != nil {
 		g.loadBalancerHealthChecker.AddEndpoints(ep)
 	}
+	if g.nodePortWatcher != nil {
+		g.nodePortWatcher.AddEndpoints(ep)
+	}
 }
 
 func (g *gateway) UpdateEndpoints(old, new *kapi.Endpoints) {
 	if g.loadBalancerHealthChecker != nil {
 		g.loadBalancerHealthChecker.UpdateEndpoints(old, new)
 	}
+	if g.nodePortWatcher != nil {
+		g.nodePortWatcher.UpdateEndpoints(old, new)
+	}
 }
 
 func (g *gateway) DeleteEndpoints(ep *kapi.Endpoints) {
 	if g.loadBalancerHealthChecker != nil {
 		g.loadBalancerHealthChecker.DeleteEndpoints(ep)
+	}
+	if g.nodePortWatcher != nil {
+		g.nodePortWatcher.DeleteEndpoints(ep)
 	}
 }
 

--- a/go-controller/pkg/node/gateway_init.go
+++ b/go-controller/pkg/node/gateway_init.go
@@ -207,7 +207,8 @@ func (n *OvnNode) initGateway(subnets []*net.IPNet, nodeAnnotator kube.Annotator
 		gw, err = newLocalGateway(n.name, subnets, gatewayNextHops, gatewayIntf, nodeAnnotator, n.recorder, managementPortConfig)
 	case config.GatewayModeShared:
 		klog.Info("Preparing Shared Gateway")
-		gw, err = newSharedGateway(n.name, subnets, gatewayNextHops, gatewayIntf, egressGWInterface, nodeAnnotator)
+		gw, err = newSharedGateway(n.name, subnets, gatewayNextHops, gatewayIntf, egressGWInterface, nodeAnnotator,
+			managementPortConfig, n.watchFactory)
 	case config.GatewayModeDisabled:
 		var chassisID string
 		klog.Info("Gateway Mode is disabled")

--- a/go-controller/pkg/node/gateway_iptables.go
+++ b/go-controller/pkg/node/gateway_iptables.go
@@ -144,20 +144,43 @@ func getNodePortIPTRules(svcPort kapi.ServicePort, targetIP string, targetPort i
 	} else {
 		protocol = iptables.ProtocolIPv4
 	}
-	natArgs := []string{
-		"-p", string(svcPort.Protocol),
-		"-m", "addrtype",
-		"--dst-type", "LOCAL",
-		"--dport", fmt.Sprintf("%d", svcPort.NodePort),
-		"-j", "DNAT",
-		"--to-destination", util.JoinHostPortInt32(targetIP, targetPort),
+	return []iptRule{
+		{
+			table: "nat",
+			chain: iptableNodePortChain,
+			args: []string{
+				"-p", string(svcPort.Protocol),
+				"-m", "addrtype",
+				"--dst-type", "LOCAL",
+				"--dport", fmt.Sprintf("%d", svcPort.NodePort),
+				"-j", "DNAT",
+				"--to-destination", util.JoinHostPortInt32(targetIP, targetPort),
+			},
+			protocol: protocol,
+		},
+	}
+}
+
+func getNodePortLocalIPTRules(svcPort kapi.ServicePort, targetIP string, targetPort int32) []iptRule {
+	var protocol iptables.Protocol
+	if utilnet.IsIPv6String(targetIP) {
+		protocol = iptables.ProtocolIPv6
+	} else {
+		protocol = iptables.ProtocolIPv4
 	}
 
 	return []iptRule{
 		{
-			table:    "nat",
-			chain:    iptableNodePortChain,
-			args:     natArgs,
+			table: "nat",
+			chain: iptableNodePortChain,
+			args: []string{
+				"-p", string(svcPort.Protocol),
+				"-m", "addrtype",
+				"--dst-type", "LOCAL",
+				"--dport", fmt.Sprintf("%d", svcPort.NodePort),
+				"-j", "REDIRECT",
+				"--to-port", fmt.Sprintf("%d", targetPort),
+			},
 			protocol: protocol,
 		},
 	}
@@ -180,6 +203,29 @@ func getExternalIPTRules(svcPort kapi.ServicePort, externalIP, dstIP string) []i
 				"--dport", fmt.Sprintf("%v", svcPort.Port),
 				"-j", "DNAT",
 				"--to-destination", util.JoinHostPortInt32(dstIP, svcPort.Port),
+			},
+			protocol: protocol,
+		},
+	}
+}
+
+func getExternalLocalIPTRules(svcPort kapi.ServicePort, externalIP string, targetPort int32) []iptRule {
+	var protocol iptables.Protocol
+	if utilnet.IsIPv6String(externalIP) {
+		protocol = iptables.ProtocolIPv6
+	} else {
+		protocol = iptables.ProtocolIPv4
+	}
+	return []iptRule{
+		{
+			table: "nat",
+			chain: iptableExternalIPChain,
+			args: []string{
+				"-p", string(svcPort.Protocol),
+				"-d", externalIP,
+				"--dport", fmt.Sprintf("%v", svcPort.Port),
+				"-j", "REDIRECT",
+				"--to-port", fmt.Sprintf("%v", targetPort),
 			},
 			protocol: protocol,
 		},
@@ -315,7 +361,7 @@ func recreateIPTRules(table, chain string, keepIPTRules []iptRule) {
 // only incoming traffic on that IP will be accepted for NodePort rules; otherwise incoming traffic on the NodePort
 // on all IPs will be accepted. If gatewayIP is "", then NodePort traffic will be DNAT'ed to the service port on
 // the service's ClusterIP. Otherwise, it will be DNAT'ed to the NodePort on the gatewayIP.
-func getGatewayIPTRules(service *kapi.Service, gatewayIPs []string) []iptRule {
+func getGatewayIPTRules(service *kapi.Service, gatewayIPs []string, hasLocalHostEndpoint bool) []iptRule {
 	rules := make([]iptRule, 0)
 	clusterIPs := util.GetClusterIPs(service)
 	for _, svcPort := range service.Spec.Ports {
@@ -331,9 +377,17 @@ func getGatewayIPTRules(service *kapi.Service, gatewayIPs []string) []iptRule {
 				continue
 			}
 			if gatewayIPs == nil {
-				for _, clusterIP := range clusterIPs {
-					rules = append(rules, getNodePortIPTRules(svcPort, clusterIP, svcPort.Port)...)
+				if !hasLocalHostEndpoint {
+					for _, clusterIP := range clusterIPs {
+						rules = append(rules, getNodePortIPTRules(svcPort, clusterIP, svcPort.Port)...)
+					}
+				} else {
+					// Port redirect host -> Nodeport -> host traffic directly to endpoint
+					for _, clusterIP := range clusterIPs {
+						rules = append(rules, getNodePortLocalIPTRules(svcPort, clusterIP, int32(svcPort.TargetPort.IntValue()))...)
+					}
 				}
+				// (astoycos) TODO remove me with LGW fix
 			} else {
 				for _, gatewayIP := range gatewayIPs {
 					rules = append(rules, getNodePortIPTRules(svcPort, gatewayIP, svcPort.Port)...)
@@ -347,7 +401,12 @@ func getGatewayIPTRules(service *kapi.Service, gatewayIPs []string) []iptRule {
 				continue
 			}
 			if clusterIP, err := util.MatchIPStringFamily(utilnet.IsIPv6String(externalIP), clusterIPs); err == nil {
-				rules = append(rules, getExternalIPTRules(svcPort, externalIP, clusterIP)...)
+				if hasLocalHostEndpoint {
+					// Port redirect host -> ExternalIP -> host
+					rules = append(rules, getExternalLocalIPTRules(svcPort, externalIP, int32(svcPort.TargetPort.IntValue()))...)
+				} else {
+					rules = append(rules, getExternalIPTRules(svcPort, externalIP, clusterIP)...)
+				}
 			}
 		}
 	}

--- a/go-controller/pkg/node/gateway_localnet.go
+++ b/go-controller/pkg/node/gateway_localnet.go
@@ -272,7 +272,7 @@ func (l *localPortWatcher) SyncServices(serviceInterface []interface{}) {
 			klog.Errorf("Spurious object in syncServices: %v", serviceInterface)
 			continue
 		}
-		keepIPTRules = append(keepIPTRules, getGatewayIPTRules(svc, []string{l.gatewayIPv4, l.gatewayIPv6})...)
+		keepIPTRules = append(keepIPTRules, getGatewayIPTRules(svc, []string{l.gatewayIPv4, l.gatewayIPv6}, false)...)
 	}
 	for _, chain := range []string{iptableNodePortChain, iptableExternalIPChain} {
 		recreateIPTRules("nat", chain, keepIPTRules)

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -361,7 +361,7 @@ func addServiceRules(service *kapi.Service, hasHostNet bool, npw *nodePortWatche
 	} else {
 		npw.updateServiceFlowCache(service, true, false)
 		npw.ofm.requestFlowSync()
-		addSharedGatewayIptRules(service, true)
+		addSharedGatewayIptRules(service, false)
 	}
 }
 

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -11,11 +11,13 @@ import (
 
 	"github.com/coreos/go-iptables/iptables"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 
 	kapi "k8s.io/api/core/v1"
+	ktypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
 	utilnet "k8s.io/utils/net"
 )
@@ -26,16 +28,43 @@ const (
 	defaultOpenFlowCookie = "0xdeff105"
 )
 
-// nodePortWatcher manages OpenfLow and iptables rules
+var (
+	HostMasqCTZone     = config.Default.ConntrackZone + 1 //64001
+	OVNMasqCTZone      = HostMasqCTZone + 1               //64002
+	HostNodePortCTZone = config.Default.ConntrackZone + 3 //64003
+)
+
+// nodePortWatcher manages OpenFlow and iptables rules
 // to ensure that services using NodePorts are accessible
 type nodePortWatcher struct {
+	gatewayIPv4 string
+	gatewayIPv6 string
 	ofportPhys  string
 	ofportPatch string
 	gwBridge    string
-	ofm         *openflowManager
+	// Map of service name to programmed iptables/OF rules
+	serviceInfo     map[ktypes.NamespacedName]*serviceConfig
+	serviceInfoLock sync.Mutex
+	ofm             *openflowManager
+	nodeIPManager   *addressManager
+	watchFactory    factory.NodeWatchFactory
 }
 
-func (npw *nodePortWatcher) updateServiceFlowCache(service *kapi.Service, add bool) {
+type serviceConfig struct {
+	// Contains the current service
+	service *kapi.Service
+	// Were those rules etp:local + Host Networked rules
+	etpHostRules bool
+}
+
+// updateServiceFlowCache handles managing shared gateway flows for ingress traffic towards kubernetes services
+// (nodeport, external, ingress). By default incoming traffic into the node is steered directly into OVN.
+// If a service has externalTrafficPolicy local, and has host-networked endpoints, traffic instead will be steered directly
+// into the host.
+// add parameter indicates if the flows should exist or be removed from the cache
+// epHostLocal indicates if a host networked endpoint exists for this
+// service func (npw *nodePortWatcher) updateServiceFlowCache(service *kapi.Service, add bool, epHostLocal bool) {
+func (npw *nodePortWatcher) updateServiceFlowCache(service *kapi.Service, add bool, epHostLocal bool) {
 	var cookie, key string
 	var err error
 
@@ -70,8 +99,42 @@ func (npw *nodePortWatcher) updateServiceFlowCache(service *kapi.Service, add bo
 					cookie = "0"
 				}
 				key = strings.Join([]string{"NodePort", service.Namespace, service.Name, flowProtocol, fmt.Sprintf("%d", svcPort.NodePort)}, "_")
+				// Delete if needed and skip to next protocol
 				if !add {
 					npw.ofm.deleteFlowsByKey(key)
+					continue
+				}
+				// (astoycos) TODO combine flow generation into a single function
+				// This allows external traffic ingress when the svc's ExternalTrafficPolicy is
+				// set to Local, and the backend pod is HostNetworked. We need to add
+				// Flows that will DNAT all traffic coming into nodeport to the nodeIP:Port and
+				// ensure that the return traffic is UnDNATed to correct the nodeIP:Nodeport
+				if epHostLocal {
+					var nodeportFlows []string
+					klog.V(5).Infof("Adding flows on breth0 for Nodeport Service %s in Namespace: %s since ExternalTrafficPolicy=local", service.Name, service.Namespace)
+					// table 0, This rule matches on all traffic with dst port == NodePort, DNAT's it to the correct NodeIP
+					// If ipv6 make sure to choose the ipv6 node address), and sends to table 6
+					if strings.Contains(flowProtocol, "6") {
+						nodeportFlows = append(nodeportFlows,
+							fmt.Sprintf("cookie=%s, priority=110, in_port=%s, %s, tp_dst=%d, actions=ct(commit,zone=%d,nat(dst=[%s]:%s),table=6)",
+								cookie, npw.ofportPhys, flowProtocol, svcPort.NodePort, HostNodePortCTZone, npw.gatewayIPv6, svcPort.TargetPort.String()))
+					} else {
+						nodeportFlows = append(nodeportFlows,
+							fmt.Sprintf("cookie=%s, priority=110, in_port=%s, %s, tp_dst=%d, actions=ct(commit,zone=%d,nat(dst=%s:%s),table=6)",
+								cookie, npw.ofportPhys, flowProtocol, svcPort.NodePort, HostNodePortCTZone, npw.gatewayIPv4, svcPort.TargetPort.String()))
+					}
+					nodeportFlows = append(nodeportFlows,
+						// table 6, Sends the packet to the host
+						fmt.Sprintf("cookie=%s, priority=110, table=6, actions=output:LOCAL",
+							cookie),
+						// table 0, Matches on return traffic, i.e traffic coming from the host networked pod's port, and unDNATs
+						fmt.Sprintf("cookie=%s, priority=110, in_port=LOCAL, %s, tp_src=%s, actions=ct(zone=%d nat,table=7)",
+							cookie, flowProtocol, svcPort.TargetPort.String(), HostNodePortCTZone),
+						// table 7, Sends the packet back out eth0 to the external client
+						fmt.Sprintf("cookie=%s, priority=110, table=7, "+
+							"actions=output:%s", cookie, npw.ofportPhys))
+
+					npw.ofm.updateFlowCacheEntry(key, nodeportFlows)
 				} else {
 					npw.ofm.updateFlowCacheEntry(key, []string{
 						fmt.Sprintf("cookie=%s, priority=110, in_port=%s, %s, tp_dst=%d, "+
@@ -83,7 +146,6 @@ func (npw *nodePortWatcher) updateServiceFlowCache(service *kapi.Service, add bo
 				}
 			}
 		}
-
 		// Flows for cloud load balancers on Azure/GCP
 		// Established traffic is handled by default conntrack rules
 		// NodePort/Ingress access in the OVS bridge will only ever come from outside of the host
@@ -111,8 +173,43 @@ func (npw *nodePortWatcher) updateServiceFlowCache(service *kapi.Service, add bo
 				nwSrc = "ipv6_src"
 			}
 			key = strings.Join([]string{"Ingress", service.Namespace, service.Name, ingIP.String(), fmt.Sprintf("%d", svcPort.Port)}, "_")
+			// Delete if needed and skip to next protocol
 			if !add {
 				npw.ofm.deleteFlowsByKey(key)
+				continue
+			}
+
+			// This allows external traffic ingress when the svc's ExternalTrafficPolicy is
+			// set to Local, and the backend pod is HostNetworked. We need to add
+			// Flows that will DNAT all external traffic destined for the lb service
+			// to the nodeIP and ensure That return traffic is UnDNATed correctly back
+			// to the ingress ip
+			if epHostLocal {
+				var nodeportFlows []string
+				klog.V(5).Infof("Adding flows on breth0 for Loadbalancer Service %s in Namespace: %s since ExternalTrafficPolicy=local", service.Name, service.Namespace)
+				// table 0, This rule matches on all traffic with dst port == LoadbalancerIP, DNAT's it to the correct NodeIP
+				// If ipv6 make sure to choose the ipv6 node address for rule
+				if strings.Contains(flowProtocol, "6") {
+					nodeportFlows = append(nodeportFlows,
+						fmt.Sprintf("cookie=%s, priority=110, in_port=%s, %s, %s=%s, tp_dst=%d, actions=ct(commit,zone=%d,nat(dst=[%s]:%s),table=6)",
+							cookie, npw.ofportPhys, flowProtocol, nwDst, ing.IP, svcPort.Port, HostNodePortCTZone, npw.gatewayIPv6, svcPort.TargetPort.String()))
+				} else {
+					nodeportFlows = append(nodeportFlows,
+						fmt.Sprintf("cookie=%s, priority=110, in_port=%s, %s, %s=%s, tp_dst=%d, actions=ct(commit,zone=%d,nat(dst=%s:%s),table=6)",
+							cookie, npw.ofportPhys, flowProtocol, nwDst, ing.IP, svcPort.Port, HostNodePortCTZone, npw.gatewayIPv4, svcPort.TargetPort.String()))
+				}
+				nodeportFlows = append(nodeportFlows,
+					// table 6, Sends the packet to the host
+					fmt.Sprintf("cookie=%s, priority=110, table=6, actions=output:LOCAL",
+						cookie),
+					// table 0, Matches on return traffic, i.e traffic coming from the host networked pod's port, and unDNATs
+					fmt.Sprintf("cookie=%s, priority=110, in_port=LOCAL, %s, tp_src=%s, actions=ct(commit,zone=%d nat,table=7)",
+						cookie, flowProtocol, svcPort.TargetPort.String(), HostNodePortCTZone),
+					// table 7, the packet back out eth0 to the external client
+					fmt.Sprintf("cookie=%s, priority=110, table=7, "+
+						"actions=output:%s", cookie, npw.ofportPhys))
+
+				npw.ofm.updateFlowCacheEntry(key, nodeportFlows)
 			} else {
 				npw.ofm.updateFlowCacheEntry(key, []string{
 					fmt.Sprintf("cookie=%s, priority=110, in_port=%s, %s, %s=%s, tp_dst=%d, "+
@@ -140,8 +237,42 @@ func (npw *nodePortWatcher) updateServiceFlowCache(service *kapi.Service, add bo
 				cookie = "0"
 			}
 			key := strings.Join([]string{"External", service.Namespace, service.Name, externalIP, fmt.Sprintf("%d", svcPort.Port)}, "_")
+			// Delete if needed and skip to next protocol
 			if !add {
 				npw.ofm.deleteFlowsByKey(key)
+				continue
+			}
+			// This allows external traffic ingress when the svc's ExternalTrafficPolicy is
+			// set to Local, and the backend pod is HostNetworked. We need to add
+			// Flows that will DNAT all external traffic destined for externalIP service
+			// to the nodeIP:port of the host networked backend. And Then ensure That return
+			// traffic is UnDNATed correctly back to the external IP
+			if epHostLocal {
+				var nodeportFlows []string
+				klog.V(5).Infof("Adding flows on breth0 for ExternalIP Service %s in Namespace: %s since ExternalTrafficPolicy=local", service.Name, service.Namespace)
+				// table 0, This rule matches on all traffic with dst ip == externalIP and DNAT's it to the correct NodeIP
+				// If ipv6 make sure to choose the ipv6 node address for rule
+				if strings.Contains(flowProtocol, "6") {
+					nodeportFlows = append(nodeportFlows,
+						fmt.Sprintf("cookie=%s, priority=110, in_port=%s, %s, %s=%s, tp_dst=%d, actions=ct(commit,zone=%d,nat(dst=[%s]:%s),table=6)",
+							cookie, npw.ofportPhys, flowProtocol, nwDst, externalIP, svcPort.Port, HostNodePortCTZone, npw.gatewayIPv6, svcPort.TargetPort.String()))
+				} else {
+					nodeportFlows = append(nodeportFlows,
+						fmt.Sprintf("cookie=%s, priority=110, in_port=%s, %s, %s=%s, tp_dst=%d, actions=ct(commit,zone=%d,nat(dst=%s:%s),table=6)",
+							cookie, npw.ofportPhys, flowProtocol, nwDst, externalIP, svcPort.Port, HostNodePortCTZone, npw.gatewayIPv4, svcPort.TargetPort.String()))
+				}
+				nodeportFlows = append(nodeportFlows,
+					// table 6, Sends the packet to the host
+					fmt.Sprintf("cookie=%s, priority=110, table=6, actions=output:LOCAL",
+						cookie),
+					// table 0, Matches on return traffic, i.e traffic coming from the host networked pod's port, and unDNATs
+					fmt.Sprintf("cookie=%s, priority=110, in_port=LOCAL, %s, tp_src=%s, actions=ct(commit,zone=%d nat,table=7)",
+						cookie, flowProtocol, svcPort.TargetPort.String(), HostNodePortCTZone),
+					// table 7, Sends the packet back out eth0 to the external client
+					fmt.Sprintf("cookie=%s, priority=110, table=7, "+
+						"actions=output:%s", cookie, npw.ofportPhys))
+
+				npw.ofm.updateFlowCacheEntry(key, nodeportFlows)
 			} else {
 				npw.ofm.updateFlowCacheEntry(key, []string{
 					fmt.Sprintf("cookie=%s, priority=110, in_port=%s, %s, %s=%s, tp_dst=%d, "+
@@ -155,69 +286,285 @@ func (npw *nodePortWatcher) updateServiceFlowCache(service *kapi.Service, add bo
 	}
 }
 
-// AddService handles configuring shared gateway bridge flows to steer External IP, Node Port, Ingress LB traffic into OVN
-func (npw *nodePortWatcher) AddService(service *kapi.Service) {
-
-	// don't process headless service or services that doesn't have NodePorts or ExternalIPs
-	if !util.ServiceTypeHasClusterIP(service) || !util.IsClusterIPSet(service) {
-		return
-	}
-	npw.updateServiceFlowCache(service, true)
-	npw.ofm.requestFlowSync()
-	addSharedGatewayIptRules(service)
+// getAndDeleteServiceInfo returns the serviceConfig for a service and if it exists and then deletes the entry
+func (npw *nodePortWatcher) getAndDeleteServiceInfo(index ktypes.NamespacedName) (out *serviceConfig, exists bool) {
+	npw.serviceInfoLock.Lock()
+	defer npw.serviceInfoLock.Unlock()
+	out, exists = npw.serviceInfo[index]
+	delete(npw.serviceInfo, index)
+	return out, exists
 }
 
-func (npw *nodePortWatcher) UpdateService(old, new *kapi.Service) {
-	if reflect.DeepEqual(new.Spec.Ports, old.Spec.Ports) &&
+// getServiceInfo returns the serviceConfig for a service and if it exists
+func (npw *nodePortWatcher) getServiceInfo(index ktypes.NamespacedName) (out *serviceConfig, exists bool) {
+	npw.serviceInfoLock.Lock()
+	defer npw.serviceInfoLock.Unlock()
+	out, exists = npw.serviceInfo[index]
+	return out, exists
+}
+
+// getAndSetServiceInfo creates and sets the serviceConfig, returns if it existed and whatever was there
+func (npw *nodePortWatcher) getAndSetServiceInfo(index ktypes.NamespacedName, service *kapi.Service, etpHostRules bool) (old *serviceConfig, exists bool) {
+	npw.serviceInfoLock.Lock()
+	defer npw.serviceInfoLock.Unlock()
+
+	old, exists = npw.serviceInfo[index]
+	npw.serviceInfo[index] = &serviceConfig{service: service, etpHostRules: etpHostRules}
+	return old, exists
+}
+
+// addOrSetServiceInfo creates and sets the serviceConfig if it doesn't exist
+func (npw *nodePortWatcher) addOrSetServiceInfo(index ktypes.NamespacedName, service *kapi.Service, etpHostRules bool) (exists bool) {
+	npw.serviceInfoLock.Lock()
+	defer npw.serviceInfoLock.Unlock()
+
+	if _, exists := npw.serviceInfo[index]; !exists {
+		// Only set this if it doesn't exist
+		npw.serviceInfo[index] = &serviceConfig{service: service, etpHostRules: etpHostRules}
+		return false
+	}
+	return true
+
+}
+
+// updateServiceInfo sets the serviceConfig for a service and returns the existing serviceConfig, if inputs are nil
+// do not update those fields, if it does not exist return nil.
+func (npw *nodePortWatcher) updateServiceInfo(index ktypes.NamespacedName, service *kapi.Service, etpHostRules *bool) (old *serviceConfig, exists bool) {
+
+	npw.serviceInfoLock.Lock()
+	defer npw.serviceInfoLock.Unlock()
+
+	if old, exists = npw.serviceInfo[index]; !exists {
+		klog.V(5).Infof("No serviceConfig found for service %s in namespace %s", index.Name, index.Namespace)
+		return nil, exists
+	}
+
+	if service != nil {
+		npw.serviceInfo[index].service = service
+	}
+
+	if etpHostRules != nil {
+		npw.serviceInfo[index].etpHostRules = *etpHostRules
+	}
+
+	return old, exists
+}
+
+// addServiceRules ensures the correct iptables rules and OpenFlow physical
+// flows are programmed for a given service and hostNetwork endpoint configuration
+func addServiceRules(service *kapi.Service, hasHostNet bool, npw *nodePortWatcher) {
+	if util.ServiceExternalTrafficPolicyLocal(service) && hasHostNet {
+		klog.V(5).Infof("Adding externalTrafficPolicy:local and hostNetworked rules for %v", service)
+		npw.updateServiceFlowCache(service, true, true)
+		npw.ofm.requestFlowSync()
+		addSharedGatewayIptRules(service, true)
+	} else {
+		npw.updateServiceFlowCache(service, true, false)
+		npw.ofm.requestFlowSync()
+		addSharedGatewayIptRules(service, true)
+	}
+}
+
+// delServiceRules deletes all possible iptables rules and OpenFlow physical
+// flows for a service
+func delServiceRules(service *kapi.Service, npw *nodePortWatcher) {
+	npw.updateServiceFlowCache(service, false, false)
+	npw.ofm.requestFlowSync()
+	// Always try and delete all rules here
+	delSharedGatewayIptRules(service, true)
+	delSharedGatewayIptRules(service, false)
+}
+
+func serviceUpdateNeeded(old, new *kapi.Service) bool {
+	return reflect.DeepEqual(new.Spec.Ports, old.Spec.Ports) &&
 		reflect.DeepEqual(new.Spec.ExternalIPs, old.Spec.ExternalIPs) &&
 		reflect.DeepEqual(new.Spec.ClusterIP, old.Spec.ClusterIP) &&
 		reflect.DeepEqual(new.Spec.Type, old.Spec.Type) &&
-		reflect.DeepEqual(new.Status.LoadBalancer.Ingress, old.Status.LoadBalancer.Ingress) {
+		reflect.DeepEqual(new.Status.LoadBalancer.Ingress, old.Status.LoadBalancer.Ingress) &&
+		reflect.DeepEqual(new.Spec.ExternalTrafficPolicy, old.Spec.ExternalTrafficPolicy)
+}
+
+// AddService handles configuring shared gateway bridge flows to steer External IP, Node Port, Ingress LB traffic into OVN
+func (npw *nodePortWatcher) AddService(service *kapi.Service) {
+	var etpHostRules bool
+	if !util.ServiceTypeHasClusterIP(service) || !util.IsClusterIPSet(service) {
+		return
+	}
+
+	klog.V(5).Infof("Adding service %s in namespace %s", service.Name, service.Namespace)
+	name := ktypes.NamespacedName{Namespace: service.Namespace, Name: service.Name}
+	ep, err := npw.watchFactory.GetEndpoint(service.Namespace, service.Name)
+	if err != nil {
+		klog.V(5).Infof("No endpoint found for service %s in namespace %s during service Add", service.Name, service.Namespace)
+		// No endpoints exist yet so default to false
+		etpHostRules = false
+	} else {
+		etpHostRules = hasHostNetworkEndpoints(ep, &npw.nodeIPManager.addresses)
+	}
+
+	// If something didn't already do it add correct Service rules
+	if exists := npw.addOrSetServiceInfo(name, service, etpHostRules); !exists {
+		klog.V(5).Infof("Service Add %s event in namespace %s came before endpoint event setting svcConfig", service.Name, service.Namespace)
+		addServiceRules(service, etpHostRules, npw)
+	} else {
+		klog.V(5).Infof("Rules already programmed for %s in namespace %s", service.Name, service.Namespace)
+	}
+}
+
+func (npw *nodePortWatcher) UpdateService(old, new *kapi.Service) {
+	name := ktypes.NamespacedName{Namespace: old.Namespace, Name: old.Name}
+
+	if serviceUpdateNeeded(old, new) {
 		klog.V(5).Infof("Skipping service update for: %s as change does not apply to any of .Spec.Ports, "+
 			".Spec.ExternalIP, .Spec.ClusterIP, .Spec.Type, .Status.LoadBalancer.Ingress", new.Name)
 		return
 	}
-	needFlowSync := false
+
+	// Update the service in svcConfig if we need to so that other handler
+	// threads do the correct thing, leave etpHostRules alone in the cache
+	svcConfig, exists := npw.updateServiceInfo(name, new, nil)
+	if !exists {
+		klog.V(5).Infof("Service %s in namespace %s was deleted during service Update", old.Name, old.Namespace)
+		return
+	}
+
 	if util.ServiceTypeHasClusterIP(old) && util.IsClusterIPSet(old) {
-		npw.updateServiceFlowCache(old, false)
-		delSharedGatewayIptRules(old)
-		needFlowSync = true
+		// Delete old rules if needed, but don't delete svcConfig
+		// so that we don't miss any endpoint update events here
+		klog.V(5).Infof("Deleting old service rules for: %v", old)
+		delServiceRules(old, npw)
 	}
 
 	if util.ServiceTypeHasClusterIP(new) && util.IsClusterIPSet(new) {
-		npw.updateServiceFlowCache(new, true)
-		addSharedGatewayIptRules(new)
-		needFlowSync = true
-	}
-
-	if needFlowSync {
-		npw.ofm.requestFlowSync()
+		klog.V(5).Infof("Adding new service rules for: %v", new)
+		addServiceRules(new, svcConfig.etpHostRules, npw)
 	}
 }
-
 func (npw *nodePortWatcher) DeleteService(service *kapi.Service) {
-	// don't process headless service
 	if !util.ServiceTypeHasClusterIP(service) || !util.IsClusterIPSet(service) {
 		return
 	}
-	npw.updateServiceFlowCache(service, false)
-	npw.ofm.requestFlowSync()
-	delSharedGatewayIptRules(service)
+
+	klog.V(5).Infof("Deleting service %s in namespace %s", service.Name, service.Namespace)
+	name := ktypes.NamespacedName{Namespace: service.Namespace, Name: service.Name}
+	if svcConfig, exists := npw.getAndDeleteServiceInfo(name); exists {
+		delServiceRules(svcConfig.service, npw)
+	} else {
+		klog.Warningf("Deletion failed No service found in cache for endpoint %s in namespace %s", service.Name, service.Namespace)
+	}
+
 }
 
 func (npw *nodePortWatcher) SyncServices(services []interface{}) {
+	keepIPTRules := []iptRule{}
 	for _, serviceInterface := range services {
+		name := ktypes.NamespacedName{Namespace: serviceInterface.(*kapi.Service).Namespace, Name: serviceInterface.(*kapi.Service).Name}
+
 		service, ok := serviceInterface.(*kapi.Service)
 		if !ok {
 			klog.Errorf("Spurious object in syncServices: %v",
 				serviceInterface)
 			continue
 		}
-		npw.updateServiceFlowCache(service, true)
+
+		ep, err := npw.watchFactory.GetEndpoint(service.Namespace, service.Name)
+		if err != nil {
+			klog.V(5).Infof("No endpoint found for service %s in namespace %s during sync", service.Name, service.Namespace)
+			continue
+		}
+
+		hasHostNet := hasHostNetworkEndpoints(ep, &npw.nodeIPManager.addresses)
+		npw.getAndSetServiceInfo(name, service, hasHostNet)
+		// Delete OF rules for service if they exist
+		npw.updateServiceFlowCache(service, false, hasHostNet)
+		npw.updateServiceFlowCache(service, true, hasHostNet)
+		// Add correct iptables rules
+		keepIPTRules = append(keepIPTRules, getGatewayIPTRules(service, nil, hasHostNet)...)
+	}
+	// sync OF rules once
+	npw.ofm.requestFlowSync()
+	// sync IPtables rules once
+	for _, chain := range []string{iptableNodePortChain, iptableExternalIPChain} {
+		recreateIPTRules("nat", chain, keepIPTRules)
+	}
+}
+
+func (npw *nodePortWatcher) AddEndpoints(ep *kapi.Endpoints) {
+	var etpHostRules bool
+	name := ktypes.NamespacedName{Namespace: ep.Namespace, Name: ep.Name}
+
+	svc, err := npw.watchFactory.GetService(ep.Namespace, ep.Name)
+	if err != nil {
+		// This is not necessarily an error. For e.g when there are endpoints
+		// without a corresponding service.
+		klog.V(5).Infof("No service found for endpoint %s in namespace %s during add", ep.Name, ep.Namespace)
+		return
 	}
 
-	npw.ofm.requestFlowSync()
-	syncSharedGatewayIptRules(services)
+	if !util.ServiceTypeHasClusterIP(svc) || !util.IsClusterIPSet(svc) {
+		return
+	}
+
+	klog.V(5).Infof("Adding endpoints %s in namespace %s", ep.Name, ep.Namespace)
+	etpHostRules = hasHostNetworkEndpoints(ep, &npw.nodeIPManager.addresses)
+
+	// Here we make sure the correct rules are programmed whenever an AddEndpoint
+	// event is received, only alter flows if we need to, i.e if cache wasn't
+	// set or if it was and etpHostRules state changed, to prevent flow churn
+	out, exists := npw.getAndSetServiceInfo(name, svc, etpHostRules)
+	if !exists {
+		klog.V(5).Infof("Endpoint %s ADD event in namespace %s is creating rules", ep.Name, ep.Namespace)
+		addServiceRules(svc, etpHostRules, npw)
+		return
+	}
+
+	if out.etpHostRules != etpHostRules {
+		klog.V(5).Infof("Endpoint %s ADD event in namespace %s is updating rules", ep.Name, ep.Namespace)
+		delServiceRules(svc, npw)
+		addServiceRules(svc, etpHostRules, npw)
+	}
+
+}
+
+func (npw *nodePortWatcher) DeleteEndpoints(ep *kapi.Endpoints) {
+	var etpHostRules = false
+
+	klog.V(5).Infof("Deleting endpoints %s in namespace %s", ep.Name, ep.Namespace)
+	// remove rules for endpoints and add back normal ones
+	name := ktypes.NamespacedName{Namespace: ep.Namespace, Name: ep.Name}
+	if svcConfig, exists := npw.updateServiceInfo(name, nil, &etpHostRules); exists {
+		// Lock the cache mutex here so we don't miss a service delete during an endpoint delete
+		// we have to do this because deleting and adding iptables rules is slow.
+		npw.serviceInfoLock.Lock()
+		defer npw.serviceInfoLock.Unlock()
+
+		delServiceRules(svcConfig.service, npw)
+		addServiceRules(svcConfig.service, etpHostRules, npw)
+	}
+}
+
+func (npw *nodePortWatcher) UpdateEndpoints(old *kapi.Endpoints, new *kapi.Endpoints) {
+	name := ktypes.NamespacedName{Namespace: old.Namespace, Name: old.Name}
+
+	if reflect.DeepEqual(new.Subsets, old.Subsets) {
+		return
+	}
+
+	klog.V(5).Infof("Updating endpoints %s in namespace %s", old.Name, old.Namespace)
+
+	// Delete old endpoint rules and add normal ones back
+	if len(new.Subsets) == 0 {
+		if _, exists := npw.getServiceInfo(name); exists {
+			npw.DeleteEndpoints(old)
+		}
+	}
+
+	// Update rules if hasHostNetworkEndpoints status changed
+	etpHostRulesNew := hasHostNetworkEndpoints(new, &npw.nodeIPManager.addresses)
+	if hasHostNetworkEndpoints(old, &npw.nodeIPManager.addresses) != etpHostRulesNew {
+		npw.DeleteEndpoints(old)
+		npw.AddEndpoints(new)
+	}
 }
 
 // since we share the host's k8s node IP, add OpenFlow flows
@@ -225,6 +572,7 @@ func (npw *nodePortWatcher) SyncServices(services []interface{}) {
 // -- to also connection track the outbound north-south traffic through l3 gateway so that
 //    the return traffic can be steered back to OVN logical topology
 // -- to handle host -> service access, via masquerading from the host to OVN GR
+// -- to handle external -> service(ExternalTrafficPolicy: Local) -> host access without SNAT
 func newSharedGatewayOpenFlowManager(gwBridge, exGWBridge *bridgeConfiguration) (*openflowManager, error) {
 	dftFlows, err := flowsForDefaultBridge(gwBridge.ofPortPhys, gwBridge.macAddress.String(), gwBridge.ofPortPatch, gwBridge.ips)
 	if err != nil {
@@ -563,7 +911,7 @@ func setBridgeOfPorts(bridge *bridgeConfiguration) error {
 	return nil
 }
 
-func newSharedGateway(nodeName string, subnets []*net.IPNet, gwNextHops []net.IP, gwIntf, egressGWIntf string, nodeAnnotator kube.Annotator) (*gateway, error) {
+func newSharedGateway(nodeName string, subnets []*net.IPNet, gwNextHops []net.IP, gwIntf, egressGWIntf string, nodeAnnotator kube.Annotator, cfg *managementPortConfig, watchFactory factory.NodeWatchFactory) (*gateway, error) {
 	klog.Info("Creating new shared gateway")
 	gw := &gateway{}
 
@@ -628,9 +976,11 @@ func newSharedGateway(nodeName string, subnets []*net.IPNet, gwNextHops []net.IP
 			return err
 		}
 
+		gw.nodeIPManager = newAddressManager(nodeAnnotator, cfg)
+
 		if config.Gateway.NodeportEnable {
 			klog.Info("Creating Shared Gateway Node Port Watcher")
-			gw.nodePortWatcher, err = newNodePortWatcher(gwBridge.patchPort, gwBridge.bridgeName, gwBridge.uplinkName, gw.openflowManager)
+			gw.nodePortWatcher, err = newNodePortWatcher(gwBridge.patchPort, gwBridge.bridgeName, gwBridge.uplinkName, gwBridge.ips, gw.openflowManager, gw.nodeIPManager, watchFactory)
 			if err != nil {
 				return err
 			}
@@ -645,7 +995,8 @@ func newSharedGateway(nodeName string, subnets []*net.IPNet, gwNextHops []net.IP
 	return gw, nil
 }
 
-func newNodePortWatcher(patchPort, gwBridge, gwIntf string, ofm *openflowManager) (*nodePortWatcher, error) {
+func newNodePortWatcher(patchPort, gwBridge, gwIntf string, ips []*net.IPNet, ofm *openflowManager,
+	nodeIPManager *addressManager, watchFactory factory.NodeWatchFactory) (*nodePortWatcher, error) {
 	// Get ofport of patchPort
 	ofportPatch, stderr, err := util.GetOVSOfPort("--if-exists", "get",
 		"interface", patchPort, "ofport")
@@ -671,11 +1022,19 @@ func newNodePortWatcher(patchPort, gwBridge, gwIntf string, ofm *openflowManager
 		return nil, err
 	}
 
+	// Get Physical IPs of Node, Can be IPV4 IPV6 or both
+	gatewayIPv4, gatewayIPv6 := getGatewayFamilyAddrs(ips)
+
 	npw := &nodePortWatcher{
-		ofportPhys:  ofportPhys,
-		ofportPatch: ofportPatch,
-		gwBridge:    gwBridge,
-		ofm:         ofm,
+		gatewayIPv4:   gatewayIPv4,
+		gatewayIPv6:   gatewayIPv6,
+		ofportPhys:    ofportPhys,
+		ofportPatch:   ofportPatch,
+		gwBridge:      gwBridge,
+		serviceInfo:   make(map[ktypes.NamespacedName]*serviceConfig),
+		nodeIPManager: nodeIPManager,
+		ofm:           ofm,
+		watchFactory:  watchFactory,
 	}
 	return npw, nil
 }

--- a/go-controller/pkg/node/healthcheck.go
+++ b/go-controller/pkg/node/healthcheck.go
@@ -13,6 +13,7 @@ import (
 
 	kapi "k8s.io/api/core/v1"
 	ktypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
 )
 
@@ -93,6 +94,20 @@ func countLocalEndpoints(ep *kapi.Endpoints, nodeName string) int {
 		}
 	}
 	return num
+}
+
+func hasHostNetworkEndpoints(ep *kapi.Endpoints, nodeAddresses *sets.String) bool {
+	for i := range ep.Subsets {
+		ss := &ep.Subsets[i]
+		for i := range ss.Addresses {
+			addr := &ss.Addresses[i]
+			if nodeAddresses.Has(addr.IP) {
+				return true
+			}
+		}
+	}
+
+	return false
 }
 
 // checkForStaleOVSInternalPorts checks for OVS internal ports without any ofport assigned,

--- a/go-controller/pkg/ovn/loadbalancer/loadbalancer.go
+++ b/go-controller/pkg/ovn/loadbalancer/loadbalancer.go
@@ -173,11 +173,9 @@ func lbToColumns(lb *LB) []string {
 	}
 
 	skipSNAT := "false"
-	// HACK(cdc)
-	// re-enable when BZ 1995326 is fixed
-	//if lb.Opts.SkipSNAT {
-	//	skipSNAT = "true"
-	//}
+	if lb.Opts.SkipSNAT {
+		skipSNAT = "true"
+	}
 
 	// Session affinity
 	// If enabled, then bucket flows by 3-tuple (proto, srcip, dstip)

--- a/go-controller/pkg/util/kube.go
+++ b/go-controller/pkg/util/kube.go
@@ -181,6 +181,10 @@ func ServiceTypeHasNodePort(service *kapi.Service) bool {
 	return service.Spec.Type == kapi.ServiceTypeNodePort || service.Spec.Type == kapi.ServiceTypeLoadBalancer
 }
 
+func ServiceExternalTrafficPolicyLocal(service *kapi.Service) bool {
+	return service.Spec.ExternalTrafficPolicy == kapi.ServiceExternalTrafficPolicyTypeLocal
+}
+
 // GetNodePrimaryIP extracts the primary IP address from the node status in the  API
 func GetNodePrimaryIP(node *kapi.Node) (string, error) {
 	if node == nil {

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -2079,6 +2079,8 @@ var _ = ginkgo.Describe("e2e ingress traffic validation", func() {
 	maxTries := 0
 	var nodes *v1.NodeList
 	var newNodeAddresses []string
+	var externalIpv4 string
+	var externalIpv6 string
 
 	ginkgo.Context("Validating ingress traffic", func() {
 		ginkgo.BeforeEach(func() {
@@ -2118,7 +2120,7 @@ var _ = ginkgo.Describe("e2e ingress traffic validation", func() {
 			ginkgo.By("Creating an external container to send the traffic from")
 			// the client uses the netexec command from the agnhost image, which is able to receive commands for poking other
 			// addresses.
-			createClusterExternalContainer(clientContainerName, agnhostImage, []string{"--network", "kind", "-P"}, []string{"netexec", "--http-port=80"})
+			externalIpv4, externalIpv6 = createClusterExternalContainer(clientContainerName, agnhostImage, []string{"--network", "kind", "-P"}, []string{"netexec", "--http-port=80"})
 		})
 
 		ginkgo.AfterEach(func() {
@@ -2137,7 +2139,7 @@ var _ = ginkgo.Describe("e2e ingress traffic validation", func() {
 		ginkgo.It("Should be allowed by nodeport services", func() {
 			serviceName := "nodeportsvc"
 			ginkgo.By("Creating the nodeport service")
-			npSpec := nodePortServiceSpecFrom(serviceName, endpointHTTPPort, endpointUDPPort, clusterHTTPPort, clusterUDPPort, endpointsSelector)
+			npSpec := nodePortServiceSpecFrom(serviceName, endpointHTTPPort, endpointUDPPort, clusterHTTPPort, clusterUDPPort, endpointsSelector, v1.ServiceExternalTrafficPolicyTypeCluster)
 			np, err := f.ClientSet.CoreV1().Services(f.Namespace.Name).Create(context.Background(), npSpec, metav1.CreateOptions{})
 			nodeTCPPort, nodeUDPPort := nodePortsFromService(np)
 			framework.ExpectNoError(err)
@@ -2178,7 +2180,71 @@ var _ = ginkgo.Describe("e2e ingress traffic validation", func() {
 				}
 			}
 		})
+		// This test validates ingress traffic to nodeports with externalTrafficPolicy Set to local.
+		// It creates a nodeport service on both udp and tcp, and creates a backend pod on each node.
+		// The backend pod is using the agnhost - netexec command which replies to commands
+		// with different protocols. We use the "hostname" and "clientip" commands to have each backend
+		// pod to reply with its hostname and the request packet's srcIP.
+		// We use an external container to poke the service exposed on the node and ensure that only the
+		// nodeport on the node with the backend actually receives traffic and that the packet is not
+		// SNATed.
+		// In case of dual stack enabled cluster, we iterate over all the nodes ips and try to hit the
+		// endpoints from both each node's ips.
+		ginkgo.It("Should be allowed to node local cluster-networked endpoints by nodeport services with externalTrafficPolicy=local", func() {
+			serviceName := "nodeportsvclocal"
+			ginkgo.By("Creating the nodeport service with externalTrafficPolicy=local")
+			npSpec := nodePortServiceSpecFrom(serviceName, endpointHTTPPort, endpointUDPPort, clusterHTTPPort, clusterUDPPort, endpointsSelector, v1.ServiceExternalTrafficPolicyTypeLocal)
+			np, err := f.ClientSet.CoreV1().Services(f.Namespace.Name).Create(context.Background(), npSpec, metav1.CreateOptions{})
+			nodeTCPPort, nodeUDPPort := nodePortsFromService(np)
+			framework.ExpectNoError(err)
 
+			ginkgo.By("Waiting for the endpoints to pop up")
+			err = framework.WaitForServiceEndpointsNum(f.ClientSet, f.Namespace.Name, serviceName, len(endPoints), time.Second, wait.ForeverTestTimeout)
+			framework.ExpectNoError(err, "failed to validate endpoints for service %s in namespace: %s", serviceName, f.Namespace.Name)
+
+			for _, protocol := range []string{"http", "udp"} {
+				for _, node := range nodes.Items {
+					for _, nodeAddress := range node.Status.Addresses {
+						// skipping hostnames
+						if !addressIsIP(nodeAddress) {
+							continue
+						}
+
+						responses := sets.NewString()
+						// Fill expected responses, it should hit the nodeLocal endpoints and not SNAT packet IP
+						expectedResponses := sets.NewString()
+
+						if utilnet.IsIPv6String(nodeAddress.Address) {
+							expectedResponses.Insert(node.Name+"-ep", externalIpv6)
+						} else {
+							expectedResponses.Insert(node.Name+"-ep", externalIpv4)
+						}
+
+						valid := false
+						nodePort := nodeTCPPort
+						if protocol == "udp" {
+							nodePort = nodeUDPPort
+						}
+
+						ginkgo.By("Hitting the nodeport on " + node.Name + " and trying to reach only the local endpoint with protocol " + protocol)
+
+						for i := 0; i < maxTries; i++ {
+							epHostname := pokeEndpointHostname(clientContainerName, protocol, nodeAddress.Address, nodePort)
+							epClientIP := pokeEndpointClientIP(clientContainerName, protocol, nodeAddress.Address, nodePort)
+							responses.Insert(epHostname, epClientIP)
+
+							if responses.Equal(expectedResponses) {
+								framework.Logf("Validated local endpoint on node %s with address %s, and packet src IP ", node.Name, nodeAddress.Address, epClientIP)
+								valid = true
+								break
+							}
+
+						}
+						framework.ExpectEqual(valid, true, "Validation failed for node", node.Name, responses, nodePort)
+					}
+				}
+			}
+		})
 		// This test validates ingress traffic to externalservices.
 		// It creates a service on both udp and tcp and assignes all the first node's addresses as
 		// external addresses. Then, creates a backend pod on each node.
@@ -2347,6 +2413,263 @@ var _ = ginkgo.Describe("e2e ingress traffic validation", func() {
 						}
 					}
 					framework.ExpectEqual(valid, true, "Validation failed for external address", externalAddress)
+				}
+			}
+		})
+	})
+})
+
+var _ = ginkgo.Describe("e2e ingress to host-networked pods traffic validation", func() {
+	const (
+		endpointHTTPPort = 8085
+		endpointUDPPort  = 9095
+		clusterHTTPPort  = 81
+		clusterUDPPort   = 91
+
+		clientContainerName = "npclient"
+	)
+
+	f := framework.NewDefaultFramework("nodeport-ingress-test")
+	hostNetEndpointsSelector := map[string]string{"hostNetservicebackend": "true"}
+	var endPoints []*v1.Pod
+	var nodesHostnames sets.String
+	maxTries := 0
+	var nodes *v1.NodeList
+	var externalIpv4 string
+	var externalIpv6 string
+
+	// This test validates ingress traffic to nodeports with externalTrafficPolicy Set to local.
+	// It creates a nodeport service on both udp and tcp, and creates a host networked
+	// backend pod on each node. The backend pod is using the agnhost - netexec command which
+	// replies to commands with different protocols. We use the "hostname" and "clientip" commands
+	// to have each backend pod to reply with its hostname and the request packet's srcIP.
+	// We use an external container to poke the service exposed on the node and ensure that only the
+	// nodeport on the node with the backend actually receives traffic and that the packet is not
+	// SNATed.
+	ginkgo.Context("Validating ingress traffic to Host Netwoked pods", func() {
+		ginkgo.BeforeEach(func() {
+			endPoints = make([]*v1.Pod, 0)
+			nodesHostnames = sets.NewString()
+
+			var err error
+			nodes, err = e2enode.GetBoundedReadySchedulableNodes(f.ClientSet, 3)
+			framework.ExpectNoError(err)
+
+			if len(nodes.Items) < 3 {
+				framework.Failf(
+					"Test requires >= 3 Ready nodes, but there are only %v nodes",
+					len(nodes.Items))
+			}
+
+			ginkgo.By("Creating the endpoints pod, one for each worker")
+			for _, node := range nodes.Items {
+				// this create a udp / http netexec listener which is able to receive the "hostname"
+				// command. We use this to validate that each endpoint is received at least once
+				args := []string{
+					"netexec",
+					fmt.Sprintf("--http-port=%d", endpointHTTPPort),
+					fmt.Sprintf("--udp-port=%d", endpointUDPPort),
+				}
+
+				// create hostNeworkedPods
+				hostNetPod, err := createPod(f, node.Name+"-hostnet-ep", node.Name, f.Namespace.Name, []string{}, hostNetEndpointsSelector, func(p *v1.Pod) {
+					p.Spec.Containers[0].Args = args
+					p.Spec.HostNetwork = true
+				})
+
+				framework.ExpectNoError(err)
+				endPoints = append(endPoints, hostNetPod)
+				nodesHostnames.Insert(hostNetPod.Name)
+
+				// this is arbitrary and mutuated from k8s network e2e tests. We aim to hit all the endpoints at least once
+				maxTries = len(endPoints)*len(endPoints) + 30
+			}
+
+			ginkgo.By("Creating an external container to send the traffic from")
+			// the client uses the netexec command from the agnhost image, which is able to receive commands for poking other
+			// addresses.
+			externalIpv4, externalIpv6 = createClusterExternalContainer(clientContainerName, agnhostImage, []string{"--network", "kind", "-P"}, []string{"netexec", "--http-port=80"})
+		})
+
+		ginkgo.AfterEach(func() {
+			deleteClusterExternalContainer(clientContainerName)
+		})
+		ginkgo.JustAfterEach(func() {
+			// Since we're using host neworked pods in the test wait until namespaces delete after each test
+			framework.WaitForNamespacesDeleted(f.ClientSet, []string{f.Namespace.Name}, wait.ForeverTestTimeout)
+		})
+
+		// Make sure ingress traffic can reach host pod backends for a service without SNAT when externalTrafficPolicy is set to local
+		ginkgo.It("Should be allowed to node local host-networked endpoints by nodeport services with externalTrafficPolicy=local", func() {
+			serviceName := "nodeportsvclocalhostnet"
+			ginkgo.By("Creating the nodeport service with externalTrafficPolicy=local")
+			npSpec := nodePortServiceSpecFrom(serviceName, endpointHTTPPort, endpointUDPPort, clusterHTTPPort, clusterUDPPort, hostNetEndpointsSelector, v1.ServiceExternalTrafficPolicyTypeLocal)
+			np, err := f.ClientSet.CoreV1().Services(f.Namespace.Name).Create(context.Background(), npSpec, metav1.CreateOptions{})
+			framework.ExpectNoError(err)
+			nodeTCPPort, nodeUDPPort := nodePortsFromService(np)
+
+			ginkgo.By("Waiting for the endpoints to pop up")
+			err = framework.WaitForServiceEndpointsNum(f.ClientSet, f.Namespace.Name, serviceName, len(endPoints), time.Second, wait.ForeverTestTimeout)
+			framework.ExpectNoError(err, "failed to validate endpoints for service %s in namespace: %s", serviceName, f.Namespace.Name)
+
+			for _, protocol := range []string{"http", "udp"} {
+				for _, node := range nodes.Items {
+					for _, nodeAddress := range node.Status.Addresses {
+						// skipping hostnames
+						if !addressIsIP(nodeAddress) {
+							continue
+						}
+
+						responses := sets.NewString()
+						// Fill expected responses, it should hit the nodeLocal endpoints and not SNAT packet IP
+						expectedResponses := sets.NewString()
+
+						if utilnet.IsIPv6String(nodeAddress.Address) {
+							expectedResponses.Insert(node.Name, externalIpv6)
+						} else {
+							expectedResponses.Insert(node.Name, externalIpv4)
+						}
+
+						valid := false
+						nodePort := nodeTCPPort
+						if protocol == "udp" {
+							nodePort = nodeUDPPort
+						}
+
+						ginkgo.By("Hitting the nodeport on " + node.Name + " and trying to reach only the local endpoint with protocol " + protocol)
+						for i := 0; i < maxTries; i++ {
+							epHostname := pokeEndpointHostname(clientContainerName, protocol, nodeAddress.Address, nodePort)
+							epClientIP := pokeEndpointClientIP(clientContainerName, protocol, nodeAddress.Address, nodePort)
+							responses.Insert(epHostname, epClientIP)
+
+							if responses.Equal(expectedResponses) {
+								framework.Logf("Validated local endpoint on node %s with address %s, and packet src IP %s ", node.Name, nodeAddress.Address, epClientIP)
+								valid = true
+								break
+							}
+
+						}
+						framework.ExpectEqual(valid, true, "Validation failed for node", node.Name, responses, nodePort)
+					}
+				}
+			}
+		})
+	})
+})
+
+// Send traffic from the cluster node itself to a nodeport service on that node
+var _ = ginkgo.Describe("host to host-networked pods traffic validation", func() {
+	const (
+		endpointHTTPPort = 8085
+		endpointUDPPort  = 9095
+		clusterHTTPPort  = 81
+		clusterUDPPort   = 91
+	)
+
+	f := framework.NewDefaultFramework("host-to-host-test")
+	hostNetEndpointsSelector := map[string]string{"hostNetservicebackend": "true"}
+	var endPoints []*v1.Pod
+	var nodesHostnames sets.String
+	maxTries := 0
+	var nodes *v1.NodeList
+	// This test validates ingress traffic to nodeports with externalTrafficPolicy Set to local.
+	// It creates a nodeport service on both udp and tcp, and creates a host networked
+	// backend pod on each node. The backend pod is using the agnhost - netexec command which
+	// replies to commands with different protocols. We use the "hostname" and "clientip" commands
+	// to have each backend pod to reply with its hostname and the request packet's srcIP.
+	// We use the docker exec command to poke the service exposed on the node from the node itself
+	// and ensure that only the nodeport on the node with the backend actually receives traffic and
+	// that the packet is not SNATed.
+	ginkgo.Context("Validating Host to Host Netwoked pods traffic", func() {
+		ginkgo.BeforeEach(func() {
+			endPoints = make([]*v1.Pod, 0)
+			nodesHostnames = sets.NewString()
+
+			var err error
+			nodes, err = e2enode.GetBoundedReadySchedulableNodes(f.ClientSet, 3)
+			framework.ExpectNoError(err)
+
+			if len(nodes.Items) < 3 {
+				framework.Failf(
+					"Test requires >= 3 Ready nodes, but there are only %v nodes",
+					len(nodes.Items))
+			}
+
+			ginkgo.By("Creating the endpoints pod, one for each worker")
+			for _, node := range nodes.Items {
+				// this create a http netexec listener which is able to receive the "hostname"
+				// command. We use this to validate that each endpoint is received at least once
+				args := []string{
+					"netexec",
+					fmt.Sprintf("--http-port=%d", endpointHTTPPort),
+				}
+
+				// create hostNeworkPods
+				hostNetPod, err := createPod(f, node.Name+"-hostnet-ep", node.Name, f.Namespace.Name, []string{}, hostNetEndpointsSelector, func(p *v1.Pod) {
+					p.Spec.Containers[0].Args = args
+					p.Spec.HostNetwork = true
+				})
+
+				framework.ExpectNoError(err)
+				endPoints = append(endPoints, hostNetPod)
+				nodesHostnames.Insert(hostNetPod.Name)
+
+				// this is arbitrary and mutuated from k8s network e2e tests. We aim to hit all the endpoints at least once
+				maxTries = len(endPoints)*len(endPoints) + 30
+			}
+		})
+		ginkgo.JustAfterEach(func() {
+			// Since we're using host neworked pods in the test wait until namespaces delete after each test
+			framework.WaitForNamespacesDeleted(f.ClientSet, []string{f.Namespace.Name}, wait.ForeverTestTimeout)
+		})
+		// Make sure host sourced traffic can reach host pod backends for a service without SNAT when externalTrafficPolicy is set to local
+		// Only verify with http
+		ginkgo.It("Should be allowed to node local host-networked endpoints by nodeport services with externalTrafficPolicy=local", func() {
+			serviceName := "nodeportsvclocalhostnet"
+			ginkgo.By("Creating the nodeport service with externalTrafficPolicy=local")
+			npSpec := nodePortServiceSpecFrom(serviceName, endpointHTTPPort, endpointUDPPort, clusterHTTPPort, clusterUDPPort, hostNetEndpointsSelector, v1.ServiceExternalTrafficPolicyTypeLocal)
+			np, err := f.ClientSet.CoreV1().Services(f.Namespace.Name).Create(context.Background(), npSpec, metav1.CreateOptions{})
+			nodeTCPPort, _ := nodePortsFromService(np)
+			framework.ExpectNoError(err)
+
+			ginkgo.By("Waiting for the endpoints to pop up")
+			err = framework.WaitForServiceEndpointsNum(f.ClientSet, f.Namespace.Name, serviceName, len(endPoints), time.Second, wait.ForeverTestTimeout)
+			framework.ExpectNoError(err, "failed to validate endpoints for service %s in namespace: %s", serviceName, f.Namespace.Name)
+
+			for _, protocol := range []string{"http"} {
+				for _, node := range nodes.Items {
+					for _, nodeAddress := range node.Status.Addresses {
+						// skipping hostnames
+						if !addressIsIP(nodeAddress) {
+							continue
+						}
+
+						responses := sets.NewString()
+						// Fill expected responses, it should hit the nodeLocal endpoints only and not SNAT packet IP
+						expectedResponses := sets.NewString()
+
+						expectedResponses.Insert(node.Name, nodeAddress.Address)
+
+						valid := false
+						nodePort := nodeTCPPort
+
+						ginkgo.By("Hitting the nodeport on " + node.Name + " and trying to reach only the local endpoint with protocol " + protocol)
+						for i := 0; i < maxTries; i++ {
+							epHostname := curlInContainer(node.Name, protocol, nodeAddress.Address, nodePort, "hostname")
+							epClientIP := curlInContainer(node.Name, protocol, nodeAddress.Address, nodePort, "clientip")
+							ip, _, err := net.SplitHostPort(epClientIP)
+							framework.ExpectNoError(err)
+							responses.Insert(epHostname, ip)
+
+							if responses.Equal(expectedResponses) {
+								framework.Logf("Validated local endpoint on node %s with address %s, and packet src IP %s ", node.Name, nodeAddress.Address, epClientIP)
+								valid = true
+								break
+							}
+
+						}
+						framework.ExpectEqual(valid, true, "Validation failed for node", node.Name, responses, nodePort)
+					}
 				}
 			}
 		})

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -184,7 +184,7 @@ func unmarshalPodAnnotation(annotations map[string]string) (*PodAnnotation, erro
 	return podAnnotation, nil
 }
 
-func nodePortServiceSpecFrom(svcName string, httpPort, updPort, clusterHTTPPort, clusterUDPPort int, selector map[string]string) *v1.Service {
+func nodePortServiceSpecFrom(svcName string, httpPort, updPort, clusterHTTPPort, clusterUDPPort int, selector map[string]string, local v1.ServiceExternalTrafficPolicyType) *v1.Service {
 	preferDual := v1.IPFamilyPolicyPreferDualStack
 
 	res := &v1.Service{
@@ -197,8 +197,9 @@ func nodePortServiceSpecFrom(svcName string, httpPort, updPort, clusterHTTPPort,
 				{Port: int32(clusterHTTPPort), Name: "http", Protocol: v1.ProtocolTCP, TargetPort: intstr.FromInt(httpPort)},
 				{Port: int32(clusterUDPPort), Name: "udp", Protocol: v1.ProtocolUDP, TargetPort: intstr.FromInt(updPort)},
 			},
-			Selector:       selector,
-			IPFamilyPolicy: &preferDual,
+			Selector:              selector,
+			IPFamilyPolicy:        &preferDual,
+			ExternalTrafficPolicy: local,
 		},
 	}
 
@@ -228,6 +229,7 @@ func externalIPServiceSpecFrom(svcName string, httpPort, updPort, clusterHTTPPor
 
 // leverages a container running the netexec command to send a "hostname" request to a target running
 // netexec on the given target host / protocol / port
+// returns either the name of backend pod or "Timeout" if the curl request timed out
 func pokeEndpointHostname(clientContainer, protocol, targetHost string, targetPort int32) string {
 	ipPort := net.JoinHostPort("localhost", "80")
 	cmd := []string{"docker", "exec", clientContainer}
@@ -243,8 +245,64 @@ func pokeEndpointHostname(clientContainer, protocol, targetHost string, targetPo
 	res, err := runCommand(cmd...)
 	framework.ExpectNoError(err, "failed to run command on external container")
 	hostName, err := parseNetexecResponse(res)
+	if err != nil {
+		fmt.Printf("FAILED Command was %s", curlCommand)
+		fmt.Printf("FAILED Response was %v", res)
+	}
 	framework.ExpectNoError(err)
+
 	return hostName
+}
+
+// leverages a container running the netexec command to send a "clientip" request to a target running
+// netexec on the given target host / protocol / port
+// returns either the src ip of the packet or "Timeout" if the curl request timed out
+func pokeEndpointClientIP(clientContainer, protocol, targetHost string, targetPort int32) string {
+	ipPort := net.JoinHostPort("localhost", "80")
+	cmd := []string{"docker", "exec", clientContainer}
+
+	// we leverage the dial command from netexec, that is already supporting multiple protocols
+	curlCommand := strings.Split(fmt.Sprintf("curl -g -q -s http://%s/dial?request=clientip&protocol=%s&host=%s&port=%d&tries=1",
+		ipPort,
+		protocol,
+		targetHost,
+		targetPort), " ")
+
+	cmd = append(cmd, curlCommand...)
+	res, err := runCommand(cmd...)
+	framework.ExpectNoError(err, "failed to run command on external container")
+	clientIP, err := parseNetexecResponse(res)
+	framework.ExpectNoError(err)
+	ip, _, err := net.SplitHostPort(clientIP)
+	if err != nil {
+		fmt.Printf("FAILED Command was %s", curlCommand)
+		fmt.Printf("FAILED Response was %v", res)
+	}
+	framework.ExpectNoError(err, "failed to parse client ip:port")
+
+	return ip
+}
+
+// leverages a container running the netexec command to send a request to a target running
+// netexec on the given target host / protocol / port
+// returns either the name of backend pod or "Timeout" if the curl request timed out
+func curlInContainer(clientContainer, protocol, targetHost string, targetPort int32, endPoint string) string {
+	cmd := []string{"docker", "exec", clientContainer}
+	if utilnet.IsIPv6String(targetHost) {
+		targetHost = fmt.Sprintf("[%s]", targetHost)
+	}
+
+	// we leverage the dial command from netexec, that is already supporting multiple protocols
+	curlCommand := strings.Split(fmt.Sprintf("curl -g -q -s http://%s:%d/%s",
+		targetHost,
+		targetPort,
+		endPoint), " ")
+
+	cmd = append(cmd, curlCommand...)
+	res, err := runCommand(cmd...)
+	framework.ExpectNoError(err, "failed to run command on external container")
+
+	return res
 }
 
 func parseNetexecResponse(response string) (string, error) {
@@ -256,6 +314,9 @@ func parseNetexecResponse(response string) (string, error) {
 		return "", fmt.Errorf("failed to unmarshal curl response %s", response)
 	}
 	if len(res.Errors) > 0 {
+		if strings.Contains(strings.ToLower(res.Errors[0]), "timeout") {
+			return "Timeout", nil
+		}
 		return "", fmt.Errorf("curl response %s contains errors", response)
 	}
 	if len(res.Responses) == 0 {

--- a/test/scripts/e2e-cp.sh
+++ b/test/scripts/e2e-cp.sh
@@ -63,6 +63,15 @@ if [ "$OVN_DISABLE_SNAT_MULTIPLE_GWS" == true ]; then
   SKIPPED_TESTS+="Should validate the egress IP functionality against remote hosts"
 fi
 
+if [ "$OVN_GATEWAY_MODE" == "local" ]; then
+  if [ "$SKIPPED_TESTS" != "" ]; then
+  	SKIPPED_TESTS+="|"
+  fi
+  SKIPPED_TESTS+="Should be allowed to node local cluster-networked endpoints by nodeport services with externalTrafficPolicy=local|\
+e2e ingress to host-networked pods traffic validation|\
+host to host-networked pods traffic validation"
+fi
+
 # setting these is required to make RuntimeClass tests work ... :/
 export KUBE_CONTAINER_RUNTIME=remote
 export KUBE_CONTAINER_RUNTIME_ENDPOINT=unix:///run/containerd/containerd.sock


### PR DESCRIPTION
This PR pulls in the code needed to land the externalTrafficPolicy feature. It adds a commit to deal with the fact that the smartnicv2 code has not made it downstream yet. That commit should be dropped before the next large merge of Upstream OVN-K into downstream.
