### PR TITLE
Bug 2024313: run RunDBChecker as goroutine

### DIFF
--- a/go-controller/cmd/ovndbchecker/ovndbchecker.go
+++ b/go-controller/cmd/ovndbchecker/ovndbchecker.go
@@ -187,7 +187,7 @@ func runOvnKubeDBChecker(ctx *cli.Context) error {
 	}
 
 	stopChan := make(chan struct{})
-	ovndbmanager.RunDBChecker(
+	go ovndbmanager.RunDBChecker(
 		&kube.Kube{
 			KClient:              ovnClientset.KubeClient,
 			EIPClient:            ovnClientset.EgressIPClient,


### PR DESCRIPTION
when the ovn-dbchecker was receiving a SIGTERM it would
catch it, but the channel never closed so it never
quits. Fix that.

Signed-off-by: Jamo Luhrsen <jluhrsen@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->