### PR TITLE
[release-4.10] Bug 2066446: Back port only leader publishes and clean stale label metrics

### DIFF
--- a/go-controller/cmd/ovnkube/ovnkube.go
+++ b/go-controller/cmd/ovnkube/ovnkube.go
@@ -242,7 +242,7 @@ func runOvnKube(ctx *cli.Context) error {
 		// register prometheus metrics exported by the master
 		// this must be done prior to calling controller start
 		// since we capture some metrics in Start()
-		metrics.RegisterMasterMetrics(libovsdbOvnSBClient)
+		metrics.RegisterMasterMetrics(libovsdbOvnNBClient)
 
 		ovnController := ovn.NewOvnController(ovnClientset, masterWatchFactory, stopChan, nil,
 			libovsdbOvnNBClient, libovsdbOvnSBClient, util.EventRecorder(ovnClientset.KubeClient))

--- a/go-controller/cmd/ovnkube/ovnkube.go
+++ b/go-controller/cmd/ovnkube/ovnkube.go
@@ -239,10 +239,8 @@ func runOvnKube(ctx *cli.Context) error {
 			return fmt.Errorf("error when trying to initialize libovsdb SB client: %v", err)
 		}
 
-		// register prometheus metrics exported by the master
-		// this must be done prior to calling controller start
-		// since we capture some metrics in Start()
-		metrics.RegisterMasterMetrics(libovsdbOvnNBClient)
+		// register prometheus metrics that do not depend on becoming ovnkube-master leader
+		metrics.RegisterMasterBase()
 
 		ovnController := ovn.NewOvnController(ovnClientset, masterWatchFactory, stopChan, nil,
 			libovsdbOvnNBClient, libovsdbOvnSBClient, util.EventRecorder(ovnClientset.KubeClient))

--- a/go-controller/pkg/metrics/master.go
+++ b/go-controller/pkg/metrics/master.go
@@ -505,10 +505,16 @@ func (ps *ControlPlaneRecorder) Run(sbClient libovsdbclient.Client) {
 
 	sbClient.Cache().AddEventHandler(&cache.EventHandlerFuncs{
 		AddFunc: func(table string, model model.Model) {
-			go ps.AddPortBindingEvent(table, model)
+			if table != portBindingTable {
+				return
+			}
+			go ps.AddPortBindingEvent(model)
 		},
 		UpdateFunc: func(table string, old model.Model, new model.Model) {
-			go ps.UpdatePortBindingEvent(table, old, new)
+			if table != portBindingTable {
+				return
+			}
+			go ps.UpdatePortBindingEvent(old, new)
 		},
 		DeleteFunc: func(table string, model model.Model) {
 		},
@@ -545,10 +551,7 @@ func (ps *ControlPlaneRecorder) AddLSPEvent(podUID kapimtypes.UID) {
 	r.timestampType = logicalSwitchPort
 }
 
-func (ps *ControlPlaneRecorder) AddPortBindingEvent(table string, m model.Model) {
-	if table != portBindingTable {
-		return
-	}
+func (ps *ControlPlaneRecorder) AddPortBindingEvent(m model.Model) {
 	var r *record
 	now := time.Now()
 	row := m.(*sbdb.PortBinding)
@@ -571,10 +574,7 @@ func (ps *ControlPlaneRecorder) AddPortBindingEvent(table string, m model.Model)
 	r.timestampType = portBinding
 }
 
-func (ps *ControlPlaneRecorder) UpdatePortBindingEvent(table string, old, new model.Model) {
-	if table != portBindingTable {
-		return
-	}
+func (ps *ControlPlaneRecorder) UpdatePortBindingEvent(old, new model.Model) {
 	var r *record
 	oldRow := old.(*sbdb.PortBinding)
 	newRow := new.(*sbdb.PortBinding)

--- a/go-controller/pkg/metrics/master.go
+++ b/go-controller/pkg/metrics/master.go
@@ -3,6 +3,7 @@ package metrics
 import (
 	"fmt"
 	"runtime"
+	"strconv"
 	"sync"
 	"time"
 
@@ -22,14 +23,27 @@ import (
 	klog "k8s.io/klog/v2"
 )
 
-// metricE2ETimestamp is a timestamp value we have persisted to nbdb. We will
-// also export a metric with the same column in sbdb. We will also bump this
-// every 30 seconds, so we can detect a hung northd.
-var metricE2ETimestamp = prometheus.NewGauge(prometheus.GaugeOpts{
+// metricNbE2eTimestamp is the UNIX timestamp value set to NB DB. A corresponding metric
+// 'sb_e2e_timestamp' for SB DB will contain the timestamp that was written to NB DB.
+// This is registered within func RunTimestamp in order to allow gathering this metric on
+// the fly when metrics are scraped.
+var metricNbE2eTimestamp = prometheus.NewGauge(prometheus.GaugeOpts{
 	Namespace: MetricOvnkubeNamespace,
 	Subsystem: MetricOvnkubeSubsystemMaster,
 	Name:      "nb_e2e_timestamp",
-	Help:      "The current e2e-timestamp value as written to the northbound database"})
+	Help:      "The current e2e-timestamp value as written to the northbound database"},
+)
+
+// metricDbTimestamp is the UNIX timestamp seen in NB and SB DBs.
+var metricDbTimestamp = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	Namespace: MetricOvnNamespace,
+	Subsystem: MetricOvnSubsystemDB,
+	Name:      "e2e_timestamp",
+	Help:      "The current e2e-timestamp value as observed in this instance of the database"},
+	[]string{
+		"db_name",
+	},
+)
 
 // metricPodCreationLatency is the time between a pod being scheduled and the
 // ovn controller setting the network annotations.
@@ -225,37 +239,16 @@ var metricPortBindingUpLatency = prometheus.NewHistogram(prometheus.HistogramOpt
 })
 
 var registerMasterMetricsOnce sync.Once
-var startMasterMetricUpdaterOnce sync.Once
 
 // RegisterMasterMetrics registers some ovnkube master metrics with the Prometheus
 // registry
-func RegisterMasterMetrics(sbClient libovsdbclient.Client) {
+func RegisterMasterMetrics(nbClient libovsdbclient.Client) {
 	registerMasterMetricsOnce.Do(func() {
 		// ovnkube-master metrics
 		// the updater for this metric is activated
 		// after leader election
-		prometheus.MustRegister(metricE2ETimestamp)
 		prometheus.MustRegister(MetricMasterLeader)
 		prometheus.MustRegister(metricPodCreationLatency)
-
-		scrapeOvnTimestamp := func() float64 {
-			sbGlobal, err := libovsdbops.FindSBGlobal(sbClient)
-			if err != nil {
-				klog.Errorf("Failed to get global options for the SB_Global table err: %v", err)
-				return 0
-			}
-			if val, ok := sbGlobal.Options["e2e_timestamp"]; ok {
-				return parseMetricToFloat(MetricOvnkubeSubsystemMaster, "sb_e2e_timestamp", val)
-			}
-			return 0
-		}
-		prometheus.MustRegister(prometheus.NewGaugeFunc(
-			prometheus.GaugeOpts{
-				Namespace: MetricOvnkubeNamespace,
-				Subsystem: MetricOvnkubeSubsystemMaster,
-				Name:      "sb_e2e_timestamp",
-				Help:      "The current e2e-timestamp value as observed in the southbound database",
-			}, scrapeOvnTimestamp))
 		prometheus.MustRegister(prometheus.NewCounterFunc(
 			prometheus.CounterOpts{
 				Namespace: MetricOvnkubeNamespace,
@@ -300,31 +293,89 @@ func RegisterMasterMetrics(sbClient libovsdbclient.Client) {
 		prometheus.MustRegister(metricV6AllocatedHostSubnetCount)
 		prometheus.MustRegister(metricEgressIPCount)
 		prometheus.MustRegister(metricEgressFirewallRuleCount)
-		prometheus.MustRegister(metricIPsecEnabled)
 		prometheus.MustRegister(metricEgressFirewallCount)
 		registerWorkqueueMetrics(MetricOvnkubeNamespace, MetricOvnkubeSubsystemMaster)
+		prometheus.MustRegister(prometheus.NewGaugeFunc(
+			prometheus.GaugeOpts{
+				Namespace: MetricOvnNamespace,
+				Subsystem: MetricOvnSubsystemNorthd,
+				Name:      "northd_probe_interval",
+				Help: "The maximum number of milliseconds of idle time on connection to the OVN SB " +
+					"and NB DB before sending an inactivity probe message",
+			}, func() float64 {
+				var nbGlobal *nbdb.NBGlobal
+				var probeInterval string
+				var ok bool
+				var err error
+
+				if nbGlobal, err = libovsdbops.FindNBGlobal(nbClient); err != nil {
+					klog.Errorf("Failed to get NB_Global table "+
+						"err: %v", err)
+					return 0
+				}
+
+				if probeInterval, ok = nbGlobal.Options["northd_probe_interval"]; !ok {
+					klog.Errorf("Failed to get northd_probe_interval from NB_Global table options column")
+					return 0
+				}
+
+				return parseMetricToFloat(MetricOvnSubsystemNorthd, "probe_interval", probeInterval)
+			},
+		))
 	})
 }
 
-// StartMasterMetricUpdater adds a goroutine that updates a "timestamp" value in the
-// nbdb every 30 seconds. This is so we can determine freshness of the database.
-// Also, update IPsec enabled or disable metric.
-func StartMasterMetricUpdater(stopChan <-chan struct{}, nbClient libovsdbclient.Client) {
-	startMasterMetricUpdaterOnce.Do(func() {
-		addIPSecMetricHandler(nbClient)
-		go func() {
-			ticker := time.NewTicker(30 * time.Second)
-			defer ticker.Stop()
-			for {
-				select {
-				case <-ticker.C:
-					updateE2ETimestampMetric(nbClient)
-				case <-stopChan:
-					return
+// RunTimestamp adds a goroutine that registers and updates timestamp metrics.
+// This is so we can determine 'freshness' of the components NB/SB DB and northd.
+// Function must be called once.
+func RunTimestamp(stopChan <-chan struct{}, sbClient, nbClient libovsdbclient.Client) {
+	// Metric named nb_e2e_timestamp is the UNIX timestamp this instance wrote to NB DB. Updated every 30s with the
+	// current timestamp.
+	prometheus.MustRegister(metricNbE2eTimestamp)
+
+	// Metric named sb_e2e_timestamp is the UNIX timestamp observed in SB DB. The value is read from the SB DB
+	// cache when metrics HTTP endpoint is scraped.
+	scrapeOvnSbE2eTimestamp := func() float64 {
+		sbGlobal, err := libovsdbops.FindSBGlobal(sbClient)
+		if err != nil {
+			klog.Errorf("Failed to get global options for the SB_Global table: %v", err)
+			return 0
+		}
+		if val, ok := sbGlobal.Options["e2e_timestamp"]; ok {
+			return parseMetricToFloat(MetricOvnkubeSubsystemMaster, "sb_e2e_timestamp", val)
+		}
+		return 0
+	}
+	prometheus.MustRegister(prometheus.NewGaugeFunc(
+		prometheus.GaugeOpts{
+			Namespace: MetricOvnkubeNamespace,
+			Subsystem: MetricOvnkubeSubsystemMaster,
+			Name:      "sb_e2e_timestamp",
+			Help:      "The current e2e-timestamp value as observed in the southbound database",
+		}, scrapeOvnSbE2eTimestamp))
+
+	// Metric named e2e_timestamp is the UNIX timestamp observed in NB and SB DBs cache with the DB name
+	// (OVN_Northbound|OVN_Southbound) set as a label. Updated every 30s.
+	prometheus.MustRegister(metricDbTimestamp)
+
+	go func() {
+		ticker := time.NewTicker(30 * time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				currentTime := time.Now().Unix()
+				if setNbE2eTimestamp(nbClient, currentTime) {
+					metricNbE2eTimestamp.Set(float64(currentTime))
 				}
+
+				metricDbTimestamp.WithLabelValues(nbClient.Schema().Name).Set(getDbOptionsTimestamp(nbClient))
+				metricDbTimestamp.WithLabelValues(sbClient.Schema().Name).Set(getDbOptionsTimestamp(sbClient))
+			case <-stopChan:
+				return
 			}
-		}()
-	})
+		}
+	}()
 }
 
 // RecordPodCreated extracts the scheduled timestamp and records how long it took
@@ -370,18 +421,11 @@ func UpdateEgressFirewallRuleCount(count float64) {
 	metricEgressFirewallRuleCount.Add(count)
 }
 
-func updateE2ETimestampMetric(ovnNBClient libovsdbclient.Client) {
-	currentTime := time.Now().Unix()
-	// assumption that only first row is relevant in NB_Global table
-	if err := libovsdbops.UpdateNBGlobalOptions(ovnNBClient, map[string]string{"e2e_timestamp": fmt.Sprintf("%d", currentTime)}); err != nil {
-		klog.Errorf("Unable to update E2E timestamp metric err: %v", err)
-		return
-	}
-
-	metricE2ETimestamp.Set(float64(currentTime))
-}
-
-func addIPSecMetricHandler(ovnNBClient libovsdbclient.Client) {
+// MonitorIPSec will register a metric to determine if IPSec is enabled/disabled. It will also add a handler
+// to NB libovsdb cache to update the IPSec metric.
+// This function should only be called once.
+func MonitorIPSec(ovnNBClient libovsdbclient.Client) {
+	prometheus.MustRegister(metricIPsecEnabled)
 	ovnNBClient.Cache().AddEventHandler(&cache.EventHandlerFuncs{
 		AddFunc: func(table string, model model.Model) {
 			ipsecMetricHandler(table, model)
@@ -569,4 +613,56 @@ func getPodUIDFromPortBinding(row *sbdb.PortBinding) kapimtypes.UID {
 		return ""
 	}
 	return kapimtypes.UID(podUID)
+}
+
+// setNbE2eTimestamp return true if setting timestamp to NB global options is successful
+func setNbE2eTimestamp(ovnNBClient libovsdbclient.Client, timestamp int64) bool {
+	// assumption that only first row is relevant in NB_Global table
+	options := map[string]string{"e2e_timestamp": fmt.Sprintf("%d", timestamp)}
+	if err := libovsdbops.UpdateNBGlobalOptions(ovnNBClient, options); err != nil {
+		klog.Errorf("Unable to update NB global options E2E timestamp metric err: %v", err)
+		return false
+	}
+	return true
+}
+
+func getDbOptionsTimestamp(client libovsdbclient.Client) float64 {
+	var options map[string]string
+	dbName := client.Schema().Name
+
+	if dbName == "OVN_Northbound" {
+		if nbGlobal, err := libovsdbops.FindNBGlobal(client); err != nil && err != libovsdbclient.ErrNotFound {
+			klog.Errorf("Failed to get NB_Global table err: %v", err)
+			return 0
+		} else {
+			options = nbGlobal.Options
+		}
+	}
+
+	if dbName == "OVN_Southbound" {
+		if sbGlobal, err := libovsdbops.FindSBGlobal(client); err != nil && err != libovsdbclient.ErrNotFound {
+			klog.Errorf("Failed to get SB_Global table err: %v", err)
+			return 0
+		} else {
+			options = sbGlobal.Options
+		}
+	}
+	return extractOptionsTimestamp(options, dbName)
+}
+
+func extractOptionsTimestamp(options map[string]string, name string) float64 {
+	var v string
+	var ok bool
+
+	if v, ok = options["e2e_timestamp"]; !ok {
+		klog.V(5).Infof("Failed to find 'e2e-timestamp' from %s options. This may occur at startup.", name)
+		return 0
+	}
+
+	if value, err := strconv.ParseFloat(v, 64); err != nil {
+		klog.Errorf("Failed to parse 'e2e-timestamp' value to float64 err: %v", err)
+		return 0
+	} else {
+		return value
+	}
 }

--- a/go-controller/pkg/metrics/master.go
+++ b/go-controller/pkg/metrics/master.go
@@ -238,91 +238,95 @@ var metricPortBindingUpLatency = prometheus.NewHistogram(prometheus.HistogramOpt
 	Buckets:   prometheus.ExponentialBuckets(.01, 2, 15),
 })
 
-var registerMasterMetricsOnce sync.Once
-
-// RegisterMasterMetrics registers some ovnkube master metrics with the Prometheus
-// registry
-func RegisterMasterMetrics(nbClient libovsdbclient.Client) {
-	registerMasterMetricsOnce.Do(func() {
-		// ovnkube-master metrics
-		// the updater for this metric is activated
-		// after leader election
-		prometheus.MustRegister(MetricMasterLeader)
-		prometheus.MustRegister(metricPodCreationLatency)
-		prometheus.MustRegister(prometheus.NewCounterFunc(
-			prometheus.CounterOpts{
-				Namespace: MetricOvnkubeNamespace,
-				Subsystem: MetricOvnkubeSubsystemMaster,
-				Name:      "skipped_nbctl_daemon_total",
-				Help:      "The number of times we skipped using ovn-nbctl daemon and directly interacted with OVN NB DB",
-			}, func() float64 {
-				return float64(util.SkippedNbctlDaemonCounter)
-			}))
-		prometheus.MustRegister(MetricMasterReadyDuration)
-		prometheus.MustRegister(metricOvnCliLatency)
-		// this is to not to create circular import between metrics and util package
-		util.MetricOvnCliLatency = metricOvnCliLatency
-		prometheus.MustRegister(MetricResourceUpdateCount)
-		prometheus.MustRegister(MetricResourceAddLatency)
-		prometheus.MustRegister(MetricResourceUpdateLatency)
-		prometheus.MustRegister(MetricResourceDeleteLatency)
-		prometheus.MustRegister(MetricRequeueServiceCount)
-		prometheus.MustRegister(MetricSyncServiceCount)
-		prometheus.MustRegister(MetricSyncServiceLatency)
-		prometheus.MustRegister(prometheus.NewGaugeFunc(
-			prometheus.GaugeOpts{
-				Namespace: MetricOvnkubeNamespace,
-				Subsystem: MetricOvnkubeSubsystemMaster,
-				Name:      "build_info",
-				Help: "A metric with a constant '1' value labeled by version, revision, branch, " +
-					"and go version from which ovnkube was built and when and who built it",
-				ConstLabels: prometheus.Labels{
-					"version":    "0.0",
-					"revision":   config.Commit,
-					"branch":     config.Branch,
-					"build_user": config.BuildUser,
-					"build_date": config.BuildDate,
-					"goversion":  runtime.Version(),
-				},
+// RegisterMasterBase registers ovnkube master base metrics with the Prometheus registry.
+// This function should only be called once.
+func RegisterMasterBase() {
+	prometheus.MustRegister(MetricMasterLeader)
+	prometheus.MustRegister(MetricMasterReadyDuration)
+	prometheus.MustRegister(prometheus.NewGaugeFunc(
+		prometheus.GaugeOpts{
+			Namespace: MetricOvnkubeNamespace,
+			Subsystem: MetricOvnkubeSubsystemMaster,
+			Name:      "build_info",
+			Help: "A metric with a constant '1' value labeled by version, revision, branch, " +
+				"and go version from which ovnkube was built and when and who built it",
+			ConstLabels: prometheus.Labels{
+				"version":    "0.0",
+				"revision":   config.Commit,
+				"branch":     config.Branch,
+				"build_user": config.BuildUser,
+				"build_date": config.BuildDate,
+				"goversion":  runtime.Version(),
 			},
-			func() float64 { return 1 },
-		))
-		prometheus.MustRegister(metricV4HostSubnetCount)
-		prometheus.MustRegister(metricV6HostSubnetCount)
-		prometheus.MustRegister(metricV4AllocatedHostSubnetCount)
-		prometheus.MustRegister(metricV6AllocatedHostSubnetCount)
-		prometheus.MustRegister(metricEgressIPCount)
-		prometheus.MustRegister(metricEgressFirewallRuleCount)
-		prometheus.MustRegister(metricEgressFirewallCount)
-		registerWorkqueueMetrics(MetricOvnkubeNamespace, MetricOvnkubeSubsystemMaster)
-		prometheus.MustRegister(prometheus.NewGaugeFunc(
-			prometheus.GaugeOpts{
-				Namespace: MetricOvnNamespace,
-				Subsystem: MetricOvnSubsystemNorthd,
-				Name:      "northd_probe_interval",
-				Help: "The maximum number of milliseconds of idle time on connection to the OVN SB " +
-					"and NB DB before sending an inactivity probe message",
-			}, func() float64 {
-				var nbGlobal *nbdb.NBGlobal
-				var probeInterval string
-				var ok bool
-				var err error
+		},
+		func() float64 { return 1 },
+	))
+}
 
-				if nbGlobal, err = libovsdbops.FindNBGlobal(nbClient); err != nil {
-					klog.Errorf("Failed to get NB_Global table "+
-						"err: %v", err)
-					return 0
-				}
+// RegisterMasterPerformance registers metrics that help us understand ovnkube-master performance. Call once after LE is won.
+func RegisterMasterPerformance(nbClient libovsdbclient.Client) {
+	// No need to unregister because process exits when leadership is lost.
+	prometheus.MustRegister(metricPodCreationLatency)
+	prometheus.MustRegister(MetricResourceUpdateCount)
+	prometheus.MustRegister(MetricResourceAddLatency)
+	prometheus.MustRegister(MetricResourceUpdateLatency)
+	prometheus.MustRegister(MetricResourceDeleteLatency)
+	prometheus.MustRegister(MetricRequeueServiceCount)
+	prometheus.MustRegister(MetricSyncServiceCount)
+	prometheus.MustRegister(MetricSyncServiceLatency)
+	prometheus.MustRegister(metricOvnCliLatency)
+	// This is set to not create circular import between metrics and util package
+	util.MetricOvnCliLatency = metricOvnCliLatency
+	registerWorkqueueMetrics(MetricOvnkubeNamespace, MetricOvnkubeSubsystemMaster)
+	prometheus.MustRegister(prometheus.NewCounterFunc(
+		prometheus.CounterOpts{
+			Namespace: MetricOvnkubeNamespace,
+			Subsystem: MetricOvnkubeSubsystemMaster,
+			Name:      "skipped_nbctl_daemon_total",
+			Help:      "The number of times we skipped using ovn-nbctl daemon and directly interacted with OVN NB DB",
+		}, func() float64 {
+			return float64(util.SkippedNbctlDaemonCounter)
+		}))
+	prometheus.MustRegister(prometheus.NewGaugeFunc(
+		prometheus.GaugeOpts{
+			Namespace: MetricOvnNamespace,
+			Subsystem: MetricOvnSubsystemNorthd,
+			Name:      "northd_probe_interval",
+			Help: "The maximum number of milliseconds of idle time on connection to the OVN SB " +
+				"and NB DB before sending an inactivity probe message",
+		}, func() float64 {
+			var nbGlobal *nbdb.NBGlobal
+			var probeInterval string
+			var ok bool
+			var err error
 
-				if probeInterval, ok = nbGlobal.Options["northd_probe_interval"]; !ok {
-					klog.Errorf("Failed to get northd_probe_interval from NB_Global table options column")
-					return 0
-				}
+			if nbGlobal, err = libovsdbops.FindNBGlobal(nbClient); err != nil {
+				klog.Errorf("Failed to get NB_Global table "+
+					"err: %v", err)
+				return 0
+			}
 
-				return parseMetricToFloat(MetricOvnSubsystemNorthd, "probe_interval", probeInterval)
-			},
-		))
-	})
+			if probeInterval, ok = nbGlobal.Options["northd_probe_interval"]; !ok {
+				klog.Errorf("Failed to get northd_probe_interval from NB_Global table options column")
+				return 0
+			}
+
+			return parseMetricToFloat(MetricOvnSubsystemNorthd, "probe_interval", probeInterval)
+		},
+	))
+}
+
+// RegisterMasterFunctional is a collection of metrics that help us understand ovnkube-master functions. Call once after
+// LE is won.
+func RegisterMasterFunctional() {
+	// No need to unregister because process exits when leadership is lost.
+	prometheus.MustRegister(metricV4HostSubnetCount)
+	prometheus.MustRegister(metricV6HostSubnetCount)
+	prometheus.MustRegister(metricV4AllocatedHostSubnetCount)
+	prometheus.MustRegister(metricV6AllocatedHostSubnetCount)
+	prometheus.MustRegister(metricEgressIPCount)
+	prometheus.MustRegister(metricEgressFirewallRuleCount)
+	prometheus.MustRegister(metricEgressFirewallCount)
 }
 
 // RunTimestamp adds a goroutine that registers and updates timestamp metrics.
@@ -491,6 +495,7 @@ func NewControlPlaneRecorder() *ControlPlaneRecorder {
 	}
 }
 
+//Run will register the necessary metrics and add event handlers.
 func (ps *ControlPlaneRecorder) Run(sbClient libovsdbclient.Client) {
 	// only register the metrics when we want them
 	prometheus.MustRegister(metricFirstSeenLSPLatency)

--- a/go-controller/pkg/metrics/master.go
+++ b/go-controller/pkg/metrics/master.go
@@ -238,6 +238,11 @@ var metricPortBindingUpLatency = prometheus.NewHistogram(prometheus.HistogramOpt
 	Buckets:   prometheus.ExponentialBuckets(.01, 2, 15),
 })
 
+const (
+	globalOptionsTimestampField     = "e2e_timestamp"
+	globalOptionsProbeIntervalField = "northd_probe_interval"
+)
+
 // RegisterMasterBase registers ovnkube master base metrics with the Prometheus registry.
 // This function should only be called once.
 func RegisterMasterBase() {
@@ -295,23 +300,7 @@ func RegisterMasterPerformance(nbClient libovsdbclient.Client) {
 			Help: "The maximum number of milliseconds of idle time on connection to the OVN SB " +
 				"and NB DB before sending an inactivity probe message",
 		}, func() float64 {
-			var nbGlobal *nbdb.NBGlobal
-			var probeInterval string
-			var ok bool
-			var err error
-
-			if nbGlobal, err = libovsdbops.FindNBGlobal(nbClient); err != nil {
-				klog.Errorf("Failed to get NB_Global table "+
-					"err: %v", err)
-				return 0
-			}
-
-			if probeInterval, ok = nbGlobal.Options["northd_probe_interval"]; !ok {
-				klog.Errorf("Failed to get northd_probe_interval from NB_Global table options column")
-				return 0
-			}
-
-			return parseMetricToFloat(MetricOvnSubsystemNorthd, "probe_interval", probeInterval)
+			return getGlobalOptionsValue(nbClient, globalOptionsProbeIntervalField)
 		},
 	))
 }
@@ -339,24 +328,15 @@ func RunTimestamp(stopChan <-chan struct{}, sbClient, nbClient libovsdbclient.Cl
 
 	// Metric named sb_e2e_timestamp is the UNIX timestamp observed in SB DB. The value is read from the SB DB
 	// cache when metrics HTTP endpoint is scraped.
-	scrapeOvnSbE2eTimestamp := func() float64 {
-		sbGlobal, err := libovsdbops.FindSBGlobal(sbClient)
-		if err != nil {
-			klog.Errorf("Failed to get global options for the SB_Global table: %v", err)
-			return 0
-		}
-		if val, ok := sbGlobal.Options["e2e_timestamp"]; ok {
-			return parseMetricToFloat(MetricOvnkubeSubsystemMaster, "sb_e2e_timestamp", val)
-		}
-		return 0
-	}
 	prometheus.MustRegister(prometheus.NewGaugeFunc(
 		prometheus.GaugeOpts{
 			Namespace: MetricOvnkubeNamespace,
 			Subsystem: MetricOvnkubeSubsystemMaster,
 			Name:      "sb_e2e_timestamp",
 			Help:      "The current e2e-timestamp value as observed in the southbound database",
-		}, scrapeOvnSbE2eTimestamp))
+		}, func() float64 {
+			return getGlobalOptionsValue(sbClient, globalOptionsTimestampField)
+		}))
 
 	// Metric named e2e_timestamp is the UNIX timestamp observed in NB and SB DBs cache with the DB name
 	// (OVN_Northbound|OVN_Southbound) set as a label. Updated every 30s.
@@ -371,10 +351,12 @@ func RunTimestamp(stopChan <-chan struct{}, sbClient, nbClient libovsdbclient.Cl
 				currentTime := time.Now().Unix()
 				if setNbE2eTimestamp(nbClient, currentTime) {
 					metricNbE2eTimestamp.Set(float64(currentTime))
+				} else {
+					metricNbE2eTimestamp.Set(0)
 				}
 
-				metricDbTimestamp.WithLabelValues(nbClient.Schema().Name).Set(getDbOptionsTimestamp(nbClient))
-				metricDbTimestamp.WithLabelValues(sbClient.Schema().Name).Set(getDbOptionsTimestamp(sbClient))
+				metricDbTimestamp.WithLabelValues(nbClient.Schema().Name).Set(getGlobalOptionsValue(nbClient, globalOptionsTimestampField))
+				metricDbTimestamp.WithLabelValues(sbClient.Schema().Name).Set(getGlobalOptionsValue(sbClient, globalOptionsTimestampField))
 			case <-stopChan:
 				return
 			}
@@ -623,7 +605,7 @@ func getPodUIDFromPortBinding(row *sbdb.PortBinding) kapimtypes.UID {
 // setNbE2eTimestamp return true if setting timestamp to NB global options is successful
 func setNbE2eTimestamp(ovnNBClient libovsdbclient.Client, timestamp int64) bool {
 	// assumption that only first row is relevant in NB_Global table
-	options := map[string]string{"e2e_timestamp": fmt.Sprintf("%d", timestamp)}
+	options := map[string]string{globalOptionsTimestampField: fmt.Sprintf("%d", timestamp)}
 	if err := libovsdbops.UpdateNBGlobalOptions(ovnNBClient, options); err != nil {
 		klog.Errorf("Unable to update NB global options E2E timestamp metric err: %v", err)
 		return false
@@ -631,7 +613,7 @@ func setNbE2eTimestamp(ovnNBClient libovsdbclient.Client, timestamp int64) bool 
 	return true
 }
 
-func getDbOptionsTimestamp(client libovsdbclient.Client) float64 {
+func getGlobalOptionsValue(client libovsdbclient.Client, field string) float64 {
 	var options map[string]string
 	dbName := client.Schema().Name
 
@@ -652,22 +634,16 @@ func getDbOptionsTimestamp(client libovsdbclient.Client) float64 {
 			options = sbGlobal.Options
 		}
 	}
-	return extractOptionsTimestamp(options, dbName)
-}
 
-func extractOptionsTimestamp(options map[string]string, name string) float64 {
-	var v string
-	var ok bool
-
-	if v, ok = options["e2e_timestamp"]; !ok {
-		klog.V(5).Infof("Failed to find 'e2e-timestamp' from %s options. This may occur at startup.", name)
-		return 0
-	}
-
-	if value, err := strconv.ParseFloat(v, 64); err != nil {
-		klog.Errorf("Failed to parse 'e2e-timestamp' value to float64 err: %v", err)
+	if v, ok := options[field]; !ok {
+		klog.V(5).Infof("Failed to find %q from %s options. This may occur at startup.", field, dbName)
 		return 0
 	} else {
-		return value
+		if value, err := strconv.ParseFloat(v, 64); err != nil {
+			klog.Errorf("Failed to parse %q value to float64 err: %v", field, err)
+			return 0
+		} else {
+			return value
+		}
 	}
 }

--- a/go-controller/pkg/metrics/ovn.go
+++ b/go-controller/pkg/metrics/ovn.go
@@ -282,16 +282,21 @@ func setOvnControllerConfigurationMetrics() (err error) {
 			}
 			metricMonitorAll.Set(ovnMonitorValue)
 		case "ovn-encap-ip":
+			// To update not only values but also labels for metrics, we use Reset() to delete previous labels+value
+			metricEncapIP.Reset()
 			metricEncapIP.WithLabelValues(fieldValue).Set(1)
 		case "ovn-remote":
+			metricSbConnectionMethod.Reset()
 			metricSbConnectionMethod.WithLabelValues(fieldValue).Set(1)
 		case "ovn-encap-type":
+			metricEncapType.Reset()
 			metricEncapType.WithLabelValues(fieldValue).Set(1)
 		case "ovn-k8s-node-port":
 			if fieldValue == "false" {
 				ovnNodePortValue = 0
 			}
 		case "ovn-bridge-mappings":
+			metricBridgeMappings.Reset()
 			metricBridgeMappings.WithLabelValues(fieldValue).Set(1)
 		}
 	}

--- a/go-controller/pkg/metrics/ovn_db.go
+++ b/go-controller/pkg/metrics/ovn_db.go
@@ -256,10 +256,12 @@ func ovnDBSizeMetricsUpdater(basePath, direction, database string) {
 	if size, err := getOvnDBSizeViaPath(basePath, direction, database); err != nil {
 		klog.Errorf("Failed to update OVN DB size metric: %v", err)
 	} else {
-		// To update not only values but also labels for metrics, we use Reset() to delete previous labels+value
-		metricDBSize.Reset()
 		metricDBSize.WithLabelValues(database).Set(float64(size))
 	}
+}
+
+func resetOvnDbSizeMetric() {
+	metricDBSize.Reset()
 }
 
 // isOvnDBFoundViaPath attempts to find the OVN DBs, return false if not found.
@@ -331,8 +333,6 @@ func ovnDBMemoryMetricsUpdater(direction, database string) {
 			// kvPair will be of the form monitors:2
 			fields := strings.Split(kvPair, ":")
 			if value, err := strconv.ParseFloat(fields[1], 64); err == nil {
-				// To update not only values but also labels for metrics, we use Reset() to delete previous labels+value
-				metricOVNDBMonitor.Reset()
 				metricOVNDBMonitor.WithLabelValues(database).Set(value)
 			} else {
 				klog.Errorf("Failed to parse the monitor's value %s to float64: err(%v)",
@@ -342,7 +342,6 @@ func ovnDBMemoryMetricsUpdater(direction, database string) {
 			// kvPair will be of the form sessions:2
 			fields := strings.Split(kvPair, ":")
 			if value, err := strconv.ParseFloat(fields[1], 64); err == nil {
-				metricOVNDBSessions.Reset()
 				metricOVNDBSessions.WithLabelValues(database).Set(value)
 			} else {
 				klog.Errorf("Failed to parse the sessions' value %s to float64: err(%v)",
@@ -350,6 +349,11 @@ func ovnDBMemoryMetricsUpdater(direction, database string) {
 			}
 		}
 	}
+}
+
+func resetOvnDbMemoryMetrics() {
+	metricOVNDBMonitor.Reset()
+	metricOVNDBSessions.Reset()
 }
 
 var (
@@ -459,6 +463,14 @@ func RegisterOvnDBMetrics(clientset kubernetes.Interface, k8sNodeName string) {
 				ovnE2eTimeStampUpdater(direction, database)
 			}
 			time.Sleep(30 * time.Second)
+			// To update not only values but also labels for metrics, we use Reset() to delete previous labels+value
+			if dbIsClustered {
+				resetOvnDbClusterMetrics()
+			}
+			if dbFoundViaPath {
+				resetOvnDbSizeMetric()
+			}
+			resetOvnDbMemoryMetrics()
 		}
 	}()
 }
@@ -576,47 +588,49 @@ func ovnDBClusterStatusMetricsUpdater(direction, database string) {
 		klog.Errorf(err.Error())
 		return
 	}
-	// To update not only values but also labels for metrics, we use Reset() to delete previous labels+value
-	metricDBClusterCID.Reset()
 	metricDBClusterCID.WithLabelValues(database, clusterStatus.cid).Set(1)
-	metricDBClusterSID.Reset()
 	metricDBClusterSID.WithLabelValues(database, clusterStatus.cid, clusterStatus.sid).Set(1)
-	metricDBClusterServerStatus.Reset()
 	metricDBClusterServerStatus.WithLabelValues(database, clusterStatus.cid, clusterStatus.sid,
 		clusterStatus.status).Set(1)
-	metricDBClusterTerm.Reset()
 	metricDBClusterTerm.WithLabelValues(database, clusterStatus.cid, clusterStatus.sid).Set(clusterStatus.term)
-	metricDBClusterServerRole.Reset()
 	metricDBClusterServerRole.WithLabelValues(database, clusterStatus.cid, clusterStatus.sid,
 		clusterStatus.role).Set(1)
-	metricDBClusterServerVote.Reset()
 	metricDBClusterServerVote.WithLabelValues(database, clusterStatus.cid, clusterStatus.sid,
 		clusterStatus.vote).Set(1)
-	metricDBClusterElectionTimer.Reset()
 	metricDBClusterElectionTimer.WithLabelValues(database, clusterStatus.cid,
 		clusterStatus.sid).Set(clusterStatus.electionTimer)
-	metricDBClusterLogIndexStart.Reset()
 	metricDBClusterLogIndexStart.WithLabelValues(database, clusterStatus.cid,
 		clusterStatus.sid).Set(clusterStatus.logIndexStart)
-	metricDBClusterLogIndexNext.Reset()
 	metricDBClusterLogIndexNext.WithLabelValues(database, clusterStatus.cid,
 		clusterStatus.sid).Set(clusterStatus.logIndexNext)
-	metricDBClusterLogNotCommitted.Reset()
 	metricDBClusterLogNotCommitted.WithLabelValues(database, clusterStatus.cid,
 		clusterStatus.sid).Set(clusterStatus.logNotCommitted)
-	metricDBClusterLogNotApplied.Reset()
 	metricDBClusterLogNotApplied.WithLabelValues(database, clusterStatus.cid,
 		clusterStatus.sid).Set(clusterStatus.logNotApplied)
-	metricDBClusterConnIn.Reset()
 	metricDBClusterConnIn.WithLabelValues(database, clusterStatus.cid,
 		clusterStatus.sid).Set(clusterStatus.connIn)
-	metricDBClusterConnOut.Reset()
 	metricDBClusterConnOut.WithLabelValues(database, clusterStatus.cid,
 		clusterStatus.sid).Set(clusterStatus.connOut)
-	metricDBClusterConnInErr.Reset()
 	metricDBClusterConnInErr.WithLabelValues(database, clusterStatus.cid,
 		clusterStatus.sid).Set(clusterStatus.connInErr)
-	metricDBClusterConnOutErr.Reset()
 	metricDBClusterConnOutErr.WithLabelValues(database, clusterStatus.cid,
 		clusterStatus.sid).Set(clusterStatus.connOutErr)
+}
+
+func resetOvnDbClusterMetrics() {
+	metricDBClusterCID.Reset()
+	metricDBClusterSID.Reset()
+	metricDBClusterServerStatus.Reset()
+	metricDBClusterTerm.Reset()
+	metricDBClusterServerRole.Reset()
+	metricDBClusterServerVote.Reset()
+	metricDBClusterElectionTimer.Reset()
+	metricDBClusterLogIndexStart.Reset()
+	metricDBClusterLogIndexNext.Reset()
+	metricDBClusterLogNotCommitted.Reset()
+	metricDBClusterLogNotApplied.Reset()
+	metricDBClusterConnIn.Reset()
+	metricDBClusterConnOut.Reset()
+	metricDBClusterConnInErr.Reset()
+	metricDBClusterConnOutErr.Reset()
 }

--- a/go-controller/pkg/metrics/ovn_db.go
+++ b/go-controller/pkg/metrics/ovn_db.go
@@ -256,6 +256,8 @@ func ovnDBSizeMetricsUpdater(basePath, direction, database string) {
 	if size, err := getOvnDBSizeViaPath(basePath, direction, database); err != nil {
 		klog.Errorf("Failed to update OVN DB size metric: %v", err)
 	} else {
+		// To update not only values but also labels for metrics, we use Reset() to delete previous labels+value
+		metricDBSize.Reset()
 		metricDBSize.WithLabelValues(database).Set(float64(size))
 	}
 }
@@ -329,6 +331,8 @@ func ovnDBMemoryMetricsUpdater(direction, database string) {
 			// kvPair will be of the form monitors:2
 			fields := strings.Split(kvPair, ":")
 			if value, err := strconv.ParseFloat(fields[1], 64); err == nil {
+				// To update not only values but also labels for metrics, we use Reset() to delete previous labels+value
+				metricOVNDBMonitor.Reset()
 				metricOVNDBMonitor.WithLabelValues(database).Set(value)
 			} else {
 				klog.Errorf("Failed to parse the monitor's value %s to float64: err(%v)",
@@ -338,6 +342,7 @@ func ovnDBMemoryMetricsUpdater(direction, database string) {
 			// kvPair will be of the form sessions:2
 			fields := strings.Split(kvPair, ":")
 			if value, err := strconv.ParseFloat(fields[1], 64); err == nil {
+				metricOVNDBSessions.Reset()
 				metricOVNDBSessions.WithLabelValues(database).Set(value)
 			} else {
 				klog.Errorf("Failed to parse the sessions' value %s to float64: err(%v)",
@@ -571,31 +576,47 @@ func ovnDBClusterStatusMetricsUpdater(direction, database string) {
 		klog.Errorf(err.Error())
 		return
 	}
+	// To update not only values but also labels for metrics, we use Reset() to delete previous labels+value
+	metricDBClusterCID.Reset()
 	metricDBClusterCID.WithLabelValues(database, clusterStatus.cid).Set(1)
+	metricDBClusterSID.Reset()
 	metricDBClusterSID.WithLabelValues(database, clusterStatus.cid, clusterStatus.sid).Set(1)
+	metricDBClusterServerStatus.Reset()
 	metricDBClusterServerStatus.WithLabelValues(database, clusterStatus.cid, clusterStatus.sid,
 		clusterStatus.status).Set(1)
+	metricDBClusterTerm.Reset()
 	metricDBClusterTerm.WithLabelValues(database, clusterStatus.cid, clusterStatus.sid).Set(clusterStatus.term)
+	metricDBClusterServerRole.Reset()
 	metricDBClusterServerRole.WithLabelValues(database, clusterStatus.cid, clusterStatus.sid,
 		clusterStatus.role).Set(1)
+	metricDBClusterServerVote.Reset()
 	metricDBClusterServerVote.WithLabelValues(database, clusterStatus.cid, clusterStatus.sid,
 		clusterStatus.vote).Set(1)
+	metricDBClusterElectionTimer.Reset()
 	metricDBClusterElectionTimer.WithLabelValues(database, clusterStatus.cid,
 		clusterStatus.sid).Set(clusterStatus.electionTimer)
+	metricDBClusterLogIndexStart.Reset()
 	metricDBClusterLogIndexStart.WithLabelValues(database, clusterStatus.cid,
 		clusterStatus.sid).Set(clusterStatus.logIndexStart)
+	metricDBClusterLogIndexNext.Reset()
 	metricDBClusterLogIndexNext.WithLabelValues(database, clusterStatus.cid,
 		clusterStatus.sid).Set(clusterStatus.logIndexNext)
+	metricDBClusterLogNotCommitted.Reset()
 	metricDBClusterLogNotCommitted.WithLabelValues(database, clusterStatus.cid,
 		clusterStatus.sid).Set(clusterStatus.logNotCommitted)
+	metricDBClusterLogNotApplied.Reset()
 	metricDBClusterLogNotApplied.WithLabelValues(database, clusterStatus.cid,
 		clusterStatus.sid).Set(clusterStatus.logNotApplied)
+	metricDBClusterConnIn.Reset()
 	metricDBClusterConnIn.WithLabelValues(database, clusterStatus.cid,
 		clusterStatus.sid).Set(clusterStatus.connIn)
+	metricDBClusterConnOut.Reset()
 	metricDBClusterConnOut.WithLabelValues(database, clusterStatus.cid,
 		clusterStatus.sid).Set(clusterStatus.connOut)
+	metricDBClusterConnInErr.Reset()
 	metricDBClusterConnInErr.WithLabelValues(database, clusterStatus.cid,
 		clusterStatus.sid).Set(clusterStatus.connInErr)
+	metricDBClusterConnOutErr.Reset()
 	metricDBClusterConnOutErr.WithLabelValues(database, clusterStatus.cid,
 		clusterStatus.sid).Set(clusterStatus.connOutErr)
 }

--- a/go-controller/pkg/metrics/ovn_northd.go
+++ b/go-controller/pkg/metrics/ovn_northd.go
@@ -94,12 +94,8 @@ func RegisterOvnNorthdMetrics(clientset kubernetes.Interface, k8sNodeName string
 		return checkPodRunsOnGivenNode(clientset, []string{"app=ovnkube-master", "name=ovnkube-master"}, k8sNodeName, true)
 	})
 	if err != nil {
-		if err == wait.ErrWaitTimeout {
-			klog.Errorf("Timed out while checking if OVNKube Master Pod runs on this %q K8s Node: %v. "+
-				"Not registering OVN North Metrics on this Node", k8sNodeName, err)
-		} else {
-			klog.Infof("Not registering OVN North Metrics on this Node since ovn-northd is not running on this node.")
-		}
+		klog.Infof("Not registering OVN North Metrics because OVNKube Master Pod was not found running on this "+
+			"node (%s)", k8sNodeName)
 		return
 	}
 	klog.Info("Found OVNKube Master Pod running on this node. Registering OVN North Metrics")

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -214,6 +214,8 @@ func (oc *Controller) upgradeOVNTopology(existingNodes *kapi.NodeList) error {
 func (oc *Controller) StartClusterMaster(masterNodeName string) error {
 	klog.Infof("Starting cluster master")
 
+	metrics.RegisterMasterPerformance(oc.nbClient)
+	metrics.RegisterMasterFunctional()
 	metrics.RunTimestamp(oc.stopChan, oc.sbClient, oc.nbClient)
 	metrics.MonitorIPSec(oc.nbClient)
 	oc.metricsRecorder.Run(oc.sbClient)

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -92,8 +92,7 @@ func (oc *Controller) Start(nodeName string, wg *sync.WaitGroup, ctx context.Con
 					end := time.Since(start)
 					metrics.MetricMasterReadyDuration.Set(end.Seconds())
 				}()
-				// run only on the active master node.
-				metrics.StartMasterMetricUpdater(oc.stopChan, oc.nbClient)
+
 				if err := oc.StartClusterMaster(nodeName); err != nil {
 					panic(err.Error())
 				}
@@ -215,6 +214,8 @@ func (oc *Controller) upgradeOVNTopology(existingNodes *kapi.NodeList) error {
 func (oc *Controller) StartClusterMaster(masterNodeName string) error {
 	klog.Infof("Starting cluster master")
 
+	metrics.RunTimestamp(oc.stopChan, oc.sbClient, oc.nbClient)
+	metrics.MonitorIPSec(oc.nbClient)
 	oc.metricsRecorder.Run(oc.sbClient)
 
 	// enableOVNLogicalDataPathGroups sets an OVN flag to enable logical datapath

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -215,6 +215,8 @@ func (oc *Controller) upgradeOVNTopology(existingNodes *kapi.NodeList) error {
 func (oc *Controller) StartClusterMaster(masterNodeName string) error {
 	klog.Infof("Starting cluster master")
 
+	oc.metricsRecorder.Run(oc.sbClient)
+
 	// enableOVNLogicalDataPathGroups sets an OVN flag to enable logical datapath
 	// groups on OVN 20.12 and later. The option is ignored if OVN doesn't
 	// understand it. Logical datapath groups reduce the size of the southbound

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -312,7 +312,7 @@ func NewOvnController(ovnClient *util.OVNClientset, wf *factory.WatchFactory, st
 		svcController:            svcController,
 		svcFactory:               svcFactory,
 		modelClient:              modelClient,
-		metricsRecorder:          metrics.NewControlPlaneRecorder(libovsdbOvnSBClient),
+		metricsRecorder:          metrics.NewControlPlaneRecorder(),
 	}
 }
 


### PR DESCRIPTION
Backport commits from 4.11 to ensure:
* Only leader publishes metrics
* Stale label metrics are removed (via Reset())
* Only spawn go-routine after checking table.

Extra cherry-picks were needed to do this cleanly. Verified any metrics that were affect by cherry-picks work ok on 4.10.