### PR TITLE
[WIP]: Fix pod handlers for egress IP

### DIFF
--- a/go-controller/pkg/ovn/egressip.go
+++ b/go-controller/pkg/ovn/egressip.go
@@ -49,25 +49,29 @@ func (oc *Controller) addEgressIP(eIP *egressipv1.EgressIP) error {
 	if err != nil {
 		return fmt.Errorf("invalid namespaceSelector on EgressIP %s: %v", eIP.Name, err)
 	}
-	h := oc.watchFactory.AddFilteredNamespaceHandler("", sel,
-		cache.ResourceEventHandlerFuncs{
-			AddFunc: func(obj interface{}) {
-				namespace := obj.(*kapi.Namespace)
-				klog.V(5).Infof("EgressIP: %s has matched on namespace: %s", eIP.Name, namespace.Name)
-				if err := oc.addNamespaceEgressIP(eIP, namespace); err != nil {
-					klog.Errorf("error: unable to add namespace handler for EgressIP: %s, err: %v", eIP.Name, err)
-				}
-			},
-			UpdateFunc: func(oldObj, newObj interface{}) {},
-			DeleteFunc: func(obj interface{}) {
-				namespace := obj.(*kapi.Namespace)
-				klog.V(5).Infof("EgressIP: %s stopped matching on namespace: %s", eIP.Name, namespace.Name)
-				if err := oc.deleteNamespaceEgressIP(eIP, namespace); err != nil {
-					klog.Errorf("error: unable to delete namespace handler for EgressIP: %s, err: %v", eIP.Name, err)
-				}
-			},
-		}, nil)
-	oc.eIPC.namespaceHandlerCache[getEgressIPKey(eIP)] = *h
+	if _, exists := oc.eIPC.namespaceHandlerCache[getEgressIPKey(eIP)]; !exists {
+		h := oc.watchFactory.AddFilteredNamespaceHandler("", sel,
+			cache.ResourceEventHandlerFuncs{
+				AddFunc: func(obj interface{}) {
+					namespace := obj.(*kapi.Namespace)
+					klog.V(5).Infof("EgressIP: %s has matched on namespace: %s", eIP.Name, namespace.Name)
+					if err := oc.addNamespaceEgressIP(eIP, namespace); err != nil {
+						klog.Errorf("error: unable to add namespace handler for EgressIP: %s, err: %v", eIP.Name, err)
+					}
+				},
+				UpdateFunc: func(oldObj, newObj interface{}) {},
+				DeleteFunc: func(obj interface{}) {
+					namespace := obj.(*kapi.Namespace)
+					klog.V(5).Infof("EgressIP: %s stopped matching on namespace: %s", eIP.Name, namespace.Name)
+					if err := oc.deleteNamespaceEgressIP(eIP, namespace); err != nil {
+						klog.Errorf("error: unable to delete namespace handler for EgressIP: %s, err: %v", eIP.Name, err)
+					}
+				},
+			}, nil)
+		oc.eIPC.namespaceHandlerCache[getEgressIPKey(eIP)] = *h
+	} else {
+		klog.Error("The namespace handler cache for egress IPs is de-synchronized: a namespace handler already exists for egress IP: %s", getEgressIPKey(eIP))
+	}
 	return nil
 }
 
