### PR TITLE
[release-4.9] Bug 2055317: Hack ITP:preferLocal for DNS service

### DIFF
--- a/go-controller/pkg/ovn/controller/services/load_balancer_test.go
+++ b/go-controller/pkg/ovn/controller/services/load_balancer_test.go
@@ -1348,3 +1348,126 @@ func Test_buildPerNodeLBs(t *testing.T) {
 		})
 	}
 }
+
+// OCP hack begin
+func Test_buildPerNodeLBs_OCPHackForDNS(t *testing.T) {
+	oldClusterSubnet := globalconfig.Default.ClusterSubnets
+	oldGwMode := globalconfig.Gateway.Mode
+	defer func() {
+		globalconfig.Gateway.Mode = oldGwMode
+		globalconfig.Default.ClusterSubnets = oldClusterSubnet
+	}()
+	_, cidr4, _ := net.ParseCIDR("10.128.0.0/16")
+	_, cidr6, _ := net.ParseCIDR("fe00::/64")
+	globalconfig.Default.ClusterSubnets = []globalconfig.CIDRNetworkEntry{{cidr4, 26}, {cidr6, 26}}
+
+	name := "dns-default"
+	namespace := "openshift-dns"
+
+	defaultService := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: v1.ServiceSpec{
+			Type: v1.ServiceTypeClusterIP,
+		},
+	}
+
+	defaultNodes := []nodeInfo{
+		{
+			name:              "node-a",
+			nodeIPs:           []string{"10.0.0.1"},
+			gatewayRouterName: "gr-node-a",
+			switchName:        "switch-node-a",
+			podSubnets:        []net.IPNet{{IP: net.ParseIP("10.128.0.0"), Mask: net.CIDRMask(24, 32)}},
+		},
+		{
+			name:              "node-b",
+			nodeIPs:           []string{"10.0.0.2"},
+			gatewayRouterName: "gr-node-b",
+			switchName:        "switch-node-b",
+			podSubnets:        []net.IPNet{{IP: net.ParseIP("10.128.1.0"), Mask: net.CIDRMask(24, 32)}},
+		},
+	}
+
+	defaultExternalIDs := map[string]string{
+		"k8s.ovn.org/kind":  "Service",
+		"k8s.ovn.org/owner": fmt.Sprintf("%s/%s", namespace, name),
+	}
+
+	//defaultRouters := []string{"gr-node-a", "gr-node-b"}
+	//defaultSwitches := []string{"switch-node-a", "switch-node-b"}
+
+	tc := []struct {
+		name     string
+		service  *v1.Service
+		configs  []lbConfig
+		expected []ovnlb.LB
+	}{
+		{
+			name:    "clusterIP service, standard pods",
+			service: defaultService,
+			configs: []lbConfig{
+				{
+					vips:     []string{"192.168.1.1"},
+					protocol: v1.ProtocolTCP,
+					inport:   80,
+					eps: util.LbEndpoints{
+						V4IPs: []string{"10.128.0.2", "10.128.1.2"},
+						Port:  8080,
+					},
+				},
+			},
+			expected: []ovnlb.LB{
+				{
+					Name:        "Service_openshift-dns/dns-default_TCP_node_router_node-a_merged",
+					ExternalIDs: defaultExternalIDs,
+					Routers:     []string{"gr-node-a", "gr-node-b"},
+					Protocol:    "TCP",
+					Rules: []ovnlb.LBRule{
+						{
+							Source:  ovnlb.Addr{"192.168.1.1", 80},
+							Targets: []ovnlb.Addr{{"10.128.0.2", 8080}, {"10.128.1.2", 8080}},
+						},
+					},
+				},
+				{
+					Name:        "Service_openshift-dns/dns-default_TCP_node_switch_node-a",
+					ExternalIDs: defaultExternalIDs,
+					Switches:    []string{"switch-node-a"},
+					Protocol:    "TCP",
+					Rules: []ovnlb.LBRule{
+						{
+							Source:  ovnlb.Addr{"192.168.1.1", 80},
+							Targets: []ovnlb.Addr{{"10.128.0.2", 8080}},
+						},
+					},
+				},
+				{
+					Name:        "Service_openshift-dns/dns-default_TCP_node_switch_node-b",
+					ExternalIDs: defaultExternalIDs,
+					Switches:    []string{"switch-node-b"},
+					Protocol:    "TCP",
+					Rules: []ovnlb.LBRule{
+						{
+							Source:  ovnlb.Addr{"192.168.1.1", 80},
+							Targets: []ovnlb.Addr{{"10.128.1.2", 8080}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for i, tt := range tc {
+		t.Run(fmt.Sprintf("%d_%s", i, tt.name), func(t *testing.T) {
+
+			globalconfig.Gateway.Mode = globalconfig.GatewayModeShared
+			actual := buildPerNodeLBs(tt.service, tt.configs, defaultNodes)
+			assert.Equal(t, tt.expected, actual, "shared gateway mode not as expected")
+
+			globalconfig.Gateway.Mode = globalconfig.GatewayModeLocal
+			actual = buildPerNodeLBs(tt.service, tt.configs, defaultNodes)
+			assert.Equal(t, tt.expected, actual, "local gateway mode not as expected")
+		})
+	}
+}
+// OCP hack end


### PR DESCRIPTION
This PR does the equivalent of https://github.com/openshift/sdn/pull/261
for OVN-K. We can remove this hack when we support
ITP:preferLocal in the future.

Signed-off-by: Surya Seetharaman <suryaseetharaman.9@gmail.com>
(cherry picked from commit bfe85db278e75b89da01657630cd718ffa1310c3)

Conflicts:
  go-controller/pkg/ovn/controller/services/load_balancer.go
    just a minor comment conflict since ETP=local and LGW refactor
    don't exist in 4.9

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->