### PR TITLE
Bug 1996886: [4.7] bump OVN to 20.12.0-183.el8fdp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN yum install -y  \
 	yum clean all
 
 ARG ovsver=2.13.0-79.el8fdp
-ARG ovnver=20.12.0-140.el8fdp
+ARG ovnver=20.12.0-183.el8fdp
 
 RUN INSTALL_PKGS=" \
 	openssl python3-pyOpenSSL firewalld-filesystem \


### PR DESCRIPTION
Includes fixes for:

- [ICNI 2.0] Loadbalancer pods do not establish BFD sessions with all workers that host pods for the routed namespace
https://bugzilla.redhat.com/show_bug.cgi?id=2007443

- BFD sessions are not created correctly from the parameters of lr-route-add
https://bugzilla.redhat.com/show_bug.cgi?id=2007549

- [scale] northd: precompute router load balancer IPs
https://bugzilla.redhat.com/show_bug.cgi?id=1962338

- [OVN-SCALE] ovn-controller: OF rule explosion for ACLs with conjunctive matches applied on multiple datapaths
https://bugzilla.redhat.com/show_bug.cgi?id=1944098

- [OVN SCALE][ovn-controller] Load_Balancer changes trigger unnecessary additional flow computations
https://bugzilla.redhat.com/show_bug.cgi?id=1978605

- lflow: Refactor OpenFlow snat hairpin flows [large OpenFlow reduction fix]
- lflow: Generate unique integer for each Load Balancer [large OpenFlow reduction fix]

Signed-off-by: Dumitru Ceara <dceara@redhat.com>