### PR TITLE
Bug 1995335: Add "iface-id-ver=${POD_UID}" tuple to the external-ids of logical and OVS ports

### DIFF
--- a/go-controller/pkg/cni/helper_linux.go
+++ b/go-controller/pkg/cni/helper_linux.go
@@ -278,6 +278,7 @@ func ConfigureOVS(ctx context.Context, namespace, podName, hostIfaceName string,
 		"interface", hostIfaceName,
 		fmt.Sprintf("external_ids:attached_mac=%s", ifInfo.MAC),
 		fmt.Sprintf("external_ids:iface-id=%s", ifaceID),
+		fmt.Sprintf("external_ids:iface-id-ver=%s", initialPodUID),
 		fmt.Sprintf("external_ids:ip_addresses=%s", strings.Join(ipStrs, ",")),
 		fmt.Sprintf("external_ids:sandbox=%s", sandboxID),
 	}

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -348,7 +348,8 @@ type HybridOverlayConfig struct {
 
 // OvnKubeNodeConfig holds ovnkube-node configurations
 type OvnKubeNodeConfig struct {
-	Mode string `gcfg:"mode"`
+	Mode                 string `gcfg:"mode"`
+	DisableOVNIfaceIdVer bool   `gcfg:"disable-ovn-iface-id-ver"`
 }
 
 // OvnDBScheme describes the OVN database connection transport method
@@ -1041,6 +1042,13 @@ var OvnKubeNodeFlags = []cli.Flag{
 		Usage:       "ovnkube-node operating mode full(default), smart-nic, smart-nic-host",
 		Value:       OvnKubeNode.Mode,
 		Destination: &cliConfig.OvnKubeNode.Mode,
+	},
+	&cli.BoolFlag{
+		Name: "disable-ovn-iface-id-ver",
+		Usage: "if iface-id-ver option is not enabled in ovn, set this flag to True " +
+			"(depends on ovn version, minimal required is 21.09)",
+		Value:       OvnKubeNode.DisableOVNIfaceIdVer,
+		Destination: &cliConfig.OvnKubeNode.DisableOVNIfaceIdVer,
 	},
 }
 

