### PR TITLE
Bug 2065782: [release-4.9][backport] Fix cleaning VF representor ports

### DIFF
--- a/go-controller/pkg/node/healthcheck.go
+++ b/go-controller/pkg/node/healthcheck.go
@@ -184,6 +184,10 @@ func checkForStaleOVSRepresentorInterfaces(nodeName string, wf factory.ObjectCac
 
 	// Remove any stale representor ports
 	for _, ifaceInfo := range interfaceInfos {
+		// ignore non-vf representor ports
+		if _, ok := ifaceInfo.Attributes["vf-netdev-name"]; !ok {
+			continue
+		}
 		ifaceId, ok := ifaceInfo.Attributes["iface-id"]
 		if !ok {
 			klog.Warningf("iface-id attribute was not found for OVS interface %s. "+
@@ -191,8 +195,6 @@ func checkForStaleOVSRepresentorInterfaces(nodeName string, wf factory.ObjectCac
 			continue
 		}
 		if _, ok := expectedIfaceIds[ifaceId]; !ok {
-			// TODO(adrianc): To make this more strict we can check if the interface is a VF representor
-			// interface via sriovnet.
 			klog.Warningf("Found stale OVS Interface, deleting OVS Port with interface %s", ifaceInfo.Name)
 			_, stderr, err := util.RunOVSVsctl("--if-exists", "--with-iface", "del-port", ifaceInfo.Name)
 			if err != nil {

--- a/go-controller/pkg/node/healthcheck_test.go
+++ b/go-controller/pkg/node/healthcheck_test.go
@@ -114,9 +114,9 @@ var _ = Describe("Healthcheck tests", func() {
 				// mock call to find OVS interfaces with non-empty external_ids:sandbox
 				execMock.AddFakeCmd(&ovntest.ExpectedCmd{
 					Cmd: genFindInterfaceWithSandboxCmd(),
-					Output: "pod-a-ifc,sandbox=123abcfaa iface-id=a-ns_a-pod\n" +
-						"pod-b-ifc,sandbox=123abcfaa iface-id=b-ns_b-pod\n" +
-						"stale-pod-ifc,sandbox=123abcfaa iface-id=stale-ns_stale-pod\n",
+					Output: "pod-a-ifc,sandbox=123abcfaa iface-id=a-ns_a-pod vf-netdev-name=blah\n" +
+						"pod-b-ifc,sandbox=123abcfaa iface-id=b-ns_b-pod vf-netdev-name=blah\n" +
+						"stale-pod-ifc,sandbox=123abcfaa iface-id=stale-ns_stale-pod vf-netdev-name=blah\n",
 					Err: nil,
 				})
 


### PR DESCRIPTION
(cherry picked from commit https://github.com/openshift/ovn-kubernetes/commit/77678fbe280a701351decded0a16017f4e7a18aa)

fixes #2065782

(the bug was found in 4.9 in SNO https://bugzilla.redhat.com/show_bug.cgi?id=2016115)