### PR TITLE
Bug 2091157: [release-4.10] Free IPs and delete resources for completed pods

### DIFF
--- a/go-controller/hybrid-overlay/pkg/controller/node_linux.go
+++ b/go-controller/hybrid-overlay/pkg/controller/node_linux.go
@@ -95,9 +95,13 @@ func (n *NodeController) AddPod(pod *kapi.Pod) error {
 	if !util.PodWantsNetwork(pod) {
 		return nil
 	}
+	if util.PodCompleted(pod) {
+		klog.Infof("Cleaning up hybrid overlay pod %s/%s because it has completed", pod.Namespace, pod.Name)
+		return n.DeletePod(pod)
+	}
 	podIPs, podMAC, err := getPodDetails(pod)
 	if err != nil {
-		klog.V(5).Infof("Cleaning up hybrid overlay pod %s/%s because %v", pod.Namespace, pod.Name, err)
+		klog.Warningf("Cleaning up hybrid overlay pod %s/%s because it has no OVN annotation %v", pod.Namespace, pod.Name, err)
 		return n.DeletePod(pod)
 	}
 

--- a/go-controller/pkg/libovsdbops/router.go
+++ b/go-controller/pkg/libovsdbops/router.go
@@ -384,8 +384,11 @@ func DeleteNATsFromRouterOps(nbClient libovsdbclient.Client, ops []libovsdb.Oper
 	}
 
 	routerNats, err := getRouterNATs(nbClient, router)
+	if err == libovsdbclient.ErrNotFound {
+		return ops, nil
+	}
 	if err != nil {
-		return ops, err
+		return ops, fmt.Errorf("unable to get NAT entries for router %+v: %w", router, err)
 	}
 
 	natUUIDs := make([]string, 0, len(nats))

--- a/go-controller/pkg/ovn/egressgw.go
+++ b/go-controller/pkg/ovn/egressgw.go
@@ -1148,6 +1148,10 @@ func (oc *Controller) buildClusterECMPCacheFromNamespaces(clusterRouteCache map[
 		}
 		for _, gwIP := range gwIPs {
 			for _, nsPod := range nsPods {
+				// ignore completed pods, host networked pods, pods not scheduled
+				if !util.PodWantsNetwork(nsPod) || util.PodCompleted(nsPod) || !util.PodScheduled(nsPod) {
+					continue
+				}
 				for _, podIP := range nsPod.Status.PodIPs {
 					if utilnet.IsIPv6(gwIP) != utilnet.IsIPv6String(podIP.IP) {
 						continue
@@ -1201,6 +1205,10 @@ func (oc *Controller) buildClusterECMPCacheFromPods(clusterRouteCache map[string
 		}
 		for _, gwIP := range gwIPs {
 			for _, nsPod := range nsPods {
+				// ignore completed pods, host networked pods, pods not scheduled
+				if !util.PodWantsNetwork(nsPod) || util.PodCompleted(nsPod) || !util.PodScheduled(nsPod) {
+					continue
+				}
 				for _, podIP := range nsPod.Status.PodIPs {
 					if utilnet.IsIPv6(gwIP) != utilnet.IsIPv6String(podIP.IP) {
 						continue

--- a/go-controller/pkg/ovn/egressip.go
+++ b/go-controller/pkg/ovn/egressip.go
@@ -277,6 +277,9 @@ func (oc *Controller) reconcileEgressIP(old, new *egressipv1.EgressIP) (err erro
 							return err
 						}
 					}
+					if util.PodCompleted(pod) {
+						continue
+					}
 					if newPodSelector.Matches(podLabels) && !oldPodSelector.Matches(podLabels) {
 						if err := oc.addPodEgressIPAssignments(name, newEIP.Status.Items, pod); err != nil {
 							return err
@@ -1197,6 +1200,10 @@ func (oc *Controller) generateCacheForEgressIP(eIPs []interface{}) (map[string]e
 				continue
 			}
 			for _, pod := range pods {
+				if util.PodCompleted(pod) {
+					continue
+				}
+				// FIXME(trozet): potential race where pod is not yet added in the cache by the pod handler
 				logicalPort, err := oc.logicalPortCache.get(util.GetLogicalPortName(pod.Namespace, pod.Name))
 				if err != nil {
 					klog.Errorf("Error getting logical port %s, err: %v", util.GetLogicalPortName(pod.Namespace, pod.Name), err)

--- a/go-controller/pkg/ovn/ipallocator/allocator.go
+++ b/go-controller/pkg/ovn/ipallocator/allocator.go
@@ -34,8 +34,6 @@ type Interface interface {
 	Release(net.IP)
 	ForEach(func(net.IP))
 	CIDR() net.IPNet
-
-	// Has is used for testing
 	Has(ip net.IP) bool
 }
 

--- a/go-controller/pkg/ovn/ipallocator/allocator.go
+++ b/go-controller/pkg/ovn/ipallocator/allocator.go
@@ -31,18 +31,17 @@ import (
 type Interface interface {
 	Allocate(net.IP) error
 	AllocateNext() (net.IP, error)
-	Release(net.IP) error
+	Release(net.IP)
 	ForEach(func(net.IP))
 	CIDR() net.IPNet
 
-	// For testing
+	// Has is used for testing
 	Has(ip net.IP) bool
 }
 
 var (
-	ErrFull              = errors.New("range is full")
-	ErrAllocated         = errors.New("provided IP is already allocated")
-	ErrMismatchedNetwork = errors.New("the provided network does not match the current range")
+	ErrFull      = errors.New("range is full")
+	ErrAllocated = errors.New("provided IP is already allocated")
 )
 
 type ErrNotInRange struct {
@@ -109,7 +108,7 @@ func NewAllocatorCIDRRange(cidr *net.IPNet, allocatorFactory allocator.Allocator
 	return &r, err
 }
 
-// Helper that wraps NewAllocatorCIDRRange, for creating a range backed by an in-memory store.
+// NewCIDRRange is a helper that wraps NewAllocatorCIDRRange, for creating a range backed by an in-memory store.
 func NewCIDRRange(cidr *net.IPNet) (*Range, error) {
 	return NewAllocatorCIDRRange(cidr, func(max int, rangeSpec string) (allocator.Interface, error) {
 		return allocator.NewAllocationMap(max, rangeSpec), nil
@@ -174,13 +173,13 @@ func (r *Range) AllocateNext() (net.IP, error) {
 // Release releases the IP back to the pool. Releasing an
 // unallocated IP or an IP out of the range is a no-op and
 // returns no error.
-func (r *Range) Release(ip net.IP) error {
+func (r *Range) Release(ip net.IP) {
 	ok, offset := r.contains(ip)
 	if !ok {
-		return nil
+		return
 	}
 
-	return r.alloc.Release(offset)
+	r.alloc.Release(offset)
 }
 
 // ForEach calls the provided function for each allocated IP.

--- a/go-controller/pkg/ovn/ipallocator/allocator/bitmap.go
+++ b/go-controller/pkg/ovn/ipallocator/allocator/bitmap.go
@@ -129,17 +129,16 @@ func (r *AllocationBitmap) AllocateNext() (int, bool, error) {
 // Release releases the item back to the pool. Releasing an
 // unallocated item or an item out of the range is a no-op and
 // returns no error.
-func (r *AllocationBitmap) Release(offset int) error {
+func (r *AllocationBitmap) Release(offset int) {
 	r.lock.Lock()
 	defer r.lock.Unlock()
 
 	if r.allocated.Bit(offset) == 0 {
-		return nil
+		return
 	}
 
 	r.allocated = r.allocated.SetBit(r.allocated, offset, 0)
 	r.count--
-	return nil
 }
 
 const (

--- a/go-controller/pkg/ovn/ipallocator/allocator/bitmap_test.go
+++ b/go-controller/pkg/ovn/ipallocator/allocator/bitmap_test.go
@@ -75,9 +75,7 @@ func TestRelease(t *testing.T) {
 		t.Errorf("expect offset %v allocated", offset)
 	}
 
-	if err := m.Release(offset); err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
+	m.Release(offset)
 
 	if m.Has(offset) {
 		t.Errorf("expect offset %v not allocated", offset)
@@ -196,9 +194,7 @@ func TestRoundRobinAllocationOrdering(t *testing.T) {
 	}
 
 	// Release one of the pre-allocated entries
-	if err := m.Release(0); err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	m.Release(0)
 
 	// Next allocation should be after the most recently allocated entry,
 	// not one of the just-released ones
@@ -264,9 +260,7 @@ func TestRoundRobinRelease(t *testing.T) {
 		t.Fatalf("expect offset %d allocated", offset)
 	}
 
-	if err := m.Release(offset); err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	m.Release(offset)
 
 	if m.Has(offset) {
 		t.Fatalf("expect offset %d not allocated", offset)
@@ -289,9 +283,7 @@ func TestRoundRobinWrapAround(t *testing.T) {
 			t.Fatalf("got offset %d but expected offset %d", offset, i)
 		}
 
-		if err := m.Release(offset); err != nil {
-			t.Fatalf("unexpected release error: %v", err)
-		}
+		m.Release(offset)
 	}
 }
 

--- a/go-controller/pkg/ovn/ipallocator/allocator/interfaces.go
+++ b/go-controller/pkg/ovn/ipallocator/allocator/interfaces.go
@@ -21,7 +21,7 @@ package allocator
 type Interface interface {
 	Allocate(int) (bool, error)
 	AllocateNext() (int, bool, error)
-	Release(int) error
+	Release(int)
 	ForEach(func(int))
 
 	// For testing

--- a/go-controller/pkg/ovn/ipallocator/allocator_test.go
+++ b/go-controller/pkg/ovn/ipallocator/allocator_test.go
@@ -114,9 +114,7 @@ func TestAllocate(t *testing.T) {
 			t.Fatal(err)
 		}
 		released := net.ParseIP(tc.released)
-		if err := r.Release(released); err != nil {
-			t.Fatal(err)
-		}
+		r.Release(released)
 		if f := r.Free(); f != 1 {
 			t.Errorf("Test %s unexpected free %d", tc.name, f)
 		}
@@ -131,9 +129,7 @@ func TestAllocate(t *testing.T) {
 			t.Errorf("Test %s unexpected %s : %s", tc.name, ip, released)
 		}
 
-		if err := r.Release(released); err != nil {
-			t.Fatal(err)
-		}
+		r.Release(released)
 		for _, outOfRange := range tc.outOfRange {
 			err = r.Allocate(net.ParseIP(outOfRange))
 			if _, ok := err.(*ErrNotInRange); !ok {

--- a/go-controller/pkg/ovn/logical_switch_manager/logical_switch_manager.go
+++ b/go-controller/pkg/ovn/logical_switch_manager/logical_switch_manager.go
@@ -215,9 +215,8 @@ func (manager *LogicalSwitchManager) AllocateIPs(nodeName string, ipnets []*net.
 			// iterate over range of already allocated indices and release
 			// ips allocated before the error occurred.
 			for relIdx, relIPNet := range allocated {
-				if relErr := lsi.ipams[relIdx].Release(relIPNet.IP); relErr != nil {
-					klog.Errorf("Error while releasing IP: %s, err: %v", relIPNet.IP, relErr)
-				} else if relIPNet.IP != nil {
+				lsi.ipams[relIdx].Release(relIPNet.IP)
+				if relIPNet.IP != nil {
 					klog.Warningf("Reserved IP: %s was released", relIPNet.IP.String())
 				}
 			}
@@ -271,9 +270,8 @@ func (manager *LogicalSwitchManager) AllocateNextIPs(nodeName string) ([]*net.IP
 			// iterate over range of already allocated indices and release
 			// ips allocated before the error occurred.
 			for relIdx, relIPNet := range ipnets {
-				if relErr := lsi.ipams[relIdx].Release(relIPNet.IP); relErr != nil {
-					klog.Errorf("Error while releasing IP: %s, err: %v", relIPNet.IP, relErr)
-				} else if relIPNet.IP != nil {
+				lsi.ipams[relIdx].Release(relIPNet.IP)
+				if relIPNet.IP != nil {
 					klog.Warningf("Reserved IP: %s was released", relIPNet.IP.String())
 				}
 			}
@@ -315,9 +313,7 @@ func (manager *LogicalSwitchManager) ReleaseIPs(nodeName string, ipnets []*net.I
 		for _, ipam := range lsi.ipams {
 			cidr := ipam.CIDR()
 			if cidr.Contains(ipnet.IP) {
-				if err := ipam.Release(ipnet.IP); err != nil {
-					return err
-				}
+				ipam.Release(ipnet.IP)
 				break
 			}
 		}

--- a/go-controller/pkg/ovn/namespace.go
+++ b/go-controller/pkg/ovn/namespace.go
@@ -312,13 +312,21 @@ func (oc *Controller) updateNamespace(old, newer *kapi.Namespace) {
 				}
 				for _, pod := range existingPods {
 					logicalPort := util.GetLogicalPortName(pod.Namespace, pod.Name)
-					portInfo, err := oc.logicalPortCache.get(logicalPort)
+					if !util.PodWantsNetwork(pod) {
+						continue
+					}
+					podIPs, err := util.GetAllPodIPs(pod)
 					if err != nil {
-						klog.Warningf("Unable to get port %s in cache for SNAT rule removal", logicalPort)
-					} else {
+						klog.Warningf("Unable to get pod %q IPs for SNAT rule removal", logicalPort)
+					}
+					ips := make([]*net.IPNet, 0, len(podIPs))
+					for _, podIP := range podIPs {
+						ips = append(ips, &net.IPNet{IP: podIP})
+					}
+					if len(ips) > 0 {
 						if extIPs, err := getExternalIPsGRSNAT(oc.watchFactory, pod.Spec.NodeName); err != nil {
 							klog.Error(err.Error())
-						} else if err = deletePerPodGRSNAT(oc.nbClient, pod.Spec.NodeName, extIPs, portInfo.ips); err != nil {
+						} else if err = deletePerPodGRSNAT(oc.nbClient, pod.Spec.NodeName, extIPs, ips); err != nil {
 							klog.Error(err.Error())
 						}
 					}

--- a/go-controller/pkg/ovn/namespace.go
+++ b/go-controller/pkg/ovn/namespace.go
@@ -638,7 +638,7 @@ func (oc *Controller) createNamespaceAddrSetAllPods(ns string) (addressset.Addre
 	} else {
 		ips = make([]net.IP, 0, len(existingPods))
 		for _, pod := range existingPods {
-			if !pod.Spec.HostNetwork {
+			if util.PodWantsNetwork(pod) && !util.PodCompleted(pod) && util.PodScheduled(pod) {
 				podIPs, err := util.GetAllPodIPs(pod)
 				if err != nil {
 					klog.Warningf(err.Error())

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -603,8 +603,32 @@ func (oc *Controller) WatchPods() {
 		AddFunc: func(obj interface{}) {
 			pod := obj.(*kapi.Pod)
 			oc.metricsRecorder.AddPod(pod.UID)
-			oc.initRetryAddPod(pod)
 			oc.checkAndSkipRetryPod(pod)
+			// in case ovnkube-master is restarted and gets all the add events with completed pods
+			if util.PodCompleted(pod) {
+				// pod is in completed state, remove it
+				klog.Infof("Detected completed pod: %s. Will remove.", getPodNamespacedName(pod))
+				oc.initRetryDelPod(pod)
+				oc.removeAddRetry(pod)
+				oc.logicalPortCache.remove(util.GetLogicalPortName(pod.Namespace, pod.Name))
+				retryEntry := oc.getPodRetryEntry(pod)
+				var portInfo *lpInfo
+				if retryEntry != nil {
+					// retryEntry shouldn't be nil since we usually add the pod to retryCache above
+					portInfo = retryEntry.needsDel
+				}
+				if err := oc.removePod(pod, portInfo); err != nil {
+					oc.recordPodEvent(err, pod)
+					klog.Errorf("Failed to delete completed pod %s, error: %v",
+						getPodNamespacedName(pod), err)
+					oc.unSkipRetryPod(pod)
+					return
+				}
+				oc.checkAndDeleteRetryPod(pod)
+				return
+			}
+			// need to add new pod
+			oc.initRetryAddPod(pod)
 			if retryEntry := oc.getPodRetryEntry(pod); retryEntry != nil && retryEntry.needsDel != nil {
 				klog.Infof("Detected leftover old pod during new pod add with the same name: %s. "+
 					"Attempting deletion of leftover old...", getPodNamespacedName(pod))
@@ -658,7 +682,7 @@ func (oc *Controller) WatchPods() {
 				}
 				// deletion was a success; remove delete retry entry
 				oc.removeDeleteRetry(pod)
-			} else if pod.Status.Phase == kapi.PodSucceeded {
+			} else if util.PodCompleted(pod) {
 				// pod is in completed state, remove it
 				klog.Infof("Detected completed pod: %s. Will remove.", getPodNamespacedName(pod))
 				oc.initRetryDelPod(pod)
@@ -686,6 +710,7 @@ func (oc *Controller) WatchPods() {
 				klog.Errorf("Failed to update pod %s, error: %v",
 					getPodNamespacedName(pod), err)
 				oc.initRetryAddPod(pod)
+
 				// unskip failed pod for next retry iteration
 				oc.unSkipRetryPod(pod)
 				return
@@ -1078,8 +1103,15 @@ func (oc *Controller) WatchEgressIPPods() {
 		UpdateFunc: func(oldObj, newObj interface{}) {
 			oldPod := oldObj.(*kapi.Pod)
 			newPod := newObj.(*kapi.Pod)
-			if err := oc.reconcileEgressIPPod(oldPod, newPod); err != nil {
-				klog.Errorf("Unable to update egress IP matching pod: %s/%s, err: %v", newPod.Name, newPod.Namespace, err)
+			if util.PodCompleted(newPod) {
+				if err := oc.reconcileEgressIPPod(oldPod, nil); err != nil {
+					klog.Errorf("Unable to delete egress IP matching completed pod: %s/%s, err: %v",
+						oldPod.Name, oldPod.Namespace, err)
+				}
+			} else {
+				if err := oc.reconcileEgressIPPod(oldPod, newPod); err != nil {
+					klog.Errorf("Unable to update egress IP matching pod: %s/%s, err: %v", newPod.Name, newPod.Namespace, err)
+				}
 			}
 		},
 		DeleteFunc: func(obj interface{}) {

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -658,7 +658,29 @@ func (oc *Controller) WatchPods() {
 				}
 				// deletion was a success; remove delete retry entry
 				oc.removeDeleteRetry(pod)
+			} else if pod.Status.Phase == kapi.PodSucceeded {
+				// pod is in completed state, remove it
+				klog.Infof("Detected completed pod: %s. Will remove.", getPodNamespacedName(pod))
+				oc.initRetryDelPod(pod)
+				oc.removeAddRetry(pod)
+				oc.logicalPortCache.remove(util.GetLogicalPortName(pod.Namespace, pod.Name))
+				retryEntry := oc.getPodRetryEntry(pod)
+				var portInfo *lpInfo
+				if retryEntry != nil {
+					// retryEntry shouldn't be nil since we usually add the pod to retryCache above
+					portInfo = retryEntry.needsDel
+				}
+				if err := oc.removePod(pod, portInfo); err != nil {
+					oc.recordPodEvent(err, pod)
+					klog.Errorf("Failed to delete completed pod %s, error: %v",
+						getPodNamespacedName(pod), err)
+					oc.unSkipRetryPod(pod)
+					return
+				}
+				oc.checkAndDeleteRetryPod(pod)
+				return
 			}
+
 			if err := oc.ensurePod(oldPod, pod, oc.checkAndSkipRetryPod(pod)); err != nil {
 				oc.recordPodEvent(err, pod)
 				klog.Errorf("Failed to update pod %s, error: %v",

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -184,6 +184,8 @@ func (oc *Controller) deleteLogicalPort(pod *kapi.Pod, portInfo *lpInfo) (err er
 		return fmt.Errorf("cannot delete logical switch port %s, %v", logicalPort, err)
 	}
 
+	klog.Infof("Attempting to release IPs for pod: %s/%s, ips: %s", pod.Namespace, pod.Name,
+		util.JoinIPNetIPs(podIfAddrs, " "))
 	if err := oc.lsManager.ReleaseIPs(pod.Spec.NodeName, podIfAddrs); err != nil {
 		return fmt.Errorf("cannot release IPs for pod %s: %w", podDesc, err)
 	}

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -44,7 +44,7 @@ func (oc *Controller) syncPodsRetriable(pods []interface{}) error {
 			return fmt.Errorf("spurious object in syncPods: %v", podInterface)
 		}
 		annotations, err := util.UnmarshalPodAnnotation(pod.Annotations)
-		if util.PodScheduled(pod) && util.PodWantsNetwork(pod) && err == nil {
+		if util.PodScheduled(pod) && util.PodWantsNetwork(pod) && !util.PodCompleted(pod) && err == nil {
 			// skip nodes that are not running ovnk (inferred from host subnets)
 			if oc.lsManager.IsNonHostSubnetSwitch(pod.Spec.NodeName) {
 				continue
@@ -167,12 +167,53 @@ func (oc *Controller) deleteLogicalPort(pod *kapi.Pod, portInfo *lpInfo) (err er
 		podIfAddrs = portInfo.ips
 	}
 
-	var allOps, ops []ovsdb.Operation
-	if ops, err = oc.deletePodFromNamespace(pod.Namespace, podIfAddrs, portUUID); err != nil {
-		return fmt.Errorf("unable to delete pod %s from namespace: %w", podDesc, err)
-	}
-	allOps = append(allOps, ops...)
+	shouldRelease := true
+	// check to make sure no other pods are using this IP before we try to release it if this is a completed pod.
+	if util.PodCompleted(pod) {
+		if shouldRelease, err = oc.lsManager.ConditionalIPRelease(pod.Spec.NodeName, podIfAddrs, func() (bool, error) {
+			pods, err := oc.watchFactory.GetAllPods()
+			if err != nil {
+				return false, fmt.Errorf("unable to get pods to determine if completed pod IP is in use by another pod. "+
+					"Will not release pod %s/%s IP: %#v from allocator", pod.Namespace, pod.Name, podIfAddrs)
+			}
+			// iterate through all pods, ignore pods on other nodes
+			for _, p := range pods {
+				if util.PodCompleted(p) || !util.PodWantsNetwork(p) || !util.PodScheduled(p) || p.Spec.NodeName != pod.Spec.NodeName {
+					continue
+				}
+				// check if the pod addresses match in the OVN annotation
+				pAddrs, err := util.GetAllPodIPs(p)
+				if err != nil {
+					continue
+				}
 
+				for _, pAddr := range pAddrs {
+					for _, podAddr := range podIfAddrs {
+						if pAddr.Equal(podAddr.IP) {
+							klog.Infof("Will not release IP address: %s for pod %s/%s. Detected another pod"+
+								" using this IP: %s/%s", pAddr.String(), pod.Namespace, pod.Name, p.Namespace, p.Name)
+							return false, nil
+						}
+					}
+				}
+			}
+			klog.Infof("Releasing IPs for Completed pod: %s/%s, ips: %s", pod.Namespace, pod.Name,
+				util.JoinIPNetIPs(podIfAddrs, " "))
+			return true, nil
+		}); err != nil {
+			return fmt.Errorf("cannot determine if IPs are safe to release for completed pod: %s: %w", podDesc, err)
+		}
+	}
+
+	var allOps, ops []ovsdb.Operation
+
+	// if the ip is in use by another pod we should not try to remove it from the address set
+	if shouldRelease {
+		if ops, err = oc.deletePodFromNamespace(pod.Namespace, podIfAddrs, portUUID); err != nil {
+			return fmt.Errorf("unable to delete pod %s from namespace: %w", podDesc, err)
+		}
+		allOps = append(allOps, ops...)
+	}
 	ops, err = oc.delLSPOps(logicalPort, pod.Spec.NodeName, portUUID)
 	if err != nil {
 		return fmt.Errorf("failed to create delete ops for the lsp: %s: %s", logicalPort, err)
@@ -184,10 +225,9 @@ func (oc *Controller) deleteLogicalPort(pod *kapi.Pod, portInfo *lpInfo) (err er
 		return fmt.Errorf("cannot delete logical switch port %s, %v", logicalPort, err)
 	}
 
-	klog.Infof("Attempting to release IPs for pod: %s/%s, ips: %s", pod.Namespace, pod.Name,
-		util.JoinIPNetIPs(podIfAddrs, " "))
-	if err := oc.lsManager.ReleaseIPs(pod.Spec.NodeName, podIfAddrs); err != nil {
-		return fmt.Errorf("cannot release IPs for pod %s: %w", podDesc, err)
+	// do not remove SNATs/GW routes/IPAM for an IP address unless we have validated no other pod is using it
+	if !shouldRelease {
+		return nil
 	}
 
 	if config.Gateway.DisableSNATMultipleGWs {
@@ -198,6 +238,16 @@ func (oc *Controller) deleteLogicalPort(pod *kapi.Pod, portInfo *lpInfo) (err er
 	podNsName := ktypes.NamespacedName{Namespace: pod.Namespace, Name: pod.Name}
 	if err := oc.deleteGWRoutesForPod(podNsName, podIfAddrs); err != nil {
 		return fmt.Errorf("cannot delete GW Routes for pod %s: %w", podDesc, err)
+	}
+
+	// Releasing IPs needs to happen last so that we can deterministically know that if delete failed that
+	// the IP of the pod needs to be released. Otherwise we could have a completed pod failed to be removed
+	// and we dont know if the IP was released or not, and subsequently could accidentally release the IP
+	// while it is now on another pod
+	klog.Infof("Attempting to release IPs for pod: %s/%s, ips: %s", pod.Namespace, pod.Name,
+		util.JoinIPNetIPs(podIfAddrs, " "))
+	if err := oc.lsManager.ReleaseIPs(pod.Spec.NodeName, podIfAddrs); err != nil {
+		return fmt.Errorf("cannot release IPs for pod %s: %w", podDesc, err)
 	}
 
 	return nil

--- a/go-controller/pkg/ovn/pods_retry.go
+++ b/go-controller/pkg/ovn/pods_retry.go
@@ -159,6 +159,15 @@ func (oc *Controller) initRetryDelPod(pod *kapi.Pod) {
 	}
 }
 
+func (oc *Controller) removeAddRetry(pod *kapi.Pod) {
+	oc.retryPodsLock.Lock()
+	defer oc.retryPodsLock.Unlock()
+	key := getPodNamespacedName(pod)
+	if entry, ok := oc.retryPods[key]; ok {
+		entry.needsAdd = false
+	}
+}
+
 func (oc *Controller) removeDeleteRetry(pod *kapi.Pod) {
 	oc.retryPodsLock.Lock()
 	defer oc.retryPodsLock.Unlock()
@@ -202,6 +211,14 @@ func (oc *Controller) requestRetryPods() {
 	default:
 		klog.V(5).Infof("Iterate retry pods already requested")
 	}
+}
+
+// unit testing only
+func (oc *Controller) hasPodRetryEntry(pod *kapi.Pod) bool {
+	oc.retryPodsLock.Lock()
+	defer oc.retryPodsLock.Unlock()
+	_, ok := oc.retryPods[getPodNamespacedName(pod)]
+	return ok
 }
 
 // getPodNamespacedName returns <namespace>_<podname> for the provided pod

--- a/go-controller/pkg/ovn/pods_retry.go
+++ b/go-controller/pkg/ovn/pods_retry.go
@@ -68,7 +68,7 @@ func (oc *Controller) iterateRetryPods(updateAll bool) {
 			if podEntry.needsAdd {
 				klog.Infof("%s retry pod setup", podDesc)
 				if err := oc.ensurePod(nil, pod, true); err != nil {
-					klog.Infof("%s setup retry failed; will try again later", podDesc)
+					klog.Infof("%s setup retry failed; will try again later: %v", podDesc, err)
 					podEntry.timeStamp = time.Now()
 				} else {
 					klog.Infof("%s pod setup successful", podDesc)

--- a/go-controller/pkg/ovn/pods_test.go
+++ b/go-controller/pkg/ovn/pods_test.go
@@ -364,6 +364,107 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		})
 
+		ginkgo.It("allows allocation after pods are completed", func() {
+			app.Action = func(ctx *cli.Context) error {
+				namespaceT := *newNamespace("namespace1")
+				t := newTPod(
+					"node1",
+					"10.128.1.0/24",
+					"10.128.1.2",
+					"10.128.1.1",
+					"myPod",
+					"10.128.1.3",
+					"0a:58:0a:80:01:03",
+					namespaceT.Name,
+				)
+
+				fakeOvn.startWithDBSetup(initialDB,
+					&v1.NamespaceList{
+						Items: []v1.Namespace{
+							namespaceT,
+						},
+					},
+					&v1.PodList{
+						Items: []v1.Pod{},
+					},
+				)
+
+				t.populateLogicalSwitchCache(fakeOvn, getLogicalSwitchUUID(fakeOvn.controller.nbClient, "node1"))
+				fakeOvn.controller.WatchNamespaces()
+				fakeOvn.controller.WatchPods()
+
+				pod, _ := fakeOvn.fakeClient.KubeClient.CoreV1().Pods(t.namespace).Get(context.TODO(), t.podName, metav1.GetOptions{})
+				gomega.Expect(pod).To(gomega.BeNil())
+
+				myPod := newPod(t.namespace, t.podName, t.nodeName, t.podIP)
+				_, err := fakeOvn.fakeClient.KubeClient.CoreV1().Pods(t.namespace).Create(context.TODO(),
+					myPod, metav1.CreateOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				gomega.Eventually(func() string {
+					return getPodAnnotations(fakeOvn.fakeClient.KubeClient, t.namespace, t.podName)
+				}, 2).Should(gomega.MatchJSON(t.getAnnotationsJson()))
+
+				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(getExpectedDataPodsAndSwitches([]testPod{t}, []string{"node1"})))
+
+				ginkgo.By("Allocating all of the rest of the node subnet")
+				// allocate all the rest of the IPs in the subnet
+				fakeOvn.controller.lsManager.AllocateUntilFull("node1")
+
+				ginkgo.By("Creating another pod which will fail due to allocation full")
+				t2 := newTPod(
+					"node1",
+					"10.128.1.0/24",
+					"10.128.1.2",
+					"10.128.1.1",
+					"myPod2",
+					"10.128.1.3",
+					"0a:58:0a:80:01:03",
+					namespaceT.Name,
+				)
+
+				myPod2, err := fakeOvn.fakeClient.KubeClient.CoreV1().Pods(t.namespace).Create(context.TODO(),
+					newPod(t2.namespace, t2.podName, t2.nodeName, t2.podIP), metav1.CreateOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Eventually(func() string {
+					return getPodAnnotations(fakeOvn.fakeClient.KubeClient, t2.namespace, t2.podName)
+				}, 2).Should(gomega.HaveLen(0))
+
+				gomega.Eventually(func() bool {
+					return fakeOvn.controller.hasPodRetryEntry(myPod2)
+				}).Should(gomega.BeTrue())
+
+				ginkgo.By("Marking myPod as completed should free IP")
+				myPod.Status.Phase = v1.PodSucceeded
+
+				_, err = fakeOvn.fakeClient.KubeClient.CoreV1().Pods(t.namespace).UpdateStatus(context.TODO(),
+					myPod, metav1.UpdateOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				// port should be gone or marked for removal in logical port cache
+				logicalPort := util.GetLogicalPortName(myPod.Namespace, myPod.Name)
+				gomega.Eventually(func() bool {
+					info, err := fakeOvn.controller.logicalPortCache.get(logicalPort)
+					return err != nil || !info.expires.IsZero()
+				}, 2).Should(gomega.BeTrue())
+
+				// there should also be no entry for this pod in the retry cache
+				gomega.Eventually(func() bool {
+					return fakeOvn.controller.getPodRetryEntry(myPod) == nil
+				}, 2).Should(gomega.BeTrue())
+				ginkgo.By("Freed IP should now allow mypod2 to come up")
+				fakeOvn.controller.requestRetryPods()
+				gomega.Eventually(func() string {
+					return getPodAnnotations(fakeOvn.fakeClient.KubeClient, t2.namespace, t2.podName)
+				}, 2).Should(gomega.MatchJSON(t2.getAnnotationsJson()))
+
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+
 		ginkgo.It("retryPod cache operations while adding a new pod", func() {
 			app.Action = func(ctx *cli.Context) error {
 				config.Gateway.DisableSNATMultipleGWs = true

--- a/go-controller/pkg/ovn/pods_test.go
+++ b/go-controller/pkg/ovn/pods_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/urfave/cli/v2"
 
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/ipallocator"
 	ovstypes "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
@@ -424,7 +425,7 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 				)
 
 				myPod2, err := fakeOvn.fakeClient.KubeClient.CoreV1().Pods(t.namespace).Create(context.TODO(),
-					newPod(t2.namespace, t2.podName, t2.nodeName, t2.podIP), metav1.CreateOptions{})
+					newPod(t2.namespace, t2.podName, t2.nodeName, ""), metav1.CreateOptions{})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				gomega.Eventually(func() string {
 					return getPodAnnotations(fakeOvn.fakeClient.KubeClient, t2.namespace, t2.podName)
@@ -434,6 +435,109 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 					return fakeOvn.controller.hasPodRetryEntry(myPod2)
 				}).Should(gomega.BeTrue())
 
+				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(getExpectedDataPodsAndSwitches([]testPod{t}, []string{"node1"})))
+				ginkgo.By("Marking myPod as completed should free IP")
+				myPod.Status.Phase = v1.PodSucceeded
+
+				_, err = fakeOvn.fakeClient.KubeClient.CoreV1().Pods(t.namespace).UpdateStatus(context.TODO(),
+					myPod, metav1.UpdateOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				// port should be gone or marked for removal in logical port cache
+				logicalPort := util.GetLogicalPortName(myPod.Namespace, myPod.Name)
+				gomega.Eventually(func() bool {
+					info, err := fakeOvn.controller.logicalPortCache.get(logicalPort)
+					return err != nil || !info.expires.IsZero()
+				}, 2).Should(gomega.BeTrue())
+
+				fakeOvn.controller.requestRetryPods()
+				ginkgo.By("Freed IP should now allow mypod2 to come up")
+				// there should also be no entry for this pod in the retry cache
+				gomega.Eventually(func() bool {
+					return fakeOvn.controller.getPodRetryEntry(myPod2) == nil
+				}, 31*time.Second).Should(gomega.BeTrue())
+				gomega.Eventually(func() string {
+					return getPodAnnotations(fakeOvn.fakeClient.KubeClient, t2.namespace, t2.podName)
+				}, 2).Should(gomega.MatchJSON(t2.getAnnotationsJson()))
+				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(getExpectedDataPodsAndSwitches([]testPod{t2}, []string{"node1"})))
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+
+		ginkgo.It("should not deallocate in-use and previously freed completed pods IP", func() {
+			app.Action = func(ctx *cli.Context) error {
+				namespaceT := *newNamespace("namespace1")
+				t := newTPod(
+					"node1",
+					"10.128.1.0/24",
+					"10.128.1.2",
+					"10.128.1.1",
+					"myPod",
+					"10.128.1.3",
+					"0a:58:0a:80:01:03",
+					namespaceT.Name,
+				)
+
+				fakeOvn.startWithDBSetup(initialDB,
+					&v1.NamespaceList{
+						Items: []v1.Namespace{
+							namespaceT,
+						},
+					},
+					&v1.PodList{
+						Items: []v1.Pod{},
+					},
+				)
+
+				t.populateLogicalSwitchCache(fakeOvn, getLogicalSwitchUUID(fakeOvn.controller.nbClient, "node1"))
+				fakeOvn.controller.WatchNamespaces()
+				fakeOvn.controller.WatchPods()
+
+				pod, _ := fakeOvn.fakeClient.KubeClient.CoreV1().Pods(t.namespace).Get(context.TODO(), t.podName, metav1.GetOptions{})
+				gomega.Expect(pod).To(gomega.BeNil())
+
+				myPod := newPod(t.namespace, t.podName, t.nodeName, t.podIP)
+				_, err := fakeOvn.fakeClient.KubeClient.CoreV1().Pods(t.namespace).Create(context.TODO(),
+					myPod, metav1.CreateOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				gomega.Eventually(func() string {
+					return getPodAnnotations(fakeOvn.fakeClient.KubeClient, t.namespace, t.podName)
+				}, 2).Should(gomega.MatchJSON(t.getAnnotationsJson()))
+
+				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(getExpectedDataPodsAndSwitches([]testPod{t}, []string{"node1"})))
+
+				ginkgo.By("Allocating all of the rest of the node subnet")
+				// allocate all the rest of the IPs in the subnet
+				fakeOvn.controller.lsManager.AllocateUntilFull("node1")
+
+				ginkgo.By("Creating another pod which will fail due to allocation full")
+				t2 := newTPod(
+					"node1",
+					"10.128.1.0/24",
+					"10.128.1.2",
+					"10.128.1.1",
+					"myPod2",
+					"10.128.1.3",
+					"0a:58:0a:80:01:03",
+					namespaceT.Name,
+				)
+
+				myPod2, err := fakeOvn.fakeClient.KubeClient.CoreV1().Pods(t.namespace).Create(context.TODO(),
+					newPod(t2.namespace, t2.podName, t2.nodeName, t2.podIP), metav1.CreateOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Eventually(func() string {
+					return getPodAnnotations(fakeOvn.fakeClient.KubeClient, t2.namespace, t2.podName)
+				}, 2).Should(gomega.HaveLen(0))
+
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Eventually(func() bool {
+					return fakeOvn.controller.hasPodRetryEntry(myPod2)
+				}).Should(gomega.BeTrue())
+				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(getExpectedDataPodsAndSwitches([]testPod{t}, []string{"node1"})))
 				ginkgo.By("Marking myPod as completed should free IP")
 				myPod.Status.Phase = v1.PodSucceeded
 
@@ -458,6 +562,107 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 					return getPodAnnotations(fakeOvn.fakeClient.KubeClient, t2.namespace, t2.podName)
 				}, 2).Should(gomega.MatchJSON(t2.getAnnotationsJson()))
 
+				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(getExpectedDataPodsAndSwitches([]testPod{t2}, []string{"node1"})))
+				// 2nd pod should now have the IP
+				myPod2, err = fakeOvn.fakeClient.KubeClient.CoreV1().Pods(t.namespace).Get(context.TODO(),
+					t2.podName, metav1.GetOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Expect(myPod2.Status.PodIP).To(gomega.Equal(t2.podIP))
+
+				ginkgo.By("Updating the completed pod should not free the IP")
+				patch := struct {
+					Metadata map[string]interface{} `json:"metadata"`
+				}{
+					Metadata: map[string]interface{}{
+						"annotations": map[string]string{"dummy": "data"},
+					},
+				}
+				patchData, err := json.Marshal(&patch)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				// trigger update event
+				_, err = fakeOvn.fakeClient.KubeClient.CoreV1().Pods(t.namespace).Patch(context.TODO(), myPod.Name, types.MergePatchType, patchData, metav1.PatchOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				// sleep a small amount to ensure the event was processed
+				time.Sleep(time.Second)
+				// try to allocate the IP and it should not work
+				annotation, err := util.UnmarshalPodAnnotation(myPod2.Annotations)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				err = fakeOvn.controller.lsManager.AllocateIPs(t.nodeName, annotation.IPs)
+				gomega.Expect(err).To(gomega.Equal(ipallocator.ErrAllocated))
+				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(getExpectedDataPodsAndSwitches([]testPod{t2}, []string{"node1"})))
+
+				ginkgo.By("Deleting the completed pod should not allow a third pod to take the IP")
+				// now delete the completed pod
+				err = fakeOvn.fakeClient.KubeClient.CoreV1().Pods(t.namespace).Delete(context.TODO(),
+					t.podName, metav1.DeleteOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				// now create a 3rd pod
+				t3 := newTPod(
+					"node1",
+					"10.128.1.0/24",
+					"10.128.1.2",
+					"10.128.1.1",
+					"myPod3",
+					"10.128.1.3",
+					"0a:58:0a:80:01:03",
+					namespaceT.Name,
+				)
+				myPod3, err := fakeOvn.fakeClient.KubeClient.CoreV1().Pods(t.namespace).Create(context.TODO(),
+					newPod(t3.namespace, t3.podName, t3.nodeName, t3.podIP), metav1.CreateOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Eventually(func() string {
+					return getPodAnnotations(fakeOvn.fakeClient.KubeClient, t3.namespace, t3.podName)
+				}, 2).Should(gomega.HaveLen(0))
+
+				// should be in retry because there are no more IPs left
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Eventually(func() bool {
+					return fakeOvn.controller.hasPodRetryEntry(myPod3)
+				}).Should(gomega.BeTrue())
+				// TODO validate that the pods also have correct GW SNATs and route policies
+				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(getExpectedDataPodsAndSwitches([]testPod{t2}, []string{"node1"})))
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+
+		ginkgo.It("should not allocate a completed pod on start up", func() {
+			app.Action = func(ctx *cli.Context) error {
+				namespaceT := *newNamespace("namespace1")
+				t := newTPod(
+					"node1",
+					"10.128.1.0/24",
+					"10.128.1.2",
+					"10.128.1.1",
+					"myPod",
+					"10.128.1.3",
+					"0a:58:0a:80:01:03",
+					namespaceT.Name,
+				)
+				myPod := newPod(t.namespace, t.podName, t.nodeName, t.podIP)
+				myPod.Status.Phase = v1.PodSucceeded
+
+				fakeOvn.startWithDBSetup(initialDB,
+					&v1.NamespaceList{
+						Items: []v1.Namespace{
+							namespaceT,
+						},
+					},
+					&v1.PodList{
+						Items: []v1.Pod{*myPod},
+					},
+				)
+
+				t.populateLogicalSwitchCache(fakeOvn, getLogicalSwitchUUID(fakeOvn.controller.nbClient, "node1"))
+				fakeOvn.controller.WatchNamespaces()
+				fakeOvn.controller.WatchPods()
+
+				expectedData := []libovsdbtest.TestData{getExpectedDataPodsAndSwitches([]testPod{}, []string{"node1"})}
+				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedData...))
+				fakeOvn.asf.ExpectAddressSetWithIPs(namespaceT.Name, []string{})
 				return nil
 			}
 

--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -455,6 +455,9 @@ func (oc *Controller) createMulticastAllowPolicy(ns string, nsInfo *namespaceInf
 		klog.Warningf("Failed to get pods for namespace %q: %v", ns, err)
 	}
 	for _, pod := range pods {
+		if util.PodCompleted(pod) {
+			continue
+		}
 		portName := util.GetLogicalPortName(pod.Namespace, pod.Name)
 		if portInfo, err := oc.logicalPortCache.get(portName); err != nil {
 			klog.Errorf(err.Error())
@@ -755,6 +758,11 @@ func (oc *Controller) processLocalPodSelectorSetPods(policy *knet.NetworkPolicy,
 	for _, obj := range objs {
 		pod := obj.(*kapi.Pod)
 
+		if util.PodCompleted(pod) {
+			// if pod is completed, do not add it to NP port group
+			continue
+		}
+
 		getPolicyPortsWg.Add(1)
 		go getPortInfo(pod)
 	}
@@ -899,7 +907,12 @@ func (oc *Controller) handleLocalPodSelector(
 				oc.handleLocalPodSelectorDelFunc(policy, np, portGroupIngressDenyName, portGroupEgressDenyName, obj)
 			},
 			UpdateFunc: func(oldObj, newObj interface{}) {
-				oc.handleLocalPodSelectorAddFunc(policy, np, portGroupIngressDenyName, portGroupEgressDenyName, newObj)
+				pod := newObj.(*kapi.Pod)
+				if util.PodCompleted(pod) {
+					oc.handleLocalPodSelectorDelFunc(policy, np, portGroupIngressDenyName, portGroupEgressDenyName, oldObj)
+				} else {
+					oc.handleLocalPodSelectorAddFunc(policy, np, portGroupIngressDenyName, portGroupEgressDenyName, newObj)
+				}
 			},
 		}, func(objs []interface{}) {
 			handleInitialItems(objs)
@@ -1418,7 +1431,12 @@ func (oc *Controller) handlePeerPodSelector(
 				oc.handlePeerPodSelectorDelete(gp, obj)
 			},
 			UpdateFunc: func(oldObj, newObj interface{}) {
-				oc.handlePeerPodSelectorAddUpdate(gp, newObj)
+				pod := newObj.(*kapi.Pod)
+				if util.PodCompleted(pod) {
+					oc.handlePeerPodSelectorDelete(gp, oldObj)
+				} else {
+					oc.handlePeerPodSelectorAddUpdate(gp, newObj)
+				}
 			},
 		}, func(objs []interface{}) {
 			oc.handlePeerPodSelectorAddUpdate(gp, objs...)
@@ -1458,7 +1476,12 @@ func (oc *Controller) handlePeerNamespaceAndPodSelector(
 							oc.handlePeerPodSelectorDelete(gp, obj)
 						},
 						UpdateFunc: func(oldObj, newObj interface{}) {
-							oc.handlePeerPodSelectorAddUpdate(gp, newObj)
+							pod := oldObj.(*kapi.Pod)
+							if util.PodCompleted(pod) {
+								oc.handlePeerPodSelectorDelete(gp, oldObj)
+							} else {
+								oc.handlePeerPodSelectorAddUpdate(gp, newObj)
+							}
 						},
 					}, func(objs []interface{}) {
 						oc.handlePeerPodSelectorAddUpdate(gp, objs...)

--- a/go-controller/pkg/ovn/port_cache.go
+++ b/go-controller/pkg/ovn/port_cache.go
@@ -37,7 +37,8 @@ func (c *portCache) get(logicalPort string) (*lpInfo, error) {
 	c.RLock()
 	defer c.RUnlock()
 	if info, ok := c.cache[logicalPort]; ok {
-		return info, nil
+		x := *info
+		return &x, nil
 	}
 	return nil, fmt.Errorf("logical port %s not found in cache", logicalPort)
 }

--- a/go-controller/pkg/util/kube.go
+++ b/go-controller/pkg/util/kube.go
@@ -235,6 +235,11 @@ func PodWantsNetwork(pod *kapi.Pod) bool {
 	return !pod.Spec.HostNetwork
 }
 
+// PodCompleted checks if the pod is marked as completed (in a terminal state)
+func PodCompleted(pod *kapi.Pod) bool {
+	return pod.Status.Phase == kapi.PodSucceeded || pod.Status.Phase == kapi.PodFailed
+}
+
 // PodScheduled returns if the given pod is scheduled
 func PodScheduled(pod *kapi.Pod) bool {
 	return pod.Spec.NodeName != ""


### PR DESCRIPTION
Not a totally clean backport due to generic retry watcher library added in 4.11.