--- a/go-controller/pkg/node/node.go
+++ b/go-controller/pkg/node/node.go
@@ -248,7 +248,13 @@ func isOVNControllerReady(name string) (bool, error) {
 // Starting with v21.03.0 OVN sets OVS.Interface.external-id:ovn-installed
 // and OVNSB.Port_Binding.up when all OVS flows associated to a
 // logical port have been successfully programmed.
+// OVS.Interface.external-id:ovn-installed can only be used correctly
+// in a combination with OVS.Interface.external-id:iface-id-ver
 func getOVNIfUpCheckMode() (bool, error) {
+	if config.OvnKubeNode.DisableOVNIfaceIdVer {
+		klog.Infof("'iface-id-ver' is manually disabled, ovn-installed feature can't be used")
+		return false, nil
+	}
 	if _, stderr, err := util.RunOVNSbctl("--columns=up", "list", "Port_Binding"); err != nil {
 		if strings.Contains(stderr, "does not contain a column") {
 			klog.Infof("Falling back to using legacy CNI OVS flow readiness checks")
@@ -433,8 +439,14 @@ func (n *OvnNode) Start(wg *sync.WaitGroup) error {
 					}
 				}
 				// ensure CNI support for port binding built into OVN, as masters have been upgraded
-				if initialTopoVersion < types.OvnPortBindingTopoVersion && cniServer != nil {
-					cniServer.EnableOVNPortUpSupport()
+				if initialTopoVersion < types.OvnPortBindingTopoVersion && cniServer != nil && !isOvnUpEnabled {
+					isOvnUpEnabled, err = getOVNIfUpCheckMode()
+					if err != nil {
+						klog.Errorf("%v", err)
+					}
+					if isOvnUpEnabled {
+						cniServer.EnableOVNPortUpSupport()
+					}
 				}
 			}()
 		}

--- a/go-controller/pkg/node/node_smartnic_test.go
+++ b/go-controller/pkg/node/node_smartnic_test.go
@@ -24,10 +24,10 @@ func genOVSFindCmd(table, column, condition string) string {
 		column, table, condition)
 }
 
-func genOVSAddPortCmd(hostIfaceName, ifaceID, mac, ip, sandboxID string) string {
+func genOVSAddPortCmd(hostIfaceName, ifaceID, mac, ip, sandboxID, podUID string) string {
 	return fmt.Sprintf("ovs-vsctl --timeout=30 add-port br-int %s -- set interface %s external_ids:attached_mac=%s "+
-		"external_ids:iface-id=%s external_ids:ip_addresses=%s external_ids:sandbox=%s",
-		hostIfaceName, hostIfaceName, mac, ifaceID, ip, sandboxID)
+		"external_ids:iface-id=%s external_ids:iface-id-ver=%s external_ids:ip_addresses=%s external_ids:sandbox=%s",
+		hostIfaceName, hostIfaceName, mac, ifaceID, podUID, ip, sandboxID)
 }
 
 func genOVSDelPortCmd(portName string) string {
@@ -157,7 +157,7 @@ var _ = Describe("Node Smart NIC tests", func() {
 					"external-ids:iface-id="+genIfaceID(pod.Namespace, pod.Name)),
 			})
 			execMock.AddFakeCmd(&ovntest.ExpectedCmd{
-				Cmd: genOVSAddPortCmd(vfRep, genIfaceID(pod.Namespace, pod.Name), "", "", "a8d09931"),
+				Cmd: genOVSAddPortCmd(vfRep, genIfaceID(pod.Namespace, pod.Name), "", "", "a8d09931", string(pod.UID)),
 				Err: fmt.Errorf("failed to run ovs command"),
 			})
 			// Mock netlink/ovs calls for cleanup
@@ -185,7 +185,7 @@ var _ = Describe("Node Smart NIC tests", func() {
 						"external-ids:iface-id="+genIfaceID(pod.Namespace, pod.Name)),
 				})
 				execMock.AddFakeCmd(&ovntest.ExpectedCmd{
-					Cmd: genOVSAddPortCmd(vfRep, genIfaceID(pod.Namespace, pod.Name), "", "", "a8d09931"),
+					Cmd: genOVSAddPortCmd(vfRep, genIfaceID(pod.Namespace, pod.Name), "", "", "a8d09931", string(pod.UID)),
 				})
 				// clearPodBandwidth
 				execMock.AddFakeCmd(&ovntest.ExpectedCmd{

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -277,16 +277,6 @@ func (oc *Controller) addLogicalPort(pod *kapi.Pod) (err error) {
 		return fmt.Errorf("unable to get the lsp: %s from the nbdb: %s", portName, err)
 	}
 
-	if lsp == nil {
-		cmd, err = oc.ovnNBClient.LSPAdd(logicalSwitch, portName)
-		if err != nil {
-			return fmt.Errorf("unable to create the LSPAdd command for port: %s from the nbdb: %v", portName, err)
-		}
-		cmds = append(cmds, cmd)
-	} else {
-		klog.Infof("LSP already exists for port: %s", portName)
-	}
-
 	// Bind the port to the node's chassis; prevents ping-ponging between
 	// chassis if ovnkube-node isn't running correctly and hasn't cleared
 	// out iface-id for an old instance of this pod, and the pod got
@@ -299,6 +289,26 @@ func (oc *Controller) addLogicalPort(pod *kapi.Pod) (err error) {
 		opts = make(map[string]string)
 	}
 	opts["requested-chassis"] = pod.Spec.NodeName
+
+	if lsp == nil {
+		cmd, err = oc.ovnNBClient.LSPAdd(logicalSwitch, portName)
+		if err != nil {
+			return fmt.Errorf("unable to create the LSPAdd command for port: %s from the nbdb: %v", portName, err)
+		}
+		cmds = append(cmds, cmd)
+		// Unique identifier to distinguish interfaces for recreated pods, also set by ovnkube-node
+		// ovn-controller will claim the OVS interface only if external_ids:iface-id
+		// matches with the Port_Binding.logical_port and external_ids:iface-id-ver matches
+		// with the Port_Binding.options:iface-id-ver. This is not mandatory.
+		// If Port_binding.options:iface-id-ver is not set, then OVS
+		// Interface.external_ids:iface-id-ver if set is ignored.
+		// Only set for new LSP for correct ovn-kube upgrade, because for old OVS Interfaces
+		// iface-id-ver is not set => ovn-controller won't bind OVS Interface
+		opts["iface-id-ver"] = string(pod.UID)
+	} else {
+		klog.Infof("LSP already exists for port: %s", portName)
+	}
+
 	cmd, err = oc.ovnNBClient.LSPSetOptions(portName, opts)
 	if err != nil {
 		return fmt.Errorf("unable to create the LSPSetOptions command for port: %s from the nbdb: %v", portName, err)
@@ -498,7 +508,8 @@ func (oc *Controller) addLogicalPort(pod *kapi.Pod) (err error) {
 
 	cmds = append(cmds, cmd)
 
-	// execute all the commands together.
+	// execute all the commands together. If a single operation fails, all commands will roll back =>
+	// for new Pod no LSP will be created
 	err = oc.ovnNBClient.Execute(cmds...)
 	if err != nil {
 		return fmt.Errorf("error while creating logical port %s error: %v",


### PR DESCRIPTION
Fixes #1995335
Newly added option [1] allows to distinguish new vs old logical
ports for recreated pod with the same name, thus making "ovn-installed"
option reliable again [2].

1. Add "iface-id-ver" option to logical and OVS ports
[Upgrade][master] add iface-id-ver only for newly created Ports,
no ovn version check, since if iface-id-ver is not enabled in ovn, it will be just ignored
[Upgrade][node] no additional actions are needed, because existing Interfaces don't need
iface-id-set since it won't be set in master. Ovn support for iface-id-ver will be checked
during cni server creation
2. Add OvnKubeNodeConfig option "ovn-iface-id-ver-disabled" to manually
   disable this feature for older ovn versions
3. Change test mock that checks ovs add-port command
4. Add common function to compose LogicalPort name = iface-id
5. Enable OVNPortUp support after upgrade based on OVNTopo version and getOVNIfUpCheckMode check
6. revert [2]
[1] ovn-org/ovn@922c45f
[2] 22bed6a

Signed-off-by: Nadia Pinaeva <npinaeva@redhat.com>
Upstream PR: https://github.com/ovn-org/ovn-kubernetes/pull/2455