### PR TITLE
[reelase-4.11] OCPBUGS-772: Fix NP upgrade bug: unexpectedly found multiple equivalent ACLs (arp v/s arp||nd)

### DIFF
--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"strings"
 	"sync"
 	"time"
 
@@ -46,6 +47,8 @@ const (
 	ingressDefaultDenySuffix = "ingressDefaultDeny"
 	// egressDefaultDenySuffix is the suffix used when creating the ingress port group for a namespace
 	egressDefaultDenySuffix = "egressDefaultDeny"
+	// arpAllowPolicySuffix is the suffix used when creating default ACLs for a namespace
+	arpAllowPolicySuffix = "ARPallowPolicy"
 )
 
 var NetworkPolicyNotCreated error
@@ -110,6 +113,45 @@ func getACLLoggingSeverity(aclLogging string) string {
 // hash the provided input to make it a valid portGroup name.
 func hashedPortGroup(s string) string {
 	return util.HashForOVN(s)
+}
+
+// updateStaleDefaultDenyACLNames updates the naming of the default ingress and egress deny ACLs per namespace
+// oldName: <namespace>_<policyname> (lucky winner will be first policy created in the namespace)
+// newName: <namespace>_egressDefaultDeny OR <namespace>_ingressDefaultDeny
+func (oc *Controller) updateStaleDefaultDenyACLNames(npType knet.PolicyType, gressSuffix string) error {
+	cleanUpDefaultDeny := make(map[string][]*nbdb.ACL)
+	p := func(item *nbdb.ACL) bool {
+		return item.ExternalIDs[defaultDenyPolicyTypeACLExtIdKey] == string(npType) && // default-deny-policy-type:Egress or default-deny-policy-type:Ingress
+			strings.Contains(item.Match, gressSuffix) && // Match:inport ==	@ablah80448_egressDefaultDeny or Match:inport == @ablah80448_ingressDefaultDeny
+			!strings.Contains(*item.Name, arpAllowPolicySuffix) && // != name: namespace_ARPallowPolicy
+			!strings.Contains(*item.Name, gressSuffix) // filter out already converted ACLs
+	}
+	gressACLs, err := libovsdbops.FindACLsWithPredicate(oc.nbClient, p)
+	if err != nil {
+		return fmt.Errorf("cannot find NetworkPolicy default deny ACLs: %v", err)
+	}
+	for _, acl := range gressACLs {
+		acl := acl
+		namespace := strings.Split(*acl.Name, "_")[0] // parse the namespace from the ACL name
+		cleanUpDefaultDeny[namespace] = append(cleanUpDefaultDeny[namespace], acl)
+	}
+	// loop through the cleanUp map and per namespace update the first ACL's name and delete the rest
+	for namespace, aclList := range cleanUpDefaultDeny {
+		newName := namespacePortGroupACLName(namespace, "", gressSuffix)
+		if len(aclList) > 1 {
+			// this should never be the case but delete everything except 1st ACL
+			err := libovsdbops.DeleteACLs(oc.nbClient, aclList[1:]...)
+			if err != nil {
+				return err
+			}
+		}
+		aclList[0].Name = &newName
+		err := libovsdbops.CreateOrUpdateACLs(oc.nbClient, aclList[0])
+		if err != nil {
+			return fmt.Errorf("cannot update old NetworkPolicy ACLs for namespace %s: %v", namespace, err)
+		}
+	}
+	return nil
 }
 
 func (oc *Controller) syncNetworkPolicies(networkPolicies []interface{}) error {
@@ -186,6 +228,28 @@ func (oc *Controller) syncNetworkPolicies(networkPolicies []interface{}) error {
 		if err != nil {
 			return fmt.Errorf("cannot update old Egress NetworkPolicy ACLs: %v", err)
 		}
+	}
+
+	if err := oc.updateStaleDefaultDenyACLNames(knet.PolicyTypeEgress, egressDefaultDenySuffix); err != nil {
+		return fmt.Errorf("cannot clean up egress default deny ACL name: %v", err)
+	}
+	if err := oc.updateStaleDefaultDenyACLNames(knet.PolicyTypeIngress, ingressDefaultDenySuffix); err != nil {
+		return fmt.Errorf("cannot clean up ingress default deny ACL name: %v", err)
+	}
+
+	// remove stale egress and ingress allow arp ACLs that were leftover as a result
+	// of ACL migration for "ARPallowPolicy" when the match changed from "arp" to "(arp || nd)"
+	p = func(item *nbdb.ACL) bool {
+		return strings.Contains(item.Match, " && arp") &&
+			strings.Contains(*item.Name, arpAllowPolicySuffix)
+	}
+	gressACLs, err := libovsdbops.FindACLsWithPredicate(oc.nbClient, p)
+	if err != nil {
+		return fmt.Errorf("cannot find stale arp allow ACLs: %v", err)
+	}
+	err = libovsdbops.DeleteACLs(oc.nbClient, gressACLs...)
+	if err != nil {
+		return fmt.Errorf("cannot delete stale arp allow ACLs: %v", err)
 	}
 
 	return nil
@@ -274,11 +338,11 @@ func buildDenyACLs(namespace, policy, pg, aclLogging string, policyType knet.Pol
 	denyMatch := getACLMatch(pg, "", policyType)
 	allowMatch := getACLMatch(pg, "(arp || nd)", policyType)
 	if policyType == knet.PolicyTypeIngress {
-		denyACL = buildACL(namespace, pg, policy, nbdb.ACLDirectionToLport, types.DefaultDenyPriority, denyMatch, nbdb.ACLActionDrop, aclLogging, policyType)
-		allowACL = buildACL(namespace, pg, "ARPallowPolicy", nbdb.ACLDirectionToLport, types.DefaultAllowPriority, allowMatch, nbdb.ACLActionAllow, "", policyType)
+		denyACL = buildACL(namespace, pg, ingressDefaultDenySuffix, nbdb.ACLDirectionToLport, types.DefaultDenyPriority, denyMatch, nbdb.ACLActionDrop, aclLogging, policyType)
+		allowACL = buildACL(namespace, pg, arpAllowPolicySuffix, nbdb.ACLDirectionToLport, types.DefaultAllowPriority, allowMatch, nbdb.ACLActionAllow, "", policyType)
 	} else {
-		denyACL = buildACL(namespace, pg, policy, nbdb.ACLDirectionFromLport, types.DefaultDenyPriority, denyMatch, nbdb.ACLActionDrop, aclLogging, policyType)
-		allowACL = buildACL(namespace, pg, "ARPallowPolicy", nbdb.ACLDirectionFromLport, types.DefaultAllowPriority, allowMatch, nbdb.ACLActionAllow, "", policyType)
+		denyACL = buildACL(namespace, pg, egressDefaultDenySuffix, nbdb.ACLDirectionFromLport, types.DefaultDenyPriority, denyMatch, nbdb.ACLActionDrop, aclLogging, policyType)
+		allowACL = buildACL(namespace, pg, arpAllowPolicySuffix, nbdb.ACLDirectionFromLport, types.DefaultAllowPriority, allowMatch, nbdb.ACLActionAllow, "", policyType)
 	}
 	return
 }

--- a/go-controller/pkg/ovn/policy_test.go
+++ b/go-controller/pkg/ovn/policy_test.go
@@ -1822,6 +1822,13 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 					egressOptions,
 				)
 				leftOverACL1FromUpgrade.UUID = *leftOverACL1FromUpgrade.Name + "-egressAllowACL-UUID"
+				testOnlyEgressDenyPG := libovsdbops.BuildPortGroup(
+					pgHash+"_"+egressDenyPG,
+					pgHash+"_"+egressDenyPG,
+					nil,
+					[]*nbdb.ACL{leftOverACL1FromUpgrade},
+				)
+				testOnlyEgressDenyPG.UUID = testOnlyEgressDenyPG.Name + "-UUID"
 				// ACL2: leftover arp allow ACL ingress with old match (arp)
 				leftOverACL2FromUpgrade := libovsdbops.BuildACL(
 					"leftover1"+"_"+arpAllowPolicySuffix,
@@ -1838,6 +1845,13 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 					nil,
 				)
 				leftOverACL2FromUpgrade.UUID = *leftOverACL2FromUpgrade.Name + "-ingressAllowACL-UUID"
+				testOnlyIngressDenyPG := libovsdbops.BuildPortGroup(
+					pgHash+"_"+ingressDenyPG,
+					pgHash+"_"+ingressDenyPG,
+					nil,
+					[]*nbdb.ACL{leftOverACL2FromUpgrade},
+				)
+				testOnlyIngressDenyPG.UUID = testOnlyIngressDenyPG.Name + "-UUID"
 
 				// ACL3: leftover default deny ACL egress with old name (namespace_policyname)
 				leftOverACL3FromUpgrade := libovsdbops.BuildACL(
@@ -1882,6 +1896,8 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 						leftOverACL2FromUpgrade,
 						leftOverACL3FromUpgrade,
 						leftOverACL4FromUpgrade,
+						testOnlyIngressDenyPG,
+						testOnlyEgressDenyPG,
 					},
 				}
 
