### PR TITLE
[release-4.10] Bug 2099843: In tests, expect that unreferenced logical router policies will not be garbage collected

### DIFF
--- a/go-controller/pkg/ovn/egressip_test.go
+++ b/go-controller/pkg/ovn/egressip_test.go
@@ -4616,6 +4616,29 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						Action:   nbdb.LogicalRouterPolicyActionAllow,
 						UUID:     "no-reroute-service-UUID",
 					},
+					// FIXME(kyrtapz): This will never happen during real operations because OVS
+					//   DB server will GC unreferenced non-root items. However
+					//   until https://github.com/ovn-org/libovsdb/issues/219 is
+					//   done, libovsdb test server won't
+					&nbdb.LogicalRouterPolicy{
+						Priority: types.EgressIPReroutePriority,
+						Match:    fmt.Sprintf("ip4.src == %s", egressPod2.Status.PodIP),
+						Action:   nbdb.LogicalRouterPolicyActionReroute,
+						ExternalIDs: map[string]string{
+							"name": eIP.Name,
+						},
+						UUID: "reroute-UUID1",
+					},
+					&nbdb.LogicalRouterPolicy{
+						Priority: types.EgressIPReroutePriority,
+						Match:    fmt.Sprintf("ip4.src == %s", egressPod1.Status.PodIP),
+						Action:   nbdb.LogicalRouterPolicyActionReroute,
+						ExternalIDs: map[string]string{
+							"name": eIP.Name,
+						},
+						UUID: "reroute-UUID2",
+					},
+
 					&nbdb.NAT{
 						UUID:       "egressip-nat-UUID1",
 						LogicalIP:  podV4IP,


### PR DESCRIPTION
libovsdb server [does not remove unreferenced non-root objects](https://github.com/ovn-org/libovsdb/issues/219).
It is expected that the entries will be there in tests and this is not something that could happen in real world.

This workaround is not needed in 4.11 and newer since we are explicitly removing logical router policies without next hops:
https://github.com/openshift/ovn-kubernetes/blob/27d489760ff7e62f025d3aa7452f44b52066a279/go-controller/pkg/libovsdbops/router.go#L352-L359

Since it is not something that will happen in real world deployments I opted for the workaround instead of changing the removal logic at the risk of introducing a regression.

/cc @flavio-fernandes @trozet 