### PR TITLE
Bug 2045577: Bump OVN to ovn-2021-21.12.0-15.el8fdp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN yum install -y  \
 	yum clean all
 
 ARG ovsver=2.16.0-33.el8fdp
-ARG ovnver=21.12.0-11.el8fdp
+ARG ovnver=21.12.0-15.el8fdp
 
 RUN INSTALL_PKGS=" \
 	openssl python3-pyOpenSSL firewalld-filesystem \


### PR DESCRIPTION
Fixes  [ovn-northd] Failure to reconcile duplicate SB Load Balancer entries.
https://bugzilla.redhat.com/show_bug.cgi?id=2046274

Signed-off-by: Tim Rozet <trozet@redhat.com>

