### PR TITLE
[release-4.11] Bug 2113860: reconcile-node-lbs

### DIFF
--- a/go-controller/pkg/ovn/controller/services/node_tracker.go
+++ b/go-controller/pkg/ovn/controller/services/node_tracker.go
@@ -112,7 +112,7 @@ func newNodeTracker(nodeInformer coreinformers.NodeInformer) *nodeTracker {
 					return
 				}
 			}
-			nt.removeNode(node.Name)
+			nt.removeNodeWithServiceReSync(node.Name)
 		},
 	})
 
@@ -147,6 +147,13 @@ func (nt *nodeTracker) updateNodeInfo(nodeName, switchName, routerName string, n
 
 	klog.Infof("Node %s switch + router changed, syncing services", nodeName)
 	// Resync all services
+	nt.resyncFn()
+}
+
+// removeNodeWithServiceReSync removes a node from the LB -> node mapper
+// *and* forces full reconciliation of services.
+func (nt *nodeTracker) removeNodeWithServiceReSync(nodeName string) {
+	nt.removeNode(nodeName)
 	nt.resyncFn()
 }
 

--- a/go-controller/pkg/ovn/controller/services/services_controller_test.go
+++ b/go-controller/pkg/ovn/controller/services/services_controller_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/onsi/gomega"
+	"github.com/onsi/gomega/format"
 	globalconfig "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
 	ovnlb "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/loadbalancer"
