### PR TITLE
OCPBUGS-660: [release-4.10] pods: deleteLogicalPort should not fail when port is already gone

### DIFF
--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -146,7 +146,7 @@ func (oc *Controller) lookupPortUUIDAndNodeName(logicalPort string) (string, str
 	lsp := &nbdb.LogicalSwitchPort{Name: logicalPort}
 	err := oc.nbClient.Get(ctx, lsp)
 	if err != nil {
-		return "", "", fmt.Errorf("error getting logical port %+v: %w", lsp, err)
+		return "", "", err
 	}
 	p := func(item *nbdb.LogicalSwitch) bool {
 		for _, currPortUUID := range item.Ports {
@@ -195,7 +195,13 @@ func (oc *Controller) deleteLogicalPort(pod *kapi.Pod, portInfo *lpInfo) (err er
 		// Since portInfo is not available, use ovn to locate the logical switch (named after the node name) for the logical port.
 		portUUID, nodeName, err = oc.lookupPortUUIDAndNodeName(logicalPort)
 		if err != nil {
-			return fmt.Errorf("unable to locate portUUID+nodeName for pod %s/%s: %w", pod.Namespace, pod.Name, err)
+			if err != libovsdbclient.ErrNotFound {
+				return fmt.Errorf("unable to locate portUUID+nodeName for pod %s/%s: %w", pod.Namespace, pod.Name, err)
+			}
+			// The logical port no longer exists in OVN. The caller expects this function to be idem-potent,
+			// so the proper action to take is to use an empty uuid and extract the node name from the pod spec.
+			portUUID = ""
+			nodeName = pod.Spec.NodeName
 		}
 		podIfAddrs = annotation.IPs
 

--- a/go-controller/pkg/ovn/pods_test.go
+++ b/go-controller/pkg/ovn/pods_test.go
@@ -925,6 +925,13 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 				gomega.Eventually(fakeOvn.controller.nbClient).Should(
 					libovsdbtest.HaveData(getExpectedDataPodsAndSwitches([]testPod{}, []string{"node1"})...))
 
+				// Once again, get pod from api with its metadata filled in
+				pod, err = fakeOvn.fakeClient.KubeClient.CoreV1().Pods(podTest.namespace).Get(context.TODO(), podTest.podName, metav1.GetOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				// Deleting port that no longer exists should be okay!
+				gomega.Expect(fakeOvn.controller.deleteLogicalPort(pod, nil)).To(gomega.Succeed(), "Deleting port that no longer exists should be okay")
+
 				err = fakeOvn.fakeClient.KubeClient.CoreV1().Pods(pod.Namespace).Delete(context.TODO(), pod.Name, *metav1.NewDeleteOptions(0))
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 


### PR DESCRIPTION
When the logical port is already deleted, deleteLogicalPort should
not return an error. Otherwise, delete will be retried up for
maxFailedAttempts (currently set to 15).

This issue introduced in commit be8786a89546effe2de121fce9c05907fae4c1ce

Signed-off-by: Flavio Fernandes <flaviof@redhat.com>
Co-authored-by: Tim Rozet <trozet@redhat.com>
Reported-at: https://issues.redhat.com/browse/OCPBUGS-469
(cherry picked from commit f7fe67d846ba15dddfc23a94b47f6aba46e04fa9)