### PR TITLE
Bug 2042494: [4.9] Set the OVS port as transient

### DIFF
--- a/go-controller/pkg/cni/helper_linux.go
+++ b/go-controller/pkg/cni/helper_linux.go
@@ -271,9 +271,10 @@ func ConfigureOVS(ctx context.Context, namespace, podName, hostIfaceName string,
 	for i, ip := range ifInfo.IPs {
 		ipStrs[i] = ip.String()
 	}
-	// Add the new sandbox's OVS port
+	// Add the new sandbox's OVS port, tag the port as transient so stale
+	// pod ports are scrubbed on hard reboot
 	ovsArgs := []string{
-		"add-port", "br-int", hostIfaceName, "--", "set",
+		"add-port", "br-int", hostIfaceName, "other_config:transient=true", "--", "set",
 		"interface", hostIfaceName,
 		fmt.Sprintf("external_ids:attached_mac=%s", ifInfo.MAC),
 		fmt.Sprintf("external_ids:iface-id=%s", ifaceID),

--- a/go-controller/pkg/node/node_smartnic_test.go
+++ b/go-controller/pkg/node/node_smartnic_test.go
@@ -2,6 +2,7 @@ package node
 
 import (
 	"fmt"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/mock"
@@ -25,7 +26,7 @@ func genOVSFindCmd(table, column, condition string) string {
 }
 
 func genOVSAddPortCmd(hostIfaceName, ifaceID, mac, ip, sandboxID, podUID string) string {
-	return fmt.Sprintf("ovs-vsctl --timeout=30 add-port br-int %s -- set interface %s external_ids:attached_mac=%s "+
+	return fmt.Sprintf("ovs-vsctl --timeout=30 add-port br-int %s other_config:transient=true -- set interface %s external_ids:attached_mac=%s "+
 		"external_ids:iface-id=%s external_ids:iface-id-ver=%s external_ids:ip_addresses=%s external_ids:sandbox=%s",
 		hostIfaceName, hostIfaceName, mac, ifaceID, podUID, ip, sandboxID)
 }


### PR DESCRIPTION
Set the ovs port as transient rather than the
interface. This along with configuring
systemd with `DELETE_TRANSIENT_PORTS = yes`
will result in the dedicated systemd service
`Delete Transient Ports` to remove stale
ovs ports and accompanying interfaces following
a hard reboot.

Signed-off-by: astoycos <astoycos@redhat.com>
(cherry picked from commit 0a4ab4713ba69f6cae73ab7b7013c2627388861a)
