### PR TITLE
Bug 2079546: [release-4.10] call clearInitialNodeNetworkUnavailableCondition for noHostSubnet nodes

### DIFF
--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -1141,7 +1141,9 @@ func (oc *Controller) WatchNodes() {
 				err := oc.lsManager.AddNoHostSubnetNode(node.Name)
 				if err != nil {
 					klog.Errorf("Error creating logical switch cache for node %s: %v", node.Name, err)
+					return
 				}
+				oc.clearInitialNodeNetworkUnavailableCondition(node, nil)
 				return
 			}
 


### PR DESCRIPTION


a correctly configured noHostSubnet node will never become avalible on
GCP because the unavailable condition will never be cleared.

slight changes required to make this work on 4.10

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->