### PR TITLE
Bug 1997072: [4.9] phase 2 scale improvements

### DIFF
--- a/go-controller/go.mod
+++ b/go-controller/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/Microsoft/go-winio v0.4.15 // indirect
 	github.com/Microsoft/hcsshim v0.8.10-0.20200715222032-5eafd1556990
 	github.com/bhendo/go-powershell v0.0.0-20190719160123-219e7fb4e41e
+	github.com/cenkalti/rpc2 v0.0.0-20210604223624-c1acbc6ec984 // indirect
 	github.com/containernetworking/cni v0.8.0
 	github.com/containernetworking/plugins v0.8.7
 	github.com/coreos/go-iptables v0.4.5

--- a/go-controller/go.sum
+++ b/go-controller/go.sum
@@ -68,6 +68,8 @@ github.com/cenkalti/hub v1.0.1/go.mod h1:tcYwtS3a2d9NO/0xDXVJWx3IedurUjYCqFCmpi0
 github.com/cenkalti/rpc2 v0.0.0-20170726070524-c51a77e5f664/go.mod h1:v2npkhrXyk5BCnkNIiPdRI23Uq6uWPUQGL2hnRcRr/M=
 github.com/cenkalti/rpc2 v0.0.0-20210220005819-4a29bc83afe1 h1:aT9Ez2drLmrviqTnVnH87AeXLXLgUrXACJ2g90cTT2w=
 github.com/cenkalti/rpc2 v0.0.0-20210220005819-4a29bc83afe1/go.mod h1:v2npkhrXyk5BCnkNIiPdRI23Uq6uWPUQGL2hnRcRr/M=
+github.com/cenkalti/rpc2 v0.0.0-20210604223624-c1acbc6ec984 h1:CNwZyGS6KpfaOWbh2yLkSy3rSTUh3jub9CzpFpP6PVQ=
+github.com/cenkalti/rpc2 v0.0.0-20210604223624-c1acbc6ec984/go.mod h1:v2npkhrXyk5BCnkNIiPdRI23Uq6uWPUQGL2hnRcRr/M=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+qY=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=

--- a/go-controller/pkg/cni/utils.go
+++ b/go-controller/pkg/cni/utils.go
@@ -57,7 +57,7 @@ func getPod(podLister corev1listers.PodLister, kclient kubernetes.Interface, nam
 		// drop through
 	}
 