@@ -65,6 +66,12 @@ func (c *serviceController) close() {
 
 // TestSyncServices - an end-to-end test for the services controller.
 func TestSyncServices(t *testing.T) {
+	initialMaxLength := format.MaxLength
+	temporarilyEnableGomegaMaxLengthFormat()
+	t.Cleanup(func() {
+		restoreGomegaMaxLengthFormat(initialMaxLength)
+	})
+
 	ns := "testns"
 	serviceName := "foo"
 
@@ -627,4 +634,12 @@ func nodeConfig(nodeName string, nodeIP string) *nodeInfo {
 		gatewayRouterName: nodeGWRouterName(nodeName),
 		switchName:        nodeSwitchName(nodeName),
 	}
+}
+
+func temporarilyEnableGomegaMaxLengthFormat() {
+	format.MaxLength = 0
+}
+
+func restoreGomegaMaxLengthFormat(originalLength int) {
+	format.MaxLength = originalLength
 }

--- a/go-controller/pkg/ovn/controller/services/services_controller_test.go
+++ b/go-controller/pkg/ovn/controller/services/services_controller_test.go
@@ -84,15 +84,19 @@ func TestSyncServices(t *testing.T) {
 	outport := int32(3456)
 	tcp := v1.ProtocolTCP
 
+	const (
+		nodeA = "node-a"
+		nodeB = "node-b"
+	)
 	defaultNodes := map[string]nodeInfo{
-		"node-a": {
-			name:              "node-a",
+		nodeA: {
+			name:              nodeA,
 			nodeIPs:           []string{"10.0.0.1"},
 			gatewayRouterName: "gr-node-a",
 			switchName:        "switch-node-a",
 		},
-		"node-b": {
-			name:              "node-b",
+		nodeB: {
+			name:              nodeB,
 			nodeIPs:           []string{"10.0.0.2"},
 			gatewayRouterName: "gr-node-b",
 			switchName:        "switch-node-b",

--- a/go-controller/pkg/ovn/controller/services/services_controller_test.go
+++ b/go-controller/pkg/ovn/controller/services/services_controller_test.go
@@ -3,6 +3,7 @@ package services
 import (
 	"fmt"
 	"net"
+	"strings"
 	"testing"
 
 	"github.com/onsi/gomega"
@@ -85,31 +86,31 @@ func TestSyncServices(t *testing.T) {
 	tcp := v1.ProtocolTCP
 
 	const (
-		nodeA = "node-a"
-		nodeB = "node-b"
+		nodeA           = "node-a"
+		nodeB           = "node-b"
+		nodeAEndpointIP = "10.128.0.2"
+		nodeBEndpointIP = "10.128.1.2"
+		nodeAHostIP     = "10.0.0.1"
+		nodeBHostIP     = "10.0.0.2"
 	)
+	firstNode := nodeConfig(nodeA, nodeAHostIP)
+	secondNode := nodeConfig(nodeB, nodeBHostIP)
 	defaultNodes := map[string]nodeInfo{
-		nodeA: {
-			name:              nodeA,
-			nodeIPs:           []string{"10.0.0.1"},
-			gatewayRouterName: "gr-node-a",
-			switchName:        "switch-node-a",
-		},
-		nodeB: {
-			name:              nodeB,
-			nodeIPs:           []string{"10.0.0.2"},
-			gatewayRouterName: "gr-node-b",
-			switchName:        "switch-node-b",
-		},
+		nodeA: *firstNode,
+		nodeB: *secondNode,
 	}
 
+	const nodePort = 8989
+
 	tests := []struct {
-		name        string
-		slice       *discovery.EndpointSlice
-		service     *v1.Service
-		initialDb   []libovsdbtest.TestData
-		expectedDb  []libovsdbtest.TestData
-		gatewayMode string
+		name                 string
+		slice                *discovery.EndpointSlice
+		service              *v1.Service
+		initialDb            []libovsdbtest.TestData
+		expectedDb           []libovsdbtest.TestData
+		gatewayMode          string
+		nodeToDelete         *nodeInfo
+		dbStateAfterDeleting []libovsdbtest.TestData
 	}{
 
 		{
@@ -331,7 +332,7 @@ func TestSyncServices(t *testing.T) {
 						Port:       80,
 						Protocol:   v1.ProtocolTCP,
 						TargetPort: intstr.FromInt(3456),
-						NodePort:   8989,
+						NodePort:   nodePort,
 					}},
 				},
 			},
@@ -362,40 +363,8 @@ func TestSyncServices(t *testing.T) {
 					},
 					ExternalIDs: serviceExternalIDs(namespacedServiceName(ns, serviceName)),
 				},
-				&nbdb.LoadBalancer{
-					UUID: nodeSwitchRouterLoadBalancerName(nodeA, ns, serviceName),
-					Name: nodeSwitchRouterLoadBalancerName(nodeA, ns, serviceName),
-					Options: map[string]string{
-						"event":     "false",
-						"reject":    "true",
-						"skip_snat": "false",
-					},
-					Protocol: &nbdb.LoadBalancerProtocolTCP,
-					Vips: map[string]string{
-						"10.0.0.1:8989": "10.128.0.2:3456,10.128.1.2:3456",
-					},
-					ExternalIDs: map[string]string{
-						"k8s.ovn.org/kind":  "Service",
-						"k8s.ovn.org/owner": "testns/foo",
-					},
-				},
-				&nbdb.LoadBalancer{
-					UUID: nodeSwitchRouterLoadBalancerName(nodeB, ns, serviceName),
-					Name: nodeSwitchRouterLoadBalancerName(nodeB, ns, serviceName),
-					Options: map[string]string{
-						"event":     "false",
-						"reject":    "true",
-						"skip_snat": "false",
-					},
-					Protocol: &nbdb.LoadBalancerProtocolTCP,
-					Vips: map[string]string{
-						"10.0.0.2:8989": "10.128.0.2:3456,10.128.1.2:3456",
-					},
-					ExternalIDs: map[string]string{
-						"k8s.ovn.org/kind":  "Service",
-						"k8s.ovn.org/owner": "testns/foo",
-					},
-				},
+				nodeRouterLoadBalancer(firstNode, nodePort, serviceName, ns, outport, nodeAEndpointIP, nodeBEndpointIP),
+				nodeRouterLoadBalancer(secondNode, nodePort, serviceName, ns, outport, nodeAEndpointIP, nodeBEndpointIP),
 				nodeLogicalSwitch(nodeA,
 					loadBalancerClusterWideTCPServiceName(ns, serviceName),
 					nodeSwitchRouterLoadBalancerName(nodeA, ns, serviceName)),
@@ -405,6 +374,115 @@ func TestSyncServices(t *testing.T) {
 				nodeLogicalRouter(nodeA,
 					loadBalancerClusterWideTCPServiceName(ns, serviceName),
 					nodeSwitchRouterLoadBalancerName(nodeA, ns, serviceName)),
+				nodeLogicalRouter(nodeB,
+					loadBalancerClusterWideTCPServiceName(ns, serviceName),
+					nodeSwitchRouterLoadBalancerName(nodeB, ns, serviceName)),
+			},
+		},
+		{
+			name: "deleting a node should not leave stale load balancers",
+			slice: &discovery.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      serviceName + "ab1",
+					Namespace: ns,
+					Labels:    map[string]string{discovery.LabelServiceName: serviceName},
+				},
+				Ports: []discovery.EndpointPort{
+					{
+						Protocol: &tcp,
+						Port:     &outport,
+					},
+				},
+				AddressType: discovery.AddressTypeIPv4,
+				Endpoints: []discovery.Endpoint{
+					{
+						Conditions: discovery.EndpointConditions{
+							Ready: utilpointer.BoolPtr(true),
+						},
+						Addresses: []string{"10.128.0.2", "10.128.1.2"},
+					},
+				},
+			},
+			service: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: ns},
+				Spec: v1.ServiceSpec{
+					Type:       v1.ServiceTypeClusterIP,
+					ClusterIP:  "192.168.1.1",
+					ClusterIPs: []string{"192.168.1.1"},
+					Selector:   map[string]string{"foo": "bar"},
+					Ports: []v1.ServicePort{{
+						Port:       80,
+						Protocol:   v1.ProtocolTCP,
+						TargetPort: intstr.FromInt(3456),
+						NodePort:   nodePort,
+					}},
+				},
+			},
+			initialDb: []libovsdbtest.TestData{
+				&nbdb.LoadBalancer{
+					UUID:     loadBalancerClusterWideTCPServiceName(ns, serviceName),
+					Name:     loadBalancerClusterWideTCPServiceName(ns, serviceName),
+					Options:  servicesOptions(),
+					Protocol: &nbdb.LoadBalancerProtocolTCP,
+					Vips: map[string]string{
+						"192.168.0.1:6443": "",
+					},
+					ExternalIDs: serviceExternalIDs(namespacedServiceName(ns, serviceName)),
+				},
+				nodeLogicalSwitch(nodeA,
+					loadBalancerClusterWideTCPServiceName(ns, serviceName)),
+				nodeLogicalSwitch(nodeB,
+					loadBalancerClusterWideTCPServiceName(ns, serviceName)),
+				nodeLogicalRouter(nodeA,
+					loadBalancerClusterWideTCPServiceName(ns, serviceName)),
+				nodeLogicalRouter(nodeB,
+					loadBalancerClusterWideTCPServiceName(ns, serviceName)),
+			},
+			expectedDb: []libovsdbtest.TestData{
+				&nbdb.LoadBalancer{
+					UUID:     loadBalancerClusterWideTCPServiceName(ns, serviceName),
+					Name:     loadBalancerClusterWideTCPServiceName(ns, serviceName),
+					Options:  servicesOptions(),
+					Protocol: &nbdb.LoadBalancerProtocolTCP,
+					Vips: map[string]string{
+						"192.168.1.1:80": "10.128.0.2:3456,10.128.1.2:3456",
+					},
+					ExternalIDs: serviceExternalIDs(namespacedServiceName(ns, serviceName)),
+				},
+				nodeRouterLoadBalancer(firstNode, nodePort, serviceName, ns, outport, nodeAEndpointIP, nodeBEndpointIP),
+				nodeRouterLoadBalancer(secondNode, nodePort, serviceName, ns, outport, nodeAEndpointIP, nodeBEndpointIP),
+				nodeLogicalSwitch(nodeA,
+					loadBalancerClusterWideTCPServiceName(ns, serviceName),
+					nodeSwitchRouterLoadBalancerName(nodeA, ns, serviceName)),
+				nodeLogicalSwitch(nodeB,
+					loadBalancerClusterWideTCPServiceName(ns, serviceName),
+					nodeSwitchRouterLoadBalancerName(nodeB, ns, serviceName)),
+				nodeLogicalRouter(nodeA,
+					loadBalancerClusterWideTCPServiceName(ns, serviceName),
+					nodeSwitchRouterLoadBalancerName(nodeA, ns, serviceName)),
+				nodeLogicalRouter(nodeB,
+					loadBalancerClusterWideTCPServiceName(ns, serviceName),
+					nodeSwitchRouterLoadBalancerName(nodeB, ns, serviceName)),
+			},
+			nodeToDelete: nodeConfig(nodeA, nodeAHostIP),
+			dbStateAfterDeleting: []libovsdbtest.TestData{&nbdb.LoadBalancer{
+				UUID:     loadBalancerClusterWideTCPServiceName(ns, serviceName),
+				Name:     loadBalancerClusterWideTCPServiceName(ns, serviceName),
+				Options:  servicesOptions(),
+				Protocol: &nbdb.LoadBalancerProtocolTCP,
+				Vips: map[string]string{
+					"192.168.1.1:80": "10.128.0.2:3456,10.128.1.2:3456",
+				},
+				ExternalIDs: serviceExternalIDs(namespacedServiceName(ns, serviceName)),
+			},
+				nodeRouterLoadBalancer(secondNode, nodePort, serviceName, ns, outport, nodeAEndpointIP, nodeBEndpointIP),
+				nodeLogicalSwitch(nodeA,
+					loadBalancerClusterWideTCPServiceName(ns, serviceName)),
+				nodeLogicalSwitch(nodeB,
+					loadBalancerClusterWideTCPServiceName(ns, serviceName),
+					nodeSwitchRouterLoadBalancerName(nodeB, ns, serviceName)),
+				nodeLogicalRouter(nodeA,
+					loadBalancerClusterWideTCPServiceName(ns, serviceName)),
 				nodeLogicalRouter(nodeB,
 					loadBalancerClusterWideTCPServiceName(ns, serviceName),
 					nodeSwitchRouterLoadBalancerName(nodeB, ns, serviceName)),
@@ -440,6 +518,12 @@ func TestSyncServices(t *testing.T) {
 			}
 
 			g.Eventually(controller.nbClient).Should(libovsdbtest.HaveData(tt.expectedDb))
+
+			if tt.nodeToDelete != nil {
+				controller.nodeTracker.removeNode(tt.nodeToDelete.name)
+				g.Expect(controller.syncService(namespacedServiceName(ns, serviceName))).To(gomega.Succeed())
+				g.Eventually(controller.nbClient).Should(libovsdbtest.HaveData(tt.dbStateAfterDeleting))
+			}
 		})
 	}
 }
@@ -508,5 +592,39 @@ func serviceExternalIDs(namespacedServiceName string) map[string]string {
 	return map[string]string{
 		"k8s.ovn.org/kind":  "Service",
 		"k8s.ovn.org/owner": namespacedServiceName,
+	}
+}
+
+func nodeRouterLoadBalancer(node *nodeInfo, nodePort int32, serviceName string, serviceNamespace string, outputPort int32, endpointIPs ...string) *nbdb.LoadBalancer {
+	return &nbdb.LoadBalancer{
+		UUID:     nodeSwitchRouterLoadBalancerName(node.name, serviceNamespace, serviceName),
+		Name:     nodeSwitchRouterLoadBalancerName(node.name, serviceNamespace, serviceName),
+		Options:  servicesOptions(),
+		Protocol: &nbdb.LoadBalancerProtocolTCP,
+		Vips: map[string]string{
+			endpoint(node.nodeIPs[0], nodePort): computeEndpoints(outputPort, endpointIPs...),
+		},
+		ExternalIDs: serviceExternalIDs(namespacedServiceName(serviceNamespace, serviceName)),
+	}
+}
+
+func computeEndpoints(outputPort int32, ips ...string) string {
+	var endpoints []string
+	for _, ip := range ips {
+		endpoints = append(endpoints, endpoint(ip, outputPort))
+	}
+	return strings.Join(endpoints, ",")
+}
+
+func endpoint(ip string, port int32) string {
+	return fmt.Sprintf("%s:%d", ip, port)
+}
+
+func nodeConfig(nodeName string, nodeIP string) *nodeInfo {
+	return &nodeInfo{
+		name:              nodeName,
+		nodeIPs:           []string{nodeIP},
+		gatewayRouterName: nodeGWRouterName(nodeName),
+		switchName:        nodeSwitchName(nodeName),
 	}
 }

