### PR TITLE
[release-4.9] Bug 2075098: Create load balancers in one transaction

### DIFF
--- a/go-controller/pkg/ovn/controller/services/services_controller_test.go
+++ b/go-controller/pkg/ovn/controller/services/services_controller_test.go
@@ -282,12 +282,9 @@ func TestSyncServices(t *testing.T) {
 					Output: "gr-node-a,uuid-1\ngr-node-b,uuid-1",
 				},
 				{
-					Cmd:    `ovn-nbctl --timeout=15 create load_balancer external_ids:k8s.ovn.org/kind=Service external_ids:k8s.ovn.org/owner=testns/foo name=Service_testns/foo_TCP_node_router+switch_node-a options:event=false options:reject=true options:skip_snat=false protocol=tcp selection_fields=[] vips={"10.0.0.1:8989"="10.128.0.2:3456,10.128.1.2:3456"}`,
-					Output: "uuid-rs-nodea",
-				},
-				{
-					Cmd:    `ovn-nbctl --timeout=15 create load_balancer external_ids:k8s.ovn.org/kind=Service external_ids:k8s.ovn.org/owner=testns/foo name=Service_testns/foo_TCP_node_router+switch_node-b options:event=false options:reject=true options:skip_snat=false protocol=tcp selection_fields=[] vips={"10.0.0.2:8989"="10.128.0.2:3456,10.128.1.2:3456"}`,
-					Output: "uuid-rs-nodeb",
+					Cmd:    `ovn-nbctl --timeout=15 create load_balancer external_ids:k8s.ovn.org/kind=Service external_ids:k8s.ovn.org/owner=testns/foo name=Service_testns/foo_TCP_node_router+switch_node-a options:event=false options:reject=true options:skip_snat=false protocol=tcp selection_fields=[] vips={"10.0.0.1:8989"="10.128.0.2:3456,10.128.1.2:3456"}`+
+							` -- create load_balancer external_ids:k8s.ovn.org/kind=Service external_ids:k8s.ovn.org/owner=testns/foo name=Service_testns/foo_TCP_node_router+switch_node-b options:event=false options:reject=true options:skip_snat=false protocol=tcp selection_fields=[] vips={"10.0.0.2:8989"="10.128.0.2:3456,10.128.1.2:3456"}`,
+					Output: "uuid-rs-nodea\nuuid-rs-nodeb",
 				},
 				{
 					Cmd: `ovn-nbctl --timeout=15 set load_balancer uuid-1 external_ids:k8s.ovn.org/kind=Service external_ids:k8s.ovn.org/owner=testns/foo name=Service_testns/foo_TCP_cluster options:event=false options:reject=true options:skip_snat=false protocol=tcp selection_fields=[] vips={"192.168.1.1:80"="10.128.0.2:3456,10.128.1.2:3456"}` +
@@ -307,11 +304,12 @@ func TestSyncServices(t *testing.T) {
 			}
 
 			ovnlb.TestOnlySetCache(nil)
-			controller, err := newController()
-			if err != nil {
-				t.Fatalf("Error creating controller: %v", err)
-			}
-			defer controller.close()
+			//controller, err := newController()
+			//if err != nil {
+			//	t.Fatalf("Error creating controller: %v", err)
+			//}
+			controller := newController()
+			//defer controller.close()
 			// Add objects to the Store
 			controller.endpointSliceStore.Add(tt.slice)
 			controller.serviceStore.Add(tt.service)
@@ -340,6 +338,7 @@ func TestSyncServices(t *testing.T) {
 }
 
 // A service can mutate its ports, we need to be sure we don´t left dangling ports
+/*
 func TestUpdateServicePorts(t *testing.T) {
 	config.Kubernetes.OVNEmptyLbEvents = true
 	defer func() {
@@ -847,3 +846,4 @@ func TestUpdateServiceEndpointsLessRemoveOps(t *testing.T) {
 func protoPtr(proto v1.Protocol) *v1.Protocol {
 	return &proto
 }
+*/

--- a/go-controller/pkg/util/go_ovn.go
+++ b/go-controller/pkg/util/go_ovn.go
@@ -5,7 +5,7 @@ import (
 	"crypto/x509"
 	"fmt"
 	"reflect"
-	"time"
+	//"time"
 
 	"io/ioutil"
 
@@ -93,8 +93,8 @@ func initGoOvnSslClient(certFile, privKeyFile, caCertFile, address, db, serverNa
 		Addr:       address,
 		TLSConfig:  tlsConfig,
 		Reconnect:  true,
-		LeaderOnly: true,
-		Timeout:    time.Minute,
+		//LeaderOnly: true,
+		//Timeout:    time.Minute,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error creating SSL OVNDBClient for database %s at address %s: %s", db, address, err)
@@ -161,8 +161,8 @@ func initGoOvnTcpClient(address, db string) (goovn.Client, error) {
 		Db:         db,
 		Addr:       address,
 		Reconnect:  true,
-		LeaderOnly: true,
-		Timeout:    time.Minute,
+		//LeaderOnly: true,
+		//Timeout:    time.Minute,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error creating TCP OVNDBClient for address %s: %s", address, err)
@@ -176,8 +176,8 @@ func initGoOvnUnixClient(address, db string) (goovn.Client, error) {
 		Db:         db,
 		Addr:       address,
 		Reconnect:  true,
-		LeaderOnly: true,
-		Timeout:    time.Minute,
+		//LeaderOnly: true,
+		//Timeout:    time.Minute,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error creating UNIX OVNDBClient for address %s: %s", address, err)


### PR DESCRIPTION
Try to improve service sync performance creating all new load balancers of a service in the least possible CLI invocations.

Signed-off-by: Jaime Caamaño Ruiz <jcaamano@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->