### PR TITLE
incorrect last-policy check when network policy is deleted

### DIFF
--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -1191,10 +1191,15 @@ func (oc *Controller) deleteNetworkPolicy(policy *knet.NetworkPolicy, np *networ
 	defer nsUnlock()
 
 	// try to use the more official np found in nsInfo
-	if foundNp := nsInfo.networkPolicies[policy.Name]; foundNp != nil {
+	// also, if this is called during the process of the policy creation, the current network policy
+	// may not be added to nsInfo.networkPolicies yet.
+	expectedLastPolicyNum := 0
+	foundNp, ok := nsInfo.networkPolicies[policy.Name]
+	if ok {
+		expectedLastPolicyNum = 1
 		np = foundNp
 	}
-	isLastPolicyInNamespace := len(nsInfo.networkPolicies) == 1
+	isLastPolicyInNamespace := len(nsInfo.networkPolicies) == expectedLastPolicyNum
 	if err := oc.destroyNetworkPolicy(np, isLastPolicyInNamespace); err != nil {
 		return fmt.Errorf("failed to destroy network policy: %s/%s", policy.Namespace, policy.Name)
 	}


### PR DESCRIPTION
** Clean cherry-pick **

deleteNetworkPolicy() can be called when addNetworkPolicy() fails. In
that case, the policy is not yet added into the nsInfo.networkPolicies
map. The current isLastPolicyInNamespace check in deleteNetworkPolicy()
needs to be fixed in order to delete the default deny port group
correctly.

Signed-off-by: Yun Zhou <yunz@nvidia.com>
(cherry picked from commit d0b54f7a21edeb1948c8c3df774c6be4ceb3dccb)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->