### PR TITLE
WIP Bug 2042999: restart pod on non-retriable failures when deleting stale objects

### DIFF
--- a/go-controller/pkg/ovn/namespace.go
+++ b/go-controller/pkg/ovn/namespace.go
@@ -44,12 +44,12 @@ func (oc *Controller) syncNamespaces(namespaces []interface{}) {
 	err := oc.addressSetFactory.ProcessEachAddressSet(func(addrSetName, namespaceName, nameSuffix string) {
 		if nameSuffix == "" && !expectedNs[namespaceName] {
 			if err := oc.addressSetFactory.DestroyAddressSetInBackingStore(addrSetName); err != nil {
-				klog.Errorf(err.Error())
+				klog.Fatalf(err.Error())
 			}
 		}
 	})
 	if err != nil {
-		klog.Errorf("Error in syncing namespaces: %v", err)
+		klog.Fatalf("Error in syncing namespaces: %v", err)
 	}
 }
 

--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -135,18 +135,18 @@ func (oc *Controller) syncNetworkPolicies(networkPolicies []interface{}) {
 			stalePGs = append(stalePGs, hashedLocalPortGroup)
 			// delete the address sets for this old policy from OVN
 			if err := oc.addressSetFactory.DestroyAddressSetInBackingStore(addrSetName); err != nil {
-				klog.Errorf(err.Error())
+				klog.Fatalf(err.Error())
 			}
 		}
 	})
 	if err != nil {
-		klog.Errorf("Error in syncing network policies: %v", err)
+		klog.Fatalf("Error in syncing network policies: %v", err)
 	}
 
 	if len(stalePGs) > 0 {
 		err = libovsdbops.DeletePortGroups(oc.nbClient, stalePGs...)
 		if err != nil {
-			klog.Errorf("Error removing stale port groups %v: %v", stalePGs, err)
+			klog.Fatalf("Error removing stale port groups %v: %v", stalePGs, err)
 		}
 	}
 }


### PR DESCRIPTION
In cases where we currently miss doing retries for removal of stale
objects, it is best to restart the pod than simply log an error and
bring the pod up. This change is changing that behavior on functions
run early on the pod start up.

Signed-off-by: Flavio Fernandes <flaviof@redhat.com>