### PR TITLE
Bug 2081069: Bumps OVN to 22.03.0-37.el8fdp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN yum install -y  \
 	yum clean all
 
 ARG ovsver=2.17.0-8.el8fdp
-ARG ovnver=22.03.0-24.el8fdp
+ARG ovnver=22.03.0-37.el8fdp
 
 RUN INSTALL_PKGS=" \
 	openssl python3-pyOpenSSL firewalld-filesystem \


### PR DESCRIPTION
Includes a fix for ovn-controller to not flush conntrack entries in zone
0 on restart.

Signed-off-by: Tim Rozet <trozet@redhat.com>

