### PR TITLE
Bug 2039253: avoid passing duplicate Flow endpoints to ovs-vsctl

### DIFF
--- a/go-controller/pkg/config/utils_test.go
+++ b/go-controller/pkg/config/utils_test.go
@@ -247,3 +247,27 @@ func TestParseFlowCollectors(t *testing.T) {
 		t.Errorf("parsed hostPorts returned unexpected results: %+v", hp)
 	}
 }
+
+func TestParseFlowCollectors_DeduplicateEntries(t *testing.T) {
+	hp, err := ParseFlowCollectors("10.0.0.2:3030,[1::1]:3333,10.0.0.2:3030,[1::1]:3333")
+	if err != nil {
+		t.Error("can't parse flowCollectors", err)
+	}
+	if len(hp) != 2 ||
+		hp[0].Host.String() != "10.0.0.2" || hp[0].Port != 3030 ||
+		hp[1].Host.String() != "1::1" || hp[1].Port != 3333 {
+		t.Errorf("parsed hostPorts returned unexpected results: %+v", hp)
+	}
+}
+
+func TestParseFlowCollectors_DeduplicateEquivalentEntries(t *testing.T) {
+	hp, err := ParseFlowCollectors(
+		"[fd00:1101:0000:0001:0000:0000:0000:0002]:1234,[fd00:1101:0000:0001::0002]:1234")
+	if err != nil {
+		t.Error("can't parse flowCollectors", err)
+	}
+	if len(hp) != 1 ||
+		hp[0].Host.String() != "fd00:1101:0:1::2" || hp[0].Port != 1234 {
+		t.Errorf("parsed hostPorts returned unexpected results: %+v", hp)
+	}
+}


### PR DESCRIPTION
Cherry-picking patch from the upstream repository: https://github.com/ovn-org/ovn-kubernetes/pull/2745

The ovnkube-node pod will fail if it receives a duplicate host:ip
for the Flow collector addresses. This commit removes the duplicate
flow collectors before forwarding to the ovs-vsctl command.

fixes #2039253

Reported-at: https://bugzilla.redhat.com/show_bug.cgi?id=2039253