### PR TITLE
Bug 2011971: Don't return err when annotation cannot be unmarshalled

### DIFF
--- a/go-controller/pkg/ovn/egressgw.go
+++ b/go-controller/pkg/ovn/egressgw.go
@@ -178,7 +178,8 @@ func (oc *Controller) addPodExternalGW(pod *kapi.Pod) error {
 
 	foundGws, err := getExGwPodIPs(pod)
 	if err != nil {
-		return err
+		klog.Errorf("Error getting exgw IPs for pod: %s, error: %v", pod.Name, err)
+		return nil
 	}
 
 	// if we found any gateways then we need to update current pods routing in the relevant namespace
@@ -823,10 +824,9 @@ func getExGwPodIPs(gatewayPod *kapi.Pod) ([]net.IP, error) {
 			}
 		}
 	} else {
-		klog.Errorf("Ignoring pod %s as an external gateway candidate. Invalid combination "+
+		return nil, fmt.Errorf("ignoring pod %s as an external gateway candidate. Invalid combination "+
 			"of host network: %t and routing-network annotation: %s", gatewayPod.Name, gatewayPod.Spec.HostNetwork,
 			gatewayPod.Annotations[routingNetworkAnnotation])
-		return nil, nil
 	}
 	return foundGws, nil
 }


### PR DESCRIPTION
**What this PR does and why is it needed**

While creating an exgw pod, we try to unmarshall the network-status
annotation that is set by the multus CNI plugin. Since multus only
sets the annotation after it calls the SRIOV plugin this means
ovn-k must return a successful CNI_ADD result.

Currently we return the error to the top and fail to create the pod,
this blocking the pod creation. Let's just log an error instead.

Signed-off-by: Surya Seetharaman <suryaseetharaman.9@gmail.com>
(cherry picked from commit 0dddf1ef726158a869edb56f50d6c28af4328e37)

