### PR TITLE
CARRY: go-ovn: prevent deadlock processing Updates during initial DB dump

### DIFF
--- a/go-controller/vendor/github.com/ebay/go-ovn/ovnimp.go
+++ b/go-controller/vendor/github.com/ebay/go-ovn/ovnimp.go
@@ -351,7 +351,7 @@ func (odbi *ovndb) getContext(dbName string) (*map[string][]string, *map[string]
 	return &odbi.tableCols, &odbi.cache, odbi.signalCreate, odbi.signalDelete
 }
 
-func (odbi *ovndb) populateCache(dbName string, updates libovsdb.TableUpdates, signal bool) {
+func (odbi *ovndb) populateCache(dbName string, updates *libovsdb.TableUpdates, signal bool) {
 	tableCols, cache, signalCreate, signalDelete := odbi.getContext(dbName)
 
 	empty := libovsdb.Row{}
@@ -512,7 +512,7 @@ func (odbi *ovndb) applyUpdatesToRow(db, table string, uuid string, rowdiff *lib
 	(*cache)[table][uuid] = row
 }
 
-func (odbi *ovndb) populateCache2(dbName string, updates libovsdb.TableUpdates2, signal bool) {
+func (odbi *ovndb) populateCache2(dbName string, updates *libovsdb.TableUpdates2, signal bool) {
 	tableCols, cache, signalCreate, signalDelete := odbi.getContext(dbName)
 
 	for table := range *tableCols {

--- a/go-controller/vendor/github.com/ebay/go-ovn/ovnnotify.go
+++ b/go-controller/vendor/github.com/ebay/go-ovn/ovnnotify.go
@@ -24,59 +24,126 @@ import (
 	"github.com/ebay/libovsdb"
 )
 
-type ovnNotifier struct {
-	odbi *ovndb
+type update struct {
+	db        string
+	updates   *libovsdb.TableUpdates
+	updates2  *libovsdb.TableUpdates2
+	lastTxnId string
 }
 
-func (notify ovnNotifier) getDBNameAndLock(context interface{}) (string, *sync.RWMutex) {
+type ovnNotifier struct {
+	sync.Mutex
+	odbi            *ovndb
+	deferUpdates    bool
+	deferredUpdates []*update
+}
+
+func newOVNNotifier(odbi *ovndb) *ovnNotifier {
+	return &ovnNotifier{
+		odbi:            odbi,
+		deferUpdates:    true,
+		deferredUpdates: make([]*update, 0),
+	}
+}
+
+func newUpdate(context interface{}, updates *libovsdb.TableUpdates, updates2 *libovsdb.TableUpdates2, lastTxnId string) *update {
 	dbName, ok := context.(string)
 	if !ok {
-		klog.Warningf("Expected string-type context but got %v", context)
-		return "", nil
+		klog.Warningf("Expected string-type OVN update context but got %v", context)
+		return nil
 	}
-
-	if dbName == DBServer {
-		return dbName, &notify.odbi.serverCacheMutex
-	}
-
-	return dbName, &notify.odbi.cachemutex
-}
-
-func (notify ovnNotifier) Update(context interface{}, tableUpdates libovsdb.TableUpdates) {
-	db, lock := notify.getDBNameAndLock(context)
-	if lock != nil {
-		lock.Lock()
-		defer lock.Unlock()
-		notify.odbi.populateCache(db, tableUpdates, true)
-	}
-}
-func (notify ovnNotifier) Update2(context interface{}, tableUpdates libovsdb.TableUpdates2) {
-	db, lock := notify.getDBNameAndLock(context)
-	if lock != nil {
-		lock.Lock()
-		defer lock.Unlock()
-		notify.odbi.populateCache2(db, tableUpdates, true)
+	return &update{
+		db:        dbName,
+		updates:   updates,
+		updates2:  updates2,
+		lastTxnId: lastTxnId,
 	}
 }
 
-func (notify ovnNotifier) Update3(context interface{}, tableUpdates libovsdb.TableUpdates2, lastTxnId string) {
-	db, lock := notify.getDBNameAndLock(context)
-	if lock != nil {
-		lock.Lock()
-		defer lock.Unlock()
-		notify.odbi.populateCache2(db, tableUpdates, true)
-		notify.odbi.currentTxn = lastTxnId
+func (n *ovnNotifier) processUpdate(u *update, signal bool) {
+	if u.updates != nil {
+		n.odbi.populateCache(u.db, u.updates, signal)
+	} else {
+		n.odbi.populateCache2(u.db, u.updates2, signal)
+		if u.lastTxnId != "" {
+			n.odbi.currentTxn = u.lastTxnId
+		}
 	}
 }
 
-func (notify ovnNotifier) Locked([]interface{}) {
-}
-func (notify ovnNotifier) Stolen([]interface{}) {
-}
-func (notify ovnNotifier) Echo([]interface{}) {
+func (n *ovnNotifier) processDeferredUpdates() {
+	// we don't need to hold the lock while iterating deferred
+	// updates since nothing can add to the array after we set
+	// deferUpdates to false
+	n.Lock()
+	n.deferUpdates = false
+	n.Unlock()
+
+	for _, u := range n.deferredUpdates {
+		n.processUpdate(u, false)
+	}
 }
 
-func (notify ovnNotifier) Disconnected(client *libovsdb.OvsdbClient) {
+// maybeDeferUpdate adds the update to the deferred updates list if it should
+// be deferred because we are in the middle of the initial DB dump. Returns
+// true if the update was deferred.
+func (n *ovnNotifier) maybeDeferUpdate(u *update) bool {
+	n.Lock()
+	defer n.Unlock()
+	if n.deferUpdates {
+		n.deferredUpdates = append(n.deferredUpdates, u)
+	}
+	return n.deferUpdates
+}
+
+// handleUpdate either adds the update to the deferred updates list or
+// processes the update immediately. Assumes the caller holds the cache
+// mutexes while updates are deferred and calls processDeferredUpdates()
+// when the initial DB dump is done. This ensures that deferred updates
+// get processed first since non-deferred updates will block on the
+// cache mutexes that the caller holds until processDeferredUpdates() is done.
+func (n *ovnNotifier) handleUpdate(u *update) {
+	if n.maybeDeferUpdate(u) {
+		return
+	}
+
+	if u.db == DBServer {
+		n.odbi.serverCacheMutex.Lock()
+		defer n.odbi.serverCacheMutex.Unlock()
+	} else {
+		n.odbi.cachemutex.Lock()
+		defer n.odbi.cachemutex.Unlock()
+	}
+
+	n.processUpdate(u, true)
+}
+
+func (n *ovnNotifier) Update(context interface{}, tableUpdates libovsdb.TableUpdates) {
+	if u := newUpdate(context, &tableUpdates, nil, ""); u != nil {
+		n.handleUpdate(u)
+	}
+}
+
+func (n *ovnNotifier) Update2(context interface{}, tableUpdates libovsdb.TableUpdates2) {
+	if u := newUpdate(context, nil, &tableUpdates, ""); u != nil {
+		n.handleUpdate(u)
+	}
+}
+
+func (n *ovnNotifier) Update3(context interface{}, tableUpdates libovsdb.TableUpdates2, lastTxnId string) {
+	if u := newUpdate(context, nil, &tableUpdates, lastTxnId); u != nil {
+		n.handleUpdate(u)
+	}
+}
+
+func (notify *ovnNotifier) Locked([]interface{}) {
+}
+func (notify *ovnNotifier) Stolen([]interface{}) {
+}
+func (notify *ovnNotifier) Echo([]interface{}) {
+}
+
+func (notify *ovnNotifier) Disconnected(client *libovsdb.OvsdbClient) {
 	if notify.odbi.reconn {
 		notify.odbi.reconnect()
 	} else if notify.odbi.disconnectCB != nil {


### PR DESCRIPTION
It appears that ovsdb-server will sometimes send updates after we register
our database monitors, but before we've received and processed the initial
database dump. This causes a deadlock because during the initial monitor
setup we must lock the database cache, but the update processing also
locks the database cache.

Avoid this by making the notifier defer updates during the initial
database dump, and processing them only after the dump is done.

@trozet @dave-tucker 