### PR TITLE
Bug 1998146: Fix lb delete during node deletion

### DIFF
--- a/go-controller/pkg/ovn/loadbalancer/lb_cache.go
+++ b/go-controller/pkg/ovn/loadbalancer/lb_cache.go
@@ -93,6 +93,24 @@ func (c *LBCache) removeVips(toRemove []DeleteVIPEntry) {
 	}
 }
 
+// RemoveSwitch removes the provided switchname from all the lb.Switches in the LBCache.
+func (c *LBCache) RemoveSwitch(switchname string) {
+	c.Lock()
+	defer c.Unlock()
+	for _, lbCache := range c.existing {
+		lbCache.Switches.Delete(switchname)
+	}
+}
+
+// RemoveRouter removes the provided routername from all the lb.Routers in the LBCache.
+func (c *LBCache) RemoveRouter(routername string) {
+	c.Lock()
+	defer c.Unlock()
+	for _, lbCache := range c.existing {
+		lbCache.Routers.Delete(routername)
+	}
+}
+
 // addNewLB is a shortcut when creating a load balancer; we know it won't have any switches or routers
 func (c *LBCache) addNewLB(lb *LB) {
 	c.Lock()

--- a/go-controller/pkg/ovn/loadbalancer/lb_cache_test.go
+++ b/go-controller/pkg/ovn/loadbalancer/lb_cache_test.go
@@ -157,4 +157,22 @@ GR_ovn-control-plane,31bb6bff-93b9-4080-a1b9-9a1fa898b1f0 cb6ebcb0-c12d-4404-ada
 		"GR_ovn-control-plane": {"31bb6bff-93b9-4080-a1b9-9a1fa898b1f0", "cb6ebcb0-c12d-4404-ada7-5aa2b898f06b", "f0747ebb-71c2-4249-bdca-f33670ae544f"},
 	})
 
+	globalCache := &LBCache{}
+	globalCache.existing = make(map[string]*CachedLB, len(lbs))
+	for i := range lbs {
+		globalCache.existing[lbs[i].UUID] = &lbs[i]
+	}
+
+	globalCache.existing["7dc190c4-c615-467f-af83-9856d832c9a0"].Routers.Insert("GR_ovn-worker2", "GR_ovn-worker", "ovn_cluster_router", "GR_ovn-control-plane")
+	globalCache.RemoveRouter("GR_ovn-worker")
+	assert.Equal(t, globalCache.existing["7dc190c4-c615-467f-af83-9856d832c9a0"].Routers, sets.String{
+		"GR_ovn-control-plane": {}, "GR_ovn-worker2": {}, "ovn_cluster_router": {},
+	})
+
+	globalCache.existing["7dc190c4-c615-467f-af83-9856d832c9a0"].Switches.Insert("ovn-worker2", "ovn-worker", "ovn-control-plane")
+	globalCache.RemoveSwitch("ovn-worker")
+	assert.Equal(t, globalCache.existing["7dc190c4-c615-467f-af83-9856d832c9a0"].Switches, sets.String{
+		"ovn-control-plane": {}, "ovn-worker2": {},
+	})
+	assert.Equal(t, globalCache.existing["cb6ebcb0-c12d-4404-ada7-5aa2b898f06b"].Switches, sets.String{}) // nothing changed
 }


### PR DESCRIPTION
When a node gets deleted, the logical switch and
gateway router get removed first. However we do
not update the LBCache and this causes dependency
failures during deletion leaving behind wrong ip->vip
pairing in the lbs.

When the pods on this node go away, ensureLBs
gets triggered and it tries to update endpoints across
load balancers. This set load_balancer command is
batched with ls-lb-del & ls-lr-del commands to remove
association of the lbs from the removed switches and
routers. These commands fail together because the switches
and routers are not present in ovn.

This PR updates the LBcache as soon as we remove the
routers and switches.

Signed-off-by: Surya Seetharaman <suryaseetharaman.9@gmail.com>
(cherry picked from commit 6de80e8dbb2c865209d6dffd32cd4d93eb46b77e)
