### PR TITLE
Bug 2009873: [4.10.0] Avoid stale annotations by re-subscribing to netlink

### DIFF
--- a/go-controller/pkg/factory/factory.go
+++ b/go-controller/pkg/factory/factory.go
@@ -247,11 +247,9 @@ func NewNodeWatchFactory(ovnClientset *util.OVNClientset, nodeName string) (*Wat
 		return nil, err
 	}
 
-	if config.HybridOverlay.Enabled {
-		wf.informers[nodeType], err = newInformer(nodeType, wf.iFactory.Core().V1().Nodes().Informer())
-		if err != nil {
-			return nil, err
-		}
+	wf.informers[nodeType], err = newInformer(nodeType, wf.iFactory.Core().V1().Nodes().Informer())
+	if err != nil {
+		return nil, err
 	}
 
 	return wf, nil

--- a/go-controller/pkg/factory/types.go
+++ b/go-controller/pkg/factory/types.go
@@ -45,6 +45,8 @@ type NodeWatchFactory interface {
 	NodeInformer() cache.SharedIndexInformer
 	LocalPodInformer() cache.SharedIndexInformer
 
+	GetNode(name string) (*kapi.Node, error)
+
 	GetService(namespace, name string) (*kapi.Service, error)
 	GetEndpoint(namespace, name string) (*kapi.Endpoints, error)
 }

--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -214,7 +214,7 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 
 			gatewayNextHops, gatewayIntf, err := getGatewayNextHops()
 			sharedGw, err := newSharedGateway(nodeName, ovntest.MustParseIPNets(nodeSubnet), gatewayNextHops, gatewayIntf, "", nil, nodeAnnotator, k,
-				&fakeMgmtPortConfig, nil)
+				&fakeMgmtPortConfig, wf)
 			Expect(err).NotTo(HaveOccurred())
 			err = sharedGw.Init(wf)
 			Expect(err).NotTo(HaveOccurred())

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -1138,7 +1138,7 @@ func newSharedGateway(nodeName string, subnets []*net.IPNet, gwNextHops []net.IP
 			return err
 		}
 
-		gw.nodeIPManager = newAddressManager(nodeName, kube, cfg)
+		gw.nodeIPManager = newAddressManager(nodeName, kube, cfg, watchFactory)
 
 		if config.Gateway.NodeportEnable {
 			klog.Info("Creating Shared Gateway Node Port Watcher")

--- a/go-controller/pkg/node/node_ip_handler_linux.go
+++ b/go-controller/pkg/node/node_ip_handler_linux.go
@@ -71,9 +71,8 @@ func (c *addressManager) Run(stopChan <-chan struct{}) {
 	var addrChan chan netlink.AddrUpdate
 	addrSubscribeOptions := netlink.AddrSubscribeOptions{
 		ErrorCallback: func(err error) {
-			klog.Errorf("Failed during AddrSubscribe callback: %v. Calling sync() explicitly", err)
-			// sync the manager with current addresses on the node
-			c.sync()
+			klog.Errorf("Failed during AddrSubscribe callback: %v", err)
+			// Note: Not calling sync() from here: it is redudant and unsafe when stopChan is closed.
 		},
 	}
 
@@ -210,7 +209,7 @@ func (c *addressManager) sync() {
 			continue
 		}
 		if !c.isValidNodeIP(ip) {
-			klog.V(5).Info("Skipping invalid IP address found on host: %s", ip.String())
+			klog.V(5).Infof("Skipping non-useable IP address for host: %s", ip.String())
 			continue
 		}
 		currAddresses.Insert(ip.String())


### PR DESCRIPTION
This PR includes the fixed needed for bug 2009873, including its dependencies.

Needed commits from trozet https://github.com/openshift/ovn-kubernetes/pull/834
