### PR TITLE
[release-4.10] Bug 2052017: Retry Pod Deletions on Failure

### DIFF
--- a/go-controller/pkg/ovn/namespace.go
+++ b/go-controller/pkg/ovn/namespace.go
@@ -325,7 +325,7 @@ func (oc *Controller) updateNamespace(old, newer *kapi.Namespace) {
 				}
 			}
 		} else {
-			oc.deleteGWRoutesForNamespace(old.Name)
+			oc.deleteGWRoutesForNamespace(old.Name, nil)
 			nsInfo.routingExternalGWs = gatewayInfo{}
 		}
 		exGateways, err := parseRoutingExternalGWAnnotation(gwAnnotation)
@@ -421,7 +421,7 @@ func (oc *Controller) deleteNamespace(ns *kapi.Namespace) {
 			delete(nsInfo.networkPolicies, np.name)
 		}
 	}
-	oc.deleteGWRoutesForNamespace(ns.Name)
+	oc.deleteGWRoutesForNamespace(ns.Name, nil)
 	oc.multicastDeleteNamespace(ns, nsInfo)
 }
 

--- a/go-controller/pkg/ovn/namespace.go
+++ b/go-controller/pkg/ovn/namespace.go
@@ -325,7 +325,9 @@ func (oc *Controller) updateNamespace(old, newer *kapi.Namespace) {
 				}
 			}
 		} else {
-			oc.deleteGWRoutesForNamespace(old.Name, nil)
+			if err := oc.deleteGWRoutesForNamespace(old.Name, nil); err != nil {
+				klog.Error(err.Error())
+			}
 			nsInfo.routingExternalGWs = gatewayInfo{}
 		}
 		exGateways, err := parseRoutingExternalGWAnnotation(gwAnnotation)
@@ -421,7 +423,9 @@ func (oc *Controller) deleteNamespace(ns *kapi.Namespace) {
 			delete(nsInfo.networkPolicies, np.name)
 		}
 	}
-	oc.deleteGWRoutesForNamespace(ns.Name, nil)
+	if err := oc.deleteGWRoutesForNamespace(ns.Name, nil); err != nil {
+		klog.Errorf("Failed to delete GW routes for namespace: %s, error: %v", ns.Name, err)
+	}
 	oc.multicastDeleteNamespace(ns, nsInfo)
 }
 

--- a/go-controller/pkg/ovn/namespace.go
+++ b/go-controller/pkg/ovn/namespace.go
@@ -121,7 +121,7 @@ func (oc *Controller) addPodToNamespace(ns string, ips []*net.IPNet) (*gatewayIn
 	return oc.getRoutingExternalGWs(nsInfo), oc.getRoutingPodGWs(nsInfo), nsInfo.hybridOverlayExternalGW, ops, nil
 }
 
