### PR TITLE
[release-4.7] Bug 2073350: Make sure reject ACL is looked up when it is not in cache

### DIFF
--- a/go-controller/pkg/ovn/loadbalancer.go
+++ b/go-controller/pkg/ovn/loadbalancer.go
@@ -290,10 +290,9 @@ func (ovn *Controller) createLoadBalancerRejectACL(lb, sourceIP string, sourcePo
 }
 
 func (ovn *Controller) deleteLoadBalancerRejectACL(lb, vip string) {
-	aclUUID, hasEndpoints := ovn.getServiceLBInfo(lb, vip)
-	if aclUUID == "" && !hasEndpoints {
-		// If no ACL and does not have endpoints, we can assume there is no valid entry in the cache here as
-		// this is an illegal state.
+	aclUUID, _ := ovn.getServiceLBInfo(lb, vip)
+	if aclUUID == "" {
+		// If no ACL in local map, make sure there's no ACL also in OVN.
 		// Determine and remove ACL by name.
 		ip, port, err := util.SplitHostPortInt32(vip)
 		if err != nil {
@@ -310,10 +309,6 @@ func (ovn *Controller) deleteLoadBalancerRejectACL(lb, vip string) {
 			klog.Infof("No reject ACL found in cache or in OVN to remove for load-balancer: %s, vip: %s", lb, vip)
 			return
 		}
-	} else if aclUUID == "" {
-		// Must have endpoints and no reject ACL to remove
-		klog.V(5).Infof("No reject ACL found to remove for load balancer: %s, vip: %s", lb, vip)
-		return
 	}
 	// check if the load balancer is on a GR, if so we need to get the join/external switches
 	gwRouterSwitch, err := ovn.getGRLogicalSwitchForLoadBalancer(lb)


### PR DESCRIPTION
The serviceLBMap cache stores, for each load balancer, a service VIP along with its endpoints and reject ACL (if any). The reject ACL is added to this cache:
1. if it was created in the current execution of ovnkube-master or
2. if it was created in a previous execution of ovnkube master and the service still needs a reject ACL (because it has no endpoints).

Now, if the reject ACL was created in the previous execution of ovnkube-master and after restart ovnkube-master first adds the backend pods for this service and only afterwards (re)creates the service along with its endpoints, **then the reject ACL will go unnoticed**. Endpoints will be added correctly, but traffic to this service will be dropped because of the reject ACL.

In order to fix this corner case, after adding endpoints, make sure to lookup reject ACLs in OVN every time the serviceLBMap cache contains no ACL name for any given (load_balancer, VIP) pair.

Signed-off-by: Riccardo Ravaioli <rravaiol@redhat.com>

Fixes #2073350