### PR TITLE
Bug 2056883: Revert "HACK: disable skip_snat for load balancers."

### DIFF
--- a/go-controller/pkg/ovn/loadbalancer/loadbalancer.go
+++ b/go-controller/pkg/ovn/loadbalancer/loadbalancer.go
@@ -173,11 +173,9 @@ func lbToColumns(lb *LB) []string {
 	}
 
 	skipSNAT := "false"
-	// HACK(cdc)
-	// re-enable when BZ 1995326 is fixed
-	//if lb.Opts.SkipSNAT {
-	//	skipSNAT = "true"
-	//}
+	if lb.Opts.SkipSNAT {
+		skipSNAT = "true"
+	}
 
 	// Session affinity
 	// If enabled, then bucket flows by 3-tuple (proto, srcip, dstip)


### PR DESCRIPTION
This reverts commit f30307618c4f7bf0a6797b7288647ab8543d499f.

This is no longer needed, now that https://bugzilla.redhat.com/show_bug.cgi?id=1995326 has landed.