### PR TITLE
[release-4.10] Bug 2104454: improve performance of service sync

### DIFF
--- a/go-controller/pkg/libovsdbops/loadbalancer.go
+++ b/go-controller/pkg/libovsdbops/loadbalancer.go
@@ -105,17 +105,6 @@ func createOrUpdateLoadBalancerOps(nbClient libovsdbclient.Client, ops []libovsd
 
 	// If LoadBalancer does not exist, create it
 	if err == libovsdbclient.ErrNotFound {
-		timeout := types.OVSDBWaitTimeout
-		ops = append(ops, libovsdb.Operation{
-			Op:      libovsdb.OperationWait,
-			Timeout: &timeout,
-			Table:   "Load_Balancer",
-			Where:   []libovsdb.Condition{{Column: "name", Function: libovsdb.ConditionEqual, Value: lb.Name}},
-			Columns: []string{"name"},
-			Until:   "!=",
-			Rows:    []libovsdb.Row{{"name": lb.Name}},
-		})
-
 		ensureLoadBalancerUUID(lb)
 		op, err := nbClient.Create(lb)
 		if err != nil {

--- a/go-controller/pkg/libovsdbops/loadbalancer.go
+++ b/go-controller/pkg/libovsdbops/loadbalancer.go
@@ -124,6 +124,27 @@ func createOrUpdateLoadBalancerOps(nbClient libovsdbclient.Client, ops []libovsd
 	return ops, nil
 }
 
+// CreateLoadBalancersOps creates the provided load balancers returning the
+// corresponding ops
+func CreateLoadBalancersOps(nbClient libovsdbclient.Client, ops []libovsdb.Operation, lbs ...*nbdb.LoadBalancer) ([]libovsdb.Operation, error) {
+	opModels := make([]OperationModel, 0, len(lbs))
+	for i := range lbs {
+		lb := lbs[i]
+		opModel := OperationModel{
+			Model:          lb,
+			OnModelUpdates: onModelUpdatesNone(),
+			ErrNotFound:    false,
+			BulkOp:         false,
+		}
+		opModels = append(opModels, opModel)
+	}
+
+	modelClient := NewModelClient(nbClient)
+	return modelClient.CreateOrUpdateOps(ops, opModels...)
+}
+
+// CreateOrUpdateLoadBalancersOps creates or updates the provided load balancers
+// returning the corresponding ops
 func CreateOrUpdateLoadBalancersOps(nbClient libovsdbclient.Client, ops []libovsdb.Operation, lbs ...*nbdb.LoadBalancer) ([]libovsdb.Operation, error) {
 	if ops == nil {
 		ops = []libovsdb.Operation{}

--- a/go-controller/pkg/libovsdbops/model.go
+++ b/go-controller/pkg/libovsdbops/model.go
@@ -4,9 +4,12 @@ import (
 	"fmt"
 	"reflect"
 
+	"github.com/ovn-org/libovsdb/client"
 	"github.com/ovn-org/libovsdb/model"
+	"github.com/ovn-org/libovsdb/ovsdb"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/sbdb"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 )
 
 func getUUID(model model.Model) string {
@@ -301,4 +304,42 @@ func onModels(models interface{}, do func(interface{}) error) error {
 		panic(fmt.Sprintf("Expected slice or struct but got %s", v.Kind()))
 	}
 	return nil
+}
+
+// buildFailOnDuplicateOps builds a wait operation on a condition that will fail
+// if a duplicate to the provided model is considered to be found. We use this
+// to avoid duplicates on certain unknown scenarios that are still to be tracked
+// down. See: https://bugzilla.redhat.com/show_bug.cgi?id=2042001.
+// When no specific operation is required for the provided model, returns an empty
+// array for convenience.
+func buildFailOnDuplicateOps(c client.Client, m model.Model) ([]ovsdb.Operation, error) {
+	// Right now we only consider models with a "Name" field that is not an
+	// index for which we don't expect duplicate names.
+	// A duplicate Name field that is an index will fail without the
+	// need of this wait operation.
+	// Models that require a complex condition to detect duplicates are not
+	// considered for the time being due to the performance hit (i.e ACLs).
+	var field interface{}
+	var value string
+	switch t := m.(type) {
+	case *nbdb.LoadBalancer:
+		field = &t.Name
+		value = t.Name
+	case *nbdb.LogicalRouter:
+		field = &t.Name
+		value = t.Name
+	case *nbdb.LogicalSwitch:
+		field = &t.Name
+		value = t.Name
+	default:
+		return []ovsdb.Operation{}, nil
+	}
+
+	timeout := types.OVSDBWaitTimeout
+	cond := model.Condition{
+		Field:    field,
+		Function: ovsdb.ConditionEqual,
+		Value:    value,
+	}
+	return c.Where(m, cond).Wait(ovsdb.WaitConditionNotEqual, &timeout, m, field)
 }

--- a/go-controller/pkg/libovsdbops/model_client.go
+++ b/go-controller/pkg/libovsdbops/model_client.go
@@ -113,12 +113,6 @@ type OperationModel struct {
 	// DoAfter is invoked at the end of the operation and allows to setup a
 	// subsequent operation with values obtained from this one.
 	DoAfter func()
-	// Name is used to signify if this model has a name being used. Typically
-	// corresponds to Name field used on ovsdb objects. Using a non-empty
-	// Name indicates that during a Create the model will have a predicate
-	// operation to ensure a duplicate txn will not occur. See:
-	// https://bugzilla.redhat.com/show_bug.cgi?id=2042001
-	Name string
 }
 
 // WithClient is useful for ad-hoc override of the targetted OVS DB. Can be used,
@@ -286,37 +280,18 @@ func (m *ModelClient) create(opModel *OperationModel) ([]ovsdb.Operation, error)
 	if uuid == "" {
 		setUUID(opModel.Model, BuildNamedUUID())
 	}
-	ops := make([]ovsdb.Operation, 0, 1)
-	o, err := m.client.Create(opModel.Model)
+
+	ops, err := buildFailOnDuplicateOps(m.client, opModel.Model)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create model, err: %v", err)
 	}
 
-	// Add wait methods accordingly
-	// ACL we would have to use external_ids + name for unique match
-	// However external_ids would be a performance hit, and in one case we use
-	// an empty name and external_ids for addAllowACLFromNode
-	if len(opModel.Name) > 0 && o[0].Table != "ACL" {
-		timeout := types.OVSDBWaitTimeout
-		ops = append(ops, ovsdb.Operation{
-			Op:      ovsdb.OperationWait,
-			Timeout: &timeout,
-			Table:   o[0].Table,
-			Where:   []ovsdb.Condition{{Column: "name", Function: ovsdb.ConditionEqual, Value: opModel.Name}},
-			Columns: []string{"name"},
-			Until:   "!=",
-			Rows:    []ovsdb.Row{{"name": opModel.Name}},
-		})
-	} else if info, err := m.client.Cache().DatabaseModel().NewModelInfo(opModel.Model); err == nil {
-		if name, err := info.FieldByColumn("name"); err == nil {
-			if len(fmt.Sprint(name)) > 0 {
-				klog.Warningf("OVSDB Create operation detected without setting opModel Name. Name: %s, %#v",
-					name, info)
-			}
-		}
+	op, err := m.client.Create(opModel.Model)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create model, err: %v", err)
 	}
+	ops = append(ops, op...)
 
-	ops = append(ops, o...)
 	klog.V(5).Infof("Create operations generated as: %+v", ops)
 	return ops, nil
 }

--- a/go-controller/pkg/libovsdbops/model_client.go
+++ b/go-controller/pkg/libovsdbops/model_client.go
@@ -157,6 +157,8 @@ func (m *ModelClient) CreateOrUpdateOps(ops []ovsdb.Operation, opModels ...Opera
 }
 
 func (m *ModelClient) createOrUpdateOps(ops []ovsdb.Operation, opModels ...OperationModel) (interface{}, []ovsdb.Operation, error) {
+	hasGuardOp := len(ops) > 0 && isGuardOp(&ops[0])
+	guardOp := []ovsdb.Operation{}
 	doWhenFound := func(model interface{}, opModel *OperationModel) ([]ovsdb.Operation, error) {
 		if opModel.OnModelUpdates != nil {
 			return m.update(model, opModel)
@@ -166,9 +168,25 @@ func (m *ModelClient) createOrUpdateOps(ops []ovsdb.Operation, opModels ...Opera
 		return nil, nil
 	}
 	doWhenNotFound := func(model interface{}, opModel *OperationModel) ([]ovsdb.Operation, error) {
+		if !hasGuardOp {
+			// for the first insert of certain models, build a wait operation
+			// that checks for duplicates as a guard op to prevent against
+			// duplicate transactions
+			var err error
+			guardOp, err = buildFailOnDuplicateOps(m.client, opModel.Model)
+			if err != nil {
+				return nil, err
+			}
+			hasGuardOp = len(guardOp) > 0
+		}
 		return m.create(opModel)
 	}
-	return m.buildOps(ops, doWhenFound, doWhenNotFound, opModels...)
+	created, ops, err := m.buildOps(ops, doWhenFound, doWhenNotFound, opModels...)
+	if len(guardOp) > 0 {
+		// set the guard op as the first of the list
+		ops = append(guardOp, ops...)
+	}
+	return created, ops, err
 }
 
 /*
@@ -281,16 +299,10 @@ func (m *ModelClient) create(opModel *OperationModel) ([]ovsdb.Operation, error)
 		setUUID(opModel.Model, BuildNamedUUID())
 	}
 
-	ops, err := buildFailOnDuplicateOps(m.client, opModel.Model)
+	ops, err := m.client.Create(opModel.Model)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create model, err: %v", err)
 	}
-
-	op, err := m.client.Create(opModel.Model)
-	if err != nil {
-		return nil, fmt.Errorf("unable to create model, err: %v", err)
-	}
-	ops = append(ops, op...)
 
 	klog.V(5).Infof("Create operations generated as: %+v", ops)
 	return ops, nil
@@ -377,4 +389,8 @@ func addToExistingResult(model interface{}, existingResult interface{}) {
 	resultPtr := reflect.ValueOf(existingResult)
 	resultVal := reflect.Indirect(resultPtr)
 	resultVal.Set(reflect.Append(resultVal, reflect.Indirect(reflect.ValueOf(model))))
+}
+
+func isGuardOp(op *ovsdb.Operation) bool {
+	return op != nil && op.Op == ovsdb.OperationWait && op.Timeout != nil && *op.Timeout == types.OVSDBWaitTimeout
 }

--- a/go-controller/pkg/libovsdbops/model_client.go
+++ b/go-controller/pkg/libovsdbops/model_client.go
@@ -122,6 +122,10 @@ func (m *ModelClient) WithClient(client client.Client) *ModelClient {
 	return &cl
 }
 
+func onModelUpdatesNone() []interface{} {
+	return nil
+}
+
 /*
  CreateOrUpdate performs idempotent operations against libovsdb according to the
  following logic:

--- a/go-controller/pkg/libovsdbops/model_client.go
+++ b/go-controller/pkg/libovsdbops/model_client.go
@@ -150,14 +150,19 @@ func (m *ModelClient) WithClient(client client.Client) *ModelClient {
  If BulkOp is set, update or mutate can happen accross multiple models found.
 */
 func (m *ModelClient) CreateOrUpdate(opModels ...OperationModel) ([]ovsdb.OperationResult, error) {
-	created, ops, err := m.CreateOrUpdateOps(opModels...)
+	created, ops, err := m.createOrUpdateOps(nil, opModels...)
 	if err != nil {
 		return nil, err
 	}
 	return TransactAndCheckAndSetUUIDs(m.client, created, ops)
 }
 
-func (m *ModelClient) CreateOrUpdateOps(opModels ...OperationModel) (interface{}, []ovsdb.Operation, error) {
+func (m *ModelClient) CreateOrUpdateOps(ops []ovsdb.Operation, opModels ...OperationModel) ([]ovsdb.Operation, error) {
+	_, ops, err := m.createOrUpdateOps(ops, opModels...)
+	return ops, err
+}
+
+func (m *ModelClient) createOrUpdateOps(ops []ovsdb.Operation, opModels ...OperationModel) (interface{}, []ovsdb.Operation, error) {
 	doWhenFound := func(model interface{}, opModel *OperationModel) ([]ovsdb.Operation, error) {
 		if opModel.OnModelUpdates != nil {
 			return m.update(model, opModel)
@@ -169,7 +174,7 @@ func (m *ModelClient) CreateOrUpdateOps(opModels ...OperationModel) (interface{}
 	doWhenNotFound := func(model interface{}, opModel *OperationModel) ([]ovsdb.Operation, error) {
 		return m.create(opModel)
 	}
-	return m.buildOps(doWhenFound, doWhenNotFound, opModels...)
+	return m.buildOps(ops, doWhenFound, doWhenNotFound, opModels...)
 }
 
 /*
@@ -188,7 +193,7 @@ func (m *ModelClient) CreateOrUpdateOps(opModels ...OperationModel) (interface{}
  If BulkOp is set, delete or mutate can happen accross multiple models found.
 */
 func (m *ModelClient) Delete(opModels ...OperationModel) error {
-	ops, err := m.DeleteOps(opModels...)
+	ops, err := m.DeleteOps(nil, opModels...)
 	if err != nil {
 		return err
 	}
@@ -196,7 +201,7 @@ func (m *ModelClient) Delete(opModels ...OperationModel) error {
 	return err
 }
 
-func (m *ModelClient) DeleteOps(opModels ...OperationModel) ([]ovsdb.Operation, error) {
+func (m *ModelClient) DeleteOps(ops []ovsdb.Operation, opModels ...OperationModel) ([]ovsdb.Operation, error) {
 	doWhenFound := func(model interface{}, opModel *OperationModel) (o []ovsdb.Operation, err error) {
 		if opModel.OnModelMutations != nil {
 			return m.mutate(model, opModel, ovsdb.MutateOperationDelete)
@@ -204,14 +209,16 @@ func (m *ModelClient) DeleteOps(opModels ...OperationModel) ([]ovsdb.Operation, 
 			return m.delete(model, opModel)
 		}
 	}
-	_, ops, err := m.buildOps(doWhenFound, nil, opModels...)
+	_, ops, err := m.buildOps(ops, doWhenFound, nil, opModels...)
 	return ops, err
 }
 
 type opModelToOpMapper func(model interface{}, opModel *OperationModel) (o []ovsdb.Operation, err error)
 
-func (m *ModelClient) buildOps(doWhenFound opModelToOpMapper, doWhenNotFound opModelToOpMapper, opModels ...OperationModel) (interface{}, []ovsdb.Operation, error) {
-	ops := []ovsdb.Operation{}
+func (m *ModelClient) buildOps(ops []ovsdb.Operation, doWhenFound opModelToOpMapper, doWhenNotFound opModelToOpMapper, opModels ...OperationModel) (interface{}, []ovsdb.Operation, error) {
+	if ops == nil {
+		ops = []ovsdb.Operation{}
+	}
 	notfound := []interface{}{}
 	for _, opModel := range opModels {
 		if opModel.ExistingResult == nil && opModel.Model != nil {

--- a/go-controller/pkg/libovsdbops/switch.go
+++ b/go-controller/pkg/libovsdbops/switch.go
@@ -304,15 +304,9 @@ func AddACLToNodeSwitch(nbClient libovsdbclient.Client, nodeName string, nodeACL
 		Name: nodeName,
 	}
 
-	aclName := ""
-	if nodeACL.Name != nil {
-		aclName = *nodeACL.Name
-	}
-
 	// Here we either need to create the ACL and add to the LS or simply add to the LS
 	opModels := []OperationModel{
 		{
-			Name:           aclName,
 			Model:          nodeACL,
 			ModelPredicate: func(acl *nbdb.ACL) bool { return IsEquivalentACL(acl, nodeACL) },
 			DoAfter: func() {
@@ -321,7 +315,6 @@ func AddACLToNodeSwitch(nbClient libovsdbclient.Client, nodeName string, nodeACL
 			},
 		},
 		{
-			Name:           nodeSwitch.Name,
 			Model:          &nodeSwitch,
 			ModelPredicate: func(ls *nbdb.LogicalSwitch) bool { return ls.Name == nodeName },
 			OnModelMutations: []interface{}{

--- a/go-controller/pkg/ovn/egressfirewall.go
+++ b/go-controller/pkg/ovn/egressfirewall.go
@@ -132,12 +132,7 @@ func (oc *Controller) syncEgressFirewallRetriable(egressFirewalls []interface{})
 		for i := range egressFirewallACLs {
 			egressFirewallACL := egressFirewallACLs[i]
 			egressFirewallACL.Direction = types.DirectionToLPort
-			aclName := ""
-			if egressFirewallACL.Name != nil {
-				aclName = *egressFirewallACL.Name
-			}
 			opModels = append(opModels, libovsdbops.OperationModel{
-				Name:  aclName,
 				Model: &egressFirewallACL,
 				OnModelUpdates: []interface{}{
 					&egressFirewallACL.Direction,
@@ -379,7 +374,6 @@ func (oc *Controller) createEgressFirewallRules(priority int, match, action, ext
 		switches = append(switches, &lsw)
 		opModels = append(opModels, []libovsdbops.OperationModel{
 			{
-				Name:           lsw.Name,
 				Model:          &lsw,
 				ModelPredicate: func(ls *nbdb.LogicalSwitch) bool { return ls.Name == lsn },
 				OnModelMutations: []interface{}{
@@ -391,14 +385,8 @@ func (oc *Controller) createEgressFirewallRules(priority int, match, action, ext
 		}...)
 	}
 
-	aclName := ""
-	if egressFirewallACL.Name != nil {
-		aclName = *egressFirewallACL.Name
-	}
-
 	opModels = append([]libovsdbops.OperationModel{
 		{
-			Name:           aclName,
 			Model:          egressFirewallACL,
 			ModelPredicate: func(acl *nbdb.ACL) bool { return libovsdbops.IsEquivalentACL(acl, egressFirewallACL) },
 			DoAfter: func() {

--- a/go-controller/pkg/ovn/egressgw.go
+++ b/go-controller/pkg/ovn/egressgw.go
@@ -295,7 +295,6 @@ func (oc *Controller) createBFDStaticRoute(bfdEnabled bool, gw net.IP, podIP, gr
 				}
 			},
 		}, {
-			Name:  logicalRouter.Name,
 			Model: &logicalRouter,
 			ModelPredicate: func(lr *nbdb.LogicalRouter) bool {
 				return lr.Name == gr
@@ -697,7 +696,6 @@ func (oc *Controller) addHybridRoutePolicyForPod(podIP net.IP, node string) erro
 				},
 			},
 			{
-				Name:           logicalRouter.Name,
 				Model:          &logicalRouter,
 				ModelPredicate: func(lr *nbdb.LogicalRouter) bool { return lr.Name == types.OVNClusterRouter },
 				OnModelMutations: []interface{}{

--- a/go-controller/pkg/ovn/egressip.go
+++ b/go-controller/pkg/ovn/egressip.go
@@ -1834,7 +1834,6 @@ func (e *egressIPController) createEgressReroutePolicy(filterOption, egressIPNam
 			},
 		},
 		{
-			Name:           logicalRouter.Name,
 			Model:          &logicalRouter,
 			ModelPredicate: func(lr *nbdb.LogicalRouter) bool { return lr.Name == types.OVNClusterRouter },
 			OnModelMutations: []interface{}{
@@ -2176,7 +2175,6 @@ func (oc *Controller) createLogicalRouterPolicy(match string, priority int) erro
 			},
 		},
 		{
-			Name:           logicalRouter.Name,
 			Model:          &logicalRouter,
 			ModelPredicate: func(lr *nbdb.LogicalRouter) bool { return lr.Name == types.OVNClusterRouter },
 			OnModelMutations: []interface{}{

--- a/go-controller/pkg/ovn/gateway_init.go
+++ b/go-controller/pkg/ovn/gateway_init.go
@@ -58,7 +58,6 @@ func (oc *Controller) gatewayInit(nodeName string, clusterIPSubnet []*net.IPNet,
 
 	opModels := []libovsdbops.OperationModel{
 		{
-			Name:           logicalRouter.Name,
 			Model:          &logicalRouter,
 			ModelPredicate: func(lr *nbdb.LogicalRouter) bool { return lr.Name == gatewayRouter },
 			OnModelUpdates: []interface{}{
@@ -118,7 +117,6 @@ func (oc *Controller) gatewayInit(nodeName string, clusterIPSubnet []*net.IPNet,
 			},
 		},
 		{
-			Name:           logicalSwitch.Name,
 			Model:          &logicalSwitch,
 			ModelPredicate: func(ls *nbdb.LogicalSwitch) bool { return ls.Name == types.OVNJoinSwitch },
 			OnModelMutations: []interface{}{
@@ -155,7 +153,6 @@ func (oc *Controller) gatewayInit(nodeName string, clusterIPSubnet []*net.IPNet,
 			},
 		},
 		{
-			Name:           logicalRouter.Name,
 			Model:          &logicalRouter,
 			ModelPredicate: func(lr *nbdb.LogicalRouter) bool { return lr.Name == gatewayRouter },
 			OnModelMutations: []interface{}{
@@ -207,7 +204,6 @@ func (oc *Controller) gatewayInit(nodeName string, clusterIPSubnet []*net.IPNet,
 				},
 			},
 			{
-				Name:           logicalRouter.Name,
 				Model:          &logicalRouter,
 				ModelPredicate: func(lr *nbdb.LogicalRouter) bool { return lr.Name == gatewayRouter },
 				OnModelMutations: []interface{}{
@@ -277,7 +273,6 @@ func (oc *Controller) gatewayInit(nodeName string, clusterIPSubnet []*net.IPNet,
 				},
 			},
 			{
-				Name:           logicalRouter.Name,
 				Model:          &logicalRouter,
 				ModelPredicate: func(lr *nbdb.LogicalRouter) bool { return lr.Name == gatewayRouter },
 				OnModelMutations: []interface{}{
@@ -319,7 +314,6 @@ func (oc *Controller) gatewayInit(nodeName string, clusterIPSubnet []*net.IPNet,
 				},
 			},
 			{
-				Name:           logicalRouter.Name,
 				Model:          &logicalRouter,
 				ModelPredicate: func(lr *nbdb.LogicalRouter) bool { return lr.Name == types.OVNClusterRouter },
 				OnModelMutations: []interface{}{
@@ -372,7 +366,6 @@ func (oc *Controller) gatewayInit(nodeName string, clusterIPSubnet []*net.IPNet,
 					},
 				},
 				{
-					Name:           logicalRouter.Name,
 					Model:          &logicalRouter,
 					ModelPredicate: func(lr *nbdb.LogicalRouter) bool { return lr.Name == types.OVNClusterRouter },
 					OnModelMutations: []interface{}{
@@ -493,7 +486,6 @@ func (oc *Controller) addExternalSwitch(prefix, interfaceID, nodeName, gatewayRo
 	}
 	opModels := []libovsdbops.OperationModel{
 		{
-			Name:           externalLogicalSwitch.Name,
 			Model:          &externalLogicalSwitch,
 			ModelPredicate: func(ls *nbdb.LogicalSwitch) bool { return ls.Name == externalSwitch },
 		},
@@ -532,7 +524,6 @@ func (oc *Controller) addExternalSwitch(prefix, interfaceID, nodeName, gatewayRo
 			},
 		},
 		{
-			Name:           externalLogicalSwitch.Name,
 			Model:          &externalLogicalSwitch,
 			ModelPredicate: func(ls *nbdb.LogicalSwitch) bool { return ls.Name == externalSwitch },
 			OnModelMutations: []interface{}{
@@ -576,7 +567,6 @@ func (oc *Controller) addExternalSwitch(prefix, interfaceID, nodeName, gatewayRo
 			},
 		},
 		{
-			Name:           logicalRouter.Name,
 			Model:          &logicalRouter,
 			ModelPredicate: func(lr *nbdb.LogicalRouter) bool { return lr.Name == gatewayRouter },
 			OnModelMutations: []interface{}{
@@ -613,7 +603,6 @@ func (oc *Controller) addExternalSwitch(prefix, interfaceID, nodeName, gatewayRo
 			},
 		},
 		{
-			Name:           externalLogicalSwitch.Name,
 			Model:          &externalLogicalSwitch,
 			ModelPredicate: func(ls *nbdb.LogicalSwitch) bool { return ls.Name == externalSwitch },
 			OnModelMutations: []interface{}{
@@ -782,7 +771,6 @@ func (oc *Controller) createPolicyBasedRoutes(match, priority, nexthops string) 
 			},
 		},
 		{
-			Name:           logicalRouter.Name,
 			Model:          &logicalRouter,
 			ModelPredicate: func(lr *nbdb.LogicalRouter) bool { return lr.Name == types.OVNClusterRouter },
 			OnModelMutations: []interface{}{

--- a/go-controller/pkg/ovn/loadbalancer/loadbalancer.go
+++ b/go-controller/pkg/ovn/loadbalancer/loadbalancer.go
@@ -51,6 +51,8 @@ func EnsureLBs(nbClient libovsdbclient.Client, externalIDs map[string]string, LB
 	}
 
 	lbs := make([]*nbdb.LoadBalancer, 0, len(LBs))
+	existinglbs := make([]*nbdb.LoadBalancer, 0, len(LBs))
+	newlbs := make([]*nbdb.LoadBalancer, 0, len(LBs))
 	addLBsToSwitch := map[string][]*nbdb.LoadBalancer{}
 	removeLBsFromSwitch := map[string][]*nbdb.LoadBalancer{}
 	addLBsToRouter := map[string][]*nbdb.LoadBalancer{}
@@ -67,10 +69,14 @@ func EnsureLBs(nbClient libovsdbclient.Client, externalIDs map[string]string, LB
 		existingSwitches := sets.String{}
 		existingGroups := sets.String{}
 		if existingLB != nil {
+			blb.UUID = existingLB.UUID
+			existinglbs = append(existinglbs, blb)
 			toDelete.Delete(existingLB.UUID)
 			existingRouters = existingLB.Routers
 			existingSwitches = existingLB.Switches
 			existingGroups = existingLB.Groups
+		} else {
+			newlbs = append(newlbs, blb)
 		}
 		wantRouters := sets.NewString(lb.Routers...)
 		wantSwitches := sets.NewString(lb.Switches...)
@@ -83,7 +89,12 @@ func EnsureLBs(nbClient libovsdbclient.Client, externalIDs map[string]string, LB
 		mapLBDifferenceByKey(removeLBsFromGroups, existingGroups, wantGroups, blb)
 	}
 
-	ops, err := libovsdbops.CreateOrUpdateLoadBalancersOps(nbClient, nil, lbs...)
+	ops, err := libovsdbops.CreateOrUpdateLoadBalancersOps(nbClient, nil, existinglbs...)
+	if err != nil {
+		return err
+	}
+
+	ops, err = libovsdbops.CreateLoadBalancersOps(nbClient, ops, newlbs...)
 	if err != nil {
 		return err
 	}

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -315,7 +315,6 @@ func (oc *Controller) StartClusterMaster(masterNodeName string) error {
 		// mention that field in OnModelUpdates or ModelPredicate.
 		opModels := []libovsdbops.OperationModel{
 			{
-				Name:  loadBalancerGroup.Name,
 				Model: &loadBalancerGroup,
 			},
 		}
@@ -368,7 +367,6 @@ func (oc *Controller) SetupMaster(masterNodeName string, existingNodeNames []str
 	}
 	opModels := []libovsdbops.OperationModel{
 		{
-			Name:           logicalRouter.Name,
 			Model:          &logicalRouter,
 			ModelPredicate: func(lr *nbdb.LogicalRouter) bool { return lr.Name == types.OVNClusterRouter },
 		},
@@ -431,7 +429,6 @@ func (oc *Controller) SetupMaster(masterNodeName string, existingNodeNames []str
 	}
 	opModels = []libovsdbops.OperationModel{
 		{
-			Name:           logicalSwitch.Name,
 			Model:          &logicalSwitch,
 			ModelPredicate: func(ls *nbdb.LogicalSwitch) bool { return ls.Name == types.OVNJoinSwitch },
 		},
@@ -481,7 +478,6 @@ func (oc *Controller) SetupMaster(masterNodeName string, existingNodeNames []str
 			},
 		},
 		{
-			Name:           logicalRouter.Name,
 			Model:          &logicalRouter,
 			ModelPredicate: func(lr *nbdb.LogicalRouter) bool { return lr.Name == types.OVNClusterRouter },
 			OnModelMutations: []interface{}{
@@ -511,7 +507,6 @@ func (oc *Controller) SetupMaster(masterNodeName string, existingNodeNames []str
 			},
 		},
 		{
-			Name:           logicalSwitch.Name,
 			Model:          &logicalSwitch,
 			ModelPredicate: func(ls *nbdb.LogicalSwitch) bool { return ls.Name == types.OVNJoinSwitch },
 			OnModelMutations: []interface{}{
@@ -546,7 +541,6 @@ func (oc *Controller) addNodeLogicalSwitchPort(logicalSwitchName, portName, port
 			},
 		},
 		{
-			Name:           logicalSwitch.Name,
 			Model:          &logicalSwitch,
 			ModelPredicate: func(ls *nbdb.LogicalSwitch) bool { return ls.Name == logicalSwitchName },
 			OnModelMutations: []interface{}{
@@ -614,7 +608,6 @@ func (oc *Controller) syncNodeManagementPort(node *kapi.Node, hostSubnets []*net
 					},
 				},
 				{
-					Name:           logicalRouter.Name,
 					Model:          &logicalRouter,
 					ModelPredicate: func(lr *nbdb.LogicalRouter) bool { return lr.Name == types.OVNClusterRouter },
 					OnModelMutations: []interface{}{
@@ -744,7 +737,6 @@ func (oc *Controller) syncNodeClusterRouterPort(node *kapi.Node, hostSubnets []*
 			},
 		},
 		{
-			Name:           logicalRouter.Name,
 			Model:          &logicalRouter,
 			ModelPredicate: func(lr *nbdb.LogicalRouter) bool { return lr.Name == types.OVNClusterRouter },
 			OnModelMutations: []interface{}{
@@ -768,7 +760,6 @@ func (oc *Controller) syncNodeClusterRouterPort(node *kapi.Node, hostSubnets []*
 
 	opModels = []libovsdbops.OperationModel{
 		{
-			Name:  gatewayChassis.Name,
 			Model: &gatewayChassis,
 			OnModelUpdates: []interface{}{
 				&gatewayChassis.ChassisName,
@@ -865,7 +856,6 @@ func (oc *Controller) ensureNodeLogicalNetwork(node *kapi.Node, hostSubnets []*n
 			},
 		},
 		{
-			Name:           logicalRouter.Name,
 			Model:          &logicalRouter,
 			ModelPredicate: func(lr *nbdb.LogicalRouter) bool { return lr.Name == types.OVNClusterRouter },
 			OnModelMutations: []interface{}{
@@ -874,7 +864,6 @@ func (oc *Controller) ensureNodeLogicalNetwork(node *kapi.Node, hostSubnets []*n
 			ErrNotFound: true,
 		},
 		{
-			Name:           logicalSwitch.Name,
 			Model:          &logicalSwitch,
 			ModelPredicate: func(ls *nbdb.LogicalSwitch) bool { return ls.Name == nodeName },
 			OnModelUpdates: []interface{}{
@@ -937,7 +926,6 @@ func (oc *Controller) ensureNodeLogicalNetwork(node *kapi.Node, hostSubnets []*n
 		// Create the Node's Logical Switch and set it's subnet
 		opModels = []libovsdbops.OperationModel{
 			{
-				Name:  logicalSwitch.Name,
 				Model: &logicalSwitch,
 				OnModelMutations: []interface{}{
 					&logicalSwitch.OtherConfig,

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -438,7 +438,6 @@ func (oc *Controller) Run(wg *sync.WaitGroup, nodeName string) error {
 		ExternalIDs: logicalRouterRes[0].ExternalIDs,
 	}
 	opModel := libovsdbops.OperationModel{
-		Name:           logicalRouter.Name,
 		Model:          &logicalRouter,
 		ModelPredicate: func(lr *nbdb.LogicalRouter) bool { return lr.Name == ovntypes.OVNClusterRouter },
 		OnModelUpdates: []interface{}{

--- a/go-controller/pkg/util/util.go
+++ b/go-controller/pkg/util/util.go
@@ -297,7 +297,6 @@ func UpdateNodeSwitchExcludeIPs(nbClient libovsdbclient.Client, nodeName string,
 
 	opModels := []libovsdbops.OperationModel{
 		{
-			Name:           logicalSwitchDes.Name,
 			Model:          &logicalSwitchDes,
 			ModelPredicate: func(ls *nbdb.LogicalSwitch) bool { return ls.Name == nodeName },
 			OnModelMutations: []interface{}{


### PR DESCRIPTION
This is a backport of #1110, containing:
* CARRY: cf3a846a3535fe85b6d6aae9d46fbd3d4a5a04d6 libovsdb: passthrough ops in ModelClient
* CARRY: 73e491c00f430d50a3418f44a825e0b26a7c723b libovsdb: refactor duplicate detection in modelClient
* 1aaad50f0cba45967444c88a623c5b97b926d60a libovsdbops: only one wait per txn
* 0573fe590a6f307200dc61a9cd0a6409db754c3d Don't lookup LBs that don't exist in cache

Conflicts:
* [go-controller/pkg/libovsdbops/loadbalancer.go](https://github.com/openshift/ovn-kubernetes/compare/release-4.10...jcaamano:ovn-kubernetes-downstream:release-4.10?expand=1#diff-685368ea628f10afd438349e793caa717e04ec15ae38a15ac0be406686f0ae5b)
* [go-controller/pkg/libovsdbops/model_client.go](https://github.com/openshift/ovn-kubernetes/compare/release-4.10...jcaamano:ovn-kubernetes-downstream:release-4.10?expand=1#diff-54373a7069b8883bb780babfb45422a0c8af7211107571b700db55cf17feb863)
* [go-controller/pkg/libovsdbops/model_client_test.go](https://github.com/openshift/ovn-kubernetes/compare/release-4.10...jcaamano:ovn-kubernetes-downstream:release-4.10?expand=1#diff-9b781bbfec7db0adeaf8d6f50acc9051b73d5abd88a8d500f91634116c67d07a)

