### PR TITLE
Clean up OWNERS a bit

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,12 +1,8 @@
 reviewers:
   - abhat
   - alexanderConstantinescu
-  - aojea
-  - danielmellado
-  - danwinship
   - dcbw
   - JacobTanenbaum
-  - rcarrillocruz
   - squeed
   - tssurya
   - trozet
@@ -16,7 +12,6 @@ approvers:
   - dcbw
   - knobunc
   - trozet
-  - rcarrillocruz
   - squeed
   - JacobTanenbaum
 


### PR DESCRIPTION
I keep getting assigned to review ovn-kubernetes PRs but I never actually review any of them, so I'm removing me from `reviewers`. Also, removing people who are no longer on the team...
