### PR TITLE
Fix gofmt for downstream files

### DIFF
--- a/go-controller/pkg/cni/OCP_HACKS.go
+++ b/go-controller/pkg/cni/OCP_HACKS.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package cni

--- a/go-controller/pkg/node/OCP_HACKS.go
+++ b/go-controller/pkg/node/OCP_HACKS.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package node


### PR DESCRIPTION
Adds go:build tag for OCP_HACKS files.

Signed-off-by: Aniket Bhat <anbhat@redhat.com>