### PR TITLE
Bug OCPBUGS-574: EgressGW: don't error out trying to add SPK when a pod without ip exists

### DIFF
--- a/go-controller/pkg/ovn/egressgw.go
+++ b/go-controller/pkg/ovn/egressgw.go
@@ -243,6 +243,10 @@ func (oc *Controller) addGWRoutesForNamespace(namespace string, egress gatewayIn
 			}
 			podIPs = append(podIPs, ipNet)
 		}
+		if len(podIPs) == 0 {
+			klog.Warningf("Will not add gateway routes for pod %s/%s. IPs not found!", pod.Namespace, pod.Name)
+			continue
+		}
 		if err := oc.addGWRoutesForPod([]*gatewayInfo{&egress}, podIPs, podNsName, pod.Spec.NodeName); err != nil {
 			return err
 		}


### PR DESCRIPTION
When the SPK is added and is serving an ICNI namespace, we will search all of the pods in the served namespace to update their routes to point to this new SPK.
If for some reason one of the pods in the namespace has no IPs, we error out trying to add the SPK.
The correct behavior should just be to warn that the pod IPs are missing and continue with adding the SPK.

Signed-off-by: Ori Braunshtein <obraunsh@redhat.com>

This is fixed in 4.10+ by https://github.com/openshift/ovn-kubernetes/commit/b94351d79ce9770a726678d26be5d67b549be83f