### PR TITLE
Bug 2059354: [4.10z] After reboot egress node, lr-policy-list was not correct

### DIFF
--- a/dist/images/Dockerfile.fedora
+++ b/dist/images/Dockerfile.fedora
@@ -9,13 +9,18 @@
 # are built locally and included in the image (instead of the rpm)
 #
 
-FROM fedora:34
+FROM fedora:35
 
 USER root
 
 ENV PYTHONDONTWRITEBYTECODE yes
 
-ARG ovnver=ovn-21.09.0-4.fc34
+ARG ovnver=ovn-21.12.0-5.fc35
+# Automatically populated when using docker buildx
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+
+RUN echo "Running on $BUILDPLATFORM, building for $TARGETPLATFORM"
 
 # install needed rpms - openvswitch must be 2.10.4 or higher
 RUN INSTALL_PKGS=" \
@@ -29,7 +34,9 @@ RUN INSTALL_PKGS=" \
 
 RUN mkdir -p /var/run/openvswitch
 
-RUN koji download-build $ovnver --arch=x86_64
+RUN if [ "$TARGETPLATFORM" = "linux/amd64" ] || [ -z "$TARGETPLATFORM"] ; then koji download-build $ovnver --arch=x86_64  ; \
+    else koji download-build $ovnver --arch=aarch64 ; fi 
+
 RUN rpm -Uhv --nodeps --force *.rpm
 
 # Built in ../../go_controller, then the binaries are copied here.

