### PR TITLE
Bug 1988440: Make config parsing more resilient for unknown fields

### DIFF
--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -1519,7 +1519,11 @@ func initConfigWithPath(ctx *cli.Context, exec kexec.Interface, saPath string, d
 
 		// Parse ovn-k8s config file.
 		if err = gcfg.ReadInto(&cfg, f); err != nil {
-			return "", fmt.Errorf("failed to parse config file %s: %v", f.Name(), err)
+			if gcfg.FatalOnly(err) != nil {
+				return "", fmt.Errorf("failed to parse config file %s: %v", f.Name(), err)
+			}
+			// error is only a warning -> log it but continue
+			klog.Warningf("Warning on parsing config file: %s", err)
 		}
 		klog.Infof("Parsed config file %s", f.Name())
 		klog.Infof("Parsed config: %+v", cfg)

--- a/go-controller/pkg/config/config_test.go
+++ b/go-controller/pkg/config/config_test.go
@@ -1150,6 +1150,59 @@ mode=shared
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 
+	It("ignores unknown fields in config file and does not return an error", func() {
+		err := ioutil.WriteFile(cfgFile.Name(), []byte(`[default]
+key=value
+mtu=1234
+
+[foobar]
+foo=bar
+`), 0644)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		app.Action = func(ctx *cli.Context) error {
+			var cfgPath string
+			cfgPath, err = InitConfig(ctx, kexec.New(), nil)
+
+			// unknown section foobar and its keys & values should be ignored
+			// same for key=value in default section
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			gomega.Expect(cfgPath).To(gomega.Equal(cfgFile.Name()))
+			gomega.Expect(Default.MTU).To(gomega.Equal(1234))
+			return nil
+		}
+		cliArgs := []string{
+			app.Name,
+			"-config-file=" + cfgFile.Name(),
+		}
+		err = app.Run(cliArgs)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+
+	It("rejects a config with invalid syntax", func() {
+		err := ioutil.WriteFile(cfgFile.Name(), []byte(`[default]
+mtu=1234
+
+[foobar
+foo=bar
+`), 0644)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		app.Action = func(ctx *cli.Context) error {
+			_, err = InitConfig(ctx, kexec.New(), nil)
+			gomega.Expect(err).To(gomega.HaveOccurred())
+
+			return nil
+		}
+		cliArgs := []string{
+			app.Name,
+			"-config-file=" + cfgFile.Name(),
+		}
+		err = app.Run(cliArgs)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+
 	Describe("OvnDBAuth operations", func() {
 		var certFile, keyFile, caFile string
 


### PR DESCRIPTION
Cherry-pick of https://github.com/ovn-org/ovn-kubernetes/pull/2579

**- What this PR does and why is it needed**
Currently ovnkube-node & -master pods fail to start, when the config files contain an unknown field or unknown section. This can lead during updates to problems in the following scenario:

1. ConfigMap is updated
2. ovnkube-node rollout starts
3. somehow an ovnkube-master pod needs to be (re-)started (be it through eviction from a node or something else)
4. the newly started ovnkube-master pod isn't aware of the new config structure and fails to parse the config, resulting in a crashloop of the newly ovnkube-master. This can result in a stucking rollout.

Fixes [BZ 1988440](https://bugzilla.redhat.com/show_bug.cgi?id=1988440)

This PR addresses this and makes the config parsing more resilient against unknown fields or sections. 

**- How to verify it**
I added two new unit tests, which parses a config with an unknown field and section and one with an syntax issue.

**- Description for the changelog**
```
Allow unknown fields and sections in config file
```