### PR TITLE
Bug 2089930: Dockerfile: bump OVN to ovn22.06

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN yum install -y  \
 	yum clean all
 
 ARG ovsver=2.17.0-8.el8fdp
-ARG ovnver=22.03.0-37.el8fdp
+ARG ovnver=22.06.0-preview.branched.38.el8fdp
 
 RUN INSTALL_PKGS=" \
 	openssl python3-pyOpenSSL firewalld-filesystem \
@@ -45,7 +45,7 @@ RUN INSTALL_PKGS=" \
 	" && \
 	yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False $INSTALL_PKGS && \
 	yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False "openvswitch2.17 = $ovsver" "openvswitch2.17-devel = $ovsver" "python3-openvswitch2.17 = $ovsver" "openvswitch2.17-ipsec = $ovsver" && \
-	yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False "ovn22.03 = $ovnver" "ovn22.03-central = $ovnver" "ovn22.03-host = $ovnver" "ovn22.03-vtep = $ovnver" && \
+	yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False "ovn22.06 = $ovnver" "ovn22.06-central = $ovnver" "ovn22.06-host = $ovnver" "ovn22.06-vtep = $ovnver" && \
 	yum clean all && rm -rf /var/cache/*
 
 RUN mkdir -p /var/run/openvswitch && \


### PR DESCRIPTION
Brings performance and bug fixes. Most notable are:

- northd: add configuration option for enabling parallelization (#2078552)
- ovn-controller: Consider zone 0 as a valid zone when restoring. (#2087194)
- northd: optimize build_gw_lrouter_nat_flows_for_lb code (#2079834)
- ovn-controller: Avoid recompute triggered by external_ids:ovn-installed update.
- northd: Add generic port security logical flows. (#2078927)