### PR TITLE
Bug 2002372: Fixes misuse of pod annotations during update event

### DIFF
--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -610,6 +610,21 @@ func (oc *Controller) WatchPods() {
 		UpdateFunc: func(old, newer interface{}) {
 			oldPod := old.(*kapi.Pod)
 			pod := newer.(*kapi.Pod)
+			// there may be a situation where this update event is not the latest
+			// and we rely on annotations to determine the pod mac/ifaddr
+			// this would create a situation where
+			// 1. addLogicalPort is executing with an older pod annotation, skips setting a new annotation
+			// 2. creates OVN logical port with old pod annotation value
+			// 3. CNI flows check fails and pod annotation does not match what is in OVN
+			// Therefore we need to get the latest version of this pod to attempt to addLogicalPort with
+			podName := pod.Name
+			podNs := pod.Namespace
+			pod, err := oc.watchFactory.GetPod(podNs, podName)
+			if err != nil {
+				klog.Warningf("Unable to get pod %s/%s for pod update, most likely it was already deleted",
+					podNs, podName)
+				return
+			}
 			if !oc.ensurePod(oldPod, pod, oc.checkAndSkipRetryPod(pod.UID)) {
 				// unskip failed pod for next retry iteration
 				oc.unSkipRetryPod(pod)


### PR DESCRIPTION
In the update pod logic, we pass the current pod event to
addLogicalPort. In addLogicalPort we assume that if the annotations
exist for the pod mac/ifaddr, then we use those and do not update
annotations on the pod. This assumption is invalid, because this event
may not be the current state of the pod. In other words we could have a
situation where:

1. A pod add event comes we annotate with 10.0.0.2, assume OVN execute
   failure
2. Before the annotate is done, the pod is modified in some other way
   signaling another pod update event
3. A pod update event comes for 2, the pod is annotated with 10.0.0.3
   because this was an update to the original pod, before it was
   annotated with 10.0.0.2, assume OVN execute failure
4. A pod update event comes for 1, since annotations existed, nothing is
   annotated and 10.0.0.2 is found to be used. OVN logical port is
   configured with 10.0.0.2. addLogicalPort succeeds.
5. Now the pod has 10.0.0.3 annotated, and 10.0.0.2 in OVN. CNI openflow
   check will fail and the pod will never come up.

Signed-off-by: Tim Rozet <trozet@redhat.com>

