### PR TITLE
Bug 2022536: Validate ExGW Cache and fix cache keys

### DIFF
--- a/go-controller/pkg/ovn/egressgw.go
+++ b/go-controller/pkg/ovn/egressgw.go
@@ -197,7 +197,7 @@ func (oc *Controller) addPodExternalGWForNamespace(namespace string, pod *kapi.P
 			pod.Namespace, pod.Name, namespace, err)
 	}
 
-	nsInfo.routingExternalPodGWs[pod.Name] = egress
+	nsInfo.routingExternalPodGWs[makePodGWKey(pod)] = egress
 	nsUnlock()
 
 	klog.Infof("Adding routes for external gateway pod: %s, next hops: %q, namespace: %s, bfd-enabled: %t",
@@ -351,19 +351,20 @@ func (oc *Controller) deletePodExternalGW(pod *kapi.Pod) {
 	klog.Infof("Deleting routes for external gateway pod: %s, for namespace(s) %s", pod.Name,
 		podRoutingNamespaceAnno)
 	for _, namespace := range strings.Split(podRoutingNamespaceAnno, ",") {
-		oc.deletePodGWRoutesForNamespace(pod.Name, namespace)
+		oc.deletePodGWRoutesForNamespace(pod, namespace)
 	}
 }
 
 // deletePodGwRoutesForNamespace handles deleting all routes in a namespace for a specific pod GW
-func (oc *Controller) deletePodGWRoutesForNamespace(pod, namespace string) {
+func (oc *Controller) deletePodGWRoutesForNamespace(pod *kapi.Pod, namespace string) {
 	nsInfo, nsUnlock := oc.getNamespaceLocked(namespace, false)
 	if nsInfo == nil {
 		return
 	}
+	podGWKey := makePodGWKey(pod)
 	// check if any gateways were stored for this pod
-	foundGws, ok := nsInfo.routingExternalPodGWs[pod]
-	delete(nsInfo.routingExternalPodGWs, pod)
+	foundGws, ok := nsInfo.routingExternalPodGWs[podGWKey]
+	delete(nsInfo.routingExternalPodGWs, podGWKey)
 	nsUnlock()
 
 	if !ok || len(foundGws.gws) == 0 {
@@ -1249,4 +1250,8 @@ func (oc *Controller) buildOVNECMPCache() map[string][]*ovnRoute {
 		}
 	}
 	return ovnRouteCache
+}
+
+func makePodGWKey(pod *kapi.Pod) string {
+	return fmt.Sprintf("%s_%s", pod.Namespace, pod.Name)
 }

--- a/go-controller/pkg/ovn/egressgw.go
+++ b/go-controller/pkg/ovn/egressgw.go
@@ -189,6 +189,14 @@ func (oc *Controller) addPodExternalGWForNamespace(namespace string, pod *kapi.P
 	if err != nil {
 		return fmt.Errorf("failed to ensure namespace locked: %v", err)
 	}
+	tmpPodGWs := oc.getRoutingPodGWs(nsInfo)
+	tmpPodGWs[pod.Name] = egress
+	if err = validateRoutingPodGWs(tmpPodGWs); err != nil {
+		nsUnlock()
+		return fmt.Errorf("unable to add pod: %s/%s as external gateway for namespace: %s, error: %v",
+			pod.Namespace, pod.Name, namespace, err)
+	}
+
 	nsInfo.routingExternalPodGWs[pod.Name] = egress
 	nsUnlock()
 

--- a/go-controller/pkg/ovn/namespace.go
+++ b/go-controller/pkg/ovn/namespace.go
@@ -14,6 +14,7 @@ import (
 
 	kapi "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
 )
 
@@ -61,12 +62,28 @@ func (oc *Controller) getRoutingExternalGWs(nsInfo *namespaceInfo) *gatewayInfo 
 	return &res
 }
 
-func (oc *Controller) getRoutingPodGWs(nsInfo *namespaceInfo) map[string]*gatewayInfo {
+// wrapper function to log if there are duplicate gateway IPs present in the cache
+func validateRoutingPodGWs(podGWs map[string]gatewayInfo) error {
+	// map to hold IP/podName
+	ipTracker := make(map[string]string)
+	for podName, gwInfo := range podGWs {
+		for _, gwIP := range gwInfo.gws {
+			if foundPod, ok := ipTracker[gwIP.String()]; ok {
+				return fmt.Errorf("duplicate IP found in ECMP Pod route cache! IP: %q, first pod: %q, second "+
+					"pod: %q", gwIP, podName, foundPod)
+			}
+			ipTracker[gwIP.String()] = podName
+		}
+	}
+	return nil
+}
+
+func (oc *Controller) getRoutingPodGWs(nsInfo *namespaceInfo) map[string]gatewayInfo {
 	// return a copy of the object so it can be handled without the
 	// namespace locked
-	res := make(map[string]*gatewayInfo)
+	res := make(map[string]gatewayInfo)
 	for k, v := range nsInfo.routingExternalPodGWs {
-		item := &gatewayInfo{
+		item := gatewayInfo{
 			bfdEnabled: v.bfdEnabled,
 			gws:        make([]net.IP, len(v.gws)),
 		}
@@ -78,7 +95,7 @@ func (oc *Controller) getRoutingPodGWs(nsInfo *namespaceInfo) map[string]*gatewa
 
 // addPodToNamespace adds the pod's IP to the namespace's address set and returns
 // pod's routing gateway info
-func (oc *Controller) addPodToNamespace(ns string, ips []*net.IPNet) (*gatewayInfo, map[string]*gatewayInfo, net.IP, error) {
+func (oc *Controller) addPodToNamespace(ns string, ips []*net.IPNet) (*gatewayInfo, map[string]gatewayInfo, net.IP, error) {
 	nsInfo, nsUnlock, err := oc.ensureNamespaceLocked(ns, true, nil)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to ensure namespace locked: %v", err)
@@ -168,11 +185,17 @@ func (oc *Controller) multicastDeleteNamespace(ns *kapi.Namespace, nsInfo *names
 
 func parseRoutingExternalGWAnnotation(annotation string) ([]net.IP, error) {
 	var routingExternalGWs []net.IP
+	ipTracker := sets.NewString()
 	for _, v := range strings.Split(annotation, ",") {
 		parsedAnnotation := net.ParseIP(v)
 		if parsedAnnotation == nil {
 			return nil, fmt.Errorf("could not parse routing external gw annotation value %s", v)
 		}
+		if ipTracker.Has(parsedAnnotation.String()) {
+			klog.Warningf("Duplicate IP detected in routing external gw annotation: %s", annotation)
+			continue
+		}
+		ipTracker.Insert(parsedAnnotation.String())
 		routingExternalGWs = append(routingExternalGWs, parsedAnnotation)
 	}
 	return routingExternalGWs, nil

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -92,6 +92,7 @@ type namespaceInfo struct {
 
 	// routingExternalPodGWs contains a map of all pods serving as exgws as well as their
 	// exgw IPs
+	// key is <namespace>_<pod name>
 	routingExternalPodGWs map[string]gatewayInfo
 
 	multicastEnabled bool

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -478,7 +478,7 @@ func (oc *Controller) addLogicalPort(pod *kapi.Pod) (err error) {
 	}
 
 	// if we have any external or pod Gateways, add routes
-	gateways := make([]*gatewayInfo, 0)
+	gateways := make([]*gatewayInfo, 0, len(routingExternalGWs.gws)+len(routingPodGWs))
 
 	if len(routingExternalGWs.gws) > 0 {
 		gateways = append(gateways, routingExternalGWs)

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -199,7 +199,7 @@ func (oc *Controller) waitForNodeLogicalSwitchInCache(nodeName string) error {
 }
 
 func (oc *Controller) addRoutesGatewayIP(pod *kapi.Pod, podAnnotation *util.PodAnnotation, nodeSubnets []*net.IPNet,
-	routingExternalGWs *gatewayInfo, routingPodGWs map[string]*gatewayInfo, hybridOverlayExternalGW net.IP) error {
+	routingExternalGWs *gatewayInfo, routingPodGWs map[string]gatewayInfo, hybridOverlayExternalGW net.IP) error {
 
 	// if there are other network attachments for the pod, then check if those network-attachment's
 	// annotation has default-route key. If present, then we need to skip adding default route for
@@ -485,7 +485,10 @@ func (oc *Controller) addLogicalPort(pod *kapi.Pod) (err error) {
 	}
 	for _, gw := range routingPodGWs {
 		if len(gw.gws) > 0 {
-			gateways = append(gateways, gw)
+			if err = validateRoutingPodGWs(routingPodGWs); err != nil {
+				klog.Error(err)
+			}
+			gateways = append(gateways, &gw)
 		} else {
 			klog.Warningf("Found routingPodGW with no gateways ip set for namespace %s", pod.Namespace)
 		}


### PR DESCRIPTION
Changes-Include:
1. Cache is now tracked with keys composed of namespace + pod name (rather than just pod name). This allows 2 exgws with the same name to serve the same namespace.
2. Validates user provided annotations do not have duplicate IPs.
3. Validates cache on pod create, so if there are duplicate IPs an error is logged.