### PR TITLE
Bug 2040594: Create iptables NAT rules also for loadbalancer services

### DIFF
--- a/go-controller/pkg/node/gateway_iptables.go
+++ b/go-controller/pkg/node/gateway_iptables.go
@@ -340,7 +340,15 @@ func getGatewayIPTRules(service *kapi.Service, gatewayIPs []string) []iptRule {
 				}
 			}
 		}
-		for _, externalIP := range service.Spec.ExternalIPs {
+		externalIPs := make([]string, 0, len(service.Spec.ExternalIPs)+len(service.Status.LoadBalancer.Ingress))
+		externalIPs = append(externalIPs, service.Spec.ExternalIPs...)
+		for _, ingress := range service.Status.LoadBalancer.Ingress {
+			if len(ingress.IP) > 0 {
+				externalIPs = append(externalIPs, ingress.IP)
+			}
+		}
+
+		for _, externalIP := range externalIPs {
 			err := util.ValidatePort(svcPort.Protocol, svcPort.Port)
 			if err != nil {
 				klog.Errorf("Skipping service: %s, invalid service port %v", svcPort.Name, err)


### PR DESCRIPTION
When the traffic directed to a service of type loadbalancer reaches the
nodes, it's not redirected to the service's cluster ips. This is
implemented for services of externalip / nodeport, but not for
loadbalancer services. All the other logic is in place.

This will enable the integration with metallb when the traffic reaches
the node from an interface different from breth0.

Also, adjust unit tests related to loadbalancer to look only at
LoadBalancer IPs. In that scenario, externalIPs are not set.