### PR TITLE
Bug 2007443: bump OVN to ovn21.09-21.09.0-20.el8fdp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN yum install -y  \
 	yum clean all
 
 ARG ovsver=2.16.0-15.el8fdp
-ARG ovnver=21.09.0-19.el8fdp
+ARG ovnver=21.09.0-20.el8fdp
 
 RUN INSTALL_PKGS=" \
 	openssl python3-pyOpenSSL firewalld-filesystem \


### PR DESCRIPTION
Includes fix for:

- ovs: Include ovsdb-data optimizations.
- nbctl: allow multiple bfd sessions with same nexthop and different outports
https://bugzilla.redhat.com/show_bug.cgi?id=2007443
https://bugzilla.redhat.com/show_bug.cgi?id=2007549

@trozet @tssurya 