### PR TITLE
Add dockerfile for MicroShift

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,7 @@
 # This is the OpenShift ovn overlay network image.
 # it provides an overlay network using ovs/ovn/ovn-kube
 #
-# The standard name for this image is ovn-kube
-
-# Notes:
-# This is for a build where the ovn-kubernetes utilities
-# are built in this Dockerfile and included in the image (instead of the rpm)
-#
+# The standard name for this image is ovn-kubernetes
 
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.18-openshift-4.12 AS builder
 
@@ -20,20 +15,11 @@ RUN cd go-controller; CGO_ENABLED=0 make windows
 
 FROM registry.ci.openshift.org/ocp/4.12:cli AS cli
 
-FROM registry.ci.openshift.org/ocp/4.12:base
+FROM registry.ci.openshift.org/ocp/4.12:ovn-kubernetes-base
 
 USER root
 
 ENV PYTHONDONTWRITEBYTECODE yes
-
-# install needed rpms - openvswitch must be 2.10.4 or higher
-# install selinux-policy first to avoid a race
-RUN yum install -y  \
-	selinux-policy && \
-	yum clean all
-
-ARG ovsver=2.17.0-22.el8fdp
-ARG ovnver=22.06.0-7.el8fdp
 
 RUN INSTALL_PKGS=" \
 	openssl python3-pyOpenSSL firewalld-filesystem \
@@ -44,16 +30,11 @@ RUN INSTALL_PKGS=" \
 	ethtool conntrack-tools \
 	" && \
 	yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False $INSTALL_PKGS && \
+	export ovsver=$(cat /ovs-version) && \
+	export ovnver=$(cat /ovn-version) && \
 	yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False "openvswitch2.17 = $ovsver" "openvswitch2.17-devel = $ovsver" "python3-openvswitch2.17 = $ovsver" "openvswitch2.17-ipsec = $ovsver" && \
 	yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False "ovn22.06 = $ovnver" "ovn22.06-central = $ovnver" "ovn22.06-host = $ovnver" "ovn22.06-vtep = $ovnver" && \
 	yum clean all && rm -rf /var/cache/*
-
-RUN mkdir -p /var/run/openvswitch && \
-    mkdir -p /var/run/ovn && \
-    mkdir -p /etc/cni/net.d && \
-    mkdir -p /opt/cni/bin && \
-    mkdir -p /usr/libexec/cni/ && \
-    mkdir -p /root/windows/
 
 COPY --from=builder /go/src/github.com/openshift/ovn-kubernetes/go-controller/_output/go/bin/ovnkube /usr/bin/
 COPY --from=builder /go/src/github.com/openshift/ovn-kubernetes/go-controller/_output/go/bin/ovn-kube-util /usr/bin/
@@ -66,29 +47,8 @@ COPY --from=cli /usr/bin/oc /usr/bin/
 RUN ln -s /usr/bin/oc /usr/bin/kubectl
 RUN stat /usr/bin/oc
 
-# copy git commit number into image
-COPY .git/HEAD /root/.git/HEAD
-COPY .git/refs/heads/ /root/.git/refs/heads/
-
-# ovnkube.sh is the entry point. This script examines environment
-# variables to direct operation and configure ovn
-COPY dist/images/ovnkube.sh /root/
-
-# iptables wrappers
-COPY ./dist/images/iptables-scripts/iptables /usr/sbin/
-COPY ./dist/images/iptables-scripts/iptables-save /usr/sbin/
-COPY ./dist/images/iptables-scripts/iptables-restore /usr/sbin/
-COPY ./dist/images/iptables-scripts/ip6tables /usr/sbin/
-COPY ./dist/images/iptables-scripts/ip6tables-save /usr/sbin/
-COPY ./dist/images/iptables-scripts/ip6tables-restore /usr/sbin/
-COPY ./dist/images/iptables-scripts/iptables /usr/sbin/
-
 LABEL io.k8s.display-name="ovn kubernetes" \
       io.k8s.description="This is a component of OpenShift Container Platform that provides an overlay network using ovn." \
       summary="This is a component of OpenShift Container Platform that provides an overlay network using ovn." \
       io.openshift.tags="openshift" \
       maintainer="Tim Rozet <trozet@redhat.com>"