--- a/go-controller/pkg/ovn/controller/services/services_controller_test.go
+++ b/go-controller/pkg/ovn/controller/services/services_controller_test.go
@@ -141,14 +141,8 @@ func TestSyncServices(t *testing.T) {
 			initialDb: []libovsdbtest.TestData{
 				nodeLogicalSwitch(nodeA),
 				nodeLogicalSwitch(nodeB),
-				&nbdb.LogicalRouter{
-					UUID: "gr-node-a",
-					Name: "gr-node-a",
-				},
-				&nbdb.LogicalRouter{
-					UUID: "gr-node-b",
-					Name: "gr-node-b",
-				},
+				nodeLogicalRouter(nodeA),
+				nodeLogicalRouter(nodeB),
 			},
 			expectedDb: []libovsdbtest.TestData{
 				&nbdb.LoadBalancer{
@@ -170,16 +164,8 @@ func TestSyncServices(t *testing.T) {
 				},
 				nodeLogicalSwitch(nodeA, "Service_testns/foo_TCP_cluster"),
 				nodeLogicalSwitch(nodeB, "Service_testns/foo_TCP_cluster"),
-				&nbdb.LogicalRouter{
-					UUID:         "gr-node-a",
-					Name:         "gr-node-a",
-					LoadBalancer: []string{"Service_testns/foo_TCP_cluster"},
-				},
-				&nbdb.LogicalRouter{
-					UUID:         "gr-node-b",
-					Name:         "gr-node-b",
-					LoadBalancer: []string{"Service_testns/foo_TCP_cluster"},
-				},
+				nodeLogicalRouter(nodeA, "Service_testns/foo_TCP_cluster"),
+				nodeLogicalRouter(nodeB, "Service_testns/foo_TCP_cluster"),
 			},
 		},
 		{
@@ -229,20 +215,9 @@ func TestSyncServices(t *testing.T) {
 				nodeLogicalSwitch(nodeA),
 				nodeLogicalSwitch(nodeB),
 				nodeLogicalSwitch("wrong-switch", "Service_testns/foo_TCP_cluster"),
-				&nbdb.LogicalRouter{
-					UUID:         "gr-node-a",
-					Name:         "gr-node-a",
-					LoadBalancer: []string{"Service_testns/foo_TCP_cluster"},
-				},
-				&nbdb.LogicalRouter{
-					UUID: "gr-node-b",
-					Name: "gr-node-b",
-				},
-				&nbdb.LogicalRouter{
-					UUID:         "gr-node-c",
-					Name:         "gr-node-c",
-					LoadBalancer: []string{"Service_testns/foo_TCP_cluster"},
-				},
+				nodeLogicalRouter(nodeA, "Service_testns/foo_TCP_cluster"),
+				nodeLogicalRouter(nodeB, "Service_testns/foo_TCP_cluster"),
+				nodeLogicalRouter("node-c", "Service_testns/foo_TCP_cluster"),
 			},
 			expectedDb: []libovsdbtest.TestData{
 				&nbdb.LoadBalancer{
@@ -265,20 +240,9 @@ func TestSyncServices(t *testing.T) {
 				nodeLogicalSwitch(nodeA, "Service_testns/foo_TCP_cluster"),
 				nodeLogicalSwitch(nodeB, "Service_testns/foo_TCP_cluster"),
 				nodeLogicalSwitch("wrong-switch"),
-				&nbdb.LogicalRouter{
-					UUID:         "gr-node-a",
-					Name:         "gr-node-a",
-					LoadBalancer: []string{"Service_testns/foo_TCP_cluster"},
-				},
-				&nbdb.LogicalRouter{
-					UUID:         "gr-node-b",
-					Name:         "gr-node-b",
-					LoadBalancer: []string{"Service_testns/foo_TCP_cluster"},
-				},
-				&nbdb.LogicalRouter{
-					UUID: "gr-node-c",
-					Name: "gr-node-c",
-				},
+				nodeLogicalRouter(nodeA, "Service_testns/foo_TCP_cluster"),
+				nodeLogicalRouter(nodeB, "Service_testns/foo_TCP_cluster"),
+				nodeLogicalRouter("node-c"),
 			},
 		},
 		{
@@ -337,16 +301,8 @@ func TestSyncServices(t *testing.T) {
 				},
 				nodeLogicalSwitch(nodeA, "Service_testns/foo_TCP_cluster"),
 				nodeLogicalSwitch(nodeB, "Service_testns/foo_TCP_cluster"),
-				&nbdb.LogicalRouter{
-					UUID:         "gr-node-a",
-					Name:         "gr-node-a",
-					LoadBalancer: []string{"Service_testns/foo_TCP_cluster"},
-				},
-				&nbdb.LogicalRouter{
-					UUID:         "gr-node-b",
-					Name:         "gr-node-b",
-					LoadBalancer: []string{"Service_testns/foo_TCP_cluster"},
-				},
+				nodeLogicalRouter(nodeA, "Service_testns/foo_TCP_cluster"),
+				nodeLogicalRouter(nodeB, "Service_testns/foo_TCP_cluster"),
 			},
 			expectedDb: []libovsdbtest.TestData{
 				&nbdb.LoadBalancer{
@@ -375,16 +331,8 @@ func TestSyncServices(t *testing.T) {
 				},
 				nodeLogicalSwitch(nodeA, "Service_testns/foo_TCP_cluster"),
 				nodeLogicalSwitch(nodeB, "Service_testns/foo_TCP_cluster"),
-				&nbdb.LogicalRouter{
-					UUID:         "gr-node-a",
-					Name:         "gr-node-a",
-					LoadBalancer: []string{"Service_testns/foo_TCP_cluster"},
-				},
-				&nbdb.LogicalRouter{
-					UUID:         "gr-node-b",
-					Name:         "gr-node-b",
-					LoadBalancer: []string{"Service_testns/foo_TCP_cluster"},
-				},
+				nodeLogicalRouter(nodeA, "Service_testns/foo_TCP_cluster"),
+				nodeLogicalRouter(nodeB, "Service_testns/foo_TCP_cluster"),
 			},
 		},
 		{
@@ -446,16 +394,8 @@ func TestSyncServices(t *testing.T) {
 				},
 				nodeLogicalSwitch(nodeA, "Service_testns/foo_TCP_cluster"),
 				nodeLogicalSwitch(nodeB, "Service_testns/foo_TCP_cluster"),
-				&nbdb.LogicalRouter{
-					UUID:         "gr-node-a",
-					Name:         "gr-node-a",
-					LoadBalancer: []string{"Service_testns/foo_TCP_cluster"},
-				},
-				&nbdb.LogicalRouter{
-					UUID:         "gr-node-b",
-					Name:         "gr-node-b",
-					LoadBalancer: []string{"Service_testns/foo_TCP_cluster"},
-				},
+				nodeLogicalRouter(nodeA, "Service_testns/foo_TCP_cluster"),
+				nodeLogicalRouter(nodeB, "Service_testns/foo_TCP_cluster"),
 			},
 			expectedDb: []libovsdbtest.TestData{
 				&nbdb.LoadBalancer{
@@ -515,22 +455,12 @@ func TestSyncServices(t *testing.T) {
 				nodeLogicalSwitch(nodeB,
 					"Service_testns/foo_TCP_cluster",
 					"Service_testns/foo_TCP_node_router+switch_node-b"),
-				&nbdb.LogicalRouter{
-					UUID: "gr-node-a",
-					Name: "gr-node-a",
-					LoadBalancer: []string{
-						"Service_testns/foo_TCP_cluster",
-						"Service_testns/foo_TCP_node_router+switch_node-a",
-					},
-				},
-				&nbdb.LogicalRouter{
-					UUID: "gr-node-b",
-					Name: "gr-node-b",
-					LoadBalancer: []string{
-						"Service_testns/foo_TCP_cluster",
-						"Service_testns/foo_TCP_node_router+switch_node-b",
-					},
-				},
+				nodeLogicalRouter(nodeA,
+					"Service_testns/foo_TCP_cluster",
+					"Service_testns/foo_TCP_node_router+switch_node-a"),
+				nodeLogicalRouter(nodeB,
+					"Service_testns/foo_TCP_cluster",
+					"Service_testns/foo_TCP_node_router+switch_node-b"),
 			},
 		},
 	}
@@ -578,6 +508,21 @@ func nodeLogicalSwitch(nodeName string, namespacedServiceNames ...string) *nbdb.
 	return ls
 }
 
+func nodeLogicalRouter(nodeName string, namespacedServiceNames ...string) *nbdb.LogicalRouter {
+	ls := &nbdb.LogicalRouter{
+		UUID: nodeGWRouterName(nodeName),
+		Name: nodeGWRouterName(nodeName),
+	}
+	if len(namespacedServiceNames) > 0 {
+		ls.LoadBalancer = namespacedServiceNames
+	}
+	return ls
+}
+
 func nodeSwitchName(nodeName string) string {
 	return fmt.Sprintf("switch-%s", nodeName)
+}
+
+func nodeGWRouterName(nodeName string) string {
+	return fmt.Sprintf("gr-%s", nodeName)
 }

--- a/go-controller/pkg/ovn/controller/services/services_controller_test.go
+++ b/go-controller/pkg/ovn/controller/services/services_controller_test.go
@@ -139,14 +139,8 @@ func TestSyncServices(t *testing.T) {
 				},
 			},
 			initialDb: []libovsdbtest.TestData{
-				&nbdb.LogicalSwitch{
-					UUID: "switch-node-a",
-					Name: "switch-node-a",
-				},
-				&nbdb.LogicalSwitch{
-					UUID: "switch-node-b",
-					Name: "switch-node-b",
-				},
+				nodeLogicalSwitch(nodeA),
+				nodeLogicalSwitch(nodeB),
 				&nbdb.LogicalRouter{
 					UUID: "gr-node-a",
 					Name: "gr-node-a",
@@ -174,16 +168,8 @@ func TestSyncServices(t *testing.T) {
 						"k8s.ovn.org/owner": "testns/foo",
 					},
 				},
-				&nbdb.LogicalSwitch{
-					UUID:         "switch-node-a",
-					Name:         "switch-node-a",
-					LoadBalancer: []string{"Service_testns/foo_TCP_cluster"},
-				},
-				&nbdb.LogicalSwitch{
-					UUID:         "switch-node-b",
-					Name:         "switch-node-b",
-					LoadBalancer: []string{"Service_testns/foo_TCP_cluster"},
-				},
+				nodeLogicalSwitch(nodeA, "Service_testns/foo_TCP_cluster"),
+				nodeLogicalSwitch(nodeB, "Service_testns/foo_TCP_cluster"),
 				&nbdb.LogicalRouter{
 					UUID:         "gr-node-a",
 					Name:         "gr-node-a",
@@ -240,19 +226,9 @@ func TestSyncServices(t *testing.T) {
 						"k8s.ovn.org/owner": "testns/foo",
 					},
 				},
-				&nbdb.LogicalSwitch{
-					UUID: "switch-node-a",
-					Name: "switch-node-a",
-				},
-				&nbdb.LogicalSwitch{
-					UUID: "switch-node-b",
-					Name: "switch-node-b",
-				},
-				&nbdb.LogicalSwitch{
-					UUID:         "wrong-switch",
-					Name:         "wrong-switch",
-					LoadBalancer: []string{"Service_testns/foo_TCP_cluster"},
-				},
+				nodeLogicalSwitch(nodeA),
+				nodeLogicalSwitch(nodeB),
+				nodeLogicalSwitch("wrong-switch", "Service_testns/foo_TCP_cluster"),
 				&nbdb.LogicalRouter{
 					UUID:         "gr-node-a",
 					Name:         "gr-node-a",
@@ -286,20 +262,9 @@ func TestSyncServices(t *testing.T) {
 						"k8s.ovn.org/owner": "testns/foo",
 					},
 				},
-				&nbdb.LogicalSwitch{
-					UUID:         "switch-node-a",
-					Name:         "switch-node-a",
-					LoadBalancer: []string{"Service_testns/foo_TCP_cluster"},
-				},
-				&nbdb.LogicalSwitch{
-					UUID:         "switch-node-b",
-					Name:         "switch-node-b",
-					LoadBalancer: []string{"Service_testns/foo_TCP_cluster"},
-				},
-				&nbdb.LogicalSwitch{
-					UUID: "wrong-switch",
-					Name: "wrong-switch",
-				},
+				nodeLogicalSwitch(nodeA, "Service_testns/foo_TCP_cluster"),
+				nodeLogicalSwitch(nodeB, "Service_testns/foo_TCP_cluster"),
+				nodeLogicalSwitch("wrong-switch"),
 				&nbdb.LogicalRouter{
 					UUID:         "gr-node-a",
 					Name:         "gr-node-a",
@@ -370,16 +335,8 @@ func TestSyncServices(t *testing.T) {
 						"TCP_lb_gateway_router": "",
 					},
 				},
-				&nbdb.LogicalSwitch{
-					UUID:         "switch-node-a",
-					Name:         "switch-node-a",
-					LoadBalancer: []string{"Service_testns/foo_TCP_cluster"},
-				},
-				&nbdb.LogicalSwitch{
-					UUID:         "switch-node-b",
-					Name:         "switch-node-b",
-					LoadBalancer: []string{"Service_testns/foo_TCP_cluster"},
-				},
+				nodeLogicalSwitch(nodeA, "Service_testns/foo_TCP_cluster"),
+				nodeLogicalSwitch(nodeB, "Service_testns/foo_TCP_cluster"),
 				&nbdb.LogicalRouter{
 					UUID:         "gr-node-a",
 					Name:         "gr-node-a",
@@ -416,16 +373,8 @@ func TestSyncServices(t *testing.T) {
 						"TCP_lb_gateway_router": "",
 					},
 				},
-				&nbdb.LogicalSwitch{
-					UUID:         "switch-node-a",
-					Name:         "switch-node-a",
-					LoadBalancer: []string{"Service_testns/foo_TCP_cluster"},
-				},
-				&nbdb.LogicalSwitch{
-					UUID:         "switch-node-b",
-					Name:         "switch-node-b",
-					LoadBalancer: []string{"Service_testns/foo_TCP_cluster"},
-				},
+				nodeLogicalSwitch(nodeA, "Service_testns/foo_TCP_cluster"),
+				nodeLogicalSwitch(nodeB, "Service_testns/foo_TCP_cluster"),
 				&nbdb.LogicalRouter{
 					UUID:         "gr-node-a",
 					Name:         "gr-node-a",
@@ -495,16 +444,8 @@ func TestSyncServices(t *testing.T) {
 						"k8s.ovn.org/owner": "testns/foo",
 					},
 				},
-				&nbdb.LogicalSwitch{
-					UUID:         "switch-node-a",
-					Name:         "switch-node-a",
-					LoadBalancer: []string{"Service_testns/foo_TCP_cluster"},
-				},
-				&nbdb.LogicalSwitch{
-					UUID:         "switch-node-b",
-					Name:         "switch-node-b",
-					LoadBalancer: []string{"Service_testns/foo_TCP_cluster"},
-				},
+				nodeLogicalSwitch(nodeA, "Service_testns/foo_TCP_cluster"),
+				nodeLogicalSwitch(nodeB, "Service_testns/foo_TCP_cluster"),
 				&nbdb.LogicalRouter{
 					UUID:         "gr-node-a",
 					Name:         "gr-node-a",
@@ -568,22 +509,12 @@ func TestSyncServices(t *testing.T) {
 						"k8s.ovn.org/owner": "testns/foo",
 					},
 				},
-				&nbdb.LogicalSwitch{
-					UUID: "switch-node-a",
-					Name: "switch-node-a",
-					LoadBalancer: []string{
-						"Service_testns/foo_TCP_cluster",
-						"Service_testns/foo_TCP_node_router+switch_node-a",
-					},
-				},
-				&nbdb.LogicalSwitch{
-					UUID: "switch-node-b",
-					Name: "switch-node-b",
-					LoadBalancer: []string{
-						"Service_testns/foo_TCP_cluster",
-						"Service_testns/foo_TCP_node_router+switch_node-b",
-					},
-				},
+				nodeLogicalSwitch(nodeA,
+					"Service_testns/foo_TCP_cluster",
+					"Service_testns/foo_TCP_node_router+switch_node-a"),
+				nodeLogicalSwitch(nodeB,
+					"Service_testns/foo_TCP_cluster",
+					"Service_testns/foo_TCP_node_router+switch_node-b"),
 				&nbdb.LogicalRouter{
 					UUID: "gr-node-a",
 					Name: "gr-node-a",
@@ -634,4 +565,19 @@ func TestSyncServices(t *testing.T) {
 			g.Eventually(controller.nbClient).Should(libovsdbtest.HaveData(tt.expectedDb))
 		})
 	}
+}
+
+func nodeLogicalSwitch(nodeName string, namespacedServiceNames ...string) *nbdb.LogicalSwitch {
+	ls := &nbdb.LogicalSwitch{
+		UUID: nodeSwitchName(nodeName),
+		Name: nodeSwitchName(nodeName),
+	}
+	if len(namespacedServiceNames) > 0 {
+		ls.LoadBalancer = namespacedServiceNames
+	}
+	return ls
+}
+
+func nodeSwitchName(nodeName string) string {
+	return fmt.Sprintf("switch-%s", nodeName)
 }