-	if kclient != nil {
+	if pod == nil && kclient != nil {
 		// If the pod wasn't in our local cache, ask for it directly
 		pod, err = kclient.CoreV1().Pods(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 	}

--- a/go-controller/pkg/ovn/address_set/fake_address_set.go
+++ b/go-controller/pkg/ovn/address_set/fake_address_set.go
@@ -1,6 +1,7 @@
 package addressset
 
 import (
+	goovn "github.com/ebay/go-ovn"
 	"net"
 	"strings"
 	"sync"
@@ -248,6 +249,13 @@ func (as *fakeAddressSets) AddIPs(ips []net.IP) error {
 		}
 	}
 	return nil
+}
+
+func (as *fakeAddressSets) UpdateIPCache(ips []net.IP) {
+}
+
+func (as *fakeAddressSets) PrepareAddIPsCmds(ips []net.IP) ([]*goovn.OvnCommand, error) {
+	return nil, nil
 }
 
 func (as *fakeAddressSets) SetIPs(ips []net.IP) error {

--- a/go-controller/pkg/ovn/address_set/fake_address_set.go
+++ b/go-controller/pkg/ovn/address_set/fake_address_set.go
@@ -263,6 +263,10 @@ func (as *fakeAddressSets) SetIPs(ips []net.IP) error {
 	return nil
 }
 
+func (as *fakeAddressSets) PrepareDeleteIPsCmds(ips []net.IP) ([]*goovn.OvnCommand, error) {
+	return nil, nil
+}
+
 func (as *fakeAddressSets) DeleteIPs(ips []net.IP) error {
 	var err error
 	as.Lock()

--- a/go-controller/pkg/ovn/controller/services/services_controller_test.go
+++ b/go-controller/pkg/ovn/controller/services/services_controller_test.go
@@ -847,4 +847,3 @@ func TestUpdateServiceEndpointsLessRemoveOps(t *testing.T) {
 func protoPtr(proto v1.Protocol) *v1.Protocol {
 	return &proto
 }
->>>>>>> parent of 59cb3ee5aac5c (Add libovsdb clients to controllers & test harness)

--- a/go-controller/pkg/ovn/egressfirewall_dns_test.go
+++ b/go-controller/pkg/ovn/egressfirewall_dns_test.go
@@ -2,6 +2,7 @@ package ovn
 
 import (
 	"fmt"
+	goovn "github.com/ebay/go-ovn"
 	"net"
 	"testing"
 	"time"
@@ -22,7 +23,9 @@ import (
 
 func TestNewEgressDNS(t *testing.T) {
 	testCh := make(chan struct{})
-	testOvnAddFtry := addressset.NewOvnAddressSetFactory()
+	ovnNbClient := ovntest.NewMockOVNClient(goovn.DBNB)
+	defer ovnNbClient.Close()
+	testOvnAddFtry := addressset.NewOvnAddressSetFactory(ovnNbClient)
 	mockDnsOps := new(util_mocks.DNSOps)
 	util.SetDNSLibOpsMockInst(mockDnsOps)
 	tests := []struct {

--- a/go-controller/pkg/ovn/egressgw.go
+++ b/go-controller/pkg/ovn/egressgw.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"strings"
+	"sync"
 	"time"
 
 	utilnet "k8s.io/utils/net"
@@ -17,6 +18,7 @@ import (
 	nettypes "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 
 	kapi "k8s.io/api/core/v1"
+	ktypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
 )
 
@@ -37,6 +39,127 @@ type ovnRoute struct {
 	router      string
 	outport     string
 	shouldExist bool
+}
+
+type externalRouteInfo struct {
+	sync.RWMutex
+	// podExternalRoutes is a cache keeping the LR routes added to the GRs when
+	// external gateways are used. The first map key is the podIP (src-ip of the route),
+	// the second the GW IP (next hop), and the third the GR name
+	podExternalRoutes map[string]map[string]string
+}
+
+// ensureRouteInfoLocked either gets the current routeInfo in the cache with a lock, or creates+locks a new one if missing
+func (oc *Controller) ensureRouteInfoLocked(podName ktypes.NamespacedName) (*externalRouteInfo, error) {
+	// We don't want to hold the cache lock while we try to lock the routeInfo (unless we are creating it, then we know
+	// no one else is using it). This could lead to dead lock. Therefore the steps here are:
+	// 1. Get the cache lock, try to find the routeInfo
+	// 2. If routeInfo existed, release the cache lock
+	// 3. If routeInfo did not exist, safe to hold the cache lock while we create the new routeInfo
+	oc.exGWCacheMutex.Lock()
+	routeInfo, routeInfoExisted := oc.externalGWCache[podName]
+	if routeInfo == nil {
+		routeInfo = &externalRouteInfo{
+			podExternalRoutes: make(map[string]map[string]string),
+		}
+		// we are creating routeInfo and going to set it in podExternalRoutes map
+		// so safe to hold the lock while we create and add it
+		defer oc.exGWCacheMutex.Unlock()
+		oc.externalGWCache[podName] = routeInfo
+	} else {
+		routeInfoExisted = true
+		// if we found an existing routeInfo, do not hold the cache lock
+		// while waiting for routeInfo to Lock
+		oc.exGWCacheMutex.Unlock()
+	}
+
+	// 4. Now lock the routeInfo
+	routeInfo.Lock()
+
+	// 5. If routeInfo originally existed in the cache, there is a chance it was altered after we
+	// released the cache lock, and before we were able to lock routeInfo
+	if routeInfoExisted {
+		// Check that the routeInfo wasn't altered in the cache while we were waiting for the lock
+		// and that routeInfo that we locked is not stale.
+		oc.exGWCacheMutex.RLock()
+		defer oc.exGWCacheMutex.RUnlock()
+		if routeInfo != oc.externalGWCache[podName] {
+			routeInfo.Unlock()
+			return nil, fmt.Errorf("routeInfo for pod %s, was altered during ensure route info", podName)
+		}
+	}
+
+	return routeInfo, nil
+}
+
+// getRouteInfosForGateway returns all routeInfos locked for a specific namespace and gateway IP
+func (oc *Controller) getRouteInfosForGateway(gatewayIP, namespace string) []*externalRouteInfo {
+	oc.exGWCacheMutex.RLock()
+	defer oc.exGWCacheMutex.RUnlock()
+
+	routes := make([]*externalRouteInfo, 0)
+	for namespacedName, routeInfo := range oc.externalGWCache {
+		if namespacedName.Namespace != namespace {
+			continue
+		}
+
+		routeFound := false
+		for _, route := range routeInfo.podExternalRoutes {
+			if _, ok := route[gatewayIP]; ok {
+				routes = append(routes, routeInfo)
+				routeFound = true
+			}
+		}
+		if routeFound {
+			routeInfo.Lock()
+		}
+	}
+
+	return routes
+}
+
+// getRouteInfosForNamespace returns all routeInfos locked for a specific namespace
+func (oc *Controller) getRouteInfosForNamespace(namespace string) []*externalRouteInfo {
+	oc.exGWCacheMutex.RLock()
+	defer oc.exGWCacheMutex.RUnlock()
+
+	routes := make([]*externalRouteInfo, 0)
+	for namespacedName, routeInfo := range oc.externalGWCache {
+		if namespacedName.Namespace != namespace {
+			continue
+		}
+		routeInfo.Lock()
+		routes = append(routes, routeInfo)
+	}
+
+	return routes
+}
+
+// deleteRouteInfoLocked removes a routeInfo from the cache, and returns it locked
+func (oc *Controller) deleteRouteInfoLocked(name ktypes.NamespacedName) *externalRouteInfo {
+	// Attempt to find the routeInfo in the cache, release the cache lock while
+	// we try to lock the routeInfo to avoid any deadlock
+	oc.exGWCacheMutex.RLock()
+	routeInfo := oc.externalGWCache[name]
+	oc.exGWCacheMutex.RUnlock()
+
+	if routeInfo == nil {
+		return nil
+	}
+	routeInfo.Lock()
+
+	// ensure the routeInfo we acquired the lock for is consistent with the
+	// one still in the cache
+	oc.exGWCacheMutex.Lock()
+	defer oc.exGWCacheMutex.Unlock()
+	if routeInfo != oc.externalGWCache[name] {
+		routeInfo.Unlock()
+		return nil
+	}
+
+	delete(oc.externalGWCache, name)
+
+	return routeInfo
 }
 
 // addPodExternalGW handles detecting if a pod is serving as an external gateway for namespace(s) and adding routes
@@ -82,15 +205,16 @@ func (oc *Controller) addPodExternalGWForNamespace(namespace string, pod *kapi.P
 		}
 		gws += ip.String()
 	}
-	klog.Infof("Adding routes for external gateway pod: %s, next hops: %q, namespace: %s, bfd-enabled: %t",
-		pod.Name, gws, namespace, egress.bfdEnabled)
 	nsInfo, nsUnlock, err := oc.ensureNamespaceLocked(namespace, false)
 	if err != nil {
 		return fmt.Errorf("failed to ensure namespace locked: %v", err)
 	}
-	defer nsUnlock()
 	nsInfo.routingExternalPodGWs[pod.Name] = egress
-	return oc.addGWRoutesForNamespace(namespace, egress, nsInfo)
+	nsUnlock()
+
+	klog.Infof("Adding routes for external gateway pod: %s, next hops: %q, namespace: %s, bfd-enabled: %t",
+		pod.Name, gws, namespace, egress.bfdEnabled)
+	return oc.addGWRoutesForNamespace(namespace, egress)
 }
 
 // addExternalGWsForNamespace handles adding annotated gw routes to all pods in namespace
@@ -100,18 +224,18 @@ func (oc *Controller) addExternalGWsForNamespace(egress gatewayInfo, nsInfo *nam
 		return fmt.Errorf("unable to add gateways routes for namespace: %s, gateways are nil", namespace)
 	}
 	nsInfo.routingExternalGWs = egress
-	return oc.addGWRoutesForNamespace(namespace, egress, nsInfo)
+	return oc.addGWRoutesForNamespace(namespace, egress)
 }
 
 // addGWRoutesForNamespace handles adding routes for all existing pods in namespace
-// This should only be called with a lock on nsInfo
-func (oc *Controller) addGWRoutesForNamespace(namespace string, egress gatewayInfo, nsInfo *namespaceInfo) error {
+func (oc *Controller) addGWRoutesForNamespace(namespace string, egress gatewayInfo) error {
 	existingPods, err := oc.watchFactory.GetPods(namespace)
 	if err != nil {
 		return fmt.Errorf("failed to get all the pods (%v)", err)
 	}
 	// TODO (trozet): use the go bindings here and batch commands
 	for _, pod := range existingPods {
+		podNsName := ktypes.NamespacedName{Namespace: pod.Namespace, Name: pod.Name}
 		if config.Gateway.DisableSNATMultipleGWs {
 			logicalPort := podLogicalPortName(pod)
 			portInfo, err := oc.logicalPortCache.get(logicalPort)
@@ -121,46 +245,18 @@ func (oc *Controller) addGWRoutesForNamespace(namespace string, egress gatewayIn
 				oc.deletePerPodGRSNAT(pod.Spec.NodeName, portInfo.ips)
 			}
 		}
-		gr := util.GetGatewayRouterFromNode(pod.Spec.NodeName)
-		prefix, err := oc.extSwitchPrefix(pod.Spec.NodeName)
-		if err != nil {
-			klog.Infof("Failed to find ext switch prefix for %s %v", pod.Spec.NodeName, err)
-			continue
-		}
 
-		port := prefix + types.GWRouterToExtSwitchPrefix + gr
-		for _, gw := range egress.gws {
-			for _, podIP := range pod.Status.PodIPs {
-				if utilnet.IsIPv6(gw) != utilnet.IsIPv6String(podIP.IP) {
-					continue
-				}
-
-				// if route was already programmed, skip it
-				if foundGR, ok := nsInfo.podExternalRoutes[podIP.IP][gw.String()]; ok && foundGR == gr {
-					continue
-				}
-
-				mask := GetIPFullMask(podIP.IP)
-				nbctlArgs := []string{"--may-exist", "--policy=src-ip", "--ecmp-symmetric-reply",
-					"lr-route-add", gr, podIP.IP + mask, gw.String(), port}
-				if egress.bfdEnabled {
-					nbctlArgs = []string{"--may-exist", "--bfd", "--policy=src-ip", "--ecmp-symmetric-reply",
-						"lr-route-add", gr, podIP.IP + mask, gw.String(), port}
-				}
-
-				_, stderr, err := util.RunOVNNbctl(nbctlArgs...)
-
-				if err != nil && !strings.Contains(stderr, DuplicateECMPError) {
-					return fmt.Errorf("unable to add src-ip route to GR router, stderr:%q, err:%v", stderr, err)
-				}
-				if err := oc.addHybridRoutePolicyForPod(net.ParseIP(podIP.IP), pod.Spec.NodeName); err != nil {
-					return err
-				}
-				if nsInfo.podExternalRoutes[podIP.IP] == nil {
-					nsInfo.podExternalRoutes[podIP.IP] = make(map[string]string)
-				}
-				nsInfo.podExternalRoutes[podIP.IP][gw.String()] = gr
+		podIPs := make([]*net.IPNet, 0)
+		for _, podIP := range pod.Status.PodIPs {
+			cidr := podIP.IP + GetIPFullMask(podIP.IP)
+			_, ipNet, err := net.ParseCIDR(cidr)
+			if err != nil {
+				return fmt.Errorf("failed to parse CIDR: %s, error: %v", cidr, err)
 			}
+			podIPs = append(podIPs, ipNet)
+		}
+		if err := oc.addGWRoutesForPod([]*gatewayInfo{&egress}, podIPs, podNsName, pod.Spec.NodeName); err != nil {
+			return err
 		}
 	}
 	return nil
@@ -186,9 +282,11 @@ func (oc *Controller) deletePodGWRoutesForNamespace(pod, namespace string) {
 	if nsInfo == nil {
 		return
 	}
-	defer nsUnlock()
 	// check if any gateways were stored for this pod
 	foundGws, ok := nsInfo.routingExternalPodGWs[pod]
+	delete(nsInfo.routingExternalPodGWs, pod)
+	nsUnlock()
+
 	if !ok || len(foundGws.gws) == 0 {
 		klog.Infof("No gateways found to remove for annotated gateway pod: %s on namespace: %s",
 			pod, namespace)
@@ -197,99 +295,100 @@ func (oc *Controller) deletePodGWRoutesForNamespace(pod, namespace string) {
 
 	for _, gwIP := range foundGws.gws {
 		// check for previously configured pod routes
-		for podIP, gwInfo := range nsInfo.podExternalRoutes {
-			if len(gwInfo) == 0 {
-				continue
-			}
-			gr := gwInfo[gwIP.String()]
-			if gr == "" {
-				continue
-			}
-			mask := GetIPFullMask(podIP)
-			node := util.GetWorkerFromGatewayRouter(gr)
-			portPrefix, err := oc.extSwitchPrefix(node)
-			if err != nil {
-				klog.Infof("Failed to find ext switch prefix for %s %v", node, err)
-				continue
-			}
-
-			_, stderr, err := util.RunOVNNbctl("--if-exists", "--policy=src-ip",
-				"lr-route-del", gr, podIP+mask, gwIP.String())
-			if err != nil {
-				klog.Errorf("Unable to delete pod %s route to GR %s, GW: %s, stderr:%q, err:%v",
-					pod, gr, gwIP.String(), stderr, err)
-			} else {
-				klog.V(5).Infof("ECMP route deleted for pod: %s, on gr: %s, to gw: %s", pod,
-					gr, gwIP.String())
-				delete(nsInfo.podExternalRoutes[podIP], gwIP.String())
-				// clean up if there are no more routes for this podIP
-				if entry := nsInfo.podExternalRoutes[podIP]; len(entry) == 0 {
-					delete(nsInfo.podExternalRoutes, podIP)
-					// TODO (trozet): use the go bindings here and batch commands
-					// delete the ovn_cluster_router policy if the pod has no more exgws to revert back to normal
-					// default gw behavior
-					if err := oc.delHybridRoutePolicyForPod(net.ParseIP(podIP), node, false); err != nil {
-						klog.Error(err)
+		routeInfos := oc.getRouteInfosForGateway(gwIP.String(), namespace)
+		for _, routeInfo := range routeInfos {
+			for podIP, route := range routeInfo.podExternalRoutes {
+				for routeGwIP, gr := range route {
+					if gwIP.String() != routeGwIP {
+						continue
 					}
+					if gr == "" {
+						continue
+					}
+					mask := GetIPFullMask(podIP)
+					node := util.GetWorkerFromGatewayRouter(gr)
+					portPrefix, err := oc.extSwitchPrefix(node)
+					if err != nil {
+						klog.Infof("Failed to find ext switch prefix for %s %v", node, err)
+						continue
+					}
+
+					_, stderr, err := util.RunOVNNbctl("--if-exists", "--policy=src-ip",
+						"lr-route-del", gr, podIP+mask, gwIP.String())
+					if err != nil {
+						klog.Errorf("Unable to delete pod %s route to GR %s, GW: %s, stderr:%q, err:%v",
+							pod, gr, gwIP.String(), stderr, err)
+					} else {
+						klog.V(5).Infof("ECMP route deleted for pod: %s, on gr: %s, to gw: %s", pod,
+							gr, gwIP.String())
+
+						delete(routeInfo.podExternalRoutes[podIP], gwIP.String())
+						// clean up if there are no more routes for this podIP
+						if entry := routeInfo.podExternalRoutes[podIP]; len(entry) == 0 {
+							// TODO (trozet): use the go bindings here and batch commands
+							// delete the ovn_cluster_router policy if the pod has no more exgws to revert back to normal
+							// default gw behavior
+							if err := oc.delHybridRoutePolicyForPod(net.ParseIP(podIP), node, false); err != nil {
+								klog.Error(err)
+							}
+						}
+					}
+					cleanUpBFDEntry(gwIP.String(), gr, portPrefix)
 				}
 			}
-			cleanUpBFDEntry(gwIP.String(), gr, portPrefix)
+			routeInfo.Unlock()
 		}
 	}
-	delete(nsInfo.routingExternalPodGWs, pod)
 }
 
 // deleteGwRoutesForNamespace handles deleting all routes to gateways for a pod on a specific GR
-// This should only be called with a lock on nsInfo
-func (oc *Controller) deleteGWRoutesForNamespace(nsInfo *namespaceInfo) {
-	if nsInfo == nil {
-		return
-	}
-
+func (oc *Controller) deleteGWRoutesForNamespace(namespace string) {
 	// TODO(trozet): batch all of these with ebay bindings
-	for podIP, gwToGr := range nsInfo.podExternalRoutes {
-		for gw, gr := range gwToGr {
-			if utilnet.IsIPv6String(gw) != utilnet.IsIPv6String(podIP) {
-				continue
-			}
-			mask := GetIPFullMask(podIP)
-			node := util.GetWorkerFromGatewayRouter(gr)
-			if err := oc.delHybridRoutePolicyForPod(net.ParseIP(podIP), node, false); err != nil {
-				klog.Error(err)
-			}
-			_, stderr, err := util.RunOVNNbctl("--if-exists", "--policy=src-ip",
-				"lr-route-del", gr, podIP+mask, gw)
-			if err != nil {
-				klog.Errorf("Unable to delete src-ip route to GR router, stderr:%q, err:%v", stderr, err)
-			} else {
-				delete(nsInfo.podExternalRoutes, podIP)
-			}
+	routeInfos := oc.getRouteInfosForNamespace(namespace)
+	for _, routeInfo := range routeInfos {
+		for podIP, gwToGr := range routeInfo.podExternalRoutes {
+			for gw, gr := range gwToGr {
+				if utilnet.IsIPv6String(gw) != utilnet.IsIPv6String(podIP) {
+					continue
+				}
+				mask := GetIPFullMask(podIP)
+				node := util.GetWorkerFromGatewayRouter(gr)
+				if err := oc.delHybridRoutePolicyForPod(net.ParseIP(podIP), node, false); err != nil {
+					klog.Error(err)
+				}
+				_, stderr, err := util.RunOVNNbctl("--if-exists", "--policy=src-ip",
+					"lr-route-del", gr, podIP+mask, gw)
+				if err != nil {
+					klog.Errorf("Unable to delete src-ip route to GR router, stderr:%q, err:%v", stderr, err)
+				} else {
+					delete(routeInfo.podExternalRoutes[podIP], gw)
+				}
 
-			portPrefix, err := oc.extSwitchPrefix(node)
-			if err != nil {
-				klog.Infof("Failed to find ext switch prefix for %s %v", node, err)
-				continue
+				portPrefix, err := oc.extSwitchPrefix(node)
+				if err != nil {
+					klog.Infof("Failed to find ext switch prefix for %s %v", node, err)
+					continue
+				}
+				cleanUpBFDEntry(gw, gr, portPrefix)
 			}
-			cleanUpBFDEntry(gw, gr, portPrefix)
 		}
+		routeInfo.Unlock()
 	}
-	nsInfo.routingExternalGWs = gatewayInfo{}
 }
 
 // deleteGwRoutesForPod handles deleting all routes to gateways for a pod IP on a specific GR
-func (oc *Controller) deleteGWRoutesForPod(namespace string, podIPNets []*net.IPNet) {
-	// delete src-ip cached route to GR
-	nsInfo, nsUnlock := oc.getNamespaceLocked(namespace, false)
-	if nsInfo == nil {
+func (oc *Controller) deleteGWRoutesForPod(name ktypes.NamespacedName, podIPNets []*net.IPNet) {
+	routeInfo := oc.deleteRouteInfoLocked(name)
+	if routeInfo == nil {
 		return
 	}
-	defer nsUnlock()
+	defer routeInfo.Unlock()
 
 	for _, podIPNet := range podIPNets {
 		pod := podIPNet.IP.String()
-		if gwToGr, ok := nsInfo.podExternalRoutes[pod]; ok {
+		if gwToGr, ok := routeInfo.podExternalRoutes[pod]; ok {
 			if len(gwToGr) == 0 {
-				delete(nsInfo.podExternalRoutes, pod)
+				delete(routeInfo.podExternalRoutes, pod)
 				return
 			}
 			mask := GetIPFullMask(pod)
@@ -307,9 +406,12 @@ func (oc *Controller) deleteGWRoutesForPod(namespace string, podIPNets []*net.IP
 				_, stderr, err := util.RunOVNNbctl("--if-exists", "--policy=src-ip",
 					"lr-route-del", gr, pod+mask, gw)
 				if err != nil {
-					klog.Errorf("Unable to delete external gw ecmp route to GR router, stderr:%q, err:%v", stderr, err)
+					klog.Errorf("Unable to delete ECMP route for pod: %s to GR %s, GW: %s, stderr:%q, err:%v",
+						name, gr, gw, stderr, err)
 				} else {
-					delete(nsInfo.podExternalRoutes, pod)
+					delete(routeInfo.podExternalRoutes[pod], gw)
+					klog.V(5).Infof("ECMP route deleted for pod: %s, on gr: %s, to gw: %s", name,
+						gr, gw)
 				}
 				cleanUpBFDEntry(gw, gr, portPrefix)
 			}
@@ -318,12 +420,7 @@ func (oc *Controller) deleteGWRoutesForPod(namespace string, podIPNets []*net.IP
 }
 
 // addEgressGwRoutesForPod handles adding all routes to gateways for a pod on a specific GR
-func (oc *Controller) addGWRoutesForPod(gateways []*gatewayInfo, podIfAddrs []*net.IPNet, namespace, node string) error {
-	nsInfo, nsUnlock := oc.getNamespaceLocked(namespace, false)
-	if nsInfo == nil {
-		return fmt.Errorf("unable to get namespace: %s", namespace)
-	}
-	defer nsUnlock()
+func (oc *Controller) addGWRoutesForPod(gateways []*gatewayInfo, podIfAddrs []*net.IPNet, podNsName ktypes.NamespacedName, node string) error {
 	gr := util.GetGatewayRouterFromNode(node)
 
 	routesAdded := 0
@@ -334,7 +431,11 @@ func (oc *Controller) addGWRoutesForPod(gateways []*gatewayInfo, podIfAddrs []*n
 	}
 
 	port := portPrefix + types.GWRouterToExtSwitchPrefix + gr
-
+	routeInfo, err := oc.ensureRouteInfoLocked(podNsName)
+	if err != nil {
+		return fmt.Errorf("failed to ensure routeInfo for %s, error: %v", podNsName, err)
+	}
+	defer routeInfo.Unlock()
 	for _, podIPNet := range podIfAddrs {
 		for _, gateway := range gateways {
 			// TODO (trozet): use the go bindings here and batch commands
@@ -345,7 +446,7 @@ func (oc *Controller) addGWRoutesForPod(gateways []*gatewayInfo, podIfAddrs []*n
 				for _, gw := range gws {
 					gwStr := gw.String()
 					// if route was already programmed, skip it
-					if foundGR, ok := nsInfo.podExternalRoutes[podIP][gwStr]; ok && foundGR == gr {
+					if foundGR, ok := routeInfo.podExternalRoutes[podIP][gwStr]; ok && foundGR == gr {
 						routesAdded++
 						continue
 					}
@@ -363,22 +464,21 @@ func (oc *Controller) addGWRoutesForPod(gateways []*gatewayInfo, podIfAddrs []*n
 					if err := oc.addHybridRoutePolicyForPod(podIPNet.IP, node); err != nil {
 						return err
 					}
-					if nsInfo.podExternalRoutes[podIP] == nil {
-						nsInfo.podExternalRoutes[podIP] = make(map[string]string)
+					if routeInfo.podExternalRoutes[podIP] == nil {
+						routeInfo.podExternalRoutes[podIP] = make(map[string]string)
 					}
-					nsInfo.podExternalRoutes[podIP][gwStr] = gr
+					routeInfo.podExternalRoutes[podIP][gwStr] = gr
 					routesAdded++
 				}
 			} else {
 				klog.Warningf("Address families for the pod address %s and gateway %s did not match", podIPNet.IP.String(), gateway.gws)
 			}
-
 		}
 	}
 	// if no routes are added return an error
 	if routesAdded < 1 {
 		return fmt.Errorf("gateway specified for namespace %s with gateway addresses %v but no valid routes exist for pod: %s",
-			namespace, podIfAddrs, node)
+			podNsName.Namespace, podIfAddrs, podNsName.Name)
 	}
 	return nil
 }

--- a/go-controller/pkg/ovn/namespace.go
+++ b/go-controller/pkg/ovn/namespace.go
@@ -79,20 +79,20 @@ func (oc *Controller) getRoutingPodGWs(nsInfo *namespaceInfo) map[string]*gatewa
 // addPodToNamespace adds the pod's IP to the namespace's address set and returns
 // pod's routing gateway info
 func (oc *Controller) addPodToNamespace(ns string, ips []*net.IPNet) (*gatewayInfo, map[string]*gatewayInfo, net.IP,
-	[]*goovn.OvnCommand, addressset.AddressSet, error) {
+	[]*goovn.OvnCommand, error) {
 	nsInfo, nsUnlock, err := oc.ensureNamespaceLocked(ns, true)
 	if err != nil {
-		return nil, nil, nil, nil, nil, fmt.Errorf("failed to ensure namespace locked: %v", err)
+		return nil, nil, nil, nil, fmt.Errorf("failed to ensure namespace locked: %v", err)
 	}
 
 	defer nsUnlock()
 
 	cmds, err := nsInfo.addressSet.PrepareAddIPsCmds(createIPAddressSlice(ips))
 	if err != nil {
-		return nil, nil, nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
-	as := nsInfo.addressSet
-	return oc.getRoutingExternalGWs(nsInfo), oc.getRoutingPodGWs(nsInfo), nsInfo.hybridOverlayExternalGW, cmds, as, nil
+
+	return oc.getRoutingExternalGWs(nsInfo), oc.getRoutingPodGWs(nsInfo), nsInfo.hybridOverlayExternalGW, cmds, nil
 }
 
 func (oc *Controller) deletePodFromNamespace(ns, name, uuid string, ips []*net.IPNet) error {

--- a/go-controller/pkg/ovn/namespace.go
+++ b/go-controller/pkg/ovn/namespace.go
@@ -78,19 +78,21 @@ func (oc *Controller) getRoutingPodGWs(nsInfo *namespaceInfo) map[string]*gatewa
 
 // addPodToNamespace adds the pod's IP to the namespace's address set and returns
 // pod's routing gateway info
-func (oc *Controller) addPodToNamespace(ns string, ips []*net.IPNet) (*gatewayInfo, map[string]*gatewayInfo, net.IP, error) {
+func (oc *Controller) addPodToNamespace(ns string, ips []*net.IPNet) (*gatewayInfo, map[string]*gatewayInfo, net.IP,
+	[]*goovn.OvnCommand, addressset.AddressSet, error) {
 	nsInfo, nsUnlock, err := oc.ensureNamespaceLocked(ns, true)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("failed to ensure namespace locked: %v", err)
+		return nil, nil, nil, nil, nil, fmt.Errorf("failed to ensure namespace locked: %v", err)
 	}
 
 	defer nsUnlock()
 
-	if err := nsInfo.addressSet.AddIPs(createIPAddressSlice(ips)); err != nil {
-		return nil, nil, nil, err
+	cmds, err := nsInfo.addressSet.PrepareAddIPsCmds(createIPAddressSlice(ips))
+	if err != nil {
+		return nil, nil, nil, nil, nil, err
 	}
-
-	return oc.getRoutingExternalGWs(nsInfo), oc.getRoutingPodGWs(nsInfo), nsInfo.hybridOverlayExternalGW, nil
+	as := nsInfo.addressSet
+	return oc.getRoutingExternalGWs(nsInfo), oc.getRoutingPodGWs(nsInfo), nsInfo.hybridOverlayExternalGW, cmds, as, nil
 }
 
 func (oc *Controller) deletePodFromNamespace(ns, name, uuid string, ips []*net.IPNet) error {

--- a/go-controller/pkg/ovn/namespace.go
+++ b/go-controller/pkg/ovn/namespace.go
@@ -313,7 +313,8 @@ func (oc *Controller) updateNamespace(old, newer *kapi.Namespace) {
 				}
 			}
 		} else {
-			oc.deleteGWRoutesForNamespace(nsInfo)
+			oc.deleteGWRoutesForNamespace(old.Name)
+			nsInfo.routingExternalGWs = gatewayInfo{}
 		}
 		exGateways, err := parseRoutingExternalGWAnnotation(gwAnnotation)
 		if err != nil {
@@ -397,7 +398,7 @@ func (oc *Controller) deleteNamespace(ns *kapi.Namespace) {
 		delete(nsInfo.networkPolicies, np.name)
 		oc.destroyNetworkPolicy(np, nsInfo)
 	}
-	oc.deleteGWRoutesForNamespace(nsInfo)
+	oc.deleteGWRoutesForNamespace(ns.Name)
 	oc.multicastDeleteNamespace(ns, nsInfo)
 }
 
@@ -462,7 +463,6 @@ func (oc *Controller) ensureNamespaceLocked(ns string, readOnly bool) (*namespac
 	if nsInfo == nil {
 		nsInfo = &namespaceInfo{
 			networkPolicies:       make(map[string]*networkPolicy),
-			podExternalRoutes:     make(map[string]map[string]string),
 			multicastEnabled:      false,
 			routingExternalPodGWs: make(map[string]gatewayInfo),
 		}

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -243,7 +243,7 @@ func GetIPFullMask(ip string) string {
 func NewOvnController(ovnClient *util.OVNClientset, wf *factory.WatchFactory,
 	stopChan <-chan struct{}, addressSetFactory addressset.AddressSetFactory, ovnNBClient goovn.Client, ovnSBClient goovn.Client, recorder record.EventRecorder) *Controller {
 	if addressSetFactory == nil {
-		addressSetFactory = addressset.NewOvnAddressSetFactory()
+		addressSetFactory = addressset.NewOvnAddressSetFactory(ovnNBClient)
 	}
 	return &Controller{
 		client: ovnClient.KubeClient,
@@ -393,7 +393,7 @@ func (oc *Controller) ovnTopologyCleanup() error {
 
 	// Cleanup address sets in non dual stack formats in all versions known to possibly exist.
 	if ver <= ovntypes.OvnPortBindingTopoVersion {
-		err = addressset.NonDualStackAddressSetCleanup()
+		err = addressset.NonDualStackAddressSetCleanup(oc.ovnNBClient)
 	}
 	return err
 }

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/ipallocator"
 	util "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 	kapi "k8s.io/api/core/v1"
+	ktypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 	utilnet "k8s.io/utils/net"
@@ -152,7 +153,9 @@ func (oc *Controller) deleteLogicalPort(pod *kapi.Pod) {
 	if config.Gateway.DisableSNATMultipleGWs {
 		oc.deletePerPodGRSNAT(pod.Spec.NodeName, portInfo.ips)
 	}
-	oc.deleteGWRoutesForPod(pod.Namespace, portInfo.ips)
+	podNsName := ktypes.NamespacedName{Namespace: pod.Namespace, Name: pod.Name}
+	oc.deleteGWRoutesForPod(podNsName, portInfo.ips)
+
 	oc.logicalPortCache.remove(logicalPort)
 }
 
@@ -495,7 +498,8 @@ func (oc *Controller) addLogicalPort(pod *kapi.Pod) (err error) {
 	}
 
 	if len(gateways) > 0 {
-		err = oc.addGWRoutesForPod(gateways, podIfAddrs, pod.Namespace, pod.Spec.NodeName)
+		podNsName := ktypes.NamespacedName{Namespace: pod.Namespace, Name: pod.Name}
+		err = oc.addGWRoutesForPod(gateways, podIfAddrs, podNsName, pod.Spec.NodeName)
 		if err != nil {
 			return err
 		}

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -390,10 +390,12 @@ func (oc *Controller) addLogicalPort(pod *kapi.Pod) (err error) {
 	}
 
 	// Ensure the namespace/nsInfo exists
-	routingExternalGWs, routingPodGWs, hybridOverlayExternalGW, err := oc.addPodToNamespace(pod.Namespace, podIfAddrs)
+	routingExternalGWs, routingPodGWs, hybridOverlayExternalGW, addrSetCmds, as, err := oc.addPodToNamespace(pod.Namespace, podIfAddrs)
 	if err != nil {
 		return err
 	}
+	defer as.Unlock()
+	cmds = append(cmds, addrSetCmds...)
 
 	if needsIP {
 		var networks []*types.NetworkSelectionElement
@@ -515,6 +517,8 @@ func (oc *Controller) addLogicalPort(pod *kapi.Pod) (err error) {
 		return fmt.Errorf("error while creating logical port %s error: %v",
 			portName, err)
 	}
+
+	as.UpdateIPCache(createIPAddressSlice(podIfAddrs))
 
 	lsp, err = oc.ovnNBClient.LSPGet(portName)
 	if err != nil || lsp == nil {

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -123,15 +123,26 @@ func (oc *Controller) deleteLogicalPort(pod *kapi.Pod) {
 
 	// FIXME: if any of these steps fails we need to stop and try again later...
 
-	if err := oc.deletePodFromNamespace(pod.Namespace, portInfo.name, portInfo.uuid, portInfo.ips); err != nil {
-		klog.Errorf(err.Error())
-	}
-
-	start1 := time.Now()
-	err = util.OvnNBLSPDel(oc.ovnNBClient, logicalPort)
-	ovnExecuteTime = time.Since(start1)
+	var cmds []*goovn.OvnCommand
+	addrSetCmds, err := oc.deletePodFromNamespace(pod.Namespace, portInfo.name, portInfo.uuid, portInfo.ips)
 	if err != nil {
 		klog.Errorf(err.Error())
+	} else {
+		cmds = append(cmds, addrSetCmds...)
+	}
+
+	cmd, err := oc.ovnNBClient.LSPDel(logicalPort)
+	if err != nil {
+		klog.Errorf(err.Error())
+	} else {
+		cmds = append(cmds, cmd)
+	}
+	start1 := time.Now()
+	// execute all the commands together.
+	err = oc.ovnNBClient.Execute(cmds...)
+	ovnExecuteTime = time.Since(start1)
+	if err != nil {
+		klog.Errorf("Error deleting logical port %s: %v", portInfo.name, err)
 	}
 
 	if err := oc.lsManager.ReleaseIPs(portInfo.logicalSwitch, portInfo.ips); err != nil {
@@ -352,8 +363,13 @@ func (oc *Controller) addLogicalPort(pod *kapi.Pod) (err error) {
 			} else {
 				klog.Infof("Released IPs: %s for node: %s", util.JoinIPNetIPs(podIfAddrs, " "), logicalSwitch)
 			}
-			if nsErr := oc.deletePodFromNamespace(pod.Namespace, portName, "", podIfAddrs); nsErr != nil {
+			if addrSetCmds, nsErr := oc.deletePodFromNamespace(pod.Namespace, portName, "", podIfAddrs); nsErr != nil {
 				klog.Errorf("Error when deleting pod: %s from namespace: %v", pod.Name, err)
+			} else {
+				err = oc.ovnNBClient.Execute(addrSetCmds...)
+				if err != nil {
+					klog.Errorf("Error removing pod %s IPs from namespace address set: %v", portName, err)
+				}
 			}
 		}
 	}()

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -390,11 +390,10 @@ func (oc *Controller) addLogicalPort(pod *kapi.Pod) (err error) {
 	}
 
 	// Ensure the namespace/nsInfo exists
-	routingExternalGWs, routingPodGWs, hybridOverlayExternalGW, addrSetCmds, as, err := oc.addPodToNamespace(pod.Namespace, podIfAddrs)
+	routingExternalGWs, routingPodGWs, hybridOverlayExternalGW, addrSetCmds, err := oc.addPodToNamespace(pod.Namespace, podIfAddrs)
 	if err != nil {
 		return err
 	}
-	defer as.Unlock()
 	cmds = append(cmds, addrSetCmds...)
 
 	if needsIP {
@@ -517,8 +516,6 @@ func (oc *Controller) addLogicalPort(pod *kapi.Pod) (err error) {
 		return fmt.Errorf("error while creating logical port %s error: %v",
 			portName, err)
 	}
-
-	as.UpdateIPCache(createIPAddressSlice(podIfAddrs))
 
 	lsp, err = oc.ovnNBClient.LSPGet(portName)
 	if err != nil || lsp == nil {

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -372,9 +372,8 @@ func (oc *Controller) addLogicalPort(pod *kapi.Pod) (err error) {
 			if addrSetCmds, nsErr := oc.deletePodFromNamespace(pod.Namespace, portName, "", podIfAddrs); nsErr != nil {
 				klog.Errorf("Error when deleting pod: %s from namespace: %v", pod.Name, err)
 			} else {
-				err = oc.ovnNBClient.Execute(addrSetCmds...)
-				if err != nil {
-					klog.Errorf("Error removing pod %s IPs from namespace address set: %v", portName, err)
+				if addrErr := oc.ovnNBClient.Execute(addrSetCmds...); addrErr != nil {
+					klog.Errorf("Error removing pod %s IPs from namespace address set: %v", portName, addrErr)
 				}
 			}
 		}

--- a/go-controller/pkg/util/go_ovn.go
+++ b/go-controller/pkg/util/go_ovn.go
@@ -88,10 +88,11 @@ func initGoOvnSslClient(certFile, privKeyFile, caCertFile, address, db, serverNa
 	}
 	tlsConfig.BuildNameToCertificate()
 	ovndbclient, err := goovn.NewClient(&goovn.Config{
-		Db:        db,
-		Addr:      address,
-		TLSConfig: tlsConfig,
-		Reconnect: true,
+		Db:         db,
+		Addr:       address,
+		TLSConfig:  tlsConfig,
+		Reconnect:  true,
+		LeaderOnly: true,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error creating SSL OVNDBClient for database %s at address %s: %s", db, address, err)
@@ -155,9 +156,10 @@ func updateSslKeyPair(ovndb, certFile, privKeyFile string, tlsConfig *tls.Config
 
 func initGoOvnTcpClient(address, db string) (goovn.Client, error) {
 	ovndbclient, err := goovn.NewClient(&goovn.Config{
-		Db:        db,
-		Addr:      address,
-		Reconnect: true,
+		Db:         db,
+		Addr:       address,
+		Reconnect:  true,
+		LeaderOnly: true,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error creating TCP OVNDBClient for address %s: %s", address, err)
@@ -168,9 +170,10 @@ func initGoOvnTcpClient(address, db string) (goovn.Client, error) {
 
 func initGoOvnUnixClient(address, db string) (goovn.Client, error) {
 	ovndbclient, err := goovn.NewClient(&goovn.Config{
-		Db:        db,
-		Addr:      address,
-		Reconnect: true,
+		Db:         db,
+		Addr:       address,
+		Reconnect:  true,
+		LeaderOnly: true,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error creating UNIX OVNDBClient for address %s: %s", address, err)

--- a/go-controller/pkg/util/go_ovn.go
+++ b/go-controller/pkg/util/go_ovn.go
@@ -5,6 +5,7 @@ import (
 	"crypto/x509"
 	"fmt"
 	"reflect"
+	"time"
 
 	"io/ioutil"
 
@@ -93,6 +94,7 @@ func initGoOvnSslClient(certFile, privKeyFile, caCertFile, address, db, serverNa
 		TLSConfig:  tlsConfig,
 		Reconnect:  true,
 		LeaderOnly: true,
+		Timeout:    time.Minute,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error creating SSL OVNDBClient for database %s at address %s: %s", db, address, err)
@@ -160,6 +162,7 @@ func initGoOvnTcpClient(address, db string) (goovn.Client, error) {
 		Addr:       address,
 		Reconnect:  true,
 		LeaderOnly: true,
+		Timeout:    time.Minute,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error creating TCP OVNDBClient for address %s: %s", address, err)
@@ -174,6 +177,7 @@ func initGoOvnUnixClient(address, db string) (goovn.Client, error) {
 		Addr:       address,
 		Reconnect:  true,
 		LeaderOnly: true,
+		Timeout:    time.Minute,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error creating UNIX OVNDBClient for address %s: %s", address, err)

--- a/go-controller/vendor/github.com/cenkalti/rpc2/jsonrpc/jsonrpc.go
+++ b/go-controller/vendor/github.com/cenkalti/rpc2/jsonrpc/jsonrpc.go
@@ -151,7 +151,20 @@ func (c *jsonCodec) ReadRequestBody(x interface{}) error {
 		return errMissingParams
 	}
 
-	return json.Unmarshal(*c.serverRequest.Params, x)
+	var err error
+
+	// Check if x points to a slice of any kind
+	rt := reflect.TypeOf(x)
+	if rt.Kind() == reflect.Ptr && rt.Elem().Kind() == reflect.Slice {
+		// If it's a slice, unmarshal as is
+		err = json.Unmarshal(*c.serverRequest.Params, x)
+	} else {
+		// Anything else unmarshal into a slice containing x
+		params := &[]interface{}{x}
+		err = json.Unmarshal(*c.serverRequest.Params, params)
+	}
+
+	return err
 }
 
 func (c *jsonCodec) ReadResponseBody(x interface{}) error {

--- a/go-controller/vendor/github.com/ebay/go-ovn/address_set.go
+++ b/go-controller/vendor/github.com/ebay/go-ovn/address_set.go
@@ -78,13 +78,16 @@ func (odbi *ovndb) asAddIPImp(name, uuid string, addrs []string) (*OvnCommand, e
 	return &OvnCommand{operations, odbi, make([][]map[string]interface{}, len(operations))}, nil
 }
 
-func (odbi *ovndb) asDelIPImp(name string, addrs []string) (*OvnCommand, error) {
+func (odbi *ovndb) asDelIPImp(name, uuid string, addrs []string) (*OvnCommand, error) {
 	addresses, err := libovsdb.NewOvsSet(addrs)
 	if err != nil {
 		return nil, err
 	}
 	mutation := libovsdb.NewMutation("addresses", "delete", addresses)
 	condition := libovsdb.NewCondition("name", "==", name)
+	if uuid != "" {
+		condition = libovsdb.NewCondition("_uuid", "==", stringToGoUUID(uuid))
+	}
 	updateOp := libovsdb.Operation{
 		Op:    opMutate,
 		Table: TableAddressSet,

--- a/go-controller/vendor/github.com/ebay/go-ovn/address_set.go
+++ b/go-controller/vendor/github.com/ebay/go-ovn/address_set.go
@@ -54,6 +54,39 @@ func (odbi *ovndb) asUpdateImp(name string, addrs []string, external_ids map[str
 	operations := []libovsdb.Operation{updateOp}
 	return &OvnCommand{operations, odbi, make([][]map[string]interface{}, len(operations))}, nil
 }
+func (odbi *ovndb) asAddIPImp(name string, addrs []string) (*OvnCommand, error) {
+	addresses, err := libovsdb.NewOvsSet(addrs)
+	if err != nil {
+		return nil, err
+	}
+	mutation := libovsdb.NewMutation("addresses", "insert", addresses)
+	condition := libovsdb.NewCondition("name", "==", name)
+	updateOp := libovsdb.Operation{
+		Op:    opMutate,
+		Table: TableAddressSet,
+		Mutations: []interface{}{mutation},
+		Where: []interface{}{condition},
+	}
+	operations := []libovsdb.Operation{updateOp}
+	return &OvnCommand{operations, odbi, make([][]map[string]interface{}, len(operations))}, nil
+}
+
+func (odbi *ovndb) asDelIPImp(name string, addrs []string) (*OvnCommand, error) {
+	addresses, err := libovsdb.NewOvsSet(addrs)
+	if err != nil {
+		return nil, err
+	}
+	mutation := libovsdb.NewMutation("addresses", "delete", addresses)
+	condition := libovsdb.NewCondition("name", "==", name)
+	updateOp := libovsdb.Operation{
+		Op:    opMutate,
+		Table: TableAddressSet,
+		Mutations: []interface{}{mutation},
+		Where: []interface{}{condition},
+	}
+	operations := []libovsdb.Operation{updateOp}
+	return &OvnCommand{operations, odbi, make([][]map[string]interface{}, len(operations))}, nil
+}
 
 func (odbi *ovndb) asAddImp(name string, addrs []string, external_ids map[string]string) (*OvnCommand, error) {
 	row := make(OVNRow)

--- a/go-controller/vendor/github.com/ebay/go-ovn/client.go
+++ b/go-controller/vendor/github.com/ebay/go-ovn/client.go
@@ -58,7 +58,7 @@ type Client interface {
 	// Get logical switch port by name
 	LSPGet(lsp string) (*LogicalSwitchPort, error)
 	// Add logical port PORT on SWITCH
-	LSPAdd(ls string, lsp string) (*OvnCommand, error)
+	LSPAdd(ls string, lsUUID string, lsp string) (*OvnCommand, error)
 	// Delete PORT from its attached switch
 	LSPDel(lsp string) (*OvnCommand, error)
 	// Set addressset per lport
@@ -674,8 +674,8 @@ func (c *ovndb) LSPGet(lsp string) (*LogicalSwitchPort, error) {
 	return c.lspGetImp(lsp)
 }
 
-func (c *ovndb) LSPAdd(ls string, lsp string) (*OvnCommand, error) {
-	return c.lspAddImp(ls, lsp)
+func (c *ovndb) LSPAdd(ls string, lsUUID string, lsp string) (*OvnCommand, error) {
+	return c.lspAddImp(ls, lsUUID, lsp)
 }
 
 func (c *ovndb) LinkSwitchToRouter(lsw, lsp, lr, lrp, lrpMac string, networks []string, externalIds map[string]string) (*OvnCommand, error) {

--- a/go-controller/vendor/github.com/ebay/go-ovn/client.go
+++ b/go-controller/vendor/github.com/ebay/go-ovn/client.go
@@ -99,10 +99,10 @@ type Client interface {
 	// Get AS
 	ASGet(name string) (*AddressSet, error)
 	// Update address set
-	ASUpdate(name string, addrs []string, external_ids map[string]string) (*OvnCommand, error)
+	ASUpdate(name, uuid string, addrs []string, external_ids map[string]string) (*OvnCommand, error)
 	// Add addressset
 	ASAdd(name string, addrs []string, external_ids map[string]string) (*OvnCommand, error)
-	ASAddIPs(name string, addrs []string) (*OvnCommand, error)
+	ASAddIPs(name, uuid string, addrs []string) (*OvnCommand, error)
 	ASDelIPs(name string, addrs []string) (*OvnCommand, error)
 	// Delete addressset
 	ASDel(name string) (*OvnCommand, error)
@@ -874,8 +874,8 @@ func (c *ovndb) ASAdd(name string, addrs []string, external_ids map[string]strin
 	return c.asAddImp(name, addrs, external_ids)
 }
 
-func (c *ovndb) ASAddIPs(name string, addrs []string) (*OvnCommand, error) {
-	return c.asAddIPImp(name, addrs)
+func (c *ovndb) ASAddIPs(name, uuid string, addrs []string) (*OvnCommand, error) {
+	return c.asAddIPImp(name, uuid, addrs)
 }
 
 func (c *ovndb) ASDelIPs(name string, addrs []string) (*OvnCommand, error) {
@@ -886,8 +886,8 @@ func (c *ovndb) ASDel(name string) (*OvnCommand, error) {
 	return c.asDelImp(name)
 }
 
-func (c *ovndb) ASUpdate(name string, addrs []string, external_ids map[string]string) (*OvnCommand, error) {
-	return c.asUpdateImp(name, addrs, external_ids)
+func (c *ovndb) ASUpdate(name, uuid string, addrs []string, external_ids map[string]string) (*OvnCommand, error) {
+	return c.asUpdateImp(name, uuid, addrs, external_ids)
 }
 
 func (c *ovndb) QoSAdd(ls string, direction string, priority int, match string, action map[string]int, bandwidth map[string]int, external_ids map[string]string) (*OvnCommand, error) {

--- a/go-controller/vendor/github.com/ebay/go-ovn/client.go
+++ b/go-controller/vendor/github.com/ebay/go-ovn/client.go
@@ -57,6 +57,8 @@ type Client interface {
 
 	// Get logical switch port by name
 	LSPGet(lsp string) (*LogicalSwitchPort, error)
+	// Get logical switch port by name
+	LSPGetUUID(uuid string) (*LogicalSwitchPort, error)
 	// Add logical port PORT on SWITCH
 	LSPAdd(ls string, lsUUID string, lsp string) (*OvnCommand, error)
 	// Delete PORT from its attached switch
@@ -684,6 +686,10 @@ func (c *ovndb) LSExtIdsDel(ls string, external_ids map[string]string) (*OvnComm
 
 func (c *ovndb) LSPGet(lsp string) (*LogicalSwitchPort, error) {
 	return c.lspGetImp(lsp)
+}
+
+func (c *ovndb) LSPGetUUID(uuid string) (*LogicalSwitchPort, error) {
+	return c.lspGetByUUIDImp(uuid)
 }
 
 func (c *ovndb) LSPAdd(ls string, lsUUID string, lsp string) (*OvnCommand, error) {

--- a/go-controller/vendor/github.com/ebay/go-ovn/client.go
+++ b/go-controller/vendor/github.com/ebay/go-ovn/client.go
@@ -99,6 +99,8 @@ type Client interface {
 	ASUpdate(name string, addrs []string, external_ids map[string]string) (*OvnCommand, error)
 	// Add addressset
 	ASAdd(name string, addrs []string, external_ids map[string]string) (*OvnCommand, error)
+	ASAddIPs(name string, addrs []string) (*OvnCommand, error)
+	ASDelIPs(name string, addrs []string) (*OvnCommand, error)
 	// Delete addressset
 	ASDel(name string) (*OvnCommand, error)
 	// Get all AS
@@ -726,6 +728,14 @@ func (c *ovndb) ACLDel(ls, direct, match string, priority int, external_ids map[
 
 func (c *ovndb) ASAdd(name string, addrs []string, external_ids map[string]string) (*OvnCommand, error) {
 	return c.asAddImp(name, addrs, external_ids)
+}
+
+func (c *ovndb) ASAddIPs(name string, addrs []string) (*OvnCommand, error) {
+	return c.asAddIPImp(name, addrs)
+}
+
+func (c *ovndb) ASDelIPs(name string, addrs []string) (*OvnCommand, error) {
+	return c. asDelIPImp(name, addrs)
 }
 
 func (c *ovndb) ASDel(name string) (*OvnCommand, error) {

--- a/go-controller/vendor/github.com/ebay/go-ovn/client.go
+++ b/go-controller/vendor/github.com/ebay/go-ovn/client.go
@@ -103,7 +103,7 @@ type Client interface {
 	// Add addressset
 	ASAdd(name string, addrs []string, external_ids map[string]string) (*OvnCommand, error)
 	ASAddIPs(name, uuid string, addrs []string) (*OvnCommand, error)
-	ASDelIPs(name string, addrs []string) (*OvnCommand, error)
+	ASDelIPs(name, uuid string, addrs []string) (*OvnCommand, error)
 	// Delete addressset
 	ASDel(name string) (*OvnCommand, error)
 	// Get all AS
@@ -878,8 +878,8 @@ func (c *ovndb) ASAddIPs(name, uuid string, addrs []string) (*OvnCommand, error)
 	return c.asAddIPImp(name, uuid, addrs)
 }
 
-func (c *ovndb) ASDelIPs(name string, addrs []string) (*OvnCommand, error) {
-	return c. asDelIPImp(name, addrs)
+func (c *ovndb) ASDelIPs(name, uuid string, addrs []string) (*OvnCommand, error) {
+	return c.asDelIPImp(name, uuid, addrs)
 }
 
 func (c *ovndb) ASDel(name string) (*OvnCommand, error) {

--- a/go-controller/vendor/github.com/ebay/go-ovn/common.go
+++ b/go-controller/vendor/github.com/ebay/go-ovn/common.go
@@ -27,6 +27,7 @@ const (
 const (
 	DBNB string = "OVN_Northbound"
 	DBSB string = "OVN_Southbound"
+	DBServer string = "_Server"
 )
 
 const (
@@ -54,6 +55,7 @@ const (
 	TableEncap                    string = "Encap"
 	TableSBGlobal                 string = "SB_Global"
 	TableChassisPrivate           string = "Chassis_Private"
+	TableDatabase                 string = "Database"
 )
 
 var NBTablesOrder = []string{
@@ -84,4 +86,8 @@ var SBTablesOrder = []string{
 	TableChassisPrivate,
 	TableEncap,
 	TableSBGlobal,
+}
+
+var ServerTablesOrder = []string{
+	TableDatabase,
 }

--- a/go-controller/vendor/github.com/ebay/go-ovn/config.go
+++ b/go-controller/vendor/github.com/ebay/go-ovn/config.go
@@ -29,4 +29,5 @@ type Config struct {
 	DisconnectCB OVNDisconnectedCallback // Callback that is called when disconnected, if "Reconnect" is false.
 	Reconnect    bool                    // Automatically reconnect when disconnected
 	TableCols    map[string][]string     // List of tables and their cols to be monitored
+	LeaderOnly   bool
 }

--- a/go-controller/vendor/github.com/ebay/go-ovn/config.go
+++ b/go-controller/vendor/github.com/ebay/go-ovn/config.go
@@ -18,6 +18,7 @@ package goovn
 
 import (
 	"crypto/tls"
+	"time"
 )
 
 // Config ovn nb and sb db client config
@@ -30,4 +31,5 @@ type Config struct {
 	Reconnect    bool                    // Automatically reconnect when disconnected
 	TableCols    map[string][]string     // List of tables and their cols to be monitored
 	LeaderOnly   bool
+	Timeout      time.Duration
 }

--- a/go-controller/vendor/github.com/ebay/go-ovn/logical_switch_port.go
+++ b/go-controller/vendor/github.com/ebay/go-ovn/logical_switch_port.go
@@ -406,6 +406,20 @@ func (odbi *ovndb) lspGetImp(lsp string) (*LogicalSwitchPort, error) {
 	return nil, ErrorNotFound
 }
 
+func (odbi *ovndb) lspGetByUUIDImp(uuid string) (*LogicalSwitchPort, error) {
+	odbi.cachemutex.RLock()
+	defer odbi.cachemutex.RUnlock()
+
+	cacheLogicalSwitchPort, ok := odbi.cache[TableLogicalSwitchPort]
+	if !ok {
+		return nil, ErrorSchema
+	}
+	if _, ok := cacheLogicalSwitchPort[uuid]; ok {
+		return odbi.rowToLogicalPort(uuid)
+	}
+	return nil, ErrorNotFound
+}
+
 // Get all lport by lswitch
 func (odbi *ovndb) lspListImp(lsw string) ([]*LogicalSwitchPort, error) {
 	odbi.cachemutex.RLock()

--- a/go-controller/vendor/github.com/ebay/go-ovn/logical_switch_port.go
+++ b/go-controller/vendor/github.com/ebay/go-ovn/logical_switch_port.go
@@ -323,15 +323,20 @@ func (odbi *ovndb) lspGetExternalIdsImp(lsp string) (map[string]string, error) {
 	return extIds, nil
 }
 
-func (odbi *ovndb) rowToLogicalPort(uuid string) (*LogicalSwitchPort, error) {
+func (odbi *ovndb) uuidToLogicalPort(uuid string) (*LogicalSwitchPort, error) {
+	row := odbi.cache[TableLogicalSwitchPort][uuid]
+	return odbi.rowToLogicalPort(uuid, &row)
+}
+
+func (odbi *ovndb) rowToLogicalPort(uuid string, row *libovsdb.Row) (*LogicalSwitchPort, error) {
 	lp := &LogicalSwitchPort{
 		UUID:       uuid,
-		Name:       odbi.cache[TableLogicalSwitchPort][uuid].Fields["name"].(string),
-		Type:       odbi.cache[TableLogicalSwitchPort][uuid].Fields["type"].(string),
-		ExternalID: odbi.cache[TableLogicalSwitchPort][uuid].Fields["external_ids"].(libovsdb.OvsMap).GoMap,
+		Name:       row.Fields["name"].(string),
+		Type:       row.Fields["type"].(string),
+		ExternalID: row.Fields["external_ids"].(libovsdb.OvsMap).GoMap,
 	}
 
-	if dhcpv4, ok := odbi.cache[TableLogicalSwitchPort][uuid].Fields["dhcpv4_options"]; ok {
+	if dhcpv4, ok := row.Fields["dhcpv4_options"]; ok {
 		switch dhcpv4.(type) {
 		case libovsdb.UUID:
 			lp.DHCPv4Options = dhcpv4.(libovsdb.UUID).GoUUID
@@ -339,7 +344,7 @@ func (odbi *ovndb) rowToLogicalPort(uuid string) (*LogicalSwitchPort, error) {
 		default:
 		}
 	}
-	if dhcpv6, ok := odbi.cache[TableLogicalSwitchPort][uuid].Fields["dhcpv6_options"]; ok {
+	if dhcpv6, ok := row.Fields["dhcpv6_options"]; ok {
 		switch dhcpv6.(type) {
 		case libovsdb.UUID:
 			lp.DHCPv6Options = dhcpv6.(libovsdb.UUID).GoUUID
@@ -348,7 +353,7 @@ func (odbi *ovndb) rowToLogicalPort(uuid string) (*LogicalSwitchPort, error) {
 		}
 	}
 
-	if addr, ok := odbi.cache[TableLogicalSwitchPort][uuid].Fields["addresses"]; ok {
+	if addr, ok := row.Fields["addresses"]; ok {
 		switch addr.(type) {
 		case string:
 			lp.Addresses = []string{addr.(string)}
@@ -359,7 +364,7 @@ func (odbi *ovndb) rowToLogicalPort(uuid string) (*LogicalSwitchPort, error) {
 		}
 	}
 
-	if portsecurity, ok := odbi.cache[TableLogicalSwitchPort][uuid].Fields["port_security"]; ok {
+	if portsecurity, ok := row.Fields["port_security"]; ok {
 		switch portsecurity.(type) {
 		case string:
 			lp.PortSecurity = []string{portsecurity.(string)}
@@ -370,11 +375,11 @@ func (odbi *ovndb) rowToLogicalPort(uuid string) (*LogicalSwitchPort, error) {
 		}
 	}
 
-	if options, ok := odbi.cache[TableLogicalSwitchPort][uuid].Fields["options"]; ok {
+	if options, ok := row.Fields["options"]; ok {
 		lp.Options = options.(libovsdb.OvsMap).GoMap
 	}
 
-	if dynamicAddresses, ok := odbi.cache[TableLogicalSwitchPort][uuid].Fields["dynamic_addresses"]; ok {
+	if dynamicAddresses, ok := row.Fields["dynamic_addresses"]; ok {
 		switch dynamicAddresses.(type) {
 		case string:
 			lp.DynamicAddresses = dynamicAddresses.(string)
@@ -400,7 +405,7 @@ func (odbi *ovndb) lspGetImp(lsp string) (*LogicalSwitchPort, error) {
 
 	for uuid, drows := range cacheLogicalSwitchPort {
 		if rlsp, ok := drows.Fields["name"].(string); ok && rlsp == lsp {
-			return odbi.rowToLogicalPort(uuid)
+			return odbi.rowToLogicalPort(uuid, &drows)
 		}
 	}
 	return nil, ErrorNotFound
@@ -414,8 +419,8 @@ func (odbi *ovndb) lspGetByUUIDImp(uuid string) (*LogicalSwitchPort, error) {
 	if !ok {
 		return nil, ErrorSchema
 	}
-	if _, ok := cacheLogicalSwitchPort[uuid]; ok {
-		return odbi.rowToLogicalPort(uuid)
+	if row, ok := cacheLogicalSwitchPort[uuid]; ok {
+		return odbi.rowToLogicalPort(uuid, &row)
 	}
 	return nil, ErrorNotFound
 }
@@ -439,7 +444,7 @@ func (odbi *ovndb) lspListImp(lsw string) ([]*LogicalSwitchPort, error) {
 						listLSP := make([]*LogicalSwitchPort, 0, len(ps.GoSet))
 						for _, p := range ps.GoSet {
 							if vp, ok := p.(libovsdb.UUID); ok {
-								tp, err := odbi.rowToLogicalPort(vp.GoUUID)
+								tp, err := odbi.uuidToLogicalPort(vp.GoUUID)
 								if err != nil {
 									return nil, fmt.Errorf("Failed to get logical port: %s", err)
 								}
@@ -452,7 +457,7 @@ func (odbi *ovndb) lspListImp(lsw string) ([]*LogicalSwitchPort, error) {
 					}
 				case libovsdb.UUID:
 					if vp, ok := ports.(libovsdb.UUID); ok {
-						tp, err := odbi.rowToLogicalPort(vp.GoUUID)
+						tp, err := odbi.uuidToLogicalPort(vp.GoUUID)
 						if err != nil {
 							return nil, fmt.Errorf("Failed to get logical port: %s", err)
 						}

--- a/go-controller/vendor/github.com/ebay/go-ovn/logical_switch_port.go
+++ b/go-controller/vendor/github.com/ebay/go-ovn/logical_switch_port.go
@@ -37,7 +37,7 @@ type LogicalSwitchPort struct {
 	ExternalID       map[interface{}]interface{}
 }
 
-func (odbi *ovndb) lspAddImp(lsw, lsp string) (*OvnCommand, error) {
+func (odbi *ovndb) lspAddImp(lsw, lswUUID, lsp string) (*OvnCommand, error) {
 	namedUUID, err := newRowUUID()
 	if err != nil {
 		return nil, err
@@ -64,6 +64,9 @@ func (odbi *ovndb) lspAddImp(lsw, lsp string) (*OvnCommand, error) {
 
 	mutation := libovsdb.NewMutation("ports", opInsert, mutateSet)
 	condition := libovsdb.NewCondition("name", "==", lsw)
+	if lswUUID != "" {
+		condition = libovsdb.NewCondition("_uuid", "==", stringToGoUUID(lswUUID))
+	}
 
 	mutateOp := libovsdb.Operation{
 		Op:        opMutate,

--- a/go-controller/vendor/github.com/ebay/go-ovn/ovnimp.go
+++ b/go-controller/vendor/github.com/ebay/go-ovn/ovnimp.go
@@ -351,7 +351,7 @@ func (odbi *ovndb) getContext(dbName string) (*map[string][]string, *map[string]
 	return &odbi.tableCols, &odbi.cache, odbi.signalCreate, odbi.signalDelete
 }
 
-func (odbi *ovndb) populateCache(dbName string, updates libovsdb.TableUpdates, signal bool) {
+func (odbi *ovndb) populateCache(dbName string, updates *libovsdb.TableUpdates, signal bool) {
 	tableCols, cache, signalCreate, signalDelete := odbi.getContext(dbName)
 
 	empty := libovsdb.Row{}
@@ -512,7 +512,7 @@ func (odbi *ovndb) applyUpdatesToRow(db, table string, uuid string, rowdiff *lib
 	(*cache)[table][uuid] = row
 }
 
-func (odbi *ovndb) populateCache2(dbName string, updates libovsdb.TableUpdates2, signal bool) {
+func (odbi *ovndb) populateCache2(dbName string, updates *libovsdb.TableUpdates2, signal bool) {
 	tableCols, cache, signalCreate, signalDelete := odbi.getContext(dbName)
 
 	for table := range *tableCols {

--- a/go-controller/vendor/github.com/ebay/go-ovn/ovnimp.go
+++ b/go-controller/vendor/github.com/ebay/go-ovn/ovnimp.go
@@ -245,7 +245,7 @@ func (odbi *ovndb) signalCreate(table, uuid string) {
 		ls := odbi.rowToLogicalSwitch(uuid)
 		odbi.signalCB.OnLogicalSwitchCreate(ls)
 	case TableLogicalSwitchPort:
-		lp, err := odbi.rowToLogicalPort(uuid)
+		lp, err := odbi.uuidToLogicalPort(uuid)
 		if err == nil {
 			odbi.signalCB.OnLogicalPortCreate(lp)
 		}
@@ -291,7 +291,7 @@ func (odbi *ovndb) signalDelete(table, uuid string) {
 		ls := odbi.rowToLogicalSwitch(uuid)
 		odbi.signalCB.OnLogicalSwitchDelete(ls)
 	case TableLogicalSwitchPort:
-		lp, err := odbi.rowToLogicalPort(uuid)
+		lp, err := odbi.uuidToLogicalPort(uuid)
 		if err == nil {
 			odbi.signalCB.OnLogicalPortDelete(lp)
 		}

--- a/go-controller/vendor/github.com/ebay/go-ovn/ovnnotify.go
+++ b/go-controller/vendor/github.com/ebay/go-ovn/ovnnotify.go
@@ -24,59 +24,126 @@ import (
 	"github.com/ebay/libovsdb"
 )
 
-type ovnNotifier struct {
-	odbi *ovndb
+type update struct {
+	db        string
+	updates   *libovsdb.TableUpdates
+	updates2  *libovsdb.TableUpdates2
+	lastTxnId string
 }
 
-func (notify ovnNotifier) getDBNameAndLock(context interface{}) (string, *sync.RWMutex) {
+type ovnNotifier struct {
+	sync.Mutex
+	odbi            *ovndb
+	deferUpdates    bool
+	deferredUpdates []*update
+}
+
+func newOVNNotifier(odbi *ovndb) *ovnNotifier {
+	return &ovnNotifier{
+		odbi:            odbi,
+		deferUpdates:    true,
+		deferredUpdates: make([]*update, 0),
+	}
+}
+
+func newUpdate(context interface{}, updates *libovsdb.TableUpdates, updates2 *libovsdb.TableUpdates2, lastTxnId string) *update {
 	dbName, ok := context.(string)
 	if !ok {
-		klog.Warningf("Expected string-type context but got %v", context)
-		return "", nil
+		klog.Warningf("Expected string-type OVN update context but got %v", context)
+		return nil
 	}
-
-	if dbName == DBServer {
-		return dbName, &notify.odbi.serverCacheMutex
-	}
-
-	return dbName, &notify.odbi.cachemutex
-}
-
-func (notify ovnNotifier) Update(context interface{}, tableUpdates libovsdb.TableUpdates) {
-	db, lock := notify.getDBNameAndLock(context)
-	if lock != nil {
-		lock.Lock()
-		defer lock.Unlock()
-		notify.odbi.populateCache(db, tableUpdates, true)
-	}
-}
-func (notify ovnNotifier) Update2(context interface{}, tableUpdates libovsdb.TableUpdates2) {
-	db, lock := notify.getDBNameAndLock(context)
-	if lock != nil {
-		lock.Lock()
-		defer lock.Unlock()
-		notify.odbi.populateCache2(db, tableUpdates, true)
+	return &update{
+		db:        dbName,
+		updates:   updates,
+		updates2:  updates2,
+		lastTxnId: lastTxnId,
 	}
 }
 
-func (notify ovnNotifier) Update3(context interface{}, tableUpdates libovsdb.TableUpdates2, lastTxnId string) {
-	db, lock := notify.getDBNameAndLock(context)
-	if lock != nil {
-		lock.Lock()
-		defer lock.Unlock()
-		notify.odbi.populateCache2(db, tableUpdates, true)
-		notify.odbi.currentTxn = lastTxnId
+func (n *ovnNotifier) processUpdate(u *update, signal bool) {
+	if u.updates != nil {
+		n.odbi.populateCache(u.db, u.updates, signal)
+	} else {
+		n.odbi.populateCache2(u.db, u.updates2, signal)
+		if u.lastTxnId != "" {
+			n.odbi.currentTxn = u.lastTxnId
+		}
 	}
 }
 
-func (notify ovnNotifier) Locked([]interface{}) {
-}
-func (notify ovnNotifier) Stolen([]interface{}) {
-}
-func (notify ovnNotifier) Echo([]interface{}) {
+func (n *ovnNotifier) processDeferredUpdates() {
+	// we don't need to hold the lock while iterating deferred
+	// updates since nothing can add to the array after we set
+	// deferUpdates to false
+	n.Lock()
+	n.deferUpdates = false
+	n.Unlock()
+
+	for _, u := range n.deferredUpdates {
+		n.processUpdate(u, false)
+	}
 }
 
-func (notify ovnNotifier) Disconnected(client *libovsdb.OvsdbClient) {
+// maybeDeferUpdate adds the update to the deferred updates list if it should
+// be deferred because we are in the middle of the initial DB dump. Returns
+// true if the update was deferred.
+func (n *ovnNotifier) maybeDeferUpdate(u *update) bool {
+	n.Lock()
+	defer n.Unlock()
+	if n.deferUpdates {
+		n.deferredUpdates = append(n.deferredUpdates, u)
+	}
+	return n.deferUpdates
+}
+
+// handleUpdate either adds the update to the deferred updates list or
+// processes the update immediately. Assumes the caller holds the cache
+// mutexes while updates are deferred and calls processDeferredUpdates()
+// when the initial DB dump is done. This ensures that deferred updates
+// get processed first since non-deferred updates will block on the
+// cache mutexes that the caller holds until processDeferredUpdates() is done.
+func (n *ovnNotifier) handleUpdate(u *update) {
+	if n.maybeDeferUpdate(u) {
+		return
+	}
+
+	if u.db == DBServer {
+		n.odbi.serverCacheMutex.Lock()
+		defer n.odbi.serverCacheMutex.Unlock()
+	} else {
+		n.odbi.cachemutex.Lock()
+		defer n.odbi.cachemutex.Unlock()
+	}
+
+	n.processUpdate(u, true)
+}
+
+func (n *ovnNotifier) Update(context interface{}, tableUpdates libovsdb.TableUpdates) {
+	if u := newUpdate(context, &tableUpdates, nil, ""); u != nil {
+		n.handleUpdate(u)
+	}
+}
+
+func (n *ovnNotifier) Update2(context interface{}, tableUpdates libovsdb.TableUpdates2) {
+	if u := newUpdate(context, nil, &tableUpdates, ""); u != nil {
+		n.handleUpdate(u)
+	}
+}
+
+func (n *ovnNotifier) Update3(context interface{}, tableUpdates libovsdb.TableUpdates2, lastTxnId string) {
+	if u := newUpdate(context, nil, &tableUpdates, lastTxnId); u != nil {
+		n.handleUpdate(u)
+	}
+}
+
+func (notify *ovnNotifier) Locked([]interface{}) {
+}
+func (notify *ovnNotifier) Stolen([]interface{}) {
+}
+func (notify *ovnNotifier) Echo([]interface{}) {
+}
+
+func (notify *ovnNotifier) Disconnected(client *libovsdb.OvsdbClient) {
 	if notify.odbi.reconn {
 		notify.odbi.reconnect()
 	} else if notify.odbi.disconnectCB != nil {

--- a/go-controller/vendor/github.com/ebay/go-ovn/ovnnotify.go
+++ b/go-controller/vendor/github.com/ebay/go-ovn/ovnnotify.go
@@ -17,6 +17,10 @@
 package goovn
 
 import (
+	"sync"
+
+	"k8s.io/klog/v2"
+
 	"github.com/ebay/libovsdb"
 )
 
@@ -24,11 +28,47 @@ type ovnNotifier struct {
 	odbi *ovndb
 }
 
-func (notify ovnNotifier) Update(context interface{}, tableUpdates libovsdb.TableUpdates) {
-	notify.odbi.cachemutex.Lock()
-	defer notify.odbi.cachemutex.Unlock()
-	notify.odbi.populateCache(tableUpdates)
+func (notify ovnNotifier) getDBNameAndLock(context interface{}) (string, *sync.RWMutex) {
+	dbName, ok := context.(string)
+	if !ok {
+		klog.Warningf("Expected string-type context but got %v", context)
+		return "", nil
+	}
+
+	if dbName == DBServer {
+		return dbName, &notify.odbi.serverCacheMutex
+	}
+
+	return dbName, &notify.odbi.cachemutex
 }
+
+func (notify ovnNotifier) Update(context interface{}, tableUpdates libovsdb.TableUpdates) {
+	db, lock := notify.getDBNameAndLock(context)
+	if lock != nil {
+		lock.Lock()
+		defer lock.Unlock()
+		notify.odbi.populateCache(db, tableUpdates, true)
+	}
+}
+func (notify ovnNotifier) Update2(context interface{}, tableUpdates libovsdb.TableUpdates2) {
+	db, lock := notify.getDBNameAndLock(context)
+	if lock != nil {
+		lock.Lock()
+		defer lock.Unlock()
+		notify.odbi.populateCache2(db, tableUpdates, true)
+	}
+}
+
+func (notify ovnNotifier) Update3(context interface{}, tableUpdates libovsdb.TableUpdates2, lastTxnId string) {
+	db, lock := notify.getDBNameAndLock(context)
+	if lock != nil {
+		lock.Lock()
+		defer lock.Unlock()
+		notify.odbi.populateCache2(db, tableUpdates, true)
+		notify.odbi.currentTxn = lastTxnId
+	}
+}
+
 func (notify ovnNotifier) Locked([]interface{}) {
 }
 func (notify ovnNotifier) Stolen([]interface{}) {

--- a/go-controller/vendor/github.com/ebay/go-ovn/port_group.go
+++ b/go-controller/vendor/github.com/ebay/go-ovn/port_group.go
@@ -252,7 +252,7 @@ func (odbi *ovndb) GetLogicalPortsByPortGroup(group string) ([]*LogicalSwitchPor
 					if ps, ok := ports.(libovsdb.OvsSet); ok {
 						for _, p := range ps.GoSet {
 							if vp, ok := p.(libovsdb.UUID); ok {
-								tp, err := odbi.rowToLogicalPort(vp.GoUUID)
+								tp, err := odbi.uuidToLogicalPort(vp.GoUUID)
 								if err != nil {
 									return nil, fmt.Errorf("Couldn't get logical port: %s", err)
 								}
@@ -264,7 +264,7 @@ func (odbi *ovndb) GetLogicalPortsByPortGroup(group string) ([]*LogicalSwitchPor
 					}
 				case libovsdb.UUID:
 					if vp, ok := ports.(libovsdb.UUID); ok {
-						tp, err := odbi.rowToLogicalPort(vp.GoUUID)
+						tp, err := odbi.uuidToLogicalPort(vp.GoUUID)
 						if err != nil {
 							return nil, fmt.Errorf("Couldn't get logical port: %s", err)
 						}

--- a/go-controller/vendor/github.com/ebay/libovsdb/notation.go
+++ b/go-controller/vendor/github.com/ebay/libovsdb/notation.go
@@ -86,6 +86,29 @@ type RowUpdate struct {
 	Old  Row  `json:"old,omitempty"`
 }
 
+// TableUpdates is a collection of TableUpdate entries
+// We cannot use TableUpdates directly by json encoding by inlining the TableUpdate Map
+// structure till GoLang issue #6213 makes it.
+// The only option is to go with raw map[string]map[string]interface{} option :-( that sucks !
+// Refer to client.go : MonitorAll() function for more details
+type TableUpdates2 struct {
+	Updates map[string]TableUpdate2 `json:"updates,overflow"`
+}
+
+// TableUpdate represents a table update according to RFC7047
+type TableUpdate2 struct {
+	Rows map[string]RowUpdate2 `json:"rows,overflow"`
+}
+
+// RowUpdate represents a row update according to RFC7047
+type RowUpdate2 struct {
+	UUID    UUID `json:"-,omitempty"`
+	Initial Row  `json:"initial,omitempty"`
+	Insert  Row  `json:"insert,omitempty"`
+	Modify  Row  `json:"modify,omitempty"`
+	Delete  Row  `json:"delete,omitempty"`
+}
+
 // OvsdbError is an OVS Error Condition
 type OvsdbError struct {
 	Error   string `json:"error"`
@@ -146,3 +169,26 @@ func ovsSliceToGoNotation(val interface{}) (interface{}, error) {
 }
 
 // TODO : add Condition, Function, Mutation and Mutator notations
+
+const (
+	// OperationInsert is an insert operation
+	OperationInsert = "insert"
+	// OperationSelect is a select operation
+	OperationSelect = "select"
+	// OperationUpdate is an update operation
+	OperationUpdate = "update"
+	// OperationMutate is a mutate operation
+	OperationMutate = "mutate"
+	// OperationDelete is a delete operation
+	OperationDelete = "delete"
+	// OperationWait is a wait operation
+	OperationWait = "wait"
+	// OperationCommit is a commit operation
+	OperationCommit = "commit"
+	// OperationAbort is an abort operation
+	OperationAbort = "abort"
+	// OperationComment is a comment operation
+	OperationComment = "comment"
+	// OperationAssert is an assert operation
+	OperationAssert = "assert"
+)

--- a/go-controller/vendor/github.com/ebay/libovsdb/rpc.go
+++ b/go-controller/vendor/github.com/ebay/libovsdb/rpc.go
@@ -29,6 +29,11 @@ func NewMonitorArgs(database string, value interface{}, requests map[string]Moni
 	return []interface{}{database, value, requests}
 }
 
+// NewMonitorArgs3 creates a new set of arguments for a monitor RPC
+func NewMonitorArgs3(database string, value interface{}, requests map[string]MonitorRequest, currentTxn string) []interface{} {
+	return []interface{}{database, value, requests, currentTxn}
+}
+
 // NewMonitorCancelArgs creates a new set of arguments for a monitor_cancel RPC
 func NewMonitorCancelArgs(value interface{}) []interface{} {
 	return []interface{}{value}

--- a/go-controller/vendor/github.com/ebay/libovsdb/schema.go
+++ b/go-controller/vendor/github.com/ebay/libovsdb/schema.go
@@ -1,8 +1,13 @@
 package libovsdb
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
+	"io/ioutil"
+	"math"
+	"os"
+	"strings"
 )
 
 // DatabaseSchema is a database schema according to RFC7047
@@ -12,62 +17,600 @@ type DatabaseSchema struct {
 	Tables  map[string]TableSchema `json:"tables"`
 }
 
-// TableSchema is a table schema according to RFC7047
-type TableSchema struct {
-	Columns map[string]ColumnSchema `json:"columns"`
-	Indexes [][]string              `json:"indexes,omitempty"`
+// UUIDColumn is a static column that represents the _uuid column, common to all tables
+var UUIDColumn = ColumnSchema{
+	Type: TypeUUID,
 }
 
-// ColumnSchema is a column schema according to RFC7047
-type ColumnSchema struct {
-	Name      string      `json:"name"`
-	Type      interface{} `json:"type"`
-	Ephemeral bool        `json:"ephemeral,omitempty"`
-	Mutable   bool        `json:"mutable,omitempty"`
+// Table returns a TableSchema Schema for a given table and column name
+func (schema DatabaseSchema) Table(tableName string) *TableSchema {
+	if table, ok := schema.Tables[tableName]; ok {
+		return &table
+	}
+	return nil
 }
 
 // Print will print the contents of the DatabaseSchema
 func (schema DatabaseSchema) Print(w io.Writer) {
 	fmt.Fprintf(w, "%s, (%s)\n", schema.Name, schema.Version)
 	for table, tableSchema := range schema.Tables {
-		fmt.Fprintf(w, "\t %s\n", table)
+		fmt.Fprintf(w, "\t %s", table)
+		if len(tableSchema.Indexes) > 0 {
+			fmt.Fprintf(w, "(%v)\n", tableSchema.Indexes)
+		} else {
+			fmt.Fprintf(w, "\n")
+		}
 		for column, columnSchema := range tableSchema.Columns {
-			fmt.Fprintf(w, "\t\t %s => %v\n", column, columnSchema)
+			fmt.Fprintf(w, "\t\t %s => %s\n", column, columnSchema)
 		}
 	}
 }
 
-// Basic validation for operations against Database Schema
-func (schema DatabaseSchema) validateOperations(operations ...Operation) bool {
+// SchemaFromFile returns a DatabaseSchema from a file
+func SchemaFromFile(f *os.File) (*DatabaseSchema, error) {
+	data, err := ioutil.ReadAll(f)
+	if err != nil {
+		return nil, err
+	}
+	var schema DatabaseSchema
+	err = json.Unmarshal(data, &schema)
+	if err != nil {
+		return nil, err
+	}
+
+	return &schema, nil
+}
+
+// ValidateOperations performs basic validation for operations against a DatabaseSchema
+func (schema DatabaseSchema) ValidateOperations(operations ...Operation) bool {
 	for _, op := range operations {
-		table, ok := schema.Tables[op.Table]
-		if ok {
-			for column := range op.Row {
-				if _, ok := table.Columns[column]; !ok {
-					if column != "_uuid" && column != "_version" {
-						return false
-					}
-				}
-			}
-			for _, row := range op.Rows {
-				for column := range row {
+		switch op.Op {
+		case OperationAbort, OperationAssert, OperationComment, OperationCommit, OperationWait:
+			continue
+		case OperationInsert, OperationSelect, OperationUpdate, OperationMutate, OperationDelete:
+			table, ok := schema.Tables[op.Table]
+			if ok {
+				for column := range op.Row {
 					if _, ok := table.Columns[column]; !ok {
 						if column != "_uuid" && column != "_version" {
 							return false
 						}
 					}
 				}
-			}
-			for _, column := range op.Columns {
-				if _, ok := table.Columns[column]; !ok {
-					if column != "_uuid" && column != "_version" {
-						return false
+				for _, row := range op.Rows {
+					for column := range row {
+						if _, ok := table.Columns[column]; !ok {
+							if column != "_uuid" && column != "_version" {
+								return false
+							}
+						}
 					}
 				}
+				for _, column := range op.Columns {
+					if _, ok := table.Columns[column]; !ok {
+						if column != "_uuid" && column != "_version" {
+							return false
+						}
+					}
+				}
+			} else {
+				return false
 			}
-		} else {
-			return false
 		}
 	}
 	return true
+}
+
+// TableSchema is a table schema according to RFC7047
+type TableSchema struct {
+	Columns map[string]*ColumnSchema `json:"columns"`
+	Indexes [][]string               `json:"indexes,omitempty"`
+}
+
+// Column returns the Column object for a specific column name
+func (t TableSchema) Column(columnName string) *ColumnSchema {
+	if columnName == "_uuid" {
+		return &UUIDColumn
+	}
+	if column, ok := t.Columns[columnName]; ok {
+		return column
+	}
+	return nil
+}
+
+/*RFC7047 defines some atomic-types (e.g: integer, string, etc). However, the Column's type
+can also hold other more complex types such as set, enum and map. The way to determine the type
+depends on internal, not directly marshallable fields. Therefore, in order to simplify the usage
+of this library, we define an ExtendedType that includes all possible column types (including
+atomic fields).
+*/
+
+//ExtendedType includes atomic types as defined in the RFC plus Enum, Map and Set
+type ExtendedType = string
+
+// RefType is used to define the possible RefTypes
+type RefType = string
+
+// unlimited is not constant as we can't take the address of int constants
+var (
+	// Unlimited is used to express unlimited "Max"
+	Unlimited = -1
+)
+
+const (
+	unlimitedString = "unlimited"
+	//Strong RefType
+	Strong RefType = "strong"
+	//Weak RefType
+	Weak RefType = "weak"
+
+	//ExtendedType associated with Atomic Types
+
+	//TypeInteger is equivalent to 'int'
+	TypeInteger ExtendedType = "integer"
+	//TypeReal is equivalent to 'float64'
+	TypeReal ExtendedType = "real"
+	//TypeBoolean is equivalent to 'bool'
+	TypeBoolean ExtendedType = "boolean"
+	//TypeString is equivalent to 'string'
+	TypeString ExtendedType = "string"
+	//TypeUUID is equivalent to 'libovsdb.UUID'
+	TypeUUID ExtendedType = "uuid"
+
+	//Extended Types used to summarize the internal type of the field.
+
+	//TypeEnum is an enumerator of type defined by Key.Type
+	TypeEnum ExtendedType = "enum"
+	//TypeMap is a map whose type depend on Key.Type and Value.Type
+	TypeMap ExtendedType = "map"
+	//TypeSet is a set whose type depend on Key.Type
+	TypeSet ExtendedType = "set"
+)
+
+// BaseType is a base-type structure as per RFC7047
+type BaseType struct {
+	Type       string
+	Enum       []interface{}
+	minReal    *float64
+	maxReal    *float64
+	minInteger *int
+	maxInteger *int
+	minLength  *int
+	maxLength  *int
+	refTable   *string
+	refType    *RefType
+}
+
+func (b *BaseType) simpleAtomic() bool {
+	return isAtomicType(b.Type) && b.Enum == nil && b.minReal == nil && b.maxReal == nil && b.minInteger == nil && b.maxInteger == nil && b.minLength == nil && b.maxLength == nil && b.refTable == nil && b.refType == nil
+}
+
+// MinReal returns the minimum real value
+// RFC7047 does not define a default, but we assume this to be
+// the smallest non zero value a float64 could hold
+func (b *BaseType) MinReal() (float64, error) {
+	if b.Type != TypeReal {
+		return 0, fmt.Errorf("%s is not a real", b.Type)
+	}
+	if b.minReal != nil {
+		return *b.minReal, nil
+	}
+	return math.SmallestNonzeroFloat64, nil
+}
+
+// MaxReal returns the maximum real value
+// RFC7047 does not define a default, but this would be the maximum
+// value held by a float64
+func (b *BaseType) MaxReal() (float64, error) {
+	if b.Type != TypeReal {
+		return 0, fmt.Errorf("%s is not a real", b.Type)
+	}
+	if b.maxReal != nil {
+		return *b.maxReal, nil
+	}
+	return math.MaxFloat64, nil
+}
+
+// MinInteger returns the minimum integer value
+// RFC7047 specifies the minimum to be -2^63
+func (b *BaseType) MinInteger() (int, error) {
+	if b.Type != TypeInteger {
+		return 0, fmt.Errorf("%s is not an integer", b.Type)
+	}
+	if b.minInteger != nil {
+		return *b.minInteger, nil
+	}
+	return int(math.Pow(-2, 63)), nil
+}
+
+// MaxInteger returns the minimum integer value
+// RFC7047 specifies the minimum to be 2^63-1
+func (b *BaseType) MaxInteger() (int, error) {
+	if b.Type != TypeInteger {
+		return 0, fmt.Errorf("%s is not an integer", b.Type)
+	}
+	if b.maxInteger != nil {
+		return *b.maxInteger, nil
+	}
+	return int(math.Pow(2, 63)) - 1, nil
+}
+
+// MinLength returns the minimum string length
+// RFC7047 doesn't specify a default, but we assume
+// that it must be >= 0
+func (b *BaseType) MinLength() (int, error) {
+	if b.Type != TypeString {
+		return 0, fmt.Errorf("%s is not an string", b.Type)
+	}
+	if b.minLength != nil {
+		return *b.minLength, nil
+	}
+	return 0, nil
+}
+
+// MaxLength returns the maximum string length
+// RFC7047 doesn't specify a default, but we assume
+// that it must 2^63-1
+func (b *BaseType) MaxLength() (int, error) {
+	if b.Type != TypeString {
+		return 0, fmt.Errorf("%s is not an string", b.Type)
+	}
+	if b.maxLength != nil {
+		return *b.maxLength, nil
+	}
+	return int(math.Pow(2, 63)) - 1, nil
+}
+
+// RefTable returns the table to which a UUID type refers
+// It will return an empty string if not set
+func (b *BaseType) RefTable() (string, error) {
+	if b.Type != TypeUUID {
+		return "", fmt.Errorf("%s is not a uuid", b.Type)
+	}
+	if b.refTable != nil {
+		return *b.refTable, nil
+	}
+	return "", nil
+}
+
+// RefType returns the reference type for a UUID field
+// RFC7047 infers the RefType is strong if omitted
+func (b *BaseType) RefType() (RefType, error) {
+	if b.Type != TypeUUID {
+		return "", fmt.Errorf("%s is not a uuid", b.Type)
+	}
+	if b.refType != nil {
+		return *b.refType, nil
+	}
+	return Strong, nil
+}
+
+// UnmarshalJSON unmarshals a json-formatted base type
+func (b *BaseType) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err == nil {
+		if isAtomicType(s) {
+			b.Type = s
+		} else {
+			return fmt.Errorf("non atomic type %s in <base-type>", s)
+		}
+		return nil
+	}
+	// temporary type to avoid recursive call to unmarshal
+	var bt struct {
+		Type       string      `json:"type"`
+		Enum       interface{} `json:"enum,omitempty"`
+		MinReal    *float64    `json:"minReal,omitempty"`
+		MaxReal    *float64    `json:"maxReal,omitempty"`
+		MinInteger *int        `json:"minInteger,omitempty"`
+		MaxInteger *int        `json:"maxInteger,omitempty"`
+		MinLength  *int        `json:"minLength,omitempty"`
+		MaxLength  *int        `json:"maxLength,omitempty"`
+		RefTable   *string     `json:"refTable,omitempty"`
+		RefType    *RefType    `json:"refType,omitempty"`
+	}
+	err := json.Unmarshal(data, &bt)
+	if err != nil {
+		return err
+	}
+
+	if bt.Enum != nil {
+		// 'enum' is a list or a single element representing a list of exactly one element
+		switch bt.Enum.(type) {
+		case []interface{}:
+			// it's an OvsSet
+			oSet := bt.Enum.([]interface{})
+			innerSet := oSet[1].([]interface{})
+			b.Enum = make([]interface{}, len(innerSet))
+			for k, val := range innerSet {
+				b.Enum[k] = val
+			}
+		default:
+			b.Enum = []interface{}{bt.Enum}
+		}
+	}
+	b.Type = bt.Type
+	b.minReal = bt.MinReal
+	b.maxReal = bt.MaxReal
+	b.minInteger = bt.MinInteger
+	b.maxInteger = bt.MaxInteger
+	b.minLength = bt.MaxLength
+	b.maxLength = bt.MaxLength
+	b.refTable = bt.RefTable
+	b.refType = bt.RefType
+	return nil
+}
+
+// MarshalJSON marshals a base type to JSON
+func (b BaseType) MarshalJSON() ([]byte, error) {
+	j := struct {
+		Type       string   `json:"type,omitempty"`
+		Enum       *OvsSet  `json:"enum,omitempty"`
+		MinReal    *float64 `json:"minReal,omitempty"`
+		MaxReal    *float64 `json:"maxReal,omitempty"`
+		MinInteger *int     `json:"minInteger,omitempty"`
+		MaxInteger *int     `json:"maxInteger,omitempty"`
+		MinLength  *int     `json:"minLength,omitempty"`
+		MaxLength  *int     `json:"maxLength,omitempty"`
+		RefTable   *string  `json:"refTable,omitempty"`
+		RefType    *RefType `json:"refType,omitempty"`
+	}{
+		Type:       b.Type,
+		MinReal:    b.minReal,
+		MaxReal:    b.maxReal,
+		MinInteger: b.minInteger,
+		MaxInteger: b.maxInteger,
+		MinLength:  b.maxLength,
+		MaxLength:  b.maxLength,
+		RefTable:   b.refTable,
+		RefType:    b.refType,
+	}
+	if len(b.Enum) > 0 {
+		set, err := NewOvsSet(b.Enum)
+		if err != nil {
+			return nil, err
+		}
+		j.Enum = set
+	}
+	return json.Marshal(j)
+}
+
+// ColumnType is a type object as per RFC7047
+// "key": <base-type>                 required
+// "value": <base-type>               optional
+// "min": <integer>                   optional (default: 1)
+// "max": <integer> or "unlimited"    optional (default: 1)
+type ColumnType struct {
+	Key   *BaseType
+	Value *BaseType
+	min   *int
+	max   *int
+}
+
+// Max returns the maximum value of a ColumnType. -1 is Unlimited
+func (c *ColumnType) Max() int {
+	if c.max == nil {
+		return 1
+	}
+	return *c.max
+}
+
+// Min returns the minimum value of a ColumnType
+func (c *ColumnType) Min() int {
+	if c.min == nil {
+		return 1
+	}
+	return *c.min
+}
+
+// UnmarshalJSON unmarshals a json-formatted column type
+func (c *ColumnType) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err == nil {
+		if isAtomicType(s) {
+			c.Key = &BaseType{Type: s}
+		} else {
+			return fmt.Errorf("non atomic type %s in <type>", s)
+		}
+		return nil
+	}
+	var colType struct {
+		Key   *BaseType   `json:"key"`
+		Value *BaseType   `json:"value"`
+		Min   *int        `json:"min"`
+		Max   interface{} `json:"max"`
+	}
+	err := json.Unmarshal(data, &colType)
+	if err != nil {
+		return err
+	}
+	c.Key = colType.Key
+	c.Value = colType.Value
+	c.min = colType.Min
+	switch v := colType.Max.(type) {
+	case string:
+		if v == unlimitedString {
+			c.max = &Unlimited
+		} else {
+			return fmt.Errorf("unexpected string value in max field")
+		}
+	case float64:
+		i := int(v)
+		c.max = &i
+	default:
+		c.max = nil
+	}
+	return nil
+}
+
+// MarshalJSON marshalls a column type to JSON
+func (c ColumnType) MarshalJSON() ([]byte, error) {
+	if c.Value == nil && c.max == nil && c.min == nil && c.Key.simpleAtomic() {
+		return json.Marshal(c.Key.Type)
+	}
+	if c.Max() == Unlimited {
+		colType := struct {
+			Key   *BaseType `json:"key"`
+			Value *BaseType `json:"value,omitempty"`
+			Min   *int      `json:"min,omitempty"`
+			Max   string    `json:"max,omitempty"`
+		}{
+			Key:   c.Key,
+			Value: c.Value,
+			Min:   c.min,
+			Max:   unlimitedString,
+		}
+		return json.Marshal(&colType)
+	}
+	colType := struct {
+		Key   *BaseType `json:"key"`
+		Value *BaseType `json:"value,omitempty"`
+		Min   *int      `json:"min,omitempty"`
+		Max   *int      `json:"max,omitempty"`
+	}{
+		Key:   c.Key,
+		Value: c.Value,
+		Min:   c.min,
+		Max:   c.max,
+	}
+	return json.Marshal(&colType)
+}
+
+// ColumnSchema is a column schema according to RFC7047
+type ColumnSchema struct {
+	// According to RFC7047, "type" field can be, either an <atomic-type>
+	// Or a ColumnType defined below. To try to simplify the usage, the
+	// json message will be parsed manually and Type will indicate the "extended"
+	// type. Depending on its value, more information may be available in TypeObj.
+	// E.g: If Type == TypeEnum, TypeObj.Key.Enum contains the possible values
+	Type      ExtendedType
+	TypeObj   *ColumnType
+	ephemeral *bool
+	mutable   *bool
+}
+
+// Mutable returns whether a column is mutable
+func (c *ColumnSchema) Mutable() bool {
+	if c.mutable != nil {
+		return *c.mutable
+	}
+	// default true
+	return true
+}
+
+// Ephemeral returns whether a column is ephemeral
+func (c *ColumnSchema) Ephemeral() bool {
+	if c.ephemeral != nil {
+		return *c.ephemeral
+	}
+	// default false
+	return false
+}
+
+// UnmarshalJSON unmarshalls a json-formatted column
+func (c *ColumnSchema) UnmarshalJSON(data []byte) error {
+	// ColumnJSON represents the known json values for a Column
+	var colJSON struct {
+		Type      *ColumnType `json:"type"`
+		Ephemeral *bool       `json:"ephemeral,omitempty"`
+		Mutable   *bool       `json:"mutable,omitempty"`
+	}
+
+	// Unmarshal known keys
+	if err := json.Unmarshal(data, &colJSON); err != nil {
+		return fmt.Errorf("cannot parse column object %s", err)
+	}
+
+	c.ephemeral = colJSON.Ephemeral
+	c.mutable = colJSON.Mutable
+	c.TypeObj = colJSON.Type
+
+	// Infer the ExtendedType from the TypeObj
+	if c.TypeObj.Value != nil {
+		c.Type = TypeMap
+	} else if c.TypeObj.Min() != 1 || c.TypeObj.Max() != 1 {
+		c.Type = TypeSet
+	} else if len(c.TypeObj.Key.Enum) > 0 {
+		c.Type = TypeEnum
+	} else {
+		c.Type = c.TypeObj.Key.Type
+	}
+	return nil
+}
+
+// MarshalJSON marshalls a column schema to JSON
+func (c ColumnSchema) MarshalJSON() ([]byte, error) {
+	type colJSON struct {
+		Type      *ColumnType `json:"type"`
+		Ephemeral *bool       `json:"ephemeral,omitempty"`
+		Mutable   *bool       `json:"mutable,omitempty"`
+	}
+	column := colJSON{
+		Type:      c.TypeObj,
+		Ephemeral: c.ephemeral,
+		Mutable:   c.mutable,
+	}
+	return json.Marshal(column)
+}
+
+// String returns a string representation of the (native) column type
+func (c *ColumnSchema) String() string {
+	var flags []string
+	var flagStr string
+	var typeStr string
+	if c.Ephemeral() {
+		flags = append(flags, "E")
+	}
+	if c.Mutable() {
+		flags = append(flags, "M")
+	}
+	if len(flags) > 0 {
+		flagStr = fmt.Sprintf("[%s]", strings.Join(flags, ","))
+	}
+
+	switch c.Type {
+	case TypeInteger, TypeReal, TypeBoolean, TypeString:
+		typeStr = string(c.Type)
+	case TypeUUID:
+		if c.TypeObj != nil && c.TypeObj.Key != nil {
+			// ignore err as we've already asserted this is a uuid
+			reftable, _ := c.TypeObj.Key.RefTable()
+			reftype := ""
+			if s, err := c.TypeObj.Key.RefType(); err != nil {
+				reftype = s
+			}
+			typeStr = fmt.Sprintf("uuid [%s (%s)]", reftable, reftype)
+		} else {
+			typeStr = "uuid"
+		}
+
+	case TypeEnum:
+		typeStr = fmt.Sprintf("enum (type: %s): %v", c.TypeObj.Key.Type, c.TypeObj.Key.Enum)
+	case TypeMap:
+		typeStr = fmt.Sprintf("[%s]%s", c.TypeObj.Key.Type, c.TypeObj.Value.Type)
+	case TypeSet:
+		var keyStr string
+		if c.TypeObj.Key.Type == TypeUUID {
+			// ignore err as we've already asserted this is a uuid
+			reftable, _ := c.TypeObj.Key.RefTable()
+			reftype, _ := c.TypeObj.Key.RefType()
+			keyStr = fmt.Sprintf(" [%s (%s)]", reftable, reftype)
+		} else {
+			keyStr = string(c.TypeObj.Key.Type)
+		}
+		typeStr = fmt.Sprintf("[]%s (min: %d, max: %d)", keyStr, c.TypeObj.Min(), c.TypeObj.Max())
+	default:
+		panic(fmt.Sprintf("Unsupported type %s", c.Type))
+	}
+
+	return strings.Join([]string{typeStr, flagStr}, " ")
+}
+
+func isAtomicType(atype string) bool {
+	switch atype {
+	case TypeInteger, TypeReal, TypeBoolean, TypeString, TypeUUID:
+		return true
+	default:
+		return false
+	}
 }

--- a/go-controller/vendor/github.com/ebay/libovsdb/set.go
+++ b/go-controller/vendor/github.com/ebay/libovsdb/set.go
@@ -24,7 +24,7 @@ func NewOvsSet(goSlice interface{}) (*OvsSet, error) {
 		return nil, errors.New("OvsSet supports only Go Slice types")
 	}
 
-	var ovsSet []interface{}
+	ovsSet := make([]interface{}, 0, v.Len())
 	for i := 0; i < v.Len(); i++ {
 		ovsSet = append(ovsSet, v.Index(i).Interface())
 	}

--- a/go-controller/vendor/modules.txt
+++ b/go-controller/vendor/modules.txt
@@ -29,7 +29,7 @@ github.com/bhendo/go-powershell/backend
 github.com/bhendo/go-powershell/utils
 # github.com/cenkalti/hub v1.0.1
 github.com/cenkalti/hub
-# github.com/cenkalti/rpc2 v0.0.0-20210220005819-4a29bc83afe1
+# github.com/cenkalti/rpc2 v0.0.0-20210604223624-c1acbc6ec984
 github.com/cenkalti/rpc2
 github.com/cenkalti/rpc2/jsonrpc
 # github.com/cespare/xxhash/v2 v2.1.1


### PR DESCRIPTION
Cherry-pick of https://github.com/openshift/ovn-kubernetes/pull/750

Changes Include:

1. batch pod operations into a single operation
2. remove unnecessary locking around address sets to avoid lock contention during pod operations
3. combine address set operations for add/remove IP into logical port OVN transactions
4. use uuids for OVSDB operations involving conditions like "where x == y"
5. update 2/3 json rpc methods for ovsdb
6. leader only connections for go-ovn
7. temporarily revert libovsdb clients until they have support for 5 and 6
8. fix an issue where reconnect in go-ovn client can hang forever if ovsdb server does not respond with a reply

Also pulls in https://github.com/openshift/ovn-kubernetes/pull/781 and https://github.com/openshift/ovn-kubernetes/pull/787

Note that we might want https://github.com/openshift/ovn-kubernetes/pull/777 to land first, or we suck that into this PR; it makes the rebase/cherry-pick easier but isn't necessary. It should certainly be fixed in 4.9 regardless.