### PR TITLE
Bug 1997114: Fixes ensure address set

### DIFF
--- a/go-controller/pkg/ovn/address_set/address_set.go
+++ b/go-controller/pkg/ovn/address_set/address_set.go
@@ -80,7 +80,7 @@ func (asf *ovnAddressSetFactory) NewAddressSet(name string, ips []net.IP) (Addre
 // EnsureAddressSet ensures the address_set with the given name exists and if it does not creates an empty addressSet
 func (asf *ovnAddressSetFactory) EnsureAddressSet(name string) error {
 	hashedAddressSetNames := []string{}
-	ip4ASName, ip6ASName := MakeAddressSetName(name)
+	ip4ASName, ip6ASName := MakeAddressSetHashNames(name)
 	if config.IPv4Mode {
 		hashedAddressSetNames = append(hashedAddressSetNames, ip4ASName)
 	}


### PR DESCRIPTION
Function was accidentally using the non-hashed names.

Signed-off-by: Tim Rozet <trozet@redhat.com>

