### PR TITLE
Bug 2017650: EF: Pull up switch names from cache

### DIFF
--- a/go-controller/pkg/libovsdbops/switch.go
+++ b/go-controller/pkg/libovsdbops/switch.go
@@ -105,6 +105,20 @@ func FindPerNodeJoinSwitches(nbClient libovsdbclient.Client) ([]nbdb.LogicalSwit
 	return switches, nil
 }
 
+func FindAllNodeLocalSwitches(nbClient libovsdbclient.Client) ([]nbdb.LogicalSwitch, error) {
+	// Find all node switches
+	nodeSwichLookupFcn := func(item *nbdb.LogicalSwitch) bool {
+		// Ignore external and Join switches(both legacy and current)
+		return !(strings.HasPrefix(item.Name, types.JoinSwitchPrefix) || item.Name == "join" || strings.HasPrefix(item.Name, types.ExternalSwitchPrefix))
+	}
+
+	switches, err := findSwitchesByPredicate(nbClient, nodeSwichLookupFcn)
+	if err != nil {
+		return nil, err
+	}
+	return switches, nil
+}
+
 func AddLoadBalancersToSwitchOps(nbClient libovsdbclient.Client, ops []libovsdb.Operation, lswitch *nbdb.LogicalSwitch, lbs ...*nbdb.LoadBalancer) ([]libovsdb.Operation, error) {
 	if ops == nil {
 		ops = []libovsdb.Operation{}

--- a/go-controller/pkg/ovn/egressfirewall.go
+++ b/go-controller/pkg/ovn/egressfirewall.go
@@ -343,12 +343,12 @@ func (oc *Controller) addEgressFirewallRules(ef *egressFirewall, hashedAddressSe
 func (oc *Controller) createEgressFirewallRules(priority int, match, action, externalID string) error {
 	logicalSwitches := []string{}
 	if config.Gateway.Mode == config.GatewayModeLocal {
-		nodes, err := oc.watchFactory.GetNodes()
+		nodeLocalSwitches, err := libovsdbops.FindAllNodeLocalSwitches(oc.nbClient)
 		if err != nil {
 			return fmt.Errorf("unable to setup egress firewall ACLs on cluster nodes, err: %v", err)
 		}
-		for _, node := range nodes {
-			logicalSwitches = append(logicalSwitches, node.Name)
+		for _, nodeLocalSwitch := range nodeLocalSwitches {
+			logicalSwitches = append(logicalSwitches, nodeLocalSwitch.Name)
 		}
 	} else {
 		logicalSwitches = append(logicalSwitches, types.OVNJoinSwitch)


### PR DESCRIPTION
While creating ACLs, we are using the
nodeNames as the switch names on which
the ACLs need to be created on. This
will break on hybrid-overlay mode
since not all nodes have the OVN
switches. Let's use the libovsdb cache.

Signed-off-by: Surya Seetharaman <suryaseetharaman.9@gmail.com>
(cherry picked from commit 649883e42ea31db907f013736eb8ca8cdcfaa94a)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->