### PR TITLE
Bug 2040357: Dockerfile: bump OVN to ovn-2021-21.12.0-11.el8fdp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN yum install -y  \
 	yum clean all
 
 ARG ovsver=2.16.0-33.el8fdp
-ARG ovnver=21.12.0-25.el8fdp
+ARG ovnver=21.12.0-11.el8fdp
 
 RUN INSTALL_PKGS=" \
 	openssl python3-pyOpenSSL firewalld-filesystem \
@@ -45,7 +45,7 @@ RUN INSTALL_PKGS=" \
 	" && \
 	yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False $INSTALL_PKGS && \
 	yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False "openvswitch2.16 = $ovsver" "openvswitch2.16-devel = $ovsver" "python3-openvswitch2.16 = $ovsver" "openvswitch2.16-ipsec = $ovsver" && \
-	yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False "ovn21.12 = $ovnver" "ovn21.12-central = $ovnver" "ovn21.12-host = $ovnver" "ovn21.12-vtep = $ovnver" && \
+	yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False "ovn-2021 = $ovnver" "ovn-2021-central = $ovnver" "ovn-2021-host = $ovnver" "ovn-2021-vtep = $ovnver" && \
 	yum clean all && rm -rf /var/cache/*
 
 RUN mkdir -p /var/run/openvswitch && \


### PR DESCRIPTION
Switches over to the ovn-2021 stream which will stay on
OVN 21.12 forever and be shared with other layered products.

(ovn21.12 was only a temporary stream for OCP 4.10 until
ovn-2021 jumped to OVN 21.12)

This update includes UBSan sanitizer fixes:

http://patchwork.ozlabs.org/project/ovn/list/?series=277507&archive=both&state=*
```
[ovs-dev,6/6] pinctrl: Avoid misaligned access to ovs_ra_msg
[ovs-dev,5/6] pinctrl: Avoid misaligned access to controller_event_opt_header
[ovs-dev,4/6] pinctrl: Ensure packet headers are properly aligned for ICMP errors
[ovs-dev,3/6] pinctrl: Ensure aligned accesses when processing DNS
[ovs-dev,2/6] pinctrl: Ensure no misaligned accesses for SCTP packets
[ovs-dev,1/6] pinctrl: Ensure proper alignment when using pinctrl_compose_ipv*()
```