### PR TITLE
Bump OVS to 2.16.0-53.el8fdp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN yum install -y  \
 	selinux-policy && \
 	yum clean all
 
-ARG ovsver=2.16.0-33.el8fdp
+ARG ovsver=2.16.0-53.el8fdp
 ARG ovnver=21.12.0-15.el8fdp
 
 RUN INSTALL_PKGS=" \


### PR DESCRIPTION
Pulls in the following relevant ovsdb-server and IDL fixes:

  ovsdb: transaction: Keep one entry in the transaction history.
  ovsdb-cs: Fix ignoring of the last id from the initial monitor reply. (#2044624)
  ovsdb: storage: Randomize should_snapshot checks when the minimum time passed.
  raft: Only allow followers to snapshot.

The ovsdb and raft patches should improve database snapshot behavior
and reliability, and fix some corner cases of downloading the whole DB
on reconnect when a large transaction occurs.