### PR TITLE
[release-4.8] Bug 2004488: panic after EgressFirewall deletion and DNS record expiration

### DIFF
--- a/test/e2e/unidling.go
+++ b/test/e2e/unidling.go
@@ -89,7 +89,7 @@ var _ = ginkgo.Describe("Unidling", func() {
 		if pollErr := wait.PollImmediate(framework.Poll, e2eservice.KubeProxyEndpointLagTimeout, func() (bool, error) {
 			_, err := framework.RunHostCmd(execPod.Namespace, execPod.Name, cmd)
 			if err != nil && strings.Contains(err.Error(), nonExpectedErr) {
-				return false, fmt.Errorf("Service is rejecting packets")
+				return false, fmt.Errorf("service is rejecting packets")
 			}
 			// An event like this must be generated
 			// oc.recorder.Eventf(&serviceRef, kapi.EventTypeNormal, "NeedPods", "The service %s needs pods", serviceName.Name)


### PR DESCRIPTION
(backport from https://github.com/openshift/ovn-kubernetes/pull/741)

- Added a new channel named "deleted" to the EgressDNS struct, so tha…t the domain name (if any) of a newly deleted EgressFirewall can be passed over to the Run() loop, which keeps track of DNS records and updates them as soon as they expire. This prevents inconsistencies between current EgressFirewalls and corresponding DNS records, which eventually led to a panic in a customer case.

- The aforementioned panic is now avoided by checking for the presence of the given DNS domain to delete in a map, before proceeding to update its (pointer) value.

(- Made error messages start with lowercase letters to comply with style guidelines, as a CI test was failing)

This patch fixes bug BZ 2004488.

Signed-off-by: Riccardo Ravaioli <rravaiol@redhat.com>
(cherry picked from commit 12ff248bd2878f98bfae0dae5e207352d7def96b)
