### PR TITLE
[release-4.10] Bug 2100092: Do not use a referance to a range variable.

### DIFF
--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -1363,7 +1363,8 @@ func (oc *Controller) syncNodesPeriodic() {
 	}
 
 	staleChassis := []*sbdb.Chassis{}
-	for _, v := range chassisHostNameMap {
+	for i, _ := range chassisHostNameMap {
+		v := chassisHostNameMap[i]
 		staleChassis = append(staleChassis, &v)
 	}
 
@@ -1474,7 +1475,8 @@ func (oc *Controller) syncNodesRetriable(nodes []interface{}) error {
 
 	knownChassisNames := sets.NewString()
 	chassisDeleteList := []*sbdb.Chassis{}
-	for _, chassis := range chassisList {
+	for i, _ := range chassisList {
+		chassis := chassisList[i]
 		knownChassisNames.Insert(chassis.Name)
 		// skip chassis that have a corresponding node
 		if foundNodes.Has(chassis.Hostname) {


### PR DESCRIPTION
While working on another unit test issue I discovered that we are wrongfully using an address of a range variable.

I think it was introduced during a backport: https://github.com/openshift/ovn-kubernetes/commit/a6956dcf0047f33dca9aa4a5ec6b8ad68a60eba1#diff-1f90f4648dc7d68c42854549c4257ddcfc9bd9a5b6fc480c74e3a23989914bc3R1479 and it does not affect 4.11/master

/assign @jcaamano @flavio-fernandes 