@@ -83,16 +87,15 @@ func (oc *Controller) deleteEgressIP(eIP *egressipv1.EgressIP) error {
 
 	oc.eIPC.podHandlerMutex.Lock()
 	defer oc.eIPC.podHandlerMutex.Unlock()
-	if pH, exists := oc.eIPC.podHandlerCache[getEgressIPKey(eIP)]; exists {
-		oc.watchFactory.RemovePodHandler(&pH)
-		delete(oc.eIPC.podHandlerCache, getEgressIPKey(eIP))
-	}
-
 	namespaces, err := oc.kube.GetNamespaces(eIP.Spec.NamespaceSelector)
 	if err != nil {
 		return err
 	}
 	for _, namespace := range namespaces.Items {
+		if pH, exists := oc.eIPC.podHandlerCache[getNamespaceKey(&namespace)]; exists {
+			oc.watchFactory.RemovePodHandler(&pH)
+			delete(oc.eIPC.podHandlerCache, getNamespaceKey(&namespace))
+		}
 		if err := oc.deleteNamespacePodsEgressIP(eIP, &namespace); err != nil {
 			return err
 		}
@@ -405,50 +408,54 @@ func (oc *Controller) addNamespaceEgressIP(eIP *egressipv1.EgressIP, namespace *
 	if err != nil {
 		return fmt.Errorf("invalid podSelector on EgressIP %s: %v", eIP.Name, err)
 	}
-	h := oc.watchFactory.AddFilteredPodHandler(namespace.Name, sel,
-		cache.ResourceEventHandlerFuncs{
-			AddFunc: func(obj interface{}) {
-				pod := obj.(*kapi.Pod)
-				klog.V(5).Infof("EgressIP: %s has matched on pod: %s in namespace: %s", eIP.Name, pod.Name, namespace.Name)
-				if err := oc.eIPC.addPodEgressIP(eIP, pod); err != nil {
-					klog.Errorf("Unable to add pod: %s/%s to EgressIP: %s, err: %v", pod.Namespace, pod.Name, eIP.Name, err)
-				}
-			},
-			UpdateFunc: func(oldObj, newObj interface{}) {
-				newPod := newObj.(*kapi.Pod)
-				// FYI: the only pod update we care about here is the pod being assigned an IP, which
-				// it didn't have when we received the ADD. If the label is changed and it stops matching:
-				// this watcher receives a delete.
-				if oc.eIPC.needsRetry(newPod) {
-					klog.V(5).Infof("EgressIP: %s update for pod: %s in namespace: %s", eIP.Name, newPod.Name, namespace.Name)
-					if err := oc.eIPC.addPodEgressIP(eIP, newPod); err != nil {
-						klog.Errorf("Unable to add pod: %s/%s to EgressIP: %s, err: %v", newPod.Namespace, newPod.Name, eIP.Name, err)
+	if _, exists := oc.eIPC.podHandlerCache[getNamespaceKey(namespace)]; !exists {
+		h := oc.watchFactory.AddFilteredPodHandler(namespace.Name, sel,
+			cache.ResourceEventHandlerFuncs{
+				AddFunc: func(obj interface{}) {
+					pod := obj.(*kapi.Pod)
+					klog.V(5).Infof("EgressIP: %s has matched on pod: %s in namespace: %s", eIP.Name, pod.Name, namespace.Name)
+					if err := oc.eIPC.addPodEgressIP(eIP, pod); err != nil {
+						klog.Errorf("Unable to add pod: %s/%s to EgressIP: %s, err: %v", pod.Namespace, pod.Name, eIP.Name, err)
 					}
-				}
-			},
-			DeleteFunc: func(obj interface{}) {
-				pod := obj.(*kapi.Pod)
-				// FYI: we can be in a situation where we processed a pod ADD for which there was no IP
-				// address assigned. If the pod is deleted before the IP address is assigned,
-				// we should not process that delete (as nothing exists in OVN for it)
-				klog.V(5).Infof("EgressIP: %s has stopped matching on pod: %s in namespace: %s, needs delete: %v", eIP.Name, pod.Name, namespace.Name, !oc.eIPC.needsRetry(pod))
-				if !oc.eIPC.needsRetry(pod) {
-					if err := oc.eIPC.deletePodEgressIP(eIP, pod); err != nil {
-						klog.Errorf("Unable to delete pod: %s/%s to EgressIP: %s, err: %v", pod.Namespace, pod.Name, eIP.Name, err)
+				},
+				UpdateFunc: func(oldObj, newObj interface{}) {
+					newPod := newObj.(*kapi.Pod)
+					// FYI: the only pod update we care about here is the pod being assigned an IP, which
+					// it didn't have when we received the ADD. If the label is changed and it stops matching:
+					// this watcher receives a delete.
+					if oc.eIPC.needsRetry(newPod) {
+						klog.V(5).Infof("EgressIP: %s update for pod: %s in namespace: %s", eIP.Name, newPod.Name, namespace.Name)
+						if err := oc.eIPC.addPodEgressIP(eIP, newPod); err != nil {
+							klog.Errorf("Unable to add pod: %s/%s to EgressIP: %s, err: %v", newPod.Namespace, newPod.Name, eIP.Name, err)
+						}
 					}
-				}
-			},
-		}, nil)
-	oc.eIPC.podHandlerCache[getEgressIPKey(eIP)] = *h
+				},
+				DeleteFunc: func(obj interface{}) {
+					pod := obj.(*kapi.Pod)
+					// FYI: we can be in a situation where we processed a pod ADD for which there was no IP
+					// address assigned. If the pod is deleted before the IP address is assigned,
+					// we should not process that delete (as nothing exists in OVN for it)
+					klog.V(5).Infof("EgressIP: %s has stopped matching on pod: %s in namespace: %s, needs delete: %v", eIP.Name, pod.Name, namespace.Name, !oc.eIPC.needsRetry(pod))
+					if !oc.eIPC.needsRetry(pod) {
+						if err := oc.eIPC.deletePodEgressIP(eIP, pod); err != nil {
+							klog.Errorf("Unable to delete pod: %s/%s to EgressIP: %s, err: %v", pod.Namespace, pod.Name, eIP.Name, err)
+						}
+					}
+				},
+			}, nil)
+		oc.eIPC.podHandlerCache[getNamespaceKey(namespace)] = *h
+	} else {
+		klog.Errorf("The pod handler cache for egress IPs is de-synchronized: a pod handler already exists for namespace: %s", getNamespaceKey(namespace))
+	}
 	return nil
 }
 
 func (oc *Controller) deleteNamespaceEgressIP(eIP *egressipv1.EgressIP, namespace *kapi.Namespace) error {
 	oc.eIPC.podHandlerMutex.Lock()
 	defer oc.eIPC.podHandlerMutex.Unlock()
-	if pH, exists := oc.eIPC.podHandlerCache[getEgressIPKey(eIP)]; exists {
+	if pH, exists := oc.eIPC.podHandlerCache[getNamespaceKey(namespace)]; exists {
 		oc.watchFactory.RemovePodHandler(&pH)
-		delete(oc.eIPC.podHandlerCache, getEgressIPKey(eIP))
+		delete(oc.eIPC.podHandlerCache, getNamespaceKey(namespace))
 	}
 	if err := oc.deleteNamespacePodsEgressIP(eIP, namespace); err != nil {
 		return err
@@ -1279,6 +1286,10 @@ func findNatIDs(egressIPName, podIP, egressIP string) ([]string, error) {
 
 func getEgressIPKey(eIP *egressipv1.EgressIP) string {
 	return eIP.Name
+}
+
+func getNamespaceKey(namespace *kapi.Namespace) string {
+	return namespace.Name
 }
 
 func getPodKey(pod *kapi.Pod) string {

--- a/go-controller/pkg/ovn/egressip.go
+++ b/go-controller/pkg/ovn/egressip.go
@@ -469,6 +469,7 @@ func (oc *Controller) deleteNamespacePodsEgressIP(eIP *egressipv1.EgressIP, name
 		return err
 	}
 	for _, pod := range pods.Items {
+		klog.Infof("Alex, I am going to delete pod: %s/%s, the clause below evaluates to %v", pod.Namespace, pod.Name, !oc.eIPC.needsRetry(&pod))
 		if !oc.eIPC.needsRetry(&pod) {
 			if err := oc.eIPC.deletePodEgressIP(eIP, &pod); err != nil {
 				return err
@@ -842,10 +843,12 @@ func (e *egressIPController) deletePodEgressIP(eIP *egressipv1.EgressIP, pod *ka
 	if pod.Spec.HostNetwork {
 		return nil
 	}
+	klog.Infof("Alex, pod: %s/%s has the following podIPs: %v and podIP: %v", pod.Namespace, pod.Name, pod.Status.PodIPs, pod.Status.PodIP)
 	podIPs := e.getPodIPs(pod)
 	if podIPs == nil {
 		return nil
 	}
+	klog.Infof("Alex, I finally made it and am going to delete pod: %s/%s", pod.Namespace, pod.Name)
 	if err := e.handleEgressReroutePolicy(podIPs, eIP.Status.Items, eIP.Name, e.deleteEgressReroutePolicy); err != nil {
 		return fmt.Errorf("unable to delete logical router policy, err: %v", err)
 	}


### PR DESCRIPTION
The pod handlers were incorrectly keyed by egress IP, which is wrong
because the are created on a per-namspace basis, meaning they need to be
keyed by namespace - otherwise we'll have watchers lingering in memory
but which are untracked


/cc 

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->