### PR TITLE
 [release-4.10] Bug 2054767: Fix cache building used for removing stale egress IPs 

### DIFF
--- a/go-controller/pkg/ovn/egressip.go
+++ b/go-controller/pkg/ovn/egressip.go
@@ -959,9 +959,13 @@ func (oc *Controller) generatePodIPCacheForEgressIP(eIPs []interface{}) (map[str
 				continue
 			}
 			for _, pod := range pods {
-				for _, podIP := range pod.Status.PodIPs {
-					ip := net.ParseIP(podIP.IP)
-					egressIPToPodIPCache[egressIP.Name].Insert(ip.String())
+				logicalPort, err := oc.logicalPortCache.get(util.GetLogicalPortName(pod.Namespace, pod.Name))
+				if err != nil {
+					klog.Errorf("Error getting logical port %s, err: %v", util.GetLogicalPortName(pod.Namespace, pod.Name), err)
+					continue
+				}
+				for _, ipNet := range logicalPort.ips {
+					egressIPToPodIPCache[egressIP.Name].Insert(ipNet.IP.String())
 				}
 			}
 		}


### PR DESCRIPTION
This is a backport of https://github.com/openshift/ovn-kubernetes/pull/947/commits/8081e22f062635e088641fe2aad92f8600e0c902

Signed-off-by: Patryk Diak <pdiak@redhat.com>
(cherry picked from commit 8081e22f062635e088641fe2aad92f8600e0c902)