### PR TITLE
Bug 2108317: two hybrid overlay fixes

### DIFF
--- a/go-controller/hybrid-overlay/pkg/controller/node_linux.go
+++ b/go-controller/hybrid-overlay/pkg/controller/node_linux.go
@@ -330,7 +330,7 @@ func (n *NodeController) hybridOverlayNodeUpdate(node *kapi.Node) error {
 			cookie, cidr.String(), hotypes.HybridOverlayVNI, nodeIP.String(), drMAC.String()))
 
 	flows = append(flows,
-		fmt.Sprintf("cookie=0x%s,table=0,priority=101,ip,nw_dst=%s,nw_src=%s"+
+		fmt.Sprintf("cookie=0x%s,table=0,priority=101,ip,nw_dst=%s,nw_src=%s,"+
 			"actions=load:%d->NXM_NX_TUN_ID[0..31],"+
 			"set_field:%s->nw_src,"+
 			"set_field:%s->tun_dst,"+
@@ -674,9 +674,9 @@ func (n *NodeController) syncFlows() {
 			flows = append(flows, entry.learnedFlow)
 		}
 	}
-	_, _, err = util.ReplaceOFFlows(extBridgeName, flows)
+	_, stderr, err = util.ReplaceOFFlows(extBridgeName, flows)
 	if err != nil {
-		klog.Errorf("Failed to add flows, error: %v, flows: %s", err, flows)
+		klog.Errorf("Failed to add flows, error: %v, stderr: %s, flows: %s", err, stderr, flows)
 		return
 	}
 

--- a/go-controller/hybrid-overlay/pkg/controller/node_linux.go
+++ b/go-controller/hybrid-overlay/pkg/controller/node_linux.go
@@ -354,16 +354,7 @@ func (n *NodeController) AddNode(node *kapi.Node) error {
 		hybridOverlayIfAddr := util.GetNodeHybridOverlayIfAddr(subnet)
 		n.drIP = hybridOverlayIfAddr.IP
 	}
-	localNode, err := n.nodeLister.Get(n.nodeName)
-	if err != nil {
-		return fmt.Errorf("failed to get local node: %v", err)
-	}
-	if n.gwLRPIP == nil {
-		n.gwLRPIP, err = util.ParseNodeGatewayRouterLRPAddr(localNode)
-		if err != nil {
-			return fmt.Errorf("invalid Gateway Router LRP IP: %v", err)
-		}
-	}
+
 	if node.Name == n.nodeName {
 		// Retry hybrid overlay initialization if the master was
 		// slow to add the hybrid overlay logical network elements
@@ -428,6 +419,13 @@ func getIPAsHexString(ip net.IP) string {
 func (n *NodeController) EnsureHybridOverlayBridge(node *kapi.Node) error {
 	if n.initialized {
 		return nil
+	}
+	if n.gwLRPIP == nil {
+		gwLRPIP, err := util.ParseNodeGatewayRouterLRPAddr(node)
+		if err != nil {
+			return fmt.Errorf("invalid Gateway Router LRP IP: %v", err)
+		}
+		n.gwLRPIP = gwLRPIP
 	}
 
 	subnet, err := getLocalNodeSubnet(n.nodeName)

--- a/go-controller/hybrid-overlay/pkg/controller/node_linux_test.go
+++ b/go-controller/hybrid-overlay/pkg/controller/node_linux_test.go
@@ -330,6 +330,7 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 
 			annotations := createNodeAnnotationsForSubnet(thisSubnet)
 			annotations[hotypes.HybridOverlayDRMAC] = thisDrMAC
+			annotations["k8s.ovn.org/node-gateway-router-lrp-ifaddr"] = "{\"ipv4\":\"100.64.0.3/16\"}"
 			node := createNode(thisNode, "linux", "10.0.0.1", annotations)
 			fakeClient := fake.NewSimpleClientset(&v1.NodeList{
 				Items: []v1.Node{*node},
@@ -377,6 +378,7 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 
 			annotations := createNodeAnnotationsForSubnet(thisSubnet)
 			annotations[hotypes.HybridOverlayDRMAC] = thisDrMAC
+			annotations["k8s.ovn.org/node-gateway-router-lrp-ifaddr"] = "{\"ipv4\":\"100.64.0.3/16\"}"
 			node := createNode(thisNode, "linux", "10.0.0.1", annotations)
 			testPod := createPod("test", "pod1", thisNode, pod1CIDR, pod1MAC)
 			fakeClient := fake.NewSimpleClientset(&v1.NodeList{


### PR DESCRIPTION
Cherry-pick of https://github.com/ovn-org/ovn-kubernetes/pull/3063 from upstream.

A missing comma before an "action=" meant that those OVS flows weren't getting added due to a parsing error.

Second, the `k8s.ovn.org/node-gateway-router-lrp-ifaddr` annotation added by https://github.com/ovn-org/ovn-kubernetes/pull/2862 was only evaluated on node add, but we can't always rely on that. It might be added slightly later in an Update event.