### PR TITLE
Bug 2080895: Ensure stale information is not present in metrics with labels when they change

### DIFF
--- a/go-controller/pkg/metrics/ovn.go
+++ b/go-controller/pkg/metrics/ovn.go
@@ -282,16 +282,21 @@ func setOvnControllerConfigurationMetrics() (err error) {
 			}
 			metricMonitorAll.Set(ovnMonitorValue)
 		case "ovn-encap-ip":
+			// To update not only values but also labels for metrics, we use Reset() to delete previous labels+value
+			metricEncapIP.Reset()
 			metricEncapIP.WithLabelValues(fieldValue).Set(1)
 		case "ovn-remote":
+			metricSbConnectionMethod.Reset()
 			metricSbConnectionMethod.WithLabelValues(fieldValue).Set(1)
 		case "ovn-encap-type":
+			metricEncapType.Reset()
 			metricEncapType.WithLabelValues(fieldValue).Set(1)
 		case "ovn-k8s-node-port":
 			if fieldValue == "false" {
 				ovnNodePortValue = 0
 			}
 		case "ovn-bridge-mappings":
+			metricBridgeMappings.Reset()
 			metricBridgeMappings.WithLabelValues(fieldValue).Set(1)
 		}
 	}

--- a/go-controller/pkg/metrics/ovn_db.go
+++ b/go-controller/pkg/metrics/ovn_db.go
@@ -256,10 +256,12 @@ func ovnDBSizeMetricsUpdater(basePath, direction, database string) {
 	if size, err := getOvnDBSizeViaPath(basePath, direction, database); err != nil {
 		klog.Errorf("Failed to update OVN DB size metric: %v", err)
 	} else {
-		// To update not only values but also labels for metrics, we use Reset() to delete previous labels+value
-		metricDBSize.Reset()
 		metricDBSize.WithLabelValues(database).Set(float64(size))
 	}
+}
+
+func resetOvnDbSizeMetric() {
+	metricDBSize.Reset()
 }
 
 // isOvnDBFoundViaPath attempts to find the OVN DBs, return false if not found.
