### PR TITLE
Bug 2115039: [release-4.8] OCP CARRY: Add the rules to EXTERNALIPs only for SGW mode

### DIFF
--- a/go-controller/pkg/node/gateway_iptables.go
+++ b/go-controller/pkg/node/gateway_iptables.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package node
@@ -340,11 +341,17 @@ func getGatewayIPTRules(service *kapi.Service, gatewayIPs []string) []iptRule {
 				}
 			}
 		}
-		externalIPs := make([]string, 0, len(service.Spec.ExternalIPs)+len(service.Status.LoadBalancer.Ingress))
+		externalIPsCount := len(service.Spec.ExternalIPs)
+		if config.Gateway.Mode == config.GatewayModeShared {
+			externalIPsCount += len(service.Status.LoadBalancer.Ingress)
+		}
+		externalIPs := make([]string, 0, externalIPsCount)
 		externalIPs = append(externalIPs, service.Spec.ExternalIPs...)
-		for _, ingress := range service.Status.LoadBalancer.Ingress {
-			if len(ingress.IP) > 0 {
-				externalIPs = append(externalIPs, ingress.IP)
+		if config.Gateway.Mode == config.GatewayModeShared {
+			for _, ingress := range service.Status.LoadBalancer.Ingress {
+				if len(ingress.IP) > 0 {
+					externalIPs = append(externalIPs, ingress.IP)
+				}
 			}
 		}
 


### PR DESCRIPTION
We call getGatewayIPTRules from both LGW and SGW. This adds
iptable rules for services to EXTERNALIPs chain. We already
add iptable rules for services of type LB.ingress.ip to
NODEPORT chain for LGW. So we need to add the LB ingress rules
to EXTERNALIPs chain only for SGW mode.

Signed-off-by: Surya Seetharaman <suryaseetharaman.9@gmail.com>
(cherry picked from commit https://github.com/openshift/ovn-kubernetes/pull/1233/commits)