@@ -1924,6 +1940,10 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				leftOverACL4FromUpgrade.Name = &newDefaultDenyIngressACLName
 				expectedData = append(expectedData, leftOverACL3FromUpgrade)
 				expectedData = append(expectedData, leftOverACL4FromUpgrade)
+				testOnlyIngressDenyPG.ACLs = nil // Sync Function should remove stale ACL from PGs and delete the ACL
+				testOnlyEgressDenyPG.ACLs = nil  // Sync Function should remove stale ACL from PGs and delete the ACL
+				expectedData = append(expectedData, testOnlyIngressDenyPG)
+				expectedData = append(expectedData, testOnlyEgressDenyPG)
 
 				fakeOvn.asf.ExpectAddressSetWithIPs(namespaceName1, []string{nPodTest.podIP})
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdb.HaveData(expectedData...))

--- a/go-controller/pkg/ovn/policy_test.go
+++ b/go-controller/pkg/ovn/policy_test.go
@@ -101,7 +101,7 @@ func (n kNetworkPolicy) getDefaultDenyData(networkPolicy *knet.NetworkPolicy, po
 		egressOptions = map[string]string{}
 	}
 	egressDenyACL := libovsdbops.BuildACL(
-		networkPolicy.Namespace+"_"+networkPolicy.Name,
+		networkPolicy.Namespace+"_"+egressDefaultDenySuffix,
 		egressDirection,
 		types.DefaultDenyPriority,
 		"inport == @"+pgHash+"_"+egressDenyPG,
@@ -117,7 +117,7 @@ func (n kNetworkPolicy) getDefaultDenyData(networkPolicy *knet.NetworkPolicy, po
 	egressDenyACL.UUID = *egressDenyACL.Name + "-egressDenyACL-UUID"
 
 	egressAllowACL := libovsdbops.BuildACL(
-		networkPolicy.Namespace+"_ARPallowPolicy",
+		networkPolicy.Namespace+"_"+arpAllowPolicySuffix,
 		egressDirection,
 		types.DefaultAllowPriority,
 		"inport == @"+pgHash+"_"+egressDenyPG+" && (arp || nd)",
@@ -133,7 +133,7 @@ func (n kNetworkPolicy) getDefaultDenyData(networkPolicy *knet.NetworkPolicy, po
 	egressAllowACL.UUID = *egressAllowACL.Name + "-egressAllowACL-UUID"
 
 	ingressDenyACL := libovsdbops.BuildACL(
-		networkPolicy.Namespace+"_"+networkPolicy.Name,
+		networkPolicy.Namespace+"_"+ingressDefaultDenySuffix,
 		nbdb.ACLDirectionToLport,
 		types.DefaultDenyPriority,
 		"outport == @"+pgHash+"_"+ingressDenyPG,
@@ -149,7 +149,7 @@ func (n kNetworkPolicy) getDefaultDenyData(networkPolicy *knet.NetworkPolicy, po
 	ingressDenyACL.UUID = *ingressDenyACL.Name + "-ingressDenyACL-UUID"
 
 	ingressAllowACL := libovsdbops.BuildACL(
-		networkPolicy.Namespace+"_ARPallowPolicy",
+		networkPolicy.Namespace+"_"+arpAllowPolicySuffix,
 		nbdb.ACLDirectionToLport,
 		types.DefaultAllowPriority,
 		"outport == @"+pgHash+"_"+ingressDenyPG+" && (arp || nd)",
@@ -1658,10 +1658,10 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				}
 				pgHash := hashedPortGroup(networkPolicy.Namespace)
 				leftOverACLFromUpgrade1 := libovsdbops.BuildACL(
-					networkPolicy.Namespace+"_ARPallowPolicy",
+					networkPolicy.Namespace+"_"+arpAllowPolicySuffix,
 					nbdb.ACLDirectionFromLport,
 					types.DefaultAllowPriority,
-					"inport == @"+pgHash+"_"+egressDenyPG+" && arp",
+					"inport == @"+pgHash+"_"+egressDenyPG+" && (arp)", // invalid ACL match; won't be cleaned up
 					nbdb.ACLActionAllow,
 					types.OvnACLLoggingMeter,
 					nbdb.ACLSeverityInfo,
@@ -1671,10 +1671,10 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 					},
 					egressOptions,
 				)
-				leftOverACLFromUpgrade1.UUID = *leftOverACLFromUpgrade1.Name + "-ingressAllowACL-UUID1"
+				leftOverACLFromUpgrade1.UUID = *leftOverACLFromUpgrade1.Name + "-egressAllowACL-UUID1"
 
 				leftOverACLFromUpgrade2 := libovsdbops.BuildACL(
-					networkPolicy.Namespace+"_ARPallowPolicy",
+					networkPolicy.Namespace+"_"+arpAllowPolicySuffix,
 					nbdb.ACLDirectionFromLport,
 					types.DefaultAllowPriority,
 					"inport == @"+pgHash+"_"+egressDenyPG+" && (arp || nd)",
@@ -1687,7 +1687,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 					},
 					egressOptions,
 				)
-				leftOverACLFromUpgrade2.UUID = *leftOverACLFromUpgrade2.Name + "-ingressAllowACL-UUID2"
+				leftOverACLFromUpgrade2.UUID = *leftOverACLFromUpgrade2.Name + "-egressAllowACL-UUID2"
 
 				initialDB1 := libovsdb.TestSetup{
 					NBData: []libovsdb.TestData{
@@ -1731,6 +1731,202 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				// I0623 policy.go:1285] Deleting network policy networkpolicy1 in namespace namespace1, np is nil: true
 				// W0623 policy.go:1315] Unable to delete network policy: namespace1/networkpolicy1 since its not found in cache
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+
+		ginkgo.It("older stale ACLs should be cleaned up or updated at startup via syncNetworkPolicies", func() {
+			app.Action = func(ctx *cli.Context) error {
+				namespace1 := *newNamespace(namespaceName1)
+				nPodTest := newTPod(
+					"node1",
+					"10.128.1.0/24",
+					"10.128.1.2",
+					"10.128.1.1",
+					"myPod",
+					"10.128.1.3",
+					"0a:58:0a:80:01:03",
+					namespace1.Name,
+				)
+				nPod := newPod(nPodTest.namespace, nPodTest.podName, nPodTest.nodeName, nPodTest.podIP)
+
+				const (
+					labelName string = "pod-name"
+					labelVal  string = "server"
+					portNum   int32  = 81
+				)
+				nPod.Labels[labelName] = labelVal
+
+				tcpProtocol := v1.Protocol(v1.ProtocolTCP)
+				networkPolicy1 := newNetworkPolicy("networkpolicy1", namespace1.Name,
+					metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							labelName: labelVal,
+						},
+					},
+					[]knet.NetworkPolicyIngressRule{{
+						Ports: []knet.NetworkPolicyPort{{
+							Port:     &intstr.IntOrString{IntVal: portNum},
+							Protocol: &tcpProtocol,
+						}},
+					}},
+					[]knet.NetworkPolicyEgressRule{{
+						Ports: []knet.NetworkPolicyPort{{
+							Port:     &intstr.IntOrString{IntVal: portNum},
+							Protocol: &tcpProtocol,
+						}},
+					}},
+				)
+				networkPolicy2 := newNetworkPolicy("networkpolicy2", namespace1.Name,
+					metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							labelName: labelVal,
+						},
+					},
+					[]knet.NetworkPolicyIngressRule{{
+						Ports: []knet.NetworkPolicyPort{{
+							Port:     &intstr.IntOrString{IntVal: portNum + 1},
+							Protocol: &tcpProtocol,
+						}},
+					}},
+					[]knet.NetworkPolicyEgressRule{{
+						Ports: []knet.NetworkPolicyPort{{
+							Port:     &intstr.IntOrString{IntVal: portNum + 1},
+							Protocol: &tcpProtocol,
+						}},
+					}},
+				)
+
+				egressOptions := map[string]string{
+					// older versions of ACLs don't have, should be added by syncNetworkPolicies on startup
+					//	"apply-after-lb": "true",
+				}
+				pgHash := hashedPortGroup("leftover1")
+				// ACL1: leftover arp allow ACL egress with old match (arp)
+				leftOverACL1FromUpgrade := libovsdbops.BuildACL(
+					"leftover1"+"_"+arpAllowPolicySuffix,
+					nbdb.ACLDirectionFromLport,
+					types.DefaultAllowPriority,
+					"inport == @"+pgHash+"_"+egressDenyPG+" && arp",
+					nbdb.ACLActionAllow,
+					types.OvnACLLoggingMeter,
+					nbdb.ACLSeverityInfo,
+					false,
+					map[string]string{
+						defaultDenyPolicyTypeACLExtIdKey: string(knet.PolicyTypeEgress),
+					},
+					egressOptions,
+				)
+				leftOverACL1FromUpgrade.UUID = *leftOverACL1FromUpgrade.Name + "-egressAllowACL-UUID"
+				// ACL2: leftover arp allow ACL ingress with old match (arp)
+				leftOverACL2FromUpgrade := libovsdbops.BuildACL(
+					"leftover1"+"_"+arpAllowPolicySuffix,
+					nbdb.ACLDirectionToLport,
+					types.DefaultAllowPriority,
+					"outport == @"+pgHash+"_"+ingressDenyPG+" && arp",
+					nbdb.ACLActionAllow,
+					types.OvnACLLoggingMeter,
+					nbdb.ACLSeverityInfo,
+					false,
+					map[string]string{
+						defaultDenyPolicyTypeACLExtIdKey: string(knet.PolicyTypeIngress),
+					},
+					nil,
+				)
+				leftOverACL2FromUpgrade.UUID = *leftOverACL2FromUpgrade.Name + "-ingressAllowACL-UUID"
+
+				// ACL3: leftover default deny ACL egress with old name (namespace_policyname)
+				leftOverACL3FromUpgrade := libovsdbops.BuildACL(
+					"leftover1"+"_"+networkPolicy2.Name,
+					nbdb.ACLDirectionFromLport,
+					types.DefaultDenyPriority,
+					"inport == @"+pgHash+"_"+egressDenyPG,
+					nbdb.ACLActionDrop,
+					types.OvnACLLoggingMeter,
+					nbdb.ACLSeverityInfo,
+					false,
+					map[string]string{
+						defaultDenyPolicyTypeACLExtIdKey: string(knet.PolicyTypeEgress),
+					},
+					egressOptions,
+				)
+				leftOverACL3FromUpgrade.UUID = *leftOverACL3FromUpgrade.Name + "-egressDenyACL-UUID"
+
+				// ACL4: leftover default deny ACL ingress with old name (namespace_policyname)
+				leftOverACL4FromUpgrade := libovsdbops.BuildACL(
+					"leftover1"+"_"+networkPolicy2.Name,
+					nbdb.ACLDirectionToLport,
+					types.DefaultDenyPriority,
+					"outport == @"+pgHash+"_"+ingressDenyPG,
+					nbdb.ACLActionDrop,
+					types.OvnACLLoggingMeter,
+					nbdb.ACLSeverityInfo,
+					false,
+					map[string]string{
+						defaultDenyPolicyTypeACLExtIdKey: string(knet.PolicyTypeIngress),
+					},
+					nil,
+				)
+				leftOverACL4FromUpgrade.UUID = *leftOverACL4FromUpgrade.Name + "-ingressDenyACL-UUID"
+
+				initialDB1 := libovsdb.TestSetup{
+					NBData: []libovsdb.TestData{
+						&nbdb.LogicalSwitch{
+							Name: "node1",
+						},
+						leftOverACL1FromUpgrade,
+						leftOverACL2FromUpgrade,
+						leftOverACL3FromUpgrade,
+						leftOverACL4FromUpgrade,
+					},
+				}
+
+				fakeOvn.startWithDBSetup(initialDB1,
+					&v1.NamespaceList{
+						Items: []v1.Namespace{namespace1},
+					},
+					&v1.PodList{
+						Items: []v1.Pod{*nPod},
+					},
+					&knet.NetworkPolicyList{
+						Items: []knet.NetworkPolicy{*networkPolicy1},
+					},
+				)
+				nPodTest.populateLogicalSwitchCache(fakeOvn, getLogicalSwitchUUID(fakeOvn.controller.nbClient, "node1"))
+				err := fakeOvn.controller.WatchNamespaces()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				fakeOvn.controller.WatchPods()
+				fakeOvn.controller.WatchNetworkPolicy()
+
+				_, err = fakeOvn.fakeClient.KubeClient.NetworkingV1().NetworkPolicies(networkPolicy1.Namespace).Create(context.TODO(), networkPolicy2, metav1.CreateOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				npTest := kNetworkPolicy{}
+				expectedData := []libovsdb.TestData{}
+				expectedData = append(expectedData, getExpectedDataPodsAndSwitches([]testPod{nPodTest}, []string{"node1"})...)
+				gressPolicy1ExpectedData := npTest.getPolicyData(networkPolicy1, []string{nPodTest.portUUID}, nil, []int32{portNum}, nbdb.ACLSeverityInfo, false)
+				defaultDeny1ExpectedData := npTest.getDefaultDenyData(networkPolicy1, []string{nPodTest.portUUID}, nbdb.ACLSeverityInfo, false)
+				expectedData = append(expectedData, gressPolicy1ExpectedData...)
+				expectedData = append(expectedData, defaultDeny1ExpectedData...)
+				gressPolicy2ExpectedData := npTest.getPolicyData(networkPolicy2, []string{nPodTest.portUUID}, nil, []int32{portNum + 1}, nbdb.ACLSeverityInfo, false)
+				expectedData = append(expectedData, gressPolicy2ExpectedData...)
+				egressOptions = map[string]string{
+					"apply-after-lb": "true",
+				}
+				leftOverACL3FromUpgrade.Options = egressOptions
+				newDefaultDenyEgressACLName := "leftover1_" + egressDefaultDenySuffix
+				newDefaultDenyIngressACLName := "leftover1_" + ingressDefaultDenySuffix
+				leftOverACL3FromUpgrade.Name = &newDefaultDenyEgressACLName
+				leftOverACL4FromUpgrade.Name = &newDefaultDenyIngressACLName
+				expectedData = append(expectedData, leftOverACL3FromUpgrade)
+				expectedData = append(expectedData, leftOverACL4FromUpgrade)
+
+				fakeOvn.asf.ExpectAddressSetWithIPs(namespaceName1, []string{nPodTest.podIP})
+				gomega.Eventually(fakeOvn.nbClient).Should(libovsdb.HaveData(expectedData...))
 
 				return nil
 			}


### PR DESCRIPTION
Minor conflict in commit 1 on the e2e file since https://github.com/openshift/ovn-kubernetes/commit/e1f7da0fe5072ca8574f0aa98fa0c80ff2c95a92 is missing in 4.11