### PR TITLE
[release-4.11] Bug 2112100: Forward routes for link-local addresses to vNIC in Windows

### DIFF
--- a/go-controller/hybrid-overlay/pkg/controller/node_windows.go
+++ b/go-controller/hybrid-overlay/pkg/controller/node_windows.go
@@ -141,6 +141,11 @@ func ensureBaseNetwork() error {
 	if err = DuplicatePersistentIPRoutes(); err != nil {
 		return fmt.Errorf("unable to refresh the persistent IP routes, error: %v", err)
 	}
+	// Duplicate link-local addresses to the newly created host vNIC
+	klog.Infof("Forwarding routes associated with link-local addresses in the physical interface to the vNIC")
+	if err = DuplicateLinkLocalIPRoutes(); err != nil {
+		return fmt.Errorf("unable to refresh the link-local IP routes, error: %v", err)
+	}
 
 	return nil
 }

--- a/go-controller/hybrid-overlay/pkg/controller/overlay_windows.go
+++ b/go-controller/hybrid-overlay/pkg/controller/overlay_windows.go
@@ -266,30 +266,53 @@ func EnsureExistingNetworkIsValid(networkName string, expectedAddressPrefix stri
 	return nil
 }
 
-func DuplicatePersistentIPRoutes() error {
+// duplicateIPv4Routes duplicates all the IPv4 network routes associated with the physical interface to the host vNIC,
+// where parameters policyStore and destinationPrefix are optional and could be used as filtering criteria.
+// Otherwise, all IPv4 routes will be forwarded from the physical interface to the host vNIC.
+func duplicateIPv4Routes(policyStore, destinationPrefix string) error {
 	shell, err := ps.New(&psBackend.Local{})
 	if err != nil {
 		return err
 	}
 	defer shell.Exit()
 
+	// build filter options for Get-NetRoute command. See https://docs.microsoft.com/en-us/powershell/module/nettcpip/get-netroute
+	var opts string
+	if policyStore != "" {
+		opts += fmt.Sprintf(" -PolicyStore %s", policyStore)
+	}
+	if destinationPrefix != "" {
+		opts += fmt.Sprintf(" -DestinationPrefix \"%s\"", destinationPrefix)
+	}
+
 	script := `
 	# Find physical adapters whose interfaces are bound to a vswitch (i.e. the MAC addresses match)
 	$boundAdapters = (Get-NetAdapter -Physical | where { (Get-NetAdapter -Name "*vEthernet*").MacAddress -eq $_.MacAddress })
 
-	# Forward all the persistent routes associated with the physical interface to the associated vNIC
+	# Forward all the matching routes associated with the physical interface to the associated vNIC
 	foreach ($boundAdapter in $boundAdapters) {
 		$associatedVNic = Get-NetAdapter -Name "*vEthernet*" | where { $_.MacAddress -eq $boundAdapter.MacAddress }
-		$routes = Get-NetRoute -PolicyStore PersistentStore -InterfaceIndex $boundAdapter.IfIndex -ErrorAction SilentlyContinue
+		$routes = Get-NetRoute` + opts + ` -AddressFamily IPv4 -InterfaceIndex $boundAdapter.IfIndex -ErrorAction SilentlyContinue
 		foreach ($route in $routes) {
-			netsh.exe int ipv4 add route interface=$($associatedVNic.ifIndex) prefix=$($route.DestinationPrefix) nexthop=$($route.NextHop) metric=$($route.RouteMetric) store=persistent
+			netsh.exe int ipv4 add route interface=$($associatedVNic.ifIndex) prefix=$($route.DestinationPrefix) nexthop=$($route.NextHop) metric=$($route.RouteMetric) store=$($route.PolicyStore)
 		}
 	}
 	`
 
 	if _, stderr, err := shell.Execute(script + "\r\n\r\n"); err != nil {
-		return fmt.Errorf("falied to refresh the network persistent routes, %v: %v", stderr, err)
+		return fmt.Errorf("falied to duplicate network routes to the associated vNIC, %v: %v", stderr, err)
 	}
 
 	return nil
+}
+
+func DuplicatePersistentIPRoutes() error {
+	return duplicateIPv4Routes("PersistentStore", "")
+}
+
+// DuplicateLinkLocalIPRoutes copies the routes for link-local addresses, that is 169.254.0.0/16 (169.254.0.0
+// through 169.254.255.255) for IPv4, that used to be on the physical network interface to the newly created host vNIC
+// See https://datatracker.ietf.org/doc/html/rfc3927
+func DuplicateLinkLocalIPRoutes() error {
+	return duplicateIPv4Routes("", "169.254.")
 }


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/ovn-org/ovn-kubernetes/pull/3074  from upstream. 


