### PR TITLE
Bug 2111619: Bump OVN to 22.06.0-27

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN yum install -y  \
 	yum clean all
 
 ARG ovsver=2.17.0-22.el8fdp
-ARG ovnver=22.06.0-preview.branched.38.el8fdp
+ARG ovnver=22.06.0-27.el8fdp
 
 RUN INSTALL_PKGS=" \
 	openssl python3-pyOpenSSL firewalld-filesystem \


### PR DESCRIPTION
Bump OVN to 22.06.0-27 to get https://patchwork.ozlabs.org/project/ovn/patch/20220727221505.1673659-1-hzhou@ovn.org/ in. This will fix https://bugzilla.redhat.com/show_bug.cgi?id=2112111