### PR TITLE
Add metrics from ovn-appctl stopwatch/show

### DIFF
--- a/go-controller/pkg/metrics/metrics_test.go
+++ b/go-controller/pkg/metrics/metrics_test.go
@@ -1,0 +1,94 @@
+package metrics
+
+import (
+	"reflect"
+	"testing"
+)
+
+func Test_parseStopwatchShowOutput(t *testing.T) {
+	tests := []struct {
+		name                string
+		stopwatchShowOutput string
+		want                map[string]int
+		wantErr             bool
+	}{
+		{
+			name: "should return all metrics",
+			stopwatchShowOutput: `Statistics for 'ovnnb_db_run'
+  Total samples: 3618
+  Maximum: 208 msec
+  Minimum: 0 msec
+  95th percentile: 52.887067 msec
+  Short term average: 22.548798 msec
+  Long term average: 26.117126 msec
+Statistics for 'ovn-northd-loop'
+  Total samples: 6269
+  Maximum: 29999 msec
+  Minimum: 0 msec
+  95th percentile: 7726.066210 msec
+  Short term average: 7778.877120 msec
+  Long term average: 2740.125211 msec
+Statistics for 'ovnsb_db_run'
+  Total samples: 5923
+  Maximum: 9 msec
+  Minimum: 0 msec
+  95th percentile: 0.970497 msec
+  Short term average: 0.000139 msec
+  Long term average: 0.136613 msec`,
+			want: map[string]int{
+				"ovnnb_db_run":    3618,
+				"ovn-northd-loop": 6269,
+				"ovnsb_db_run":    5923,
+			},
+			wantErr: false,
+		},
+		{
+			name: "should return all metrics, even if 'Total samples' is not on first",
+			stopwatchShowOutput: `Statistics for 'ovnnb_db_run'
+  Maximum: 208 msec
+  Minimum: 0 msec
+  95th percentile: 52.887067 msec
+  Total samples: 3618
+  Short term average: 22.548798 msec
+  Long term average: 26.117126 msec
+Statistics for 'ovn-northd-loop'
+  Total samples: 6269
+  Maximum: 29999 msec
+  Minimum: 0 msec
+  95th percentile: 7726.066210 msec
+  Short term average: 7778.877120 msec
+  Long term average: 2740.125211 msec`,
+			want: map[string]int{
+				"ovnnb_db_run":    3618,
+				"ovn-northd-loop": 6269,
+			},
+			wantErr: false,
+		},
+		{
+			name: "should be able to parse only one metric",
+			stopwatchShowOutput: `Statistics for 'ovnnb_db_run'
+  Maximum: 208 msec
+  Minimum: 0 msec
+  95th percentile: 52.887067 msec
+  Total samples: 3618
+  Short term average: 22.548798 msec
+  Long term average: 26.117126 msec`,
+			want: map[string]int{
+				"ovnnb_db_run": 3618,
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseStopwatchShowOutput(tt.stopwatchShowOutput)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseStopwatchShowOutput() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("parseStopwatchShowOutput() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/go-controller/pkg/metrics/ovn.go
+++ b/go-controller/pkg/metrics/ovn.go
@@ -2,9 +2,10 @@ package metrics
 
 import (
 	"fmt"
-	"k8s.io/klog/v2"
 	"strings"
 	"time"
+
+	"k8s.io/klog/v2"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 	"github.com/prometheus/client_golang/prometheus"
@@ -209,6 +210,36 @@ var ovnControllerCoverageShowMetricsMap = map[string]*metricDetails{
 	},
 }
 
+var ovnControllerStopwatchShowMetricsMap = map[string]*metricDetails{
+	"bfd_run": {
+		srcName: "bfd-run",
+	},
+	"flow_installation": {
+		srcName: "flow-installation",
+	},
+	"if_status_mgr_run": {
+		srcName: "if-status-mgr-run",
+	},
+	"if_status_mgr_update": {
+		srcName: "if-status-mgr-update",
+	},
+	"flow_generation": {
+		srcName: "flow-generation",
+	},
+	"pinctrl_run": {
+		srcName: "pinctrl-run",
+	},
+	"ofctrl_seqno_run": {
+		srcName: "ofctrl-seqno-run",
+	},
+	"patch_run": {
+		srcName: "patch-run",
+	},
+	"ct_zone_commit": {
+		srcName: "ct-zone-commit",
+	},
+}
+
 // setOvnControllerConfigurationMetrics updates ovn-controller configuration
 // values (ovn-openflow-probe-interval, ovn-remote-probe-interval, ovn-monitor-all,
 // ovn-encap-ip, ovn-encap-type, ovn-remote) through
@@ -376,8 +407,14 @@ func RegisterOvnControllerMetrics() {
 	componentCoverageShowMetricsMap[ovnController] = ovnControllerCoverageShowMetricsMap
 	registerCoverageShowMetrics(ovnController, MetricOvnNamespace, MetricOvnSubsystemController)
 
+	// Register the ovn-controller coverage/show metrics
+	componentStopwatchShowMetricsMap[ovnController] = ovnControllerStopwatchShowMetricsMap
+	registerStopwatchShowMetrics(ovnController, MetricOvnNamespace, MetricOvnSubsystemController)
+
 	// ovn-controller configuration metrics updater
 	go ovnControllerConfigurationMetricsUpdater()
 	// ovn-controller coverage show metrics updater
 	go coverageShowMetricsUpdater(ovnController)
+	// ovn-controller stopwatch show metrics updater
+	go stopwatchShowMetricsUpdater(ovnController)
 }

--- a/go-controller/pkg/metrics/ovn_northd.go
+++ b/go-controller/pkg/metrics/ovn_northd.go
@@ -73,6 +73,14 @@ var ovnNorthdCoverageShowMetricsMap = map[string]*metricDetails{
 	},
 }
 
+var ovnNorthdStopwatchShowMetricsMap = map[string]*metricDetails{
+	"ovnnb_db_run": {},
+	"ovn_northd_loop": {
+		srcName: "ovn-northd-loop",
+	},
+	"ovnsb_db_run": {},
+}
+
 func RegisterOvnNorthdMetrics(clientset kubernetes.Interface, k8sNodeName string) {
 	err := wait.PollImmediate(1*time.Second, 300*time.Second, func() (bool, error) {
 		return checkPodRunsOnGivenNode(clientset, "name=ovnkube-master", k8sNodeName, true)
@@ -154,4 +162,9 @@ func RegisterOvnNorthdMetrics(clientset kubernetes.Interface, k8sNodeName string
 	componentCoverageShowMetricsMap[ovnNorthd] = ovnNorthdCoverageShowMetricsMap
 	registerCoverageShowMetrics(ovnNorthd, MetricOvnNamespace, MetricOvnSubsystemNorthd)
 	go coverageShowMetricsUpdater(ovnNorthd)
+
+	// Register the ovn-northd stopwatch/show metrics with prometheus
+	componentStopwatchShowMetricsMap[ovnNorthd] = ovnNorthdStopwatchShowMetricsMap
+	registerStopwatchShowMetrics(ovnNorthd, MetricOvnNamespace, MetricOvnSubsystemNorthd)
+	go stopwatchShowMetricsUpdater(ovnNorthd)
 }


### PR DESCRIPTION
**- What this PR does and why is it needed**
This PR adds the metrics from `ovn-appctl stopwatch/show` to the metrics endpoint so they can be scraped by Prometheus.

**- Special notes for reviewers**
1. I am not aware of the meaning of all the metrics. It would be great if somebody could provide a "help text" for the following metric names, so these could show up in the metrics endpoint (via `# HELP ovnnb_db_run <some description what this metric is about>`):
   * ovnnb_db_run
   * ovn-northd-loop
   * ovnsb_db_run
   * bfd-run
   * flow-installation
   * if-status-mgr-run
   * if-status-mgr-update
   * flow-generation
   * pinctrl-run
   * ofctrl-seqno-run
   * patch-run
   * ct-zone-commit
2. Since upstream doesn't have the latest ovn version (with support of the `stopwatch/show` command), I had to do this against downstream (task to port it to upstream: [SDN-2148](https://issues.redhat.com/browse/SDN-2148)).
3. `ovn-appctl stopwatch/show` seems to collect the metrics as a histogram. E.g:
   ```
   Statistics for 'ovn-northd-loop'
     Total samples: 6269
     Maximum: 29999 msec
     Minimum: 0 msec
     95th percentile: 7726.066210 msec
     Short term average: 7778.877120 msec
     Long term average: 2740.125211 msec
   ```
   I did not find a way to bring this to a Prometheus histogram, so I collect only the number of `Total samples` in a Gauge for now. Any advice will be appreciated.

**- How to verify it**
1. Deploy a cluster with this patch
2. Check the metrics endpoint for the new metrics (e.g. ssh to one of the nodes and do a `curl $HOSTNAME:9410/metrics | grep -i if_status_mgr_run`)

**- Description for the changelog**
Add stopwatch/show metrics