@@ -331,8 +333,6 @@ func ovnDBMemoryMetricsUpdater(direction, database string) {
 			// kvPair will be of the form monitors:2
 			fields := strings.Split(kvPair, ":")
 			if value, err := strconv.ParseFloat(fields[1], 64); err == nil {
-				// To update not only values but also labels for metrics, we use Reset() to delete previous labels+value
-				metricOVNDBMonitor.Reset()
 				metricOVNDBMonitor.WithLabelValues(database).Set(value)
 			} else {
 				klog.Errorf("Failed to parse the monitor's value %s to float64: err(%v)",
@@ -342,7 +342,6 @@ func ovnDBMemoryMetricsUpdater(direction, database string) {
 			// kvPair will be of the form sessions:2
 			fields := strings.Split(kvPair, ":")
 			if value, err := strconv.ParseFloat(fields[1], 64); err == nil {
-				metricOVNDBSessions.Reset()
 				metricOVNDBSessions.WithLabelValues(database).Set(value)
 			} else {
 				klog.Errorf("Failed to parse the sessions' value %s to float64: err(%v)",
@@ -350,6 +349,11 @@ func ovnDBMemoryMetricsUpdater(direction, database string) {
 			}
 		}
 	}
+}
+
+func resetOvnDbMemoryMetrics() {
+	metricOVNDBMonitor.Reset()
+	metricOVNDBSessions.Reset()
 }
 
 var (
@@ -459,6 +463,14 @@ func RegisterOvnDBMetrics(clientset kubernetes.Interface, k8sNodeName string) {
 				ovnE2eTimeStampUpdater(direction, database)
 			}
 			time.Sleep(30 * time.Second)
+			// To update not only values but also labels for metrics, we use Reset() to delete previous labels+value
+			if dbIsClustered {
+				resetOvnDbClusterMetrics()
+			}
+			if dbFoundViaPath {
+				resetOvnDbSizeMetric()
+			}
+			resetOvnDbMemoryMetrics()
 		}
 	}()
 }
@@ -576,47 +588,49 @@ func ovnDBClusterStatusMetricsUpdater(direction, database string) {
 		klog.Errorf(err.Error())
 		return
 	}
-	// To update not only values but also labels for metrics, we use Reset() to delete previous labels+value
-	metricDBClusterCID.Reset()
 	metricDBClusterCID.WithLabelValues(database, clusterStatus.cid).Set(1)
-	metricDBClusterSID.Reset()
 	metricDBClusterSID.WithLabelValues(database, clusterStatus.cid, clusterStatus.sid).Set(1)
-	metricDBClusterServerStatus.Reset()
 	metricDBClusterServerStatus.WithLabelValues(database, clusterStatus.cid, clusterStatus.sid,
 		clusterStatus.status).Set(1)
-	metricDBClusterTerm.Reset()
 	metricDBClusterTerm.WithLabelValues(database, clusterStatus.cid, clusterStatus.sid).Set(clusterStatus.term)
-	metricDBClusterServerRole.Reset()
 	metricDBClusterServerRole.WithLabelValues(database, clusterStatus.cid, clusterStatus.sid,
 		clusterStatus.role).Set(1)
-	metricDBClusterServerVote.Reset()
 	metricDBClusterServerVote.WithLabelValues(database, clusterStatus.cid, clusterStatus.sid,
 		clusterStatus.vote).Set(1)
-	metricDBClusterElectionTimer.Reset()
 	metricDBClusterElectionTimer.WithLabelValues(database, clusterStatus.cid,
 		clusterStatus.sid).Set(clusterStatus.electionTimer)
-	metricDBClusterLogIndexStart.Reset()
 	metricDBClusterLogIndexStart.WithLabelValues(database, clusterStatus.cid,
 		clusterStatus.sid).Set(clusterStatus.logIndexStart)
-	metricDBClusterLogIndexNext.Reset()
 	metricDBClusterLogIndexNext.WithLabelValues(database, clusterStatus.cid,
 		clusterStatus.sid).Set(clusterStatus.logIndexNext)
-	metricDBClusterLogNotCommitted.Reset()
 	metricDBClusterLogNotCommitted.WithLabelValues(database, clusterStatus.cid,
 		clusterStatus.sid).Set(clusterStatus.logNotCommitted)
-	metricDBClusterLogNotApplied.Reset()
 	metricDBClusterLogNotApplied.WithLabelValues(database, clusterStatus.cid,
 		clusterStatus.sid).Set(clusterStatus.logNotApplied)
-	metricDBClusterConnIn.Reset()
 	metricDBClusterConnIn.WithLabelValues(database, clusterStatus.cid,
 		clusterStatus.sid).Set(clusterStatus.connIn)
-	metricDBClusterConnOut.Reset()
 	metricDBClusterConnOut.WithLabelValues(database, clusterStatus.cid,
 		clusterStatus.sid).Set(clusterStatus.connOut)
-	metricDBClusterConnInErr.Reset()
 	metricDBClusterConnInErr.WithLabelValues(database, clusterStatus.cid,
 		clusterStatus.sid).Set(clusterStatus.connInErr)
-	metricDBClusterConnOutErr.Reset()
 	metricDBClusterConnOutErr.WithLabelValues(database, clusterStatus.cid,
 		clusterStatus.sid).Set(clusterStatus.connOutErr)
+}
+
+func resetOvnDbClusterMetrics() {
+	metricDBClusterCID.Reset()
+	metricDBClusterSID.Reset()
+	metricDBClusterServerStatus.Reset()
+	metricDBClusterTerm.Reset()
+	metricDBClusterServerRole.Reset()
+	metricDBClusterServerVote.Reset()
+	metricDBClusterElectionTimer.Reset()
+	metricDBClusterLogIndexStart.Reset()
+	metricDBClusterLogIndexNext.Reset()
+	metricDBClusterLogNotCommitted.Reset()
+	metricDBClusterLogNotApplied.Reset()
+	metricDBClusterConnIn.Reset()
+	metricDBClusterConnOut.Reset()
+	metricDBClusterConnInErr.Reset()
+	metricDBClusterConnOutErr.Reset()
 }

--- a/go-controller/pkg/metrics/ovn_db.go
+++ b/go-controller/pkg/metrics/ovn_db.go
@@ -256,6 +256,8 @@ func ovnDBSizeMetricsUpdater(basePath, direction, database string) {
 	if size, err := getOvnDBSizeViaPath(basePath, direction, database); err != nil {
 		klog.Errorf("Failed to update OVN DB size metric: %v", err)
 	} else {
+		// To update not only values but also labels for metrics, we use Reset() to delete previous labels+value
+		metricDBSize.Reset()
 		metricDBSize.WithLabelValues(database).Set(float64(size))
 	}
 }
