### PR TITLE
Bug 2099755: Add new EgressIP config option "egressip-reachability-total-timeout"

### DIFF
--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -115,7 +115,9 @@ var (
 	Metrics MetricsConfig
 
 	// OVNKubernetesFeatureConfig holds OVN-Kubernetes feature enhancement config file parameters and command-line overrides
-	OVNKubernetesFeature OVNKubernetesFeatureConfig
+	OVNKubernetesFeature = OVNKubernetesFeatureConfig{
+		EgressIPReachabiltyTotalTimeout: 1,
+	}
 
 	// OvnNorth holds northbound OVN database client and server authentication and location details
 	OvnNorth OvnAuthConfig
@@ -323,9 +325,12 @@ type MetricsConfig struct {
 
 // OVNKubernetesFeatureConfig holds OVN-Kubernetes feature enhancement config file parameters and command-line overrides
 type OVNKubernetesFeatureConfig struct {
-	EnableEgressIP       bool `gcfg:"enable-egress-ip"`
-	EnableEgressFirewall bool `gcfg:"enable-egress-firewall"`
-	EnableEgressQoS      bool `gcfg:"enable-egress-qos"`
+	// EgressIP feature is enabled
+	EnableEgressIP bool `gcfg:"enable-egress-ip"`
+	// EgressIP node reachability total timeout in seconds
+	EgressIPReachabiltyTotalTimeout int  `gcfg:"egressip-reachability-total-timeout"`
+	EnableEgressFirewall            bool `gcfg:"enable-egress-firewall"`
+	EnableEgressQoS                 bool `gcfg:"enable-egress-qos"`
 }
 
 // GatewayMode holds the node gateway mode
@@ -846,6 +851,12 @@ var OVNK8sFeatureFlags = []cli.Flag{
 		Usage:       "Configure to use EgressIP CRD feature with ovn-kubernetes.",
 		Destination: &cliConfig.OVNKubernetesFeature.EnableEgressIP,
 		Value:       OVNKubernetesFeature.EnableEgressIP,
+	},
+	&cli.IntFlag{
+		Name:        "egressip-reachability-total-timeout",
+		Usage:       "EgressIP node reachability total timeout in seconds (default: 1)",
+		Destination: &cliConfig.OVNKubernetesFeature.EgressIPReachabiltyTotalTimeout,
+		Value:       1,
 	},
 	&cli.BoolFlag{
 		Name:        "enable-egress-firewall",

--- a/go-controller/pkg/config/config_test.go
+++ b/go-controller/pkg/config/config_test.go
@@ -206,6 +206,9 @@ cluster-subnets=11.132.0.0/14/23
 
 [ovnkubenode]
 mode=full
+
+[ovnkubernetesfeature]
+egressip-reachability-total-timeout=3
 `
 
 	var newData string
@@ -292,6 +295,7 @@ var _ = Describe("Config Operations", func() {
 			gomega.Expect(OvnKubeNode.Mode).To(gomega.Equal(types.NodeModeFull))
 			gomega.Expect(OvnKubeNode.MgmtPortNetdev).To(gomega.Equal(""))
 			gomega.Expect(Gateway.RouterSubnet).To(gomega.Equal(""))
+			gomega.Expect(OVNKubernetesFeature.EgressIPReachabiltyTotalTimeout).To(gomega.Equal(1))
 
 			for _, a := range []OvnAuthConfig{OvnNorth, OvnSouth} {
 				gomega.Expect(a.Scheme).To(gomega.Equal(OvnDBSchemeUnix))
@@ -594,6 +598,7 @@ var _ = Describe("Config Operations", func() {
 			gomega.Expect(Gateway.RouterSubnet).To(gomega.Equal("10.50.0.0/16"))
 
 			gomega.Expect(HybridOverlay.Enabled).To(gomega.BeTrue())
+			gomega.Expect(OVNKubernetesFeature.EgressIPReachabiltyTotalTimeout).To(gomega.Equal(3))
 			gomega.Expect(HybridOverlay.ClusterSubnets).To(gomega.Equal([]CIDRNetworkEntry{
 				{ovntest.MustParseIPNet("11.132.0.0/14"), 23},
 			}))
@@ -673,6 +678,7 @@ var _ = Describe("Config Operations", func() {
 			gomega.Expect(Gateway.RouterSubnet).To(gomega.Equal("10.55.0.0/16"))
 
 			gomega.Expect(HybridOverlay.Enabled).To(gomega.BeTrue())
+			gomega.Expect(OVNKubernetesFeature.EgressIPReachabiltyTotalTimeout).To(gomega.Equal(5))
 			gomega.Expect(HybridOverlay.ClusterSubnets).To(gomega.Equal([]CIDRNetworkEntry{
 				{ovntest.MustParseIPNet("11.132.0.0/14"), 23},
 			}))
@@ -727,6 +733,7 @@ var _ = Describe("Config Operations", func() {
 			"-metrics-enable-pprof=false",
 			"-ofctrl-wait-before-clear=5000",
 			"-metrics-enable-config-duration=true",
+			"-egressip-reachability-total-timeout=5",
 		}
 		err = app.Run(cliArgs)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -1062,7 +1069,7 @@ enable-pprof=true
 			gomega.Expect(OvnSouth.Address).To(
 				gomega.Equal("ssl:6.5.4.1:6652,ssl:6.5.4.2:6652,ssl:6.5.4.3:6652"))
 			gomega.Expect(OvnSouth.CertCommonName).To(gomega.Equal("testsbcommonname"))
-
+			gomega.Expect(OVNKubernetesFeature.EgressIPReachabiltyTotalTimeout).To(gomega.Equal(3))
 			return nil
 		}
 		cliArgs := []string{
@@ -1098,6 +1105,7 @@ enable-pprof=true
 			"-sb-client-cert=/client/cert2",
 			"-sb-client-cacert=/client/cacert2",
 			"-sb-cert-common-name=testsbcommonname",
+			"-egressip-reachability-total-timeout=3",
 		}
 		err = app.Run(cliArgs)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())

--- a/go-controller/pkg/ovn/egressip_test.go
+++ b/go-controller/pkg/ovn/egressip_test.go
@@ -24,7 +24,7 @@ import (
 
 type fakeEgressIPDialer struct{}
 
-func (f fakeEgressIPDialer) dial(ip net.IP) bool {
+func (f fakeEgressIPDialer) dial(ip net.IP, timeout time.Duration) bool {
 	return true
 }
 

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -300,6 +300,7 @@ func NewOvnController(ovnClient *util.OVNClientset, wf *factory.WatchFactory, st
 			allocator:                         allocator{&sync.Mutex{}, make(map[string]*egressNode)},
 			nbClient:                          libovsdbOvnNBClient,
 			watchFactory:                      wf,
+			egressIPTotalTimeout:              config.OVNKubernetesFeature.EgressIPReachabiltyTotalTimeout,
 		},
 		loadbalancerClusterCache:  make(map[kapi.Protocol]string),
 		multicastSupport:          config.EnableMulticast,
@@ -396,6 +397,9 @@ func (oc *Controller) Run(ctx context.Context, wg *sync.WaitGroup) error {
 			if err := oc.WatchCloudPrivateIPConfig(); err != nil {
 				return err
 			}
+		}
+		if config.OVNKubernetesFeature.EgressIPReachabiltyTotalTimeout == 0 {
+			klog.V(2).Infof("EgressIP node reachability check disabled")
 		}
 	}
 


### PR DESCRIPTION
Users can change node's reachability total timeout from 1sec "default"
to different values using this new option.

Also it can be used to disable reachability check if users specify a value
of 0.

Signed-off-by: Mohamed Mahmoud <mmahmoud@redhat.com>
(cherry picked from commit 9e4358d1001febbaf440644484fd4335e0660911)

