### PR TITLE
[release-4.8] Bug 2054225: Fix gateway routers answer ARP/NDP requests for LoadBalancer/ExternalIP services

### DIFF
--- a/go-controller/pkg/util/ovs.go
+++ b/go-controller/pkg/util/ovs.go
@@ -727,6 +727,31 @@ func ReplaceOFFlows(bridgeName string, flows []string) (string, string, error) {
 	return strings.Trim(stdout.String(), "\" \n"), stderr.String(), err
 }
 
+// Get OpenFlow Port names or numbers for a given bridge
+func GetOpenFlowPorts(bridgeName string, namedPorts bool) ([]string, error) {
+	stdout, stderr, err := RunOVSOfctl("show", bridgeName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get list of ports on bridge %q:, stderr: %q, error: %v",
+			bridgeName, stderr, err)
+	}
+
+	index := 0
+	if namedPorts {
+		index = 1
+	}
+	var ports []string
+	re := regexp.MustCompile("[(|)]")
+	for _, line := range strings.Split(stdout, "\n") {
+		if strings.Contains(line, "addr:") {
+			port := strings.TrimSpace(
+				re.Split(line, -1)[index],
+			)
+			ports = append(ports, port)
+		}
+	}
+	return ports, nil
+}
+
 // GetOvnRunDir returns the OVN's rundir.
 func GetOvnRunDir() string {
 	return runner.ovnRunDir


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->
Backport of https://github.com/openshift/ovn-kubernetes/pull/952

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

~~~
commit 917d97ccc28cbfca9a44bd2eebe5b66f1cdd4ad9 (HEAD -> bz2054225, downstream-akaris/bz2054225)
Author: Ori Braunshtein <obraunsh@redhat.com>
Date:   Wed Oct 13 12:35:33 2021 +0300

    Neighbor solicitations and ARP requests used to hit all 3 OVN
    load-balancers in addition to the node local IP for ExternalIP.
    ARP requests or IPv6 NS would receive <node number + 1> replies.
    
    This fix stops ARP requests and IPv6 NS for ExternalIPs from entering
    the OVN dataplane. Only the node with the actual local IP will now
    answer to the NS or ARP request.
    
    Signed-off-by: Andreas Karis <ak.karis@gmail.com>
    (cherry picked from commit 91d37a667d041574f58e27b4aebbc0258a627816)
    (cherry picked from commit 1813ea577927fdfe9baa3bd07020f1a551f1d7cc)
    
    Conflicts:
            go-controller/pkg/node/gateway_shared_intf.go
    Due to absence of 2c0ec2337e590e2287c57f80975dadb79a9ad1cf in 4.8

commit 8b2409fd0990005548f168caecb513d4a66351f8
Author: Ori Braunshtein <obraunsh@redhat.com>
Date:   Thu Jul 29 16:27:55 2021 +0300

    Output address resolution requests to LOCAL port
    
    Currently address resolution requests (ARP/Neighbor solicitation) for
    LoadBalancer/External IPs are answered by all of the gateway routers in the cluster.
    By forwarding these requests to the local port, a network load balancer implementation
    like MetalLB is able to be the only one replying to them - thus enabling it
    to be the only one announcing a specific LoadBalancer service IP.
    
    Signed-off-by: Ori Braunshtein <obraunsh@redhat.com>
    (cherry picked from commit 5d546a0498dd0a55b80c05cfbcd60bf761581cc7)
    (cherry picked from commit bb4eeedfd6908de46cc996d51c24451de10f5856)
    
    Conflicts:
        go-controller/pkg/node/gateway_shared_intf.go
    Due to absence of 2c0ec2337e590e2287c57f80975dadb79a9ad1cf in 4.8
~~~


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->