### PR TITLE
Bug 2022042: [4.9z] Avoid stale annotations by re-subscribing to netlink

### DIFF
--- a/go-controller/hybrid-overlay/pkg/controller/master.go
+++ b/go-controller/hybrid-overlay/pkg/controller/master.go
@@ -311,7 +311,7 @@ func (m *MasterController) deleteOverlayPort(node *kapi.Node) {
 // AddNode handles node additions
 func (m *MasterController) AddNode(node *kapi.Node) error {
 	klog.V(5).Infof("Processing add event for node %s", node.Name)
-	annotator := kube.NewNodeAnnotator(m.kube, node)
+	annotator := kube.NewNodeAnnotator(m.kube, node.Name)
 
 	var allocatedSubnet *net.IPNet
 	if houtil.IsHybridOverlayNode(node) {

--- a/go-controller/hybrid-overlay/pkg/controller/master_test.go
+++ b/go-controller/hybrid-overlay/pkg/controller/master_test.go
@@ -365,7 +365,7 @@ var _ = Describe("Hybrid SDN Master Operations", func() {
 			updatedNode, err := k.GetNode(nodeName)
 			Expect(err).NotTo(HaveOccurred())
 
-			nodeAnnotator := kube.NewNodeAnnotator(k, updatedNode)
+			nodeAnnotator := kube.NewNodeAnnotator(k, updatedNode.Name)
 			util.DeleteNodeHostSubnetAnnotation(nodeAnnotator)
 			err = nodeAnnotator.Run()
 			Expect(err).NotTo(HaveOccurred())

--- a/go-controller/hybrid-overlay/pkg/controller/master_test.go
+++ b/go-controller/hybrid-overlay/pkg/controller/master_test.go
@@ -543,7 +543,7 @@ var _ = Describe("Hybrid SDN Master Operations", func() {
 
 			updatedNs, err := fakeClient.CoreV1().Namespaces().Get(context.TODO(), nsName, metav1.GetOptions{})
 			Expect(err).NotTo(HaveOccurred())
-			nsAnnotator := kube.NewNamespaceAnnotator(k, updatedNs)
+			nsAnnotator := kube.NewNamespaceAnnotator(k, updatedNs.Name)
 			nsAnnotator.Set(hotypes.HybridOverlayVTEP, nsVTEPUpdated)
 			nsAnnotator.Set(hotypes.HybridOverlayExternalGw, nsExGwUpdated)
 			err = nsAnnotator.Run()

--- a/go-controller/hybrid-overlay/pkg/controller/node_windows.go
+++ b/go-controller/hybrid-overlay/pkg/controller/node_windows.go
@@ -318,7 +318,7 @@ func (n *NodeController) initSelf(node *kapi.Node, nodeSubnet *net.IPNet) error 
 			if len(policySettings.Address) == 0 {
 				return fmt.Errorf("error creating the network: no DRMAC address")
 			}
-			if err := n.kube.SetAnnotationsOnNode(node, map[string]interface{}{
+			if err := n.kube.SetAnnotationsOnNode(node.Name, map[string]interface{}{
 				types.HybridOverlayDRMAC: policySettings.Address,
 			}); err != nil {
 				klog.Errorf("Failed to set DRMAC annotation on node: %v", err)

--- a/go-controller/hybrid-overlay/pkg/util/util.go
+++ b/go-controller/hybrid-overlay/pkg/util/util.go
@@ -85,7 +85,7 @@ func StartNodeWatch(h types.NodeHandler, wf *factory.WatchFactory) {
 func CopyNamespaceAnnotationsToPod(k kube.Interface, ns *kapi.Namespace, pod *kapi.Pod) error {
 	nsGw, nsGwExists := ns.Annotations[types.HybridOverlayExternalGw]
 	nsVTEP, nsVTEPExists := ns.Annotations[types.HybridOverlayVTEP]
-	annotator := kube.NewPodAnnotator(k, pod)
+	annotator := kube.NewPodAnnotator(k, pod.Name, pod.Namespace)
 	if nsGwExists {
 		if err := annotator.Set(types.HybridOverlayExternalGw, nsGw); err != nil {
 			return err

--- a/go-controller/pkg/cni/cnismartnic.go
+++ b/go-controller/pkg/cni/cnismartnic.go
@@ -46,7 +46,11 @@ func (pr *PodRequest) addSmartNICConnectionDetailsAnnot(kube kube.Interface) err
 		return fmt.Errorf("failed to generate %s annotation for pod. %v", util.SmartNicConnectionDetailsAnnot, err)
 	}
 
-	err = kube.SetAnnotationsOnPod(pr.PodNamespace, pr.PodName, smartNicAnnotation)
+	annot := make(map[string]interface{}, len(smartNicAnnotation))
+	for key, val := range smartNicAnnotation {
+		annot[key] = val
+	}
+	err = kube.SetAnnotationsOnPod(pr.PodNamespace, pr.PodName, annot)
 	if err != nil {
 		return err
 	}

--- a/go-controller/pkg/cni/cnismartnic_test.go
+++ b/go-controller/pkg/cni/cnismartnic_test.go
@@ -48,8 +48,12 @@ var _ = Describe("cnismartnic tests", func() {
 				SandboxId: pr.SandboxID,
 			}
 			expectedAnnot, err := smartNicCd.AsAnnotation()
+			annnot := make(map[string]interface{}, len(expectedAnnot))
+			for key, val := range expectedAnnot {
+				annnot[key] = val
+			}
 			Expect(err).ToNot(HaveOccurred())
-			fakeKubeInterface.On("SetAnnotationsOnPod", pr.PodNamespace, pr.PodName, expectedAnnot).Return(nil)
+			fakeKubeInterface.On("SetAnnotationsOnPod", pr.PodNamespace, pr.PodName, annnot).Return(nil)
 			err = pr.addSmartNICConnectionDetailsAnnot(&fakeKubeInterface)
 			Expect(err).ToNot(HaveOccurred())
 

--- a/go-controller/pkg/factory/factory.go
+++ b/go-controller/pkg/factory/factory.go
@@ -236,11 +236,9 @@ func NewNodeWatchFactory(ovnClientset *util.OVNClientset, nodeName string) (*Wat
 		return nil, err
 	}
 
-	if config.HybridOverlay.Enabled {
-		wf.informers[nodeType], err = newInformer(nodeType, wf.iFactory.Core().V1().Nodes().Informer())
-		if err != nil {
-			return nil, err
-		}
+	wf.informers[nodeType], err = newInformer(nodeType, wf.iFactory.Core().V1().Nodes().Informer())
+	if err != nil {
+		return nil, err
 	}
 
 	wf.iFactory.Start(wf.stopChan)

--- a/go-controller/pkg/factory/types.go
+++ b/go-controller/pkg/factory/types.go
@@ -42,6 +42,8 @@ type NodeWatchFactory interface {
 
 	NodeInformer() cache.SharedIndexInformer
 	LocalPodInformer() cache.SharedIndexInformer
+
+	GetNode(name string) (*kapi.Node, error)
 }
 
 type Shutdownable interface {

--- a/go-controller/pkg/kube/annotator.go
+++ b/go-controller/pkg/kube/annotator.go
@@ -141,7 +141,7 @@ func (pa *podAnnotator) Delete(key string) {
 }
 
 func (pa *podAnnotator) Run() error {
-	annotations := make(map[string]string)
+	annotations := make(map[string]interface{})
 	pa.Lock()
 	defer pa.Unlock()
 	for k, act := range pa.changes {

--- a/go-controller/pkg/kube/annotator.go
+++ b/go-controller/pkg/kube/annotator.go
@@ -90,7 +90,7 @@ func (na *nodeAnnotator) Run() error {
 		return nil
 	}
 
-	return na.kube.SetAnnotationsOnNode(na.node, annotations)
+	return na.kube.SetAnnotationsOnNode(na.node.Name, annotations)
 }
 
 // NewPodAnnotator returns a new annotator for Pod objects

--- a/go-controller/pkg/kube/annotator.go
+++ b/go-controller/pkg/kube/annotator.go
@@ -211,7 +211,7 @@ func (na *namespaceAnnotator) Delete(key string) {
 }
 
 func (na *namespaceAnnotator) Run() error {
-	annotations := make(map[string]string)
+	annotations := make(map[string]interface{})
 	na.Lock()
 	defer na.Unlock()
 	for k, act := range na.changes {
@@ -230,5 +230,5 @@ func (na *namespaceAnnotator) Run() error {
 		return nil
 	}
 
-	return na.kube.SetAnnotationsOnNamespace(na.namespace, annotations)
+	return na.kube.SetAnnotationsOnNamespace(na.namespace.Name, annotations)
 }

--- a/go-controller/pkg/kube/annotator_test.go
+++ b/go-controller/pkg/kube/annotator_test.go
@@ -1,0 +1,107 @@
+package kube
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/stretchr/testify/mock"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	kubeMocks "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube/mocks"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Annotator", func() {
+
+	Describe("Node annotator", func() {
+		Context("with annotation changes", func() {
+			const (
+				deleteKey string = "deleteKey"
+				nodeName  string = "TestNode"
+			)
+			initialAnnotations := map[string]string{"initialKey": "initialVal", deleteKey: "val"}
+			expectedAnnotations := map[string]interface{}{"key1": "val1", "key2": "val2", deleteKey: nil}
+
+			fakeClient := fake.NewSimpleClientset()
+			kube := &Kube{
+				KClient: fakeClient,
+			}
+			newNode := &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        nodeName,
+					Annotations: initialAnnotations,
+				},
+			}
+			node, err := kube.KClient.CoreV1().Nodes().Create(context.TODO(), newNode, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(node).NotTo(BeZero())
+
+			nodeAnnot := NewNodeAnnotator(kube, nodeName)
+
+			It("should not run if there are no changes", func() {
+				fakeKubeInterface := kubeMocks.KubeInterface{}
+				fakeKubeInterface.On("SetAnnotationsOnNode", mock.Anything, mock.Anything, mock.Anything).Return(fmt.Errorf("should not be called"))
+				nodeAnnot := NewNodeAnnotator(&fakeKubeInterface, "")
+				err := nodeAnnot.Run()
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("should successfully set/delete all provided annotations", func() {
+				for key, val := range expectedAnnotations {
+					if val != nil {
+						err := nodeAnnot.Set(key, val)
+						Expect(err).ToNot(HaveOccurred())
+					} else {
+						nodeAnnot.Delete(key)
+					}
+				}
+			})
+
+			It("should cache all provided annotations", func() {
+				for key := range expectedAnnotations {
+					_, ok := nodeAnnot.(*nodeAnnotator).changes[key]
+					Expect(ok).To(BeTrue())
+				}
+			})
+
+			It("should set the deleted key value to nil", func() {
+				val, ok := nodeAnnot.(*nodeAnnotator).changes[deleteKey]
+				Expect(ok).To(BeTrue())
+				Expect(val).To(BeNil())
+			})
+
+			It("should update nodes annotations", func() {
+				err := nodeAnnot.Run()
+				Expect(err).ToNot(HaveOccurred())
+
+				node, err := kube.GetNode(nodeName)
+				Expect(err).ToNot(HaveOccurred())
+
+				// should contain initial annotations
+				// deleteKey annotation should not exist
+				for key, val := range initialAnnotations {
+					if key != deleteKey {
+						Expect(node.Annotations[key]).To(Equal(val))
+					} else {
+						_, ok := node.Annotations[key]
+						Expect(ok).To(BeFalse())
+					}
+				}
+
+				// should contain new annotations
+				for key, val := range expectedAnnotations {
+					if key != deleteKey {
+						Expect(node.Annotations[key]).To(Equal(val))
+					} else {
+						_, ok := node.Annotations[key]
+						Expect(ok).To(BeFalse())
+					}
+				}
+			})
+		})
+	})
+})

--- a/go-controller/pkg/kube/kube.go
+++ b/go-controller/pkg/kube/kube.go
@@ -22,7 +22,7 @@ import (
 // Interface represents the exported methods for dealing with getting/setting
 // kubernetes resources
 type Interface interface {
-	SetAnnotationsOnPod(namespace, podName string, annotations map[string]string) error
+	SetAnnotationsOnPod(namespace, podName string, annotations map[string]interface{}) error
 	SetAnnotationsOnNode(nodeName string, annotations map[string]interface{}) error
 	SetAnnotationsOnNamespace(namespaceName string, annotations map[string]interface{}) error
 	SetTaintOnNode(nodeName string, taint *kapi.Taint) error
@@ -52,7 +52,7 @@ type Kube struct {
 }
 
 // SetAnnotationsOnPod takes the pod object and map of key/value string pairs to set as annotations
-func (k *Kube) SetAnnotationsOnPod(namespace, podName string, annotations map[string]string) error {
+func (k *Kube) SetAnnotationsOnPod(namespace, podName string, annotations map[string]interface{}) error {
 	var err error
 	var patchData []byte
 	patch := struct {

--- a/go-controller/pkg/kube/kube.go
+++ b/go-controller/pkg/kube/kube.go
@@ -23,7 +23,7 @@ import (
 // kubernetes resources
 type Interface interface {
 	SetAnnotationsOnPod(namespace, podName string, annotations map[string]string) error
-	SetAnnotationsOnNode(node *kapi.Node, annotations map[string]interface{}) error
+	SetAnnotationsOnNode(nodeName string, annotations map[string]interface{}) error
 	SetAnnotationsOnNamespace(namespace *kapi.Namespace, annotations map[string]string) error
 	SetTaintOnNode(nodeName string, taint *kapi.Taint) error
 	RemoveTaintFromNode(nodeName string, taint *kapi.Taint) error
@@ -78,8 +78,8 @@ func (k *Kube) SetAnnotationsOnPod(namespace, podName string, annotations map[st
 	return err
 }
 
-// SetAnnotationsOnNode takes the node object and map of key/value string pairs to set as annotations
-func (k *Kube) SetAnnotationsOnNode(node *kapi.Node, annotations map[string]interface{}) error {
+// SetAnnotationsOnNode takes the node name and map of key/value string pairs to set as annotations
+func (k *Kube) SetAnnotationsOnNode(nodeName string, annotations map[string]interface{}) error {
 	var err error
 	var patchData []byte
 	patch := struct {
@@ -90,16 +90,16 @@ func (k *Kube) SetAnnotationsOnNode(node *kapi.Node, annotations map[string]inte
 		},
 	}
 
-	klog.Infof("Setting annotations %v on node %s", annotations, node.Name)
+	klog.Infof("Setting annotations %v on node %s", annotations, nodeName)
 	patchData, err = json.Marshal(&patch)
 	if err != nil {
-		klog.Errorf("Error in setting annotations on node %s: %v", node.Name, err)
+		klog.Errorf("Error in setting annotations on node %s: %v", nodeName, err)
 		return err
 	}
 
-	_, err = k.KClient.CoreV1().Nodes().Patch(context.TODO(), node.Name, types.MergePatchType, patchData, metav1.PatchOptions{})
+	_, err = k.KClient.CoreV1().Nodes().Patch(context.TODO(), nodeName, types.MergePatchType, patchData, metav1.PatchOptions{})
 	if err != nil {
-		klog.Errorf("Error in setting annotation on node %s: %v", node.Name, err)
+		klog.Errorf("Error in setting annotation on node %s: %v", nodeName, err)
 	}
 	return err
 }

--- a/go-controller/pkg/kube/kube.go
+++ b/go-controller/pkg/kube/kube.go
@@ -24,7 +24,7 @@ import (
 type Interface interface {
 	SetAnnotationsOnPod(namespace, podName string, annotations map[string]string) error
 	SetAnnotationsOnNode(nodeName string, annotations map[string]interface{}) error
-	SetAnnotationsOnNamespace(namespace *kapi.Namespace, annotations map[string]string) error
+	SetAnnotationsOnNamespace(namespaceName string, annotations map[string]interface{}) error
 	SetTaintOnNode(nodeName string, taint *kapi.Taint) error
 	RemoveTaintFromNode(nodeName string, taint *kapi.Taint) error
 	PatchNode(old, new *kapi.Node) error
@@ -104,8 +104,8 @@ func (k *Kube) SetAnnotationsOnNode(nodeName string, annotations map[string]inte
 	return err
 }
 
-// SetAnnotationsOnNamespace takes the namespace object and map of key/value string pairs to set as annotations
-func (k *Kube) SetAnnotationsOnNamespace(namespace *kapi.Namespace, annotations map[string]string) error {
+// SetAnnotationsOnNamespace takes the namespace name and map of key/value string pairs to set as annotations
+func (k *Kube) SetAnnotationsOnNamespace(namespaceName string, annotations map[string]interface{}) error {
 	var err error
 	var patchData []byte
 	patch := struct {
@@ -116,16 +116,16 @@ func (k *Kube) SetAnnotationsOnNamespace(namespace *kapi.Namespace, annotations 
 		},
 	}
 
-	klog.Infof("Setting annotations %v on namespace %s", annotations, namespace.Name)
+	klog.Infof("Setting annotations %v on namespace %s", annotations, namespaceName)
 	patchData, err = json.Marshal(&patch)
 	if err != nil {
-		klog.Errorf("Error in setting annotations on namespace %s: %v", namespace.Name, err)
+		klog.Errorf("Error in setting annotations on namespace %s: %v", namespaceName, err)
 		return err
 	}
 
-	_, err = k.KClient.CoreV1().Namespaces().Patch(context.TODO(), namespace.Name, types.MergePatchType, patchData, metav1.PatchOptions{})
+	_, err = k.KClient.CoreV1().Namespaces().Patch(context.TODO(), namespaceName, types.MergePatchType, patchData, metav1.PatchOptions{})
 	if err != nil {
-		klog.Errorf("Error in setting annotation on namespace %s: %v", namespace.Name, err)
+		klog.Errorf("Error in setting annotation on namespace %s: %v", namespaceName, err)
 	}
 	return err
 }

--- a/go-controller/pkg/kube/kube_test.go
+++ b/go-controller/pkg/kube/kube_test.go
@@ -163,10 +163,10 @@ var _ = Describe("Kube", func() {
 			})
 
 			Context("With adding additional annotations", func() {
-				var newAnnotations map[string]string
+				var newAnnotations map[string]interface{}
 
 				BeforeEach(func() {
-					newAnnotations = map[string]string{"foobar": "foobarfoobar", "foobarbaz": "foobarbazfoobarbaz"}
+					newAnnotations = map[string]interface{}{"foobar": "foobarfoobar", "foobarbaz": "foobarbazfoobarbaz"}
 
 					// update the annotations
 					err := kube.SetAnnotationsOnPod(pod.Namespace, pod.Name, newAnnotations)

--- a/go-controller/pkg/kube/mocks/Interface.go
+++ b/go-controller/pkg/kube/mocks/Interface.go
@@ -322,11 +322,11 @@ func (_m *KubeInterface) SetAnnotationsOnNode(nodeName string, annotations map[s
 }
 
 // SetAnnotationsOnPod provides a mock function with given fields: namespace, podName, annotations
-func (_m *KubeInterface) SetAnnotationsOnPod(namespace string, podName string, annotations map[string]string) error {
+func (_m *KubeInterface) SetAnnotationsOnPod(namespace string, podName string, annotations map[string]interface{}) error {
 	ret := _m.Called(namespace, podName, annotations)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string, string, map[string]string) error); ok {
+	if rf, ok := ret.Get(0).(func(string, string, map[string]interface{}) error); ok {
 		r0 = rf(namespace, podName, annotations)
 	} else {
 		r0 = ret.Error(0)

--- a/go-controller/pkg/kube/mocks/Interface.go
+++ b/go-controller/pkg/kube/mocks/Interface.go
@@ -293,13 +293,13 @@ func (_m *KubeInterface) RemoveTaintFromNode(nodeName string, taint *v1.Taint) e
 	return r0
 }
 
-// SetAnnotationsOnNamespace provides a mock function with given fields: namespace, annotations
-func (_m *KubeInterface) SetAnnotationsOnNamespace(namespace *v1.Namespace, annotations map[string]string) error {
-	ret := _m.Called(namespace, annotations)
+// SetAnnotationsOnNamespace provides a mock function with given fields: namespaceName, annotations
+func (_m *KubeInterface) SetAnnotationsOnNamespace(namespaceName string, annotations map[string]interface{}) error {
+	ret := _m.Called(namespaceName, annotations)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(*v1.Namespace, map[string]string) error); ok {
-		r0 = rf(namespace, annotations)
+	if rf, ok := ret.Get(0).(func(string, map[string]interface{}) error); ok {
+		r0 = rf(namespaceName, annotations)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/go-controller/pkg/kube/mocks/Interface.go
+++ b/go-controller/pkg/kube/mocks/Interface.go
@@ -307,13 +307,13 @@ func (_m *KubeInterface) SetAnnotationsOnNamespace(namespace *v1.Namespace, anno
 	return r0
 }
 
-// SetAnnotationsOnNode provides a mock function with given fields: node, annotations
-func (_m *KubeInterface) SetAnnotationsOnNode(node *v1.Node, annotations map[string]interface{}) error {
-	ret := _m.Called(node, annotations)
+// SetAnnotationsOnNode provides a mock function with given fields: nodeName, annotations
+func (_m *KubeInterface) SetAnnotationsOnNode(nodeName string, annotations map[string]interface{}) error {
+	ret := _m.Called(nodeName, annotations)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(*v1.Node, map[string]interface{}) error); ok {
-		r0 = rf(node, annotations)
+	if rf, ok := ret.Get(0).(func(string, map[string]interface{}) error); ok {
+		r0 = rf(nodeName, annotations)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/go-controller/pkg/node/gateway_init.go
+++ b/go-controller/pkg/node/gateway_init.go
@@ -207,7 +207,7 @@ func (n *OvnNode) initGateway(subnets []*net.IPNet, nodeAnnotator kube.Annotator
 		gw, err = newLocalGateway(n.name, subnets, gatewayNextHops, gatewayIntf, nodeAnnotator, n.recorder, managementPortConfig)
 	case config.GatewayModeShared:
 		klog.Info("Preparing Shared Gateway")
-		gw, err = newSharedGateway(n.name, subnets, gatewayNextHops, gatewayIntf, egressGWInterface, nodeAnnotator)
+		gw, err = newSharedGateway(n.name, subnets, gatewayNextHops, gatewayIntf, egressGWInterface, nodeAnnotator, n.Kube, managementPortConfig)
 	case config.GatewayModeDisabled:
 		var chassisID string
 		klog.Info("Gateway Mode is disabled")
@@ -231,10 +231,6 @@ func (n *OvnNode) initGateway(subnets []*net.IPNet, nodeAnnotator kube.Annotator
 	// value is nil. so, you cannot directly set the value to an interface and later check if
 	// value was nil by comparing the interface to nil. this is because if the value is `nil`,
 	// then the interface will still hold the type of the value being set.
-
-	if config.Gateway.Mode == config.GatewayModeShared {
-		gw.nodeIPManager = newAddressManager(nodeAnnotator, managementPortConfig)
-	}
 
 	if loadBalancerHealthChecker != nil {
 		gw.loadBalancerHealthChecker = loadBalancerHealthChecker

--- a/go-controller/pkg/node/gateway_init.go
+++ b/go-controller/pkg/node/gateway_init.go
@@ -207,7 +207,7 @@ func (n *OvnNode) initGateway(subnets []*net.IPNet, nodeAnnotator kube.Annotator
 		gw, err = newLocalGateway(n.name, subnets, gatewayNextHops, gatewayIntf, nodeAnnotator, n.recorder, managementPortConfig)
 	case config.GatewayModeShared:
 		klog.Info("Preparing Shared Gateway")
-		gw, err = newSharedGateway(n.name, subnets, gatewayNextHops, gatewayIntf, egressGWInterface, nodeAnnotator, n.Kube, managementPortConfig)
+		gw, err = newSharedGateway(n.name, subnets, gatewayNextHops, gatewayIntf, egressGWInterface, nodeAnnotator, n.Kube, managementPortConfig, n.watchFactory)
 	case config.GatewayModeDisabled:
 		var chassisID string
 		klog.Info("Gateway Mode is disabled")

--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -179,7 +179,7 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 
 		iptV4, iptV6 := util.SetFakeIPTablesHelpers()
 
-		nodeAnnotator := kube.NewNodeAnnotator(k, &existingNode)
+		nodeAnnotator := kube.NewNodeAnnotator(k, existingNode.Name)
 
 		err = util.SetNodeHostSubnetAnnotation(nodeAnnotator, ovntest.MustParseIPNets(nodeSubnet))
 		Expect(err).NotTo(HaveOccurred())
@@ -325,7 +325,7 @@ func localNetInterfaceTest(app *cli.App, testNS ns.NetNS,
 			},
 		)
 
-		nodeAnnotator := kube.NewNodeAnnotator(&kube.Kube{fakeOvnNode.fakeClient.KubeClient, &egressipfake.Clientset{}, &egressfirewallfake.Clientset{}}, &existingNode)
+		nodeAnnotator := kube.NewNodeAnnotator(&kube.Kube{fakeOvnNode.fakeClient.KubeClient, &egressipfake.Clientset{}, &egressfirewallfake.Clientset{}}, existingNode.Name)
 		err := util.SetNodeHostSubnetAnnotation(nodeAnnotator, subnets)
 		Expect(err).NotTo(HaveOccurred())
 		err = nodeAnnotator.Run()

--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -209,7 +209,7 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 			defer GinkgoRecover()
 
 			gatewayNextHops, gatewayIntf, err := getGatewayNextHops()
-			sharedGw, err := newSharedGateway(nodeName, ovntest.MustParseIPNets(nodeSubnet), gatewayNextHops, gatewayIntf, "", nodeAnnotator, k, &fakeMgmtPortConfig)
+			sharedGw, err := newSharedGateway(nodeName, ovntest.MustParseIPNets(nodeSubnet), gatewayNextHops, gatewayIntf, "", nodeAnnotator, k, &fakeMgmtPortConfig, wf)
 			Expect(err).NotTo(HaveOccurred())
 			err = sharedGw.Init(wf)
 			Expect(err).NotTo(HaveOccurred())

--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -156,6 +156,25 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 			Name: nodeName,
 		}}
 
+		_, nodeNet, err := net.ParseCIDR(nodeSubnet)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Make a fake MgmtPortConfig with only the fields we care about
+		fakeMgmtPortIPFamilyConfig := managementPortIPFamilyConfig{
+			ipt:        nil,
+			allSubnets: nil,
+			ifAddr:     nodeNet,
+			gwIP:       nodeNet.IP,
+		}
+
+		fakeMgmtPortConfig := managementPortConfig{
+			ifName:    nodeName,
+			link:      nil,
+			routerMAC: nil,
+			ipv4:      &fakeMgmtPortIPFamilyConfig,
+			ipv6:      nil,
+		}
+
 		kubeFakeClient := fake.NewSimpleClientset(&v1.NodeList{
 			Items: []v1.Node{existingNode},
 		})
@@ -190,7 +209,7 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 			defer GinkgoRecover()
 
 			gatewayNextHops, gatewayIntf, err := getGatewayNextHops()
-			sharedGw, err := newSharedGateway(nodeName, ovntest.MustParseIPNets(nodeSubnet), gatewayNextHops, gatewayIntf, "", nodeAnnotator)
+			sharedGw, err := newSharedGateway(nodeName, ovntest.MustParseIPNets(nodeSubnet), gatewayNextHops, gatewayIntf, "", nodeAnnotator, k, &fakeMgmtPortConfig)
 			Expect(err).NotTo(HaveOccurred())
 			err = sharedGw.Init(wf)
 			Expect(err).NotTo(HaveOccurred())

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -563,7 +563,8 @@ func setBridgeOfPorts(bridge *bridgeConfiguration) error {
 	return nil
 }
 
-func newSharedGateway(nodeName string, subnets []*net.IPNet, gwNextHops []net.IP, gwIntf, egressGWIntf string, nodeAnnotator kube.Annotator) (*gateway, error) {
+func newSharedGateway(nodeName string, subnets []*net.IPNet, gwNextHops []net.IP, gwIntf, egressGWIntf string, nodeAnnotator kube.Annotator,
+	kube kube.Interface, cfg *managementPortConfig) (*gateway, error) {
 	klog.Info("Creating new shared gateway")
 	gw := &gateway{}
 
@@ -627,6 +628,8 @@ func newSharedGateway(nodeName string, subnets []*net.IPNet, gwNextHops []net.IP
 		if err != nil {
 			return err
 		}
+
+		gw.nodeIPManager = newAddressManager(nodeName, kube, cfg)
 
 		if config.Gateway.NodeportEnable {
 			klog.Info("Creating Shared Gateway Node Port Watcher")

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/coreos/go-iptables/iptables"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
@@ -564,7 +565,7 @@ func setBridgeOfPorts(bridge *bridgeConfiguration) error {
 }
 
 func newSharedGateway(nodeName string, subnets []*net.IPNet, gwNextHops []net.IP, gwIntf, egressGWIntf string, nodeAnnotator kube.Annotator,
-	kube kube.Interface, cfg *managementPortConfig) (*gateway, error) {
+	kube kube.Interface, cfg *managementPortConfig, watchFactory factory.NodeWatchFactory) (*gateway, error) {
 	klog.Info("Creating new shared gateway")
 	gw := &gateway{}
 
@@ -629,7 +630,7 @@ func newSharedGateway(nodeName string, subnets []*net.IPNet, gwNextHops []net.IP
 			return err
 		}
 
-		gw.nodeIPManager = newAddressManager(nodeName, kube, cfg)
+		gw.nodeIPManager = newAddressManager(nodeName, kube, cfg, watchFactory)
 
 		if config.Gateway.NodeportEnable {
 			klog.Info("Creating Shared Gateway Node Port Watcher")

--- a/go-controller/pkg/node/management-port_linux_test.go
+++ b/go-controller/pkg/node/management-port_linux_test.go
@@ -132,7 +132,7 @@ func testManagementPort(ctx *cli.Context, fexec *ovntest.FakeExec, testNS ns.Net
 	_, err = config.InitConfig(ctx, fexec, nil)
 	Expect(err).NotTo(HaveOccurred())
 
-	nodeAnnotator := kube.NewNodeAnnotator(&kube.Kube{fakeClient, egressipv1fake.NewSimpleClientset(), &egressfirewallfake.Clientset{}}, &existingNode)
+	nodeAnnotator := kube.NewNodeAnnotator(&kube.Kube{fakeClient, egressipv1fake.NewSimpleClientset(), &egressfirewallfake.Clientset{}}, existingNode.Name)
 	waiter := newStartupWaiter()
 
 	err = testNS.Do(func(ns.NetNS) error {

--- a/go-controller/pkg/node/node.go
+++ b/go-controller/pkg/node/node.go
@@ -343,7 +343,7 @@ func (n *OvnNode) Start(wg *sync.WaitGroup) error {
 			return err
 		}
 
-		nodeAnnotator := kube.NewNodeAnnotator(n.Kube, node)
+		nodeAnnotator := kube.NewNodeAnnotator(n.Kube, node.Name)
 		waiter := newStartupWaiter()
 
 		// Initialize management port resources on the node

--- a/go-controller/pkg/node/node_smartnic.go
+++ b/go-controller/pkg/node/node_smartnic.go
@@ -160,7 +160,7 @@ func (n *OvnNode) addRepPort(pod *kapi.Pod, vfRepName string, ifInfo *cni.PodInt
 	// Update connection-status annotation
 	// TODO(adrianc): we should update Status in case of error as well
 	connStatus := util.SmartNICConnectionStatus{Status: util.SmartNicConnectionStatusReady, Reason: ""}
-	podAnnotator := kube.NewPodAnnotator(n.Kube, pod)
+	podAnnotator := kube.NewPodAnnotator(n.Kube, pod.Name, pod.Namespace)
 	err = connStatus.SetPodAnnotation(podAnnotator)
 	if err != nil {
 		// we should not get here

--- a/go-controller/pkg/node/node_smartnic_test.go
+++ b/go-controller/pkg/node/node_smartnic_test.go
@@ -269,7 +269,7 @@ var _ = Describe("Node Smart NIC tests", func() {
 			})
 
 			It("Sets smartnic-connection-status pod annotation on success", func() {
-				expectedAnnot := map[string]string{util.SmartNicConnetionStatusAnnot: `{"Status":"Ready"}`}
+				expectedAnnot := map[string]interface{}{util.SmartNicConnetionStatusAnnot: `{"Status":"Ready"}`}
 				netlinkOpsMock.On("LinkByName", vfRep).Return(vfLink, nil)
 				netlinkOpsMock.On("LinkSetMTU", vfLink, ifInfo.MTU).Return(nil)
 				netlinkOpsMock.On("LinkSetUp", vfLink).Return(nil)

--- a/go-controller/pkg/ovn/gateway_init.go
+++ b/go-controller/pkg/ovn/gateway_init.go
@@ -690,7 +690,7 @@ func (oc *Controller) addNodeLocalNatEntries(node *kapi.Node, mgmtPortMAC string
 		return fmt.Errorf("failed to marshal node %q annotation for node local NAT IP %s",
 			node.Name, externalIP.String())
 	}
-	err = oc.kube.SetAnnotationsOnNode(node, nodeAnnotations)
+	err = oc.kube.SetAnnotationsOnNode(node.Name, nodeAnnotations)
 	if err != nil {
 		return fmt.Errorf("failed to set node local NAT IP annotation on node %s: %v",
 			node.Name, err)

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -152,7 +152,7 @@ func (oc *Controller) upgradeToSingleSwitchOVNTopology(existingNodeList *kapi.No
 		existingNodes[node.Name] = true
 
 		// delete the obsoleted node-join-subnets annotation
-		err := oc.kube.SetAnnotationsOnNode(&node, map[string]interface{}{"k8s.ovn.org/node-join-subnets": nil})
+		err := oc.kube.SetAnnotationsOnNode(node.Name, map[string]interface{}{"k8s.ovn.org/node-join-subnets": nil})
 		if err != nil {
 			klog.Errorf("Failed to remove node-join-subnets annotation for node %s", node.Name)
 		}
@@ -860,7 +860,7 @@ func (oc *Controller) addNodeAnnotations(node *kapi.Node, hostSubnets []*net.IPN
 	// implementation where we can add the item back to the work queue when it fails to
 	// reconcile, we can get rid of the PollImmediate.
 	err = utilwait.PollImmediate(OvnNodeAnnotationRetryInterval, OvnNodeAnnotationRetryTimeout, func() (bool, error) {
-		err = oc.kube.SetAnnotationsOnNode(node, nodeAnnotations)
+		err = oc.kube.SetAnnotationsOnNode(node.Name, nodeAnnotations)
 		if err != nil {
 			klog.Warningf("Failed to set node annotation, will retry for: %v",
 				OvnNodeAnnotationRetryTimeout)

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -411,7 +411,7 @@ var _ = ginkgo.Describe("Master Operations", func() {
 			mockOVNSBClient := ovntest.NewMockOVNClient(goovn.DBSB)
 			lsp := "int-" + nodeName
 			populatePortAddresses(nodeName, lsp, hybMAC, hybIP, mockOVNNBClient)
-			nodeAnnotator := kube.NewNodeAnnotator(&kube.Kube{kubeFakeClient, egressIPFakeClient, egressFirewallFakeClient}, &testNode)
+			nodeAnnotator := kube.NewNodeAnnotator(&kube.Kube{kubeFakeClient, egressIPFakeClient, egressFirewallFakeClient}, testNode.Name)
 			err = util.SetL3GatewayConfig(nodeAnnotator, &util.L3GatewayConfig{Mode: config.GatewayModeDisabled})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			err = util.SetNodeManagementPortMACAddress(nodeAnnotator, ovntest.MustParseMAC(mgmtMAC))
@@ -515,7 +515,7 @@ var _ = ginkgo.Describe("Master Operations", func() {
 			mockOVNSBClient := ovntest.NewMockOVNClient(goovn.DBSB)
 			lsp := "int-" + nodeName
 			populatePortAddresses(nodeName, lsp, hybMAC, hybIP, mockOVNNBClient)
-			nodeAnnotator := kube.NewNodeAnnotator(&kube.Kube{kubeFakeClient, egressIPFakeClient, egressFirewallFakeClient}, &testNode)
+			nodeAnnotator := kube.NewNodeAnnotator(&kube.Kube{kubeFakeClient, egressIPFakeClient, egressFirewallFakeClient}, testNode.Name)
 			err = util.SetL3GatewayConfig(nodeAnnotator, &util.L3GatewayConfig{Mode: config.GatewayModeDisabled})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			err = util.SetNodeManagementPortMACAddress(nodeAnnotator, ovntest.MustParseMAC(mgmtMAC))
@@ -616,7 +616,7 @@ var _ = ginkgo.Describe("Master Operations", func() {
 			mockOVNSBClient := ovntest.NewMockOVNClient(goovn.DBSB)
 			lsp := "int-" + nodeName
 			populatePortAddresses(nodeName, lsp, hybMAC, hybIP, mockOVNNBClient)
-			nodeAnnotator := kube.NewNodeAnnotator(&kube.Kube{kubeFakeClient, egressIPFakeClient, egressFirewallFakeClient}, &testNode)
+			nodeAnnotator := kube.NewNodeAnnotator(&kube.Kube{kubeFakeClient, egressIPFakeClient, egressFirewallFakeClient}, testNode.Name)
 			err = util.SetL3GatewayConfig(nodeAnnotator, &util.L3GatewayConfig{Mode: config.GatewayModeDisabled})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			err = util.SetNodeManagementPortMACAddress(nodeAnnotator, ovntest.MustParseMAC(mgmtMAC))
@@ -775,7 +775,7 @@ subnet=%s
 			_, err = config.InitConfig(ctx, fexec, nil)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			nodeAnnotator := kube.NewNodeAnnotator(&kube.Kube{kubeFakeClient, egressIPFakeClient, egressFirewallFakeClient}, &masterNode)
+			nodeAnnotator := kube.NewNodeAnnotator(&kube.Kube{kubeFakeClient, egressIPFakeClient, egressFirewallFakeClient}, masterNode.Name)
 			err = util.SetL3GatewayConfig(nodeAnnotator, &util.L3GatewayConfig{Mode: config.GatewayModeDisabled})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			err = util.SetNodeManagementPortMACAddress(nodeAnnotator, ovntest.MustParseMAC(masterMgmtPortMAC))
@@ -912,7 +912,7 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 			_, err = config.InitConfig(ctx, fexec, nil)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			nodeAnnotator := kube.NewNodeAnnotator(&kube.Kube{kubeFakeClient, egressIPFakeClient, egressFirewallFakeClient}, &testNode)
+			nodeAnnotator := kube.NewNodeAnnotator(&kube.Kube{kubeFakeClient, egressIPFakeClient, egressFirewallFakeClient}, testNode.Name)
 			ifaceID := localnetBridgeName + "_" + nodeName
 			err = util.SetL3GatewayConfig(nodeAnnotator, &util.L3GatewayConfig{
 				Mode:           config.GatewayModeLocal,
@@ -1108,7 +1108,7 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 			_, err = config.InitConfig(ctx, fexec, nil)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			config.Kubernetes.HostNetworkNamespace = ""
-			nodeAnnotator := kube.NewNodeAnnotator(&kube.Kube{kubeFakeClient, egressIPFakeClient, egressFirewallFakeClient}, &testNode)
+			nodeAnnotator := kube.NewNodeAnnotator(&kube.Kube{kubeFakeClient, egressIPFakeClient, egressFirewallFakeClient}, testNode.Name)
 			ifaceID := node1.PhysicalBridgeName + "_" + node1.Name
 			vlanID := uint(1024)
 			err = util.SetL3GatewayConfig(nodeAnnotator, &util.L3GatewayConfig{

--- a/go-controller/pkg/ovn/namespace_test.go
+++ b/go-controller/pkg/ovn/namespace_test.go
@@ -209,7 +209,7 @@ var _ = ginkgo.Describe("OVN Namespace Operations", func() {
 				_, err := fakeClient.KubeClient.CoreV1().Nodes().Create(context.TODO(), &testNode, metav1.CreateOptions{})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-				nodeAnnotator := kube.NewNodeAnnotator(&kube.Kube{fakeClient.KubeClient, fakeClient.EgressIPClient, fakeClient.EgressFirewallClient}, &testNode)
+				nodeAnnotator := kube.NewNodeAnnotator(&kube.Kube{fakeClient.KubeClient, fakeClient.EgressIPClient, fakeClient.EgressFirewallClient}, testNode.Name)
 
 				ifaceID := node1.PhysicalBridgeName + "_" + node1.Name
 				vlanID := uint(1024)

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -379,7 +379,7 @@ func (oc *Controller) Run(wg *sync.WaitGroup, nodeName string) error {
 	if err != nil {
 		return fmt.Errorf("unable to get node: %s", nodeName)
 	}
-	err = oc.kube.SetAnnotationsOnNode(node, map[string]interface{}{ovntypes.OvnK8sTopoAnno: strconv.Itoa(ovntypes.OvnCurrentTopologyVersion)})
+	err = oc.kube.SetAnnotationsOnNode(node.Name, map[string]interface{}{ovntypes.OvnK8sTopoAnno: strconv.Itoa(ovntypes.OvnCurrentTopologyVersion)})
 	if err != nil {
 		return fmt.Errorf("failed to set topology annotation for node %s", node.Name)
 	}

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -925,7 +925,7 @@ func (oc *Controller) syncNodeGateway(node *kapi.Node, hostSubnets []*net.IPNet)
 		var hostAddrs sets.String
 		if config.Gateway.Mode == config.GatewayModeShared {
 			hostAddrs, err = util.ParseNodeHostAddresses(node)
-			if err != nil {
+			if err != nil && !util.IsAnnotationNotSetError(err) {
 				return fmt.Errorf("failed to get host addresses for node: %s: %v", node.Name, err)
 			}
 		}

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -478,7 +478,7 @@ func (oc *Controller) addLogicalPort(pod *kapi.Pod) (err error) {
 		if err != nil {
 			return err
 		}
-		var marshalledAnnotation map[string]string
+		var marshalledAnnotation map[string]interface{}
 		marshalledAnnotation, err = util.MarshalPodAnnotation(&podAnnotation)
 		if err != nil {
 			return fmt.Errorf("error creating pod network annotation: %v", err)

--- a/go-controller/pkg/util/pod_annotation.go
+++ b/go-controller/pkg/util/pod_annotation.go
@@ -87,7 +87,7 @@ type podRoute struct {
 
 // MarshalPodAnnotation returns a JSON-formatted annotation describing the pod's
 // network details
-func MarshalPodAnnotation(podInfo *PodAnnotation) (map[string]string, error) {
+func MarshalPodAnnotation(podInfo *PodAnnotation) (map[string]interface{}, error) {
 	pa := podAnnotation{
 		MAC: podInfo.MAC.String(),
 	}
@@ -129,7 +129,7 @@ func MarshalPodAnnotation(podInfo *PodAnnotation) (map[string]string, error) {
 		klog.Errorf("Failed marshaling podNetworks map %v", podNetworks)
 		return nil, err
 	}
-	return map[string]string{
+	return map[string]interface{}{
 		OvnPodAnnotationName: string(bytes),
 	}, nil
 }

--- a/go-controller/pkg/util/pod_annotation_unit_test.go
+++ b/go-controller/pkg/util/pod_annotation_unit_test.go
@@ -19,19 +19,19 @@ func TestMarshalPodAnnotation(t *testing.T) {
 		inpPodAnnot    PodAnnotation
 		errAssert      bool  // used when an error string CANNOT be matched or sub-matched
 		errMatch       error //used when an error string CAN be matched or sub-matched
-		expectedOutput map[string]string
+		expectedOutput map[string]interface{}
 	}{
 		{
 			desc:           "PodAnnotation instance with no fields set",
 			inpPodAnnot:    PodAnnotation{},
-			expectedOutput: map[string]string{"k8s.ovn.org/pod-networks": `{"default":{"ip_addresses":null,"mac_address":""}}`},
+			expectedOutput: map[string]interface{}{"k8s.ovn.org/pod-networks": `{"default":{"ip_addresses":null,"mac_address":""}}`},
 		},
 		{
 			desc: "single IP assigned to pod with MAC, Gateway, Routes NOT SPECIFIED",
 			inpPodAnnot: PodAnnotation{
 				IPs: []*net.IPNet{ovntest.MustParseIPNet("192.168.0.5/24")},
 			},
-			expectedOutput: map[string]string{"k8s.ovn.org/pod-networks": `{"default":{"ip_addresses":["192.168.0.5/24"],"mac_address":"","ip_address":"192.168.0.5/24"}}`},
+			expectedOutput: map[string]interface{}{"k8s.ovn.org/pod-networks": `{"default":{"ip_addresses":["192.168.0.5/24"],"mac_address":"","ip_address":"192.168.0.5/24"}}`},
 		},
 		{
 			desc: "multiple IPs assigned to pod with MAC, Gateway, Routes NOT SPECIFIED",
@@ -41,7 +41,7 @@ func TestMarshalPodAnnotation(t *testing.T) {
 					ovntest.MustParseIPNet("fd01::1234/64"),
 				},
 			},
-			expectedOutput: map[string]string{"k8s.ovn.org/pod-networks": `{"default":{"ip_addresses":["192.168.0.5/24","fd01::1234/64"],"mac_address":""}}`},
+			expectedOutput: map[string]interface{}{"k8s.ovn.org/pod-networks": `{"default":{"ip_addresses":["192.168.0.5/24","fd01::1234/64"],"mac_address":""}}`},
 		},
 		{
 			desc: "test code path when podInfo.Gateways count is equal to ONE",
@@ -51,7 +51,7 @@ func TestMarshalPodAnnotation(t *testing.T) {
 					net.ParseIP("192.168.0.1"),
 				},
 			},
-			expectedOutput: map[string]string{"k8s.ovn.org/pod-networks": `{"default":{"ip_addresses":["192.168.0.5/24"],"mac_address":"","gateway_ips":["192.168.0.1"],"ip_address":"192.168.0.5/24","gateway_ip":"192.168.0.1"}}`},
+			expectedOutput: map[string]interface{}{"k8s.ovn.org/pod-networks": `{"default":{"ip_addresses":["192.168.0.5/24"],"mac_address":"","gateway_ips":["192.168.0.1"],"ip_address":"192.168.0.5/24","gateway_ip":"192.168.0.1"}}`},
 		},
 		{
 			desc:     "verify error thrown when number of gateways greater than one for a single-stack network",
@@ -86,7 +86,7 @@ func TestMarshalPodAnnotation(t *testing.T) {
 					},
 				},
 			},
-			expectedOutput: map[string]string{"k8s.ovn.org/pod-networks": `{"default":{"ip_addresses":null,"mac_address":"","routes":[{"dest":"192.168.1.0/24","nextHop":"192.168.1.1"}]}}`},
+			expectedOutput: map[string]interface{}{"k8s.ovn.org/pod-networks": `{"default":{"ip_addresses":null,"mac_address":"","routes":[{"dest":"192.168.1.0/24","nextHop":"192.168.1.1"}]}}`},
 		},
 		{
 			desc: "next hop not set for route",
@@ -97,7 +97,7 @@ func TestMarshalPodAnnotation(t *testing.T) {
 					},
 				},
 			},
-			expectedOutput: map[string]string{"k8s.ovn.org/pod-networks": `{"default":{"ip_addresses":null,"mac_address":"","routes":[{"dest":"192.168.1.0/24","nextHop":""}]}}`},
+			expectedOutput: map[string]interface{}{"k8s.ovn.org/pod-networks": `{"default":{"ip_addresses":null,"mac_address":"","routes":[{"dest":"192.168.1.0/24","nextHop":""}]}}`},
 		},
 	}
 

--- a/go-controller/pkg/util/subnet_annotations_unit_test.go
+++ b/go-controller/pkg/util/subnet_annotations_unit_test.go
@@ -66,7 +66,7 @@ func TestCreateSubnetAnnotation(t *testing.T) {
 func TestSetSubnetAnnotation(t *testing.T) {
 	fakeClient := fake.NewSimpleClientset(&v1.NodeList{})
 	k := &kube.Kube{KClient: fakeClient}
-	testAnnotator := kube.NewNodeAnnotator(k, &v1.Node{})
+	testAnnotator := kube.NewNodeAnnotator(k, "")
 	tests := []struct {
 		desc             string
 		inpNodeAnnotator kube.Annotator
@@ -214,7 +214,7 @@ func TestCreateNodeHostSubnetAnnotation(t *testing.T) {
 func TestSetNodeHostSubnetAnnotation(t *testing.T) {
 	fakeClient := fake.NewSimpleClientset(&v1.NodeList{})
 	k := &kube.Kube{KClient: fakeClient}
-	testAnnotator := kube.NewNodeAnnotator(k, &v1.Node{})
+	testAnnotator := kube.NewNodeAnnotator(k, "")
 
 	tests := []struct {
 		desc             string
@@ -242,7 +242,7 @@ func TestSetNodeHostSubnetAnnotation(t *testing.T) {
 func TestDeleteNodeHostSubnetAnnotation(t *testing.T) {
 	fakeClient := fake.NewSimpleClientset(&v1.NodeList{})
 	k := &kube.Kube{KClient: fakeClient}
-	testAnnotator := kube.NewNodeAnnotator(k, &v1.Node{})
+	testAnnotator := kube.NewNodeAnnotator(k, "")
 
 	tests := []struct {
 		desc             string
@@ -324,7 +324,7 @@ func TestCreateNodeLocalNatAnnotation(t *testing.T) {
 func TestSetNodeLocalNatAnnotation(t *testing.T) {
 	fakeClient := fake.NewSimpleClientset(&v1.NodeList{})
 	k := &kube.Kube{KClient: fakeClient}
-	testAnnotator := kube.NewNodeAnnotator(k, &v1.Node{})
+	testAnnotator := kube.NewNodeAnnotator(k, "")
 	tests := []struct {
 		desc             string
 		inpNodeAnnotator kube.Annotator


### PR DESCRIPTION
This PR includes the fixed needed for bug 2022042, including its dependencies.

Needed commits were cherry picked from trozet:fix_downstream_merge.
