### PR TITLE
Bug 2018398: [4.9z] findLegacyLBs to also include idling LBs

### DIFF
--- a/go-controller/pkg/ovn/controller/services/utils.go
+++ b/go-controller/pkg/ovn/controller/services/utils.go
@@ -82,6 +82,7 @@ func deleteServiceFromLegacyLBs(service *v1.Service) error {
 // This is any load balancer with one of the following external ID keys
 // - k8s-worker-lb-<proto>
 // - k8s-cluster-lb-<proto>
+// - k8s-idling-lb-<proto>
 // - <PROTO>_lb_gateway_router
 func findLegacyLBs() ([]ovnlb.CachedLB, error) {
 	lbCache, err := ovnlb.GetLBCache()
@@ -90,7 +91,7 @@ func findLegacyLBs() ([]ovnlb.CachedLB, error) {
 	}
 	lbs := lbCache.Find(nil)
 
-	legacyLBPattern := regexp.MustCompile(`(k8s-(worker|cluster)-lb-(tcp|udp|sctp)|(TCP|UDP|SCTP)_lb_gateway_router)`)
+	legacyLBPattern := regexp.MustCompile(`(k8s-(worker|cluster|idling)-lb-(tcp|udp|sctp)|(TCP|UDP|SCTP)_lb_gateway_router)`)
 
 	out := []ovnlb.CachedLB{}
 	for _, lb := range lbs {


### PR DESCRIPTION
This is a small fix for the changes done in https://github.com/ovn-org/ovn-kubernetes/pull/2294.
When upgrading to a codebase where there is a per-service load balancer, the
cleanup needs to also account for idling load balancers in the regex.

Signed-off-by: Flavio Fernandes <flaviof@redhat.com>
Co-Authored-By: Surya Seetharaman <suryaseetharaman.9@gmail.com>
(cherry picked from commit 727e162812bc7daafad899f925299f72883c5961)
