### PR TITLE
Bug 2102241: Dockerfile: bump to ovn22.06-22.06.0-7.el8fdp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@
 # are built in this Dockerfile and included in the image (instead of the rpm)
 #
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.17-openshift-4.10 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.18-openshift-4.11 AS builder
 
 WORKDIR /go/src/github.com/openshift/ovn-kubernetes
 COPY . .
@@ -18,9 +18,9 @@ COPY . .
 RUN cd go-controller; CGO_ENABLED=0 make
 RUN cd go-controller; CGO_ENABLED=0 make windows
 
-FROM registry.ci.openshift.org/ocp/4.10:cli AS cli
+FROM registry.ci.openshift.org/ocp/4.11:cli AS cli
 
-FROM registry.ci.openshift.org/ocp/4.10:base
+FROM registry.ci.openshift.org/ocp/4.11:base
 
 USER root
 
@@ -33,7 +33,7 @@ RUN yum install -y  \
 	yum clean all
 
 ARG ovsver=2.17.0-22.el8fdp
-ARG ovnver=22.06.0-preview.branched.38.el8fdp
+ARG ovnver=22.06.0-7.el8fdp
 
 RUN INSTALL_PKGS=" \
 	openssl python3-pyOpenSSL firewalld-filesystem \


### PR DESCRIPTION
Upgrade to a final/released version of OVN 22.06 which includes
the following relevant fixes:

- [OVN HWOL] Avoid masked access to ct_label to allow offloading of ECMP symmetric reply and load balanced traffic
  https://bugzilla.redhat.com/show_bug.cgi?id=2097221
  Which is already in 22.06 but needs the following fixups:
  - controller: Use ct_mark by default for load balancer hairpin flows.
  - northd: Use ct_mark.blocked and ecmp_reply_port only when all chassis support it. (#2091565)
  - northd: ovn-controller: Use ct_mark.natted only when ct_lb_mark is used.
  - northd: Use ct_lb_mark only when all chassis support it. (#2091565)
- binding.c: Make sure that localport is removed from local datapath (#2076604)
- physical.c: Move localport remote output flow definition (#2076604)
- physical.c: Avoid NULL ptr deref in populate_remote_chassis_macs (#2082341)

Backport of https://github.com/openshift/ovn-kubernetes/pull/1170
(cherry picked from commit f87888c39632b4bf384a3e72c34089e67345f3b2)