### PR TITLE
[release-4.9] Bug 2096802: duplicated IPs can be assigned to multiple Pods

### DIFF
--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -607,20 +607,6 @@ func (oc *Controller) requestRetryPods() {
 
 // WatchPods starts the watching of Pod resource and calls back the appropriate handler logic
 func (oc *Controller) WatchPods() {
-	go func() {
-		// track the retryPods map and every 30 seconds check if any pods need to be retried
-		for {
-			select {
-			case <-time.After(30 * time.Second):
-				oc.iterateRetryPods(false)
-			case <-oc.retryPodsChan:
-				oc.iterateRetryPods(true)
-			case <-oc.stopChan:
-				return
-			}
-		}
-	}()
-
 	start := time.Now()
 	oc.watchFactory.AddPodHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
@@ -668,6 +654,21 @@ func (oc *Controller) WatchPods() {
 			oc.deleteLogicalPort(pod)
 		},
 	}, oc.syncPods)
+
+	go func() {
+		// track the retryPods map and every 30 seconds check if any pods need to be retried
+		for {
+			select {
+			case <-time.After(30 * time.Second):
+				oc.iterateRetryPods(false)
+			case <-oc.retryPodsChan:
+				oc.iterateRetryPods(true)
+			case <-oc.stopChan:
+				return
+			}
+		}
+	}()
+
 	klog.Infof("Bootstrapping existing pods and cleaning stale pods took %v", time.Since(start))
 }
 

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -25,6 +25,10 @@ func podLogicalPortName(pod *kapi.Pod) string {
 }
 
 func (oc *Controller) syncPods(pods []interface{}) {
+	// get the list of logical switch ports (equivalent to pods). Reserve all existing Pod IPs to
+	// avoid subsequent new Pods getting the same duplicate Pod IP.
+	//
+	// TBD: Before this succeeds, add Pod handler should not continue to allocate IPs for the new Pods.
 	// get the list of logical switch ports (equivalent to pods)
 	expectedLogicalPorts := make(map[string]bool)
 	for _, podInterface := range pods {


### PR DESCRIPTION
This commit is is not a clean cherry-pick of
12848e73062711e67d04bd676d2a7eb84fc7cad2.

This patch ensures that retry logic for pods is after syncPods
is executed. This is accomplished serially with the AddPodHandler
func's parameter 'processExisting' which we pass the syncPods func.
This ensures we exec 'syncPods' once before calling the retry funcs.
However, we need to fix the case where 'syncPods' fails in future
patches.

Also, when addNode() failed in addNodeAnnotations(), the node's IPAM can be
overwritten by subsequent addNode() retry attempts. As the result, the
same IP can be allocated to multiple pods.

All credit to Yun Zhou (yunz@nvidia.com).

Signed-off-by: Martin Kennelly <mkennell@redhat.com>

/cc @trozet 
