### PR TITLE
Bug 2042001: Adds wait method for ovsdb operations that created named objects

### DIFF
--- a/go-controller/go.mod
+++ b/go-controller/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/onsi/gomega v1.14.0
 	github.com/openshift/api v0.0.0-20211201215911-5a82bae32e46
 	github.com/openshift/client-go v0.0.0-20211202194848-d3f186f2d366
-	github.com/ovn-org/libovsdb v0.6.1-0.20220124205349-71bfee870326
+	github.com/ovn-org/libovsdb v0.6.1-0.20220127023511-a619f0fd93be
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.11.0
 	github.com/spf13/afero v1.4.1

--- a/go-controller/go.sum
+++ b/go-controller/go.sum
@@ -356,6 +356,8 @@ github.com/ovn-org/libovsdb v0.6.1-0.20220124145117-91cb4186eaac h1:tMGFxsOz6GTU
 github.com/ovn-org/libovsdb v0.6.1-0.20220124145117-91cb4186eaac/go.mod h1:aLvY7gPs/vLyJXF+PpZzvWlR5LB4QNJvBYIQMskJLZk=
 github.com/ovn-org/libovsdb v0.6.1-0.20220124205349-71bfee870326 h1:UOTIIm6MHpSEu0i48BoTkyKT85YwugrmUADec5OVSe4=
 github.com/ovn-org/libovsdb v0.6.1-0.20220124205349-71bfee870326/go.mod h1:aLvY7gPs/vLyJXF+PpZzvWlR5LB4QNJvBYIQMskJLZk=
