### PR TITLE
[release-4.9] Bug 2054139: Don't return err when annotation cannot be unmarshalled

### DIFF
--- a/go-controller/pkg/ovn/egressgw.go
+++ b/go-controller/pkg/ovn/egressgw.go
@@ -175,7 +175,9 @@ func (oc *Controller) addPodExternalGW(pod *kapi.Pod) error {
 
 	foundGws, err := getExGwPodIPs(pod)
 	if err != nil {
-		return err
+		klog.Errorf("Error getting exgw IPs for pod: %s, error: %v", pod.Name, err)
+		oc.recordPodEvent(err, pod)
+		return nil
 	}
 
 	// if we found any gateways then we need to update current pods routing in the relevant namespace
@@ -833,10 +835,9 @@ func getExGwPodIPs(gatewayPod *kapi.Pod) ([]net.IP, error) {
 			}
 		}
 	} else {
-		klog.Errorf("Ignoring pod %s as an external gateway candidate. Invalid combination "+
+		return nil, fmt.Errorf("ignoring pod %s as an external gateway candidate. Invalid combination "+
 			"of host network: %t and routing-network annotation: %s", gatewayPod.Name, gatewayPod.Spec.HostNetwork,
 			gatewayPod.Annotations[routingNetworkAnnotation])
-		return nil, nil
 	}
 	return foundGws, nil
 }


### PR DESCRIPTION
Signed-off-by: Surya Seetharaman <suryaseetharaman.9@gmail.com>
(cherry picked from commit 4c47ef946f07c25f9db272e076de003782e0e703)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->