### PR TITLE
Bug 2088582: Bumps OVN to 21.12.0-58.el8fdp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN yum install -y  \
 	yum clean all
 
 ARG ovsver=2.16.0-33.el8fdp
-ARG ovnver=21.12.0-32.el8fdp
+ARG ovnver=21.12.0-58.el8fdp
 
 RUN INSTALL_PKGS=" \
 	openssl python3-pyOpenSSL firewalld-filesystem \


### PR DESCRIPTION
Includes fix for OVN flushing all conntrack entries in zone 0 on
ovn-controller restart.

Signed-off-by: Tim Rozet <trozet@redhat.com>
