### PR TITLE
[release-4.10] Bug 2107903: Append the SNAT rule in management chain

### DIFF
--- a/go-controller/pkg/node/management-port_linux.go
+++ b/go-controller/pkg/node/management-port_linux.go
@@ -231,7 +231,8 @@ func setupManagementPortIPFamilyConfig(mpcfg *managementPortConfig, cfg *managem
 	if exists, err = cfg.ipt.Exists("nat", iptableMgmPortChain, rule...); err == nil && !exists {
 		warnings = append(warnings, fmt.Sprintf("missing management port nat rule in chain %s, adding it",
 			iptableMgmPortChain))
-		err = cfg.ipt.Insert("nat", iptableMgmPortChain, 1, rule...)
+		// NOTE: SNAT to mp0 rule should be the last in the chain, so append it
+		err = cfg.ipt.Append("nat", iptableMgmPortChain, rule...)
 	}
 	if err != nil {
 		return warnings, fmt.Errorf("could not insert iptable rule %q for management port: %v",

--- a/go-controller/pkg/util/iptables.go
+++ b/go-controller/pkg/util/iptables.go
@@ -29,6 +29,8 @@ type IPTablesHelper interface {
 	Exists(string, string, ...string) (bool, error)
 	// Insert inserts a rule into the specified table/chain
 	Insert(string, string, int, ...string) error
+	// Append appends rulespec to specified table/chain
+	Append(string, string, ...string) error
 	// Delete removes rulespec in specified table/chain
 	Delete(string, string, ...string) error
 }
@@ -216,6 +218,21 @@ func (f *FakeIPTables) Insert(tableName, chainName string, pos int, rulespec ...
 		last := append([]string{rule}, chain[pos-1:]...)
 		(*table)[chainName] = append(chain[:pos-1], last...)
 	}
+	return nil
+}
+
+// Append appends rulespec to specified table/chain
+func (f *FakeIPTables) Append(tableName, chainName string, rulespec ...string) error {
+	table, err := f.getTable(tableName)
+	if err != nil {
+		return err
+	}
+	rule := strings.Join(rulespec, " ")
+	chain, err := table.getChain(chainName)
+	if err != nil {
+		return err
+	}
+	(*table)[chainName] = append(chain, rule)
 	return nil
 }
 


### PR DESCRIPTION
On startup we are flushing all the rules in ovnk
chains. The MGTM chain particularly gets flushed
from `createPlatformManagementPort` which calls
`tearDownManagementPortConfig` before `setupManagementPortConfig`
that readds these rules back. This PR doesn't
fix the flushing bug, but fixes the ovn-k8s-mp0 SNAT
rule to be always added last in the chain (append)
on startup. The other rules in the chain are inserted
or prepend-ed so we should be good.

Signed-off-by: Surya Seetharaman <suryaseetharaman.9@gmail.com>
(cherry picked from commit 023fb7aa0133695091c8703e2593bb2176759972)
(cherry picked from commit e394194fe70f013f8e7b77b205aef4b8137d5d7b)
(cherry picked from commit be27fa05cd4ddf5a4181add6de3e95487a85410c)

CLEAN PICK