### PR TITLE
OCPBUGS-811: [Release 4.9] correct creation and update of egressFirewall 

### DIFF
--- a/go-controller/pkg/ovn/egressfirewall.go
+++ b/go-controller/pkg/ovn/egressfirewall.go
@@ -468,7 +468,7 @@ func (oc *Controller) createEgressFirewallRules(priority int, match, action, ext
 	}
 	uuids, stderr, err := util.RunOVNNbctl("--data=bare", "--no-heading",
 		"--columns=_uuid", "--format=table", "find", "ACL", match, "action="+action,
-		fmt.Sprintf("external-ids:egressFirewall=%s", externalID))
+		fmt.Sprintf("external-ids:egressFirewall=%s", externalID), fmt.Sprintf("priority=%d", priority))
 	if err != nil {
 		return fmt.Errorf("error executing find ACL command, stderr: %q, %+v", stderr, err)
 	}

--- a/go-controller/pkg/ovn/egressfirewall.go
+++ b/go-controller/pkg/ovn/egressfirewall.go
@@ -466,17 +466,34 @@ func (oc *Controller) createEgressFirewallRules(priority int, match, action, ext
 	} else {
 		logicalSwitches = append(logicalSwitches, types.OVNJoinSwitch)
 	}
+	uuids, stderr, err := util.RunOVNNbctl("--data=bare", "--no-heading",
+		"--columns=_uuid", "--format=table", "find", "ACL", match, "action="+action,
+		fmt.Sprintf("external-ids:egressFirewall=%s", externalID))
+	if err != nil {
+		return fmt.Errorf("error executing find ACL command, stderr: %q, %+v", stderr, err)
+	}
 	sort.Strings(logicalSwitches)
 	for _, logicalSwitch := range logicalSwitches {
-		id := fmt.Sprintf("%s-%d", logicalSwitch, priority)
-		_, stderr, err := txn.AddOrCommit([]string{"--id=@" + id, "create", "acl",
-			fmt.Sprintf("priority=%d", priority),
-			fmt.Sprintf("direction=%s", types.DirectionToLPort), match, "action=" + action,
-			fmt.Sprintf("external-ids:egressFirewall=%s", externalID),
-			"--", "add", "logical_switch", logicalSwitch,
-			"acls", "@" + id})
-		if err != nil {
-			return fmt.Errorf("failed to commit db changes for egressFirewall  stderr: %q, err: %+v", stderr, err)
+		if uuids == "" {
+			id := fmt.Sprintf("%s-%d", logicalSwitch, priority)
+			_, stderr, err := txn.AddOrCommit([]string{"--id=@" + id, "create", "acl",
+				fmt.Sprintf("priority=%d", priority),
+				fmt.Sprintf("direction=%s", types.DirectionToLPort), match, "action=" + action,
+				fmt.Sprintf("external-ids:egressFirewall=%s", externalID),
+				"--", "add", "logical_switch", logicalSwitch,
+				"acls", "@" + id})
+			if err != nil {
+				return fmt.Errorf("failed to commit db changes for egressFirewall  stderr: %q, err: %+v", stderr, err)
+
+			}
+
+		} else {
+			for _, uuid := range strings.Fields(uuids) {
+				_, stderr, err := txn.AddOrCommit([]string{"add", "logical_switch", logicalSwitch, "acls", uuid})
+				if err != nil {
+					return fmt.Errorf("failed to commit db changes for egressFirewall stderr: %q, err: %+v", stderr, err)
+				}
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
commit 1: 

revert https://github.com/openshift/ovn-kubernetes/commit/02d349323c254c4c106ff65520835946d75f29ce
which causes new egressfirewall ACLs to be created everytime a new master is elected 

commit 2:
correct the way that egressFirewalls are updated. When updating an
egressfirewall rule we need to check the previous rules priority to
figure out if we actually need to delete it.



<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->