### PR TITLE
Bug 2105444: ITP=local, host->svc case failure

### DIFF
--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -122,6 +122,10 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 			Cmd:    "ip -4 rule add fwmark 0x1745ec lookup 7 prio 30",
 			Output: "0",
 		})
+		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+			Cmd:    "sysctl -w net.ipv4.conf.ovn-k8s-mp0.rp_filter=2",
+			Output: "net.ipv4.conf.ovn-k8s-mp0.rp_filter = 2",
+		})
 		fexec.AddFakeCmdsNoOutputNoError([]string{
 			"ovs-ofctl -O OpenFlow13 --bundle replace-flows breth0 -",
 		})
@@ -707,6 +711,10 @@ func localGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 			Cmd:    "ip -4 rule add fwmark 0x1745ec lookup 7 prio 30",
 			Output: "0",
+		})
+		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+			Cmd:    "sysctl -w net.ipv4.conf.ovn-k8s-mp0.rp_filter=2",
+			Output: "net.ipv4.conf.ovn-k8s-mp0.rp_filter = 2",
 		})
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 			Cmd: "ovs-ofctl show breth0",

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -1281,6 +1281,17 @@ func initSvcViaMgmPortRoutingRules(hostSubnets []*net.IPNet) error {
 		}
 	}
 
+	// lastly update the reverse path filtering options for ovn-k8s-mp0 interface to avoid dropping return packets
+	// NOTE: v6 doesn't have rp_filter strict mode block
+	rpFilterLooseMode := "2"
+	// TODO: Convert testing framework to mock golang module utilities. Example:
+	// result, err := sysctl.Sysctl(fmt.Sprintf("net/ipv4/conf/%s/rp_filter", types.K8sMgmtIntfName), rpFilterLooseMode)
+	stdout, stderr, err := util.RunSysctl("-w", fmt.Sprintf("net.ipv4.conf.%s.rp_filter=%s", types.K8sMgmtIntfName, rpFilterLooseMode))
+	if err != nil || stdout != fmt.Sprintf("net.ipv4.conf.%s.rp_filter = %s", types.K8sMgmtIntfName, rpFilterLooseMode) {
+		return fmt.Errorf("could not set the correct rp_filter value for interface %s: stdout: %v, stderr: %v, err: %v",
+			types.K8sMgmtIntfName, stdout, stderr, err)
+	}
+
 	return nil
 }
 

