### PR TITLE
Bug 2091990: fix lflow-cache-limit-kb ovs external-id

### DIFF
--- a/go-controller/pkg/node/node.go
+++ b/go-controller/pkg/node/node.go
@@ -210,7 +210,7 @@ func setupOVNNode(node *kapi.Node) error {
 
 	if config.Default.LFlowCacheLimitKb > 0 {
 		setExternalIdsCmd = append(setExternalIdsCmd,
-			fmt.Sprintf("external_ids:ovn-limit-lflow-cache-kb=%d", config.Default.LFlowCacheLimitKb),
+			fmt.Sprintf("external_ids:ovn-memlimit-lflow-cache-kb=%d", config.Default.LFlowCacheLimitKb),
 		)
 	}
 

--- a/go-controller/pkg/node/node_test.go
+++ b/go-controller/pkg/node/node_test.go
@@ -366,7 +366,7 @@ var _ = Describe("Node", func() {
 						"external_ids:ovn-ofctrl-wait-before-clear=0 "+
 						"external_ids:ovn-enable-lflow-cache=false "+
 						"external_ids:ovn-limit-lflow-cache=1000 "+
-						"external_ids:ovn-limit-lflow-cache-kb=100000",
+						"external_ids:ovn-memlimit-lflow-cache-kb=100000",
 						nodeIP, interval, ofintval, nodeName),
 				})
 				fexec.AddFakeCmd(&ovntest.ExpectedCmd{


### PR DESCRIPTION
Signed-off-by: Zenghui Shi <zshi@redhat.com>
(cherry picked from commit bb014893878d36e3c955ad706d99fe0262e6f4b9)

