### PR TITLE
[release-4.8] Bug 2105655: egressIP: node retrieval failure is not respected, causes panic

### DIFF
--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -770,7 +770,7 @@ func (oc *Controller) WatchEgressNodes() {
 				oc.setNodeEgressReachable(node.Name, true)
 			}
 			if hasEgressLabel && isReachable && isReady {
-				if err := oc.addEgressNode(node); err != nil {
+				if err := oc.addEgressNode(node.Name); err != nil {
 					klog.Error(err)
 				}
 			}
@@ -791,7 +791,7 @@ func (oc *Controller) WatchEgressNodes() {
 			if oldHadEgressLabel && !newHasEgressLabel {
 				klog.Infof("Node: %s has been un-labelled, deleting it from egress assignment", newNode.Name)
 				oc.setNodeEgressAssignable(oldNode.Name, false)
-				if err := oc.deleteEgressNode(oldNode); err != nil {
+				if err := oc.deleteEgressNode(oldNode.Name); err != nil {
 					klog.Error(err)
 				}
 				return
@@ -805,7 +805,7 @@ func (oc *Controller) WatchEgressNodes() {
 				klog.Infof("Node: %s has been labelled, adding it for egress assignment", newNode.Name)
 				oc.setNodeEgressAssignable(newNode.Name, true)
 				if isNewReady && isNewReachable {
-					if err := oc.addEgressNode(newNode); err != nil {
+					if err := oc.addEgressNode(newNode.Name); err != nil {
 						klog.Error(err)
 					}
 				} else {
@@ -818,12 +818,12 @@ func (oc *Controller) WatchEgressNodes() {
 			}
 			if !isNewReady {
 				klog.Warningf("Node: %s is not ready, deleting it from egress assignment", newNode.Name)
-				if err := oc.deleteEgressNode(newNode); err != nil {
+				if err := oc.deleteEgressNode(newNode.Name); err != nil {
 					klog.Error(err)
 				}
 			} else if isNewReady && isNewReachable {
 				klog.Infof("Node: %s is ready and reachable, adding it for egress assignment", newNode.Name)
-				if err := oc.addEgressNode(newNode); err != nil {
+				if err := oc.addEgressNode(newNode.Name); err != nil {
 					klog.Error(err)
 				}
 			}
@@ -835,7 +835,7 @@ func (oc *Controller) WatchEgressNodes() {
 			}
 			nodeLabels := node.GetLabels()
 			if _, hasEgressLabel := nodeLabels[nodeEgressLabel]; hasEgressLabel {
-				if err := oc.deleteEgressNode(node); err != nil {
+				if err := oc.deleteEgressNode(node.Name); err != nil {
 					klog.Error(err)
 				}
 			}


### PR DESCRIPTION
Fixes panic seen during checkEgressNodesReachability
E0606 11:57:34.063567       1 egressip.go:2096] Node:
huirwang-0606c-m5w24-worker-2-dkjmc reachability changed, but could not
retrieve node from cache, err: node
"huirwang-0606c-m5w24-worker-2-dkjmc" not found
W0606 11:57:34.063658       1 egressip.go:1657] Unable to remove GARP
configuration on external logical switch port for egress node:
huirwang-0606c-m5w24-worker-2-dkjmc, err: object not found
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x176626d]

goroutine 487 [running]:
github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn.(*Controller).checkEgressNodesReachability(0xc000171c00)
	/home/surya/go/src/github.com/openshift/ovn-kubernetes/go-controller/pkg/ovn/egressip.go:2099
+0x3ed
created by
github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn.(*Controller).initClusterEgressPolicies
	/home/surya/go/src/github.com/openshift/ovn-kubernetes/go-controller/pkg/ovn/egressip.go:1772
+0xdb

The problem here is that the node retrieval fails since the node has
already been deleted, instead of respecting that failure we just
log the error saying node object not found and actually continue
to use that object further in the code which causes this panic.

Signed-off-by: Surya Seetharaman <suryaseetharaman.9@gmail.com>
(cherry picked from commit 36176e5fcc4fb36ce175a02770f84c4556c6ef76)
(cherry picked from commit f436d25441dfbbf6dbd08c4d9535032426be923f)

Conflicts:
go-controller/pkg/ovn/egressip.go
go-controller/pkg/ovn/obj_retry.go

Since https://github.com/ovn-org/ovn-kubernetes/pull/2965 (EIP retry)
is missing in 4.10 and below

(cherry picked from commit 011f274144610302ad48c39cb21824ded4f2a72a)

Conflicts:
go-controller/pkg/ovn/egressip.go

Conflict again on 4.9 because libovsdb changes are missing.

NO Conflicts on 4.8 from 4.9

(cherry picked from commit 636445e113c27b0d505bf45eb5961f01b7de278d)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->