-func (oc *Controller) deletePodFromNamespace(ns string, portInfo *lpInfo) ([]ovsdb.Operation, error) {
+func (oc *Controller) deletePodFromNamespace(ns string, podIfAddrs []*net.IPNet, portUUID string) ([]ovsdb.Operation, error) {
 	nsInfo, nsUnlock := oc.getNamespaceLocked(ns, true)
 	if nsInfo == nil {
 		return nil, nil
@@ -130,14 +130,14 @@ func (oc *Controller) deletePodFromNamespace(ns string, portInfo *lpInfo) ([]ovs
 	var ops []ovsdb.Operation
 	var err error
 	if nsInfo.addressSet != nil {
-		if ops, err = nsInfo.addressSet.DeleteIPsReturnOps(createIPAddressSlice(portInfo.ips)); err != nil {
+		if ops, err = nsInfo.addressSet.DeleteIPsReturnOps(createIPAddressSlice(podIfAddrs)); err != nil {
 			return nil, err
 		}
 	}
 
 	// Remove the port from the multicast allow policy.
-	if oc.multicastSupport && nsInfo.multicastEnabled {
-		if err = podDeleteAllowMulticastPolicy(oc.nbClient, ns, portInfo); err != nil {
+	if oc.multicastSupport && nsInfo.multicastEnabled && len(portUUID) > 0 {
+		if err = podDeleteAllowMulticastPolicy(oc.nbClient, ns, portUUID); err != nil {
 			return nil, err
 		}
 	}

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
-	"math/rand"
 	"net"
 	"reflect"
 	"strconv"
@@ -39,12 +38,10 @@ import (
 
 	kapi "k8s.io/api/core/v1"
 	kapisnetworking "k8s.io/api/networking/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
-	"k8s.io/apimachinery/pkg/types"
 	ktypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/informers"
@@ -197,7 +194,8 @@ type Controller struct {
 	v6HostSubnetsUsed float64
 
 	// Map of pods that need to be retried, and the timestamp of when they last failed
-	retryPods     map[types.UID]*retryEntry
+	// The key is a string which holds "namespace_podName"
+	retryPods     map[string]*retryEntry
 	retryPodsLock sync.Mutex
 
 	// channel to indicate we need to retry pods immediately
@@ -220,6 +218,11 @@ type retryEntry struct {
 	backoffSec time.Duration
 	// whether to include this pod in retry iterations
 	ignore bool
+	// used to indicate if add events need to be retried
+	needsAdd bool
+	// used to indicate if delete event needs to be retried;
+	// this will hold a copy of its value from the oc.logicalSwitchPort cache
+	needsDel *lpInfo
 }
 
 type retryNetPolEntry struct {
@@ -302,7 +305,7 @@ func NewOvnController(ovnClient *util.OVNClientset, wf *factory.WatchFactory, st
 		loadBalancerGroupUUID:    "",
 		aclLoggingEnabled:        true,
 		joinSwIPManager:          nil,
-		retryPods:                make(map[types.UID]*retryEntry),
+		retryPods:                make(map[string]*retryEntry),
 		retryPodsChan:            make(chan struct{}, 1),
 		retryNetPolices:          make(map[string]*retryNetPolEntry),
 		retryPolicyChan:          make(chan struct{}, 1),
@@ -532,112 +535,6 @@ func (oc *Controller) recordPodEvent(addErr error, pod *kapi.Pod) {
 	}
 }
 
-// iterateRetryPods checks if any outstanding pods have been waiting for 60 seconds of last known failure
-// then tries to re-add them if so
-// updateAll forces all pods to be attempted to be retried regardless of the 1 minute delay
-func (oc *Controller) iterateRetryPods(updateAll bool) {
-	oc.retryPodsLock.Lock()
-	defer oc.retryPodsLock.Unlock()
-	now := time.Now()
-	for uid, podEntry := range oc.retryPods {
-		if podEntry.ignore {
-			continue
-		}
-
-		pod := podEntry.pod
-		podDesc := fmt.Sprintf("[%s/%s/%s]", pod.UID, pod.Namespace, pod.Name)
-		// it could be that the Pod got deleted, but Pod's DeleteFunc has not been called yet, so don't retry
-		kPod, err := oc.watchFactory.GetPod(pod.Namespace, pod.Name)
-		if err != nil && errors.IsNotFound(err) {
-			klog.Infof("%s pod not found in the informers cache, not going to retry pod setup", podDesc)
-			delete(oc.retryPods, uid)
-			continue
-		}
-
-		if !util.PodScheduled(kPod) {
-			klog.V(5).Infof("retry: %s not scheduled", podDesc)
-			continue
-		}
-		podEntry.backoffSec = (podEntry.backoffSec * 2)
-		if podEntry.backoffSec > 60 {
-			podEntry.backoffSec = 60
-		}
-		backoff := (podEntry.backoffSec * time.Second) + (time.Duration(rand.Intn(500)) * time.Millisecond)
-		podTimer := podEntry.timeStamp.Add(backoff)
-		if updateAll || now.After(podTimer) {
-			klog.Infof("%s retry pod setup", podDesc)
-
-			if oc.ensurePod(nil, kPod, true) {
-				klog.Infof("%s pod setup successful", podDesc)
-				delete(oc.retryPods, uid)
-			} else {
-				klog.Infof("%s setup retry failed; will try again later", podDesc)
-				oc.retryPods[uid] = &retryEntry{pod, time.Now(), podEntry.backoffSec, false}
-			}
-		} else {
-			klog.V(5).Infof("%s retry pod not after timer yet, time: %s", podDesc, podTimer)
-		}
-	}
-}
-
-// checkAndDeleteRetryPod deletes a specific entry from the map, if it existed, returns true
-func (oc *Controller) checkAndDeleteRetryPod(uid types.UID) bool {
-	oc.retryPodsLock.Lock()
-	defer oc.retryPodsLock.Unlock()
-	if _, ok := oc.retryPods[uid]; ok {
-		delete(oc.retryPods, uid)
-		return true
-	}
-	return false
-}
-
-// checkAndSkipRetryPod sets a specific entry from the map to be ignored for subsequent retries
-// if it existed, returns true
-func (oc *Controller) checkAndSkipRetryPod(uid types.UID) bool {
-	oc.retryPodsLock.Lock()
-	defer oc.retryPodsLock.Unlock()
-	if entry, ok := oc.retryPods[uid]; ok {
-		entry.ignore = true
-		return true
-	}
-	return false
-}
-
-// unSkipRetryPod ensures a pod is no longer ignored for retry loop
-func (oc *Controller) unSkipRetryPod(pod *kapi.Pod) {
-	oc.retryPodsLock.Lock()
-	defer oc.retryPodsLock.Unlock()
-	if entry, ok := oc.retryPods[pod.UID]; ok {
-		entry.ignore = false
-	}
-}
-
-// initRetryPod tracks a failed pod to potentially retry later
-// initially it is marked as skipped for retry loop (ignore = true)
-func (oc *Controller) initRetryPod(pod *kapi.Pod) {
-	oc.retryPodsLock.Lock()
-	defer oc.retryPodsLock.Unlock()
-	if entry, ok := oc.retryPods[pod.UID]; ok {
-		entry.timeStamp = time.Now()
-	} else {
-		oc.retryPods[pod.UID] = &retryEntry{pod, time.Now(), 1, true}
-	}
-}
-
-// addRetryPods adds multiple pods to retry later
-func (oc *Controller) addRetryPods(pods []kapi.Pod) {
-	oc.retryPodsLock.Lock()
-	defer oc.retryPodsLock.Unlock()
-	for _, pod := range pods {
-		pod := pod
-		if entry, ok := oc.retryPods[pod.UID]; ok {
-			entry.timeStamp = time.Now()
-		} else {
-			oc.retryPods[pod.UID] = &retryEntry{&pod, time.Now(), 1, false}
-		}
-	}
-}
-
 func exGatewayAnnotationsChanged(oldPod, newPod *kapi.Pod) bool {
 	return oldPod.Annotations[routingNamespaceAnnotation] != newPod.Annotations[routingNamespaceAnnotation] ||
 		oldPod.Annotations[routingNetworkAnnotation] != newPod.Annotations[routingNetworkAnnotation] ||
@@ -648,12 +545,12 @@ func networkStatusAnnotationsChanged(oldPod, newPod *kapi.Pod) bool {
 	return oldPod.Annotations[nettypes.NetworkStatusAnnot] != newPod.Annotations[nettypes.NetworkStatusAnnot]
 }
 
-// ensurePod tries to set up a pod. It returns success or failure; failure
-// indicates the pod should be retried later.
-func (oc *Controller) ensurePod(oldPod, pod *kapi.Pod, addPort bool) bool {
+// ensurePod tries to set up a pod. It returns nil on success and error on failure; failure
+// indicates the pod set up should be retried later.
+func (oc *Controller) ensurePod(oldPod, pod *kapi.Pod, addPort bool) error {
 	// Try unscheduled pods later
 	if !util.PodScheduled(pod) {
-		return false
+		return fmt.Errorf("failed to ensurePod %s/%s since it is not yet scheduled", pod.Namespace, pod.Name)
 	}
 
 	if oldPod != nil && (exGatewayAnnotationsChanged(oldPod, pod) || networkStatusAnnotationsChanged(oldPod, pod)) {
@@ -661,39 +558,41 @@ func (oc *Controller) ensurePod(oldPod, pod *kapi.Pod, addPort bool) bool {
 		// annotations. If the pod is ovn networked and is in update reschedule, addLogicalPort will take
 		// care of updating the exgw updates
 		if err := oc.deletePodExternalGW(oldPod); err != nil {
-			klog.Errorf(err.Error())
-			oc.recordPodEvent(err, pod)
-			return false
+			return fmt.Errorf("ensurePod failed %s/%s: %w", pod.Namespace, pod.Name, err)
 		}
 	}
 
 	if util.PodWantsNetwork(pod) && addPort {
 		if err := oc.addLogicalPort(pod); err != nil {
-			klog.Errorf(err.Error())
-			oc.recordPodEvent(err, pod)
-			return false
+			return fmt.Errorf("addLogicalPort failed for %s/%s: %w", pod.Namespace, pod.Name, err)
 		}
 	} else {
 		// either pod is host-networked or its an update for a normal pod (addPort=false case)
 		if oldPod == nil || exGatewayAnnotationsChanged(oldPod, pod) || networkStatusAnnotationsChanged(oldPod, pod) {
 			if err := oc.addPodExternalGW(pod); err != nil {
-				klog.Errorf(err.Error())
-				oc.recordPodEvent(err, pod)
-				return false
+				return fmt.Errorf("addPodExternalGW failed for %s/%s: %w", pod.Namespace, pod.Name, err)
 			}
 		}
 	}
 
-	return true
+	return nil
 }
 
-func (oc *Controller) requestRetryPods() {
-	select {
-	case oc.retryPodsChan <- struct{}{}:
-		klog.V(5).Infof("Iterate retry pods requested")
-	default:
-		klog.V(5).Infof("Iterate retry pods already requested")
+// removePod tried to tear down a pod. It returns nil on success and error on failure;
+// failure indicates the pod tear down should be retried later.
+func (oc *Controller) removePod(pod *kapi.Pod, portInfo *lpInfo) error {
+	if !util.PodWantsNetwork(pod) {
+		if err := oc.deletePodExternalGW(pod); err != nil {
+			return fmt.Errorf("unable to delete external gateway routes for pod %s: %w",
+				getPodNamespacedName(pod), err)
+		}
+		return nil
 	}
+	if err := oc.deleteLogicalPort(pod, portInfo); err != nil {
+		return fmt.Errorf("deleteLogicalPort failed for pod %s: %w",
+			getPodNamespacedName(pod), err)
+	}
+	return nil
 }
 
 // WatchPods starts the watching of Pod resource and calls back the appropriate handler logic
@@ -718,12 +617,29 @@ func (oc *Controller) WatchPods() {
 		AddFunc: func(obj interface{}) {
 			pod := obj.(*kapi.Pod)
 			go oc.metricsRecorder.AddPodEvent(pod.UID)
-			oc.initRetryPod(pod)
-			if !oc.ensurePod(nil, pod, true) {
+			oc.initRetryAddPod(pod)
+			oc.checkAndSkipRetryPod(pod)
+			if retryEntry := oc.getPodRetryEntry(pod); retryEntry != nil && retryEntry.needsDel != nil {
+				klog.Infof("Detected leftover old pod during new pod add with the same name: %s. "+
+					"Attempting deletion of leftover old...", getPodNamespacedName(pod))
+				if err := oc.removePod(pod, retryEntry.needsDel); err != nil {
+					oc.recordPodEvent(err, pod)
+					klog.Errorf("Failed to delete pod %s, error: %v",
+						getPodNamespacedName(pod), err)
+					oc.unSkipRetryPod(pod)
+					return
+				}
+				// deletion was a success; remove delete retry entry
+				oc.removeDeleteRetry(pod)
+			}
+			if err := oc.ensurePod(nil, pod, true); err != nil {
+				oc.recordPodEvent(err, pod)
+				klog.Errorf("Failed to add pod %s, error: %v",
+					getPodNamespacedName(pod), err)
 				oc.unSkipRetryPod(pod)
 				return
 			}
-			oc.checkAndDeleteRetryPod(pod.UID)
+			oc.checkAndDeleteRetryPod(pod)
 		},
 		UpdateFunc: func(old, newer interface{}) {
 			oldPod := old.(*kapi.Pod)
@@ -743,23 +659,52 @@ func (oc *Controller) WatchPods() {
 					podNs, podName)
 				return
 			}
-			if !oc.ensurePod(oldPod, pod, oc.checkAndSkipRetryPod(pod.UID)) {
+			oc.checkAndSkipRetryPod(pod)
+			if retryEntry := oc.getPodRetryEntry(pod); retryEntry != nil && retryEntry.needsDel != nil {
+				klog.Infof("Detected leftover old pod during new pod add with the same name: %s. "+
+					"Attempting deletion of leftover old...", getPodNamespacedName(pod))
+				if err := oc.removePod(pod, retryEntry.needsDel); err != nil {
+					oc.recordPodEvent(err, pod)
+					klog.Errorf("Failed to delete pod %s, error: %v",
+						getPodNamespacedName(pod), err)
+					oc.unSkipRetryPod(pod)
+					return
+				}
+				// deletion was a success; remove delete retry entry
+				oc.removeDeleteRetry(pod)
+			}
+			if err := oc.ensurePod(oldPod, pod, oc.checkAndSkipRetryPod(pod)); err != nil {
+				oc.recordPodEvent(err, pod)
+				klog.Errorf("Failed to update pod %s, error: %v",
+					getPodNamespacedName(pod), err)
 				// unskip failed pod for next retry iteration
 				oc.unSkipRetryPod(pod)
 				return
 			}
-			oc.checkAndDeleteRetryPod(pod.UID)
+			oc.checkAndDeleteRetryPod(pod)
 		},
 		DeleteFunc: func(obj interface{}) {
 			pod := obj.(*kapi.Pod)
 			go oc.metricsRecorder.CleanPodRecord(pod.UID)
-			oc.checkAndDeleteRetryPod(pod.UID)
-			if !util.PodWantsNetwork(pod) {
-				oc.deletePodExternalGW(pod)
+			oc.initRetryDelPod(pod)
+			// we have a copy of portInfo in the retry cache now, we can remove it from
+			// logicalPortCache so that we don't race with a new add pod that comes with
+			// the same name.
+			oc.logicalPortCache.remove(util.GetLogicalPortName(pod.Namespace, pod.Name))
+			retryEntry := oc.getPodRetryEntry(pod)
+			var portInfo *lpInfo
+			if retryEntry != nil {
+				// retryEntry shouldn't be nil since we usually add the pod to retryCache above
+				portInfo = retryEntry.needsDel
+			}
+			if err := oc.removePod(pod, portInfo); err != nil {
+				oc.recordPodEvent(err, pod)
+				klog.Errorf("Failed to delete pod %s, error: %v",
+					getPodNamespacedName(pod), err)
+				oc.unSkipRetryPod(pod)
 				return
 			}
-			// deleteLogicalPort will take care of removing exgw for ovn networked pods
-			oc.deleteLogicalPort(pod)
+			oc.checkAndDeleteRetryPod(pod)
 		},
 	}, oc.syncPods)
 	klog.Infof("Bootstrapping existing pods and cleaning stale pods took %v", time.Since(start))

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -677,6 +677,7 @@ func (oc *Controller) WatchPods() {
 				oc.recordPodEvent(err, pod)
 				klog.Errorf("Failed to update pod %s, error: %v",
 					getPodNamespacedName(pod), err)
+				oc.initRetryAddPod(pod)
 				// unskip failed pod for next retry iteration
 				oc.unSkipRetryPod(pod)
 				return

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -660,7 +660,11 @@ func (oc *Controller) ensurePod(oldPod, pod *kapi.Pod, addPort bool) bool {
 		// No matter if a pod is ovn networked, or host networked, we still need to check for exgw
 		// annotations. If the pod is ovn networked and is in update reschedule, addLogicalPort will take
 		// care of updating the exgw updates
-		oc.deletePodExternalGW(oldPod)
+		if err := oc.deletePodExternalGW(oldPod); err != nil {
+			klog.Errorf(err.Error())
+			oc.recordPodEvent(err, pod)
+			return false
+		}
 	}
 
 	if util.PodWantsNetwork(pod) && addPort {

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -152,7 +152,7 @@ func (oc *Controller) deleteLogicalPort(pod *kapi.Pod) {
 		klog.Errorf(err.Error())
 		// If ovnkube-master restarts, it is also possible the Pod's logical switch port
 		// is not re-added into the cache. Delete logical switch port anyway.
-		ops, err := oc.ovnNBLSPDel(logicalPort, pod.Spec.NodeName, "")
+		ops, err := oc.delLSPOps(logicalPort, pod.Spec.NodeName, "")
 		if err != nil {
 			klog.Errorf(err.Error())
 		} else {
@@ -180,7 +180,7 @@ func (oc *Controller) deleteLogicalPort(pod *kapi.Pod) {
 		allOps = append(allOps, ops...)
 	}
 
-	ops, err = oc.ovnNBLSPDel(logicalPort, pod.Spec.NodeName, portInfo.uuid)
+	ops, err = oc.delLSPOps(logicalPort, pod.Spec.NodeName, portInfo.uuid)
 	if err != nil {
 		klog.Errorf(err.Error())
 	} else {
@@ -693,15 +693,9 @@ func (oc *Controller) getPortAddresses(nodeName, portName string) (net.HardwareA
 	return podMac, podIPNets, nil
 }
 
-// ovnNBLSPDel deletes the given logical switch using the libovsdb library
-func (oc *Controller) ovnNBLSPDel(logicalPort, logicalSwitch, lspUUID string) ([]ovsdb.Operation, error) {
+// delLSPOps returns the ovsdb operations required to delete the given logical switch port (LSP)
+func (oc *Controller) delLSPOps(logicalPort, logicalSwitch, lspUUID string) ([]ovsdb.Operation, error) {
 	var allOps []ovsdb.Operation
-	ls := &nbdb.LogicalSwitch{}
-	if lsUUID, ok := oc.lsManager.GetUUID(logicalSwitch); !ok {
-		return nil, fmt.Errorf("error getting logical switch for node %s: switch not in logical switch cache", logicalSwitch)
-	} else {
-		ls.UUID = lsUUID
-	}
 
 	lsp := &nbdb.LogicalSwitchPort{
 		UUID: lspUUID,
@@ -710,9 +704,24 @@ func (oc *Controller) ovnNBLSPDel(logicalPort, logicalSwitch, lspUUID string) ([
 	if lspUUID == "" {
 		ctx, cancel := context.WithTimeout(context.Background(), ovntypes.OVSDBTimeout)
 		defer cancel()
-		if err := oc.nbClient.Get(ctx, lsp); err != nil {
+		if err := oc.nbClient.Get(ctx, lsp); err != nil && err != libovsdbclient.ErrNotFound {
 			return nil, fmt.Errorf("cannot delete logical switch port %s failed retrieving the object %v", logicalPort, err)
+		} else if err == libovsdbclient.ErrNotFound {
+			// lsp doesn't exist; nothing to do
+			return allOps, nil
 		}
+	}
+
+	ls := &nbdb.LogicalSwitch{}
+	var err error
+	if lsUUID, ok := oc.lsManager.GetUUID(logicalSwitch); !ok {
+		klog.Errorf("Error getting logical switch for node %s: switch not in logical switch cache", logicalSwitch)
+		// Not in cache: Try getting the logical switch from ovn database (slower method)
+		if ls, err = libovsdbops.FindSwitchByName(oc.nbClient, logicalSwitch); err != nil {
+			return nil, fmt.Errorf("can't find switch for node %s: %v", logicalSwitch, err)
+		}
+	} else {
+		ls.UUID = lsUUID
 	}
 
 	ops, err := oc.nbClient.Where(ls).Mutate(ls, model.Mutation{

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -152,7 +152,7 @@ func (oc *Controller) deleteLogicalPort(pod *kapi.Pod) {
 		klog.Errorf(err.Error())
 		// If ovnkube-master restarts, it is also possible the Pod's logical switch port
 		// is not re-added into the cache. Delete logical switch port anyway.
-		ops, err := oc.ovnNBLSPDel(logicalPort, pod.Spec.NodeName)
+		ops, err := oc.ovnNBLSPDel(logicalPort, pod.Spec.NodeName, "")
 		if err != nil {
 			klog.Errorf(err.Error())
 		} else {
@@ -180,7 +180,7 @@ func (oc *Controller) deleteLogicalPort(pod *kapi.Pod) {
 		allOps = append(allOps, ops...)
 	}
 
-	ops, err = oc.ovnNBLSPDel(logicalPort, pod.Spec.NodeName)
+	ops, err = oc.ovnNBLSPDel(logicalPort, pod.Spec.NodeName, portInfo.uuid)
 	if err != nil {
 		klog.Errorf(err.Error())
 	} else {
@@ -694,22 +694,27 @@ func (oc *Controller) getPortAddresses(nodeName, portName string) (net.HardwareA
 }
 
 // ovnNBLSPDel deletes the given logical switch using the libovsdb library
-func (oc *Controller) ovnNBLSPDel(logicalPort, logicalSwitch string) ([]ovsdb.Operation, error) {
+func (oc *Controller) ovnNBLSPDel(logicalPort, logicalSwitch, lspUUID string) ([]ovsdb.Operation, error) {
 	var allOps []ovsdb.Operation
 	ls := &nbdb.LogicalSwitch{}
 	if lsUUID, ok := oc.lsManager.GetUUID(logicalSwitch); !ok {
-		return nil, fmt.Errorf("error getting logical switch for node %s: %s", logicalSwitch, "switch not in logical switch cache")
+		return nil, fmt.Errorf("error getting logical switch for node %s: switch not in logical switch cache", logicalSwitch)
 	} else {
 		ls.UUID = lsUUID
 	}
 
-	lsp := &nbdb.LogicalSwitchPort{Name: logicalPort}
-	ctx, cancel := context.WithTimeout(context.Background(), ovntypes.OVSDBTimeout)
-	defer cancel()
-	err := oc.nbClient.Get(ctx, lsp)
-	if err != nil {
-		return nil, fmt.Errorf("cannot delete logical switch port %s failed retrieving the object %v", logicalPort, err)
+	lsp := &nbdb.LogicalSwitchPort{
+		UUID: lspUUID,
+		Name: logicalPort,
 	}
+	if lspUUID == "" {
+		ctx, cancel := context.WithTimeout(context.Background(), ovntypes.OVSDBTimeout)
+		defer cancel()
+		if err := oc.nbClient.Get(ctx, lsp); err != nil {
+			return nil, fmt.Errorf("cannot delete logical switch port %s failed retrieving the object %v", logicalPort, err)
+		}
+	}
+
 	ops, err := oc.nbClient.Where(ls).Mutate(ls, model.Mutation{
 		Field:   &ls.Ports,
 		Mutator: ovsdb.MutateOperationDelete,
@@ -719,7 +724,8 @@ func (oc *Controller) ovnNBLSPDel(logicalPort, logicalSwitch string) ([]ovsdb.Op
 		return nil, fmt.Errorf("cannot generate ops delete logical switch port %s: %v", logicalPort, err)
 	}
 	allOps = append(allOps, ops...)
-	//for testing purposes the explicit delete of the logical switch port is required
+
+	// for testing purposes the explicit delete of the logical switch port is required
 	ops, err = oc.nbClient.Where(lsp).Delete()
 	if err != nil {
 		return nil, fmt.Errorf("cannot generate ops delete logical switch port %s: %v", logicalPort, err)

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -134,13 +134,13 @@ func (oc *Controller) syncPodsRetriable(pods []interface{}) error {
 	return nil
 }
 
-func (oc *Controller) deleteLogicalPort(pod *kapi.Pod) {
+func (oc *Controller) deleteLogicalPort(pod *kapi.Pod) (err error) {
 	oc.deletePodExternalGW(pod)
 	if pod.Spec.HostNetwork {
-		return
+		return nil
 	}
 	if !util.PodScheduled(pod) {
-		return
+		return nil
 	}
 
 	podDesc := pod.Namespace + "/" + pod.Name
@@ -154,57 +154,55 @@ func (oc *Controller) deleteLogicalPort(pod *kapi.Pod) {
 		// is not re-added into the cache. Delete logical switch port anyway.
 		ops, err := oc.delLSPOps(logicalPort, pod.Spec.NodeName, "")
 		if err != nil {
-			klog.Errorf(err.Error())
-		} else {
-			_, err = libovsdbops.TransactAndCheck(oc.nbClient, ops)
-			if err != nil {
-				klog.Errorf("Cannot delete logical switch port %s, %v", logicalPort, err)
-			}
+			return fmt.Errorf("failed to create delete ops for the lsp: %s: %s", logicalPort, err)
+		}
+		_, err = libovsdbops.TransactAndCheck(oc.nbClient, ops)
+		if err != nil {
+			return fmt.Errorf("cannot delete logical switch port %s, %v", logicalPort, err)
 		}
 
 		// Even if the port is not in the cache, IPs annotated in the Pod annotation may already be allocated,
 		// need to release them to avoid leakage.
 		annotation, err := util.UnmarshalPodAnnotation(pod.Annotations)
-		if err == nil {
-			podIfAddrs := annotation.IPs
-			_ = oc.lsManager.ReleaseIPs(pod.Spec.NodeName, podIfAddrs)
+		if err != nil {
+			return fmt.Errorf("unable to unmarshal pod annocations for pod %s/%s: %w", pod.Namespace, pod.Name, err)
 		}
-		return
+		podIfAddrs := annotation.IPs
+		return oc.lsManager.ReleaseIPs(pod.Spec.NodeName, podIfAddrs)
 	}
 
 	// FIXME: if any of these steps fails we need to stop and try again later...
 	var allOps, ops []ovsdb.Operation
 	if ops, err = oc.deletePodFromNamespace(pod.Namespace, portInfo); err != nil {
-		klog.Errorf(err.Error())
-	} else {
-		allOps = append(allOps, ops...)
+		return fmt.Errorf("unable to delete pod %s from namespace: %w", podDesc, err)
 	}
+	allOps = append(allOps, ops...)
 
 	ops, err = oc.delLSPOps(logicalPort, pod.Spec.NodeName, portInfo.uuid)
 	if err != nil {
-		klog.Errorf(err.Error())
-	} else {
-		allOps = append(allOps, ops...)
+		return fmt.Errorf("failed to create delete ops for the lsp: %s: %s", logicalPort, err)
 	}
+	allOps = append(allOps, ops...)
 
 	_, err = libovsdbops.TransactAndCheck(oc.nbClient, allOps)
 	if err != nil {
-		klog.Errorf("Cannot delete logical switch port %s, %v", logicalPort, err)
+		return fmt.Errorf("cannot delete logical switch port %s, %v", logicalPort, err)
 	}
 
 	if err := oc.lsManager.ReleaseIPs(portInfo.logicalSwitch, portInfo.ips); err != nil {
-		klog.Errorf(err.Error())
+		return fmt.Errorf("cannot release IPs for pod %s: %w", podDesc, err)
 	}
 
 	if config.Gateway.DisableSNATMultipleGWs {
 		if err := deletePerPodGRSNAT(oc.nbClient, pod.Spec.NodeName, []*net.IPNet{}, portInfo.ips); err != nil {
-			klog.Errorf(err.Error())
+			return fmt.Errorf("cannot delete GR SNAT for pod %s: %w", podDesc, err)
 		}
 	}
 	podNsName := ktypes.NamespacedName{Namespace: pod.Namespace, Name: pod.Name}
 	oc.deleteGWRoutesForPod(podNsName, portInfo.ips)
 
 	oc.logicalPortCache.remove(logicalPort)
+	return nil
 }
 
 func (oc *Controller) waitForNodeLogicalSwitch(nodeName string) (*nbdb.LogicalSwitch, error) {

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -134,7 +134,7 @@ func (oc *Controller) syncPodsRetriable(pods []interface{}) error {
 	return nil
 }
 
-func (oc *Controller) deleteLogicalPort(pod *kapi.Pod) (err error) {
+func (oc *Controller) deleteLogicalPort(pod *kapi.Pod, portInfo *lpInfo) (err error) {
 	podDesc := pod.Namespace + "/" + pod.Name
 	klog.Infof("Deleting pod: %s", podDesc)
 
@@ -149,38 +149,28 @@ func (oc *Controller) deleteLogicalPort(pod *kapi.Pod) (err error) {
 	}
 
 	logicalPort := util.GetLogicalPortName(pod.Namespace, pod.Name)
-	portInfo, err := oc.logicalPortCache.get(logicalPort)
-	if err != nil {
-		klog.Errorf(err.Error())
+	portUUID := ""
+	var podIfAddrs []*net.IPNet
+	if portInfo == nil {
 		// If ovnkube-master restarts, it is also possible the Pod's logical switch port
 		// is not re-added into the cache. Delete logical switch port anyway.
-		ops, err := oc.delLSPOps(logicalPort, pod.Spec.NodeName, "")
-		if err != nil {
-			return fmt.Errorf("failed to create delete ops for the lsp: %s: %s", logicalPort, err)
-		}
-		_, err = libovsdbops.TransactAndCheck(oc.nbClient, ops)
-		if err != nil {
-			return fmt.Errorf("cannot delete logical switch port %s, %v", logicalPort, err)
-		}
-
-		// Even if the port is not in the cache, IPs annotated in the Pod annotation may already be allocated,
-		// need to release them to avoid leakage.
 		annotation, err := util.UnmarshalPodAnnotation(pod.Annotations)
 		if err != nil {
 			return fmt.Errorf("unable to unmarshal pod annocations for pod %s/%s: %w", pod.Namespace, pod.Name, err)
 		}
-		podIfAddrs := annotation.IPs
-		return oc.lsManager.ReleaseIPs(pod.Spec.NodeName, podIfAddrs)
+		podIfAddrs = annotation.IPs
+	} else {
+		portUUID = portInfo.uuid
+		podIfAddrs = portInfo.ips
 	}
 
-	// FIXME: if any of these steps fails we need to stop and try again later...
 	var allOps, ops []ovsdb.Operation
-	if ops, err = oc.deletePodFromNamespace(pod.Namespace, portInfo); err != nil {
+	if ops, err = oc.deletePodFromNamespace(pod.Namespace, podIfAddrs, portUUID); err != nil {
 		return fmt.Errorf("unable to delete pod %s from namespace: %w", podDesc, err)
 	}
 	allOps = append(allOps, ops...)
 
-	ops, err = oc.delLSPOps(logicalPort, pod.Spec.NodeName, portInfo.uuid)
+	ops, err = oc.delLSPOps(logicalPort, pod.Spec.NodeName, portUUID)
 	if err != nil {
 		return fmt.Errorf("failed to create delete ops for the lsp: %s: %s", logicalPort, err)
 	}
@@ -191,21 +181,20 @@ func (oc *Controller) deleteLogicalPort(pod *kapi.Pod) (err error) {
 		return fmt.Errorf("cannot delete logical switch port %s, %v", logicalPort, err)
 	}
 
-	if err := oc.lsManager.ReleaseIPs(portInfo.logicalSwitch, portInfo.ips); err != nil {
+	if err := oc.lsManager.ReleaseIPs(pod.Spec.NodeName, podIfAddrs); err != nil {
 		return fmt.Errorf("cannot release IPs for pod %s: %w", podDesc, err)
 	}
 
 	if config.Gateway.DisableSNATMultipleGWs {
-		if err := deletePerPodGRSNAT(oc.nbClient, pod.Spec.NodeName, []*net.IPNet{}, portInfo.ips); err != nil {
+		if err := deletePerPodGRSNAT(oc.nbClient, pod.Spec.NodeName, []*net.IPNet{}, podIfAddrs); err != nil {
 			return fmt.Errorf("cannot delete GR SNAT for pod %s: %w", podDesc, err)
 		}
 	}
 	podNsName := ktypes.NamespacedName{Namespace: pod.Namespace, Name: pod.Name}
-	if err := oc.deleteGWRoutesForPod(podNsName, portInfo.ips); err != nil {
+	if err := oc.deleteGWRoutesForPod(podNsName, podIfAddrs); err != nil {
 		return fmt.Errorf("cannot delete GW Routes for pod %s: %w", podDesc, err)
 	}
 
-	oc.logicalPortCache.remove(logicalPort)
 	return nil
 }
 

--- a/go-controller/pkg/ovn/pods_retry.go
+++ b/go-controller/pkg/ovn/pods_retry.go
@@ -1,0 +1,211 @@
+package ovn
+
+import (
+	"fmt"
+	"math/rand"
+	"net"
+	"time"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	kapi "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/klog/v2"
+)
+
+// iterateRetryPods checks if any outstanding pods have been waiting for 60 seconds of last known failure
+// then tries to re-add them if so
+// updateAll forces all pods to be attempted to be retried regardless of the 1 minute delay
+func (oc *Controller) iterateRetryPods(updateAll bool) {
+	oc.retryPodsLock.Lock()
+	defer oc.retryPodsLock.Unlock()
+	now := time.Now()
+	for key, podEntry := range oc.retryPods {
+		if podEntry.ignore {
+			// neither addition nor deletion is being retried
+			continue
+		}
+
+		pod := podEntry.pod
+		podDesc := fmt.Sprintf("[%s/%s/%s]", pod.UID, pod.Namespace, pod.Name)
+		// it could be that the Pod got deleted, but Pod's DeleteFunc has not been called yet, so don't retry creation
+		if podEntry.needsAdd {
+			kPod, err := oc.watchFactory.GetPod(pod.Namespace, pod.Name)
+			if err != nil && errors.IsNotFound(err) {
+				klog.Infof("%s pod not found in the informers cache, not going to retry pod setup", podDesc)
+				podEntry.needsAdd = false
+			} else {
+				pod = kPod
+			}
+		}
+
+		if !util.PodScheduled(pod) {
+			klog.V(5).Infof("Retry: %s not scheduled", podDesc)
+			continue
+		}
+
+		podEntry.backoffSec = (podEntry.backoffSec * 2)
+		if podEntry.backoffSec > 60 {
+			podEntry.backoffSec = 60
+		}
+		backoff := (podEntry.backoffSec * time.Second) + (time.Duration(rand.Intn(500)) * time.Millisecond)
+		podTimer := podEntry.timeStamp.Add(backoff)
+		if updateAll || now.After(podTimer) {
+			// check if we need to retry delete first
+			if podEntry.needsDel != nil {
+				klog.Infof("%s retry pod teardown", podDesc)
+				if err := oc.removePod(pod, podEntry.needsDel); err != nil {
+					klog.Infof("%s teardown retry failed; will try again later", podDesc)
+					podEntry.timeStamp = time.Now()
+					continue // if deletion failed we will not retry add
+				}
+				klog.Infof("%s pod teardown successful", podDesc)
+				podEntry.needsDel = nil
+				if !podEntry.needsAdd {
+					delete(oc.retryPods, key) // this means retryDelete worked, we can remove entry safely
+				}
+			}
+			// check if we need to retry add
+			if podEntry.needsAdd {
+				klog.Infof("%s retry pod setup", podDesc)
+				if err := oc.ensurePod(nil, pod, true); err != nil {
+					klog.Infof("%s setup retry failed; will try again later", podDesc)
+					podEntry.timeStamp = time.Now()
+				} else {
+					klog.Infof("%s pod setup successful", podDesc)
+					delete(oc.retryPods, key) // this means retryDelete and retryAdd both worked, we can remove entry safely
+				}
+			}
+		} else {
+			klog.V(5).Infof("%s retry pod not after timer yet, time: %s", podDesc, podTimer)
+		}
+	}
+}
+
+// checkAndDeleteRetryPod deletes a specific entry from the map, if it existed, returns true
+func (oc *Controller) checkAndDeleteRetryPod(pod *kapi.Pod) bool {
+	oc.retryPodsLock.Lock()
+	defer oc.retryPodsLock.Unlock()
+	key := getPodNamespacedName(pod)
+	if _, ok := oc.retryPods[key]; ok {
+		delete(oc.retryPods, key)
+		return true
+	}
+	return false
+}
+
+// checkAndSkipRetryPod sets a specific entry from the map to be ignored for subsequent retries
+// if it existed, returns true
+func (oc *Controller) checkAndSkipRetryPod(pod *kapi.Pod) bool {
+	oc.retryPodsLock.Lock()
+	defer oc.retryPodsLock.Unlock()
+	key := getPodNamespacedName(pod)
+	if entry, ok := oc.retryPods[key]; ok {
+		entry.ignore = true
+		return true
+	}
+	return false
+}
+
+// unSkipRetryPod ensures a pod is no longer ignored for retry loop
+func (oc *Controller) unSkipRetryPod(pod *kapi.Pod) {
+	oc.retryPodsLock.Lock()
+	defer oc.retryPodsLock.Unlock()
+	key := getPodNamespacedName(pod)
+	if entry, ok := oc.retryPods[key]; ok {
+		entry.ignore = false
+	}
+}
+
+// initRetryAddPod tracks a pod that failed to be created to potentially retry later (needsAdd = true)
+// initially it is marked as skipped for retry loop (ignore = true)
+func (oc *Controller) initRetryAddPod(pod *kapi.Pod) {
+	oc.retryPodsLock.Lock()
+	defer oc.retryPodsLock.Unlock()
+	key := getPodNamespacedName(pod)
+	if entry, ok := oc.retryPods[key]; ok {
+		entry.timeStamp = time.Now()
+		entry.pod = pod
+		entry.needsAdd = true
+	} else {
+		oc.retryPods[key] = &retryEntry{pod, time.Now(), 1, true, true, nil}
+	}
+}
+
+// initRetryDelPod tracks a pod that failed to be deleted to potentially retry later (needsDel != nil)
+// initially it is marked as skipped for retry loop (ignore = true)
+func (oc *Controller) initRetryDelPod(pod *kapi.Pod) {
+	oc.retryPodsLock.Lock()
+	defer oc.retryPodsLock.Unlock()
+	key := getPodNamespacedName(pod)
+	var portInfo *lpInfo
+	if !util.PodWantsNetwork(pod) {
+		// create dummy logicalPortInfo for host-networked pods
+		mac, _ := net.ParseMAC("00:00:00:00:00:00")
+		portInfo = &lpInfo{
+			logicalSwitch: "host-networked",
+			name:          getPodNamespacedName(pod),
+			uuid:          "host-networked",
+			ips:           []*net.IPNet{},
+			mac:           mac,
+		}
+	} else {
+		portInfo, _ = oc.logicalPortCache.get(key)
+	}
+	if entry, ok := oc.retryPods[key]; ok {
+		entry.timeStamp = time.Now()
+		entry.needsDel = portInfo
+	} else {
+		oc.retryPods[key] = &retryEntry{pod, time.Now(), 1, true, false, portInfo}
+	}
+}
+
+func (oc *Controller) removeDeleteRetry(pod *kapi.Pod) {
+	oc.retryPodsLock.Lock()
+	defer oc.retryPodsLock.Unlock()
+	key := getPodNamespacedName(pod)
+	if entry, ok := oc.retryPods[key]; ok {
+		entry.needsDel = nil
+	}
+}
+
+func (oc *Controller) getPodRetryEntry(pod *kapi.Pod) *retryEntry {
+	oc.retryPodsLock.Lock()
+	defer oc.retryPodsLock.Unlock()
+	key := getPodNamespacedName(pod)
+	if entry, ok := oc.retryPods[key]; ok {
+		entryCopy := *entry
+		return &entryCopy
+	}
+	return nil
+}
+
+// addRetryPods adds multiple pods to be retried later for their add events
+func (oc *Controller) addRetryPods(pods []kapi.Pod) {
+	oc.retryPodsLock.Lock()
+	defer oc.retryPodsLock.Unlock()
+	for _, pod := range pods {
+		pod := pod
+		key := getPodNamespacedName(&pod)
+		if entry, ok := oc.retryPods[key]; ok {
+			entry.timeStamp = time.Now()
+			entry.pod = &pod
+		} else {
+			oc.retryPods[key] = &retryEntry{&pod, time.Now(), 1, false, true, nil}
+		}
+	}
+}
+
+func (oc *Controller) requestRetryPods() {
+	select {
+	case oc.retryPodsChan <- struct{}{}:
+		klog.V(5).Infof("Iterate retry pods requested")
+	default:
+		klog.V(5).Infof("Iterate retry pods already requested")
+	}
+}
+
+// getPodNamespacedName returns <namespace>_<podname> for the provided pod
+// this is to maintain the same key format as used by logicalPortCache
+func getPodNamespacedName(pod *kapi.Pod) string {
+	return fmt.Sprintf("%s_%s", pod.Namespace, pod.Name)
+}

--- a/go-controller/pkg/ovn/pods_test.go
+++ b/go-controller/pkg/ovn/pods_test.go
@@ -402,27 +402,168 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      t.podName,
 						Namespace: namespaceT.Name,
-						UID:       types.UID("123"),
 					},
 				}
-				success := fakeOvn.controller.ensurePod(nil, podObj, true) // this fails since pod doesn't exist to set annotations
-				gomega.Expect(success).To(gomega.BeFalse())
+				err := fakeOvn.controller.ensurePod(nil, podObj, true) // this fails since pod doesn't exist to set annotations
+				gomega.Expect(err).To(gomega.HaveOccurred())
 
 				gomega.Expect(len(fakeOvn.controller.retryPods)).To(gomega.Equal(0))
 				fakeOvn.controller.addRetryPods([]v1.Pod{*podObj})
+				key := getPodNamespacedName(podObj)
 				gomega.Expect(len(fakeOvn.controller.retryPods)).To(gomega.Equal(1))
-				gomega.Expect(fakeOvn.controller.retryPods["123"]).ToNot(gomega.BeNil())
-				gomega.Expect(fakeOvn.controller.retryPods["123"].ignore).To(gomega.BeFalse())
-				gomega.Expect(fakeOvn.controller.retryPods["123"].pod.UID).To(gomega.Equal(podObj.UID))
+				gomega.Expect(fakeOvn.controller.retryPods[key]).ToNot(gomega.BeNil())
+				gomega.Expect(fakeOvn.controller.retryPods[key].ignore).To(gomega.BeFalse())
+				gomega.Expect(fakeOvn.controller.retryPods[key].pod.UID).To(gomega.Equal(podObj.UID))
 
-				fakeOvn.controller.checkAndSkipRetryPod(podObj.UID)
-				gomega.Expect(fakeOvn.controller.retryPods["123"].ignore).To(gomega.BeTrue())
+				fakeOvn.controller.checkAndSkipRetryPod(podObj)
+				gomega.Expect(fakeOvn.controller.retryPods[key].ignore).To(gomega.BeTrue())
 
 				fakeOvn.controller.unSkipRetryPod(podObj)
-				gomega.Expect(fakeOvn.controller.retryPods["123"].ignore).To(gomega.BeFalse())
+				gomega.Expect(fakeOvn.controller.retryPods[key].ignore).To(gomega.BeFalse())
 
-				fakeOvn.controller.checkAndDeleteRetryPod(podObj.UID)
-				gomega.Expect(fakeOvn.controller.retryPods["123"]).To(gomega.BeNil())
+				fakeOvn.controller.checkAndDeleteRetryPod(podObj)
+				gomega.Expect(fakeOvn.controller.retryPods[key]).To(gomega.BeNil())
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+
+		ginkgo.It("correctly retries a failure while adding a pod", func() {
+			app.Action = func(ctx *cli.Context) error {
+				namespace1 := *newNamespace("namespace1")
+				podTest := newTPod(
+					"node1",
+					"10.128.1.0/24",
+					"10.128.1.2",
+					"10.128.1.1",
+					"myPod",
+					"10.128.1.3",
+					"0a:58:0a:80:01:03",
+					namespace1.Name,
+				)
+				pod := newPod(podTest.namespace, podTest.podName, podTest.nodeName, podTest.podIP)
+
+				fakeOvn.startWithDBSetup(initialDB,
+					&v1.NamespaceList{
+						Items: []v1.Namespace{
+							namespace1,
+						},
+					},
+					&v1.PodList{
+						Items: []v1.Pod{*pod},
+					},
+				)
+
+				podTest.populateLogicalSwitchCache(fakeOvn, getLogicalSwitchUUID(fakeOvn.controller.nbClient, "node1"))
+				fakeOvn.controller.WatchNamespaces()
+				fakeOvn.asf.ExpectAddressSetWithIPs(podTest.namespace, []string{podTest.podIP})
+				gomega.Eventually(fakeOvn.controller.nbClient).Should(
+					libovsdbtest.HaveData(getExpectedDataPodsAndSwitches([]testPod{}, []string{"node1"})...))
+
+				// inject transient problem, nbdb is down
+				fakeOvn.controller.nbClient.Close()
+				gomega.Eventually(func() bool {
+					return fakeOvn.controller.nbClient.Connected()
+				}).Should(gomega.BeFalse())
+				// trigger pod add which will fail with "context deadline exceeded: while awaiting reconnection"
+				fakeOvn.controller.WatchPods()
+
+				// sleep long enough for TransactWithRetry to fail, causing pod delete to fail
+				time.Sleep(ovstypes.OVSDBTimeout + time.Second)
+
+				// check to see if the pod retry cache has an entry for this policy
+				gomega.Eventually(func() *retryEntry {
+					return fakeOvn.controller.getPodRetryEntry(pod)
+				}).ShouldNot(gomega.BeNil())
+				connCtx, cancel := context.WithTimeout(context.Background(), ovstypes.OVSDBTimeout)
+
+				defer cancel()
+				fakeOvn.resetNBClient(connCtx)
+				fakeOvn.controller.requestRetryPods() // retry the failed entry
+
+				_, err := fakeOvn.fakeClient.KubeClient.CoreV1().Pods(podTest.namespace).Get(context.TODO(), podTest.podName, metav1.GetOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				fakeOvn.asf.ExpectAddressSetWithIPs(podTest.namespace, []string{podTest.podIP})
+				gomega.Eventually(fakeOvn.controller.nbClient).Should(
+					libovsdbtest.HaveData(getExpectedDataPodsAndSwitches([]testPod{podTest}, []string{"node1"})...))
+				// check the retry cache no longer has the entry
+				gomega.Eventually(func() *retryEntry {
+					return fakeOvn.controller.getPodRetryEntry(pod)
+				}).Should(gomega.BeNil())
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+
+		ginkgo.It("correctly retries a failure while deleting a pod", func() {
+			app.Action = func(ctx *cli.Context) error {
+				namespace1 := *newNamespace("namespace1")
+				podTest := newTPod(
+					"node1",
+					"10.128.1.0/24",
+					"10.128.1.2",
+					"10.128.1.1",
+					"myPod",
+					"10.128.1.3",
+					"0a:58:0a:80:01:03",
+					namespace1.Name,
+				)
+				pod := newPod(podTest.namespace, podTest.podName, podTest.nodeName, podTest.podIP)
+				expectedData := []libovsdbtest.TestData{getExpectedDataPodsAndSwitches([]testPod{podTest}, []string{"node1"})}
+
+				fakeOvn.startWithDBSetup(initialDB,
+					&v1.NamespaceList{
+						Items: []v1.Namespace{
+							namespace1,
+						},
+					},
+					&v1.PodList{
+						Items: []v1.Pod{*pod},
+					},
+				)
+
+				podTest.populateLogicalSwitchCache(fakeOvn, getLogicalSwitchUUID(fakeOvn.controller.nbClient, "node1"))
+				fakeOvn.controller.WatchNamespaces()
+				fakeOvn.controller.WatchPods()
+
+				_, err := fakeOvn.fakeClient.KubeClient.CoreV1().Pods(podTest.namespace).Get(context.TODO(), podTest.podName, metav1.GetOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedData...))
+				fakeOvn.asf.ExpectAddressSetWithIPs(podTest.namespace, []string{podTest.podIP})
+
+				// inject transient problem, nbdb is down
+				fakeOvn.controller.nbClient.Close()
+				gomega.Eventually(func() bool {
+					return fakeOvn.controller.nbClient.Connected()
+				}).Should(gomega.BeFalse())
+				// trigger pod delete which will fail with "context deadline exceeded: while awaiting reconnection"
+				err = fakeOvn.fakeClient.KubeClient.CoreV1().Pods(pod.Namespace).Delete(context.TODO(), pod.Name, *metav1.NewDeleteOptions(0))
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				// sleep long enough for TransactWithRetry to fail, causing pod delete to fail
+				time.Sleep(ovstypes.OVSDBTimeout + time.Second)
+
+				// check to see if the pod retry cache has an entry for this policy
+				gomega.Eventually(func() *retryEntry {
+					return fakeOvn.controller.getPodRetryEntry(pod)
+				}).ShouldNot(gomega.BeNil())
+				connCtx, cancel := context.WithTimeout(context.Background(), ovstypes.OVSDBTimeout)
+
+				defer cancel()
+				fakeOvn.resetNBClient(connCtx)
+				fakeOvn.controller.requestRetryPods() // retry the failed entry
+
+				fakeOvn.asf.ExpectEmptyAddressSet(podTest.namespace)
+				gomega.Eventually(fakeOvn.controller.nbClient).Should(
+					libovsdbtest.HaveData(getExpectedDataPodsAndSwitches([]testPod{}, []string{"node1"})...))
+				// check the retry cache no longer has the entry
+				gomega.Eventually(func() *retryEntry {
+					return fakeOvn.controller.getPodRetryEntry(pod)
+				}).Should(gomega.BeNil())
 				return nil
 			}
 

--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -587,8 +587,8 @@ func podAddAllowMulticastPolicy(nbClient libovsdbclient.Client, ns string, portI
 // podDeleteAllowMulticastPolicy removes the pod's logical switch port from the
 // namespace's multicast port group. Caller must hold the namespace's
 // namespaceInfo object lock.
-func podDeleteAllowMulticastPolicy(nbClient libovsdbclient.Client, ns string, portInfo *lpInfo) error {
-	return libovsdbops.DeletePortsFromPortGroup(nbClient, hashedPortGroup(ns), portInfo.uuid)
+func podDeleteAllowMulticastPolicy(nbClient libovsdbclient.Client, ns string, portUUID string) error {
+	return libovsdbops.DeletePortsFromPortGroup(nbClient, hashedPortGroup(ns), portUUID)
 }
 
 // localPodAddDefaultDeny ensures ports (i.e. pods) are in the correct


### PR DESCRIPTION
When a pod gets deleted, a number of things could fail. But we used to just log warnings and proceed to releasing the IP of the pod which means two LSP's could now have the same IP in corner cases where let's say a LSP deletion wasn't successful. This PR adds the mechanism for retrying a deletion of pod if it fails.

Note to reviewers: One commit had conflict:

Add retry logic for pod deletion
Signed-off-by: Surya Seetharaman <suryaseetharaman.9@gmail.com>
Idea-Credit: Timothy Rozet<trozet@redhat.com>
(cherry picked from commit https://github.com/openshift/ovn-kubernetes/commit/51a4b092bff26df6685034c6fad8fcdd0d9ed8ac)

Conflicts:
Small conflict in go-controller/pkg/ovn/ovn.go because
https://github.com/ovn-org/ovn-kubernetes/commit/b885431979443cd2a864fe045be21a00867fb600
is missing.

/cc @dcbw @trozet 