### PR TITLE
Bug 2090843: addLogicalPort() optimization cherry-picks

### DIFF
--- a/go-controller/hybrid-overlay/pkg/controller/master.go
+++ b/go-controller/hybrid-overlay/pkg/controller/master.go
@@ -237,8 +237,12 @@ func (m *MasterController) handleOverlayPort(node *kapi.Node, annotator kube.Ann
 		return nil
 	}
 
-	// retrieve port configuration. If port isn't set up, portMAC will be nil
-	portMAC, _, _ = util.GetPortAddresses(portName, m.nbClient)
+	// Retrieve port MAC address; if the port isn't set up, portMAC will be nil
+	lsp := &nbdb.LogicalSwitchPort{Name: portName}
+	lsp, err = libovsdbops.GetLogicalSwitchPort(m.nbClient, lsp)
+	if err == nil {
+		portMAC, _, _ = util.ExtractPortAddresses(lsp)
+	}
 
 	// compare port configuration to annotation MAC, reconcile as needed
 	lspOK := false

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -556,15 +556,9 @@ func (oc *Controller) addLogicalPort(pod *kapi.Pod) (err error) {
 		// namespace annotations to go through external egress router
 		if extIPs, err := getExternalIPsGRSNAT(oc.watchFactory, pod.Spec.NodeName); err != nil {
 			return err
-		} else if err = addOrUpdatePerPodGRSNAT(oc.nbClient, pod.Spec.NodeName, extIPs, podIfAddrs); err != nil {
+		} else if ops, err = oc.addOrUpdatePerPodGRSNATReturnOps(pod.Spec.NodeName, extIPs, podIfAddrs, ops); err != nil {
 			return err
 		}
-	}
-
-	// check if this pod is serving as an external GW
-	err = oc.addPodExternalGW(pod)
-	if err != nil {
-		return fmt.Errorf("failed to handle external GW check: %v", err)
 	}
 
 	// set addresses on the port
@@ -602,6 +596,12 @@ func (oc *Controller) addLogicalPort(pod *kapi.Pod) (err error) {
 	}
 	txOkCallBack()
 	oc.podRecorder.AddLSP(pod.UID)
+
+	// check if this pod is serving as an external GW
+	err = oc.addPodExternalGW(pod)
+	if err != nil {
+		return fmt.Errorf("failed to handle external GW check: %v", err)
+	}
 
 	// if somehow lspUUID is empty, there is a bug here with interpreting OVSDB results
 	if len(lsp.UUID) == 0 {

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -441,13 +441,16 @@ func (oc *Controller) addLogicalPort(pod *kapi.Pod) (err error) {
 	}
 
 	if needsIP {
-		// try to get the IP from existing port in OVN first
-		podMac, podIfAddrs, err = oc.getPortAddresses(logicalSwitch, portName)
-		if err != nil {
-			return fmt.Errorf("failed to get pod addresses for pod %s on node: %s, err: %v",
-				portName, logicalSwitch, err)
+		if existingLSP != nil {
+			// try to get the MAC and IPs from existing OVN port first
+			podMac, podIfAddrs, err = oc.getPortAddresses(logicalSwitch, existingLSP)
+			if err != nil {
+				return fmt.Errorf("failed to get pod addresses for pod %s on node: %s, err: %v",
+					portName, logicalSwitch, err)
+			}
 		}
 		needsNewAllocation := false
+
 		// ensure we have reserved the IPs found in OVN
 		if len(podIfAddrs) == 0 {
 			needsNewAllocation = true
@@ -643,15 +646,13 @@ func (oc *Controller) assignPodAddresses(nodeName string) (net.HardwareAddr, []*
 	return podMAC, podCIDRs, nil
 }
 
-// Given a pod and the node on which it is scheduled, get all addresses currently assigned
-// to it from the nbdb.
-func (oc *Controller) getPortAddresses(nodeName, portName string) (net.HardwareAddr, []*net.IPNet, error) {
-	podMac, podIPs, err := util.GetPortAddresses(portName, oc.nbClient)
+// Given a logical switch port and the node on which it is scheduled, get all
+// addresses currently assigned to it including subnet masks.
+func (oc *Controller) getPortAddresses(nodeName string, existingLSP *nbdb.LogicalSwitchPort) (net.HardwareAddr, []*net.IPNet, error) {
+	podMac, podIPs, err := util.ExtractPortAddresses(existingLSP)
 	if err != nil {
 		return nil, nil, err
-	}
-
-	if podMac == nil || len(podIPs) == 0 {
+	} else if podMac == nil || len(podIPs) == 0 {
 		return nil, nil, nil
 	}
 

--- a/go-controller/pkg/util/net.go
+++ b/go-controller/pkg/util/net.go
@@ -35,16 +35,8 @@ func intToIP(i *big.Int) net.IP {
 	return net.IP(i.Bytes())
 }
 
-// GetPortAddresses returns the MAC and IPs of the given logical switch port
-func GetPortAddresses(portName string, nbClient client.Client) (net.HardwareAddr, []net.IP, error) {
-	lsp := &nbdb.LogicalSwitchPort{Name: portName}
-	lsp, err := libovsdbops.GetLogicalSwitchPort(nbClient, lsp)
-	if err == client.ErrNotFound {
-		return nil, nil, nil
-	} else if err != nil {
-		return nil, nil, err
-	}
-
+// ExtractPortAddresses returns the MAC and IPs of the given logical switch port
+func ExtractPortAddresses(lsp *nbdb.LogicalSwitchPort) (net.HardwareAddr, []net.IP, error) {
 	var addresses []string
 
 	if lsp.DynamicAddresses == nil {
@@ -63,13 +55,13 @@ func GetPortAddresses(portName string, nbClient client.Client) (net.HardwareAddr
 
 	mac, err := net.ParseMAC(addresses[0])
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to parse logical switch port %q MAC %q: %v", portName, addresses[0], err)
+		return nil, nil, fmt.Errorf("failed to parse logical switch port %q MAC %q: %v", lsp.Name, addresses[0], err)
 	}
 	var ips []net.IP
 	for _, addr := range addresses[1:] {
 		ip := net.ParseIP(addr)
 		if ip == nil {
-			return nil, nil, fmt.Errorf("failed to parse logical switch port %q IP %q is not a valid ip address", portName, addr)
+			return nil, nil, fmt.Errorf("failed to parse logical switch port %q IP %q is not a valid ip address", lsp.Name, addr)
 		}
 		ips = append(ips, ip)
 	}


### PR DESCRIPTION
Cherry-pick the following upstream PRs to improve performance in scale tests by batching GRSNAT operations and not doing redundant LSP lookups:

https://github.com/ovn-org/ovn-kubernetes/pull/2999
https://github.com/ovn-org/ovn-kubernetes/pull/2769
