### PR TITLE
[release-4.8] Bug 2106089: Fix panics in DestroyNetworkPolicy if policy is nil

### DIFF
--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -1282,10 +1282,15 @@ func (oc *Controller) deleteNetworkPolicy(policy *knet.NetworkPolicy, np *networ
 	defer nsUnlock()
 
 	// try to use the more official np found in nsInfo
-	if foundNp := nsInfo.networkPolicies[policy.Name]; foundNp != nil {
+	// also, if this is called during the process of the policy creation, the current network policy
+	// may not be added to nsInfo.networkPolicies yet.
+	expectedLastPolicyNum := 0
+	foundNp, ok := nsInfo.networkPolicies[policy.Name]
+	if ok {
+		expectedLastPolicyNum = 1
 		np = foundNp
 	}
-	isLastPolicyInNamespace := len(nsInfo.networkPolicies) == 1
+	isLastPolicyInNamespace := len(nsInfo.networkPolicies) == expectedLastPolicyNum
 	if err := oc.destroyNetworkPolicy(np, isLastPolicyInNamespace); err != nil {
 		return fmt.Errorf("failed to destroy network policy: %s/%s", policy.Namespace, policy.Name)
 	}

--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -1315,12 +1315,20 @@ func (oc *Controller) destroyNetworkPolicy(np *networkPolicy, lastPolicy bool) e
 		return true
 	})
 
+	var err error
 	ingressPGName := defaultDenyPortGroup(np.namespace, ingressDefaultDenySuffix)
 	egressPGName := defaultDenyPortGroup(np.namespace, egressDefaultDenySuffix)
 
-	if err := oc.localPodDelDefaultDeny(np, ingressPGName, egressPGName, ports...); err != nil {
+	if err = oc.localPodDelDefaultDeny(np, ingressPGName, egressPGName, ports...); err != nil {
 		return err
 	}
+	defer func() {
+		// In case of error, undo localPodDelDefaultDeny() and restore lspIngressDenyCache/lspEgressDenyCache refcnt.
+		// Deletion will be retried.
+		if err != nil {
+			oc.localPodAddDefaultDeny(np.policy, ingressPGName, egressPGName, ports...)
+		}
+	}()
 
 	// we haven't deleted our np from the namespace yet so there should be 1 policy
 	// if there are no more policies left on the namespace
@@ -1338,7 +1346,7 @@ func (oc *Controller) destroyNetworkPolicy(np *networkPolicy, lastPolicy bool) e
 	}
 
 	// Delete the port group
-	err := deletePortGroup(oc.ovnNBClient, np.portGroupName)
+	err = deletePortGroup(oc.ovnNBClient, np.portGroupName)
 	if err != nil {
 		return fmt.Errorf("failed to make delete network policy port group ops, policy: %s/%s, group name: %s,"+
 			" error: %v", np.namespace, np.name, np.portGroupName, err)
@@ -1346,13 +1354,15 @@ func (oc *Controller) destroyNetworkPolicy(np *networkPolicy, lastPolicy bool) e
 
 	// Delete ingress/egress address sets
 	for _, policy := range np.ingressPolicies {
-		if err := policy.destroy(); err != nil {
+		err = policy.destroy()
+		if err != nil {
 			return fmt.Errorf("failed to delete network policy ingress address sets, policy: %s/%s, error: %v",
 				np.namespace, np.name, err)
 		}
 	}
 	for _, policy := range np.egressPolicies {
-		if err := policy.destroy(); err != nil {
+		err = policy.destroy()
+		if err != nil {
 			return fmt.Errorf("failed to delete network policy egress address sets, policy: %s/%s, error: %v",
 				np.namespace, np.name, err)
 		}


### PR DESCRIPTION
@trozet Good news, clean cherry-pick from the 4.9 one https://github.com/openshift/ovn-kubernetes/pull/1183 no conflicts.
/assign @trozet 