### PR TITLE
Bug 2034577: Set l3GWConfig.mode correctly

### DIFF
--- a/go-controller/pkg/node/gateway.go
+++ b/go-controller/pkg/node/gateway.go
@@ -216,7 +216,7 @@ func gatewayInitInternal(nodeName, gwIntf, egressGatewayIntf string, subnets []*
 	}
 
 	l3GwConfig := util.L3GatewayConfig{
-		Mode:           config.GatewayModeShared,
+		Mode:           config.Gateway.Mode,
 		ChassisID:      chassisID,
 		InterfaceID:    gatewayBridge.interfaceID,
 		MACAddress:     gatewayBridge.macAddress,

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -897,7 +897,7 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 			ifaceID := node1.PhysicalBridgeName + "_" + node1.Name
 			vlanID := uint(1024)
 			l3Config := &util.L3GatewayConfig{
-				Mode:           config.GatewayModeShared,
+				Mode:           config.GatewayModeLocal,
 				ChassisID:      node1.SystemID,
 				InterfaceID:    ifaceID,
 				MACAddress:     ovntest.MustParseMAC(node1.PhysicalBridgeMAC),

--- a/go-controller/pkg/util/node_annotations.go
+++ b/go-controller/pkg/util/node_annotations.go
@@ -163,9 +163,6 @@ func (cfg *L3GatewayConfig) UnmarshalJSON(bytes []byte) error {
 		if err != nil {
 			return fmt.Errorf("bad 'vlan-id' value %q: %v", cfgjson.VLANID, err)
 		}
-		if cfg.Mode != config.GatewayModeShared && uint(vlanID64) != 0 {
-			return fmt.Errorf("vlan-id is supported only in shared gateway mode")
-		}
 		// VLANID is used for specifying TagRequest on the logical switch port
 		// connected to the external logical switch, NB DB specifies a maximum
 		// value on the TagRequest to 4095, hence validate this:

--- a/go-controller/pkg/util/node_annotations_unit_test.go
+++ b/go-controller/pkg/util/node_annotations_unit_test.go
@@ -113,10 +113,6 @@ func TestL3GatewayConfig_UnmarshalJSON(t *testing.T) {
 			inputParam: []byte(`{"mode":"shared","vlan-id":"A"}`),
 			errMatch:   fmt.Errorf("bad 'vlan-id' value"),
 		},
-		{desc: "error: test VLANID is supported only in shared gateway mode",
-			inputParam: []byte(`{"mode":"local","vlan-id":"223"}`),
-			errMatch:   fmt.Errorf("vlan-id is supported only in shared gateway mode"),
-		},
 		{
 			desc:       "success: test valid VLANID input",
 			inputParam: []byte(`{"mode":"shared","vlan-id":"223"}`),


### PR DESCRIPTION
The "mode" field in the l3gw annotation
actually denotes if there is a gateway
or not, and it means "have we created
an interface that we share with the node".
The value for this is always "shared" for
both local and shared modes and this is
confusing. Let's just update this with
the right mode.

We can also remove the check for modes
when checking vlan-id since both modes
support this.

Signed-off-by: Surya Seetharaman <suryaseetharaman.9@gmail.com>
(cherry picked from commit 7922e0687bae1d2c7ee869b88e08e520f36d11b8)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->