### PR TITLE
Bug 2003195: Ensure host interfaces are deleted by CNI

### DIFF
--- a/go-controller/pkg/cni/helper_linux.go
+++ b/go-controller/pkg/cni/helper_linux.go
@@ -8,7 +8,6 @@ import (
 	"io/ioutil"
 	"net"
 	"os"
-	"os/exec"
 	"strconv"
 	"strings"
 
@@ -420,10 +419,7 @@ func (pr *PodRequest) deletePodConntrack() {
 // PlatformSpecificCleanup deletes the OVS port
 func (pr *PodRequest) PlatformSpecificCleanup() error {
 	ifaceName := pr.SandboxID[:15]
-	ovsArgs := []string{
-		"del-port", "br-int", ifaceName,
-	}
-	out, err := exec.Command("ovs-vsctl", ovsArgs...).CombinedOutput()
+	out, err := ovsExec("del-port", "br-int", ifaceName)
 	if err != nil && !strings.Contains(string(out), "no port named") {
 		// DEL should be idempotent; don't return an error just log it
 		klog.Warningf("Failed to delete OVS port %s: %v\n  %q", ifaceName, err, string(out))


### PR DESCRIPTION
    Due to https://bugzilla.redhat.com/show_bug.cgi?id=2003193 where crio
    is not cleaning up leftover veths/netns...overtime OVS CPU climbs to
    100% and performance degrades in the node. This ensures OVN CNI cleans
    up the ports rather than relying on kublet/crio.
