### PR TITLE
Bug 2052975: Bump OVN to ovn-2021-21.12.0-30.el8fdp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN yum install -y  \
 	yum clean all
 
 ARG ovsver=2.16.0-53.el8fdp
-ARG ovnver=21.12.0-15.el8fdp
+ARG ovnver=21.12.0-30.el8fdp
 
 RUN INSTALL_PKGS=" \
 	openssl python3-pyOpenSSL firewalld-filesystem \


### PR DESCRIPTION
Note: We still need https://github.com/ovn-org/ovn-kubernetes/pull/2835 to fix the bug, but at least this BUMP will prepare the floor for the future downstream merge that will pick that fix.