### PR TITLE
Bug 2005519: [4.7z] Remove waiting for namespace and namespace lock contention

### DIFF
--- a/go-controller/pkg/ovn/address_set/fake_address_set.go
+++ b/go-controller/pkg/ovn/address_set/fake_address_set.go
@@ -104,12 +104,6 @@ func (f *FakeAddressSetFactory) removeAddressSet(name string) {
 	delete(f.sets, name)
 }
 
-// ExpectNoAddressSet ensures the named address set does not exist
-func (f *FakeAddressSetFactory) ExpectNoAddressSet(name string) {
-	_, ok := f.sets[name]
-	Expect(ok).To(BeFalse())
-}
-
 // ExpectAddressSetWithIPs ensures the named address set exists with the given set of IPs
 func (f *FakeAddressSetFactory) ExpectAddressSetWithIPs(name string, ips []string) {
 	var lenAddressSet int

--- a/go-controller/pkg/ovn/egressgw.go
+++ b/go-controller/pkg/ovn/egressgw.go
@@ -78,10 +78,7 @@ func (oc *Controller) addPodExternalGWForNamespace(namespace string, pod *kapi.P
 	}
 	klog.Infof("Adding routes for external gateway pod: %s, next hops: %q, namespace: %s, bfd-enabled: %t",
 		pod.Name, gws, namespace, egress.bfdEnabled)
-	nsInfo, err := oc.waitForNamespaceLocked(namespace)
-	if err != nil {
-		return err
-	}
+	nsInfo := oc.ensureNamespaceLocked(namespace)
 	defer nsInfo.Unlock()
 	nsInfo.routingExternalPodGWs[pod.Name] = egress
 	return oc.addGWRoutesForNamespace(namespace, egress, nsInfo)
@@ -110,6 +107,11 @@ func (oc *Controller) addGWRoutesForNamespace(namespace string, egress gatewayIn
 		for _, gw := range egress.gws {
 			for _, podIP := range pod.Status.PodIPs {
 				if utilnet.IsIPv6(gw) != utilnet.IsIPv6String(podIP.IP) {
+					continue
+				}
+
+				// if route was already programmed, skip it
+				if foundGR, ok := nsInfo.podExternalRoutes[podIP.IP][gw.String()]; ok && foundGR == gr {
 					continue
 				}
 
@@ -272,10 +274,7 @@ func (oc *Controller) deleteGWRoutesForPod(namespace string, podIPNets []*net.IP
 
 // addEgressGwRoutesForPod handles adding all routes to gateways for a pod on a specific GR
 func (oc *Controller) addGWRoutesForPod(gateways []gatewayInfo, podIfAddrs []*net.IPNet, namespace, node string) error {
-	nsInfo, err := oc.waitForNamespaceLocked(namespace)
-	if err != nil {
-		return err
-	}
+	nsInfo := oc.getNamespaceLocked(namespace)
 	defer nsInfo.Unlock()
 	gr := "GR_" + node
 	for _, podIPNet := range podIfAddrs {
@@ -288,6 +287,10 @@ func (oc *Controller) addGWRoutesForPod(gateways []gatewayInfo, podIfAddrs []*ne
 				podIP := podIPNet.IP.String()
 				for _, gw := range gws {
 					gwStr := gw.String()
+					// if route was already programmed, skip it
+					if foundGR, ok := nsInfo.podExternalRoutes[podIP][gwStr]; ok && foundGR == gr {
+						continue
+					}
 					mask := GetIPFullMask(podIP)
 					nbctlArgs := []string{"--may-exist", "--policy=src-ip", "--ecmp-symmetric-reply",
 						"lr-route-add", gr, podIP + mask, gw.String()}

--- a/go-controller/pkg/ovn/egressgw.go
+++ b/go-controller/pkg/ovn/egressgw.go
@@ -78,8 +78,11 @@ func (oc *Controller) addPodExternalGWForNamespace(namespace string, pod *kapi.P
 	}
 	klog.Infof("Adding routes for external gateway pod: %s, next hops: %q, namespace: %s, bfd-enabled: %t",
 		pod.Name, gws, namespace, egress.bfdEnabled)
-	nsInfo := oc.ensureNamespaceLocked(namespace)
-	defer nsInfo.Unlock()
+	nsInfo, nsUnlock, err := oc.ensureNamespaceLocked(namespace, false)
+	if err != nil {
+		return fmt.Errorf("failed to ensure namespace locked: %v", err)
+	}
+	defer nsUnlock()
 	nsInfo.routingExternalPodGWs[pod.Name] = egress
 	return oc.addGWRoutesForNamespace(namespace, egress, nsInfo)
 }
@@ -157,11 +160,11 @@ func (oc *Controller) deletePodExternalGW(pod *kapi.Pod) {
 
 // deletePodGwRoutesForNamespace handles deleting all routes in a namespace for a specific pod GW
 func (oc *Controller) deletePodGWRoutesForNamespace(pod, namespace string) {
-	nsInfo := oc.getNamespaceLocked(namespace)
+	nsInfo, nsUnlock := oc.getNamespaceLocked(namespace, false)
 	if nsInfo == nil {
 		return
 	}
-	defer nsInfo.Unlock()
+	defer nsUnlock()
 	// check if any gateways were stored for this pod
 	foundGws, ok := nsInfo.routingExternalPodGWs[pod]
 	if !ok {
@@ -241,11 +244,12 @@ func (oc *Controller) deleteGWRoutesForNamespace(nsInfo *namespaceInfo) {
 // deleteGwRoutesForPod handles deleting all routes to gateways for a pod IP on a specific GR
 func (oc *Controller) deleteGWRoutesForPod(namespace string, podIPNets []*net.IPNet) {
 	// delete src-ip cached route to GR
-	nsInfo := oc.getNamespaceLocked(namespace)
+	nsInfo, nsUnlock := oc.getNamespaceLocked(namespace, false)
 	if nsInfo == nil {
 		return
 	}
-	defer nsInfo.Unlock()
+	defer nsUnlock()
+
 	for _, podIPNet := range podIPNets {
 		pod := podIPNet.IP.String()
 		if gwToGr, ok := nsInfo.podExternalRoutes[pod]; ok {
@@ -274,8 +278,11 @@ func (oc *Controller) deleteGWRoutesForPod(namespace string, podIPNets []*net.IP
 
 // addEgressGwRoutesForPod handles adding all routes to gateways for a pod on a specific GR
 func (oc *Controller) addGWRoutesForPod(gateways []gatewayInfo, podIfAddrs []*net.IPNet, namespace, node string) error {
-	nsInfo := oc.getNamespaceLocked(namespace)
-	defer nsInfo.Unlock()
+	nsInfo, nsUnlock := oc.getNamespaceLocked(namespace, false)
+	if nsInfo == nil {
+		return fmt.Errorf("unable to get namespace: %s", namespace)
+	}
+	defer nsUnlock()
 	gr := "GR_" + node
 	for _, podIPNet := range podIfAddrs {
 		for _, gateway := range gateways {

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -745,15 +745,11 @@ func (oc *Controller) ensureNodeLogicalNetwork(node *kapi.Node, hostSubnets []*n
 	if err = func() error {
 		hostNetworkNamespace := config.Kubernetes.HostNetworkNamespace
 		if hostNetworkNamespace != "" {
-			nsInfo := oc.ensureNamespaceLocked(hostNetworkNamespace)
-			defer nsInfo.Unlock()
-			if nsInfo.addressSet == nil {
-				nsInfo.addressSet, err = oc.createNamespaceAddrSetAllPods(hostNetworkNamespace)
-				if err != nil {
-					return fmt.Errorf("cannot create address set for namespace: %s,"+
-						"error: %v", hostNetworkNamespace, err)
-				}
+			nsInfo, nsUnlock, err := oc.ensureNamespaceLocked(hostNetworkNamespace, true)
+			if err != nil {
+				return fmt.Errorf("failed to ensure namespace locked: %v", err)
 			}
+			defer nsUnlock()
 			if err = nsInfo.addressSet.AddIPs(hostNetworkPolicyIPs); err != nil {
 				return err
 			}

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -745,12 +745,7 @@ func (oc *Controller) ensureNodeLogicalNetwork(node *kapi.Node, hostSubnets []*n
 	if err = func() error {
 		hostNetworkNamespace := config.Kubernetes.HostNetworkNamespace
 		if hostNetworkNamespace != "" {
-			nsInfo, err := oc.waitForNamespaceLocked(hostNetworkNamespace)
-			if err != nil {
-				klog.Errorf("Failed to get namespace %s (%v)",
-					hostNetworkNamespace, err)
-				return err
-			}
+			nsInfo := oc.ensureNamespaceLocked(hostNetworkNamespace)
 			defer nsInfo.Unlock()
 			if nsInfo.addressSet == nil {
 				nsInfo.addressSet, err = oc.createNamespaceAddrSetAllPods(hostNetworkNamespace)

--- a/go-controller/pkg/ovn/namespace.go
+++ b/go-controller/pkg/ovn/namespace.go
@@ -49,13 +49,11 @@ func (oc *Controller) syncNamespaces(namespaces []interface{}) {
 }
 
 func (oc *Controller) addPodToNamespace(ns string, portInfo *lpInfo) error {
-	nsInfo, err := oc.waitForNamespaceLocked(ns)
-	if err != nil {
-		return err
-	}
+	nsInfo := oc.ensureNamespaceLocked(ns)
 	defer nsInfo.Unlock()
 
 	if nsInfo.addressSet == nil {
+		var err error
 		nsInfo.addressSet, err = oc.createNamespaceAddrSetAllPods(ns)
 		if err != nil {
 			return fmt.Errorf("unable to add pod to namespace. Cannot create address set for namespace: %s,"+
@@ -186,11 +184,16 @@ func parseRoutingExternalGWAnnotation(annotation string) ([]net.IP, error) {
 
 // AddNamespace creates corresponding addressset in ovn db
 func (oc *Controller) AddNamespace(ns *kapi.Namespace) {
-	klog.V(5).Infof("Adding namespace: %s", ns.Name)
-	nsInfo := oc.createNamespaceLocked(ns.Name)
+	klog.Infof("[%s] adding namespace", ns.Name)
+	// Keep track of how long syncs take.
+	start := time.Now()
+	defer func() {
+		klog.Infof("[%s] adding namespace took %v", ns.Name, time.Since(start))
+	}()
+
+	nsInfo := oc.ensureNamespaceLocked(ns.Name)
 	defer nsInfo.Unlock()
 
-	var err error
 	annotation := ns.Annotations[hotypes.HybridOverlayExternalGw]
 	if annotation != "" {
 		parsedAnnotation := net.ParseIP(annotation)
@@ -209,18 +212,31 @@ func (oc *Controller) AddNamespace(ns *kapi.Namespace) {
 			nsInfo.hybridOverlayVTEP = parsedAnnotation
 		}
 	}
+
 	if annotation, ok := ns.Annotations[routingExternalGWsAnnotation]; ok {
-		nsInfo.routingExternalGWs.gws, err = parseRoutingExternalGWAnnotation(annotation)
+		exGateways, err := parseRoutingExternalGWAnnotation(annotation)
 		if err != nil {
 			klog.Errorf(err.Error())
+		} else {
+			_, bfdEnabled := ns.Annotations[bfdAnnotation]
+			err = oc.addExternalGWsForNamespace(gatewayInfo{gws: exGateways, bfdEnabled: bfdEnabled}, nsInfo, ns.Name)
+			if err != nil {
+				klog.Error(err.Error())
+			}
 		}
 		if _, ok := ns.Annotations[bfdAnnotation]; ok {
 			nsInfo.routingExternalGWs.bfdEnabled = true
 		}
 	}
-	nsInfo.addressSet, err = oc.createNamespaceAddrSetAllPods(ns.Name)
-	if err != nil {
-		klog.Errorf(err.Error())
+
+	if nsInfo.addressSet == nil {
+		var err error
+		nsInfo.addressSet, err = oc.createNamespaceAddrSetAllPods(ns.Name)
+		if err != nil {
+			klog.Errorf(err.Error())
+		}
+	} else {
+		klog.V(5).Infof("Address set already exists for namespace: %s", ns.Name)
 	}
 
 	// TODO(trozet) figure out if there is any possibility of detecting if a pod GW already exists, which
@@ -228,6 +244,7 @@ func (oc *Controller) AddNamespace(ns *kapi.Namespace) {
 	// For now it is required that a pod serving as a gateway for a namespace is added AFTER the serving namespace is
 	// created
 
+	// If multicast enabled, adds all current pods in the namespace to the allow policy
 	oc.multicastUpdateNamespace(ns, nsInfo)
 }
 
@@ -383,20 +400,41 @@ func (oc *Controller) getNamespaceLocked(ns string) *namespaceInfo {
 	return nsInfo
 }
 
-// createNamespaceLocked locks namespacesMutex, creates an entry for ns, and returns it
+// ensureNamespaceLocked locks namespacesMutex, gets/creates an entry for ns, and returns it
 // with its mutex locked.
-func (oc *Controller) createNamespaceLocked(ns string) *namespaceInfo {
+func (oc *Controller) ensureNamespaceLocked(ns string) *namespaceInfo {
 	oc.namespacesMutex.Lock()
-	defer oc.namespacesMutex.Unlock()
-
-	nsInfo := &namespaceInfo{
-		networkPolicies:       make(map[string]*namespacePolicy),
-		podExternalRoutes:     make(map[string]map[string]string),
-		multicastEnabled:      false,
-		routingExternalPodGWs: make(map[string]gatewayInfo),
+	nsInfo := oc.namespaces[ns]
+	nsInfoExisted := false
+	if nsInfo == nil {
+		nsInfo = &namespaceInfo{
+			networkPolicies:       make(map[string]*namespacePolicy),
+			podExternalRoutes:     make(map[string]map[string]string),
+			multicastEnabled:      false,
+			routingExternalPodGWs: make(map[string]gatewayInfo),
+		}
+		// we are creating nsInfo and going to set it in namespaces map
+		// so safe to hold the lock while we create and add it
+		defer oc.namespacesMutex.Unlock()
+		oc.namespaces[ns] = nsInfo
+	} else {
+		nsInfoExisted = true
+		// if we found and existing nsInfo, do not hold the namespaces lock
+		// while waiting for nsInfo to Lock
+		oc.namespacesMutex.Unlock()
 	}
+
 	nsInfo.Lock()
-	oc.namespaces[ns] = nsInfo
+
+	if nsInfoExisted {
+		// Check that the namespace wasn't deleted while we were waiting for the lock
+		oc.namespacesMutex.Lock()
+		defer oc.namespacesMutex.Unlock()
+		if nsInfo != oc.namespaces[ns] {
+			nsInfo.Unlock()
+			return nil
+		}
+	}
 
 	return nsInfo
 }

--- a/go-controller/pkg/ovn/namespace.go
+++ b/go-controller/pkg/ovn/namespace.go
@@ -49,17 +49,12 @@ func (oc *Controller) syncNamespaces(namespaces []interface{}) {
 }
 
 func (oc *Controller) addPodToNamespace(ns string, portInfo *lpInfo) error {
-	nsInfo := oc.ensureNamespaceLocked(ns)
-	defer nsInfo.Unlock()
-
-	if nsInfo.addressSet == nil {
-		var err error
-		nsInfo.addressSet, err = oc.createNamespaceAddrSetAllPods(ns)
-		if err != nil {
-			return fmt.Errorf("unable to add pod to namespace. Cannot create address set for namespace: %s,"+
-				"error: %v", ns, err)
-		}
+	nsInfo, nsUnlock, err := oc.ensureNamespaceLocked(ns, true)
+	if err != nil {
+		return fmt.Errorf("failed to ensure namespace locked: %v", err)
 	}
+
+	defer nsUnlock()
 
 	if err := nsInfo.addressSet.AddIPs(createIPAddressSlice(portInfo.ips)); err != nil {
 		return err
@@ -77,11 +72,11 @@ func (oc *Controller) addPodToNamespace(ns string, portInfo *lpInfo) error {
 }
 
 func (oc *Controller) deletePodFromNamespace(ns string, portInfo *lpInfo) error {
-	nsInfo := oc.getNamespaceLocked(ns)
+	nsInfo, nsUnlock := oc.getNamespaceLocked(ns, true)
 	if nsInfo == nil {
 		return nil
 	}
-	defer nsInfo.Unlock()
+	defer nsUnlock()
 
 	if nsInfo.addressSet != nil {
 		if err := nsInfo.addressSet.DeleteIPs(createIPAddressSlice(portInfo.ips)); err != nil {
@@ -191,8 +186,13 @@ func (oc *Controller) AddNamespace(ns *kapi.Namespace) {
 		klog.Infof("[%s] adding namespace took %v", ns.Name, time.Since(start))
 	}()
 
-	nsInfo := oc.ensureNamespaceLocked(ns.Name)
-	defer nsInfo.Unlock()
+	nsInfo, nsUnlock, err := oc.ensureNamespaceLocked(ns.Name, false)
+	if err != nil {
+		klog.Errorf("Failed to ensure namespace locked: %v", err)
+		return
+	}
+
+	defer nsUnlock()
 
 	annotation := ns.Annotations[hotypes.HybridOverlayExternalGw]
 	if annotation != "" {
@@ -229,16 +229,6 @@ func (oc *Controller) AddNamespace(ns *kapi.Namespace) {
 		}
 	}
 
-	if nsInfo.addressSet == nil {
-		var err error
-		nsInfo.addressSet, err = oc.createNamespaceAddrSetAllPods(ns.Name)
-		if err != nil {
-			klog.Errorf(err.Error())
-		}
-	} else {
-		klog.V(5).Infof("Address set already exists for namespace: %s", ns.Name)
-	}
-
 	// TODO(trozet) figure out if there is any possibility of detecting if a pod GW already exists, which
 	// is servicing this namespace. Right now that would mean searching through all pods, which is very inefficient.
 	// For now it is required that a pod serving as a gateway for a namespace is added AFTER the serving namespace is
@@ -251,12 +241,12 @@ func (oc *Controller) AddNamespace(ns *kapi.Namespace) {
 func (oc *Controller) updateNamespace(old, newer *kapi.Namespace) {
 	klog.V(5).Infof("Updating namespace: %s", old.Name)
 
-	nsInfo := oc.getNamespaceLocked(old.Name)
+	nsInfo, nsUnlock := oc.getNamespaceLocked(old.Name, false)
 	if nsInfo == nil {
 		klog.Warningf("Update event for unknown namespace %q", old.Name)
 		return
 	}
-	defer nsInfo.Unlock()
+	defer nsUnlock()
 
 	gwAnnotation := newer.Annotations[routingExternalGWsAnnotation]
 	oldGWAnnotation := old.Annotations[routingExternalGWsAnnotation]
@@ -359,24 +349,25 @@ func (oc *Controller) deleteNamespace(ns *kapi.Namespace) {
 // rather than getNamespaceLocked when calling from a thread where you might be processing
 // an event in a namespace before the Namespace factory thread has processed the Namespace
 // addition.
-func (oc *Controller) waitForNamespaceLocked(namespace string) (*namespaceInfo, error) {
+func (oc *Controller) waitForNamespaceLocked(namespace string, readOnly bool) (*namespaceInfo, func(), error) {
 	var nsInfo *namespaceInfo
+	var nsUnlock func()
 
 	err := utilwait.PollImmediate(100*time.Millisecond, 10*time.Second,
 		func() (bool, error) {
-			nsInfo = oc.getNamespaceLocked(namespace)
+			nsInfo, nsUnlock = oc.getNamespaceLocked(namespace, readOnly)
 			return nsInfo != nil, nil
 		},
 	)
 	if err != nil {
-		return nil, fmt.Errorf("timeout waiting for namespace event")
+		return nil, nil, fmt.Errorf("timeout waiting for namespace event")
 	}
-	return nsInfo, nil
+	return nsInfo, nsUnlock, nil
 }
 
 // getNamespaceLocked locks namespacesMutex, looks up ns, and (if found), returns it with
 // its mutex locked. If ns is not known, nil will be returned
-func (oc *Controller) getNamespaceLocked(ns string) *namespaceInfo {
+func (oc *Controller) getNamespaceLocked(ns string, readOnly bool) (*namespaceInfo, func()) {
 	// Only hold namespacesMutex while reading/modifying oc.namespaces. In particular,
 	// we drop namespacesMutex while trying to claim nsInfo.Mutex, because something
 	// else might have locked the nsInfo and be doing something slow with it, and we
@@ -386,23 +377,29 @@ func (oc *Controller) getNamespaceLocked(ns string) *namespaceInfo {
 	oc.namespacesMutex.Unlock()
 
 	if nsInfo == nil {
-		return nil
+		return nil, nil
 	}
-	nsInfo.Lock()
-
+	var unlockFunc func()
+	if readOnly {
+		unlockFunc = func() { nsInfo.RUnlock() }
+		nsInfo.RLock()
+	} else {
+		unlockFunc = func() { nsInfo.Unlock() }
+		nsInfo.Lock()
+	}
 	// Check that the namespace wasn't deleted while we were waiting for the lock
 	oc.namespacesMutex.Lock()
 	defer oc.namespacesMutex.Unlock()
 	if nsInfo != oc.namespaces[ns] {
-		nsInfo.Unlock()
-		return nil
+		unlockFunc()
+		return nil, nil
 	}
-	return nsInfo
+	return nsInfo, unlockFunc
 }
 
 // ensureNamespaceLocked locks namespacesMutex, gets/creates an entry for ns, and returns it
-// with its mutex locked.
-func (oc *Controller) ensureNamespaceLocked(ns string) *namespaceInfo {
+// with its mutex locked. Also returns an unlock function and error.
+func (oc *Controller) ensureNamespaceLocked(ns string, readOnly bool) (*namespaceInfo, func(), error) {
 	oc.namespacesMutex.Lock()
 	nsInfo := oc.namespaces[ns]
 	nsInfoExisted := false
@@ -416,6 +413,12 @@ func (oc *Controller) ensureNamespaceLocked(ns string) *namespaceInfo {
 		// we are creating nsInfo and going to set it in namespaces map
 		// so safe to hold the lock while we create and add it
 		defer oc.namespacesMutex.Unlock()
+		// create the adddress set for the new namespace
+		var err error
+		nsInfo.addressSet, err = oc.createNamespaceAddrSetAllPods(ns)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to create address set for namespace: %s, error: %v", ns, err)
+		}
 		oc.namespaces[ns] = nsInfo
 	} else {
 		nsInfoExisted = true
@@ -424,19 +427,26 @@ func (oc *Controller) ensureNamespaceLocked(ns string) *namespaceInfo {
 		oc.namespacesMutex.Unlock()
 	}
 
-	nsInfo.Lock()
+	var unlockFunc func()
+	if readOnly {
+		unlockFunc = func() { nsInfo.RUnlock() }
+		nsInfo.RLock()
+	} else {
+		unlockFunc = func() { nsInfo.Unlock() }
+		nsInfo.Lock()
+	}
 
 	if nsInfoExisted {
 		// Check that the namespace wasn't deleted while we were waiting for the lock
 		oc.namespacesMutex.Lock()
 		defer oc.namespacesMutex.Unlock()
 		if nsInfo != oc.namespaces[ns] {
-			nsInfo.Unlock()
-			return nil
+			unlockFunc()
+			return nil, nil, fmt.Errorf("namespace %s, was removed during ensure", ns)
 		}
 	}
 
-	return nsInfo
+	return nsInfo, unlockFunc, nil
 }
 
 // deleteNamespaceLocked locks namespacesMutex, finds and deletes ns, and returns the
@@ -475,9 +485,9 @@ func (oc *Controller) deleteNamespaceLocked(ns string) *namespaceInfo {
 			case <-time.After(20 * time.Second):
 				// Check to see if the NS was re-added in the meanwhile. If so,
 				// only delete if the new NS's AddressSet shouldn't exist.
-				nsInfo := oc.getNamespaceLocked(ns)
+				nsInfo, nsUnlock := oc.getNamespaceLocked(ns, true)
 				if nsInfo != nil {
-					defer nsInfo.Unlock()
+					defer nsUnlock()
 					if nsInfo.addressSet != nil {
 						klog.V(5).Infof("Skipping deferred deletion of AddressSet for NS %s: re-created", ns)
 						return

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -74,7 +74,7 @@ type loadBalancerConf struct {
 // nsInfo.Unlock() on it when you are done with it. (No code outside of the code that
 // manages the oc.namespaces map is ever allowed to hold an unlocked namespaceInfo.)
 type namespaceInfo struct {
-	sync.Mutex
+	sync.RWMutex
 
 	// addressSet is an address set object that holds the IP addresses
 	// of all pods in the namespace.

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -510,7 +510,7 @@ func (oc *Controller) addLogicalPort(pod *kapi.Pod) (err error) {
 	// Add the pod's logical switch port to the port cache
 	portInfo := oc.logicalPortCache.add(logicalSwitch, portName, lsp.UUID, podMac, podIfAddrs)
 
-	// Wait for namespace to exist, no calls after this should ever use waitForNamespaceLocked
+	// Ensure the namespace/nsInfo exists
 	if err = oc.addPodToNamespace(pod.Namespace, portInfo); err != nil {
 		return err
 	}

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -248,11 +248,11 @@ func (oc *Controller) addRoutesGatewayIP(pod *kapi.Pod, podAnnotation *util.PodA
 
 func (oc *Controller) getRoutingExternalGWs(ns string) gatewayInfo {
 	res := gatewayInfo{}
-	nsInfo := oc.getNamespaceLocked(ns)
+	nsInfo, nsUnlock := oc.getNamespaceLocked(ns, true)
 	if nsInfo == nil {
 		return res
 	}
-	defer nsInfo.Unlock()
+	defer nsUnlock()
 	// return a copy of the object so it can be handled without the
 	// namespace locked
 	res.bfdEnabled = nsInfo.routingExternalGWs.bfdEnabled
@@ -262,11 +262,11 @@ func (oc *Controller) getRoutingExternalGWs(ns string) gatewayInfo {
 }
 
 func (oc *Controller) getRoutingPodGWs(ns string) map[string]gatewayInfo {
-	nsInfo := oc.getNamespaceLocked(ns)
+	nsInfo, nsUnlock := oc.getNamespaceLocked(ns, true)
 	if nsInfo == nil {
 		return nil
 	}
-	defer nsInfo.Unlock()
+	defer nsUnlock()
 	// return a copy of the object so it can be handled without the
 	// namespace locked
 	res := make(map[string]gatewayInfo)
@@ -282,11 +282,13 @@ func (oc *Controller) getRoutingPodGWs(ns string) map[string]gatewayInfo {
 }
 
 func (oc *Controller) getHybridOverlayExternalGwAnnotation(ns string) (net.IP, error) {
-	nsInfo, err := oc.waitForNamespaceLocked(ns)
+	// NOTE (trozet): we have to wait for namespace locked because namespace update for
+	// hybrid overlay exgw cannot update pod routes inside the pod
+	nsInfo, nsUnlock, err := oc.waitForNamespaceLocked(ns, true)
 	if err != nil {
 		return nil, err
 	}
-	defer nsInfo.Unlock()
+	defer nsUnlock()
 	return nsInfo.hybridOverlayExternalGW, nil
 }
 

--- a/go-controller/pkg/ovn/pods_test.go
+++ b/go-controller/pkg/ovn/pods_test.go
@@ -405,7 +405,7 @@ var _ = Describe("OVN Pod Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("retries a failed pod Add when namespace doesn't yet exist", func() {
+		It("pod Add should succeed even when namespace doesn't yet exist", func() {
 			app.Action = func(ctx *cli.Context) error {
 
 				namespaceT := newNamespace("namespace1")
@@ -433,13 +433,7 @@ var _ = Describe("OVN Pod Operations", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Eventually(func() string { return getPodAnnotations(fakeOvn.fakeClient.KubeClient, t.namespace, t.podName) }, 2).Should(MatchJSON(podJSON))
 
-				fakeOvn.asf.ExpectNoAddressSet(t.namespace)
-
-				// Now add the namespace
-				_, err = fakeOvn.fakeClient.KubeClient.CoreV1().Namespaces().Create(context.TODO(), namespaceT, metav1.CreateOptions{})
-				Expect(err).NotTo(HaveOccurred())
-
-				// Pod creation should be retried on Update event
+				// Add Pod logical port should succeed even without namespace
 				Eventually(fExec.CalledMatchesExpected).Should(BeTrue(), fExec.ErrorDesc)
 				Expect(getPodAnnotations(fakeOvn.fakeClient.KubeClient, t.namespace, t.podName)).Should(MatchJSON(podJSON))
 


### PR DESCRIPTION
Removes waiting for namespace event to show up. Now it is just ensured when needed. Also changes nsinfo to use a RWMutex so that pod handlers can all simultaneously RLock and not be blocked trying to add many pods for a single namespace.