### PR TITLE
[release-4.9] Bug 2055549: Fix podHandlerCache key

### DIFF
--- a/go-controller/pkg/ovn/egressip.go
+++ b/go-controller/pkg/ovn/egressip.go
@@ -92,9 +92,9 @@ func (oc *Controller) deleteEgressIP(eIP *egressipv1.EgressIP) error {
 		return err
 	}
 	for _, namespace := range namespaces.Items {
-		if pH, exists := oc.eIPC.podHandlerCache[getNamespaceKey(&namespace)]; exists {
+		if pH, exists := oc.eIPC.podHandlerCache[getPodHandlerKey(eIP, &namespace)]; exists {
 			oc.watchFactory.RemovePodHandler(pH)
-			delete(oc.eIPC.podHandlerCache, getNamespaceKey(&namespace))
+			delete(oc.eIPC.podHandlerCache, getPodHandlerKey(eIP, &namespace))
 		}
 		if err := oc.deleteNamespacePodsEgressIP(eIP, &namespace); err != nil {
 			return err
@@ -408,7 +408,7 @@ func (oc *Controller) addNamespaceEgressIP(eIP *egressipv1.EgressIP, namespace *
 	if err != nil {
 		return fmt.Errorf("invalid podSelector on EgressIP %s: %v", eIP.Name, err)
 	}
-	if _, exists := oc.eIPC.podHandlerCache[getNamespaceKey(namespace)]; !exists {
+	if _, exists := oc.eIPC.podHandlerCache[getPodHandlerKey(eIP, namespace)]; !exists {
 		h := oc.watchFactory.AddFilteredPodHandler(namespace.Name, sel,
 			cache.ResourceEventHandlerFuncs{
 				AddFunc: func(obj interface{}) {
@@ -443,9 +443,9 @@ func (oc *Controller) addNamespaceEgressIP(eIP *egressipv1.EgressIP, namespace *
 					}
 				},
 			}, nil)
-		oc.eIPC.podHandlerCache[getNamespaceKey(namespace)] = h
+		oc.eIPC.podHandlerCache[getPodHandlerKey(eIP, namespace)] = h
 	} else {
-		klog.Errorf("The pod handler cache for egress IPs is de-synchronized: a pod handler already exists for namespace: %s", getNamespaceKey(namespace))
+		klog.Errorf("The pod handler cache for egress IPs is de-synchronized: a pod handler already exists for: %s", getPodHandlerKey(eIP, namespace))
 	}
 	return nil
 }
@@ -453,9 +453,9 @@ func (oc *Controller) addNamespaceEgressIP(eIP *egressipv1.EgressIP, namespace *
 func (oc *Controller) deleteNamespaceEgressIP(eIP *egressipv1.EgressIP, namespace *kapi.Namespace) error {
 	oc.eIPC.podHandlerMutex.Lock()
 	defer oc.eIPC.podHandlerMutex.Unlock()
-	if pH, exists := oc.eIPC.podHandlerCache[getNamespaceKey(namespace)]; exists {
+	if pH, exists := oc.eIPC.podHandlerCache[getPodHandlerKey(eIP, namespace)]; exists {
 		oc.watchFactory.RemovePodHandler(pH)
-		delete(oc.eIPC.podHandlerCache, getNamespaceKey(namespace))
+		delete(oc.eIPC.podHandlerCache, getPodHandlerKey(eIP, namespace))
 	}
 	if err := oc.deleteNamespacePodsEgressIP(eIP, namespace); err != nil {
 		return err
@@ -1312,8 +1312,8 @@ func getEgressIPKey(eIP *egressipv1.EgressIP) string {
 	return eIP.Name
 }
 
-func getNamespaceKey(namespace *kapi.Namespace) string {
-	return namespace.Name
+func getPodHandlerKey(eIP *egressipv1.EgressIP, namespace *kapi.Namespace) string {
+	return fmt.Sprintf("%s_%s", namespace.Name, eIP.Name)
 }
 
 func getPodKey(pod *kapi.Pod) string {


### PR DESCRIPTION
Fix podHandlerCache key  to allow a scenario where multiple egress IPs match the same namespace

With podHandlerCache key being the namespace name it meant that there can be only one egress IP that matches a particular namespace.

Reproducer I used in kind:
```
apiVersion: k8s.ovn.org/v1
kind: EgressIP
metadata:
  name: egressip-1
spec:
  egressIPs:
  - 172.18.0.33
  namespaceSelector:
    matchLabels:
      name: test
  podSelector:
    matchLabels:
      name: test-1
---

apiVersion: k8s.ovn.org/v1
kind: EgressIP
metadata:
  name: egressip-2
spec:
  egressIPs:
  - 172.18.0.44
  namespaceSelector:
    matchLabels:
      name: test
  podSelector:
    matchLabels:
      name: test-2

```
Signed-off-by: Patryk Diak <pdiak@redhat.com>