### PR TITLE
Bug 2019093: Not exit when ovnkube runs with '--gateway-interface none'

### DIFF
--- a/go-controller/pkg/node/gateway_init.go
+++ b/go-controller/pkg/node/gateway_init.go
@@ -179,7 +179,9 @@ func (n *OvnNode) initGateway(subnets []*net.IPNet, nodeAnnotator kube.Annotator
 	}
 
 	ifAddrs, err := getNetworkInterfaceIPAddresses(gatewayIntf)
-	if err != nil {
+	// Downstream-only hack: Do not return error when gatewayIntf is 'none', this is only for the intermediate
+	// phase of SDN migration when ovnkube runs with '--gateway-interface none'
+	if err != nil && gatewayIntf != "none" {
 		return err
 	}
 


### PR DESCRIPTION

**- What this PR does and why is it needed**
During SDN migration, there is an intermediate phase, ovn-kube runs with '--gateway-interface none' before br-ex is not created. This PR allows ovn-kube to run in such a scenario.


**- Special notes for reviewers**
Fix the regression introduced by https://github.com/openshift/ovn-kubernetes/commit/1c28b968f1b0fb6252e7f4d3061b107d5cc498e0. 


**- How to verify it**
Trigger SDN migration

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->