### PR TITLE
Bug 2005391: [4.7z] Fixes misuse of pod annotations during update event

### DIFF
--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -692,6 +692,22 @@ func (oc *Controller) WatchPods() {
 		UpdateFunc: func(old, newer interface{}) {
 			oldPod := old.(*kapi.Pod)
 			pod := newer.(*kapi.Pod)
+
+			// there may be a situation where this update event is not the latest
+			// and we rely on annotations to determine the pod mac/ifaddr
+			// this would create a situation where
+			// 1. addLogicalPort is executing with an older pod annotation, skips setting a new annotation
+			// 2. creates OVN logical port with old pod annotation value
+			// 3. CNI flows check fails and pod annotation does not match what is in OVN
+			// Therefore we need to get the latest version of this pod to attempt to addLogicalPort with
+			podName := pod.Name
+			podNs := pod.Namespace
+			pod, err := oc.watchFactory.GetPod(podNs, podName)
+			if err != nil {
+				klog.Warningf("Unable to get pod %s/%s for pod update, most likely it was already deleted",
+					podNs, podName)
+				return
+			}
 			if !oc.ensurePod(oldPod, pod, oc.checkAndDeleteRetryPod(pod.UID)) {
 				// add back the failed pod
 				oc.addRetryPod(pod)


### PR DESCRIPTION
In the update pod logic, we pass the current pod event to
addLogicalPort. In addLogicalPort we assume that if the annotations
exist for the pod mac/ifaddr, then we use those and do not update
annotations on the pod. This assumption is invalid, because this event
may not be the current state of the pod. In other words we could have a
situation where:

1. A pod add event comes we annotate with 10.0.0.2, assume OVN execute
   failure
2. Before the annotate is done, the pod is modified in some other way
   signaling another pod update event
3. A pod update event comes for 2, the pod is annotated with 10.0.0.3
   because this was an update to the original pod, before it was
   annotated with 10.0.0.2, assume OVN execute failure
4. A pod update event comes for 1, since annotations existed, nothing is
   annotated and 10.0.0.2 is found to be used. OVN logical port is
   configured with 10.0.0.2. addLogicalPort succeeds.
5. Now the pod has 10.0.0.3 annotated, and 10.0.0.2 in OVN. CNI openflow
   check will fail and the pod will never come up.

Signed-off-by: Tim Rozet <trozet@redhat.com>
(cherry picked from commit 20ded5087b163e84d0406d8fae0ca165a108cf11)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->