### PR TITLE
Test: EgressIP: Merge ops into pendingCloudPrivateIPConfigsOps on add

### DIFF
--- a/go-controller/pkg/ovn/egressip.go
+++ b/go-controller/pkg/ovn/egressip.go
@@ -841,11 +841,18 @@ func (oc *Controller) executeCloudPrivateIPConfigOps(egressIPName string, ops ma
 				oc.recorder.Eventf(&eIPRef, kapi.EventTypeWarning, "CloudAssignmentFailed", "egress IP: %s for object EgressIP: %s could not be created, err: %v", egressIP, egressIPName, err)
 				return fmt.Errorf("cloud add request failed for CloudPrivateIPConfig: %s, err: %v", cloudPrivateIPConfigName, err)
 			}
-			// toDelete is non-empty, this indicates an DELETE for which
-			// the object **must** exist, if not: that's an error.
+			// toDelete is non-empty, this indicates a DELETE - if the object does not exist, log an Info message and continue with the next op.
+			// The reason for why we are not throwing an error here is that desired state (deleted) == isState (object not found).
+			// If for whatever reason we have a pending toDelete op for a deleted object, then this op should simply be silently ignored.
+			// Any other error, return an error to trigger a retry.
 		} else if op.toDelete != "" {
 			if err != nil {
-				return fmt.Errorf("cloud deletion request failed for CloudPrivateIPConfig: %s, could not get item, err: %v", cloudPrivateIPConfigName, err)
+				if apierrors.IsNotFound(err) {
+					klog.Infof("Cloud deletion request failed for CloudPrivateIPConfig: %s, item already deleted, err: %v", cloudPrivateIPConfigName, err)
+					continue
+				} else {
+					return fmt.Errorf("cloud deletion request failed for CloudPrivateIPConfig: %s, could not get item, err: %v", cloudPrivateIPConfigName, err)
+				}
 			}
 			if err := oc.kube.DeleteCloudPrivateIPConfig(cloudPrivateIPConfigName); err != nil {
 				eIPRef := kapi.ObjectReference{

--- a/go-controller/pkg/ovn/egressip.go
+++ b/go-controller/pkg/ovn/egressip.go
@@ -772,8 +772,18 @@ func (oc *Controller) executeCloudPrivateIPConfigChange(egressIPName string, toA
 			}
 		}
 	}
+	// Merge ops into the existing pendingCloudPrivateIPConfigsOps.
+	// This allows us to:
+	// a) execute only the new ops
+	// b) keep track of any pending changes
 	if len(ops) > 0 {
-		oc.eIPC.pendingCloudPrivateIPConfigsOps[egressIPName] = ops
+		if _, ok := oc.eIPC.pendingCloudPrivateIPConfigsOps[egressIPName]; !ok {
+			oc.eIPC.pendingCloudPrivateIPConfigsOps[egressIPName] = ops
+		} else {
+			for cloudPrivateIP, op := range ops {
+				oc.eIPC.pendingCloudPrivateIPConfigsOps[egressIPName][cloudPrivateIP] = op
+			}
+		}
 	}
 	return oc.executeCloudPrivateIPConfigOps(egressIPName, ops)
 }


### PR DESCRIPTION
Up until now, the Cloud Private IP Conf add operation unconditionally
overwrote the current entry in pendingCloudPrivateIPConfigsOps for
the egressIPName. This lead to race conditions when updating an
EgressIP's IP address to a different one. During such a simultaneous
CloudPrivateIP add and remove operation, the add could overwrite the
map entry before the remove had the time to remove its own op.
The delete operation would be rescheduled and log an error until the
reschedule was killed off.

To address this:
* Merge the add op into the existing map, using the
  same logic as for remove operations.
* Do not throw an error when the cache contains a delete operation
  for an IsNotFound API object. Instead, log an Info and go on with
  the business logic. The desired state is already == the current
  state, so there is no reason to throw an error and retry in such
  a scenario.

Signed-off-by: Andreas Karis <ak.karis@gmail.com>
Reported-at: https://bugzilla.redhat.com/show_bug.cgi?id=2105706
(cherry picked from commit 9f18735b995889c6ae908747fa09db315ba73735)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->