### PR TITLE
Patryk orphan removal

### DIFF
--- a/go-controller/pkg/ovn/egressip_test.go
+++ b/go-controller/pkg/ovn/egressip_test.go
@@ -4616,6 +4616,28 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						Action:   nbdb.LogicalRouterPolicyActionAllow,
 						UUID:     "no-reroute-service-UUID",
 					},
+					// This will never happen during real operations because OVS
+					// DB server will GC unreferenced non-root items. However
+					// until https://github.com/ovn-org/libovsdb/issues/219 is
+					// done, libovsdb test server won't
+					&nbdb.LogicalRouterPolicy{
+						Priority: types.EgressIPReroutePriority,
+						Match:    fmt.Sprintf("ip4.src == %s", egressPod2.Status.PodIP),
+						Action:   nbdb.LogicalRouterPolicyActionReroute,
+						ExternalIDs: map[string]string{
+							"name": eIP.Name,
+						},
+						UUID: "reroute-UUID1",
+					},
+					&nbdb.LogicalRouterPolicy{
+						Priority: types.EgressIPReroutePriority,
+						Match:    fmt.Sprintf("ip4.src == %s", egressPod1.Status.PodIP),
+						Action:   nbdb.LogicalRouterPolicyActionReroute,
+						ExternalIDs: map[string]string{
+							"name": eIP.Name,
+						},
+						UUID: "reroute-UUID2",
+					},
 					&nbdb.NAT{
 						UUID:       "egressip-nat-UUID1",
 						LogicalIP:  podV4IP,


### PR DESCRIPTION
WIP: Do not merge: egressip: explicitly remove logical router policy

This is a POC change, where egressip will explicitly remove the logical router policy
when logical router no longer uses it. Currently in 4.10, the implementation expects
ovsdb server to automatically garbage collect it, since that is a non-root table.

NOTE: This change will break unit tests, since libovsdb ovsdb server used does not have
garbage collection. See: https://github.com/ovn-org/libovsdb/issues/219
