### PR TITLE
Bug 1998614: Ensure client handling of canceled/dropped OVSDB monitor

### DIFF
--- a/go-controller/vendor/github.com/ebay/go-ovn/ovnimp.go
+++ b/go-controller/vendor/github.com/ebay/go-ovn/ovnimp.go
@@ -146,6 +146,8 @@ func (odbi *ovndb) getRowsMatchingUUID(table, field, uuid string) ([]string, err
 }
 
 func (odbi *ovndb) transact(db string, ops ...libovsdb.Operation) ([]libovsdb.OperationResult, error) {
+	odbi.tranmutex.RLock()
+	defer odbi.tranmutex.RUnlock()
 	reply, err := odbi.client.Transact(db, ops...)
 
 	if err != nil {
@@ -164,7 +166,8 @@ func (odbi *ovndb) transact(db string, ops ...libovsdb.Operation) ([]libovsdb.Op
 			if i < len(ops) {
 				opsInfo = fmt.Sprintf("%v", ops[i])
 			}
-			return nil, fmt.Errorf("Transaction Failed due to an error: %v details: %v in %s",
+			odbi.close()
+			return nil, fmt.Errorf("Reconnecting...Transaction Failed due to an error: %v details: %v in %s",
 				o.Error, o.Details, opsInfo)
 		}
 	}

--- a/go-controller/vendor/github.com/ebay/libovsdb/client.go
+++ b/go-controller/vendor/github.com/ebay/libovsdb/client.go
@@ -95,11 +95,17 @@ func Connect(endpoints string, tlsConfig *tls.Config) (*OvsdbClient, error) {
 	return nil, fmt.Errorf("failed to connect: %s", err.Error())
 }
 
+func handleMonitorCancel(client *rpc2.Client, params []interface{}, reply *interface{}) error {
+	log.Println("monitor cancel received")
+	return client.Close()
+}
+
 func newRPC2Client(conn net.Conn) (*OvsdbClient, error) {
 	c := rpc2.NewClientWithCodec(jsonrpc.NewJSONCodec(conn))
 	c.SetBlocking(true)
 	c.Handle("echo", echo)
 	c.Handle("update", update)
+	c.Handle("monitor_cancel", handleMonitorCancel)
 	go c.Run()
 	go handleDisconnectNotification(c)
 


### PR DESCRIPTION
Under heavy load, monitor gets dropped silently and we stop receiving `update` messages from ovsdbserver. This leads to stale cache and inconsistency with what's in the DB leading to transaction errors. While this is originally a ovsdbserver bug, a workwround fix here would be to trigger reconnect to recreate the monitor and start receiving update messages, when a transaction error occurs.

Co-Authored-By: trozet@redhat.com