### PR TITLE
[release-4.8] Bug 2057152: Fix egress IP allocator sync

### DIFF
--- a/go-controller/pkg/ovn/egressip.go
+++ b/go-controller/pkg/ovn/egressip.go
@@ -200,6 +200,11 @@ func (oc *Controller) syncEgressIPs(eIPs []interface{}) {
 				klog.Error(err)
 				continue
 			}
+		} else {
+			for _, eIPStatus := range eIP.Status.Items {
+				eNode, _ := oc.eIPC.allocator[eIPStatus.Node]
+				eNode.allocations[eIPStatus.EgressIP] = true
+			}
 		}
 		for _, eNode := range oc.eIPC.allocator {
 			eNode.tainted = false


### PR DESCRIPTION
EgressIP: fix egress node allocation sync 
This is a smaller mistake that probably needs to get back-ported to
earlier versions. When syncing egress IPs we never added the assigned
and valid egress IPs to the allocator used to track assignments, this
could mean that we might have future assignments being made to nodes
which do not respect all assignment constraints because the allocator is
out of sync.

Signed-off-by: Alexander Constantinescu <aconstan@redhat.com>
(cherry picked from commit 65e5a2f46501f9796fbe42e6162e6bdf3a47db09)
