### PR TITLE
Bug 2088627: EgressIP NATs are not being cleared correctly from the logical router 

### DIFF
--- a/go-controller/pkg/ovn/egressip.go
+++ b/go-controller/pkg/ovn/egressip.go
@@ -1962,12 +1962,19 @@ func (e *egressIPController) deleteEgressIPStatusSetup(name string, status egres
 		{
 			Model: &natLogicalRouter,
 			ModelPredicate: func(lr *nbdb.LogicalRouter) bool {
-				return lr.Name == util.GetGatewayRouterFromNode(status.Node)
+				// Find the router that has the removed nat
+				for _, lrNat := range lr.Nat {
+					for _, delNat := range natLogicalRouter.Nat {
+						if lrNat == delNat {
+							return true
+						}
+					}
+				}
+				return false
 			},
 			OnModelMutations: []interface{}{
 				&natLogicalRouter.Nat,
 			},
-			ErrNotFound: true,
 		},
 	}
 	if err := e.modelClient.Delete(opsModel...); err != nil {


### PR DESCRIPTION
While deleting EgressIP nats from a logical router find the router that has the nat instead of relying on the node name.

Signed-off-by: Patryk Diak <pdiak@redhat.com>
(cherry picked from commit 2f8ec3310ea608b7e0b3e905f8ad3fdcd5d057e3)
