### PR TITLE
[release-4.10] Bug 2092895: update all egress ACLs' direction to "from-lport"

### DIFF
--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -1291,8 +1291,7 @@ func (oc *Controller) destroyNetworkPolicy(np *networkPolicy, lastPolicy bool) e
 		return fmt.Errorf("error cannot sync NetworkPolicy Egress obj: %v", err)
 	}
 	allEgressACLs = append(allEgressACLs, egressACLs...)
-	// if the first egress ACL is correct they should all be correct and not need to update
-	if allEgressACLs != nil && allEgressACLs[0].Direction != nbdb.ACLDirectionFromLport {
+	if len(allEgressACLs) != 0 {
 		// TODO(jtanenba) make all the libovsdbops.ACL commands deal with pointers to ACLs
 		var egressACLsPTR []*nbdb.ACL
 		for _, acl := range allEgressACLs {


### PR DESCRIPTION
This is not a clean application of https://github.com/openshift/ovn-kubernetes/commit/bc941c289d6e8ddfd6fcee4e31fb85100ae97cf8 but it gets the functionality. There would have been many more patches to backport if we wanted a clean application of the upstream patch. 



Direction of the ACLs built for multicast egress policy was always
"from-lport", so we cannot determine if we need to update egress ACL
direction based on the first egress ACL that found.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->