### PR TITLE
[4.9z] CARRY: addressManager should not call sync() from ErrorCallback

### DIFF
--- a/go-controller/pkg/node/node_ip_handler_linux.go
+++ b/go-controller/pkg/node/node_ip_handler_linux.go
@@ -71,9 +71,8 @@ func (c *addressManager) Run(stopChan <-chan struct{}) {
 	var addrChan chan netlink.AddrUpdate
 	addrSubscribeOptions := netlink.AddrSubscribeOptions{
 		ErrorCallback: func(err error) {
-			klog.Errorf("Failed during AddrSubscribe callback: %v. Calling sync() explicitly", err)
-			// sync the manager with current addresses on the node
-			c.sync()
+			klog.Errorf("Failed during AddrSubscribe callback: %v", err)
+			// Note: Not calling sync() from here: it is redudant and unsafe when stopChan is closed.
 		},
 	}
 
@@ -210,7 +209,7 @@ func (c *addressManager) sync() {
 			continue
 		}
 		if !c.isValidNodeIP(ip) {
-			klog.V(5).Info("Skipping invalid IP address found on host: %s", ip.String())
+			klog.V(5).Infof("Skipping non-useable IP address for host: %s", ip.String())
 			continue
 		}
 		currAddresses.Insert(ip.String())


### PR DESCRIPTION
Should ErrorCallback from addressManager take place after
stopChan is closed, it is not safe to call sync() because
c.watchFactory is no longer useable [1].

Fortunately, sync() is already called via subScribeFcn as
well as periodically, so removing it from ErrorCallback
is a simple way of resolving this case.

Also fixing a trivial formatting issue in sync() when doing
isValidNodeIP().

Fixes: https://github.com/ovn-org/ovn-kubernetes/pull/2657

[1]: https://github.com/ovn-org/ovn-kubernetes/runs/4267007250?check_suite_focus=true

I1119 17:12:47.755099   18058 node_ip_handler_linux.go:213] Skipping invalid IP address found on host: %s::1
I1119 17:12:47.755140   18058 node_ip_handler_linux.go:213] Skipping invalid IP address found on host: %sfe80::20d:3aff:fe8e:860c
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x48 pc=0x251de6c]

goroutine 85 [running]:
github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node.(*addressManager).doesNodeHostAddressesMatch(0xc000099590, 0xc0005e1b00)
	/home/runner/work/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/node_ip_handler_linux.go:157 +0xec
github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node.(*addressManager).sync(0xc000099590)
	/home/runner/work/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/node_ip_handler_linux.go:220 +0x8c5
github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node.(*addressManager).Run.func1(0x2d139e0, 0xc00031b4d0)
	/home/runner/work/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/node_ip_handler_linux.go:76 +0x165
github.com/vishvananda/netlink.addrSubscribeAt.func2(0xc000689980, 0xc0000495c0, 0xc00031af20)
	/home/runner/work/ovn-kubernetes/ovn-kubernetes/go-controller/vendor/github.com/vishvananda/netlink/addr_linux.go:360 +0x7ab
created by github.com/vishvananda/netlink.addrSubscribeAt
	/home/runner/work/ovn-kubernetes/ovn-kubernetes/go-controller/vendor/github.com/vishvananda/netlink/addr_linux.go:354 +0x130
make: *** [Makefile:46: check] Error 2
Error: Process completed with exit code 2.

Signed-off-by: Flavio Fernandes <flaviof@redhat.com>
(cherry picked from commit 7f0b1a65aa56d7a4201b9defefb535df6c130246)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->