### PR TITLE
[release-4.10] Bug 2073137: Fix lgw flows for ingress-svc traffic

### DIFF
--- a/docs/design/service_traffic_policy.md
+++ b/docs/design/service_traffic_policy.md
@@ -1,14 +1,15 @@
-# K8's Services' ExternalTraffic Policy Implementation
+# Kubernetes Service Traffic Policy Implementation
 
-## Background
+
+## External Traffic Policy
 
 For [Kubernetes Services](https://kubernetes.io/docs/concepts/services-networking/service/) of type Nodeport or
 Loadbalancer a user can set the `service.spec.externalTrafficPolicy` field to either `cluster` or `local` to denote
 whether or not external traffic is routed to cluster-wide or node-local endpoints. The default value for the
 `externalTrafficPolicy` field is `cluster`. In this configuration in ingress traffic is equally disributed across all
 backends and the original client IP address is lost due to SNAT. If set to `local` then the client
-source IP is propagated through the service and to the destination, while service traffic arriving at nodes without
-local endpoints is dropped.
+source IP is preserved throughout the service flow and if service traffic arrives at nodes without
+local endpoints it gets dropped. See [sources](#sources) for more information on ETP=local.
 
 Setting an `ExternalTrafficPolicy` to `Local` is only allowed for Services of type `NodePort` or `LoadBalancer`. The
 APIServer enforces this requirement.
@@ -18,7 +19,9 @@ APIServer enforces this requirement.
 To properly implement this feature for all relevant traffic flows, required changing how OVN, Iptables rules, and
 Physical OVS flows are updated and managed in OVN-Kubernetes
 
-## OVN Load_Balancer configuration
+## ExternalTrafficPolicy=Local
+
+### OVN Load_Balancer configuration
 
 Normally, each service in Kubernetes has a corresponding single Load_Balancer row created in OVN. This LB is attached
 to all node switches and gateway routers (GWRs). ExternalTrafficPolicy creates multiple LBs, however.
@@ -34,18 +37,20 @@ All externally-accessible vips (NodePort, ExternalIPs, LoadBalancer Status IPs) 
 will reside on this loadbalancer. The loadbalancer backends may be empty, depending on whether there are pods local
 to that node.
 
-## Handling Flows between the overlay and underlay
+### Handling Flows between the overlay and underlay
 
 In this section we will look at some relevant traffic flows when a service's `externalTrafficPolicy` is `local`.  For
 these examples we will be using a Nodeport service, but the flow is generally the same for ExternalIP and Loadbalancer
 type services.
 
-## Ingress Traffic
+### Ingress Traffic
 
 This section will cover the networking entities hit when traffic ingresses a cluster via a service to either host
 networked pods or cluster networked pods. If its host networked pods, then the traffic flow is the same on both gateway modes. If its cluster networked pods, they will be different for each mode.
 
 ### External Source -> Service -> OVN pod
+
+#### **Shared Gateway Mode**
 
 This case is the same as normal shared gateway traffic ingress, meaning the externally sourced traffic is routed into
 OVN via flows on breth0, except in this case the new local load balancer is hit on the GR, which ensures the ip of the
@@ -73,22 +78,22 @@ eth0--->|breth0|
 
 ```
 
-1. Match on the incoming traffic via it's nodePort, send it to `table=6`:
+1. Match on the incoming traffic via default flow on `table0`, send it to `table1`:
 
 ```
- cookie=0xb4e7084fbba8bb8a, duration=100.388s, table=0, n_packets=6, n_bytes=484, idle_age=9, priority=110,tcp,in_port=1,tp_dst=30820 actions=ct(commit,table=6,zone=64003)
+cookie=0xdeff105, duration=3189.786s, table=0, n_packets=99979, n_bytes=298029215, priority=50,ip,in_port=eth0 actions=ct(table=1,zone=64000)
 ```
 
 2. Send it out to LOCAL ovs port on breth0 and traffic is delivered to the host:
 
 ```
- cookie=0xe745ecf105, duration=119.391s, table=6, n_packets=6, n_bytes=484, idle_age=28, priority=110 actions=LOCAL
+cookie=0xdeff105, duration=3189.787s, table=1, n_packets=108, n_bytes=23004, priority=0 actions=NORMAL
 ```
 
 3. In the host, we have an IPtable rule in the PREROUTING chain that DNATs this packet matched on nodePort to a masqueradeIP (169.254.169.3) used specially for this traffic flow.
 
 ```
-[1:60] -A OVN-KUBE-NODEPORT -p tcp -m addrtype --dst-type LOCAL -m tcp --dport 31787 -j DNAT --to-destination 169.254.169.3:31787
+[3:180] -A OVN-KUBE-NODEPORT -p tcp -m addrtype --dst-type LOCAL -m tcp --dport 31746 -j DNAT --to-destination 169.254.169.3:31746
 ```
 
 4. The special masquerade route in the host sends this packet into OVN via the management port.
@@ -100,7 +105,7 @@ eth0--->|breth0|
 5. Since by default, all traffic into `ovn-k8s-mp0` gets SNAT-ed, we add an IPtable rule to `OVN-KUBE-SNAT-MGMTPORT` chain to ensure it doesn't get SNAT-ed to preserve its source-ip.
 
 ```
-[1:60] -A OVN-KUBE-SNAT-MGMTPORT -p tcp -m tcp --dport 31787 -j RETURN
+[3:180] -A OVN-KUBE-SNAT-MGMTPORT -p tcp -m tcp --dport 31746 -j RETURN
 ```
 
 6. Traffic enters the node local switch on the worker node and hits the load-balancer where we add a new vip for this masqueradeIP to DNAT it correctly to the local backends. Note that this vip will translate only to the backends that are local to that worker node and hence traffic will be rejected if there is no local endpoint thus respecting ETP=local type traffic rules.
@@ -116,7 +121,7 @@ name                : "Service_default/example-service-1_TCP_node_switch_ovn-wor
 options             : {event="false", reject="true", skip_snat="false"}
 protocol            : tcp
 selection_fields    : []
-vips                : {"169.254.169.3:30820"="10.244.1.4:8080,10.244.1.5:8080", "172.18.0.4:30820"="10.244.1.4:8080,10.244.1.5:8080"}
+vips                : {"169.254.169.3:31746"="10.244.1.3:8080", "172.18.0.3:31746"="10.244.1.3:8080,10.244.2.3:8080"}
 ```
 
 The switch load-balancer on a node without local endpoints will look like this:
@@ -129,43 +134,37 @@ name                : "Service_default/example-service-1_TCP_node_switch_ovn-wor
 options             : {event="false", reject="true", skip_snat="false"}
 protocol            : tcp
 selection_fields    : []
-vips                : {"169.254.169.3:30820"="", "172.18.0.3:30820"="10.244.1.4:8080,10.244.1.5:8080"}
+vips                : {"169.254.169.3:31746"="", "172.18.0.4:31746"="10.244.1.3:8080,10.244.2.3:8080"}
 ```
 
-Response traffic will follow the same path (backend->node switch->mp0->host->breth0).
+Response traffic will follow the same path (backend->node switch->mp0->host->breth0->eth0).
 
-7. Return traffic gets matched on src port being that of the nodePort and is sent to `table=7`
-
-```
- cookie=0xb4e7084fbba8bb8a, duration=190.099s, table=0, n_packets=4, n_bytes=408, idle_age=99, priority=110,tcp,in_port=LOCAL,tp_src=30820 actions=ct(table=7,zone=64003)
-```
-
-8. Send the traffic back out breth0 back to the external source in `table=7`
+7. Return traffic gets matched on default flow in `table0` and it sent out via default interface back to the external source.
 
 ```
- cookie=0xe745ecf105, duration=210.560s, table=7, n_packets=4, n_bytes=408, priority=110 actions=output:eth0
+cookie=0xdeff105, duration=12994.192s, table=0, n_packets=47706, n_bytes=3199460, idle_age=0, priority=100,ip,in_port=LOCAL actions=ct(commit,zone=64000,exec(load:0x2->NXM_NX_CT_MARK[])),output:1
 ```
 
 The conntrack state looks like this:
 ```
-[NEW] tcp      6 120 SYN_SENT src=172.18.0.1 dst=172.18.0.4 sport=30366 dport=30820 [UNREPLIED] src=172.18.0.4 dst=172.18.0.1 sport=30820 dport=30366 zone=64003
-[NEW] tcp      6 120 SYN_SENT src=172.18.0.1 dst=172.18.0.4 sport=30366 dport=30820 [UNREPLIED] src=169.254.169.3 dst=172.18.0.1 sport=30820 dport=30366
-[NEW] tcp      6 120 SYN_SENT src=172.18.0.1 dst=169.254.169.3 sport=30366 dport=30820 [UNREPLIED] src=10.244.1.4 dst=172.18.0.1 sport=8080 dport=30366 zone=9
-[NEW] tcp      6 120 SYN_SENT src=172.18.0.1 dst=10.244.1.4 sport=30366 dport=8080 [UNREPLIED] src=10.244.1.4 dst=172.18.0.1 sport=8080 dport=30366 zone=14
-[UPDATE] tcp   6 60 SYN_RECV src=172.18.0.1 dst=172.18.0.4 sport=30366 dport=30820 src=169.254.169.3 dst=172.18.0.1 sport=30820 dport=30366
-[UPDATE] tcp   6 432000 ESTABLISHED src=172.18.0.1 dst=172.18.0.4 sport=30366 dport=30820 src=169.254.169.3 dst=172.18.0.1 sport=30820 dport=30366 [ASSURED]
-[UPDATE] tcp   6 120 FIN_WAIT src=172.18.0.1 dst=172.18.0.4 sport=30366 dport=30820 src=169.254.169.3 dst=172.18.0.1 sport=30820 dport=30366 [ASSURED]
-[UPDATE] tcp   6 30 LAST_ACK src=172.18.0.1 dst=172.18.0.4 sport=30366 dport=30820 src=169.254.169.3 dst=172.18.0.1 sport=30820 dport=30366 [ASSURED]
-[UPDATE] tcp   6 120 TIME_WAIT src=172.18.0.1 dst=172.18.0.4 sport=30366 dport=30820 src=169.254.169.3 dst=172.18.0.1 sport=30820 dport=30366 [ASSURED]
+    [NEW] tcp      6 120 SYN_SENT src=172.18.0.1 dst=172.18.0.3 sport=36366 dport=31746 [UNREPLIED] src=169.254.169.3 dst=172.18.0.1 sport=31746 dport=36366
+    [NEW] tcp      6 120 SYN_SENT src=172.18.0.1 dst=169.254.169.3 sport=36366 dport=31746 [UNREPLIED] src=10.244.1.3 dst=172.18.0.1 sport=8080 dport=36366 zone=9
+    [NEW] tcp      6 120 SYN_SENT src=172.18.0.1 dst=10.244.1.3 sport=36366 dport=8080 [UNREPLIED] src=10.244.1.3 dst=172.18.0.1 sport=8080 dport=36366 zone=11
+ [UPDATE] tcp      6 60 SYN_RECV src=172.18.0.1 dst=172.18.0.3 sport=36366 dport=31746 src=169.254.169.3 dst=172.18.0.1 sport=31746 dport=36366
+ [UPDATE] tcp      6 432000 ESTABLISHED src=172.18.0.1 dst=172.18.0.3 sport=36366 dport=31746 src=169.254.169.3 dst=172.18.0.1 sport=31746 dport=36366 [ASSURED]
+    [NEW] tcp      6 300 ESTABLISHED src=172.18.0.3 dst=172.18.0.1 sport=31746 dport=36366 [UNREPLIED] src=172.18.0.1 dst=172.18.0.3 sport=36366 dport=31746 mark=2 zone=64000
+ [UPDATE] tcp      6 120 FIN_WAIT src=172.18.0.1 dst=172.18.0.3 sport=36366 dport=31746 src=169.254.169.3 dst=172.18.0.1 sport=31746 dport=36366 [ASSURED]
+ [UPDATE] tcp      6 30 LAST_ACK src=172.18.0.1 dst=172.18.0.3 sport=36366 dport=31746 src=169.254.169.3 dst=172.18.0.1 sport=31746 dport=36366 [ASSURED]
+ [UPDATE] tcp      6 120 TIME_WAIT src=172.18.0.1 dst=172.18.0.3 sport=36366 dport=31746 src=169.254.169.3 dst=172.18.0.1 sport=31746 dport=36366 [ASSURED]
 ```
 
 
 ### External Source -> Service -> Host Networked pod
 
 This Scenario is a bit different, specifically traffic now needs to be directed from an external source to service and
-then to the host itself(a host networked pod)
+then to the host itself (a host networked pod)
 
-In this flow, rather than going from breth0 into OVN we shortcircuit the path with physical flows on breth0
+In this flow, rather than going from breth0 into OVN we shortcircuit the path with physical flows on breth0. This is the same for both the gateway modes.
 
 ```text
           host (ovn-worker, 172.18.0.3) 
@@ -201,16 +200,16 @@ cookie=0x790ba3355d0c209b, duration=113.033s, table=6, n_packets=18, n_bytes=146
 cookie=0x790ba3355d0c209b, duration=501.037s, table=7, n_packets=12, n_bytes=1259, idle_age=448, priority=100 actions=output:1
 ```
 
-## Host Traffic
+### Host Traffic
 
 This section will cover the networking entities hit when traffic travels from a cluster host via a service to either host
-networked pods or cluster networked pods
+networked pods or cluster networked pods. These flows are the same for both the gateway modes.
 
 ### Host -> Service -> OVN Pod
 
 This case is similar to steps 3-6 on `External -> Service -> OVN Pod` traffic senario we saw above for local gateway. The traffic will flow from host->PRE-ROUTING iptable rule DNAT towards `169.254.169.3`, which gets routed into `ovn-k8s-mp0` and hits the load balancer on the node-local-switch preserving sourceIP.
 
-### Host -> Service -> Host
+### Host -> Service -> Host Networked Pod
 
 Again when the backend is a host networked pod we shortcircuit OVN to avoid SNAT and use iptables rules on the host
 to DNAT directly to the correct host endpoint.
@@ -219,9 +218,100 @@ to DNAT directly to the correct host endpoint.
 [0:0] -A OVN-KUBE-NODEPORT -p tcp -m addrtype --dst-type LOCAL -m tcp --dport 30940 -j REDIRECT --to-ports 8080
 ```
 
-## Intra Cluster traffic
+### Intra Cluster traffic
 
 For all service traffic that stays in the overlay the flows will remain the same for `externaltrafficpolicy:local`. If the traffic crosses over to the underlay then its not guaranteed to be the same. See https://bugzilla.redhat.com/show_bug.cgi?id=2027270.
+
+## ExternalTrafficPolicy=Cluster
+
+#### **Local Gateway Mode**
+
+The implementation of this case differs for local gateway from that for shared gateway. In local gateway all service traffic is sent straight to host (instead of sending it to OVN) to allow users to apply custom routes according to their use cases.
+
+In local gateway mode, rather than sending the traffic from breth0 into OVN via gateway router, we use flows on breth0 to send it into the host.
+
+```text
+          host (ovn-worker, 172.18.0.3) ---- 172.18.0.3 LOCAL(host) -- iptables -- breth0 -- GR -- 10.244.1.3 pod
+           ^
+           ^
+           |
+eth0--->|breth0|
+
+```
+
+1. Match on the incoming traffic via default flow on `table0`, send it to `table1`:
+
+```
+cookie=0xdeff105, duration=3189.786s, table=0, n_packets=99979, n_bytes=298029215, priority=50,ip,in_port=eth0 actions=ct(table=1,zone=64000)
+```
+
+2. Send it out to LOCAL ovs port on breth0 and traffic is delivered to the host:
+
+```
+cookie=0xdeff105, duration=3189.787s, table=1, n_packets=108, n_bytes=23004, priority=0 actions=NORMAL
+```
+
+3. In the host, we have an IPtable rule in the PREROUTING chain that DNATs this packet matched on nodePort to its clusterIP:targetPort
+
+```
+[8:480] -A OVN-KUBE-NODEPORT -p tcp -m addrtype --dst-type LOCAL -m tcp --dport 31842 -j DNAT --to-destination 10.96.67.170:80
+```
+
+4. The service route in the host sends this packet back to breth0.
+
+```
+10.96.0.0/16 via 172.18.0.1 dev breth0 mtu 1400
+```
+
+5. On breth0, we have priority 500 flows meant to handle hairpining, that will SNAT the srcIP to the special `169.254.169.2` masqueradeIP and send it to `table2`
+
+```
+cookie=0xdeff105, duration=3189.786s, table=0, n_packets=11, n_bytes=814, priority=500,ip,in_port=LOCAL,nw_dst=10.96.0.0/16 actions=ct(commit,table=2,zone=64001,nat(src=169.254.169.2))
+```
+
+6. In `table2` we have a flow that forwards this to patch port that takes the traffic in OVN:
+
+```
+cookie=0xdeff105, duration=6.308s, table=2, n_packets=11, n_bytes=814, actions=mod_dl_dst:02:42:ac:12:00:03,output:"patch-breth0_ov"
+```
+
+7. Traffic enters the GR on the worker node and hits the load-balancer where we DNAT it correctly to the local backends.
+
+The GR load-balancer on a node with endpoints for the clusterIP will look like this:
+
+```
+_uuid               : b3201caf-3089-4462-b96e-1406fd7c4256
+external_ids        : {"k8s.ovn.org/kind"=Service, "k8s.ovn.org/owner"="default/example-service-1"}
+health_check        : []
+ip_port_mappings    : {}
+name                : "Service_default/example-service-1_TCP_cluster"
+options             : {event="false", reject="true", skip_snat="false"}
+protocol            : tcp
+selection_fields    : []
+vips                : {"10.96.67.170:80"="10.244.1.3:8080,10.244.2.3:8080"}
+```
+
+Response traffic will follow the same path (backend->GR->breth0->host->breth0->eth0).
+
+7. Return traffic gets matched on the priority 500 flow in `table0` which sends it to `table3`.
+
+```
+cookie=0xdeff105, duration=3189.786s, table=0, n_packets=10, n_bytes=540, priority=500,ip,in_port="patch-breth0_ov",nw_src=10.96.0.0/16,nw_dst=169.254.169.2 actions=ct(table=3,zone=64001,nat)
+```
+
+8. In `table3`, we send it to host:
+
+```
+cookie=0xdeff105, duration=6.308s, table=3, n_packets=10, n_bytes=540, actions=move:NXM_OF_ETH_DST[]->NXM_OF_ETH_SRC[],mod_dl_dst:02:42:ac:12:00:03,LOCAL
+```
+
+9. From host we send it back to breth0 using:
+
+```
+cookie=0xdeff105, duration=5992.878s, table=0, n_packets=89312, n_bytes=6154654, idle_age=0, priority=100,ip,in_port=LOCAL actions=ct(commit,zone=64000,exec(load:0x2->NXM_NX_CT_MARK[])),output:eth0
+```
+
+where packet leaves the node and goes back to the external entity that initiated the connection.
 
 ## Sources
 - https://www.asykim.com/blog/deep-dive-into-kubernetes-external-traffic-policies

--- a/go-controller/pkg/node/gateway_localnet_linux_test.go
+++ b/go-controller/pkg/node/gateway_localnet_linux_test.go
@@ -440,18 +440,12 @@ var _ = Describe("Node Operations", func() {
 					},
 					"filter": {},
 				}
-				expectedFlows := []string{
-					"cookie=0x453ae29bcbbc08bd, priority=110, in_port=eth0, tcp, tp_dst=31111, actions=ct(commit,zone=64003,table=6)",
-					"cookie=0x453ae29bcbbc08bd, priority=110, in_port=LOCAL, tcp, tp_src=31111, actions=ct(zone=64003,table=7)",
-					"cookie=0xe745ecf105, priority=110, table=6, actions=output:LOCAL",
-					"cookie=0xe745ecf105, priority=110, table=7, actions=output:eth0",
-				}
 
 				f4 := iptV4.(*util.FakeIPTables)
 				err := f4.MatchState(expectedTables)
 				Expect(err).NotTo(HaveOccurred())
 				flows := fNPW.ofm.flowCache["NodePort_namespace1_service1_tcp_31111"]
-				Expect(flows).To(Equal(expectedFlows))
+				Expect(flows).To(BeNil())
 				fakeOvnNode.shutdown()
 				return nil
 			}
@@ -597,30 +591,103 @@ var _ = Describe("Node Operations", func() {
 					},
 					"filter": {},
 				}
-				expectedNodePortFlows := []string{
-					"cookie=0x453ae29bcbbc08bd, priority=110, in_port=eth0, tcp, tp_dst=31111, actions=ct(commit,zone=64003,table=6)",
-					"cookie=0x453ae29bcbbc08bd, priority=110, in_port=LOCAL, tcp, tp_src=31111, actions=ct(zone=64003,table=7)",
-					"cookie=0xe745ecf105, priority=110, table=6, actions=output:LOCAL",
-					"cookie=0xe745ecf105, priority=110, table=7, actions=output:eth0",
-				}
 				expectedLBIngressFlows := []string{
-					"cookie=0x10c6b89e483ea111, priority=110, in_port=eth0, tcp, nw_dst=5.5.5.5, tp_dst=8080, actions=ct(commit,zone=64003,table=6)",
-					"cookie=0x10c6b89e483ea111, priority=110, in_port=LOCAL, tcp, nw_src=5.5.5.5, tp_src=8080, actions=ct(zone=64003,table=7)",
-					"cookie=0xe745ecf105, priority=110, table=6, actions=output:LOCAL",
-					"cookie=0xe745ecf105, priority=110, table=7, actions=output:eth0",
+					"cookie=0x10c6b89e483ea111, priority=110, in_port=eth0, arp, arp_op=1, arp_tpa=5.5.5.5, actions=output:LOCAL",
 				}
 				expectedLBExternalIPFlows := []string{
-					"cookie=0x71765945a31dc2f1, priority=110, in_port=eth0, tcp, nw_dst=1.1.1.1, tp_dst=8080, actions=ct(commit,zone=64003,table=6)",
-					"cookie=0x71765945a31dc2f1, priority=110, in_port=LOCAL, tcp, nw_src=1.1.1.1, tp_src=8080, actions=ct(zone=64003,table=7)",
-					"cookie=0xe745ecf105, priority=110, table=6, actions=output:LOCAL",
-					"cookie=0xe745ecf105, priority=110, table=7, actions=output:eth0",
+					"cookie=0x71765945a31dc2f1, priority=110, in_port=eth0, arp, arp_op=1, arp_tpa=1.1.1.1, actions=output:LOCAL",
 				}
 
 				f4 := iptV4.(*util.FakeIPTables)
 				err := f4.MatchState(expectedTables)
 				Expect(err).NotTo(HaveOccurred())
 				flows := fNPW.ofm.flowCache["NodePort_namespace1_service1_tcp_31111"]
-				Expect(flows).To(Equal(expectedNodePortFlows))
+				Expect(flows).To(BeNil())
+				flows = fNPW.ofm.flowCache["Ingress_namespace1_service1_5.5.5.5_8080"]
+				Expect(flows).To(Equal(expectedLBIngressFlows))
+				flows = fNPW.ofm.flowCache["External_namespace1_service1_1.1.1.1_8080"]
+				Expect(flows).To(Equal(expectedLBExternalIPFlows))
+
+				fakeOvnNode.shutdown()
+				return nil
+			}
+			err := app.Run([]string{app.Name})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("inits iptables rules and openflows with LoadBalancer where ETP=cluster, LGW mode", func() {
+			app.Action = func(ctx *cli.Context) error {
+				externalIP := "1.1.1.1"
+				config.Gateway.Mode = config.GatewayModeLocal
+				service := *newService("service1", "namespace1", "10.129.0.2",
+					[]v1.ServicePort{
+						{
+							NodePort: int32(31111),
+							Protocol: v1.ProtocolTCP,
+							Port:     int32(8080),
+						},
+					},
+					v1.ServiceTypeLoadBalancer,
+					[]string{externalIP},
+					v1.ServiceStatus{
+						LoadBalancer: v1.LoadBalancerStatus{
+							Ingress: []v1.LoadBalancerIngress{{
+								IP: "5.5.5.5",
+							}},
+						},
+					},
+					false, // ETP=cluster
+				)
+				// endpoints.Subset is empty and yet this will come under !hasLocalHostNetEp case
+				endpoints := *newEndpoints("service1", "namespace1", []v1.EndpointSubset{})
+
+				fakeOvnNode.start(ctx,
+					&v1.ServiceList{
+						Items: []v1.Service{
+							service,
+						},
+					},
+					&endpoints,
+				)
+
+				fNPW.watchFactory = fakeOvnNode.watcher
+				startNodePortWatcher(fNPW, fakeOvnNode.fakeClient, &fakeMgmtPortConfig)
+				fNPW.AddService(&service)
+
+				expectedTables := map[string]util.FakeTable{
+					"nat": {
+						"PREROUTING": []string{
+							"-j OVN-KUBE-EXTERNALIP",
+							"-j OVN-KUBE-NODEPORT",
+						},
+						"OUTPUT": []string{
+							"-j OVN-KUBE-EXTERNALIP",
+							"-j OVN-KUBE-NODEPORT",
+						},
+						"OVN-KUBE-NODEPORT": []string{
+							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
+						},
+						"OVN-KUBE-SNAT-MGMTPORT": []string{},
+						"OVN-KUBE-EXTERNALIP": []string{
+							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Status.LoadBalancer.Ingress[0].IP, service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
+							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, externalIP, service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
+						},
+					},
+					"filter": {},
+				}
+
+				expectedLBIngressFlows := []string{
+					"cookie=0x10c6b89e483ea111, priority=110, in_port=eth0, arp, arp_op=1, arp_tpa=5.5.5.5, actions=output:LOCAL",
+				}
+				expectedLBExternalIPFlows := []string{
+					"cookie=0x71765945a31dc2f1, priority=110, in_port=eth0, arp, arp_op=1, arp_tpa=1.1.1.1, actions=output:LOCAL",
+				}
+
+				f4 := iptV4.(*util.FakeIPTables)
+				err := f4.MatchState(expectedTables)
+				Expect(err).NotTo(HaveOccurred())
+				flows := fNPW.ofm.flowCache["NodePort_namespace1_service1_tcp_31111"]
+				Expect(flows).To(BeNil())
 				flows = fNPW.ofm.flowCache["Ingress_namespace1_service1_5.5.5.5_8080"]
 				Expect(flows).To(Equal(expectedLBIngressFlows))
 				flows = fNPW.ofm.flowCache["External_namespace1_service1_1.1.1.1_8080"]
@@ -700,14 +767,14 @@ var _ = Describe("Node Operations", func() {
 					"cookie=0x453ae29bcbbc08bd, priority=110, in_port=patch-breth0_ov, tcp, tp_src=31111, actions=output:eth0",
 				}
 				expectedLBIngressFlows := []string{
+					"cookie=0x10c6b89e483ea111, priority=110, in_port=eth0, arp, arp_op=1, arp_tpa=5.5.5.5, actions=output:LOCAL",
 					"cookie=0x10c6b89e483ea111, priority=110, in_port=eth0, tcp, nw_dst=5.5.5.5, tp_dst=8080, actions=check_pkt_larger(1414)->reg0[0],resubmit(,11)",
 					"cookie=0x10c6b89e483ea111, priority=110, in_port=patch-breth0_ov, tcp, nw_src=5.5.5.5, tp_src=8080, actions=output:eth0",
-					"cookie=0x10c6b89e483ea111, priority=110, in_port=eth0, arp, arp_op=1, arp_tpa=5.5.5.5, actions=output:LOCAL",
 				}
 				expectedLBExternalIPFlows := []string{
+					"cookie=0x71765945a31dc2f1, priority=110, in_port=eth0, arp, arp_op=1, arp_tpa=1.1.1.1, actions=output:LOCAL",
 					"cookie=0x71765945a31dc2f1, priority=110, in_port=eth0, tcp, nw_dst=1.1.1.1, tp_dst=8080, actions=check_pkt_larger(1414)->reg0[0],resubmit(,11)",
 					"cookie=0x71765945a31dc2f1, priority=110, in_port=patch-breth0_ov, tcp, nw_src=1.1.1.1, tp_src=8080, actions=output:eth0",
-					"cookie=0x71765945a31dc2f1, priority=110, in_port=eth0, arp, arp_op=1, arp_tpa=1.1.1.1, actions=output:LOCAL",
 				}
 
 				f4 := iptV4.(*util.FakeIPTables)
@@ -1027,10 +1094,10 @@ var _ = Describe("Node Operations", func() {
 		It("manages iptables rules with ExternalIP", func() {
 			app.Action = func(ctx *cli.Context) error {
 				externalIP := "10.10.10.1"
-				externalIPPort := int32(8034)
 				fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
 					Cmd: "ovs-ofctl show ",
 				})
+				externalIPPort := int32(8034)
 				service := *newService("service1", "namespace1", "10.129.0.2",
 					[]v1.ServicePort{
 						{
@@ -1257,18 +1324,12 @@ var _ = Describe("Node Operations", func() {
 					},
 					"filter": {},
 				}
-				expectedFlows := []string{
-					"cookie=0x453ae29bcbbc08bd, priority=110, in_port=eth0, tcp, tp_dst=31111, actions=ct(commit,zone=64003,table=6)",
-					"cookie=0x453ae29bcbbc08bd, priority=110, in_port=LOCAL, tcp, tp_src=31111, actions=ct(zone=64003,table=7)",
-					"cookie=0xe745ecf105, priority=110, table=6, actions=output:LOCAL",
-					"cookie=0xe745ecf105, priority=110, table=7, actions=output:eth0",
-				}
 
 				f4 := iptV4.(*util.FakeIPTables)
 				err := f4.MatchState(expectedTables)
 				Expect(err).NotTo(HaveOccurred())
 				flows := fNPW.ofm.flowCache["NodePort_namespace1_service1_tcp_31111"]
-				Expect(flows).To(Equal(expectedFlows))
+				Expect(flows).To(BeNil())
 
 				fNPW.DeleteService(&service)
 


### PR DESCRIPTION

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->
This commit does two things:

1) No need to steer service traffic for LGW via breth0 into OVN.
Let's pass it into the host where user can apply custom routes
and modulate the traffic as needed.
Flow: external->br-ex->host->iptables->br-ex->GR->pod
reply will follow the same path (check docs for details)
2) Cleanup some ETP=local code since this simplifies things on
br-ex for LGW.

Signed-off-by: Surya Seetharaman <suryaseetharaman.9@gmail.com>
(cherry picked from commit dbd824057551a2aea3cfef61c346ee50fe66e036)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->


**- Special notes for reviewers**
clean cherry pick from master