### PR TITLE
Bug 2095113: Dockerfile: bump to openvswitch2.17-2.17.0-22.el8fdp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN yum install -y  \
 	selinux-policy && \
 	yum clean all
 
-ARG ovsver=2.17.0-8.el8fdp
+ARG ovsver=2.17.0-22.el8fdp
 ARG ovnver=22.06.0-preview.branched.38.el8fdp
 
 RUN INSTALL_PKGS=" \


### PR DESCRIPTION
Most important fixes are:

- ovsdb: raft: Fix transaction double commit due to lost leadership. (#2046340)
- UBSan and undefined behavior fixes