### PR TITLE
[release-4.8] Bug 2065303: [CARRY][Downstream-only] Give warning when ipFamilyPolicy implicitly set

### DIFF
--- a/go-controller/pkg/ovn/controller/services/OCP_HACKS.go
+++ b/go-controller/pkg/ovn/controller/services/OCP_HACKS.go
@@ -1,0 +1,59 @@
+package services
+
+import (
+	"encoding/json"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+// isImplicitDualStackIpFamilyPolicy checks if the service implicitly sets ipFamilyPolicy for DualStack services.
+// This is deprecated in 4.8 and 4.9 as admins must set ipFamilyPolicy explicitly in 4.10 and beyond.
+// Note that this will only work with K8s v1.22 and v1.21 as earlier versions set the f:ipFamilyPolicy
+// field even if the client had ommitted it.
+func isImplicitDualStackIpFamilyPolicy(service *v1.Service) bool {
+	// return false if this is not a DualStack Service
+	if len(service.Spec.ClusterIPs) < 2 && len(service.Spec.IPFamilies) < 2 {
+		return false
+	}
+
+	// check if any of the managedFieldEntries contains "f:ipFamilyPolicy". We'd ideally use
+	// https://github.com/kubernetes/apiserver/blob/v0.21.0/pkg/endpoints/handlers/fieldmanager/fieldmanager.go#L115
+	// but that's only available with apiserver v0.21.0 and beyond, and OCP 4.9 and 4.8 are on v0.20.0
+	// for a lot of dependencies. So, using that library creates a lot of dependency issues
+	managedFieldEntries := service.GetManagedFields()
+
+	for _, entry := range managedFieldEntries {
+		// fallback, continue if FieldsV1 is not set
+		if entry.FieldsV1 == nil {
+			continue
+		}
+
+		var fieldsV1Map map[string]interface{}
+		err := json.Unmarshal(entry.FieldsV1.Raw, &fieldsV1Map)
+		// fallback, continue if we cannot decode
+		if err != nil {
+			continue
+		}
+		// fallback, continue if key "f:spec" is not set
+		// fallback, continue if "f:spec" is set but is nil
+		fspec, ok := fieldsV1Map["f:spec"]
+		if !ok || fspec == nil {
+			continue
+		}
+		// fallback, continue if "f:spec" is set, is not nil but is not a map with string keys
+		fspecMap, ok := fspec.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		// If this service definition contains an explicit ipFamilyPolicy, return false
+		if _, ok := fspecMap["f:ipFamilyPolicy"]; ok {
+			return false
+		}
+	}
+
+	// This service set field ipFamilyPolicy implicitly if
+	//     (len(service.Spec.ClusterIPs) == 2 || len(service.Spec.IpFamilies) == 2)
+	//         and "f:ipFamilyPolicy"
+	// is not set for any of the managedFieldEntries
+	return true
+}

--- a/go-controller/pkg/ovn/controller/services/services_controller.go
+++ b/go-controller/pkg/ovn/controller/services/services_controller.go
@@ -251,6 +251,16 @@ func (c *Controller) syncServices(key string) error {
 		c.serviceTracker.deleteService(name, namespace)
 		return nil
 	}
+
+	// OCP HACK
+	// Check if the service implicitly sets ipFamilyPolicy for DualStack services.
+	// This is deprecated in 4.8 and 4.9 as admins must set ipFamilyPolicy explicitly in 4.10 and beyond.
+	if isImplicitDualStackIpFamilyPolicy(service) {
+		c.eventRecorder.Eventf(service, v1.EventTypeWarning, "ImplicitDualStackIpFamilyPolicy",
+			"DualStack ipFamilyPolicy set implicitly for service %s/%s", namespace, name)
+	}
+	// END OCP HACK
+
 	klog.Infof("Creating service %s on namespace %s on OVN", name, namespace)
 	// The Service exists in the cache: update it in OVN
 	// Get the endpoint slices associated to the Service


### PR DESCRIPTION
In kube 1.21 and 1.22 (OCP 4.8 and 4.9), the apiserver will default
the value of ipFamilyPolicy to RequireDualStack if you create a
Service with two ipFamilies or two clusterIPs but no explicitly
specified ipFamilyPolicy. In 1.23/4.10, you must explicitly specify
either PreferDualStack or RequireDualStack for DualStack services.
Emit a warning in 4.8 and 4.9 to raise awareness about the upcoming
API changes. See BZ2045576 for a thorough discussion.

Minor conflict in services_controller.go (rearrangement of a couple
of lines only affecting the comments).

(cherry picked from commit 06338af79912421be4ec760101b85841d111978e)

Conflicts:
	go-controller/pkg/ovn/controller/services/services_controller.go

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->