### PR TITLE
pods: remove unnecessary LSPGet() calls

### DIFF
--- a/go-controller/vendor/github.com/ebay/go-ovn/client.go
+++ b/go-controller/vendor/github.com/ebay/go-ovn/client.go
@@ -57,6 +57,8 @@ type Client interface {
 
 	// Get logical switch port by name
 	LSPGet(lsp string) (*LogicalSwitchPort, error)
+	// Get logical switch port by name
+	LSPGetUUID(uuid string) (*LogicalSwitchPort, error)
 	// Add logical port PORT on SWITCH
 	LSPAdd(ls string, lsUUID string, lsp string) (*OvnCommand, error)
 	// Delete PORT from its attached switch
@@ -684,6 +686,10 @@ func (c *ovndb) LSExtIdsDel(ls string, external_ids map[string]string) (*OvnComm
 
 func (c *ovndb) LSPGet(lsp string) (*LogicalSwitchPort, error) {
 	return c.lspGetImp(lsp)
+}
+
+func (c *ovndb) LSPGetUUID(uuid string) (*LogicalSwitchPort, error) {
+	return c.lspGetByUUIDImp(uuid)
 }
 
 func (c *ovndb) LSPAdd(ls string, lsUUID string, lsp string) (*OvnCommand, error) {

--- a/go-controller/vendor/github.com/ebay/go-ovn/logical_switch_port.go
+++ b/go-controller/vendor/github.com/ebay/go-ovn/logical_switch_port.go
@@ -406,6 +406,20 @@ func (odbi *ovndb) lspGetImp(lsp string) (*LogicalSwitchPort, error) {
 	return nil, ErrorNotFound
 }
 
+func (odbi *ovndb) lspGetByUUIDImp(uuid string) (*LogicalSwitchPort, error) {
+	odbi.cachemutex.RLock()
+	defer odbi.cachemutex.RUnlock()
+
+	cacheLogicalSwitchPort, ok := odbi.cache[TableLogicalSwitchPort]
+	if !ok {
+		return nil, ErrorSchema
+	}
+	if _, ok := cacheLogicalSwitchPort[uuid]; ok {
+		return odbi.rowToLogicalPort(uuid)
+	}
+	return nil, ErrorNotFound
+}
+
 // Get all lport by lswitch
 func (odbi *ovndb) lspListImp(lsw string) ([]*LogicalSwitchPort, error) {
 	odbi.cachemutex.RLock()

--- a/go-controller/vendor/github.com/ebay/go-ovn/logical_switch_port.go
+++ b/go-controller/vendor/github.com/ebay/go-ovn/logical_switch_port.go
@@ -323,15 +323,20 @@ func (odbi *ovndb) lspGetExternalIdsImp(lsp string) (map[string]string, error) {
 	return extIds, nil
 }
 
-func (odbi *ovndb) rowToLogicalPort(uuid string) (*LogicalSwitchPort, error) {
+func (odbi *ovndb) uuidToLogicalPort(uuid string) (*LogicalSwitchPort, error) {
+	row := odbi.cache[TableLogicalSwitchPort][uuid]
+	return odbi.rowToLogicalPort(uuid, &row)
+}
+
+func (odbi *ovndb) rowToLogicalPort(uuid string, row *libovsdb.Row) (*LogicalSwitchPort, error) {
 	lp := &LogicalSwitchPort{
 		UUID:       uuid,
-		Name:       odbi.cache[TableLogicalSwitchPort][uuid].Fields["name"].(string),
-		Type:       odbi.cache[TableLogicalSwitchPort][uuid].Fields["type"].(string),
-		ExternalID: odbi.cache[TableLogicalSwitchPort][uuid].Fields["external_ids"].(libovsdb.OvsMap).GoMap,
+		Name:       row.Fields["name"].(string),
+		Type:       row.Fields["type"].(string),
+		ExternalID: row.Fields["external_ids"].(libovsdb.OvsMap).GoMap,
 	}
 
-	if dhcpv4, ok := odbi.cache[TableLogicalSwitchPort][uuid].Fields["dhcpv4_options"]; ok {
+	if dhcpv4, ok := row.Fields["dhcpv4_options"]; ok {
 		switch dhcpv4.(type) {
 		case libovsdb.UUID:
 			lp.DHCPv4Options = dhcpv4.(libovsdb.UUID).GoUUID
@@ -339,7 +344,7 @@ func (odbi *ovndb) rowToLogicalPort(uuid string) (*LogicalSwitchPort, error) {
 		default:
 		}
 	}
-	if dhcpv6, ok := odbi.cache[TableLogicalSwitchPort][uuid].Fields["dhcpv6_options"]; ok {
+	if dhcpv6, ok := row.Fields["dhcpv6_options"]; ok {
 		switch dhcpv6.(type) {
 		case libovsdb.UUID:
 			lp.DHCPv6Options = dhcpv6.(libovsdb.UUID).GoUUID
@@ -348,7 +353,7 @@ func (odbi *ovndb) rowToLogicalPort(uuid string) (*LogicalSwitchPort, error) {
 		}
 	}
 
-	if addr, ok := odbi.cache[TableLogicalSwitchPort][uuid].Fields["addresses"]; ok {
+	if addr, ok := row.Fields["addresses"]; ok {
 		switch addr.(type) {
 		case string:
 			lp.Addresses = []string{addr.(string)}
@@ -359,7 +364,7 @@ func (odbi *ovndb) rowToLogicalPort(uuid string) (*LogicalSwitchPort, error) {
 		}
 	}
 
-	if portsecurity, ok := odbi.cache[TableLogicalSwitchPort][uuid].Fields["port_security"]; ok {
+	if portsecurity, ok := row.Fields["port_security"]; ok {
 		switch portsecurity.(type) {
 		case string:
 			lp.PortSecurity = []string{portsecurity.(string)}
@@ -370,11 +375,11 @@ func (odbi *ovndb) rowToLogicalPort(uuid string) (*LogicalSwitchPort, error) {
 		}
 	}
 
-	if options, ok := odbi.cache[TableLogicalSwitchPort][uuid].Fields["options"]; ok {
+	if options, ok := row.Fields["options"]; ok {
 		lp.Options = options.(libovsdb.OvsMap).GoMap
 	}
 
-	if dynamicAddresses, ok := odbi.cache[TableLogicalSwitchPort][uuid].Fields["dynamic_addresses"]; ok {
+	if dynamicAddresses, ok := row.Fields["dynamic_addresses"]; ok {
 		switch dynamicAddresses.(type) {
 		case string:
 			lp.DynamicAddresses = dynamicAddresses.(string)
@@ -400,7 +405,7 @@ func (odbi *ovndb) lspGetImp(lsp string) (*LogicalSwitchPort, error) {
 
 	for uuid, drows := range cacheLogicalSwitchPort {
 		if rlsp, ok := drows.Fields["name"].(string); ok && rlsp == lsp {
-			return odbi.rowToLogicalPort(uuid)
+			return odbi.rowToLogicalPort(uuid, &drows)
 		}
 	}
 	return nil, ErrorNotFound
@@ -414,8 +419,8 @@ func (odbi *ovndb) lspGetByUUIDImp(uuid string) (*LogicalSwitchPort, error) {
 	if !ok {
 		return nil, ErrorSchema
 	}
-	if _, ok := cacheLogicalSwitchPort[uuid]; ok {
-		return odbi.rowToLogicalPort(uuid)
+	if row, ok := cacheLogicalSwitchPort[uuid]; ok {
+		return odbi.rowToLogicalPort(uuid, &row)
 	}
 	return nil, ErrorNotFound
 }
@@ -439,7 +444,7 @@ func (odbi *ovndb) lspListImp(lsw string) ([]*LogicalSwitchPort, error) {
 						listLSP := make([]*LogicalSwitchPort, 0, len(ps.GoSet))
 						for _, p := range ps.GoSet {
 							if vp, ok := p.(libovsdb.UUID); ok {
-								tp, err := odbi.rowToLogicalPort(vp.GoUUID)
+								tp, err := odbi.uuidToLogicalPort(vp.GoUUID)
 								if err != nil {
 									return nil, fmt.Errorf("Failed to get logical port: %s", err)
 								}
@@ -452,7 +457,7 @@ func (odbi *ovndb) lspListImp(lsw string) ([]*LogicalSwitchPort, error) {
 					}
 				case libovsdb.UUID:
 					if vp, ok := ports.(libovsdb.UUID); ok {
-						tp, err := odbi.rowToLogicalPort(vp.GoUUID)
+						tp, err := odbi.uuidToLogicalPort(vp.GoUUID)
 						if err != nil {
 							return nil, fmt.Errorf("Failed to get logical port: %s", err)
 						}

--- a/go-controller/vendor/github.com/ebay/go-ovn/ovnimp.go
+++ b/go-controller/vendor/github.com/ebay/go-ovn/ovnimp.go
@@ -245,7 +245,7 @@ func (odbi *ovndb) signalCreate(table, uuid string) {
 		ls := odbi.rowToLogicalSwitch(uuid)
 		odbi.signalCB.OnLogicalSwitchCreate(ls)
 	case TableLogicalSwitchPort:
-		lp, err := odbi.rowToLogicalPort(uuid)
+		lp, err := odbi.uuidToLogicalPort(uuid)
 		if err == nil {
 			odbi.signalCB.OnLogicalPortCreate(lp)
 		}
@@ -291,7 +291,7 @@ func (odbi *ovndb) signalDelete(table, uuid string) {
 		ls := odbi.rowToLogicalSwitch(uuid)
 		odbi.signalCB.OnLogicalSwitchDelete(ls)
 	case TableLogicalSwitchPort:
-		lp, err := odbi.rowToLogicalPort(uuid)
+		lp, err := odbi.uuidToLogicalPort(uuid)
 		if err == nil {
 			odbi.signalCB.OnLogicalPortDelete(lp)
 		}

--- a/go-controller/vendor/github.com/ebay/go-ovn/port_group.go
+++ b/go-controller/vendor/github.com/ebay/go-ovn/port_group.go
@@ -252,7 +252,7 @@ func (odbi *ovndb) GetLogicalPortsByPortGroup(group string) ([]*LogicalSwitchPor
 					if ps, ok := ports.(libovsdb.OvsSet); ok {
 						for _, p := range ps.GoSet {
 							if vp, ok := p.(libovsdb.UUID); ok {
-								tp, err := odbi.rowToLogicalPort(vp.GoUUID)
+								tp, err := odbi.uuidToLogicalPort(vp.GoUUID)
 								if err != nil {
 									return nil, fmt.Errorf("Couldn't get logical port: %s", err)
 								}
@@ -264,7 +264,7 @@ func (odbi *ovndb) GetLogicalPortsByPortGroup(group string) ([]*LogicalSwitchPor
 					}
 				case libovsdb.UUID:
 					if vp, ok := ports.(libovsdb.UUID); ok {
-						tp, err := odbi.rowToLogicalPort(vp.GoUUID)
+						tp, err := odbi.uuidToLogicalPort(vp.GoUUID)
 						if err != nil {
 							return nil, fmt.Errorf("Couldn't get logical port: %s", err)
 						}


### PR DESCRIPTION
LSPGet() already returns the LSP's Options so just copy them
instead of calling LSPGetOptions() which has to lock the go-ovn
cache and look up the LSP.

Second, change the after-OVN-execute LSPGet() to LSPGetUUID()
after reading the UUID from the OVN execute response. go-ovn
uses the UUID as a cache index, so LSPGetUUID() is much faster
than getting an LSP by name which requires walking the cache
row-by-row.

Third, eliminate the LSPGet() that GetPortAddresses() does.
We already know the addresses from the first LSPGet() so we
only need to parse them. If the port didn't exist in the
first place, we know there are no addresses to parse so
don't even bother.

Finally, don't repeatedly access two levels of maps to get the
cache row when building a LSP object. Micro-benchmarks
indicate that's about 2x as slow as just getting the row once
and reading fields out of it.

@trozet