### PR TITLE
OCPBUGS-658: [release-4.11] pods: deleteLogicalPort should not fail when port is already gone

### DIFF
--- a/go-controller/pkg/ovn/pods_test.go
+++ b/go-controller/pkg/ovn/pods_test.go
@@ -951,6 +951,13 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 				gomega.Eventually(fakeOvn.controller.nbClient).Should(
 					libovsdbtest.HaveData(getExpectedDataPodsAndSwitches([]testPod{}, []string{"node1"})...))
 
+				// Once again, get pod from api with its metadata filled in
+				pod, err = fakeOvn.fakeClient.KubeClient.CoreV1().Pods(podTest.namespace).Get(context.TODO(), podTest.podName, metav1.GetOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				// Deleting port that no longer exists should be okay!
+				gomega.Expect(fakeOvn.controller.deleteLogicalPort(pod, nil)).To(gomega.Succeed(), "Deleting port that no longer exists should be okay")
+
 				err = fakeOvn.fakeClient.KubeClient.CoreV1().Pods(pod.Namespace).Delete(context.TODO(), pod.Name, *metav1.NewDeleteOptions(0))
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 


### PR DESCRIPTION
When the logical port is already deleted, deleteLogicalPort should
not return an error. Otherwise, delete will be retried up for
maxFailedAttempts (currently set to 15).

This issue introduced in commit be8786a89546effe2de121fce9c05907fae4c1ce

Signed-off-by: Flavio Fernandes <flaviof@redhat.com>
Co-authored-by: Tim Rozet <trozet@redhat.com>
Reported-at: https://issues.redhat.com/browse/OCPBUGS-469
(cherry picked from commit f7fe67d846ba15dddfc23a94b47f6aba46e04fa9)