--- a/go-controller/pkg/ovn/controller/services/services_controller_test.go
+++ b/go-controller/pkg/ovn/controller/services/services_controller_test.go
@@ -146,8 +146,8 @@ func TestSyncServices(t *testing.T) {
 			},
 			expectedDb: []libovsdbtest.TestData{
 				&nbdb.LoadBalancer{
-					UUID: "Service_testns/foo_TCP_cluster",
-					Name: "Service_testns/foo_TCP_cluster",
+					UUID: loadBalancerClusterWideTCPServiceName(ns, serviceName),
+					Name: loadBalancerClusterWideTCPServiceName(ns, serviceName),
 					Options: map[string]string{
 						"event":     "false",
 						"reject":    "true",
@@ -162,10 +162,10 @@ func TestSyncServices(t *testing.T) {
 						"k8s.ovn.org/owner": "testns/foo",
 					},
 				},
-				nodeLogicalSwitch(nodeA, "Service_testns/foo_TCP_cluster"),
-				nodeLogicalSwitch(nodeB, "Service_testns/foo_TCP_cluster"),
-				nodeLogicalRouter(nodeA, "Service_testns/foo_TCP_cluster"),
-				nodeLogicalRouter(nodeB, "Service_testns/foo_TCP_cluster"),
+				nodeLogicalSwitch(nodeA, loadBalancerClusterWideTCPServiceName(ns, serviceName)),
+				nodeLogicalSwitch(nodeB, loadBalancerClusterWideTCPServiceName(ns, serviceName)),
+				nodeLogicalRouter(nodeA, loadBalancerClusterWideTCPServiceName(ns, serviceName)),
+				nodeLogicalRouter(nodeB, loadBalancerClusterWideTCPServiceName(ns, serviceName)),
 			},
 		},
 		{
@@ -196,8 +196,8 @@ func TestSyncServices(t *testing.T) {
 			},
 			initialDb: []libovsdbtest.TestData{
 				&nbdb.LoadBalancer{
-					UUID: "Service_testns/foo_TCP_cluster",
-					Name: "Service_testns/foo_TCP_cluster",
+					UUID: loadBalancerClusterWideTCPServiceName(ns, serviceName),
+					Name: loadBalancerClusterWideTCPServiceName(ns, serviceName),
 					Options: map[string]string{
 						"event":     "false",
 						"reject":    "true",
@@ -214,15 +214,15 @@ func TestSyncServices(t *testing.T) {
 				},
 				nodeLogicalSwitch(nodeA),
 				nodeLogicalSwitch(nodeB),
-				nodeLogicalSwitch("wrong-switch", "Service_testns/foo_TCP_cluster"),
-				nodeLogicalRouter(nodeA, "Service_testns/foo_TCP_cluster"),
-				nodeLogicalRouter(nodeB, "Service_testns/foo_TCP_cluster"),
-				nodeLogicalRouter("node-c", "Service_testns/foo_TCP_cluster"),
+				nodeLogicalSwitch("wrong-switch", loadBalancerClusterWideTCPServiceName(ns, serviceName)),
+				nodeLogicalRouter(nodeA, loadBalancerClusterWideTCPServiceName(ns, serviceName)),
+				nodeLogicalRouter(nodeB, loadBalancerClusterWideTCPServiceName(ns, serviceName)),
+				nodeLogicalRouter("node-c", loadBalancerClusterWideTCPServiceName(ns, serviceName)),
 			},
 			expectedDb: []libovsdbtest.TestData{
 				&nbdb.LoadBalancer{
-					UUID: "Service_testns/foo_TCP_cluster",
-					Name: "Service_testns/foo_TCP_cluster",
+					UUID: loadBalancerClusterWideTCPServiceName(ns, serviceName),
+					Name: loadBalancerClusterWideTCPServiceName(ns, serviceName),
 					Options: map[string]string{
 						"event":     "false",
 						"reject":    "true",
@@ -237,11 +237,11 @@ func TestSyncServices(t *testing.T) {
 						"k8s.ovn.org/owner": "testns/foo",
 					},
 				},
-				nodeLogicalSwitch(nodeA, "Service_testns/foo_TCP_cluster"),
-				nodeLogicalSwitch(nodeB, "Service_testns/foo_TCP_cluster"),
+				nodeLogicalSwitch(nodeA, loadBalancerClusterWideTCPServiceName(ns, serviceName)),
+				nodeLogicalSwitch(nodeB, loadBalancerClusterWideTCPServiceName(ns, serviceName)),
 				nodeLogicalSwitch("wrong-switch"),
-				nodeLogicalRouter(nodeA, "Service_testns/foo_TCP_cluster"),
-				nodeLogicalRouter(nodeB, "Service_testns/foo_TCP_cluster"),
+				nodeLogicalRouter(nodeA, loadBalancerClusterWideTCPServiceName(ns, serviceName)),
+				nodeLogicalRouter(nodeB, loadBalancerClusterWideTCPServiceName(ns, serviceName)),
 				nodeLogicalRouter("node-c"),
 			},
 		},
@@ -273,8 +273,8 @@ func TestSyncServices(t *testing.T) {
 			},
 			initialDb: []libovsdbtest.TestData{
 				&nbdb.LoadBalancer{
-					UUID: "Service_testns/foo_TCP_cluster",
-					Name: "Service_testns/foo_TCP_cluster",
+					UUID: loadBalancerClusterWideTCPServiceName(ns, serviceName),
+					Name: loadBalancerClusterWideTCPServiceName(ns, serviceName),
 					Options: map[string]string{
 						"event":     "false",
 						"reject":    "true",
@@ -299,15 +299,15 @@ func TestSyncServices(t *testing.T) {
 						"TCP_lb_gateway_router": "",
 					},
 				},
-				nodeLogicalSwitch(nodeA, "Service_testns/foo_TCP_cluster"),
-				nodeLogicalSwitch(nodeB, "Service_testns/foo_TCP_cluster"),
-				nodeLogicalRouter(nodeA, "Service_testns/foo_TCP_cluster"),
-				nodeLogicalRouter(nodeB, "Service_testns/foo_TCP_cluster"),
+				nodeLogicalSwitch(nodeA, loadBalancerClusterWideTCPServiceName(ns, serviceName)),
+				nodeLogicalSwitch(nodeB, loadBalancerClusterWideTCPServiceName(ns, serviceName)),
+				nodeLogicalRouter(nodeA, loadBalancerClusterWideTCPServiceName(ns, serviceName)),
+				nodeLogicalRouter(nodeB, loadBalancerClusterWideTCPServiceName(ns, serviceName)),
 			},
 			expectedDb: []libovsdbtest.TestData{
 				&nbdb.LoadBalancer{
-					UUID: "Service_testns/foo_TCP_cluster",
-					Name: "Service_testns/foo_TCP_cluster",
+					UUID: loadBalancerClusterWideTCPServiceName(ns, serviceName),
+					Name: loadBalancerClusterWideTCPServiceName(ns, serviceName),
 					Options: map[string]string{
 						"event":     "false",
 						"reject":    "true",
@@ -329,10 +329,10 @@ func TestSyncServices(t *testing.T) {
 						"TCP_lb_gateway_router": "",
 					},
 				},
-				nodeLogicalSwitch(nodeA, "Service_testns/foo_TCP_cluster"),
-				nodeLogicalSwitch(nodeB, "Service_testns/foo_TCP_cluster"),
-				nodeLogicalRouter(nodeA, "Service_testns/foo_TCP_cluster"),
-				nodeLogicalRouter(nodeB, "Service_testns/foo_TCP_cluster"),
+				nodeLogicalSwitch(nodeA, loadBalancerClusterWideTCPServiceName(ns, serviceName)),
+				nodeLogicalSwitch(nodeB, loadBalancerClusterWideTCPServiceName(ns, serviceName)),
+				nodeLogicalRouter(nodeA, loadBalancerClusterWideTCPServiceName(ns, serviceName)),
+				nodeLogicalRouter(nodeB, loadBalancerClusterWideTCPServiceName(ns, serviceName)),
 			},
 		},
 		{
@@ -376,8 +376,8 @@ func TestSyncServices(t *testing.T) {
 			},
 			initialDb: []libovsdbtest.TestData{
 				&nbdb.LoadBalancer{
-					UUID: "Service_testns/foo_TCP_cluster",
-					Name: "Service_testns/foo_TCP_cluster",
+					UUID: loadBalancerClusterWideTCPServiceName(ns, serviceName),
+					Name: loadBalancerClusterWideTCPServiceName(ns, serviceName),
 					Options: map[string]string{
 						"event":     "false",
 						"reject":    "true",
@@ -392,15 +392,15 @@ func TestSyncServices(t *testing.T) {
 						"k8s.ovn.org/owner": "testns/foo",
 					},
 				},
-				nodeLogicalSwitch(nodeA, "Service_testns/foo_TCP_cluster"),
-				nodeLogicalSwitch(nodeB, "Service_testns/foo_TCP_cluster"),
-				nodeLogicalRouter(nodeA, "Service_testns/foo_TCP_cluster"),
-				nodeLogicalRouter(nodeB, "Service_testns/foo_TCP_cluster"),
+				nodeLogicalSwitch(nodeA, loadBalancerClusterWideTCPServiceName(ns, serviceName)),
+				nodeLogicalSwitch(nodeB, loadBalancerClusterWideTCPServiceName(ns, serviceName)),
+				nodeLogicalRouter(nodeA, loadBalancerClusterWideTCPServiceName(ns, serviceName)),
+				nodeLogicalRouter(nodeB, loadBalancerClusterWideTCPServiceName(ns, serviceName)),
 			},
 			expectedDb: []libovsdbtest.TestData{
 				&nbdb.LoadBalancer{
-					UUID: "Service_testns/foo_TCP_cluster",
-					Name: "Service_testns/foo_TCP_cluster",
+					UUID: loadBalancerClusterWideTCPServiceName(ns, serviceName),
+					Name: loadBalancerClusterWideTCPServiceName(ns, serviceName),
 					Options: map[string]string{
 						"event":     "false",
 						"reject":    "true",
@@ -416,8 +416,8 @@ func TestSyncServices(t *testing.T) {
 					},
 				},
 				&nbdb.LoadBalancer{
-					UUID: "Service_testns/foo_TCP_node_router+switch_node-a",
-					Name: "Service_testns/foo_TCP_node_router+switch_node-a",
+					UUID: nodeSwitchRouterLoadBalancerName(nodeA, ns, serviceName),
+					Name: nodeSwitchRouterLoadBalancerName(nodeA, ns, serviceName),
 					Options: map[string]string{
 						"event":     "false",
 						"reject":    "true",
@@ -433,8 +433,8 @@ func TestSyncServices(t *testing.T) {
 					},
 				},
 				&nbdb.LoadBalancer{
-					UUID: "Service_testns/foo_TCP_node_router+switch_node-b",
-					Name: "Service_testns/foo_TCP_node_router+switch_node-b",
+					UUID: nodeSwitchRouterLoadBalancerName(nodeB, ns, serviceName),
+					Name: nodeSwitchRouterLoadBalancerName(nodeB, ns, serviceName),
 					Options: map[string]string{
 						"event":     "false",
 						"reject":    "true",
@@ -450,17 +450,17 @@ func TestSyncServices(t *testing.T) {
 					},
 				},
 				nodeLogicalSwitch(nodeA,
-					"Service_testns/foo_TCP_cluster",
-					"Service_testns/foo_TCP_node_router+switch_node-a"),
+					loadBalancerClusterWideTCPServiceName(ns, serviceName),
+					nodeSwitchRouterLoadBalancerName(nodeA, ns, serviceName)),
 				nodeLogicalSwitch(nodeB,
-					"Service_testns/foo_TCP_cluster",
-					"Service_testns/foo_TCP_node_router+switch_node-b"),
+					loadBalancerClusterWideTCPServiceName(ns, serviceName),
+					nodeSwitchRouterLoadBalancerName(nodeB, ns, serviceName)),
 				nodeLogicalRouter(nodeA,
-					"Service_testns/foo_TCP_cluster",
-					"Service_testns/foo_TCP_node_router+switch_node-a"),
+					loadBalancerClusterWideTCPServiceName(ns, serviceName),
+					nodeSwitchRouterLoadBalancerName(nodeA, ns, serviceName)),
 				nodeLogicalRouter(nodeB,
-					"Service_testns/foo_TCP_cluster",
-					"Service_testns/foo_TCP_node_router+switch_node-b"),
+					loadBalancerClusterWideTCPServiceName(ns, serviceName),
+					nodeSwitchRouterLoadBalancerName(nodeB, ns, serviceName)),
 			},
 		},
 	}
@@ -525,4 +525,20 @@ func nodeSwitchName(nodeName string) string {
 
 func nodeGWRouterName(nodeName string) string {
 	return fmt.Sprintf("gr-%s", nodeName)
+}
+
+func loadBalancerClusterWideTCPServiceName(ns string, serviceName string) string {
+	return fmt.Sprintf("Service_%s_TCP_cluster", namespacedServiceName(ns, serviceName))
+}
+
+func namespacedServiceName(ns string, name string) string {
+	return fmt.Sprintf("%s/%s", ns, name)
+}
+
+func nodeSwitchRouterLoadBalancerName(nodeName string, serviceNamespace string, serviceName string) string {
+	return fmt.Sprintf(
+		"Service_%s/%s_TCP_node_router+switch_%s",
+		serviceNamespace,
+		serviceName,
+		nodeName)
 }

--- a/go-controller/pkg/ovn/controller/services/services_controller_test.go
+++ b/go-controller/pkg/ovn/controller/services/services_controller_test.go
@@ -527,7 +527,7 @@ func TestSyncServices(t *testing.T) {
 				t.Errorf("syncServices error: %v", err)
 			}
 
-			g.Eventually(controller.nbClient).Should(libovsdbtest.HaveData(tt.expectedDb))
+			g.Expect(controller.nbClient).To(libovsdbtest.HaveData(tt.expectedDb))
 
 			if tt.nodeToDelete != nil {
 				controller.nodeTracker.removeNode(tt.nodeToDelete.name)
@@ -555,7 +555,7 @@ func TestSyncServices(t *testing.T) {
 				expectedData := patchLogicalRouterAndSwitchLoadBalancerUUIDs(
 					nodeLoadBalancerUUID, tt.dbStateAfterDeleting, nodeSwitchName(nodeA), nodeGWRouterName(nodeA))
 
-				g.Eventually(controller.nbClient).Should(libovsdbtest.HaveData(expectedData))
+				g.Expect(controller.nbClient).To(libovsdbtest.HaveData(expectedData))
 			}
 		})
 	}

--- a/go-controller/pkg/ovn/controller/services/services_controller_test.go
+++ b/go-controller/pkg/ovn/controller/services/services_controller_test.go
@@ -153,10 +153,7 @@ func TestSyncServices(t *testing.T) {
 					Vips: map[string]string{
 						"192.168.1.1:80": "",
 					},
-					ExternalIDs: map[string]string{
-						"k8s.ovn.org/kind":  "Service",
-						"k8s.ovn.org/owner": "testns/foo",
-					},
+					ExternalIDs: serviceExternalIDs(namespacedServiceName(ns, serviceName)),
 				},
 				nodeLogicalSwitch(nodeA, loadBalancerClusterWideTCPServiceName(ns, serviceName)),
 				nodeLogicalSwitch(nodeB, loadBalancerClusterWideTCPServiceName(ns, serviceName)),
@@ -199,10 +196,7 @@ func TestSyncServices(t *testing.T) {
 					Vips: map[string]string{
 						"192.168.0.1:6443": "",
 					},
-					ExternalIDs: map[string]string{
-						"k8s.ovn.org/kind":  "Service",
-						"k8s.ovn.org/owner": "testns/foo",
-					},
+					ExternalIDs: serviceExternalIDs(namespacedServiceName(ns, serviceName)),
 				},
 				nodeLogicalSwitch(nodeA),
 				nodeLogicalSwitch(nodeB),
@@ -220,10 +214,7 @@ func TestSyncServices(t *testing.T) {
 					Vips: map[string]string{
 						"192.168.1.1:80": "",
 					},
-					ExternalIDs: map[string]string{
-						"k8s.ovn.org/kind":  "Service",
-						"k8s.ovn.org/owner": "testns/foo",
-					},
+					ExternalIDs: serviceExternalIDs(namespacedServiceName(ns, serviceName)),
 				},
 				nodeLogicalSwitch(nodeA, loadBalancerClusterWideTCPServiceName(ns, serviceName)),
 				nodeLogicalSwitch(nodeB, loadBalancerClusterWideTCPServiceName(ns, serviceName)),
@@ -268,10 +259,7 @@ func TestSyncServices(t *testing.T) {
 					Vips: map[string]string{
 						"192.168.0.1:6443": "",
 					},
-					ExternalIDs: map[string]string{
-						"k8s.ovn.org/kind":  "Service",
-						"k8s.ovn.org/owner": "testns/foo",
-					},
+					ExternalIDs: serviceExternalIDs(namespacedServiceName(ns, serviceName)),
 				},
 				&nbdb.LoadBalancer{
 					UUID:     "TCP_lb_gateway_router",
@@ -279,9 +267,7 @@ func TestSyncServices(t *testing.T) {
 					Vips: map[string]string{
 						"192.168.1.1:80": "",
 					},
-					ExternalIDs: map[string]string{
-						"TCP_lb_gateway_router": "",
-					},
+					ExternalIDs: tcpGatewayRouterExternalIDs(),
 				},
 				nodeLogicalSwitch(nodeA, loadBalancerClusterWideTCPServiceName(ns, serviceName)),
 				nodeLogicalSwitch(nodeB, loadBalancerClusterWideTCPServiceName(ns, serviceName)),
@@ -297,17 +283,12 @@ func TestSyncServices(t *testing.T) {
 					Vips: map[string]string{
 						"192.168.1.1:80": "",
 					},
-					ExternalIDs: map[string]string{
-						"k8s.ovn.org/kind":  "Service",
-						"k8s.ovn.org/owner": "testns/foo",
-					},
+					ExternalIDs: serviceExternalIDs(namespacedServiceName(ns, serviceName)),
 				},
 				&nbdb.LoadBalancer{
-					UUID:     "TCP_lb_gateway_router",
-					Protocol: &nbdb.LoadBalancerProtocolTCP,
-					ExternalIDs: map[string]string{
-						"TCP_lb_gateway_router": "",
-					},
+					UUID:        "TCP_lb_gateway_router",
+					Protocol:    &nbdb.LoadBalancerProtocolTCP,
+					ExternalIDs: tcpGatewayRouterExternalIDs(),
 				},
 				nodeLogicalSwitch(nodeA, loadBalancerClusterWideTCPServiceName(ns, serviceName)),
 				nodeLogicalSwitch(nodeB, loadBalancerClusterWideTCPServiceName(ns, serviceName)),
@@ -363,10 +344,7 @@ func TestSyncServices(t *testing.T) {
 					Vips: map[string]string{
 						"192.168.0.1:6443": "",
 					},
-					ExternalIDs: map[string]string{
-						"k8s.ovn.org/kind":  "Service",
-						"k8s.ovn.org/owner": "testns/foo",
-					},
+					ExternalIDs: serviceExternalIDs(namespacedServiceName(ns, serviceName)),
 				},
 				nodeLogicalSwitch(nodeA, loadBalancerClusterWideTCPServiceName(ns, serviceName)),
 				nodeLogicalSwitch(nodeB, loadBalancerClusterWideTCPServiceName(ns, serviceName)),
@@ -382,10 +360,7 @@ func TestSyncServices(t *testing.T) {
 					Vips: map[string]string{
 						"192.168.1.1:80": "10.128.0.2:3456,10.128.1.2:3456",
 					},
-					ExternalIDs: map[string]string{
-						"k8s.ovn.org/kind":  "Service",
-						"k8s.ovn.org/owner": "testns/foo",
-					},
+					ExternalIDs: serviceExternalIDs(namespacedServiceName(ns, serviceName)),
 				},
 				&nbdb.LoadBalancer{
 					UUID: nodeSwitchRouterLoadBalancerName(nodeA, ns, serviceName),
@@ -520,5 +495,18 @@ func servicesOptions() map[string]string {
 		"event":     "false",
 		"reject":    "true",
 		"skip_snat": "false",
+	}
+}
+
+func tcpGatewayRouterExternalIDs() map[string]string {
+	return map[string]string{
+		"TCP_lb_gateway_router": "",
+	}
+}
+
+func serviceExternalIDs(namespacedServiceName string) map[string]string {
+	return map[string]string{
+		"k8s.ovn.org/kind":  "Service",
+		"k8s.ovn.org/owner": namespacedServiceName,
 	}
 }

--- a/go-controller/pkg/ovn/controller/services/services_controller_test.go
+++ b/go-controller/pkg/ovn/controller/services/services_controller_test.go
@@ -146,13 +146,9 @@ func TestSyncServices(t *testing.T) {
 			},
 			expectedDb: []libovsdbtest.TestData{
 				&nbdb.LoadBalancer{
-					UUID: loadBalancerClusterWideTCPServiceName(ns, serviceName),
-					Name: loadBalancerClusterWideTCPServiceName(ns, serviceName),
-					Options: map[string]string{
-						"event":     "false",
-						"reject":    "true",
-						"skip_snat": "false",
-					},
+					UUID:     loadBalancerClusterWideTCPServiceName(ns, serviceName),
+					Name:     loadBalancerClusterWideTCPServiceName(ns, serviceName),
+					Options:  servicesOptions(),
 					Protocol: &nbdb.LoadBalancerProtocolTCP,
 					Vips: map[string]string{
 						"192.168.1.1:80": "",
@@ -196,13 +192,9 @@ func TestSyncServices(t *testing.T) {
 			},
 			initialDb: []libovsdbtest.TestData{
 				&nbdb.LoadBalancer{
-					UUID: loadBalancerClusterWideTCPServiceName(ns, serviceName),
-					Name: loadBalancerClusterWideTCPServiceName(ns, serviceName),
-					Options: map[string]string{
-						"event":     "false",
-						"reject":    "true",
-						"skip_snat": "false",
-					},
+					UUID:     loadBalancerClusterWideTCPServiceName(ns, serviceName),
+					Name:     loadBalancerClusterWideTCPServiceName(ns, serviceName),
+					Options:  servicesOptions(),
 					Protocol: &nbdb.LoadBalancerProtocolTCP,
 					Vips: map[string]string{
 						"192.168.0.1:6443": "",
@@ -221,13 +213,9 @@ func TestSyncServices(t *testing.T) {
 			},
 			expectedDb: []libovsdbtest.TestData{
 				&nbdb.LoadBalancer{
-					UUID: loadBalancerClusterWideTCPServiceName(ns, serviceName),
-					Name: loadBalancerClusterWideTCPServiceName(ns, serviceName),
-					Options: map[string]string{
-						"event":     "false",
-						"reject":    "true",
-						"skip_snat": "false",
-					},
+					UUID:     loadBalancerClusterWideTCPServiceName(ns, serviceName),
+					Name:     loadBalancerClusterWideTCPServiceName(ns, serviceName),
+					Options:  servicesOptions(),
 					Protocol: &nbdb.LoadBalancerProtocolTCP,
 					Vips: map[string]string{
 						"192.168.1.1:80": "",
@@ -273,13 +261,9 @@ func TestSyncServices(t *testing.T) {
 			},
 			initialDb: []libovsdbtest.TestData{
 				&nbdb.LoadBalancer{
-					UUID: loadBalancerClusterWideTCPServiceName(ns, serviceName),
-					Name: loadBalancerClusterWideTCPServiceName(ns, serviceName),
-					Options: map[string]string{
-						"event":     "false",
-						"reject":    "true",
-						"skip_snat": "false",
-					},
+					UUID:     loadBalancerClusterWideTCPServiceName(ns, serviceName),
+					Name:     loadBalancerClusterWideTCPServiceName(ns, serviceName),
+					Options:  servicesOptions(),
 					Protocol: &nbdb.LoadBalancerProtocolTCP,
 					Vips: map[string]string{
 						"192.168.0.1:6443": "",
@@ -306,13 +290,9 @@ func TestSyncServices(t *testing.T) {
 			},
 			expectedDb: []libovsdbtest.TestData{
 				&nbdb.LoadBalancer{
-					UUID: loadBalancerClusterWideTCPServiceName(ns, serviceName),
-					Name: loadBalancerClusterWideTCPServiceName(ns, serviceName),
-					Options: map[string]string{
-						"event":     "false",
-						"reject":    "true",
-						"skip_snat": "false",
-					},
+					UUID:     loadBalancerClusterWideTCPServiceName(ns, serviceName),
+					Name:     loadBalancerClusterWideTCPServiceName(ns, serviceName),
+					Options:  servicesOptions(),
 					Protocol: &nbdb.LoadBalancerProtocolTCP,
 					Vips: map[string]string{
 						"192.168.1.1:80": "",
@@ -376,13 +356,9 @@ func TestSyncServices(t *testing.T) {
 			},
 			initialDb: []libovsdbtest.TestData{
 				&nbdb.LoadBalancer{
-					UUID: loadBalancerClusterWideTCPServiceName(ns, serviceName),
-					Name: loadBalancerClusterWideTCPServiceName(ns, serviceName),
-					Options: map[string]string{
-						"event":     "false",
-						"reject":    "true",
-						"skip_snat": "false",
-					},
+					UUID:     loadBalancerClusterWideTCPServiceName(ns, serviceName),
+					Name:     loadBalancerClusterWideTCPServiceName(ns, serviceName),
+					Options:  servicesOptions(),
 					Protocol: &nbdb.LoadBalancerProtocolTCP,
 					Vips: map[string]string{
 						"192.168.0.1:6443": "",
@@ -399,13 +375,9 @@ func TestSyncServices(t *testing.T) {
 			},
 			expectedDb: []libovsdbtest.TestData{
 				&nbdb.LoadBalancer{
-					UUID: loadBalancerClusterWideTCPServiceName(ns, serviceName),
-					Name: loadBalancerClusterWideTCPServiceName(ns, serviceName),
-					Options: map[string]string{
-						"event":     "false",
-						"reject":    "true",
-						"skip_snat": "false",
-					},
+					UUID:     loadBalancerClusterWideTCPServiceName(ns, serviceName),
+					Name:     loadBalancerClusterWideTCPServiceName(ns, serviceName),
+					Options:  servicesOptions(),
 					Protocol: &nbdb.LoadBalancerProtocolTCP,
 					Vips: map[string]string{
 						"192.168.1.1:80": "10.128.0.2:3456,10.128.1.2:3456",
@@ -541,4 +513,12 @@ func nodeSwitchRouterLoadBalancerName(nodeName string, serviceNamespace string, 
 		serviceNamespace,
 		serviceName,
 		nodeName)
+}
+
+func servicesOptions() map[string]string {
+	return map[string]string{
+		"event":     "false",
+		"reject":    "true",
+		"skip_snat": "false",
+	}
 }

--- a/go-controller/pkg/ovn/controller/services/services_controller_test.go
+++ b/go-controller/pkg/ovn/controller/services/services_controller_test.go
@@ -522,7 +522,7 @@ func TestSyncServices(t *testing.T) {
 			if tt.nodeToDelete != nil {
 				controller.nodeTracker.removeNode(tt.nodeToDelete.name)
 				g.Expect(controller.syncService(namespacedServiceName(ns, serviceName))).To(gomega.Succeed())
-				g.Eventually(controller.nbClient).Should(libovsdbtest.HaveData(tt.dbStateAfterDeleting))
+				g.Eventually(controller.nbClient).Should(libovsdbtest.HaveDataIgnoringUUIDs(tt.dbStateAfterDeleting))
 			}
 		})
 	}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->
services controller: reconcile on node deletion

A node load balancer is a load balancer associated to any of the following
services:
- service with NodePort set
- service with host-network endpoints
- service with ExternalTrafficPolicy=Local
- service with InternalTrafficPolicy=Local

This commit forces the reconciliation of the load balancers upon node
deletion. Since the node was deleted, the newly generated list of load
balancers will not feature the deleted node's load balancers, which will
lead to their deletion.

Leaking these load balancers causes an issue when the deleted node is re-added
(as part of a remediation procedure, for instance) since the newly created node
logical switch does not point to these node load balancers, thus breaking
connectivity of pods on the node to the services described in the list above.

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->
**Clean pick** of the commits in the master branch.

**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
1. Backup one of your node's configuration - kubectl get node <nodeXYZ> -oyaml > nodexyz-backup.yaml
2. Delete said node - kubectl delete node <nodeXYZ>
3. Ensure the node load balancers are deleted from the OVN NB database. These end with the nodeXYZ suffix
4. Add the node back - kubectl apply -f nodexyz-backup.yaml
5. Ensure the node load balancers are found from the OVN NB database. These end with the nodeXYZ suffix

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Force service reconciliation whenever a node is deleted.