### PR TITLE
Bug 2086891: policy: Fix multicast allow policy type.

### DIFF
--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -557,7 +557,7 @@ func (oc *Controller) createDefaultAllowMulticastPolicy() error {
 	egressACL := buildACL("", types.ClusterRtrPortGroupName, "DefaultAllowMulticastEgress", nbdb.ACLDirectionFromLport, types.DefaultMcastAllowPriority, egressMatch, nbdb.ACLActionAllow, "", knet.PolicyTypeEgress)
 
 	ingressMatch := getACLMatch(types.ClusterRtrPortGroupName, mcastMatch, knet.PolicyTypeIngress)
-	ingressACL := buildACL("", types.ClusterRtrPortGroupName, "DefaultAllowMulticastIngress", nbdb.ACLDirectionToLport, types.DefaultMcastAllowPriority, ingressMatch, nbdb.ACLActionAllow, "", knet.PolicyTypeEgress)
+	ingressACL := buildACL("", types.ClusterRtrPortGroupName, "DefaultAllowMulticastIngress", nbdb.ACLDirectionToLport, types.DefaultMcastAllowPriority, ingressMatch, nbdb.ACLActionAllow, "", knet.PolicyTypeIngress)
 
 	ops, err := libovsdbops.CreateOrUpdateACLsOps(oc.nbClient, nil, egressACL, ingressACL)
 	if err != nil {


### PR DESCRIPTION
There was a typo for multicast ingress allow policies causing their ACLs
to be turned into "from-lport" ACLs that would never be matched.

Closes #2926: Multicast flaking in CI.
Fixes: f68d302664e6 ("libovsdb: Use libovsdb for ACLs and port groups")
Signed-off-by: Dumitru Ceara <dceara@redhat.com>
(cherry picked from commit 288cf591f09b18a14c6fa1a3935480a578024f7e)

