### PR TITLE
[release-4.10] Bug 2082467: Fix cluster/status parsing for single-member db cluster (SNO)

### DIFF
--- a/go-controller/pkg/metrics/ovn_db.go
+++ b/go-controller/pkg/metrics/ovn_db.go
@@ -559,6 +559,10 @@ func getOVNDBClusterStatusInfo(timeout int, direction, database string) (cluster
 				clusterStatus.logNotApplied = value
 			}
 		case "Connections":
+			// db cluster with 1 member has empty Connections list
+			if idx+2 >= len(line) {
+				continue
+			}
 			// the value is of the format `->0000 (->56d7) <-46ac <-56d7`
 			var connIn, connOut, connInErr, connOutErr float64
 			for _, conn := range strings.Fields(line[idx+2:]) {


### PR DESCRIPTION
Backport bugfix from https://github.com/openshift/ovn-kubernetes/pull/1049/commits/76699afae1229cacb178c369ea5916d35e7a2788. Explained here https://github.com/ovn-org/ovn-kubernetes/pull/2890