### PR TITLE
[release-4.8] Bug 2097018: Duplicated IPs can be assigned to multiple Pods

### DIFF
--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -1051,11 +1051,6 @@ func (oc *Controller) addNode(node *kapi.Node) ([]*net.IPNet, error) {
 			}
 		}
 	}()
-	// Ensure that the node's logical network has been created
-	err = oc.ensureNodeLogicalNetwork(node, hostSubnets)
-	if err != nil {
-		return nil, err
-	}
 
 	// Set the HostSubnet annotation on the node object to signal
 	// to nodes that their logical infrastructure is set up and they can
@@ -1067,6 +1062,15 @@ func (oc *Controller) addNode(node *kapi.Node) ([]*net.IPNet, error) {
 
 	// delete stale chassis in SBDB if any
 	oc.deleteStaleNodeChassis(node)
+
+	// Ensure that the node's logical network has been created. Note that if the
+	// subsequent operation in addNode() fails, oc.lsManager.DeleteNode(node.Name)
+	// needs to be done, otherwise, this node's IPAM will be overwritten and the
+	// same IP could be allocated to multiple Pods scheduled on this node.
+	err = oc.ensureNodeLogicalNetwork(node, hostSubnets)
+	if err != nil {
+		return nil, err
+	}
 
 	// If node annotation succeeds and subnets were allocated, update the used subnet count
 	if len(allocatedSubnets) > 0 {

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -529,11 +529,6 @@ func (oc *Controller) ensurePod(oldPod, pod *kapi.Pod, addPort bool) bool {
 
 // WatchPods starts the watching of Pod resource and calls back the appropriate handler logic
 func (oc *Controller) WatchPods() {
-	go func() {
-		// track the retryPods map and every 30 seconds check if any pods need to be retried
-		utilwait.Until(oc.iterateRetryPods, 30*time.Second, oc.stopChan)
-	}()
-
 	start := time.Now()
 	oc.watchFactory.AddPodHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
@@ -578,6 +573,12 @@ func (oc *Controller) WatchPods() {
 			oc.deleteLogicalPort(pod)
 		},
 	}, oc.syncPods)
+
+	go func() {
+		// track the retryPods map and every 30 seconds check if any pods need to be retried
+		utilwait.Until(oc.iterateRetryPods, 30*time.Second, oc.stopChan)
+	}()
+
 	klog.Infof("Bootstrapping existing pods and cleaning stale pods took %v", time.Since(start))
 }
 

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -25,6 +25,10 @@ func podLogicalPortName(pod *kapi.Pod) string {
 }
 
 func (oc *Controller) syncPods(pods []interface{}) {
+	// get the list of logical switch ports (equivalent to pods). Reserve all existing Pod IPs to
+	// avoid subsequent new Pods getting the same duplicate Pod IP.
+	//
+	// TBD: Before this succeeds, add Pod handler should not continue to allocate IPs for the new Pods.
 	// get the list of logical switch ports (equivalent to pods)
 	expectedLogicalPorts := make(map[string]bool)
 	for _, podInterface := range pods {


### PR DESCRIPTION
This commit is is not a clean cherry-pick of
https://github.com/openshift/ovn-kubernetes/commit/12848e73062711e67d04bd676d2a7eb84fc7cad2.

This patch ensures that retry logic for pods is after syncPods
is executed. This is accomplished serially with the AddPodHandler
func's parameter 'processExisting' which we pass the syncPods func.
This ensures we exec 'syncPods' once before calling the retry funcs.
However, we need to fix the case where 'syncPods' fails in future
patches.

Also, when addNode() failed in addNodeAnnotations(), the node's IPAM can be
overwritten by subsequent addNode() retry attempts. As the result, the
same IP can be allocated to multiple pods.

All credit to Yun Zhou (yunz@nvidia.com).

Signed-off-by: Martin Kennelly <mkennell@redhat.com>