### PR TITLE
Fix cache building used for removing stale egress IPs

### DIFF
--- a/go-controller/pkg/ovn/egressip.go
+++ b/go-controller/pkg/ovn/egressip.go
@@ -1138,9 +1138,13 @@ func (oc *Controller) generatePodIPCacheForEgressIP(eIPs []interface{}) (map[str
 				continue
 			}
 			for _, pod := range pods {
-				for _, podIP := range pod.Status.PodIPs {
-					ip := net.ParseIP(podIP.IP)
-					egressIPToPodIPCache[egressIP.Name].Insert(ip.String())
+				logicalPort, err := oc.logicalPortCache.get(util.GetLogicalPortName(pod.Namespace, pod.Name))
+				if err != nil {
+					klog.Errorf("Error getting logical port %s, err: %v", util.GetLogicalPortName(pod.Namespace, pod.Name), err)
+					continue
+				}
+				for _, ipNet := range logicalPort.ips {
+					egressIPToPodIPCache[egressIP.Name].Insert(ipNet.IP.String())
 				}
 			}
 		}


### PR DESCRIPTION
Instead of relying on kapi.Pod.Status.PodIPs use the same approach as addPodEgressIPAssignments
Upstream PR: https://github.com/ovn-org/ovn-kubernetes/pull/2783
Signed-off-by: Patryk Diak <pdiak@redhat.com>
(cherry picked from commit 8081e22f062635e088641fe2aad92f8600e0c902)