### PR TITLE
[release-4.9] Bug 2054299: Lock the reassignment procedure during node deletion to avoid races

### DIFF
--- a/go-controller/pkg/ovn/egressip.go
+++ b/go-controller/pkg/ovn/egressip.go
@@ -663,6 +663,9 @@ func (oc *Controller) deleteEgressNode(egressNode *kapi.Node) error {
 	); err != nil {
 		klog.Errorf("Unable to remove GARP configuration on external logical switch port for egress node: %s, stdout: %s, stderr: %s, err: %v", egressNode.Name, stdout, stderr, err)
 	}
+
+	oc.eIPC.assignmentRetryMutex.Lock()
+	defer oc.eIPC.assignmentRetryMutex.Unlock()
 	egressIPs, err := oc.kube.GetEgressIPs()
 	if err != nil {
 		return fmt.Errorf("unable to list egressIPs, err: %v", err)


### PR DESCRIPTION
`deleteEgressNode` takes care of reassigning egress IPs that are hosted on that node when it gets deleted, becomes unreachable, the label `k8s.ovn.org/egress-assignable` gets removed.

It is possible that when `deleteEgressNode` takes a long time to reassign the egress ips another one is called(e.g node becomes unreachable and then `NotReady`).
Best case scenario the egressIP is reassigned twice, worst case the status doesn't get updated properly or the egress IP is not correctly assigned.

**I do not think that this change brings any deadlock potential as this approach is already used in `addEgressNode`, nevertheless it would be good to focus on that while reviewing the change.**

I was able to reproduce the bug and verify the fix by creating 400 pods that match the egress IP assigned to `node` and then run:
```
# make the node offline for egressip
oc debug node/$node -- chroot host iptables -A INPUT -i ovn-k8s-mp0 -p tcp --destination-port 9 -j DROP
#wait for egress IP to start reassigning
sleep 5s
#remove the node from egress IP pool
oc label nodes $node k8s.ovn.org/egress-assignable-
```
Signed-off-by: Patryk Diak <pdiak@redhat.com>