### PR TITLE
[release-4.7] Bug 2001543: fix reserve joinSwitch LRP IPs

### DIFF
--- a/go-controller/pkg/ovn/gateway.go
+++ b/go-controller/pkg/ovn/gateway.go
@@ -2,10 +2,8 @@ package ovn
 
 import (
 	"fmt"
-	"net"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/gateway"
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 
 	kapi "k8s.io/api/core/v1"
@@ -138,36 +136,4 @@ func (ovn *Controller) deleteIngressVIPs(service *kapi.Service, svcPort kapi.Ser
 		}
 	}
 	return nil
-}
-
-// getJoinLRPAddresses check if IPs of gateway logical router port are within the join switch IP range, and return them if true.
-func (oc *Controller) getJoinLRPAddresses(nodeName string) []*net.IPNet {
-	// try to get the IPs from the logical router port
-	gwLRPIPs := []*net.IPNet{}
-	gwLrpName := types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + nodeName
-	joinSubnets := oc.joinSwIPManager.lsm.GetSwitchSubnets(nodeName)
-	ifAddrs, err := util.GetLRPAddrs(gwLrpName)
-	if err == nil {
-		for _, ifAddr := range ifAddrs {
-			for _, subnet := range joinSubnets {
-				if subnet.Contains(ifAddr.IP) {
-					gwLRPIPs = append(gwLRPIPs, &net.IPNet{IP: ifAddr.IP, Mask: subnet.Mask})
-					break
-				}
-			}
-		}
-	}
-
-	if len(gwLRPIPs) != len(joinSubnets) {
-		var errStr string
-		if len(gwLRPIPs) == 0 {
-			errStr = fmt.Sprintf("Failed to get IPs for logical router port %s", gwLrpName)
-		} else {
-			errStr = fmt.Sprintf("Invalid IPs %s (possibly not in the range of subnet %s)",
-				util.JoinIPNetIPs(gwLRPIPs, " "), util.JoinIPNetIPs(joinSubnets, " "))
-		}
-		klog.Warningf("%s for logical router port %s", errStr, gwLrpName)
-		return []*net.IPNet{}
-	}
-	return gwLRPIPs
 }

