### PR TITLE
Dockerfile: bump to Go 1.18 base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@
 # are built in this Dockerfile and included in the image (instead of the rpm)
 #
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.17-openshift-4.10 AS builder
+FROM registry.ci.openshift.org/openshift/release:golang-1.18 AS builder
 
 WORKDIR /go/src/github.com/openshift/ovn-kubernetes
 COPY . .


### PR DESCRIPTION
Might as well get on the same train the rest of 4.11 is on.