### PR TITLE
[dnm][test][wip]Delete stale egress ip before assigning new ip

### DIFF
--- a/go-controller/pkg/ovn/egressip.go
+++ b/go-controller/pkg/ovn/egressip.go
@@ -230,21 +230,6 @@ func (oc *Controller) reconcileEgressIP(old, new *egressipv1.EgressIP) (err erro
 				return err
 			}
 		}
-		// If running on a public cloud we should not program OVN just yet for assignment
-		// operations. We need confirmation from the cloud-network-config-controller that
-		// it can assign the IPs. reconcileCloudPrivateIPConfig will take care of
-		// processing the answer from the requests we make here, and update OVN
-		// accordingly when we know what the outcome is.
-		if len(ipsToAssign) > 0 {
-			statusToAdd = oc.assignEgressIPs(name, ipsToAssign.UnsortedList())
-			statusToKeep = append(statusToKeep, statusToAdd...)
-		}
-		// Same as above: Add all assignments which are to be kept to the
-		// allocator cache, allowing us to track all assignments which have been
-		// performed and avoid incorrect future assignments due to a
-		// de-synchronized cache.
-		oc.addAllocatorEgressIPAssignments(name, statusToKeep)
-
 		// When egress IP is not fully assigned to a node, then statusToRemove may not
 		// have those entries, hence retrieve it from staleEgressIPs for removing
 		// the item from cloudprivateipconfig.
@@ -260,6 +245,20 @@ func (oc *Controller) reconcileEgressIP(old, new *egressipv1.EgressIP) (err erro
 					egressipv1.EgressIPStatusItem{EgressIP: staleEgressIP, Node: nodeName})
 			}
 		}
+		// If running on a public cloud we should not program OVN just yet for assignment
+		// operations. We need confirmation from the cloud-network-config-controller that
+		// it can assign the IPs. reconcileCloudPrivateIPConfig will take care of
+		// processing the answer from the requests we make here, and update OVN
+		// accordingly when we know what the outcome is.
+		if len(ipsToAssign) > 0 {
+			statusToAdd = oc.assignEgressIPs(name, ipsToAssign.UnsortedList())
+			statusToKeep = append(statusToKeep, statusToAdd...)
+		}
+		// Same as above: Add all assignments which are to be kept to the
+		// allocator cache, allowing us to track all assignments which have been
+		// performed and avoid incorrect future assignments due to a
+		// de-synchronized cache.
+		oc.addAllocatorEgressIPAssignments(name, statusToKeep)
 
 		// Execute CloudPrivateIPConfig changes for assignments which need to be
 		// added/removed, assignments which don't change do not require any


### PR DESCRIPTION
This deletes any stale ip from node allocations map before assignment
so that update on same egress ip object would assign new ip address
on a particular assignable node in any timing scenarios.

Signed-off-by: Periyasamy Palanisamy <pepalani@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->