@@ -329,6 +331,8 @@ func ovnDBMemoryMetricsUpdater(direction, database string) {
 			// kvPair will be of the form monitors:2
 			fields := strings.Split(kvPair, ":")
 			if value, err := strconv.ParseFloat(fields[1], 64); err == nil {
+				// To update not only values but also labels for metrics, we use Reset() to delete previous labels+value
+				metricOVNDBMonitor.Reset()
 				metricOVNDBMonitor.WithLabelValues(database).Set(value)
 			} else {
 				klog.Errorf("Failed to parse the monitor's value %s to float64: err(%v)",
@@ -338,6 +342,7 @@ func ovnDBMemoryMetricsUpdater(direction, database string) {
 			// kvPair will be of the form sessions:2
 			fields := strings.Split(kvPair, ":")
 			if value, err := strconv.ParseFloat(fields[1], 64); err == nil {
+				metricOVNDBSessions.Reset()
 				metricOVNDBSessions.WithLabelValues(database).Set(value)
 			} else {
 				klog.Errorf("Failed to parse the sessions' value %s to float64: err(%v)",
@@ -571,31 +576,47 @@ func ovnDBClusterStatusMetricsUpdater(direction, database string) {
 		klog.Errorf(err.Error())
 		return
 	}
+	// To update not only values but also labels for metrics, we use Reset() to delete previous labels+value
+	metricDBClusterCID.Reset()
 	metricDBClusterCID.WithLabelValues(database, clusterStatus.cid).Set(1)
+	metricDBClusterSID.Reset()
 	metricDBClusterSID.WithLabelValues(database, clusterStatus.cid, clusterStatus.sid).Set(1)
+	metricDBClusterServerStatus.Reset()
 	metricDBClusterServerStatus.WithLabelValues(database, clusterStatus.cid, clusterStatus.sid,
 		clusterStatus.status).Set(1)
+	metricDBClusterTerm.Reset()
 	metricDBClusterTerm.WithLabelValues(database, clusterStatus.cid, clusterStatus.sid).Set(clusterStatus.term)
+	metricDBClusterServerRole.Reset()
 	metricDBClusterServerRole.WithLabelValues(database, clusterStatus.cid, clusterStatus.sid,
 		clusterStatus.role).Set(1)
+	metricDBClusterServerVote.Reset()
 	metricDBClusterServerVote.WithLabelValues(database, clusterStatus.cid, clusterStatus.sid,
 		clusterStatus.vote).Set(1)
+	metricDBClusterElectionTimer.Reset()
 	metricDBClusterElectionTimer.WithLabelValues(database, clusterStatus.cid,
 		clusterStatus.sid).Set(clusterStatus.electionTimer)
+	metricDBClusterLogIndexStart.Reset()
 	metricDBClusterLogIndexStart.WithLabelValues(database, clusterStatus.cid,
 		clusterStatus.sid).Set(clusterStatus.logIndexStart)
+	metricDBClusterLogIndexNext.Reset()
 	metricDBClusterLogIndexNext.WithLabelValues(database, clusterStatus.cid,
 		clusterStatus.sid).Set(clusterStatus.logIndexNext)
+	metricDBClusterLogNotCommitted.Reset()
 	metricDBClusterLogNotCommitted.WithLabelValues(database, clusterStatus.cid,
 		clusterStatus.sid).Set(clusterStatus.logNotCommitted)
+	metricDBClusterLogNotApplied.Reset()
 	metricDBClusterLogNotApplied.WithLabelValues(database, clusterStatus.cid,
 		clusterStatus.sid).Set(clusterStatus.logNotApplied)
+	metricDBClusterConnIn.Reset()
 	metricDBClusterConnIn.WithLabelValues(database, clusterStatus.cid,
 		clusterStatus.sid).Set(clusterStatus.connIn)
+	metricDBClusterConnOut.Reset()
 	metricDBClusterConnOut.WithLabelValues(database, clusterStatus.cid,
 		clusterStatus.sid).Set(clusterStatus.connOut)
+	metricDBClusterConnInErr.Reset()
 	metricDBClusterConnInErr.WithLabelValues(database, clusterStatus.cid,
 		clusterStatus.sid).Set(clusterStatus.connInErr)
+	metricDBClusterConnOutErr.Reset()
 	metricDBClusterConnOutErr.WithLabelValues(database, clusterStatus.cid,
 		clusterStatus.sid).Set(clusterStatus.connOutErr)
 }


### PR DESCRIPTION
We are using labelled (vector) metrics to export
info and if the label values change, we still
export the old labels values which confuses users
because they have no way of determining which labelled
metric is the latest.

We must reset each vector metric prior to using it to
ensure we are only exporting the current state and not
old states which should have been scraped previously due
to our usage of labels that can be dynamically updated
during runtime.

This is occurring in the OVN metrics exported by
ovnkube-node.

Follow on work is needed to fix OVS metrics that are
used by ovs-exporter.

Steps to reproduce:
1. Get OVN Northbound database leader (use cluster/status command from ovn-nbctl)
2. Login to the ovnkube-node container on that node.
3. Curl the metrics endpoint and grep for ovn_db_cluster_server_role. Note the server_role label is leader.
4. On the same pod, repeatedly kill the nbdb container process only until the ovn_db_cluster_server_role metric changes it label 'server_role' from leader to 'follower'. Do not kill the whole pod. Exec into the container continuously and send a sigterm to the container nbdb process.
5. The metric ovn_db_cluster_server_role has two values - it still exposes 'server_role' as leader but also as 'follower'.
