### PR TITLE
[release-4.7] Bug 2004489: panic after EgressFirewall deletion and DNS record expiration

### DIFF
--- a/go-controller/pkg/ovn/egressfirewall.go
+++ b/go-controller/pkg/ovn/egressfirewall.go
@@ -162,7 +162,7 @@ func (oc *Controller) syncEgressFirewall(egressFirwalls []interface{}) {
 		return
 	}
 	if egressFirewallACLIDs != "" {
-		for _, egressFirewallACLID := range strings.Split(egressFirewallACLIDs, "\n") {
+		for _, egressFirewallACLID := range strings.Fields(egressFirewallACLIDs) {
 			_, stderr, err := util.RunOVNNbctl(
 				"set",
 				"acl",


### PR DESCRIPTION
(backport for 4.7 of upstream ovn-org/ovn-kubernetes#2471)

- Added a new channel named "deleted" to the EgressDNS struct, so that the domain name (if any) of a newly deleted EgressFirewall can be passed over to the Run() loop, which keeps track of DNS records and updates them as soon as they expire. This prevents inconsistencies between current EgressFirewalls and corresponding DNS records, which eventually led to a panic in a customer case.

- The aforementioned panic is now avoided by checking for the presence of the given DNS domain to delete in a map, before proceeding to update its (pointer) value.

- (also completed backport of upstream commit 0106ec77896e7d492a737e790b635e52fe72b57c that was not carried over in PR #724)

This patch fixes bug BZ #2004489.

Signed-off-by: Riccardo Ravaioli <rravaiol@redhat.com>
(cherry picked from commit 12ff248bd2878f98bfae0dae5e207352d7def96b)