### PR TITLE
Bug 2075475: allow creating cluster subnet route for egress router pod

### DIFF
--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -275,6 +275,15 @@ func (oc *Controller) addRoutesGatewayIP(pod *kapi.Pod, podAnnotation *util.PodA
 		if isIPv6 {
 			otherDefaultRoute = otherDefaultRouteV6
 		}
+
+		// OCP HACK
+        // Alert for egress router CNI we delete the default route to eth0
+        // so we need to have route to cluster subnets and service CIDR to be able to connect
+        // to pods on different nodes.
+		if len(pod.Labels) != 0 && pod.Labels["app"] == "egress-router-cni" {
+			otherDefaultRoute = true
+		}
+		// END OCP HACK
 		var gatewayIP net.IP
 		hasRoutingExternalGWs := len(routingExternalGWs.gws) > 0
 		hasPodRoutingGWs := len(routingPodGWs) > 0


### PR DESCRIPTION
egress router pod doesn't have route to allow this pod to connect
to other pods on different nodes.

to be able to reach svc backed by egress router pod from pods
on different node we need to install this route

unit-test

started cluster-bot with this PR and checked the routing table inside egress router pod after the changes
[root@ci-ln-4gkcnf2-72292-zxd7p-worker-a-7p29w /]# ip r
default via 192.168.123.1 dev net1 
10.128.0.0/14 via 10.131.0.1 dev eth0 <<<<
10.131.0.0/23 dev eth0 proto kernel scope link src 10.131.0.20 
172.30.0.0/16 via 10.131.0.1 dev eth0 <<<<
192.168.123.0/24 dev net1 proto kernel scope link src 192.168.123.144 
192.168.123.1 dev net1 

```
oc get pod egress-router-cni-deployment-6f8c4647d6-gbjv6  -o yaml
apiVersion: v1
kind: Pod
metadata:
  annotations:
    k8s.ovn.org/pod-networks: '{"default":{"ip_addresses":["10.131.0.20/23"],"mac_address":"0a:58:0a:83:00:14","routes":[{"dest":"10.128.0.0/14","nextHop":"10.131.0.1"},{"dest":"172.30.0.0/16","nextHop":"10.131.0.1"}],"ip_address":"10.131.0.20/23"}}'
```

Signed-off-by: Mohamed Mahmoud <mmahmoud@redhat.com>
