### PR TITLE
Bug 1989615: Fix GetPortAddresses for HBO

### DIFF
--- a/go-controller/pkg/util/net.go
+++ b/go-controller/pkg/util/net.go
@@ -59,9 +59,6 @@ func GetPortAddresses(portName string, ovnNBClient goovn.Client) (net.HardwareAd
 		return nil, nil, nil
 	}
 
-	if len(addresses) < 2 {
-		return nil, nil, fmt.Errorf("error while obtaining addresses for %s: %v", portName, addresses)
-	}
 	mac, err := net.ParseMAC(addresses[0])
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to parse logical switch port %q MAC %q: %v", portName, addresses[0], err)

--- a/go-controller/pkg/util/net_unit_test.go
+++ b/go-controller/pkg/util/net_unit_test.go
@@ -97,9 +97,8 @@ func TestGetPortAddresses(t *testing.T) {
 			onRetArgsOvnNBClient: &ovntest.TestifyMockHelper{OnCallMethodName: "LSPGet", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{&goovn.LogicalSwitchPort{DynamicAddresses: "06:c6:d4:fb:fb:ba 10.244.2.2"}, nil}},
 		},
 		{
-			desc:                 "test code path where addresses list count is less than 2",
+			desc:                 "test code path where port has MAC but no IPs",
 			inpPort:              "TEST_PORT",
-			errMatch:             fmt.Errorf("error while obtaining addresses for"),
 			onRetArgsOvnNBClient: &ovntest.TestifyMockHelper{OnCallMethodName: "LSPGet", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{&goovn.LogicalSwitchPort{DynamicAddresses: "06:c6:d4:fb:fb:ba"}, nil}},
 		},
 		{


### PR DESCRIPTION
In GetPortAddresses, we check if we have both PortMAC and IP for
the port. If not we return nil for both values. While this works
for normal ports, for the HBO ports which don't have IPs for
the int-<node> interface, we will always hit this condition and
return an empty PortMAC which in turn triggers the lsp-add even
if the portMAC already exists.

When we have an external entity updating the node object, the
watcher triggers handleOverlayPort and we keep hitting this
condition.

Let's remove the "len(addresses)<2" check since its not needed
for HBO and in normal pod port case, pods.getPortAddresses already
handles the case for empty podMac or podIPs. This way when portMAC
is set but not the IPs, we will still return the portMAC and the
respective code paths handle it as needed.

Signed-off-by: Surya Seetharaman <suryaseetharaman.9@gmail.com>
(cherry picked from commit 1a6f9c912d634f9fd2d135f74752c56a376abd9f)
