### PR TITLE
Bug 2080069: Cleanup conntrack entries when services are deleted

### DIFF
--- a/go-controller/pkg/cni/helper_linux.go
+++ b/go-controller/pkg/cni/helper_linux.go
@@ -491,7 +491,7 @@ func (pr *PodRequest) deletePodConntrack() {
 				continue
 			}
 		}
-		err = util.DeleteConntrack(ip.Address.IP.String(), 0, "")
+		err = util.DeleteConntrack(ip.Address.IP.String(), 0, "", netlink.ConntrackReplyAnyIP)
 		if err != nil {
 			klog.Errorf("Failed to delete Conntrack Entry for %s: %v", ip.Address.IP.String(), err)
 			continue

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	"github.com/vishvananda/netlink"
 
 	kapi "k8s.io/api/core/v1"
 	ktypes "k8s.io/apimachinery/pkg/types"
@@ -571,6 +572,48 @@ func (npw *nodePortWatcher) UpdateService(old, new *kapi.Service) {
 	}
 }
 
+// deleteConntrackForServiceVIP deletes the conntrack entries for the provided svcVIP:svcPort by comparing them to ConntrackOrigDstIP:ConntrackOrigDstPort
+func deleteConntrackForServiceVIP(svcVIPs []string, svcPorts []kapi.ServicePort, ns, name string) error {
+	for _, svcVIP := range svcVIPs {
+		for _, svcPort := range svcPorts {
+			err := util.DeleteConntrack(svcVIP, svcPort.Port, svcPort.Protocol, netlink.ConntrackOrigDstIP)
+			if err != nil {
+				return fmt.Errorf("failed to delete conntrack entry for service %s/%s with svcVIP %s, svcPort %d, protocol %s: %v",
+					ns, name, svcVIP, svcPort.Port, svcPort.Protocol, err)
+			}
+		}
+	}
+	return nil
+}
+
+// deleteConntrackForService deletes the conntrack entries corresponding to the service VIPs of the provided service
+func (npw *nodePortWatcher) deleteConntrackForService(service *kapi.Service) error {
+	// remove conntrack entries for LB VIPs and External IPs
+	externalIPs := util.GetExternalAndLBIPs(service)
+	if err := deleteConntrackForServiceVIP(externalIPs, service.Spec.Ports, service.Namespace, service.Name); err != nil {
+		return err
+	}
+	if util.ServiceTypeHasNodePort(service) {
+		// remove conntrack entries for NodePorts
+		nodeIPs := npw.nodeIPManager.ListAddresses()
+		for _, nodeIP := range nodeIPs {
+			for _, svcPort := range service.Spec.Ports {
+				err := util.DeleteConntrack(nodeIP.String(), svcPort.NodePort, svcPort.Protocol, netlink.ConntrackOrigDstIP)
+				if err != nil {
+					return fmt.Errorf("failed to delete conntrack entry for service %s/%s with nodeIP %s, nodePort %d, protocol %s: %v",
+						service.Namespace, service.Name, nodeIP, svcPort.Port, svcPort.Protocol, err)
+				}
+			}
+		}
+	}
+	// remove conntrack entries for ClusterIPs
+	clusterIPs := util.GetClusterIPs(service)
+	if err := deleteConntrackForServiceVIP(clusterIPs, service.Spec.Ports, service.Namespace, service.Name); err != nil {
+		return err
+	}
+	return nil
+}
+
 func (npw *nodePortWatcher) DeleteService(service *kapi.Service) {
 	if !util.ServiceTypeHasClusterIP(service) || !util.IsClusterIPSet(service) {
 		return
@@ -578,6 +621,13 @@ func (npw *nodePortWatcher) DeleteService(service *kapi.Service) {
 
 	klog.V(5).Infof("Deleting service %s in namespace %s", service.Name, service.Namespace)
 	name := ktypes.NamespacedName{Namespace: service.Namespace, Name: service.Name}
+	// Remove all conntrack entries for the serviceVIPs of this service irrespective of protocol stack
+	// since service deletion is considered as unplugging the network cable and hence graceful termination
+	// is not guaranteed. See https://github.com/kubernetes/kubernetes/issues/108523#issuecomment-1074044415.
+	err := npw.deleteConntrackForService(service)
+	if err != nil {
+		klog.Errorf("Failed to delete conntrack entry for service %v: %v", name, err)
+	}
 	if svcConfig, exists := npw.getAndDeleteServiceInfo(name); exists {
 		delServiceRules(svcConfig.service, npw)
 	} else {

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -529,7 +529,8 @@ func (npw *nodePortWatcher) AddService(service *kapi.Service) {
 		// No endpoint object exists yet so default to false
 		hasLocalHostNetworkEp = false
 	} else {
-		hasLocalHostNetworkEp = hasLocalHostNetworkEndpoints(ep, &npw.nodeIPManager.addresses)
+		nodeIPs := npw.nodeIPManager.ListAddresses()
+		hasLocalHostNetworkEp = hasLocalHostNetworkEndpoints(ep, nodeIPs)
 	}
 
 	// If something didn't already do it add correct Service rules
@@ -602,7 +603,8 @@ func (npw *nodePortWatcher) SyncServices(services []interface{}) {
 			klog.V(5).Infof("No endpoint found for service %s in namespace %s during sync", service.Name, service.Namespace)
 			continue
 		}
-		hasLocalHostNetworkEp := hasLocalHostNetworkEndpoints(ep, &npw.nodeIPManager.addresses)
+		nodeIPs := npw.nodeIPManager.ListAddresses()
+		hasLocalHostNetworkEp := hasLocalHostNetworkEndpoints(ep, nodeIPs)
 		npw.getAndSetServiceInfo(name, service, hasLocalHostNetworkEp)
 		// Delete OF rules for service if they exist
 		npw.updateServiceFlowCache(service, false, hasLocalHostNetworkEp)
@@ -638,7 +640,8 @@ func (npw *nodePortWatcher) AddEndpoints(ep *kapi.Endpoints) {
 	}
 
 	klog.V(5).Infof("Adding endpoints %s in namespace %s", ep.Name, ep.Namespace)
-	hasLocalHostNetworkEp := hasLocalHostNetworkEndpoints(ep, &npw.nodeIPManager.addresses)
+	nodeIPs := npw.nodeIPManager.ListAddresses()
+	hasLocalHostNetworkEp := hasLocalHostNetworkEndpoints(ep, nodeIPs)
 
 	// Here we make sure the correct rules are programmed whenever an AddEndpoint
 	// event is received, only alter flows if we need to, i.e if cache wasn't
@@ -692,8 +695,9 @@ func (npw *nodePortWatcher) UpdateEndpoints(old *kapi.Endpoints, new *kapi.Endpo
 	}
 
 	// Update rules if hasLocalHostNetworkEpNew status changed.
-	hasLocalHostNetworkEpOld := hasLocalHostNetworkEndpoints(old, &npw.nodeIPManager.addresses)
-	hasLocalHostNetworkEpNew := hasLocalHostNetworkEndpoints(new, &npw.nodeIPManager.addresses)
+	nodeIPs := npw.nodeIPManager.ListAddresses()
+	hasLocalHostNetworkEpOld := hasLocalHostNetworkEndpoints(old, nodeIPs)
+	hasLocalHostNetworkEpNew := hasLocalHostNetworkEndpoints(new, nodeIPs)
 	if hasLocalHostNetworkEpOld != hasLocalHostNetworkEpNew {
 		npw.DeleteEndpoints(old)
 		npw.AddEndpoints(new)

--- a/go-controller/pkg/node/healthcheck.go
+++ b/go-controller/pkg/node/healthcheck.go
@@ -1,6 +1,7 @@
 package node
 
 import (
+	"net"
 	"os"
 	"strings"
 	"sync"
@@ -13,7 +14,6 @@ import (
 
 	kapi "k8s.io/api/core/v1"
 	ktypes "k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
 )
 
@@ -99,17 +99,18 @@ func countLocalEndpoints(ep *kapi.Endpoints, nodeName string) int {
 // hasLocalHostNetworkEndpoints returns true if there is at least one host-networked endpoint
 // in the provided list that is local to this node.
 // It returns false if none of the endpoints are local host-networked endpoints or if ep.Subsets is nil.
-func hasLocalHostNetworkEndpoints(ep *kapi.Endpoints, nodeAddresses *sets.String) bool {
+func hasLocalHostNetworkEndpoints(ep *kapi.Endpoints, nodeAddresses []net.IP) bool {
 	for i := range ep.Subsets {
 		ss := &ep.Subsets[i]
 		for i := range ss.Addresses {
 			addr := &ss.Addresses[i]
-			if nodeAddresses.Has(addr.IP) {
-				return true
+			for _, nodeIP := range nodeAddresses {
+				if nodeIP.String() == addr.IP {
+					return true
+				}
 			}
 		}
 	}
-
 	return false
 }
 

--- a/go-controller/pkg/node/helper_linux.go
+++ b/go-controller/pkg/node/helper_linux.go
@@ -11,7 +11,6 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 	"github.com/pkg/errors"
 	"github.com/vishvananda/netlink"
-	kapi "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
 )
 
@@ -110,8 +109,4 @@ func getIntfName(gatewayIntf string) (string, error) {
 			intfName, stderr, err)
 	}
 	return intfName, nil
-}
-
-func deleteConntrack(ip string, port int32, protocol kapi.Protocol) error {
-	return util.DeleteConntrack(ip, port, protocol)
 }

--- a/go-controller/pkg/node/node.go
+++ b/go-controller/pkg/node/node.go
@@ -35,6 +35,7 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/controllers/upgrade"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	"github.com/vishvananda/netlink"
 )
 
 // OvnNode is the object holder for utilities meant for node management
@@ -590,8 +591,8 @@ func (n *OvnNode) WatchEndpoints() {
 			epOld := old.(*kapi.Endpoints)
 			newEpAddressMap := buildEndpointAddressMap(epNew.Subsets)
 			for item := range buildEndpointAddressMap(epOld.Subsets) {
-				if _, ok := newEpAddressMap[item]; !ok {
-					err := deleteConntrack(item.ip, item.port, item.protocol)
+				if _, ok := newEpAddressMap[item]; !ok && item.protocol == kapi.ProtocolUDP { // flush conntrack only for UDP
+					err := util.DeleteConntrack(item.ip, item.port, item.protocol, netlink.ConntrackReplyAnyIP)
 					if err != nil {
 						klog.Errorf("Failed to delete conntrack entry for %s: %v", item.ip, err)
 					}
@@ -601,11 +602,12 @@ func (n *OvnNode) WatchEndpoints() {
 		DeleteFunc: func(obj interface{}) {
 			ep := obj.(*kapi.Endpoints)
 			for item := range buildEndpointAddressMap(ep.Subsets) {
-				err := deleteConntrack(item.ip, item.port, item.protocol)
-				if err != nil {
-					klog.Errorf("Failed to delete conntrack entry for %s: %v", item.ip, err)
+				if item.protocol == kapi.ProtocolUDP { // flush conntrack only for UDP
+					err := util.DeleteConntrack(item.ip, item.port, item.protocol, netlink.ConntrackReplyAnyIP)
+					if err != nil {
+						klog.Errorf("Failed to delete conntrack entry for %s: %v", item.ip, err)
+					}
 				}
-
 			}
 		},
 	}, nil)

--- a/go-controller/pkg/node/node_ip_handler_linux.go
+++ b/go-controller/pkg/node/node_ip_handler_linux.go
@@ -68,6 +68,22 @@ func (c *addressManager) delAddr(ip net.IP) bool {
 	return false
 }
 
+// ListAddresses returns all the addresses we know about
+func (c *addressManager) ListAddresses() []net.IP {
+	c.Lock()
+	defer c.Unlock()
+	addrs := c.addresses.List()
+	out := make([]net.IP, 0, len(addrs))
+	for _, addr := range addrs {
+		ip := net.ParseIP(addr)
+		if ip == nil {
+			continue
+		}
+		out = append(out, ip)
+	}
+	return out
+}
+
 func (c *addressManager) Run(stopChan <-chan struct{}) {
 	var addrChan chan netlink.AddrUpdate
 	addrSubscribeOptions := netlink.AddrSubscribeOptions{

--- a/go-controller/pkg/util/kube.go
+++ b/go-controller/pkg/util/kube.go
@@ -161,6 +161,20 @@ func GetClusterIPs(service *kapi.Service) []string {
 	return []string{}
 }
 
+// GetExternalAndLBIPs returns an array with the ExternalIPs and LoadBalancer IPs present in the service
+func GetExternalAndLBIPs(service *kapi.Service) []string {
+	svcVIPs := []string{}
+	svcVIPs = append(svcVIPs, service.Spec.ExternalIPs...)
+	if ServiceTypeHasLoadBalancer(service) {
+		for _, ingressVIP := range service.Status.LoadBalancer.Ingress {
+			if len(ingressVIP.IP) > 0 {
+				svcVIPs = append(svcVIPs, ingressVIP.IP)
+			}
+		}
+	}
+	return svcVIPs
+}
+
 // ValidatePort checks if the port is non-zero and port protocol is valid
 func ValidatePort(proto kapi.Protocol, port int32) error {
 	if port <= 0 || port > 65535 {
@@ -185,6 +199,11 @@ func ServiceTypeHasClusterIP(service *kapi.Service) bool {
 // ServiceTypeHasNodePort checks if the service has an associated NodePort or not
 func ServiceTypeHasNodePort(service *kapi.Service) bool {
 	return service.Spec.Type == kapi.ServiceTypeNodePort || service.Spec.Type == kapi.ServiceTypeLoadBalancer
+}
+
+// ServiceTypeHasLoadBalancer checks if the service has an associated LoadBalancer or not
+func ServiceTypeHasLoadBalancer(service *kapi.Service) bool {
+	return service.Spec.Type == kapi.ServiceTypeLoadBalancer
 }
 
 func ServiceExternalTrafficPolicyLocal(service *kapi.Service) bool {


### PR DESCRIPTION
    Cleanup conntrack entries when clusterIPs are deleted
    
    This PR does two things:
    1) cleanup conntrack entries irrespective of protocolstack
    for service deletion
    2) cleanup conntrack entries only for UDP during endpoint
    deletion.
    See https://github.com/kubernetes/kubernetes/issues/108523#issuecomment-1074044415
    for details.
    
    Signed-off-by: Surya Seetharaman <suryaseetharaman.9@gmail.com>
    (cherry picked from commit 8f46895a9fb05f05047ddd61936db89ffddeca38)

NOTE to Reviewers:

I had to add an extra commit :

Author: Surya Seetharaman <suryaseetharaman.9@gmail.com>
Date:   Fri Apr 29 00:12:53 2022 +0200

    Add ListAddresses() utility
    
    Had to take this from
    https://github.com/openshift/ovn-kubernetes/pull/1040/commits/bfb5ac17a2ddb350bee956e16af7d69c4af6046b#diff-9eaecf6cd5a03cd786e33bc636507897362732e6fbdfaa8e0471e0930c22b395R74-R89
    since its needed for this PR but the original PR
    hasn't been backported.
    
    Authored-By: Casey Callendrello <cdc@redhat.com>
since that change wasn't backported, but my change is dependent on that new function being there.

Original two commits with the fix had no conflicts.