### PR TITLE
[release-4.9] Bug 2090315: Remove conntrack entries after rules

### DIFF
--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -291,6 +291,9 @@ func (npw *nodePortWatcher) DeleteService(service *kapi.Service) {
 	if !util.ServiceTypeHasClusterIP(service) || !util.IsClusterIPSet(service) {
 		return
 	}
+	npw.updateServiceFlowCache(service, false)
+	npw.ofm.requestFlowSync()
+	delSharedGatewayIptRules(service)
 	// Remove all conntrack entries for the serviceVIPs of this service irrespective of protocol stack
 	// since service deletion is considered as unplugging the network cable and hence graceful termination
 	// is not guaranteed. See https://github.com/kubernetes/kubernetes/issues/108523#issuecomment-1074044415.
@@ -298,9 +301,6 @@ func (npw *nodePortWatcher) DeleteService(service *kapi.Service) {
 	if err != nil {
 		klog.Errorf("Failed to delete conntrack entry for service %v/%v: %v", service.Namespace, service.Name, err)
 	}
-	npw.updateServiceFlowCache(service, false)
-	npw.ofm.requestFlowSync()
-	delSharedGatewayIptRules(service)
 }
 
 func (npw *nodePortWatcher) SyncServices(services []interface{}) {


### PR DESCRIPTION
When service is deleted, we were removing the conntrack
entries before removing the flows/iptable rules. It's
safer to do the reverse so that in the nano second interim
the conntrack entries don't get recreated before the rules/flows
get deleted.

Signed-off-by: Surya Seetharaman <suryaseetharaman.9@gmail.com>
(cherry picked from commit 58b23ea)
(cherry picked from commit 525e7f1)
(cherry picked from commit bedef57)

Conflicts from 4.10 since ETP isn't present in 4.9

