### PR TITLE
[release-4.10] Bug 2095193: duplicated IPs can be assigned to multiple Pods

### DIFF
--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -1119,11 +1119,6 @@ func (oc *Controller) addNode(node *kapi.Node) ([]*net.IPNet, error) {
 			}
 		}
 	}()
-	// Ensure that the node's logical network has been created
-	err = oc.ensureNodeLogicalNetwork(node, hostSubnets)
-	if err != nil {
-		return nil, err
-	}
 
 	// Set the HostSubnet annotation on the node object to signal
 	// to nodes that their logical infrastructure is set up and they can
@@ -1135,6 +1130,15 @@ func (oc *Controller) addNode(node *kapi.Node) ([]*net.IPNet, error) {
 
 	// delete stale chassis in SBDB if any
 	oc.deleteStaleNodeChassis(node)
+
+	// Ensure that the node's logical network has been created. Note that if the
+	// subsequent operation in addNode() fails, oc.lsManager.DeleteNode(node.Name)
+	// needs to be done, otherwise, this node's IPAM will be overwritten and the
+	// same IP could be allocated to multiple Pods scheduled on this node.
+	err = oc.ensureNodeLogicalNetwork(node, hostSubnets)
+	if err != nil {
+		return nil, err
+	}
 
 	// If node annotation succeeds and subnets were allocated, update the used subnet count
 	if len(allocatedSubnets) > 0 {

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -33,7 +33,10 @@ func (oc *Controller) syncPods(pods []interface{}) {
 // Upon failure, it may be invoked multiple times in order to avoid a pod restart.
 func (oc *Controller) syncPodsRetriable(pods []interface{}) error {
 	var allOps []ovsdb.Operation
-	// get the list of logical switch ports (equivalent to pods)
+	// get the list of logical switch ports (equivalent to pods). Reserve all existing Pod IPs to
+	// avoid subsequent new Pods getting the same duplicate Pod IP.
+	//
+	// TBD: Before this succeeds, add Pod handler should not continue to allocate IPs for the new Pods.
 	expectedLogicalPorts := make(map[string]bool)
 	for _, podInterface := range pods {
 		pod, ok := podInterface.(*kapi.Pod)


### PR DESCRIPTION
This commit is is not a clean cherry-pick of
12848e73062711e67d04bd676d2a7eb84fc7cad2.
Half of the original commit is not relevent to 4.10 because retry
logic is not developed.

When addNode() failed in addNodeAnnotations(), the node's IPAM can be
overwritten by subsequent addNode() retry attempts. As the result, the
same IP can be allocated to multiple pods.

All credit to Yun Zhou (yunz@nvidia.com).

Signed-off-by: Martin Kennelly <mkennell@redhat.com>