### PR TITLE
Bug 2089392: Update logging for specific policy when creating it

### DIFF
--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -1205,13 +1205,19 @@ func (oc *Controller) addNetworkPolicy(policy *knet.NetworkPolicy) error {
 	}
 	defer nsUnlock()
 	nsInfo.networkPolicies[policy.Name] = np
-	// there may have been a namespace update for ACL logging while we were creating the NP
-	// update it
-	if err := oc.setACLLoggingForNamespace(policy.Namespace, nsInfo); err != nil {
-		klog.Warningf(err.Error())
-	} else {
-		klog.Infof("Namespace %s: ACL logging setting updated to deny=%s allow=%s",
-			policy.Namespace, nsInfo.aclLogging.Deny, nsInfo.aclLogging.Allow)
+	// The allow logging level was updated while we were creating the policy if
+	// the current allow logging level is different than the one we have from
+	// the first time we locked the namespace. If this is the case, update the
+	// policy logging level. We don't care about deny logging level as that only
+	// applies to the default deny ACLS which were created while the namespace
+	// was locked.
+	if nsInfo.aclLogging.Allow != aclLogAllow {
+		if err := oc.updateACLLoggingForPolicy(np, nsInfo.aclLogging.Allow); err != nil {
+			klog.Warningf(err.Error())
+		} else {
+			klog.Infof("Policy %s: ACL logging setting updated to deny=%s allow=%s",
+				getPolicyNamespacedName(policy), nsInfo.aclLogging.Deny, nsInfo.aclLogging.Allow)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Cherry-picked from ovn-org/ovn-kubernetes#3011

All the namespace policies ACLs were being updated when adding a single
policy to make sure that the ACL logging levels were current on the
policies in case it changed while the policy was being created. This is
unnecessary and has performance issues.

When creating a policy, only update the ACL logging of that policy, and
only if it changed from the value we created it with. The other
namespace policies will be handled through the namespace update handler.

Signed-off-by: Jaime Caamaño Ruiz <jcaamano@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->