### PR TITLE
Bug 2106298: populate sock address for ovndb connection in unix mode

### DIFF
--- a/go-controller/pkg/config/config_test.go
+++ b/go-controller/pkg/config/config_test.go
@@ -303,7 +303,7 @@ var _ = Describe("Config Operations", func() {
 				gomega.Expect(a.PrivKey).To(gomega.Equal(""))
 				gomega.Expect(a.Cert).To(gomega.Equal(""))
 				gomega.Expect(a.CACert).To(gomega.Equal(""))
-				gomega.Expect(a.Address).To(gomega.Equal(""))
+				gomega.Expect(a.Address).To(gomega.MatchRegexp("unix:/var/run/ovn/ovn[sn]b_db.sock"))
 				gomega.Expect(a.CertCommonName).To(gomega.Equal(""))
 			}
 			return nil
@@ -372,7 +372,7 @@ var _ = Describe("Config Operations", func() {
 			gomega.Expect(OvnSouth.PrivKey).To(gomega.Equal(""))
 			gomega.Expect(OvnSouth.Cert).To(gomega.Equal(""))
 			gomega.Expect(OvnSouth.CACert).To(gomega.Equal(""))
-			gomega.Expect(OvnSouth.Address).To(gomega.Equal(""))
+			gomega.Expect(OvnSouth.Address).To(gomega.Equal("unix:/var/run/ovn/ovnsb_db.sock"))
 			gomega.Expect(OvnSouth.CertCommonName).To(gomega.Equal(""))
 
 			return nil
@@ -447,7 +447,7 @@ var _ = Describe("Config Operations", func() {
 			gomega.Expect(OvnSouth.PrivKey).To(gomega.Equal(""))
 			gomega.Expect(OvnSouth.Cert).To(gomega.Equal(""))
 			gomega.Expect(OvnSouth.CACert).To(gomega.Equal(""))
-			gomega.Expect(OvnSouth.Address).To(gomega.Equal(""))
+			gomega.Expect(OvnSouth.Address).To(gomega.Equal("unix:/var/run/ovn/ovnsb_db.sock"))
 			gomega.Expect(OvnSouth.CertCommonName).To(gomega.Equal(""))
 
 			return nil


### PR DESCRIPTION
Auth scheme is retrieved from sock address in libovsdb.
Empty sock address results in "unknown network protocol"
error when connecting in unix mode.

Signed-off-by: Zenghui Shi <zshi@redhat.com>
(cherry picked from commit 876a864a7d17d182e9595bec643f135de579d4f7)
