### PR TITLE
Introduce ovn-kubernetes-{base|singlenode} images

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,0 +1,44 @@
+#
+# This is the OpenShift ovn overlay network image.
+# it provides an overlay network using ovs/ovn/ovn-kube
+#
+# The standard name for this image is ovn-kubernetes-base
+
+# build base image shared by both OpenShift and MicroShift
+FROM registry.ci.openshift.org/ocp/4.12:base
+
+# install selinux-policy first to avoid a race
+RUN yum install -y  \
+	selinux-policy && \
+	yum clean all
+
+ARG ovsver=2.17.0-22.el8fdp
+ARG ovnver=22.06.0-7.el8fdp
+RUN echo $ovsver > /ovs-version && echo $ovnver > /ovn-version
+
+RUN mkdir -p /var/run/openvswitch && \
+    mkdir -p /var/run/ovn && \
+    mkdir -p /etc/cni/net.d && \
+    mkdir -p /opt/cni/bin && \
+    mkdir -p /usr/libexec/cni/ && \
+    mkdir -p /root/windows/
+
+# copy git commit number into image
+COPY .git/HEAD /root/.git/HEAD
+COPY .git/refs/heads/ /root/.git/refs/heads/
+
+# ovnkube.sh is the entry point. This script examines environment
+# variables to direct operation and configure ovn
+COPY dist/images/ovnkube.sh /root/
+
+# iptables wrappers
+COPY ./dist/images/iptables-scripts/iptables /usr/sbin/
+COPY ./dist/images/iptables-scripts/iptables-save /usr/sbin/
+COPY ./dist/images/iptables-scripts/iptables-restore /usr/sbin/
+COPY ./dist/images/iptables-scripts/ip6tables /usr/sbin/
+COPY ./dist/images/iptables-scripts/ip6tables-save /usr/sbin/
+COPY ./dist/images/iptables-scripts/ip6tables-restore /usr/sbin/
+COPY ./dist/images/iptables-scripts/iptables /usr/sbin/
+
+WORKDIR /root
+ENTRYPOINT /root/ovnkube.sh

--- a/Dockerfile.microshift
+++ b/Dockerfile.microshift
@@ -1,0 +1,36 @@
+#
+# This is the MicroShift ovn overlay network image.
+# it provides an overlay network using ovs/ovn/ovn-kube
+#
+# The standard name for this image is ovn-kubernetes-singlenode
+#
+# ovn-kubernetes-singlenode is a simplified version of
+# ovn-kubernetes image built for MicroShift product.
+# Some rpm packages and ovn-kubernetes binaries are removed
+# from this image, for example:
+#
+# openvswitch-devel, openvswitch-ipsec, libpcap, iproute etc
+# ovn-kube-util, hybrid-overlay-node.exe, ovndbchecker and ovnkube-trace
+
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.18-openshift-4.12 AS builder
+
+WORKDIR /go/src/github.com/openshift/ovn-kubernetes
+COPY . .
+
+# build the binaries
+RUN cd go-controller; CGO_ENABLED=0 make
+
+FROM registry.ci.openshift.org/ocp/4.12:ovn-kubernetes-base
+
+USER root
+
+ENV PYTHONDONTWRITEBYTECODE yes
+
+RUN export ovsver=$(cat /ovs-version) && \
+	export ovnver=$(cat /ovn-version) && \
+	yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False "openvswitch2.17 = $ovsver" "python3-openvswitch2.17 = $ovsver" && \
+        yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False "ovn22.06 = $ovnver" "ovn22.06-central = $ovnver" "ovn22.06-host = $ovnver" && \
+        yum clean all && rm -rf /var/cache/*
+
+COPY --from=builder /go/src/github.com/openshift/ovn-kubernetes/go-controller/_output/go/bin/ovnkube /usr/bin/
+COPY --from=builder /go/src/github.com/openshift/ovn-kubernetes/go-controller/_output/go/bin/ovn-k8s-cni-overlay /usr/libexec/cni/


### PR DESCRIPTION
ovn-kubernetes-base image is built from Dockerfile.base
ovn-kubernetes-singlenode image is built from Dockerfile.microshift
ovn-kubernetes-singlenode uses ovn-kubernetes-base as its base image.