### PR TITLE
Bug 1999255: Node wait for Controller before initializing Gateway

### DIFF
--- a/go-controller/pkg/node/gateway_init.go
+++ b/go-controller/pkg/node/gateway_init.go
@@ -243,11 +243,21 @@ func (n *OvnNode) initGateway(subnets []*net.IPNet, nodeAnnotator kube.Annotator
 	if portClaimWatcher != nil {
 		gw.portClaimWatcher = portClaimWatcher
 	}
-	initGw := func() error {
+
+	initGwFunc := func() error {
 		return gw.Init(n.watchFactory)
 	}
 
-	waiter.AddWait(gw.readyFunc, initGw)
+	readyGwFunc := func() (bool, error) {
+		controllerReady, err := isOVNControllerReady()
+		if err != nil || !controllerReady {
+			return false, err
+		}
+
+		return gw.readyFunc()
+	}
+
+	waiter.AddWait(readyGwFunc, initGwFunc)
 	n.gateway = gw
 
 	return n.validateGatewayMTU(gatewayIntf)

--- a/go-controller/pkg/node/node.go
+++ b/go-controller/pkg/node/node.go
@@ -192,54 +192,39 @@ func setupOVNNode(node *kapi.Node) error {
 	return nil
 }
 
-func isOVNControllerReady(name string) (bool, error) {
+func isOVNControllerReady() (bool, error) {
+	// check node's connection status
 	runDir := util.GetOvnRunDir()
-
 	pid, err := ioutil.ReadFile(runDir + "ovn-controller.pid")
 	if err != nil {
 		return false, fmt.Errorf("unknown pid for ovn-controller process: %v", err)
 	}
-
-	err = wait.PollImmediate(500*time.Millisecond, 60*time.Second, func() (bool, error) {
-		ctlFile := runDir + fmt.Sprintf("ovn-controller.%s.ctl", strings.TrimSuffix(string(pid), "\n"))
-		ret, _, err := util.RunOVSAppctl("-t", ctlFile, "connection-status")
-		if err == nil {
-			klog.Infof("Node %s connection status = %s", name, ret)
-			return ret == "connected", nil
-		}
-		return false, err
-	})
+	ctlFile := runDir + fmt.Sprintf("ovn-controller.%s.ctl", strings.TrimSuffix(string(pid), "\n"))
+	ret, _, err := util.RunOVSAppctl("-t", ctlFile, "connection-status")
 	if err != nil {
-		return false, fmt.Errorf("timed out waiting sbdb for node %s: %v", name, err)
+		return false, fmt.Errorf("could not get connection status: %w", err)
+	}
+	klog.Infof("Node connection status = %s", ret)
+	if ret != "connected" {
+		return false, nil
 	}
 
-	err = wait.PollImmediate(500*time.Millisecond, 60*time.Second, func() (bool, error) {
-		_, _, err := util.RunOVSVsctl("--", "br-exists", "br-int")
-		if err != nil {
-			return false, nil
-		}
-		return true, nil
-	})
+	// check whether br-int exists on node
+	_, _, err = util.RunOVSVsctl("--", "br-exists", "br-int")
 	if err != nil {
-		return false, fmt.Errorf("timed out checking whether br-int exists or not on node %s: %v", name, err)
+		return false, nil
 	}
 
-	err = wait.PollImmediate(500*time.Millisecond, 60*time.Second, func() (bool, error) {
-		stdout, _, err := util.RunOVSOfctl("dump-aggregate", "br-int")
-		if err != nil {
-			klog.V(5).Infof("Error dumping aggregate flows: %v "+
-				"for node: %s", err, name)
-			return false, nil
-		}
-		ret := strings.Contains(stdout, "flow_count=0")
-		if ret {
-			klog.V(5).Infof("Got a flow count of 0 when "+
-				"dumping flows for node: %s", name)
-		}
-		return !ret, nil
-	})
+	// check by dumping br-int flow entries
+	stdout, _, err := util.RunOVSOfctl("dump-aggregate", "br-int")
 	if err != nil {
-		return false, fmt.Errorf("timed out dumping br-int flow entries for node %s: %v", name, err)
+		klog.V(5).Infof("Error dumping aggregate flows: %v", err)
+		return false, nil
+	}
+	hasFlowCountZero := strings.Contains(stdout, "flow_count=0")
+	if hasFlowCountZero {
+		klog.V(5).Info("Got a flow count of 0 when dumping flows for node")
+		return false, nil
 	}
 
 	return true, nil
@@ -339,7 +324,7 @@ func (n *OvnNode) Start(wg *sync.WaitGroup) error {
 	if config.OvnKubeNode.Mode != types.NodeModeSmartNICHost {
 		klog.Infof("Node %s ready for ovn initialization with subnet %s", n.name, util.JoinIPNets(subnets, ","))
 
-		if _, err = isOVNControllerReady(n.name); err != nil {
+		if _, err = isOVNControllerReady(); err != nil {
 			return err
 		}
 

--- a/go-controller/pkg/node/node.go
+++ b/go-controller/pkg/node/node.go
@@ -324,10 +324,6 @@ func (n *OvnNode) Start(wg *sync.WaitGroup) error {
 	if config.OvnKubeNode.Mode != types.NodeModeSmartNICHost {
 		klog.Infof("Node %s ready for ovn initialization with subnet %s", n.name, util.JoinIPNets(subnets, ","))
 
-		if _, err = isOVNControllerReady(); err != nil {
-			return err
-		}
-
 		nodeAnnotator := kube.NewNodeAnnotator(n.Kube, node)
 		waiter := newStartupWaiter()
 


### PR DESCRIPTION
**- What this PR does and why is it needed**
We observed ovnkube node crashing sometimes the first time it started with the following message:
```
F0830 07:32:04.337095    2679 ovnkube.go:131] error waiting for node readiness: failed while waiting on patch port "patch-br-ex_xyz-to-br-int" to be created by ovn-controller and while getting ofport. stderr: "ovs-vsctl: no row \"patch-br-ex_xyz-to-br-int\" in table Interface\n", error: exit status 1
```

The corresponding ovn-controller log suggests ovnkube-node just didn't wait long enough. Actually, despite the claim in the error message, it looks like ovnkube-node is not actually *waiting* for ovn-controller, but rather, simply assuming ovn-controller will already be ready by the time it reaches that check. Which is turning out to be false ([BZ 1999255](https://bugzilla.redhat.com/show_bug.cgi?id=1999255)).

This PR addresses it waits for the controller to be ready, before initializing the gateway.

**- Special notes for reviewers**
Cherry-pick of https://github.com/ovn-org/ovn-kubernetes/pull/2523