### PR TITLE
Bug 2011386: pods: fix overwriting returned error from defer()

### DIFF
--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -372,9 +372,8 @@ func (oc *Controller) addLogicalPort(pod *kapi.Pod) (err error) {
 			if addrSetCmds, nsErr := oc.deletePodFromNamespace(pod.Namespace, portName, "", podIfAddrs); nsErr != nil {
 				klog.Errorf("Error when deleting pod: %s from namespace: %v", pod.Name, err)
 			} else {
-				err = oc.ovnNBClient.Execute(addrSetCmds...)
-				if err != nil {
-					klog.Errorf("Error removing pod %s IPs from namespace address set: %v", portName, err)
+				if addrErr := oc.ovnNBClient.Execute(addrSetCmds...); addrErr != nil {
+					klog.Errorf("Error removing pod %s IPs from namespace address set: %v", portName, addrErr)
 				}
 			}
 		}


### PR DESCRIPTION
Using the same error variable name in the defer() overwrote
the error itself, and caused the function to return nil even
though an error had occurred.

This is only an issue downstream as the problem code only exists downstream as a CARRY.

@trozet 