--- a/go-controller/pkg/ovn/logical_switch_manager.go
+++ b/go-controller/pkg/ovn/logical_switch_manager.go
@@ -386,6 +386,17 @@ func (jsIPManager *joinSwitchIPManager) ensureJoinLRPIPs(nodeName string) (gwLRP
 	if ok {
 		return gwLRPIPs, nil
 	}
+	// second check the running DB
+	gwLRPIPs = jsIPManager.getJoinLRPAddresses(nodeName)
+	if len(gwLRPIPs) > 0 {
+		// Saving the hit in the cache
+		err = jsIPManager.reserveJoinLRPIPs(nodeName, gwLRPIPs)
+		if err != nil {
+			klog.Errorf("Failed to add reserve IPs to the join switch IP cache: %s", err.Error())
+			return nil, err
+		}
+		return gwLRPIPs, nil
+	}
 	gwLRPIPs, err = jsIPManager.lsm.AllocateNextIPs(types.OVNJoinSwitch)
 	if err != nil {
 		return nil, err
@@ -406,6 +417,38 @@ func (jsIPManager *joinSwitchIPManager) ensureJoinLRPIPs(nodeName string) (gwLRP
 	}
 
 	return gwLRPIPs, nil
+}
+
+// getJoinLRPAddresses check if IPs of gateway logical router port are within the join switch IP range, and return them if true.
+func (jsIPManager *joinSwitchIPManager) getJoinLRPAddresses(nodeName string) []*net.IPNet {
+	// try to get the IPs from the logical router port
+	gwLRPIPs := []*net.IPNet{}
+	gwLrpName := types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + nodeName
+	joinSubnets := jsIPManager.lsm.GetSwitchSubnets(types.OVNJoinSwitch)
+	ifAddrs, err := util.GetLRPAddrs(gwLrpName)
+	if err == nil {
+		for _, ifAddr := range ifAddrs {
+			for _, subnet := range joinSubnets {
+				if subnet.Contains(ifAddr.IP) {
+					gwLRPIPs = append(gwLRPIPs, &net.IPNet{IP: ifAddr.IP, Mask: subnet.Mask})
+					break
+				}
+			}
+		}
+	}
+
+	if len(gwLRPIPs) != len(joinSubnets) {
+		var errStr string
+		if len(gwLRPIPs) == 0 {
+			errStr = fmt.Sprintf("Failed to get IPs for logical router port %s", gwLrpName)
+		} else {
+			errStr = fmt.Sprintf("Invalid IPs %s (possibly not in the range of subnet %s)",
+				util.JoinIPNetIPs(gwLRPIPs, " "), util.JoinIPNetIPs(joinSubnets, " "))
+		}
+		klog.Warningf("%s for logical router port %s", errStr, gwLrpName)
+		return []*net.IPNet{}
+	}
+	return gwLRPIPs
 }
 
 func (jsIPManager *joinSwitchIPManager) releaseJoinLRPIPs(nodeName string) error {

--- a/go-controller/pkg/ovn/logical_switch_manager/logical_switch_manager_test.go
+++ b/go-controller/pkg/ovn/logical_switch_manager/logical_switch_manager_test.go
@@ -1,4 +1,4 @@
-package ovn
+package logicalswitchmanager
 
 import (
 	"github.com/urfave/cli/v2"
@@ -20,7 +20,7 @@ var _ = Describe("OVN Logical Switch Manager operations", func() {
 	var (
 		app       *cli.App
 		fexec     *ovntest.FakeExec
-		lsManager *logicalSwitchManager
+		lsManager *LogicalSwitchManager
 	)
 
 	BeforeEach(func() {
@@ -30,7 +30,7 @@ var _ = Describe("OVN Logical Switch Manager operations", func() {
 		app = cli.NewApp()
 		app.Name = "test"
 		app.Flags = config.Flags
-		lsManager = newLogicalSwitchManager()
+		lsManager = NewLogicalSwitchManager()
 	})
 
 	Context("when adding node", func() {

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -272,7 +272,9 @@ func (oc *Controller) StartClusterMaster(masterNodeName string) error {
 		klog.V(5).Infof("Added network range %s to the allocator", clusterEntry.CIDR)
 		util.CalculateHostSubnetsForClusterEntry(clusterEntry, &v4HostSubnetCount, &v6HostSubnetCount)
 	}
+	nodeNames := []string{}
 	for _, node := range existingNodes.Items {
+		nodeNames = append(nodeNames, node.Name)
 		hostSubnets, _ := util.ParseNodeHostSubnetAnnotation(&node)
 		klog.V(5).Infof("Node %s contains subnets: %v", node.Name, hostSubnets)
 		for _, hostSubnet := range hostSubnets {
@@ -313,7 +315,7 @@ func (oc *Controller) StartClusterMaster(masterNodeName string) error {
 		}
 	}
 
-	if err := oc.SetupMaster(masterNodeName); err != nil {
+	if err := oc.SetupMaster(masterNodeName, nodeNames); err != nil {
 		klog.Errorf("Failed to setup master (%v)", err)
 		return err
 	}
@@ -337,7 +339,7 @@ func (oc *Controller) StartClusterMaster(masterNodeName string) error {
 }
 
 // SetupMaster creates the central router and load-balancers for the network
-func (oc *Controller) SetupMaster(masterNodeName string) error {
+func (oc *Controller) SetupMaster(masterNodeName string, existingNodeNames []string) error {
 	// Create a single common distributed router for the cluster.
 	stdout, stderr, err := util.RunOVNNbctl("--", "--may-exist", "lr-add", types.OVNClusterRouter,
 		"--", "set", "logical_router", types.OVNClusterRouter, "external_ids:k8s-cluster-router=yes",
@@ -448,7 +450,7 @@ func (oc *Controller) SetupMaster(masterNodeName string) error {
 
 	// Initialize the OVNJoinSwitch switch IP manager
 	// The OVNJoinSwitch will be allocated IP addresses in the range 100.64.0.0/16 or fd98::/64.
-	oc.joinSwIPManager, err = initJoinLogicalSwitchIPManager()
+	oc.joinSwIPManager, err = newJoinLogicalSwitchIPManager(existingNodeNames)
 	if err != nil {
 		return err
 	}

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -1226,8 +1226,10 @@ func (oc *Controller) syncNodes(nodes []interface{}) {
 		}
 		foundNodes[node.Name] = node
 		// For each existing node, reserve its joinSwitch LRP IPs if they already exist.
-		gwLRPIPs := oc.getJoinLRPAddresses(node.Name)
-		_ = oc.joinSwIPManager.reserveJoinLRPIPs(node.Name, gwLRPIPs)
+		_, err := oc.joinSwIPManager.ensureJoinLRPIPs(node.Name)
+		if err != nil {
+			klog.Errorf("Failed to get join switch port IP address for node %s: %v", node.Name, err)
+		}
 	}
 
 	// We only deal with cleaning up nodes that shouldn't exist here, since

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -602,7 +602,7 @@ func (oc *Controller) syncGatewayLogicalNetwork(node *kapi.Node, l3GatewayConfig
 	// GatewayModeLocal is only used if Local mode is specified and None shared gateway bridge is specified
 	// This is to allow local gateway mode without having to configure/use the shared gateway bridge
 	// See https://github.com/openshift/ovn-kubernetes/pull/281
-	drLRPIPs, _ := oc.joinSwIPManager.getJoinLRPCacheIPs(types.OVNClusterRouter)
+	drLRPIPs, _ := oc.joinSwIPManager.ensureJoinLRPIPs(types.OVNClusterRouter)
 	if l3GatewayConfig.Mode == config.GatewayModeLocal {
 		err = gatewayInitMinimal(node.Name, l3GatewayConfig, oc.SCTPSupport)
 		if err != nil {

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -1264,6 +1264,9 @@ var _ = Describe("Gateway Init Operations", func() {
 			l3GatewayConfig, err := util.ParseNodeL3GatewayAnnotation(updatedNode)
 			Expect(err).NotTo(HaveOccurred())
 
+			fexec.AddFakeCmdsNoOutputNoError([]string{
+				"ovn-nbctl --timeout=15 --if-exist get logical_router_port rtoj-GR_" + types.OVNClusterRouter + " networks",
+			})
 			addNodeLogicalFlows(fexec, &node1, clusterCIDR, config.IPv6Mode, true)
 
 			addPBRandNATRules(fexec, node1.Name, node1.NodeSubnet, node1.GatewayRouterIP, node1.NodeMgmtPortIP, node1.NodeMgmtPortMAC)

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
 	addressset "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/address_set"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/ipallocator"
+	lsm "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/logical_switch_manager"
 	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
@@ -1291,8 +1292,8 @@ var _ = Describe("Gateway Init Operations", func() {
 			clusterController.UDPLoadBalancerUUID = node1.UDPLBUUID
 			clusterController.SCTPLoadBalancerUUID = node1.SCTPLBUUID
 			clusterController.SCTPSupport = true
-			clusterController.joinSwIPManager, _ = newJoinLogicalSwitchIPManager([]string{node1.Name})
-			_, _ = clusterController.joinSwIPManager.ensureJoinLRPIPs(types.OVNClusterRouter)
+			clusterController.joinSwIPManager, _ = lsm.NewJoinLogicalSwitchIPManager([]string{node1.Name})
+			_, _ = clusterController.joinSwIPManager.EnsureJoinLRPIPs(types.OVNClusterRouter)
 
 			clusterController.nodeLocalNatIPv4Allocator, _ = ipallocator.NewCIDRRange(ovntest.MustParseIPNet(types.V4NodeLocalNATSubnet))
 

--- a/go-controller/pkg/ovn/namespace.go
+++ b/go-controller/pkg/ovn/namespace.go
@@ -481,7 +481,7 @@ func (oc *Controller) createNamespaceAddrSetAllPods(ns string) (addressset.Addre
 				}
 				// for shared gateway mode we will use LRP IPs to SNAT host network traffic
 				// so add these to the address set.
-				lrpIPs, err := oc.joinSwIPManager.ensureJoinLRPIPs(node.Name)
+				lrpIPs, err := oc.joinSwIPManager.EnsureJoinLRPIPs(node.Name)
 				if err != nil {
 					klog.Errorf("Failed to get join switch port IP address for node %s: %v", node.Name, err)
 				}

--- a/go-controller/pkg/ovn/namespace_test.go
+++ b/go-controller/pkg/ovn/namespace_test.go
@@ -258,6 +258,10 @@ var _ = Describe("OVN Namespace Operations", func() {
 				fakeOvn.controller.SCTPSupport = true
 
 				fexec := fakeOvn.fakeExec
+				fexec.AddFakeCmdsNoOutputNoError([]string{
+					"ovn-nbctl --timeout=15 --if-exist get logical_router_port rtoj-GR_" + ovntypes.OVNClusterRouter + " networks",
+				})
+
 				addNodeLogicalFlows(fexec, &node1, clusterCIDR, config.IPv6Mode, false)
 				fakeOvn.controller.joinSwIPManager, _ = initJoinLogicalSwitchIPManager()
 				_, err = fakeOvn.controller.joinSwIPManager.ensureJoinLRPIPs(ovntypes.OVNClusterRouter)

--- a/go-controller/pkg/ovn/namespace_test.go
+++ b/go-controller/pkg/ovn/namespace_test.go
@@ -10,6 +10,7 @@ import (
 	egressfirewallfake "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressfirewall/v1/apis/clientset/versioned/fake"
 	egressipfake "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressip/v1/apis/clientset/versioned/fake"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
+	lsm "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/logical_switch_manager"
 	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
 	ovntypes "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	util "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
@@ -267,10 +268,10 @@ var _ = Describe("OVN Namespace Operations", func() {
 				})
 
 				addNodeLogicalFlows(fexec, &node1, clusterCIDR, config.IPv6Mode, false)
-				fakeOvn.controller.joinSwIPManager, _ = newJoinLogicalSwitchIPManager([]string{node1.Name})
-				_, err = fakeOvn.controller.joinSwIPManager.ensureJoinLRPIPs(ovntypes.OVNClusterRouter)
+				fakeOvn.controller.joinSwIPManager, _ = lsm.NewJoinLogicalSwitchIPManager([]string{node1.Name})
+				_, err = fakeOvn.controller.joinSwIPManager.EnsureJoinLRPIPs(ovntypes.OVNClusterRouter)
 				Expect(err).NotTo(HaveOccurred())
-				gwLRPIPs, err := fakeOvn.controller.joinSwIPManager.ensureJoinLRPIPs(node1.Name)
+				gwLRPIPs, err := fakeOvn.controller.joinSwIPManager.EnsureJoinLRPIPs(node1.Name)
 				Expect(len(gwLRPIPs) != 0).To(BeTrue())
 
 				fakeOvn.controller.WatchNamespaces()

--- a/go-controller/pkg/ovn/namespace_test.go
+++ b/go-controller/pkg/ovn/namespace_test.go
@@ -261,9 +261,13 @@ var _ = Describe("OVN Namespace Operations", func() {
 				fexec.AddFakeCmdsNoOutputNoError([]string{
 					"ovn-nbctl --timeout=15 --if-exist get logical_router_port rtoj-GR_" + ovntypes.OVNClusterRouter + " networks",
 				})
+				fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+					Cmd:    "ovn-nbctl --timeout=15 --if-exist get logical_router_port rtoj-GR_" + node1.Name + " networks",
+					Output: "[\"100.64.0.2/16\"]",
+				})
 
 				addNodeLogicalFlows(fexec, &node1, clusterCIDR, config.IPv6Mode, false)
-				fakeOvn.controller.joinSwIPManager, _ = initJoinLogicalSwitchIPManager()
+				fakeOvn.controller.joinSwIPManager, _ = newJoinLogicalSwitchIPManager([]string{node1.Name})
 				_, err = fakeOvn.controller.joinSwIPManager.ensureJoinLRPIPs(ovntypes.OVNClusterRouter)
 				Expect(err).NotTo(HaveOccurred())
 				gwLRPIPs, err := fakeOvn.controller.joinSwIPManager.ensureJoinLRPIPs(node1.Name)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

Background to this PR:

- #683 fixed a problem w.r.t syncing the join IP for each node upon a ovnkube-master restart
- it however introduced the regression: https://bugzilla.redhat.com/show_bug.cgi?id=1999896
- Hence #707 reverted it.
- Bug 1998423: kube master don't fail trying to cache same GW LRP IPs as already exist #705 fixed the regression on master
- Hence we now have to revert the revert (#707) and back-port the complete fix Bug 1998423: kube master don't fail trying to cache same GW LRP IPs as already exist #705

/assign @abhat @dcbw

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->