### PR TITLE
[release-4.9] Bug 2028812: Modification of ClusterIPs shall trigger svc update

### DIFF
--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -172,10 +172,11 @@ func (npw *nodePortWatcher) UpdateService(old, new *kapi.Service) {
 	if reflect.DeepEqual(new.Spec.Ports, old.Spec.Ports) &&
 		reflect.DeepEqual(new.Spec.ExternalIPs, old.Spec.ExternalIPs) &&
 		reflect.DeepEqual(new.Spec.ClusterIP, old.Spec.ClusterIP) &&
+		reflect.DeepEqual(new.Spec.ClusterIPs, old.Spec.ClusterIPs) &&
 		reflect.DeepEqual(new.Spec.Type, old.Spec.Type) &&
 		reflect.DeepEqual(new.Status.LoadBalancer.Ingress, old.Status.LoadBalancer.Ingress) {
 		klog.V(5).Infof("Skipping service update for: %s as change does not apply to any of .Spec.Ports, "+
-			".Spec.ExternalIP, .Spec.ClusterIP, .Spec.Type, .Status.LoadBalancer.Ingress", new.Name)
+			".Spec.ExternalIP, .Spec.ClusterIP, .Spec.ClusterIPs, .Spec.Type, .Status.LoadBalancer.Ingress", new.Name)
 		return
 	}
 	needFlowSync := false


### PR DESCRIPTION
**- What this PR does and why is it needed**
When switching a service from SingleStack to DualStack, its ClusterIPs are updated. This change to ClusterIPs will now be detected and ovnkube will write IPv6 DNAT rules to the host. Before this fix, upgrading IPv4 only services to DualStack via a patch or oc edit would not trigger a service update. In 4.9, this affects both connections from outside the cluster as well as connections which are initialized from the node itself. 

**- Special notes for reviewers**
In 4.10, we have a very similar upstream bug, but due to changes in the code, one can actually curl the node port from the outside and hit the service through the OVN flows.
However, in both 4.9 and 4.10 alike, the ip6tables rules are not created. Thus, even in 4.10 it is not possible to curl the node's node port from the node itself after an upgrade of a service from singlestack to dualstack.
The 4.10 upstream bug is: https://github.com/ovn-org/ovn-kubernetes/issues/2700


**- How to verify it**
See the lengthy comment below in this pull request.


**- Description for the changelog**
When switching a service from SingleStack to DualStack, its
ClusterIPs are updated. This change to ClusterIPs will now be detected
and ovnkube will write IPv6 DNAT rules to the host.