--- a/go-controller/pkg/kube/kube.go
+++ b/go-controller/pkg/kube/kube.go
@@ -235,7 +235,7 @@ func (k *Kube) UpdateEgressFirewall(egressfirewall *egressfirewall.EgressFirewal
 
 // UpdateEgressIP updates the EgressIP with the provided EgressIP data
 func (k *Kube) UpdateEgressIP(eIP *egressipv1.EgressIP) error {
-	klog.Infof("Updating status on EgressIP %s", eIP.Name)
+	klog.Infof("Updating status on EgressIP %s status %v", eIP.Name, eIP.Status)
 	_, err := k.EIPClient.K8sV1().EgressIPs().Update(context.TODO(), eIP, metav1.UpdateOptions{})
 	return err
 }

--- a/go-controller/pkg/ovn/address_set/address_set.go
+++ b/go-controller/pkg/ovn/address_set/address_set.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
 	utilnet "k8s.io/utils/net"
@@ -29,7 +30,7 @@ const (
 	ipv6AddressSetSuffix = "_v6"
 )
 
-type AddressSetIterFunc func(hashedName, namespace, suffix string)
+type AddressSetIterFunc func(hashedName, namespace, suffix string) error
 type AddressSetDoFunc func(as AddressSet) error
 
 // AddressSetFactory is an interface for managing address set objects
@@ -175,7 +176,7 @@ func (asf *ovnAddressSetFactory) EnsureAddressSet(name string) (AddressSet, erro
 	return &ovnAddressSets{nbClient: asf.nbClient, name: name, ipv4: v4set, ipv6: v6set}, nil
 }
 
-func forEachAddressSet(nbClient libovsdbclient.Client, do func(string)) error {
+func forEachAddressSet(nbClient libovsdbclient.Client, do func(string) error) error {
 	addrSetList := &[]nbdb.AddressSet{}
 	ctx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout)
 	defer cancel()
@@ -188,9 +189,17 @@ func forEachAddressSet(nbClient libovsdbclient.Client, do func(string)) error {
 		return fmt.Errorf("error reading address sets: %+v", err)
 	}
 
+	var errors []error
 	for _, addrSet := range *addrSetList {
-		do(addrSet.ExternalIDs["name"])
+		if err := do(addrSet.ExternalIDs["name"]); err != nil {
+			errors = append(errors, err)
+		}
 	}
+
+	if len(errors) > 0 {
+		return fmt.Errorf("failed to iterate address sets: %v", utilerrors.NewAggregate(errors))
+	}
+
 	return nil
 }
 
@@ -199,14 +208,14 @@ func forEachAddressSet(nbClient libovsdbclient.Client, do func(string)) error {
 // OVN. (Unhashed address set names are of the form namespaceName[.suffix1.suffix2. .suffixN])
 func (asf *ovnAddressSetFactory) ProcessEachAddressSet(iteratorFn AddressSetIterFunc) error {
 	processedAddressSets := sets.String{}
-	err := forEachAddressSet(asf.nbClient, func(name string) {
+	return forEachAddressSet(asf.nbClient, func(name string) error {
 		// Remove the suffix from the address set name and normalize
 		addrSetName := truncateSuffixFromAddressSet(name)
 		if processedAddressSets.Has(addrSetName) {
 			// We have already processed the address set. In case of dual stack we will have _v4 and _v6
 			// suffixes for address sets. Since we are normalizing these two address sets through this API
 			// we will process only one normalized address set name.
-			return
+			return nil
 		}
 		processedAddressSets.Insert(addrSetName)
 		names := strings.Split(addrSetName, ".")
@@ -215,10 +224,8 @@ func (asf *ovnAddressSetFactory) ProcessEachAddressSet(iteratorFn AddressSetIter
 		if len(names) >= 2 {
 			nameSuffix = names[1]
 		}
-		iteratorFn(addrSetName, addrSetNamespace, nameSuffix)
+		return iteratorFn(addrSetName, addrSetNamespace, nameSuffix)
 	})
-
-	return err
 }
 
 func truncateSuffixFromAddressSet(asName string) string {

--- a/go-controller/pkg/ovn/address_set/address_set_cleanup.go
+++ b/go-controller/pkg/ovn/address_set/address_set_cleanup.go
@@ -16,7 +16,7 @@ func NonDualStackAddressSetCleanup(nbClient libovsdbclient.Client) error {
 	const old = 0
 	const new = 1
 	addressSets := map[string][2]bool{}
-	err := forEachAddressSet(nbClient, func(name string) {
+	err := forEachAddressSet(nbClient, func(name string) error {
 		shortName := truncateSuffixFromAddressSet(name)
 		spec, found := addressSets[shortName]
 		if !found {
@@ -30,6 +30,7 @@ func NonDualStackAddressSetCleanup(nbClient libovsdbclient.Client) error {
 			spec[new] = true
 		}
 		addressSets[shortName] = spec
+		return nil
 	})
 
 	if err != nil {

--- a/go-controller/pkg/ovn/address_set/address_set_test.go
+++ b/go-controller/pkg/ovn/address_set/address_set_test.go
@@ -106,7 +106,7 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 					},
 				}
 
-				err = asFactory.ProcessEachAddressSet(func(addrSetName, namespaceName, nameSuffix string) {
+				err = asFactory.ProcessEachAddressSet(func(addrSetName, namespaceName, nameSuffix string) error {
 					found := false
 					for _, n := range namespaces {
 						name := n.makeNames()
@@ -116,6 +116,7 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 						}
 					}
 					gomega.Expect(found).To(gomega.BeTrue())
+					return nil
 				})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				return nil

--- a/go-controller/pkg/ovn/address_set/fake_address_set.go
+++ b/go-controller/pkg/ovn/address_set/fake_address_set.go
@@ -86,7 +86,9 @@ func (f *FakeAddressSetFactory) ProcessEachAddressSet(iteratorFn AddressSetIterF
 		if len(parts) >= 2 {
 			nameSuffix = parts[1]
 		}
-		iteratorFn(asName, addrSetNamespace, nameSuffix)
+		if err := iteratorFn(asName, addrSetNamespace, nameSuffix); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/go-controller/pkg/ovn/egressgw_test.go
+++ b/go-controller/pkg/ovn/egressgw_test.go
@@ -2190,6 +2190,10 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 								Name: types.GWRouterPrefix + nodeName,
 								UUID: types.GWRouterPrefix + nodeName + "-UUID",
 							},
+							&nbdb.LogicalSwitch{
+								UUID: "node1",
+								Name: "node1",
+							},
 						},
 					},
 					&v1.NamespaceList{
@@ -2220,6 +2224,10 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 						Name:     ovntypes.GWRouterToJoinSwitchPrefix + ovntypes.GWRouterPrefix + nodeName,
 						Networks: []string{"100.64.0.4/32"},
 					},
+					&nbdb.LogicalSwitch{
+						UUID: "node1",
+						Name: "node1",
+					},
 				}
 				injectNode(fakeOvn)
 				fakeOvn.controller.WatchNamespaces()
@@ -2240,6 +2248,10 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 						UUID:     ovntypes.GWRouterToJoinSwitchPrefix + ovntypes.GWRouterPrefix + nodeName + "-UUID",
 						Name:     ovntypes.GWRouterToJoinSwitchPrefix + ovntypes.GWRouterPrefix + nodeName,
 						Networks: []string{"100.64.0.4/32"},
+					},
+					&nbdb.LogicalSwitch{
+						UUID: "node1",
+						Name: "node1",
 					},
 				}
 				err = deletePerPodGRSNAT(fakeOvn.controller.nbClient, nodeName, extIPs, []*net.IPNet{fullMaskPodNet})

--- a/go-controller/pkg/ovn/egressip.go
+++ b/go-controller/pkg/ovn/egressip.go
@@ -1283,7 +1283,7 @@ func (oc *Controller) assignEgressIPs(name string, egressIPs []string) []egressi
 					Node:     eNode.name,
 					EgressIP: eIPC.String(),
 				})
-				klog.V(5).Infof("Successful assignment of egress IP: %s on node: %+v", egressIP, eNode)
+				klog.Infof("Successful assignment of egress IP: %s on node: %+v", egressIP, eNode)
 				eNode.allocations[eIPC.String()] = name
 				break
 			}

--- a/go-controller/pkg/ovn/egressip.go
+++ b/go-controller/pkg/ovn/egressip.go
@@ -992,6 +992,12 @@ func (oc *Controller) isEgressNodeReachable(egressNode *kapi.Node) bool {
 	return false
 }
 
+type egressIPCacheEntry struct {
+	podIPs           sets.String
+	gatewayRouterIPs sets.String
+	egressIPs        sets.String
+}
+
 func (oc *Controller) syncEgressIPs(eIPs []interface{}) {
 	// This part will take of syncing stale data which we might have in OVN if
 	// there's no ovnkube-master running for a while, while there are changes to
@@ -1001,14 +1007,14 @@ func (oc *Controller) syncEgressIPs(eIPs []interface{}) {
 	// - pods/namespaces which have stopped matching on egress IPs while
 	//   ovnkube-master was down
 	oc.syncWithRetry("syncEgressIPs", func() error {
-		egressIPToPodIPCache, err := oc.generatePodIPCacheForEgressIP(eIPs)
+		egressIPCache, err := oc.generateCacheForEgressIP(eIPs)
 		if err != nil {
 			return fmt.Errorf("syncEgressIPs unable to generate cache for egressip: %v", err)
 		}
-		if err = oc.syncStaleEgressReroutePolicy(egressIPToPodIPCache); err != nil {
+		if err = oc.syncStaleEgressReroutePolicy(egressIPCache); err != nil {
 			return fmt.Errorf("syncEgressIPs unable to remove stale reroute policies: %v", err)
 		}
-		if err = oc.syncStaleSNATRules(egressIPToPodIPCache); err != nil {
+		if err = oc.syncStaleSNATRules(egressIPCache); err != nil {
 			return fmt.Errorf("syncEgressIPs unable to remove stale nats: %v", err)
 		}
 		return nil
@@ -1017,10 +1023,12 @@ func (oc *Controller) syncEgressIPs(eIPs []interface{}) {
 
 // This function implements a portion of syncEgressIPs.
 // It removes OVN logical router policies used by EgressIPs deleted while ovnkube-master was down.
+// It also removes stale nexthops from router policies used by EgressIPs.
 // Upon failure, it may be invoked multiple times in order to avoid a pod restart.
-func (oc *Controller) syncStaleEgressReroutePolicy(egressIPToPodIPCache map[string]sets.String) error {
+func (oc *Controller) syncStaleEgressReroutePolicy(egressIPCache map[string]egressIPCacheEntry) error {
 	logicalRouter := nbdb.LogicalRouter{}
 	logicalRouterPolicyRes := []nbdb.LogicalRouterPolicy{}
+	logicalRouterPolicyStaleNexthops := make(map[string]nbdb.LogicalRouterPolicy)
 	opModels := []libovsdbops.OperationModel{
 		{
 			ModelPredicate: func(lrp *nbdb.LogicalRouterPolicy) bool {
@@ -1028,13 +1036,35 @@ func (oc *Controller) syncStaleEgressReroutePolicy(egressIPToPodIPCache map[stri
 					return false
 				}
 				egressIPName := lrp.ExternalIDs["name"]
-				podIPCache, exists := egressIPToPodIPCache[egressIPName]
+				cacheEntry, exists := egressIPCache[egressIPName]
 				splitMatch := strings.Split(lrp.Match, " ")
 				logicalIP := splitMatch[len(splitMatch)-1]
 				parsedLogicalIP := net.ParseIP(logicalIP)
-				if !exists || !podIPCache.Has(parsedLogicalIP.String()) {
-					klog.Infof("syncStaleEgressReroutePolicy will delete %s: %v", egressIPName, lrp)
+				if !exists || cacheEntry.gatewayRouterIPs.Len() == 0 || !cacheEntry.podIPs.Has(parsedLogicalIP.String()) {
+					klog.Infof("syncStaleEgressReroutePolicy will delete %s due to no nexthop or stale logical ip: %v", egressIPName, lrp)
 					return true
+				}
+				// Check for stale nexthops that may exist in the logical router policy and store that in logicalRouterPolicyStaleNexthops.
+				// Note: adding missing nexthop(s) to the logical router policy is done outside the scope of this function.
+				onlyStaleNextHops := true
+				staleNextHops := sets.NewString()
+				for _, nexthop := range lrp.Nexthops {
+					if cacheEntry.gatewayRouterIPs.Has(nexthop) {
+						onlyStaleNextHops = false
+					} else {
+						staleNextHops.Insert(nexthop)
+					}
+				}
+				if staleNextHops.Len() > 0 {
+					// If all nexthops are stale, let's go ahead and remove the entire row
+					if onlyStaleNextHops {
+						klog.Infof("syncStaleEgressReroutePolicy will delete %s due to stale nexthops: %v", egressIPName, lrp)
+						return true
+					}
+					logicalRouterPolicyStaleNexthops[lrp.UUID] = nbdb.LogicalRouterPolicy{
+						UUID:     lrp.UUID,
+						Nexthops: staleNextHops.UnsortedList(),
+					}
 				}
 				return false
 			},
@@ -1055,13 +1085,31 @@ func (oc *Controller) syncStaleEgressReroutePolicy(egressIPToPodIPCache map[stri
 	if err := oc.modelClient.Delete(opModels...); err != nil {
 		return fmt.Errorf("unable to remove stale logical router policies, err: %v", err)
 	}
+
+	// Update Logical Router Policies that have stale nexthops. Notice that we must do this separately
+	// because 1) there is no model predicates, and 2) logicalRouterPolicyStaleNexthops must be populated
+	opModels2 := make([]libovsdbops.OperationModel, 0, len(logicalRouterPolicyStaleNexthops))
+	for lrpUUID := range logicalRouterPolicyStaleNexthops {
+		lrp := logicalRouterPolicyStaleNexthops[lrpUUID]
+		klog.Infof("syncStaleEgressReroutePolicy will update %s to remove stale nexthops: %v", lrp.UUID, lrp.Nexthops)
+		opModels2 = append(opModels2, libovsdbops.OperationModel{
+			Model: &lrp,
+			OnModelMutations: []interface{}{
+				&lrp.Nexthops,
+			},
+		})
+	}
+	if err := oc.modelClient.Delete(opModels2...); err != nil {
+		return fmt.Errorf("unable to remove stale next hops from logical router policies, err: %v", err)
+	}
+
 	return nil
 }
 
 // This function implements a portion of syncEgressIPs.
 // It removes OVN NAT rules used by EgressIPs deleted while ovnkube-master was down.
 // Upon failure, it may be invoked multiple times in order to avoid a pod restart.
-func (oc *Controller) syncStaleSNATRules(egressIPToPodIPCache map[string]sets.String) error {
+func (oc *Controller) syncStaleSNATRules(egressIPCache map[string]egressIPCacheEntry) error {
 	predicate := func(item *nbdb.NAT) bool {
 		egressIPName, exists := item.ExternalIDs["name"]
 		// Exclude rows that have no name or are not the right type
@@ -1069,9 +1117,13 @@ func (oc *Controller) syncStaleSNATRules(egressIPToPodIPCache map[string]sets.St
 			return false
 		}
 		parsedLogicalIP := net.ParseIP(item.LogicalIP).String()
-		podIPCache, exists := egressIPToPodIPCache[egressIPName]
-		if !exists || !podIPCache.Has(parsedLogicalIP) {
-			klog.Infof("syncStaleSNATRules will delete %s: %v", egressIPName, item)
+		cacheEntry, exists := egressIPCache[egressIPName]
+		if !exists || !cacheEntry.podIPs.Has(parsedLogicalIP) {
+			klog.Infof("syncStaleSNATRules will delete %s due to logical ip: %v", egressIPName, item)
+			return true
+		}
+		if !cacheEntry.egressIPs.Has(item.ExternalIP) {
+			klog.Infof("syncStaleSNATRules will delete %s due to external ip: %v", egressIPName, item)
 			return true
 		}
 		return false
@@ -1113,19 +1165,34 @@ func (oc *Controller) syncStaleSNATRules(egressIPToPodIPCache map[string]sets.St
 	return nil
 }
 
-// generatePodIPCacheForEgressIP builds a cache of egressIP name -> podIPs for fast
+// generateCacheForEgressIP builds a cache of egressIP name -> podIPs for fast
 // access when syncing egress IPs. The Egress IP setup will return a lot of
 // atomic items with the same general information repeated across most (egressIP
 // name, logical IP defined for that name), hence use a cache to avoid round
 // trips to the API server per item.
-func (oc *Controller) generatePodIPCacheForEgressIP(eIPs []interface{}) (map[string]sets.String, error) {
-	egressIPToPodIPCache := make(map[string]sets.String)
+func (oc *Controller) generateCacheForEgressIP(eIPs []interface{}) (map[string]egressIPCacheEntry, error) {
+	egressIPCache := make(map[string]egressIPCacheEntry)
 	for _, eIP := range eIPs {
 		egressIP, ok := eIP.(*egressipv1.EgressIP)
 		if !ok {
 			continue
 		}
-		egressIPToPodIPCache[egressIP.Name] = sets.NewString()
+		egressIPCache[egressIP.Name] = egressIPCacheEntry{
+			podIPs:           sets.NewString(),
+			gatewayRouterIPs: sets.NewString(),
+			egressIPs:        sets.NewString(),
+		}
+		for _, status := range egressIP.Status.Items {
+			isEgressIPv6 := utilnet.IsIPv6String(status.EgressIP)
+			gatewayRouterIP, err := oc.eIPC.getGatewayRouterJoinIP(status.Node, isEgressIPv6)
+			if err != nil {
+				klog.Errorf("Unable to retrieve gateway IP for node: %s, protocol is IPv6: %v, err: %v", status.Node, isEgressIPv6, err)
+				continue
+			}
+			egressIPCache[egressIP.Name].gatewayRouterIPs.Insert(gatewayRouterIP.String())
+			egressIPCache[egressIP.Name].egressIPs.Insert(status.EgressIP)
+		}
+
 		namespaces, err := oc.watchFactory.GetNamespacesBySelector(egressIP.Spec.NamespaceSelector)
 		if err != nil {
 			klog.Errorf("Error building egress IP sync cache, cannot retrieve namespaces for EgressIP: %s, err: %v", egressIP.Name, err)
@@ -1144,12 +1211,12 @@ func (oc *Controller) generatePodIPCacheForEgressIP(eIPs []interface{}) (map[str
 					continue
 				}
 				for _, ipNet := range logicalPort.ips {
-					egressIPToPodIPCache[egressIP.Name].Insert(ipNet.IP.String())
+					egressIPCache[egressIP.Name].podIPs.Insert(ipNet.IP.String())
 				}
 			}
 		}
 	}
-	return egressIPToPodIPCache, nil
+	return egressIPCache, nil
 }
 
 // isAnyClusterNodeIP verifies that the IP is not any node IP.

--- a/go-controller/pkg/ovn/egressip.go
+++ b/go-controller/pkg/ovn/egressip.go
@@ -1117,9 +1117,13 @@ func (oc *Controller) generatePodIPCacheForEgressIP(eIPs []interface{}) (map[str
 				continue
 			}
 			for _, pod := range pods {
-				for _, podIP := range pod.Status.PodIPs {
-					ip := net.ParseIP(podIP.IP)
-					egressIPToPodIPCache[egressIP.Name].Insert(ip.String())
+				logicalPort, err := oc.logicalPortCache.get(util.GetLogicalPortName(pod.Namespace, pod.Name))
+				if err != nil {
+					klog.Errorf("Error getting logical port %s, err: %v", util.GetLogicalPortName(pod.Namespace, pod.Name), err)
+					continue
+				}
+				for _, ipNet := range logicalPort.ips {
+					egressIPToPodIPCache[egressIP.Name].Insert(ipNet.IP.String())
 				}
 			}
 		}

--- a/go-controller/pkg/ovn/namespace.go
+++ b/go-controller/pkg/ovn/namespace.go
@@ -41,12 +41,14 @@ func (oc *Controller) syncNamespaces(namespaces []interface{}) {
 		expectedNs[ns.Name] = true
 	}
 
-	err := oc.addressSetFactory.ProcessEachAddressSet(func(addrSetName, namespaceName, nameSuffix string) {
+	err := oc.addressSetFactory.ProcessEachAddressSet(func(addrSetName, namespaceName, nameSuffix string) error {
 		if nameSuffix == "" && !expectedNs[namespaceName] {
 			if err := oc.addressSetFactory.DestroyAddressSetInBackingStore(addrSetName); err != nil {
 				klog.Errorf(err.Error())
+				return err
 			}
 		}
+		return nil
 	})
 	if err != nil {
 		klog.Errorf("Error in syncing namespaces: %v", err)

--- a/go-controller/pkg/ovn/namespace.go
+++ b/go-controller/pkg/ovn/namespace.go
@@ -31,12 +31,17 @@ const (
 )
 
 func (oc *Controller) syncNamespaces(namespaces []interface{}) {
+	oc.syncWithRetry("syncNamespaces", func() error { return oc.syncNamespacesRetriable(namespaces) })
+}
+
+// This function implements the main body of work of syncNamespaces.
+// Upon failure, it may be invoked multiple times in order to avoid a pod restart.
+func (oc *Controller) syncNamespacesRetriable(namespaces []interface{}) error {
 	expectedNs := make(map[string]bool)
 	for _, nsInterface := range namespaces {
 		ns, ok := nsInterface.(*kapi.Namespace)
 		if !ok {
-			klog.Errorf("Spurious object in syncNamespaces: %v", nsInterface)
-			continue
+			return fmt.Errorf("spurious object in syncNamespaces: %v", nsInterface)
 		}
 		expectedNs[ns.Name] = true
 	}
@@ -51,8 +56,9 @@ func (oc *Controller) syncNamespaces(namespaces []interface{}) {
 		return nil
 	})
 	if err != nil {
-		klog.Errorf("Error in syncing namespaces: %v", err)
+		return fmt.Errorf("error in syncing namespaces: %v", err)
 	}
+	return nil
 }
 
 func (oc *Controller) getRoutingExternalGWs(nsInfo *namespaceInfo) *gatewayInfo {

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -26,27 +26,39 @@ import (
 )
 
 func (oc *Controller) syncPods(pods []interface{}) {
+	oc.syncWithRetry("syncPods", func() error { return oc.syncPodsRetriable(pods) })
+}
+
+// This function implements the main body of work of syncPods.
+// Upon failure, it may be invoked multiple times in order to avoid a pod restart.
+func (oc *Controller) syncPodsRetriable(pods []interface{}) error {
 	var allOps []ovsdb.Operation
 	// get the list of logical switch ports (equivalent to pods)
 	expectedLogicalPorts := make(map[string]bool)
 	for _, podInterface := range pods {
 		pod, ok := podInterface.(*kapi.Pod)
 		if !ok {
-			klog.Errorf("Spurious object in syncPods: %v", podInterface)
-			continue
+			return fmt.Errorf("spurious object in syncPods: %v", podInterface)
 		}
 		annotations, err := util.UnmarshalPodAnnotation(pod.Annotations)
 		if util.PodScheduled(pod) && util.PodWantsNetwork(pod) && err == nil {
 			logicalPort := util.GetLogicalPortName(pod.Namespace, pod.Name)
 			expectedLogicalPorts[logicalPort] = true
 			if err = oc.waitForNodeLogicalSwitchInCache(pod.Spec.NodeName); err != nil {
-				klog.Errorf("Failed to wait for node %s to be added to cache. IP allocation may fail!",
+				return fmt.Errorf("failed to wait for node %s to be added to cache. IP allocation may fail!",
 					pod.Spec.NodeName)
 			}
 			if err = oc.lsManager.AllocateIPs(pod.Spec.NodeName, annotations.IPs); err != nil {
-				klog.Errorf("couldn't allocate IPs: %s for pod: %s on node: %s"+
-					" error: %v", util.JoinIPNetIPs(annotations.IPs, " "), logicalPort,
-					pod.Spec.NodeName, err)
+				if err == ipallocator.ErrAllocated {
+					// already allocated: log an error but not stop syncPod from continuing
+					klog.Errorf("Already allocated IPs: %s for pod: %s on node: %s",
+						util.JoinIPNetIPs(annotations.IPs, " "), logicalPort,
+						pod.Spec.NodeName)
+				} else {
+					return fmt.Errorf("Couldn't allocate IPs: %s for pod: %s on node: %s"+
+						" error: %v", util.JoinIPNetIPs(annotations.IPs, " "), logicalPort,
+						pod.Spec.NodeName, err)
+				}
 			}
 		}
 	}
@@ -58,8 +70,7 @@ func (oc *Controller) syncPods(pods []interface{}) {
 	defer cancel()
 	err := oc.nbClient.List(ctx, &lspList)
 	if err != nil {
-		klog.Errorf("Cannot sync pods, cannot retrieve list of logical switch ports (%+v)", err)
-		return
+		return fmt.Errorf("cannot sync pods, cannot retrieve list of logical switch ports (%+v)", err)
 	}
 	for _, lsp := range lspList {
 		portCache[lsp.UUID] = lsp
@@ -67,8 +78,7 @@ func (oc *Controller) syncPods(pods []interface{}) {
 	// get all the nodes from the watchFactory
 	nodes, err := oc.watchFactory.GetNodes()
 	if err != nil {
-		klog.Errorf("Failed to get nodes: %v", err)
-		return
+		return fmt.Errorf("failed to get nodes: %v", err)
 	}
 	for _, n := range nodes {
 		stalePorts := []string{}
@@ -76,17 +86,19 @@ func (oc *Controller) syncPods(pods []interface{}) {
 		ls := &nbdb.LogicalSwitch{}
 		if lsUUID, ok := oc.lsManager.GetUUID(n.Name); !ok {
 			klog.Errorf("Error getting logical switch for node %s: %s", n.Name, "Switch not in logical switch cache")
-			continue
+
+			// Not in cache: Try getting the logical switch from ovn database (slower method)
+			if ls, err = libovsdbops.FindSwitchByName(oc.nbClient, n.Name); err != nil {
+				return fmt.Errorf("can't find switch for node %s: %v", n.Name, err)
+			}
 		} else {
 			ctx, cancel := context.WithTimeout(context.Background(), ovntypes.OVSDBTimeout)
 			defer cancel()
 
 			ls.UUID = lsUUID
 			if err := oc.nbClient.Get(ctx, ls); err != nil {
-				klog.Errorf("Error getting logical switch for node %d (UUID: %d) from ovn database (%v)", n.Name, ls.UUID, err)
-				continue
+				return fmt.Errorf("error getting logical switch for node %s (UUID: %s) from ovn database (%v)", n.Name, ls.UUID, err)
 			}
-
 		}
 		for _, port := range ls.Ports {
 			if portCache[port].ExternalIDs["pod"] == "true" {
@@ -102,16 +114,16 @@ func (oc *Controller) syncPods(pods []interface{}) {
 				Value:   stalePorts,
 			})
 			if err != nil {
-				klog.Errorf("Could not generate ops to delete stale ports from logical switch %s (%+v)", n.Name, err)
-				continue
+				return fmt.Errorf("could not generate ops to delete stale ports from logical switch %s (%+v)", n.Name, err)
 			}
 			allOps = append(allOps, ops...)
 		}
 	}
 	_, err = libovsdbops.TransactAndCheck(oc.nbClient, allOps)
 	if err != nil {
-		klog.Errorf("Could not remove stale logicalPorts from switches (%+v)", err)
+		return fmt.Errorf("could not remove stale logicalPorts from switches (%+v)", err)
 	}
+	return nil
 }
 
 func (oc *Controller) deleteLogicalPort(pod *kapi.Pod) {

--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -112,13 +112,17 @@ func hashedPortGroup(s string) string {
 }
 
 func (oc *Controller) syncNetworkPolicies(networkPolicies []interface{}) {
+	oc.syncWithRetry("syncNetworkPolicies", func() error { return oc.syncNetworkPoliciesRetriable(networkPolicies) })
+}
+
+// This function implements the main body of work of syncNetworkPolicies.
+// Upon failure, it may be invoked multiple times in order to avoid a pod restart.
+func (oc *Controller) syncNetworkPoliciesRetriable(networkPolicies []interface{}) error {
 	expectedPolicies := make(map[string]map[string]bool)
 	for _, npInterface := range networkPolicies {
 		policy, ok := npInterface.(*knet.NetworkPolicy)
 		if !ok {
-			klog.Errorf("Spurious object in syncNetworkPolicies: %v",
-				npInterface)
-			continue
+			return fmt.Errorf("spurious object in syncNetworkPolicies: %v", npInterface)
 		}
 
 		if nsMap, ok := expectedPolicies[policy.Namespace]; ok {
@@ -146,13 +150,13 @@ func (oc *Controller) syncNetworkPolicies(networkPolicies []interface{}) {
 		return nil
 	})
 	if err != nil {
-		klog.Errorf("Error in syncing network policies: %v", err)
+		return fmt.Errorf("error in syncing network policies: %v", err)
 	}
 
 	if len(stalePGs) > 0 {
 		err = libovsdbops.DeletePortGroups(oc.nbClient, stalePGs...)
 		if err != nil {
-			klog.Errorf("Error removing stale port groups %v: %v", stalePGs, err)
+			return fmt.Errorf("error removing stale port groups %v: %v", stalePGs, err)
 		}
 	}
 
@@ -160,12 +164,12 @@ func (oc *Controller) syncNetworkPolicies(networkPolicies []interface{}) {
 	var allEgressACLs []nbdb.ACL
 	egressACLs, err := libovsdbops.FindACLsByExternalID(oc.nbClient, map[string]string{policyTypeACLExtIdKey: string(knet.PolicyTypeEgress)})
 	if err != nil {
-		klog.Errorf("error cannot sync NetworkPolicy Egress obj: %v", err)
+		return fmt.Errorf("error cannot sync NetworkPolicy Egress obj: %v", err)
 	}
 	allEgressACLs = append(allEgressACLs, egressACLs...)
 	egressACLs, err = libovsdbops.FindACLsByExternalID(oc.nbClient, map[string]string{defaultDenyPolicyTypeACLExtIdKey: string(knet.PolicyTypeEgress)})
 	if err != nil {
-		klog.Errorf("error cannot sync NetworkPolicy Egress obj: %v", err)
+		return fmt.Errorf("error cannot sync NetworkPolicy Egress obj: %v", err)
 	}
 	allEgressACLs = append(allEgressACLs, egressACLs...)
 	// if the first egress ACL is correct they should all be correct and not need to update
@@ -179,15 +183,16 @@ func (oc *Controller) syncNetworkPolicies(networkPolicies []interface{}) {
 		}
 		ops, err := libovsdbops.CreateOrUpdateACLsOps(oc.nbClient, nil, egressACLsPTR...)
 		if err != nil {
-			klog.Errorf("cannot create ops to update old Egress NetworkPolicy ACLs: %v", err)
+			return fmt.Errorf("cannot create ops to update old Egress NetworkPolicy ACLs: %v", err)
 		}
 		_, err = libovsdbops.TransactAndCheck(oc.nbClient, ops)
 		if err != nil {
-			klog.Errorf("cannot update old Egress NetworkPolicy ACLs: %v", err)
+			return fmt.Errorf("cannot update old Egress NetworkPolicy ACLs: %v", err)
 		}
 
 	}
 
+	return nil
 }
 
 func addAllowACLFromNode(nodeName string, mgmtPortIP net.IP, nbClient libovsdbclient.Client) error {

--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -131,7 +131,7 @@ func (oc *Controller) syncNetworkPolicies(networkPolicies []interface{}) {
 	}
 
 	stalePGs := []string{}
-	err := oc.addressSetFactory.ProcessEachAddressSet(func(addrSetName, namespaceName, policyName string) {
+	err := oc.addressSetFactory.ProcessEachAddressSet(func(addrSetName, namespaceName, policyName string) error {
 		if policyName != "" && !expectedPolicies[namespaceName][policyName] {
 			// policy doesn't exist on k8s. Delete the port group
 			portGroupName := fmt.Sprintf("%s_%s", namespaceName, policyName)
@@ -140,8 +140,10 @@ func (oc *Controller) syncNetworkPolicies(networkPolicies []interface{}) {
 			// delete the address sets for this old policy from OVN
 			if err := oc.addressSetFactory.DestroyAddressSetInBackingStore(addrSetName); err != nil {
 				klog.Errorf(err.Error())
+				return err
 			}
 		}
+		return nil
 	})
 	if err != nil {
 		klog.Errorf("Error in syncing network policies: %v", err)


### PR DESCRIPTION
In cases where OVN database for logical router policies or NATs
used by EgressIPs have stale nexthops or wrong external_ips, the
sync function should remove them, so the proper row/column gets set.

In order to cleanly apply these changes from 4.11, the following commits were also added:
- https://github.com/openshift/ovn-kubernetes/pull/940 (pulled in upstream  https://github.com/ovn-org/ovn-kubernetes/pull/2773)
-  https://github.com/openshift/ovn-kubernetes/pull/947 (pulled in upstream https://github.com/ovn-org/ovn-kubernetes/pull/2783)

Signed-off-by: Flavio Fernandes [flaviof@redhat.com](mailto:flaviof@redhat.com)