+github.com/ovn-org/libovsdb v0.6.1-0.20220127023511-a619f0fd93be h1:U8WVtNNTfBKj/5OE3uBe57oNJ+x5KSMl+3hM7iLSbdk=
+github.com/ovn-org/libovsdb v0.6.1-0.20220127023511-a619f0fd93be/go.mod h1:aLvY7gPs/vLyJXF+PpZzvWlR5LB4QNJvBYIQMskJLZk=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/go-controller/pkg/libovsdbops/acl.go
+++ b/go-controller/pkg/libovsdbops/acl.go
@@ -165,6 +165,8 @@ func createOrUpdateACLOps(nbClient libovsdbclient.Client, ops []libovsdb.Operati
 
 	// If ACL does not exist, create it
 	if err == libovsdbclient.ErrNotFound {
+		// FIXME(trozet): Wait method for ACL would need to use external_ids and name for matching
+		// external_ids matching will have a performance impact, so we should move to name ACLs uniquely
 		ensureACLUUID(acl)
 		op, err := nbClient.Create(acl)
 		if err != nil {

--- a/go-controller/pkg/libovsdbops/loadbalancer.go
+++ b/go-controller/pkg/libovsdbops/loadbalancer.go
@@ -105,6 +105,17 @@ func createOrUpdateLoadBalancerOps(nbClient libovsdbclient.Client, ops []libovsd
 
 	// If LoadBalancer does not exist, create it
 	if err == libovsdbclient.ErrNotFound {
+		timeout := types.OVSDBWaitTimeout
+		ops = append(ops, libovsdb.Operation{
+			Op:      libovsdb.OperationWait,
+			Timeout: &timeout,
+			Table:   "Load_Balancer",
+			Where:   []libovsdb.Condition{{Column: "name", Function: libovsdb.ConditionEqual, Value: lb.Name}},
+			Columns: []string{"name"},
+			Until:   "!=",
+			Rows:    []libovsdb.Row{{"name": lb.Name}},
+		})
+
 		ensureLoadBalancerUUID(lb)
 		op, err := nbClient.Create(lb)
 		if err != nil {

--- a/go-controller/pkg/libovsdbops/portgroup.go
+++ b/go-controller/pkg/libovsdbops/portgroup.go
@@ -65,6 +65,16 @@ func createOrUpdatePortGroupOps(nbClient libovsdbclient.Client, ops []libovsdb.O
 	}
 
 	if err == libovsdbclient.ErrNotFound {
+		timeout := types.OVSDBWaitTimeout
+		ops = append(ops, libovsdb.Operation{
+			Op:      libovsdb.OperationWait,
+			Timeout: &timeout,
+			Table:   "Port_Group",
+			Where:   []libovsdb.Condition{{Column: "name", Function: libovsdb.ConditionEqual, Value: pg.Name}},
+			Columns: []string{"name"},
+			Until:   "!=",
+			Rows:    []libovsdb.Row{{"name": pg.Name}},
+		})
 		op, err := nbClient.Create(pg)
 		if err != nil {
 			return nil, err

--- a/go-controller/pkg/libovsdbops/router.go
+++ b/go-controller/pkg/libovsdbops/router.go
@@ -314,6 +314,10 @@ func addOrUpdateNATToRouterOps(nbClient libovsdbclient.Client, ops []libovsdb.Op
 	if natIndex == -1 {
 		nat.UUID = BuildNamedUUID()
 
+		// FIXME(trozet): we cannot use the OVSDB wait method predicate here
+		// to avoid: https://bugzilla.redhat.com/show_bug.cgi?id=2042001
+		// NAT has no name field, and extIDS we currently set to nil.
+		// Need to update NAT's to use extIDs potentially and use wait method here
 		op, err := nbClient.Create(nat)
 		if err != nil {
 			return ops, fmt.Errorf("error creating NAT %s for logical router %s %#v : %v", nat.UUID, router.Name, *nat, err)

--- a/go-controller/pkg/libovsdbops/transact.go
+++ b/go-controller/pkg/libovsdbops/transact.go
@@ -56,8 +56,8 @@ func TransactAndCheck(c client.Client, ops []ovsdb.Operation) ([]ovsdb.Operation
 	return results, nil
 }
 
-// TransactAndCheckAndSetUUIDs transacts the given ops againts client and returns
-// results if no error ocurred or an error otherwise. It sets the real uuids for
+// TransactAndCheckAndSetUUIDs transacts the given ops against client and returns
+// results if no error occurred or an error otherwise. It sets the real uuids for
 // the passed models if they were inserted and have a named-uuid (as built by
 // BuildNamedUUID)
 func TransactAndCheckAndSetUUIDs(client client.Client, models interface{}, ops []ovsdb.Operation) ([]ovsdb.OperationResult, error) {

--- a/go-controller/pkg/ovn/address_set/address_set.go
+++ b/go-controller/pkg/ovn/address_set/address_set.go
@@ -103,15 +103,15 @@ func ensureOvnAddressSet(nbClient libovsdbclient.Client, name string) (*ovnAddre
 		hashName: hashedAddressSet(name),
 	}
 
-	addrset := &nbdb.AddressSet{Name: as.hashName, ExternalIDs: map[string]string{"name": name}}
+	addrSet := &nbdb.AddressSet{Name: as.hashName, ExternalIDs: map[string]string{"name": name}}
 	ctx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout)
 	defer cancel()
-	err := as.nbClient.Get(ctx, addrset)
+	err := as.nbClient.Get(ctx, addrSet)
 	if err != nil && err != libovsdbclient.ErrNotFound {
 		return nil, fmt.Errorf("ensuring address set %s failed: %+v", name, err)
 	}
 
-	if len(addrset.UUID) == 0 {
+	if len(addrSet.UUID) == 0 {
 		ops := make([]ovsdb.Operation, 0, 2)
 		timeout := types.OVSDBWaitTimeout
 		ops = append(ops, ovsdb.Operation{
@@ -123,30 +123,30 @@ func ensureOvnAddressSet(nbClient libovsdbclient.Client, name string) (*ovnAddre
 			Until:   "!=",
 			Rows:    []ovsdb.Row{{"name": name}},
 		})
-		//create the address_set with no IPs
-		op, err := as.nbClient.Create(&nbdb.AddressSet{
-			Name:        as.hashName,
-			ExternalIDs: map[string]string{"name": name},
-		})
+		// hack used to make TransactAndCheckAndSetUUIDs track the model correctly
+		addrSet.UUID = libovsdbops.BuildNamedUUID()
+		// create the address_set with no IPs
+		op, err := as.nbClient.Create(addrSet)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create address set %s (%v)",
 				name, err)
 		}
 		ops = append(ops, op...)
-		results, err := libovsdbops.TransactAndCheck(as.nbClient, ops)
+		results, err := libovsdbops.TransactAndCheckAndSetUUIDs(as.nbClient, addrSet, ops)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create address set %s (%v)",
 				name, err)
 		}
-		if len(results) == 1 {
-			as.uuid = results[0].UUID.GoUUID
-		} else {
+		as.uuid = addrSet.UUID
+
+		if len(as.uuid) == 0 {
 			//should never happen
-			return nil, fmt.Errorf("returned too many results from addressSet creation")
+			return nil, fmt.Errorf("ensureOvnAddressSet: empty UUID in address set %q, model: %#v, results: %#v",
+				name, *addrSet, results)
 		}
 	} else {
 		// if there is already an addressSet, reuse the addressSet and return it
-		as.uuid = addrset.UUID
+		as.uuid = addrSet.UUID
 	}
 
 	return as, nil
@@ -338,17 +338,16 @@ func newOvnAddressSet(nbClient libovsdbclient.Client, name string, ips []net.IP)
 		return nil, err
 	}
 
+	// Update address set IPs and external ID
+	addrSet.Addresses = uniqIPs
+	addrSet.ExternalIDs = map[string]string{"name": as.name}
+
 	if len(addrSet.UUID) > 0 {
 		// if there is already an addressSet, reuse the addressSet and set the IPs to the slice provided
 		as.uuid = addrSet.UUID
 		klog.V(5).Infof("New(%s) already exists; updating IPs", asDetail(as))
 
-		addrset := &nbdb.AddressSet{
-			UUID:        as.uuid,
-			Addresses:   uniqIPs,
-			ExternalIDs: map[string]string{"name": as.name},
-		}
-		ops, err := as.nbClient.Where(addrset).Update(addrset, &addrset.Addresses)
+		ops, err := as.nbClient.Where(addrSet).Update(addrSet, &addrSet.Addresses)
 		if err != nil {
 			return nil, err
 		}
@@ -358,26 +357,38 @@ func newOvnAddressSet(nbClient libovsdbclient.Client, name string, ips []net.IP)
 				name, err)
 		}
 	} else {
-		//create a new addressSet
-		ops, err := nbClient.Create(&nbdb.AddressSet{
-			Name:        as.hashName,
-			Addresses:   uniqIPs,
-			ExternalIDs: map[string]string{"name": as.name},
+		ops := make([]ovsdb.Operation, 0, 2)
+		timeout := types.OVSDBWaitTimeout
+		ops = append(ops, ovsdb.Operation{
+			Op:      ovsdb.OperationWait,
+			Timeout: &timeout,
+			Table:   "Address_Set",
+			Where:   []ovsdb.Condition{{Column: "name", Function: ovsdb.ConditionEqual, Value: name}},
+			Columns: []string{"name"},
+			Until:   "!=",
+			Rows:    []ovsdb.Row{{"name": name}},
 		})
+		if addrSet.UUID == "" {
+			// hack used to make TransactAndCheckAndSetUUIDs track the model correctly
+			addrSet.UUID = libovsdbops.BuildNamedUUID()
+		}
+		// create a new addressSet
+		op, err := nbClient.Create(addrSet)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create address set %s (%v)",
 				name, err)
 		}
-		results, err := libovsdbops.TransactAndCheck(nbClient, ops)
+		ops = append(ops, op...)
+		results, err := libovsdbops.TransactAndCheckAndSetUUIDs(nbClient, addrSet, ops)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create new address set %s (%v)",
 				name, err)
 		}
-		if len(results) == 1 {
-			as.uuid = results[0].UUID.GoUUID
-		} else {
-			//should never happen
-			return nil, fmt.Errorf("returned too many results from addressSet creation")
+		as.uuid = addrSet.UUID
+		if len(as.uuid) == 0 {
+			// should never happen
+			return nil, fmt.Errorf("newOVNAddressSet: empty UUID in address set %q, model: %#v,"+
+				" results: %#v", name, *addrSet, results)
 		}
 	}
 

--- a/go-controller/pkg/ovn/egressfirewall.go
+++ b/go-controller/pkg/ovn/egressfirewall.go
@@ -129,7 +129,12 @@ func (oc *Controller) syncEgressFirewall(egressFirewalls []interface{}) {
 		for i := range egressFirewallACLs {
 			egressFirewallACL := egressFirewallACLs[i]
 			egressFirewallACL.Direction = types.DirectionToLPort
+			aclName := ""
+			if egressFirewallACL.Name != nil {
+				aclName = *egressFirewallACL.Name
+			}
 			opModels = append(opModels, libovsdbops.OperationModel{
+				Name:  aclName,
 				Model: &egressFirewallACL,
 				OnModelUpdates: []interface{}{
 					&egressFirewallACL.Direction,
@@ -371,6 +376,7 @@ func (oc *Controller) createEgressFirewallRules(priority int, match, action, ext
 		switches = append(switches, &lsw)
 		opModels = append(opModels, []libovsdbops.OperationModel{
 			{
+				Name:           lsw.Name,
 				Model:          &lsw,
 				ModelPredicate: func(ls *nbdb.LogicalSwitch) bool { return ls.Name == lsn },
 				OnModelMutations: []interface{}{
@@ -382,8 +388,14 @@ func (oc *Controller) createEgressFirewallRules(priority int, match, action, ext
 		}...)
 	}
 
+	aclName := ""
+	if egressFirewallACL.Name != nil {
+		aclName = *egressFirewallACL.Name
+	}
+
 	opModels = append([]libovsdbops.OperationModel{
 		{
+			Name:           aclName,
 			Model:          egressFirewallACL,
 			ModelPredicate: func(acl *nbdb.ACL) bool { return libovsdbops.IsEquivalentACL(acl, egressFirewallACL) },
 			DoAfter: func() {

--- a/go-controller/pkg/ovn/egressgw.go
+++ b/go-controller/pkg/ovn/egressgw.go
@@ -295,6 +295,7 @@ func (oc *Controller) createBFDStaticRoute(bfdEnabled bool, gw net.IP, podIP, gr
 				}
 			},
 		}, {
+			Name:  logicalRouter.Name,
 			Model: &logicalRouter,
 			ModelPredicate: func(lr *nbdb.LogicalRouter) bool {
 				return lr.Name == gr
@@ -721,6 +722,7 @@ func (oc *Controller) addHybridRoutePolicyForPod(podIP net.IP, node string) erro
 				},
 			},
 			{
+				Name:           logicalRouter.Name,
 				Model:          &logicalRouter,
 				ModelPredicate: func(lr *nbdb.LogicalRouter) bool { return lr.Name == types.OVNClusterRouter },
 				OnModelMutations: []interface{}{

--- a/go-controller/pkg/ovn/egressip.go
+++ b/go-controller/pkg/ovn/egressip.go
@@ -1732,6 +1732,7 @@ func (e *egressIPController) createEgressReroutePolicy(filterOption, egressIPNam
 			},
 		},
 		{
+			Name:           logicalRouter.Name,
 			Model:          &logicalRouter,
 			ModelPredicate: func(lr *nbdb.LogicalRouter) bool { return lr.Name == types.OVNClusterRouter },
 			OnModelMutations: []interface{}{
@@ -2066,6 +2067,7 @@ func (oc *Controller) createLogicalRouterPolicy(match string, priority int) erro
 			},
 		},
 		{
+			Name:           logicalRouter.Name,
 			Model:          &logicalRouter,
 			ModelPredicate: func(lr *nbdb.LogicalRouter) bool { return lr.Name == types.OVNClusterRouter },
 			OnModelMutations: []interface{}{

--- a/go-controller/pkg/ovn/gateway_init.go
+++ b/go-controller/pkg/ovn/gateway_init.go
@@ -58,6 +58,7 @@ func (oc *Controller) gatewayInit(nodeName string, clusterIPSubnet []*net.IPNet,
 
 	opModels := []libovsdbops.OperationModel{
 		{
+			Name:           logicalRouter.Name,
 			Model:          &logicalRouter,
 			ModelPredicate: func(lr *nbdb.LogicalRouter) bool { return lr.Name == gatewayRouter },
 			OnModelUpdates: []interface{}{
@@ -117,6 +118,7 @@ func (oc *Controller) gatewayInit(nodeName string, clusterIPSubnet []*net.IPNet,
 			},
 		},
 		{
+			Name:           logicalSwitch.Name,
 			Model:          &logicalSwitch,
 			ModelPredicate: func(ls *nbdb.LogicalSwitch) bool { return ls.Name == types.OVNJoinSwitch },
 			OnModelMutations: []interface{}{
@@ -153,6 +155,7 @@ func (oc *Controller) gatewayInit(nodeName string, clusterIPSubnet []*net.IPNet,
 			},
 		},
 		{
+			Name:           logicalRouter.Name,
 			Model:          &logicalRouter,
 			ModelPredicate: func(lr *nbdb.LogicalRouter) bool { return lr.Name == gatewayRouter },
 			OnModelMutations: []interface{}{
@@ -204,6 +207,7 @@ func (oc *Controller) gatewayInit(nodeName string, clusterIPSubnet []*net.IPNet,
 				},
 			},
 			{
+				Name:           logicalRouter.Name,
 				Model:          &logicalRouter,
 				ModelPredicate: func(lr *nbdb.LogicalRouter) bool { return lr.Name == gatewayRouter },
 				OnModelMutations: []interface{}{
@@ -273,6 +277,7 @@ func (oc *Controller) gatewayInit(nodeName string, clusterIPSubnet []*net.IPNet,
 				},
 			},
 			{
+				Name:           logicalRouter.Name,
 				Model:          &logicalRouter,
 				ModelPredicate: func(lr *nbdb.LogicalRouter) bool { return lr.Name == gatewayRouter },
 				OnModelMutations: []interface{}{
@@ -314,6 +319,7 @@ func (oc *Controller) gatewayInit(nodeName string, clusterIPSubnet []*net.IPNet,
 				},
 			},
 			{
+				Name:           logicalRouter.Name,
 				Model:          &logicalRouter,
 				ModelPredicate: func(lr *nbdb.LogicalRouter) bool { return lr.Name == types.OVNClusterRouter },
 				OnModelMutations: []interface{}{
@@ -366,6 +372,7 @@ func (oc *Controller) gatewayInit(nodeName string, clusterIPSubnet []*net.IPNet,
 					},
 				},
 				{
+					Name:           logicalRouter.Name,
 					Model:          &logicalRouter,
 					ModelPredicate: func(lr *nbdb.LogicalRouter) bool { return lr.Name == types.OVNClusterRouter },
 					OnModelMutations: []interface{}{
@@ -486,6 +493,7 @@ func (oc *Controller) addExternalSwitch(prefix, interfaceID, nodeName, gatewayRo
 	}
 	opModels := []libovsdbops.OperationModel{
 		{
+			Name:           externalLogicalSwitch.Name,
 			Model:          &externalLogicalSwitch,
 			ModelPredicate: func(ls *nbdb.LogicalSwitch) bool { return ls.Name == externalSwitch },
 		},
@@ -524,6 +532,7 @@ func (oc *Controller) addExternalSwitch(prefix, interfaceID, nodeName, gatewayRo
 			},
 		},
 		{
+			Name:           externalLogicalSwitch.Name,
 			Model:          &externalLogicalSwitch,
 			ModelPredicate: func(ls *nbdb.LogicalSwitch) bool { return ls.Name == externalSwitch },
 			OnModelMutations: []interface{}{
@@ -567,6 +576,7 @@ func (oc *Controller) addExternalSwitch(prefix, interfaceID, nodeName, gatewayRo
 			},
 		},
 		{
+			Name:           logicalRouter.Name,
 			Model:          &logicalRouter,
 			ModelPredicate: func(lr *nbdb.LogicalRouter) bool { return lr.Name == gatewayRouter },
 			OnModelMutations: []interface{}{
@@ -603,6 +613,7 @@ func (oc *Controller) addExternalSwitch(prefix, interfaceID, nodeName, gatewayRo
 			},
 		},
 		{
+			Name:           externalLogicalSwitch.Name,
 			Model:          &externalLogicalSwitch,
 			ModelPredicate: func(ls *nbdb.LogicalSwitch) bool { return ls.Name == externalSwitch },
 			OnModelMutations: []interface{}{
@@ -771,6 +782,7 @@ func (oc *Controller) createPolicyBasedRoutes(match, priority, nexthops string) 
 			},
 		},
 		{
+			Name:           logicalRouter.Name,
 			Model:          &logicalRouter,
 			ModelPredicate: func(lr *nbdb.LogicalRouter) bool { return lr.Name == types.OVNClusterRouter },
 			OnModelMutations: []interface{}{

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -312,6 +312,7 @@ func (oc *Controller) StartClusterMaster(masterNodeName string) error {
 		// mention that field in OnModelUpdates or ModelPredicate.
 		opModels := []libovsdbops.OperationModel{
 			{
+				Name:  loadBalancerGroup.Name,
 				Model: &loadBalancerGroup,
 			},
 		}
@@ -364,6 +365,7 @@ func (oc *Controller) SetupMaster(masterNodeName string, existingNodeNames []str
 	}
 	opModels := []libovsdbops.OperationModel{
 		{
+			Name:           logicalRouter.Name,
 			Model:          &logicalRouter,
 			ModelPredicate: func(lr *nbdb.LogicalRouter) bool { return lr.Name == types.OVNClusterRouter },
 		},
@@ -426,6 +428,7 @@ func (oc *Controller) SetupMaster(masterNodeName string, existingNodeNames []str
 	}
 	opModels = []libovsdbops.OperationModel{
 		{
+			Name:           logicalSwitch.Name,
 			Model:          &logicalSwitch,
 			ModelPredicate: func(ls *nbdb.LogicalSwitch) bool { return ls.Name == types.OVNJoinSwitch },
 		},
@@ -475,6 +478,7 @@ func (oc *Controller) SetupMaster(masterNodeName string, existingNodeNames []str
 			},
 		},
 		{
+			Name:           logicalRouter.Name,
 			Model:          &logicalRouter,
 			ModelPredicate: func(lr *nbdb.LogicalRouter) bool { return lr.Name == types.OVNClusterRouter },
 			OnModelMutations: []interface{}{
@@ -504,6 +508,7 @@ func (oc *Controller) SetupMaster(masterNodeName string, existingNodeNames []str
 			},
 		},
 		{
+			Name:           logicalSwitch.Name,
 			Model:          &logicalSwitch,
 			ModelPredicate: func(ls *nbdb.LogicalSwitch) bool { return ls.Name == types.OVNJoinSwitch },
 			OnModelMutations: []interface{}{
@@ -538,6 +543,7 @@ func (oc *Controller) addNodeLogicalSwitchPort(logicalSwitchName, portName, port
 			},
 		},
 		{
+			Name:           logicalSwitch.Name,
 			Model:          &logicalSwitch,
 			ModelPredicate: func(ls *nbdb.LogicalSwitch) bool { return ls.Name == logicalSwitchName },
 			OnModelMutations: []interface{}{
@@ -605,6 +611,7 @@ func (oc *Controller) syncNodeManagementPort(node *kapi.Node, hostSubnets []*net
 					},
 				},
 				{
+					Name:           logicalRouter.Name,
 					Model:          &logicalRouter,
 					ModelPredicate: func(lr *nbdb.LogicalRouter) bool { return lr.Name == types.OVNClusterRouter },
 					OnModelMutations: []interface{}{
@@ -734,6 +741,7 @@ func (oc *Controller) syncNodeClusterRouterPort(node *kapi.Node, hostSubnets []*
 			},
 		},
 		{
+			Name:           logicalRouter.Name,
 			Model:          &logicalRouter,
 			ModelPredicate: func(lr *nbdb.LogicalRouter) bool { return lr.Name == types.OVNClusterRouter },
 			OnModelMutations: []interface{}{
@@ -757,6 +765,7 @@ func (oc *Controller) syncNodeClusterRouterPort(node *kapi.Node, hostSubnets []*
 
 	opModels = []libovsdbops.OperationModel{
 		{
+			Name:  gatewayChassis.Name,
 			Model: &gatewayChassis,
 			OnModelUpdates: []interface{}{
 				&gatewayChassis.ChassisName,
@@ -853,6 +862,7 @@ func (oc *Controller) ensureNodeLogicalNetwork(node *kapi.Node, hostSubnets []*n
 			},
 		},
 		{
+			Name:           logicalRouter.Name,
 			Model:          &logicalRouter,
 			ModelPredicate: func(lr *nbdb.LogicalRouter) bool { return lr.Name == types.OVNClusterRouter },
 			OnModelMutations: []interface{}{
@@ -861,6 +871,7 @@ func (oc *Controller) ensureNodeLogicalNetwork(node *kapi.Node, hostSubnets []*n
 			ErrNotFound: true,
 		},
 		{
+			Name:           logicalSwitch.Name,
 			Model:          &logicalSwitch,
 			ModelPredicate: func(ls *nbdb.LogicalSwitch) bool { return ls.Name == nodeName },
 			OnModelUpdates: []interface{}{
@@ -923,6 +934,7 @@ func (oc *Controller) ensureNodeLogicalNetwork(node *kapi.Node, hostSubnets []*n
 		// Create the Node's Logical Switch and set it's subnet
 		opModels = []libovsdbops.OperationModel{
 			{
+				Name:  logicalSwitch.Name,
 				Model: &logicalSwitch,
 				OnModelMutations: []interface{}{
 					&logicalSwitch.OtherConfig,

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -415,6 +415,7 @@ func (oc *Controller) Run(wg *sync.WaitGroup, nodeName string) error {
 		ExternalIDs: logicalRouterRes[0].ExternalIDs,
 	}
 	opModel := libovsdbops.OperationModel{
+		Name:           logicalRouter.Name,
 		Model:          &logicalRouter,
 		ModelPredicate: func(lr *nbdb.LogicalRouter) bool { return lr.Name == ovntypes.OVNClusterRouter },
 		OnModelUpdates: []interface{}{

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -558,6 +558,17 @@ func (oc *Controller) addLogicalPort(pod *kapi.Pod) (err error) {
 	// Save this index to be able to calculate the next index where lsp UUID will be present.
 	lspUUIDIndex := len(allOps)
 	if !lspExist {
+		timeout := ovntypes.OVSDBWaitTimeout
+		allOps = append(allOps, ovsdb.Operation{
+			Op:      ovsdb.OperationWait,
+			Timeout: &timeout,
+			Table:   "Logical_Switch_Port",
+			Where:   []ovsdb.Condition{{Column: "name", Function: ovsdb.ConditionEqual, Value: lsp.Name}},
+			Columns: []string{"name"},
+			Until:   "!=",
+			Rows:    []ovsdb.Row{{"name": lsp.Name}},
+		})
+
 		// create new logical switch port
 		ops, err := oc.nbClient.Create(lsp)
 		if err != nil {

--- a/go-controller/pkg/types/const.go
+++ b/go-controller/pkg/types/const.go
@@ -130,7 +130,8 @@ const (
 	ClusterPortGroupName    = "clusterPortGroup"
 	ClusterRtrPortGroupName = "clusterRtrPortGroup"
 
-	OVSDBTimeout = 10 * time.Second
+	OVSDBTimeout     = 10 * time.Second
+	OVSDBWaitTimeout = 0
 
 	ClusterLBGroupName = "clusterLBGroup"
 )

--- a/go-controller/pkg/util/util.go
+++ b/go-controller/pkg/util/util.go
@@ -297,6 +297,7 @@ func UpdateNodeSwitchExcludeIPs(nbClient libovsdbclient.Client, nodeName string,
 
 	opModels := []libovsdbops.OperationModel{
 		{
+			Name:           logicalSwitchDes.Name,
 			Model:          &logicalSwitchDes,
 			ModelPredicate: func(ls *nbdb.LogicalSwitch) bool { return ls.Name == nodeName },
 			OnModelMutations: []interface{}{

--- a/go-controller/vendor/github.com/ovn-org/libovsdb/ovsdb/notation.go
+++ b/go-controller/vendor/github.com/ovn-org/libovsdb/ovsdb/notation.go
@@ -35,7 +35,7 @@ type Operation struct {
 	Rows      []Row       `json:"rows,omitempty"`
 	Columns   []string    `json:"columns,omitempty"`
 	Mutations []Mutation  `json:"mutations,omitempty"`
-	Timeout   int         `json:"timeout,omitempty"`
+	Timeout   *int        `json:"timeout,omitempty"`
 	Where     []Condition `json:"where,omitempty"`
 	Until     string      `json:"until,omitempty"`
 	Durable   *bool       `json:"durable,omitempty"`

--- a/go-controller/vendor/modules.txt
+++ b/go-controller/vendor/modules.txt
@@ -183,7 +183,7 @@ github.com/openshift/client-go/cloudnetwork/informers/externalversions/cloudnetw
 github.com/openshift/client-go/cloudnetwork/informers/externalversions/cloudnetwork/v1
 github.com/openshift/client-go/cloudnetwork/informers/externalversions/internalinterfaces
 github.com/openshift/client-go/cloudnetwork/listers/cloudnetwork/v1
-# github.com/ovn-org/libovsdb v0.6.1-0.20220124205349-71bfee870326
+# github.com/ovn-org/libovsdb v0.6.1-0.20220127023511-a619f0fd93be
 github.com/ovn-org/libovsdb/cache
 github.com/ovn-org/libovsdb/client
 github.com/ovn-org/libovsdb/mapper


### PR DESCRIPTION
Due to a bug in OVSDB server where a single txn may become duplicated and cause multiple DB entries or txn failures, we add a wait method to every create operation where the resource has a unique name. This guards against OVSDB server from creating the duplicate db entry. 