### PR TITLE
Bug 2080925: Don't spawn go routines for adding metric events

### DIFF
--- a/go-controller/pkg/metrics/master.go
+++ b/go-controller/pkg/metrics/master.go
@@ -451,6 +451,7 @@ type record struct {
 // item is the data structure for ControlPlaneRecorders queue
 type item struct {
 	op     operation
+	t      time.Time
 	old    model.Model
 	new    model.Model
 	podUID kapimtypes.UID
@@ -482,13 +483,13 @@ func (cpr *ControlPlaneRecorder) Run(sbClient client.Client, stop <-chan struct{
 			if table != portBindingTable {
 				return
 			}
-			cpr.queue.Add(item{op: addPortBinding, old: model})
+			cpr.queue.Add(item{op: addPortBinding, old: model, t: time.Now()})
 		},
 		UpdateFunc: func(table string, old model.Model, new model.Model) {
 			if table != portBindingTable {
 				return
 			}
-			cpr.queue.Add(item{op: updatePortBinding, old: old, new: new})
+			cpr.queue.Add(item{op: updatePortBinding, old: old, new: new, t: time.Now()})
 		},
 		DeleteFunc: func(table string, model model.Model) {
 		},
@@ -502,12 +503,12 @@ func (cpr *ControlPlaneRecorder) Run(sbClient client.Client, stop <-chan struct{
 
 func (cpr *ControlPlaneRecorder) AddPod(podUID kapimtypes.UID) {
 	if cpr.queue != nil {
-		cpr.queue.Add(item{op: addPod, podUID: podUID})
+		cpr.queue.Add(item{op: addPod, podUID: podUID, t: time.Now()})
 	}
 }
 
-func (cpr *ControlPlaneRecorder) addPod(podUID kapimtypes.UID) {
-	cpr.podRecords[podUID] = &record{timestamp: time.Now(), timestampType: firstSeen}
+func (cpr *ControlPlaneRecorder) addPod(podUID kapimtypes.UID, t time.Time) {
+	cpr.podRecords[podUID] = &record{timestamp: t, timestampType: firstSeen}
 }
 
 func (cpr *ControlPlaneRecorder) CleanPod(podUID kapimtypes.UID) {
@@ -522,12 +523,11 @@ func (cpr *ControlPlaneRecorder) cleanPod(podUID kapimtypes.UID) {
 
 func (cpr *ControlPlaneRecorder) AddLSP(podUID kapimtypes.UID) {
 	if cpr.queue != nil {
-		cpr.queue.Add(item{op: addLogicalSwitchPort, podUID: podUID})
+		cpr.queue.Add(item{op: addLogicalSwitchPort, podUID: podUID, t: time.Now()})
 	}
 }
 
-func (cpr *ControlPlaneRecorder) addLSP(podUID kapimtypes.UID) {
-	now := time.Now()
+func (cpr *ControlPlaneRecorder) addLSP(podUID kapimtypes.UID, t time.Time) {
 	var r *record
 	if r = cpr.getRecord(podUID); r == nil {
 		klog.V(5).Infof("Add Logical Switch Port event expected pod with UID %q in cache", podUID)
@@ -537,14 +537,13 @@ func (cpr *ControlPlaneRecorder) addLSP(podUID kapimtypes.UID) {
 		klog.V(5).Infof("Unexpected last event type (%d) in cache for pod with UID %q", r.timestampType, podUID)
 		return
 	}
-	metricFirstSeenLSPLatency.Observe(now.Sub(r.timestamp).Seconds())
-	r.timestamp = now
+	metricFirstSeenLSPLatency.Observe(t.Sub(r.timestamp).Seconds())
+	r.timestamp = t
 	r.timestampType = logicalSwitchPort
 }
 
-func (cpr *ControlPlaneRecorder) addPortBinding(m model.Model) {
+func (cpr *ControlPlaneRecorder) addPortBinding(m model.Model, t time.Time) {
 	var r *record
-	now := time.Now()
 	row := m.(*sbdb.PortBinding)
 	podUID := getPodUIDFromPortBinding(row)
 	if podUID == "" {
@@ -558,16 +557,15 @@ func (cpr *ControlPlaneRecorder) addPortBinding(m model.Model) {
 		klog.V(5).Infof("Unexpected last event entry (%d) in cache for pod with UID %q", r.timestampType, podUID)
 		return
 	}
-	metricLSPPortBindingLatency.Observe(now.Sub(r.timestamp).Seconds())
-	r.timestamp = now
+	metricLSPPortBindingLatency.Observe(t.Sub(r.timestamp).Seconds())
+	r.timestamp = t
 	r.timestampType = portBinding
 }
 
-func (cpr *ControlPlaneRecorder) updatePortBinding(old, new model.Model) {
+func (cpr *ControlPlaneRecorder) updatePortBinding(old, new model.Model, t time.Time) {
 	var r *record
 	oldRow := old.(*sbdb.PortBinding)
 	newRow := new.(*sbdb.PortBinding)
-	now := time.Now()
 	podUID := getPodUIDFromPortBinding(newRow)
 	if podUID == "" {
 		return
@@ -577,12 +575,12 @@ func (cpr *ControlPlaneRecorder) updatePortBinding(old, new model.Model) {
 		return
 	}
 	if oldRow.Chassis == nil && newRow.Chassis != nil && r.timestampType == portBinding {
-		metricPortBindingChassisLatency.Observe(now.Sub(r.timestamp).Seconds())
-		r.timestamp = now
+		metricPortBindingChassisLatency.Observe(t.Sub(r.timestamp).Seconds())
+		r.timestamp = t
 		r.timestampType = portBindingChassis
 	}
 	if oldRow.Up != nil && !*oldRow.Up && newRow.Up != nil && *newRow.Up && r.timestampType == portBindingChassis {
-		metricPortBindingUpLatency.Observe(now.Sub(r.timestamp).Seconds())
+		metricPortBindingUpLatency.Observe(t.Sub(r.timestamp).Seconds())
 	}
 }
 
@@ -604,15 +602,15 @@ func (cpr *ControlPlaneRecorder) processNextItem() bool {
 func (cpr *ControlPlaneRecorder) processItem(i item) {
 	switch i.op {
 	case addPortBinding:
-		cpr.addPortBinding(i.old)
+		cpr.addPortBinding(i.old, i.t)
 	case updatePortBinding:
-		cpr.updatePortBinding(i.old, i.new)
+		cpr.updatePortBinding(i.old, i.new, i.t)
 	case addPod:
-		cpr.addPod(i.podUID)
+		cpr.addPod(i.podUID, i.t)
 	case cleanPod:
 		cpr.cleanPod(i.podUID)
 	case addLogicalSwitchPort:
-		cpr.addLSP(i.podUID)
+		cpr.addLSP(i.podUID, i.t)
 	}
 }
 

--- a/go-controller/pkg/metrics/master.go
+++ b/go-controller/pkg/metrics/master.go
@@ -500,33 +500,33 @@ func (cpr *ControlPlaneRecorder) Run(sbClient client.Client, stop <-chan struct{
 	}()
 }
 
-func (cpr *ControlPlaneRecorder) AddPodEvent(podUID kapimtypes.UID) {
+func (cpr *ControlPlaneRecorder) AddPod(podUID kapimtypes.UID) {
 	if cpr.queue != nil {
 		cpr.queue.Add(item{op: addPod, podUID: podUID})
 	}
 }
 
-func (cpr *ControlPlaneRecorder) addPodEvent(podUID kapimtypes.UID) {
+func (cpr *ControlPlaneRecorder) addPod(podUID kapimtypes.UID) {
 	cpr.podRecords[podUID] = &record{timestamp: time.Now(), timestampType: firstSeen}
 }
 
-func (cpr *ControlPlaneRecorder) CleanPodRecord(podUID kapimtypes.UID) {
+func (cpr *ControlPlaneRecorder) CleanPod(podUID kapimtypes.UID) {
 	if cpr.queue != nil {
 		cpr.queue.Add(item{op: cleanPod, podUID: podUID})
 	}
 }
 
-func (cpr *ControlPlaneRecorder) cleanPodRecord(podUID kapimtypes.UID) {
+func (cpr *ControlPlaneRecorder) cleanPod(podUID kapimtypes.UID) {
 	delete(cpr.podRecords, podUID)
 }
 
-func (cpr *ControlPlaneRecorder) AddLSPEvent(podUID kapimtypes.UID) {
+func (cpr *ControlPlaneRecorder) AddLSP(podUID kapimtypes.UID) {
 	if cpr.queue != nil {
 		cpr.queue.Add(item{op: addLogicalSwitchPort, podUID: podUID})
 	}
 }
 
-func (cpr *ControlPlaneRecorder) addLSPEvent(podUID kapimtypes.UID) {
+func (cpr *ControlPlaneRecorder) addLSP(podUID kapimtypes.UID) {
 	now := time.Now()
 	var r *record
 	if r = cpr.getRecord(podUID); r == nil {
@@ -542,7 +542,7 @@ func (cpr *ControlPlaneRecorder) addLSPEvent(podUID kapimtypes.UID) {
 	r.timestampType = logicalSwitchPort
 }
 
-func (cpr *ControlPlaneRecorder) addPortBindingEvent(m model.Model) {
+func (cpr *ControlPlaneRecorder) addPortBinding(m model.Model) {
 	var r *record
 	now := time.Now()
 	row := m.(*sbdb.PortBinding)
@@ -563,7 +563,7 @@ func (cpr *ControlPlaneRecorder) addPortBindingEvent(m model.Model) {
 	r.timestampType = portBinding
 }
 
-func (cpr *ControlPlaneRecorder) updatePortBindingEvent(old, new model.Model) {
+func (cpr *ControlPlaneRecorder) updatePortBinding(old, new model.Model) {
 	var r *record
 	oldRow := old.(*sbdb.PortBinding)
 	newRow := new.(*sbdb.PortBinding)
@@ -604,15 +604,15 @@ func (cpr *ControlPlaneRecorder) processNextItem() bool {
 func (cpr *ControlPlaneRecorder) processItem(i item) {
 	switch i.op {
 	case addPortBinding:
-		cpr.addPortBindingEvent(i.old)
+		cpr.addPortBinding(i.old)
 	case updatePortBinding:
-		cpr.updatePortBindingEvent(i.old, i.new)
+		cpr.updatePortBinding(i.old, i.new)
 	case addPod:
-		cpr.addPodEvent(i.podUID)
+		cpr.addPod(i.podUID)
 	case cleanPod:
-		cpr.cleanPodRecord(i.podUID)
+		cpr.cleanPod(i.podUID)
 	case addLogicalSwitchPort:
-		cpr.addLSPEvent(i.podUID)
+		cpr.addLSP(i.podUID)
 	}
 }
 

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -215,6 +215,8 @@ func (oc *Controller) upgradeOVNTopology(existingNodes *kapi.NodeList) error {
 func (oc *Controller) StartClusterMaster(masterNodeName string) error {
 	klog.Infof("Starting cluster master")
 
+	oc.metricsRecorder.Run(oc.sbClient, oc.stopChan)
+
 	// enableOVNLogicalDataPathGroups sets an OVN flag to enable logical datapath
 	// groups on OVN 20.12 and later. The option is ignored if OVN doesn't
 	// understand it. Logical datapath groups reduce the size of the southbound

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -616,7 +616,7 @@ func (oc *Controller) WatchPods() {
 	oc.watchFactory.AddPodHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			pod := obj.(*kapi.Pod)
-			oc.metricsRecorder.AddPodEvent(pod.UID)
+			oc.metricsRecorder.AddPod(pod.UID)
 			oc.initRetryAddPod(pod)
 			oc.checkAndSkipRetryPod(pod)
 			if retryEntry := oc.getPodRetryEntry(pod); retryEntry != nil && retryEntry.needsDel != nil {
@@ -686,7 +686,7 @@ func (oc *Controller) WatchPods() {
 		},
 		DeleteFunc: func(obj interface{}) {
 			pod := obj.(*kapi.Pod)
-			oc.metricsRecorder.CleanPodRecord(pod.UID)
+			oc.metricsRecorder.CleanPod(pod.UID)
 			oc.initRetryDelPod(pod)
 			// we have a copy of portInfo in the retry cache now, we can remove it from
 			// logicalPortCache so that we don't race with a new add pod that comes with

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -315,7 +315,7 @@ func NewOvnController(ovnClient *util.OVNClientset, wf *factory.WatchFactory, st
 		svcController:            svcController,
 		svcFactory:               svcFactory,
 		modelClient:              modelClient,
-		metricsRecorder:          metrics.NewControlPlaneRecorder(libovsdbOvnSBClient),
+		metricsRecorder:          metrics.NewControlPlaneRecorder(),
 	}
 }
 
@@ -616,7 +616,7 @@ func (oc *Controller) WatchPods() {
 	oc.watchFactory.AddPodHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			pod := obj.(*kapi.Pod)
-			go oc.metricsRecorder.AddPodEvent(pod.UID)
+			oc.metricsRecorder.AddPodEvent(pod.UID)
 			oc.initRetryAddPod(pod)
 			oc.checkAndSkipRetryPod(pod)
 			if retryEntry := oc.getPodRetryEntry(pod); retryEntry != nil && retryEntry.needsDel != nil {
@@ -686,7 +686,7 @@ func (oc *Controller) WatchPods() {
 		},
 		DeleteFunc: func(obj interface{}) {
 			pod := obj.(*kapi.Pod)
-			go oc.metricsRecorder.CleanPodRecord(pod.UID)
+			oc.metricsRecorder.CleanPodRecord(pod.UID)
 			oc.initRetryDelPod(pod)
 			// we have a copy of portInfo in the retry cache now, we can remove it from
 			// logicalPortCache so that we don't race with a new add pod that comes with

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -608,7 +608,7 @@ func (oc *Controller) addLogicalPort(pod *kapi.Pod) (err error) {
 
 		return fmt.Errorf("could not perform creation or update of logical switch port %s - %+v", portName, err)
 	}
-	go oc.metricsRecorder.AddLSPEvent(pod.UID)
+	oc.metricsRecorder.AddLSPEvent(pod.UID)
 
 	// if somehow lspUUID is empty, there is a bug here with interpreting OVSDB results
 	if len(lsp.UUID) == 0 {

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -608,7 +608,7 @@ func (oc *Controller) addLogicalPort(pod *kapi.Pod) (err error) {
 
 		return fmt.Errorf("could not perform creation or update of logical switch port %s - %+v", portName, err)
 	}
-	oc.metricsRecorder.AddLSPEvent(pod.UID)
+	oc.metricsRecorder.AddLSP(pod.UID)
 
 	// if somehow lspUUID is empty, there is a bug here with interpreting OVSDB results
 	if len(lsp.UUID) == 0 {


### PR DESCRIPTION
Use a queue instead of spawning go routines to add events.