### PR TITLE
Bug 2031012: Create iptables NAT rules also for loadbalancer services

### DIFF
--- a/go-controller/pkg/node/gateway_iptables.go
+++ b/go-controller/pkg/node/gateway_iptables.go
@@ -438,7 +438,15 @@ func getGatewayIPTRules(service *kapi.Service, svcHasLocalHostNetEndPnt bool) []
 				}
 			}
 		}
-		for _, externalIP := range service.Spec.ExternalIPs {
+		externalIPs := make([]string, 0, len(service.Spec.ExternalIPs)+len(service.Status.LoadBalancer.Ingress))
+		externalIPs = append(externalIPs, service.Spec.ExternalIPs...)
+		for _, ingress := range service.Status.LoadBalancer.Ingress {
+			if len(ingress.IP) > 0 {
+				externalIPs = append(externalIPs, ingress.IP)
+			}
+		}
+
+		for _, externalIP := range externalIPs {
 			err := util.ValidatePort(svcPort.Protocol, svcPort.Port)
 			if err != nil {
 				klog.Errorf("Skipping service: %s, invalid service port %v", svcPort.Name, err)

--- a/go-controller/pkg/node/gateway_localnet_linux_test.go
+++ b/go-controller/pkg/node/gateway_localnet_linux_test.go
@@ -516,6 +516,7 @@ var _ = Describe("Node Operations", func() {
 							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
 						},
 						"OVN-KUBE-EXTERNALIP": []string{
+							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Status.LoadBalancer.Ingress[0].IP, service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
 							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, externalIP, service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
 						},
 						"OVN-KUBE-SNAT-MGMTPORT": []string{},
@@ -589,6 +590,7 @@ var _ = Describe("Node Operations", func() {
 							fmt.Sprintf("-p TCP --dport %v -j RETURN", service.Spec.Ports[0].NodePort),
 						},
 						"OVN-KUBE-EXTERNALIP": []string{
+							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Status.LoadBalancer.Ingress[0].IP, service.Spec.Ports[0].Port, types.V4HostETPLocalMasqueradeIP, service.Spec.Ports[0].NodePort),
 							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, externalIP, service.Spec.Ports[0].Port, types.V4HostETPLocalMasqueradeIP, service.Spec.Ports[0].NodePort),
 						},
 					},
@@ -622,6 +624,7 @@ var _ = Describe("Node Operations", func() {
 				Expect(flows).To(Equal(expectedLBIngressFlows))
 				flows = fNPW.ofm.flowCache["External_namespace1_service1_1.1.1.1_8080"]
 				Expect(flows).To(Equal(expectedLBExternalIPFlows))
+
 				fakeOvnNode.shutdown()
 				return nil
 			}


### PR DESCRIPTION
When the traffic directed to a service of type loadbalancer reaches the nodes, it's not redirected to the service's cluster ips. This is implemented for services of externalip / nodeport, but not for loadbalancer services. All the other logic is in place.

This will enable the integration with metallb when the traffic reaches the node from an interface different from breth0.

Also, adjust unit tests related to loadbalancer to look only at LoadBalancer IPs. In that scenario, externalIPs are not set.