-
-WORKDIR /root
-ENTRYPOINT /root/ovnkube.sh
-

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,0 +1,44 @@
+#
+# This is the OpenShift ovn overlay network image.
+# it provides an overlay network using ovs/ovn/ovn-kube
+#
+# The standard name for this image is ovn-kubernetes-base
+
+# build base image shared by both OpenShift and MicroShift
+FROM registry.ci.openshift.org/ocp/4.12:base
+
+# install selinux-policy first to avoid a race
+RUN yum install -y  \
+	selinux-policy && \
+	yum clean all
+
+ARG ovsver=2.17.0-22.el8fdp
+ARG ovnver=22.06.0-7.el8fdp
+RUN echo $ovsver > /ovs-version && echo $ovnver > /ovn-version
+
+RUN mkdir -p /var/run/openvswitch && \
+    mkdir -p /var/run/ovn && \
+    mkdir -p /etc/cni/net.d && \
+    mkdir -p /opt/cni/bin && \
+    mkdir -p /usr/libexec/cni/ && \
+    mkdir -p /root/windows/
+
+# copy git commit number into image
+COPY .git/HEAD /root/.git/HEAD
+COPY .git/refs/heads/ /root/.git/refs/heads/
+
+# ovnkube.sh is the entry point. This script examines environment
+# variables to direct operation and configure ovn
+COPY dist/images/ovnkube.sh /root/
+
+# iptables wrappers
+COPY ./dist/images/iptables-scripts/iptables /usr/sbin/
+COPY ./dist/images/iptables-scripts/iptables-save /usr/sbin/
+COPY ./dist/images/iptables-scripts/iptables-restore /usr/sbin/
+COPY ./dist/images/iptables-scripts/ip6tables /usr/sbin/
+COPY ./dist/images/iptables-scripts/ip6tables-save /usr/sbin/
+COPY ./dist/images/iptables-scripts/ip6tables-restore /usr/sbin/
+COPY ./dist/images/iptables-scripts/iptables /usr/sbin/
+
+WORKDIR /root
+ENTRYPOINT /root/ovnkube.sh

--- a/Dockerfile.microshift
+++ b/Dockerfile.microshift
@@ -1,0 +1,36 @@
+#
+# This is the MicroShift ovn overlay network image.
+# it provides an overlay network using ovs/ovn/ovn-kube
+#
+# The standard name for this image is ovn-kubernetes-singlenode
+#
+# ovn-kubernetes-singlenode is a simplified version of
+# ovn-kubernetes image built for MicroShift product.
+# Some rpm packages and ovn-kubernetes binaries are removed
+# from this image, for example:
+#
+# openvswitch-devel, openvswitch-ipsec, libpcap, iproute etc
+# ovn-kube-util, hybrid-overlay-node.exe, ovndbchecker and ovnkube-trace
+
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.18-openshift-4.12 AS builder
+
+WORKDIR /go/src/github.com/openshift/ovn-kubernetes
+COPY . .
+
+# build the binaries
+RUN cd go-controller; CGO_ENABLED=0 make
+
+FROM registry.ci.openshift.org/ocp/4.12:ovn-kubernetes-base
+
+USER root
+
+ENV PYTHONDONTWRITEBYTECODE yes
+
+RUN export ovsver=$(cat /ovs-version) && \
+	export ovnver=$(cat /ovn-version) && \
+	yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False "openvswitch2.17 = $ovsver" "python3-openvswitch2.17 = $ovsver" && \
+        yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False "ovn22.06 = $ovnver" "ovn22.06-central = $ovnver" "ovn22.06-host = $ovnver" && \
+        yum clean all && rm -rf /var/cache/*
+
+COPY --from=builder /go/src/github.com/openshift/ovn-kubernetes/go-controller/_output/go/bin/ovnkube /usr/bin/
+COPY --from=builder /go/src/github.com/openshift/ovn-kubernetes/go-controller/_output/go/bin/ovn-k8s-cni-overlay /usr/libexec/cni/


### PR DESCRIPTION
With this change, three images will be built from ovnkube repo:
1) ovn-kubernetes-base as base image from Dockerfile.base
2) ovn-kubernetes for OpenShift product built from Dockerfile
3) ovn-kubernetes-singlenode for MicroShift product built from
    Dockerfile.microshift
    
ovn-kubernetes-base image contains common artifacts and serves
as input parant image to OpenShift and MicroShift images.

Downstream only

Signed-off-by: Zenghui Shi <zshi@redhat.com>