### PR TITLE
Bug 2031926: Shared gateway: Modification of ClusterIPs shall trigger svc update

### DIFF
--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -504,10 +504,11 @@ func delServiceRules(service *kapi.Service, npw *nodePortWatcher) {
 	delGatewayIptRules(service, false)
 }
 
-func serviceUpdateNeeded(old, new *kapi.Service) bool {
+func serviceUpdateNotNeeded(old, new *kapi.Service) bool {
 	return reflect.DeepEqual(new.Spec.Ports, old.Spec.Ports) &&
 		reflect.DeepEqual(new.Spec.ExternalIPs, old.Spec.ExternalIPs) &&
 		reflect.DeepEqual(new.Spec.ClusterIP, old.Spec.ClusterIP) &&
+		reflect.DeepEqual(new.Spec.ClusterIPs, old.Spec.ClusterIPs) &&
 		reflect.DeepEqual(new.Spec.Type, old.Spec.Type) &&
 		reflect.DeepEqual(new.Status.LoadBalancer.Ingress, old.Status.LoadBalancer.Ingress) &&
 		reflect.DeepEqual(new.Spec.ExternalTrafficPolicy, old.Spec.ExternalTrafficPolicy)
@@ -543,9 +544,9 @@ func (npw *nodePortWatcher) AddService(service *kapi.Service) {
 func (npw *nodePortWatcher) UpdateService(old, new *kapi.Service) {
 	name := ktypes.NamespacedName{Namespace: old.Namespace, Name: old.Name}
 
-	if serviceUpdateNeeded(old, new) {
+	if serviceUpdateNotNeeded(old, new) {
 		klog.V(5).Infof("Skipping service update for: %s as change does not apply to any of .Spec.Ports, "+
-			".Spec.ExternalIP, .Spec.ClusterIP, .Spec.Type, .Status.LoadBalancer.Ingress, .Spec.ExternalTrafficPolicy", new.Name)
+			".Spec.ExternalIP, .Spec.ClusterIP, .Spec.ClusterIPs, .Spec.Type, .Status.LoadBalancer.Ingress, .Spec.ExternalTrafficPolicy", new.Name)
 		return
 	}
 	// Update the service in svcConfig if we need to so that other handler
@@ -708,9 +709,9 @@ func (npwipt *nodePortWatcherIptables) AddService(service *kapi.Service) {
 }
 
 func (npwipt *nodePortWatcherIptables) UpdateService(old, new *kapi.Service) {
-	if serviceUpdateNeeded(old, new) {
+	if serviceUpdateNotNeeded(old, new) {
 		klog.V(5).Infof("Skipping service update for: %s as change does not apply to any of .Spec.Ports, "+
-			".Spec.ExternalIP, .Spec.ClusterIP, .Spec.Type, .Status.LoadBalancer.Ingress", new.Name)
+			".Spec.ExternalIP, .Spec.ClusterIP, .Spec.ClusterIPs, .Spec.Type, .Status.LoadBalancer.Ingress", new.Name)
 		return
 	}
 


### PR DESCRIPTION
When switching a service from SingleStack to DualStack, its
ClusterIPs are updated. This change to ClusterIPs will now be detected
and ovnkube will write IPv6 DNAT rules to the host.

Signed-off-by: Andreas Karis <ak.karis@gmail.com>
(cherry picked from commit aa63b983474f7f7d3a1d086198ba83b4404b2ca3)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->