### PR TITLE
[release-4.10] Bug 2111552: Remove conntrack entries after rules

### DIFF
--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -566,17 +566,17 @@ func (npw *nodePortWatcher) DeleteService(service *kapi.Service) {
 
 	klog.V(5).Infof("Deleting service %s in namespace %s", service.Name, service.Namespace)
 	name := ktypes.NamespacedName{Namespace: service.Namespace, Name: service.Name}
+	if svcConfig, exists := npw.getAndDeleteServiceInfo(name); exists {
+		delServiceRules(svcConfig.service, npw)
+	} else {
+		klog.Warningf("Deletion failed No service found in cache for endpoint %s in namespace %s", service.Name, service.Namespace)
+	}
 	// Remove all conntrack entries for the serviceVIPs of this service irrespective of protocol stack
 	// since service deletion is considered as unplugging the network cable and hence graceful termination
 	// is not guaranteed. See https://github.com/kubernetes/kubernetes/issues/108523#issuecomment-1074044415.
 	err := npw.deleteConntrackForService(service)
 	if err != nil {
 		klog.Errorf("Failed to delete conntrack entry for service %v: %v", name, err)
-	}
-	if svcConfig, exists := npw.getAndDeleteServiceInfo(name); exists {
-		delServiceRules(svcConfig.service, npw)
-	} else {
-		klog.Warningf("Deletion failed No service found in cache for endpoint %s in namespace %s", service.Name, service.Namespace)
 	}
 
 }


### PR DESCRIPTION
When service is deleted, we were removing the conntrack
entries before removing the flows/iptable rules. It's
safer to do the reverse so that in the nano second interim
the conntrack entries don't get recreated before the rules/flows
get deleted.

Signed-off-by: Surya Seetharaman <suryaseetharaman.9@gmail.com>
(cherry picked from commit 58b23eaf049e2e1b38dee8f29ee990a181dfa463)
(cherry picked from commit 525e7f14818e02a913426a1fcdcbec456d8caf75)

CLEAN PICK from https://github.com/openshift/ovn-kubernetes/pull/1218