### PR TITLE
Bug 2039516: Dockerfile: bump OVN to ovn21.12-21.12.0-25

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN yum install -y  \
 	yum clean all
 
 ARG ovsver=2.16.0-33.el8fdp
-ARG ovnver=21.12.0-24.el8fdp
+ARG ovnver=21.12.0-25.el8fdp
 
 RUN INSTALL_PKGS=" \
 	openssl python3-pyOpenSSL firewalld-filesystem \


### PR DESCRIPTION
Add the following relevant changes:

- ovn-controller: Add command debug/dump-lflow-conj-ids
- controller/pinctrl: improve packet-in debuggability
- ovn-trace: honor ct state in execute_ct_lb
- ovn-ctl: use user-provided control socket paths
- ovn-ctl: allow overriding the database pidfile path
- ovn-ctl: add RAFT election timer argument and pass to ovsdb-tool