### PR TITLE
Bug 2027873: [4.8z] Fixes race between node handler and pod sync

### DIFF
--- a/go-controller/pkg/ovn/logical_switch_manager/logical_switch_manager.go
+++ b/go-controller/pkg/ovn/logical_switch_manager/logical_switch_manager.go
@@ -160,11 +160,17 @@ func (manager *LogicalSwitchManager) GetSwitchSubnets(nodeName string) []*net.IP
 // AllocateIPs will block off IPs in the ipnets slice as already allocated
 // for a given switch
 func (manager *LogicalSwitchManager) AllocateIPs(nodeName string, ipnets []*net.IPNet) error {
+	if len(ipnets) == 0 {
+		return fmt.Errorf("unable to allocate empty IPs")
+	}
 	manager.RLock()
 	defer manager.RUnlock()
 	lsi, ok := manager.cache[nodeName]
-	if len(ipnets) == 0 || !ok || len(lsi.ipams) == 0 {
-		return fmt.Errorf("unable to allocate ips %v for node: %s",
+	if !ok {
+		return fmt.Errorf("unable to allocate ips: %v, node: %s does not exist in logical switch manager",
+			ipnets, nodeName)
+	} else if len(lsi.ipams) == 0 {
+		return fmt.Errorf("unable to allocate ips %v for node: %s. logical switch manager has no IPAM",
 			ipnets, nodeName)
 
 	}
@@ -190,7 +196,7 @@ func (manager *LogicalSwitchManager) AllocateIPs(nodeName string, ipnets []*net.
 			cidr := ipam.CIDR()
 			if cidr.Contains(ipnet.IP) {
 				if _, ok = allocated[idx]; ok {
-					err = fmt.Errorf("Error: attempt to reserve multiple IPs in the same IPAM instance")
+					err = fmt.Errorf("error attempting to reserve multiple IPs in the same IPAM instance")
 					return err
 				}
 				if err = ipam.Allocate(ipnet.IP); err != nil {

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -37,6 +37,10 @@ func (oc *Controller) syncPods(pods []interface{}) {
 		if util.PodScheduled(pod) && util.PodWantsNetwork(pod) && err == nil {
 			logicalPort := podLogicalPortName(pod)
 			expectedLogicalPorts[logicalPort] = true
+			if err = oc.waitForNodeLogicalSwitch(pod.Spec.NodeName); err != nil {
+				klog.Errorf("Failed to wait for node %s to be added to cache. IP allocation may fail!",
+					pod.Spec.NodeName)
+			}
 			if err = oc.lsManager.AllocateIPs(pod.Spec.NodeName, annotations.IPs); err != nil {
 				klog.Errorf("Couldn't allocate IPs: %s for pod: %s on node: %s"+
 					" error: %v", util.JoinIPNetIPs(annotations.IPs, " "), logicalPort,


### PR DESCRIPTION
With ovnkube-master start, we start up the node handler and then the pod
handler. When the pod sync is running, it attempts to pre-allocate all
of the already reserved IP addresses for pods. However, the IP
allocation in the sync depends on the logical switch manager being setup
for the node via the node add handler. There is no guarantee that the
node has been added by the time we pod sync, and thus we may up in a
situation where IP reservation for a pod in sync fails, and another pod
ends up getting that IP in a subsequent pod add event.

This commit adds a wait to ensure the node is in the cache before we try
to sync the pod and reserve its IP.

Signed-off-by: Tim Rozet <trozet@redhat.com>
(cherry picked from commit 2f8b9c1c3a4788aaba28d1abc4af43456c783086)
(cherry picked from commit 7740023242bcce8a38e9e0230b37d626f89b506a)

