### PR TITLE
Bug 1986708: Add routes for pod: fail only after checking all the gw addresses / ips

### DIFF
--- a/go-controller/pkg/ovn/egressgw.go
+++ b/go-controller/pkg/ovn/egressgw.go
@@ -282,9 +282,10 @@ func (oc *Controller) addGWRoutesForPod(gateways []gatewayInfo, podIfAddrs []*ne
 	}
 	defer nsInfo.Unlock()
 	gr := util.GetGatewayRouterFromNode(node)
+
+	routesAdded := 0
 	for _, podIPNet := range podIfAddrs {
 		for _, gateway := range gateways {
-			routesAdded := 0
 			// TODO (trozet): use the go bindings here and batch commands
 			// validate the ip and gateway belong to the same address family
 			gws, err := util.MatchIPFamily(utilnet.IsIPv6(podIPNet.IP), gateway.gws)
@@ -315,12 +316,13 @@ func (oc *Controller) addGWRoutesForPod(gateways []gatewayInfo, podIfAddrs []*ne
 			} else {
 				klog.Warningf("Address families for the pod address %s and gateway %s did not match", podIPNet.IP.String(), gateway.gws)
 			}
-			// if no routes are added return an error
-			if routesAdded < 1 {
-				return fmt.Errorf("gateway specified for namespace %s with gateway addresses %v but no valid routes exist for pod: %s",
-					namespace, podIfAddrs, node)
-			}
+
 		}
+	}
+	// if no routes are added return an error
+	if routesAdded < 1 {
+		return fmt.Errorf("gateway specified for namespace %s with gateway addresses %v but no valid routes exist for pod: %s",
+			namespace, podIfAddrs, node)
 	}
 	return nil
 }


### PR DESCRIPTION
When adding routes to pod, we fail inside the inner loop returning an
error. What happens is that if the pod has two ip addresses, and the gw
is set only for the second address, the function will mistakenly return
an error.

Signed-off-by: Federico Paolinelli <fpaoline@redhat.com>
(cherry picked from commit d2e05937f75c067bee3de3b2cdbea9a554116da2)