--- a/go-controller/pkg/util/ovs.go
+++ b/go-controller/pkg/util/ovs.go
@@ -41,6 +41,7 @@ const (
 	powershellCommand  = "powershell"
 	netshCommand       = "netsh"
 	routeCommand       = "route"
+	sysctlCommand      = "sysctl"
 	osRelease          = "/etc/os-release"
 	rhel               = "RHEL"
 	ubuntu             = "Ubuntu"
@@ -168,6 +169,7 @@ type execHelper struct {
 	powershellPath  string
 	netshPath       string
 	routePath       string
+	sysctlPath      string
 }
 
 var runner *execHelper
@@ -291,6 +293,10 @@ func SetExecWithoutOVS(exec kexec.Interface) error {
 			return err
 		}
 		runner.arpingPath, err = exec.LookPath(arpingCommand)
+		if err != nil {
+			return err
+		}
+		runner.sysctlPath, err = exec.LookPath(sysctlCommand)
 		if err != nil {
 			return err
 		}
@@ -626,6 +632,12 @@ func RunIP(args ...string) (string, string, error) {
 // RunArping runs a command via the "arping" utility
 func RunArping(args ...string) (string, string, error) {
 	stdout, stderr, err := run(runner.arpingPath, args...)
+	return strings.TrimSpace(stdout.String()), stderr.String(), err
+}
+
+// RunSysctl runs a command via the procps "sysctl" utility
+func RunSysctl(args ...string) (string, string, error) {
+	stdout, stderr, err := run(runner.sysctlPath, args...)
 	return strings.TrimSpace(stdout.String()), stderr.String(), err
 }
 

--- a/go-controller/pkg/util/ovs_unit_test.go
+++ b/go-controller/pkg/util/ovs_unit_test.go
@@ -527,13 +527,13 @@ func TestSetExec(t *testing.T) {
 		{
 			desc:         "positive, test when 'runner' is nil",
 			expectedErr:  nil,
-			onRetArgs:    &ovntest.TestifyMockHelper{OnCallMethodName: "LookPath", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{"ip", nil, "arping", nil}, CallTimes: 10},
+			onRetArgs:    &ovntest.TestifyMockHelper{OnCallMethodName: "LookPath", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{"ip", nil, "arping", nil}, CallTimes: 11},
 			setRunnerNil: true,
 		},
 		{
 			desc:         "positive, test when 'runner' is not nil",
 			expectedErr:  nil,
-			onRetArgs:    &ovntest.TestifyMockHelper{OnCallMethodName: "LookPath", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{"", nil, "", nil}, CallTimes: 10},
+			onRetArgs:    &ovntest.TestifyMockHelper{OnCallMethodName: "LookPath", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{"", nil, "", nil}, CallTimes: 11},
 			setRunnerNil: false,
 		},
 	}
@@ -562,12 +562,22 @@ func TestSetExecWithoutOVS(t *testing.T) {
 		{
 			desc:        "positive, ip and arping path found",
 			expectedErr: nil,
-			onRetArgs:   &ovntest.TestifyMockHelper{OnCallMethodName: "LookPath", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{"ip", nil, "arping", nil}, CallTimes: 2},
+			onRetArgs:   &ovntest.TestifyMockHelper{OnCallMethodName: "LookPath", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{"ip", nil, "arping", nil}, CallTimes: 3},
+		},
+		{
+			desc:        "positive, sysctl path found",
+			expectedErr: nil,
+			onRetArgs:   &ovntest.TestifyMockHelper{OnCallMethodName: "LookPath", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{"sysctl", nil}, CallTimes: 3},
 		},
 		{
 			desc:        "negative, ip path not found",
 			expectedErr: fmt.Errorf(`exec: \"ip:\" executable file not found in $PATH`),
 			onRetArgs:   &ovntest.TestifyMockHelper{OnCallMethodName: "LookPath", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{"", fmt.Errorf(`exec: \"ip:\" executable file not found in $PATH`), "arping", nil}},
+		},
+		{
+			desc:        "negative, sysctl path not found",
+			expectedErr: fmt.Errorf(`exec: \"sysctl:\" executable file not found in $PATH`),
+			onRetArgs:   &ovntest.TestifyMockHelper{OnCallMethodName: "LookPath", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{"", fmt.Errorf(`exec: \"sysctl:\" executable file not found in $PATH`)}},
 		},
 	}
 
@@ -1540,6 +1550,41 @@ func TestRunIP(t *testing.T) {
 			ovntest.ProcessMockFn(&mockKexecIface.Mock, *tc.onRetArgsKexecIface)
 
 			_, _, e := RunIP()
+
+			assert.Equal(t, e, tc.expectedErr)
+			mockExecRunner.AssertExpectations(t)
+			mockKexecIface.AssertExpectations(t)
+		})
+	}
+}
+
+func TestRunSysctl(t *testing.T) {
+	mockKexecIface := new(mock_k8s_io_utils_exec.Interface)
+	mockExecRunner := new(mocks.ExecRunner)
+	mockCmd := new(mock_k8s_io_utils_exec.Cmd)
+	// below is defined in ovs.go
+	runCmdExecRunner = mockExecRunner
+	// note runner is defined in ovs.go file
+	runner = &execHelper{exec: mockKexecIface}
+	tests := []struct {
+		desc                    string
+		expectedErr             error
+		onRetArgsExecUtilsIface *ovntest.TestifyMockHelper
+		onRetArgsKexecIface     *ovntest.TestifyMockHelper
+	}{
+		{
+			desc:                    "positive: run sysctl",
+			expectedErr:             nil,
+			onRetArgsExecUtilsIface: &ovntest.TestifyMockHelper{OnCallMethodName: "RunCmd", OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string", "string", "string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("testblah")), bytes.NewBuffer([]byte("")), nil}},
+			onRetArgsKexecIface:     &ovntest.TestifyMockHelper{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
+		},
+	}
+	for i, tc := range tests {
+		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
+			ovntest.ProcessMockFn(&mockExecRunner.Mock, *tc.onRetArgsExecUtilsIface)
+			ovntest.ProcessMockFn(&mockKexecIface.Mock, *tc.onRetArgsKexecIface)
+
+			_, _, e := RunSysctl("-w", "net.ipv4.conf.eth0.rp_filter=2")
 
 			assert.Equal(t, e, tc.expectedErr)
 			mockExecRunner.AssertExpectations(t)


### PR DESCRIPTION
Cherry picked from https://github.com/openshift/ovn-kubernetes/pull/1210/commits/944b5c2f606b06c0a82624a9dea5a9fc4e7d4124 NOT CLEAN, conflict mentioned in commit message
```
net.ipv4.conf.all.rp_filter = 1
net.ipv4.conf.br-ex.rp_filter = 0
net.ipv4.conf.br-int.rp_filter = 0
net.ipv4.conf.c1798a1ec76c1f4.rp_filter = 0
net.ipv4.conf.d1517e738ed8391.rp_filter = 0
net.ipv4.conf.default.rp_filter = 0
net.ipv4.conf.ebc08262035b15d.rp_filter = 0
net.ipv4.conf.ens5.rp_filter = 0
net.ipv4.conf.fa15be590ac0579.rp_filter = 0
net.ipv4.conf.genev_sys_6081.rp_filter = 0
net.ipv4.conf.lo.rp_filter = 0
net.ipv4.conf.ovn-k8s-mp0.rp_filter = 2
net.ipv4.conf.ovs-system.rp_filter = 0

```
works!