### PR TITLE
Bug 2001363: [4.8z] Ensure client handling of canceled/dropped OVSDB monitor

### DIFF
--- a/go-controller/vendor/github.com/ebay/go-ovn/client.go
+++ b/go-controller/vendor/github.com/ebay/go-ovn/client.go
@@ -281,7 +281,7 @@ type ovndb struct {
 	client       *libovsdb.OvsdbClient
 	cache        map[string]map[string]libovsdb.Row
 	cachemutex   sync.RWMutex
-	tranmutex    sync.Mutex
+	tranmutex    sync.RWMutex
 	signalCB     OVNSignal
 	disconnectCB OVNDisconnectedCallback
 	db           string
@@ -360,6 +360,8 @@ func (c *ovndb) reconnect() {
 	ticker := time.NewTicker(500 * time.Millisecond)
 	go func() {
 		log.Printf("%s disconnected. Reconnecting ... \n", c.addr)
+		c.tranmutex.Lock()
+		defer c.tranmutex.Unlock()
 		retry := 0
 		for range ticker.C {
 			if err := connect(c); err != nil {
@@ -392,7 +394,7 @@ func (c *ovndb) filterTablesFromSchema() []string {
 		tables = SBTablesOrder
 	}
 
-	dbSchema := c.GetSchema()
+	dbSchema := c.getSchema(c.db)
 	schemaTables := make([]string, 0)
 	for _, table := range tables {
 		if _, ok := dbSchema.Tables[table]; ok {
@@ -443,14 +445,26 @@ func (c *ovndb) MonitorTables(jsonContext interface{}) (*libovsdb.TableUpdates, 
 	return c.client.Monitor(c.db, jsonContext, requests)
 }
 
-// TODO return proper error
-func (c *ovndb) Close() error {
+func (c *ovndb) close() error {
 	c.client.Disconnect()
 	return nil
 }
 
+// TODO return proper error
+func (c *ovndb) Close() error {
+	c.tranmutex.Lock()
+	defer c.tranmutex.Unlock()
+	return c.close()
+}
+
+func (c *ovndb) getSchema(db string) libovsdb.DatabaseSchema {
+	return c.client.Schema[db]
+}
+
 func (c *ovndb) GetSchema() libovsdb.DatabaseSchema {
-	return c.client.Schema[c.db]
+	c.tranmutex.RLock()
+	defer c.tranmutex.RUnlock()
+	return c.getSchema(c.db)
 }
 
 func (c *ovndb) EncapList(chname string) ([]*Encap, error) {

--- a/go-controller/vendor/github.com/ebay/go-ovn/ovnimp.go
+++ b/go-controller/vendor/github.com/ebay/go-ovn/ovnimp.go
@@ -146,9 +146,8 @@ func (odbi *ovndb) getRowsMatchingUUID(table, field, uuid string) ([]string, err
 }
 
 func (odbi *ovndb) transact(db string, ops ...libovsdb.Operation) ([]libovsdb.OperationResult, error) {
-	// Only support one trans at same time now.
-	odbi.tranmutex.Lock()
-	defer odbi.tranmutex.Unlock()
+	odbi.tranmutex.RLock()
+	defer odbi.tranmutex.RUnlock()
 	reply, err := odbi.client.Transact(db, ops...)
 
 	if err != nil {
@@ -167,7 +166,8 @@ func (odbi *ovndb) transact(db string, ops ...libovsdb.Operation) ([]libovsdb.Op
 			if i < len(ops) {
 				opsInfo = fmt.Sprintf("%v", ops[i])
 			}
-			return nil, fmt.Errorf("Transaction Failed due to an error: %v details: %v in %s",
+			odbi.close()
+			return nil, fmt.Errorf("Reconnecting...Transaction Failed due to an error: %v details: %v in %s",
 				o.Error, o.Details, opsInfo)
 		}
 	}

--- a/go-controller/vendor/github.com/ebay/libovsdb/client.go
+++ b/go-controller/vendor/github.com/ebay/libovsdb/client.go
@@ -95,11 +95,17 @@ func Connect(endpoints string, tlsConfig *tls.Config) (*OvsdbClient, error) {
 	return nil, fmt.Errorf("failed to connect: %s", err.Error())
 }
 
+func handleMonitorCancel(client *rpc2.Client, params []interface{}, reply *interface{}) error {
+	log.Println("monitor cancel received")
+	return client.Close()
+}
+
 func newRPC2Client(conn net.Conn) (*OvsdbClient, error) {
 	c := rpc2.NewClientWithCodec(jsonrpc.NewJSONCodec(conn))
 	c.SetBlocking(true)
 	c.Handle("echo", echo)
 	c.Handle("update", update)
+	c.Handle("monitor_cancel", handleMonitorCancel)
 	go c.Run()
 	go handleDisconnectNotification(c)
 


### PR DESCRIPTION
Under heavy load, monitor gets dropped silently and we stop receiving update messages from ovsdbserver. This leads to stale cache and inconsistency with what's in the DB leading to transaction errors. While this is originally a ovsdbserver bug, a workwround fix here would be to trigger reconnect to recreate the monitor and start receiving update messages, when a transaction error occurs.

