### PR TITLE
WIP [release-4.9] Bug 2047416: restart pod on non-retriable failures when deleting stale objects

### DIFF
--- a/go-controller/pkg/ovn/namespace.go
+++ b/go-controller/pkg/ovn/namespace.go
@@ -42,12 +42,12 @@ func (oc *Controller) syncNamespaces(namespaces []interface{}) {
 	err := oc.addressSetFactory.ProcessEachAddressSet(func(addrSetName, namespaceName, nameSuffix string) {
 		if nameSuffix == "" && !expectedNs[namespaceName] {
 			if err := oc.addressSetFactory.DestroyAddressSetInBackingStore(addrSetName); err != nil {
-				klog.Errorf(err.Error())
+				klog.Fatalf(err.Error())
 			}
 		}
 	})
 	if err != nil {
-		klog.Errorf("Error in syncing namespaces: %v", err)
+		klog.Fatalf("Error in syncing namespaces: %v", err)
 	}
 }
 

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -53,7 +53,7 @@ func (oc *Controller) syncPods(pods []interface{}) {
 	// get the list of logical ports from OVN
 	nodes, err := oc.watchFactory.GetNodes()
 	if err != nil {
-		klog.Errorf("Failed to get nodes")
+		klog.Fatalf("Failed to get nodes")
 		return
 	}
 	for _, n := range nodes {
@@ -75,12 +75,12 @@ func (oc *Controller) syncPods(pods []interface{}) {
 			klog.Infof("Stale logical port found: %s. This logical port will be deleted.", existingPort)
 			cmd, err := oc.ovnNBClient.LSPDel(existingPort)
 			if err != nil {
-				klog.Errorf("Error in getting the cmd to delete pod's logical port %s %v", existingPort, err)
+				klog.Fatalf("Error in getting the cmd to delete pod's logical port %s %v", existingPort, err)
 				continue
 			}
 			err = oc.ovnNBClient.Execute(cmd)
 			if err != nil {
-				klog.Errorf("Error deleting pod's logical port %s %v", existingPort, err)
+				klog.Fatalf("Error deleting pod's logical port %s %v", existingPort, err)
 				continue
 			}
 		}

--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -106,7 +106,7 @@ func (oc *Controller) syncNetworkPolicies(networkPolicies []interface{}) {
 			hashedLocalPortGroup := hashedPortGroup(portGroupName)
 			err := deletePortGroup(oc.ovnNBClient, hashedLocalPortGroup)
 			if err != nil {
-				klog.Errorf("%v", err)
+				klog.Fatalf("%v", err)
 			}
 
 			// delete the address sets for this old policy from OVN


### PR DESCRIPTION
In cases where we currently miss doing retries for removal of stale
objects, it is best to restart the pod than simply log an error and
bring the pod up. This change is changing that behavior on functions
run early on the pod start up.

Conflicts:
  go-controller/pkg/ovn/pods.go
  go-controller/pkg/ovn/policy.go

Signed-off-by: Flavio Fernandes <flaviof@redhat.com>
(cherry picked from commit 033cc76d0c1398b6e430d49e94b9a40efbc1f933)
