### PR TITLE
Bug 2000057: panic after EgressFirewall deletion and DNS record expiration

### DIFF
--- a/go-controller/pkg/ovn/egressfirewall.go
+++ b/go-controller/pkg/ovn/egressfirewall.go
@@ -333,10 +333,16 @@ func (oc *Controller) deleteEgressFirewall(egressFirewallObj *egressfirewallapi.
 	deleteDNS := false
 	obj, loaded := oc.egressFirewalls.LoadAndDelete(egressFirewallObj.Namespace)
 	if !loaded {
-		return fmt.Errorf("there is no egressFirewall found in namespace %s", egressFirewallObj.Namespace)
+		return fmt.Errorf("there is no egressFirewall found in namespace %s",
+			egressFirewallObj.Namespace)
 	}
 
-	ef, _ := obj.(egressFirewall)
+	ef, ok := obj.(*egressFirewall)
+	if !ok {
+		return fmt.Errorf("deleteEgressFirewall failed: type assertion to *egressFirewall"+
+			" failed for EgressFirewall %s of type %T in namespace %s.",
+			egressFirewallObj.Name, obj, egressFirewallObj.Namespace)
+	}
 
 	ef.Lock()
 	defer ef.Unlock()

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -2945,7 +2945,7 @@ var _ = ginkgo.Describe("e2e delete databases", func() {
 			}
 			return nil
 		}
-		return fmt.Errorf("Gave up after waiting %v for pod %q to be %q: pod is not found", timeout, podName, desc)
+		return fmt.Errorf("gave up after waiting %v for pod %q to be %q: pod is not found", timeout, podName, desc)
 	}
 
 	// waitForPodToFinishFullRestart waits for a the pod to finish it's reset cycle and returns.

--- a/test/e2e/unidling.go
+++ b/test/e2e/unidling.go
@@ -89,7 +89,7 @@ var _ = ginkgo.Describe("Unidling", func() {
 		if pollErr := wait.PollImmediate(framework.Poll, e2eservice.KubeProxyEndpointLagTimeout, func() (bool, error) {
 			_, err := framework.RunHostCmd(execPod.Namespace, execPod.Name, cmd)
 			if err != nil && strings.Contains(err.Error(), nonExpectedErr) {
-				return false, fmt.Errorf("Service is rejecting packets")
+				return false, fmt.Errorf("service is rejecting packets")
 			}
 			// An event like this must be generated
 			// oc.recorder.Eventf(&serviceRef, kapi.EventTypeNormal, "NeedPods", "The service %s needs pods", serviceName.Name)


### PR DESCRIPTION
(backport of upstream https://github.com/ovn-org/ovn-kubernetes/pull/2471)

- Add a new channel named "deleted" to the EgressDNS struct, so that the domain name (if any) of a newly deleted EgressFirewall can be passed over to the Run() loop, which keeps track of DNS records and updates them as soon as they expire. This prevents inconsistencies between current EgressFirewalls and corresponding DNS records, which eventually led to a panic in a customer case.

- The aforementioned panic is now avoided by checking for the presence of the given DNS domain to delete in a map, before proceeding to update its (pointer) value.
- Fix type assertion when deleting EgressFirewalls, which resulted in DNS records never being deleted from the Run() loop.
(- Make error messages start with lowercase letters to comply with style guidelines, as a CI test was failing)

This patch fixes #2000057.

Signed-off-by: Riccardo Ravaioli <rravaiol@redhat.com>
(cherry picked from commit 12ff248bd2878f98bfae0dae5e207352d7def96b)