### PR TITLE
[release-4.8] Bug 1996739: Fix ensurePod to call addPodExternalGW only for annotation updates

### DIFF
--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -496,10 +496,13 @@ func (oc *Controller) ensurePod(oldPod, pod *kapi.Pod, addPort bool) bool {
 			return false
 		}
 	} else {
-		if err := oc.addPodExternalGW(pod); err != nil {
-			klog.Errorf(err.Error())
-			oc.recordPodEvent(err, pod)
-			return false
+		// either pod is host-networked or its an update for a normal pod (addPort=false case)
+		if oldPod == nil || exGatewayAnnotationsChanged(oldPod, pod) || networkStatusAnnotationsChanged(oldPod, pod) {
+			if err := oc.addPodExternalGW(pod); err != nil {
+				klog.Errorf(err.Error())
+				oc.recordPodEvent(err, pod)
+				return false
+			}
 		}
 	}
 


### PR DESCRIPTION
Fix ensurePod to call addPodExternalGW only for annotation updates
    
 Currently we call addPodExternalGW from both ensurePod and
addLogicalPort. If ensurePod is called with addPort=false
 from the UpdatePodHandler, it will keep trying to call
 addPodExternalGW to add routes and policies repeatedly
    for the same pod. During exgw pod creation, we see same routes
    and policies getting added 3 times in a row.
    
 Note that https://github.com/ovn-org/ovn-kubernetes/pull/2337
    fixed this by adding a check into addGWRoutesForNamespace to
    return if routes already exist for the pod, but this comes
    later in the code flow. Its better to not call addPodExternalGW
    at all unless needed. This would save time and help with
    pod latency issues specially at scale.
    
Signed-off-by: Surya Seetharaman <suryaseetharaman.9@gmail.com>
    (cherry picked from commit 6b24df28da27310dce1f56e1a033945c1f8cac94)
    (cherry picked from commit 5c503bfa38a65dfa72645da3a39fa6dff5a70b82)
