### PR TITLE
[release-4.10] OCPBUGS-1454: Fix NP upgrade bug: unexpectedly found multiple equivalent ACLs (arp v/s arp||nd)

### DIFF
--- a/go-controller/pkg/libovsdbops/acl.go
+++ b/go-controller/pkg/libovsdbops/acl.go
@@ -42,8 +42,8 @@ func IsEquivalentACL(existing *nbdb.ACL, searched *nbdb.ACL) bool {
 		existing.Action == searched.Action
 }
 
-// findACLsByPredicate looks up ACLs from the cache based on a given predicate
-func findACLsByPredicate(nbClient libovsdbclient.Client, lookupFunction func(item *nbdb.ACL) bool) ([]nbdb.ACL, error) {
+// FindACLsByPredicate looks up ACLs from the cache based on a given predicate
+func FindACLsByPredicate(nbClient libovsdbclient.Client, lookupFunction func(item *nbdb.ACL) bool) ([]nbdb.ACL, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout)
 	defer cancel()
 	acls := []nbdb.ACL{}
@@ -61,7 +61,7 @@ func findACL(nbClient libovsdbclient.Client, acl *nbdb.ACL) error {
 		return nil
 	}
 
-	acls, err := findACLsByPredicate(nbClient, func(item *nbdb.ACL) bool {
+	acls, err := FindACLsByPredicate(nbClient, func(item *nbdb.ACL) bool {
 		return IsEquivalentACL(item, acl)
 	})
 
@@ -87,7 +87,7 @@ func FindRejectACLs(nbClient libovsdbclient.Client) ([]nbdb.ACL, error) {
 		return acl.Action == nbdb.ACLActionReject
 	}
 
-	return findACLsByPredicate(nbClient, rejectACLLookupFcn)
+	return FindACLsByPredicate(nbClient, rejectACLLookupFcn)
 }
 
 // FindACLsByPriorityRange looks up the acls with priorities within a given inclusive range
@@ -97,7 +97,7 @@ func FindACLsByPriorityRange(nbClient libovsdbclient.Client, minPriority, maxPri
 		return (item.Priority >= minPriority) && (item.Priority <= maxPriority)
 	}
 
-	return findACLsByPredicate(nbClient, priorityRangeLookupFcn)
+	return FindACLsByPredicate(nbClient, priorityRangeLookupFcn)
 }
 
 // FindACLsByExternalID looks up the acls with the given externalID/s
@@ -115,7 +115,7 @@ func FindACLsByExternalID(nbClient libovsdbclient.Client, externalIDs map[string
 		return aclMatch
 	}
 
-	return findACLsByPredicate(nbClient, ACLLookupFcn)
+	return FindACLsByPredicate(nbClient, ACLLookupFcn)
 }
 
 func ensureACLUUID(acl *nbdb.ACL) {

--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"reflect"
+	"strings"
 	"sync"
 	"time"
 
@@ -45,6 +46,8 @@ const (
 	ingressDefaultDenySuffix = "ingressDefaultDeny"
 	// egressDefaultDenySuffix is the suffix used when creating the ingress port group for a namespace
 	egressDefaultDenySuffix = "egressDefaultDeny"
+	// arpAllowPolicySuffix is the suffix used when creating default ACLs for a namespace
+	arpAllowPolicySuffix = "ARPallowPolicy"
 )
 
 var NetworkPolicyNotCreated error
@@ -109,6 +112,46 @@ func getACLLoggingSeverity(aclLogging string) string {
 // hash the provided input to make it a valid portGroup name.
 func hashedPortGroup(s string) string {
 	return util.HashForOVN(s)
+}
+
+// updateStaleDefaultDenyACLNames updates the naming of the default ingress and egress deny ACLs per namespace
+// oldName: <namespace>_<policyname> (lucky winner will be first policy created in the namespace)
+// newName: <namespace>_egressDefaultDeny OR <namespace>_ingressDefaultDeny
+func (oc *Controller) updateStaleDefaultDenyACLNames(npType knet.PolicyType, gressSuffix string) error {
+	cleanUpDefaultDeny := make(map[string][]nbdb.ACL)
+	p := func(item *nbdb.ACL) bool {
+		return item.ExternalIDs[defaultDenyPolicyTypeACLExtIdKey] == string(npType) && // default-deny-policy-type:Egress or default-deny-policy-type:Ingress
+			strings.Contains(item.Match, gressSuffix) && // Match:inport ==	@ablah80448_egressDefaultDeny or Match:inport == @ablah80448_ingressDefaultDeny
+			!strings.Contains(*item.Name, arpAllowPolicySuffix) && // != name: namespace_ARPallowPolicy
+			!strings.Contains(*item.Name, gressSuffix) // filter out already converted ACLs
+	}
+	gressACLs, err := libovsdbops.FindACLsByPredicate(oc.nbClient, p)
+	if err != nil {
+		return fmt.Errorf("cannot find NetworkPolicy default deny ACLs: %v", err)
+	}
+	for _, acl := range gressACLs {
+		acl := acl
+		namespace := strings.Split(*acl.Name, "_")[0] // parse the namespace from the ACL name
+		cleanUpDefaultDeny[namespace] = append(cleanUpDefaultDeny[namespace], acl)
+	}
+	// loop through the cleanUp map and per namespace update the first ACL's name and delete the rest
+	for namespace, aclList := range cleanUpDefaultDeny {
+		aclList := aclList
+		newName := namespacePortGroupACLName(namespace, "", gressSuffix)
+		if len(aclList) > 1 {
+			// this should never be the case but delete everything except 1st ACL
+			err := libovsdbops.DeleteACLs(oc.nbClient, aclList[1:])
+			if err != nil {
+				return err
+			}
+		}
+		aclList[0].Name = &newName
+		err := libovsdbops.CreateOrUpdateACLs(oc.nbClient, &aclList[0])
+		if err != nil {
+			return fmt.Errorf("cannot update old NetworkPolicy ACLs for namespace %s: %v", namespace, err)
+		}
+	}
+	return nil
 }
 
 func (oc *Controller) syncNetworkPolicies(networkPolicies []interface{}) {
@@ -193,6 +236,28 @@ func (oc *Controller) syncNetworkPoliciesRetriable(networkPolicies []interface{}
 
 	}
 
+	if err := oc.updateStaleDefaultDenyACLNames(knet.PolicyTypeEgress, egressDefaultDenySuffix); err != nil {
+		return fmt.Errorf("cannot clean up egress default deny ACL name: %v", err)
+	}
+	if err := oc.updateStaleDefaultDenyACLNames(knet.PolicyTypeIngress, ingressDefaultDenySuffix); err != nil {
+		return fmt.Errorf("cannot clean up ingress default deny ACL name: %v", err)
+	}
+
+	// remove stale egress and ingress allow arp ACLs that were leftover as a result
+	// of ACL migration for "ARPallowPolicy" when the match changed from "arp" to "(arp || nd)"
+	p := func(item *nbdb.ACL) bool {
+		return strings.Contains(item.Match, " && arp") &&
+			strings.Contains(*item.Name, arpAllowPolicySuffix)
+	}
+	gressACLs, err := libovsdbops.FindACLsByPredicate(oc.nbClient, p)
+	if err != nil {
+		return fmt.Errorf("cannot find stale arp allow ACLs: %v", err)
+	}
+	err = libovsdbops.DeleteACLs(oc.nbClient, gressACLs)
+	if err != nil {
+		return fmt.Errorf("cannot delete stale arp allow ACLs: %v", err)
+	}
+
 	return nil
 }
 
@@ -262,11 +327,11 @@ func buildDenyACLs(namespace, policy, pg, aclLogging string, policyType knet.Pol
 	denyMatch := getACLMatch(pg, "", policyType)
 	allowMatch := getACLMatch(pg, "(arp || nd)", policyType)
 	if policyType == knet.PolicyTypeIngress {
-		denyACL = buildACL(namespace, pg, policy, nbdb.ACLDirectionToLport, types.DefaultDenyPriority, denyMatch, nbdb.ACLActionDrop, aclLogging, policyType)
-		allowACL = buildACL(namespace, pg, "ARPallowPolicy", nbdb.ACLDirectionToLport, types.DefaultAllowPriority, allowMatch, nbdb.ACLActionAllow, "", policyType)
+		denyACL = buildACL(namespace, pg, ingressDefaultDenySuffix, nbdb.ACLDirectionToLport, types.DefaultDenyPriority, denyMatch, nbdb.ACLActionDrop, aclLogging, policyType)
+		allowACL = buildACL(namespace, pg, arpAllowPolicySuffix, nbdb.ACLDirectionToLport, types.DefaultAllowPriority, allowMatch, nbdb.ACLActionAllow, "", policyType)
 	} else {
-		denyACL = buildACL(namespace, pg, policy, nbdb.ACLDirectionFromLport, types.DefaultDenyPriority, denyMatch, nbdb.ACLActionDrop, aclLogging, policyType)
-		allowACL = buildACL(namespace, pg, "ARPallowPolicy", nbdb.ACLDirectionFromLport, types.DefaultAllowPriority, allowMatch, nbdb.ACLActionAllow, "", policyType)
+		denyACL = buildACL(namespace, pg, egressDefaultDenySuffix, nbdb.ACLDirectionFromLport, types.DefaultDenyPriority, denyMatch, nbdb.ACLActionDrop, aclLogging, policyType)
+		allowACL = buildACL(namespace, pg, arpAllowPolicySuffix, nbdb.ACLDirectionFromLport, types.DefaultAllowPriority, allowMatch, nbdb.ACLActionAllow, "", policyType)
 	}
 	return
 }

--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -123,7 +123,7 @@ func (oc *Controller) updateStaleDefaultDenyACLNames(npType knet.PolicyType, gre
 		return item.ExternalIDs[defaultDenyPolicyTypeACLExtIdKey] == string(npType) && // default-deny-policy-type:Egress or default-deny-policy-type:Ingress
 			strings.Contains(item.Match, gressSuffix) && // Match:inport ==	@ablah80448_egressDefaultDeny or Match:inport == @ablah80448_ingressDefaultDeny
 			!strings.Contains(*item.Name, arpAllowPolicySuffix) && // != name: namespace_ARPallowPolicy
-			!strings.Contains(*item.Name, gressSuffix) // filter out already converted ACLs
+			!strings.Contains(*item.Name, gressSuffix) // filter out already converted ACLs (we still continue to pick the cases where names were >45 chars)
 	}
 	gressACLs, err := libovsdbops.FindACLsByPredicate(oc.nbClient, p)
 	if err != nil {
@@ -159,8 +159,26 @@ func (oc *Controller) updateStaleDefaultDenyACLNames(npType knet.PolicyType, gre
 				return err
 			}
 		}
-		aclList[0].Name = &newName
-		err := libovsdbops.CreateOrUpdateACLs(oc.nbClient, &aclList[0])
+		meter := ""
+		if aclList[0].Meter != nil {
+			meter = *aclList[0].Meter
+		}
+		severity := ""
+		if aclList[0].Severity != nil {
+			severity = *aclList[0].Severity
+		}
+		newACL := libovsdbops.BuildACL(
+			newName, // this is the only thing we need to change, keep the rest same
+			aclList[0].Direction,
+			aclList[0].Priority,
+			aclList[0].Match,
+			aclList[0].Action,
+			meter,
+			severity,
+			aclList[0].Log,
+			aclList[0].ExternalIDs,
+		)
+		err := libovsdbops.CreateOrUpdateACLs(oc.nbClient, newACL)
 		if err != nil {
 			return fmt.Errorf("cannot update old NetworkPolicy ACLs for namespace %s: %v", namespace, err)
 		}

--- a/go-controller/pkg/ovn/policy_test.go
+++ b/go-controller/pkg/ovn/policy_test.go
@@ -33,6 +33,7 @@ import (
 	apimachinerytypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	utilnet "k8s.io/utils/net"
+	utilpointer "k8s.io/utils/pointer"
 )
 
 type ipMode struct {
@@ -115,7 +116,7 @@ func (n kNetworkPolicy) getDefaultDenyData(networkPolicy *knet.NetworkPolicy, po
 		networkPolicy.Namespace+"_"+arpAllowPolicySuffix,
 		egressDirection,
 		types.DefaultAllowPriority,
-		"inport == @"+pgHash+"_"+egressDenyPG+" && (arp || nd)",
+		"inport == @"+pgHash+"_"+egressDenyPG+" && "+arpAllowPolicyMatch,
 		nbdb.ACLActionAllow,
 		types.OvnACLLoggingMeter,
 		nbdb.ACLSeverityInfo,
@@ -145,7 +146,7 @@ func (n kNetworkPolicy) getDefaultDenyData(networkPolicy *knet.NetworkPolicy, po
 		networkPolicy.Namespace+"_"+arpAllowPolicySuffix,
 		nbdb.ACLDirectionToLport,
 		types.DefaultAllowPriority,
-		"outport == @"+pgHash+"_"+ingressDenyPG+" && (arp || nd)",
+		"outport == @"+pgHash+"_"+ingressDenyPG+" && "+arpAllowPolicyMatch,
 		nbdb.ACLActionAllow,
 		types.OvnACLLoggingMeter,
 		nbdb.ACLSeverityInfo,
@@ -1589,7 +1590,8 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 
 		ginkgo.It("deleting a network policy that failed half-way through creation succeeds", func() {
 			app.Action = func(ctx *cli.Context) error {
-				namespace1 := *newNamespace(namespaceName1)
+				longNameSpaceName := "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk" // create with 63 characters
+				namespace1 := *newNamespace(longNameSpaceName)
 				nPodTest := newTPod(
 					"node1",
 					"10.128.1.0/24",
@@ -1650,7 +1652,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 					networkPolicy.Namespace+"_"+arpAllowPolicySuffix,
 					nbdb.ACLDirectionFromLport,
 					types.DefaultAllowPriority,
-					"inport == @"+pgHash+"_"+egressDenyPG+" && (arp || nd)",
+					"inport == @"+pgHash+"_"+egressDenyPG+" && "+arpAllowPolicyMatch,
 					nbdb.ACLActionAllow,
 					types.OvnACLLoggingMeter,
 					nbdb.ACLSeverityInfo,
@@ -1688,7 +1690,9 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 
 				err := fakeOvn.controller.addNetworkPolicy(networkPolicy)
 				gomega.Expect(err).To(gomega.HaveOccurred())
-				gomega.Expect(err.Error()).To(gomega.ContainSubstring("failed to create default port groups and acls for policy: namespace1/networkpolicy1, error: unexpectedly found multiple equivalent ACLs"))
+				gomega.Expect(err.Error()).To(gomega.ContainSubstring("failed to create default port groups and acls " +
+					"for policy: abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk/networkpolicy1, " +
+					"error: unexpectedly found multiple equivalent ACLs"))
 
 				//ensure the default PGs and ACLs were removed via rollback from add failure
 				expectedData := []libovsdb.TestData{}
@@ -1782,7 +1786,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 					"leftover1"+"_"+arpAllowPolicySuffix,
 					nbdb.ACLDirectionFromLport,
 					types.DefaultAllowPriority,
-					"inport == @"+pgHash+"_"+egressDenyPG+" && arp",
+					"inport == @"+pgHash+"_"+egressDenyPG+" && "+staleArpAllowPolicyMatch,
 					nbdb.ACLActionAllow,
 					types.OvnACLLoggingMeter,
 					nbdb.ACLSeverityInfo,
@@ -1804,7 +1808,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 					"leftover1"+"_"+arpAllowPolicySuffix,
 					nbdb.ACLDirectionToLport,
 					types.DefaultAllowPriority,
-					"outport == @"+pgHash+"_"+ingressDenyPG+" && arp",
+					"outport == @"+pgHash+"_"+ingressDenyPG+" && "+staleArpAllowPolicyMatch,
 					nbdb.ACLActionAllow,
 					types.OvnACLLoggingMeter,
 					nbdb.ACLSeverityInfo,
@@ -1913,6 +1917,284 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 
 				fakeOvn.asf.ExpectAddressSetWithIPs(namespaceName1, []string{nPodTest.podIP})
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdb.HaveData(expectedData...))
+
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+
+		ginkgo.It("Create ACLs with long names and run syncNetworkPolicies", func() {
+			app.Action = func(ctx *cli.Context) error {
+				longNameSpaceName := "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk" // create with 63 characters
+				longNamespace := *newNamespace(longNameSpaceName)
+				nPodTest := newTPod(
+					"node1",
+					"10.128.1.0/24",
+					"10.128.1.2",
+					"10.128.1.1",
+					"myPod",
+					"10.128.1.3",
+					"0a:58:0a:80:01:03",
+					longNamespace.Name,
+				)
+				nPod := newPod(nPodTest.namespace, nPodTest.podName, nPodTest.nodeName, nPodTest.podIP)
+
+				const (
+					labelName string = "pod-name"
+					labelVal  string = "server"
+					portNum   int32  = 81
+				)
+				nPod.Labels[labelName] = labelVal
+
+				tcpProtocol := v1.Protocol(v1.ProtocolTCP)
+				networkPolicy1 := newNetworkPolicy("networkpolicy1", longNamespace.Name,
+					metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							labelName: labelVal,
+						},
+					},
+					[]knet.NetworkPolicyIngressRule{{
+						Ports: []knet.NetworkPolicyPort{{
+							Port:     &intstr.IntOrString{IntVal: portNum},
+							Protocol: &tcpProtocol,
+						}},
+					}},
+					[]knet.NetworkPolicyEgressRule{{
+						Ports: []knet.NetworkPolicyPort{{
+							Port:     &intstr.IntOrString{IntVal: portNum},
+							Protocol: &tcpProtocol,
+						}},
+					}},
+				)
+				networkPolicy2 := newNetworkPolicy("networkpolicy2", longNamespace.Name,
+					metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							labelName: labelVal,
+						},
+					},
+					[]knet.NetworkPolicyIngressRule{{
+						Ports: []knet.NetworkPolicyPort{{
+							Port:     &intstr.IntOrString{IntVal: portNum + 1},
+							Protocol: &tcpProtocol,
+						}},
+					}},
+					[]knet.NetworkPolicyEgressRule{{
+						Ports: []knet.NetworkPolicyPort{{
+							Port:     &intstr.IntOrString{IntVal: portNum + 1},
+							Protocol: &tcpProtocol,
+						}},
+					}},
+				)
+
+				egressOptions := map[string]string{
+					// older versions of ACLs don't have, should be added by syncNetworkPolicies on startup
+					//	"apply-after-lb": "true",
+				}
+				longLeftOverNameSpaceName := "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz" // namespace is >45 characters long
+				pgHash := hashedPortGroup(longLeftOverNameSpaceName)
+				// ACL1: leftover arp allow ACL egress with old match (arp)
+				leftOverACL1FromUpgrade := libovsdbops.BuildACL(
+					longLeftOverNameSpaceName+"_"+arpAllowPolicySuffix,
+					nbdb.ACLDirectionFromLport,
+					types.DefaultAllowPriority,
+					"inport == @"+pgHash+"_"+egressDenyPG+" && "+staleArpAllowPolicyMatch,
+					nbdb.ACLActionAllow,
+					types.OvnACLLoggingMeter,
+					nbdb.ACLSeverityInfo,
+					false,
+					map[string]string{
+						defaultDenyPolicyTypeACLExtIdKey: string(knet.PolicyTypeEgress),
+					},
+				)
+				leftOverACL1FromUpgrade.UUID = *leftOverACL1FromUpgrade.Name + "-egressAllowACL-UUID"
+				testOnlyEgressDenyPG := libovsdbops.BuildPortGroup(
+					pgHash+"_"+egressDenyPG,
+					pgHash+"_"+egressDenyPG,
+					nil,
+					[]*nbdb.ACL{leftOverACL1FromUpgrade},
+				)
+				testOnlyEgressDenyPG.UUID = testOnlyEgressDenyPG.Name + "-UUID"
+				// ACL2: leftover arp allow ACL ingress with old match (arp)
+				leftOverACL2FromUpgrade := libovsdbops.BuildACL(
+					longLeftOverNameSpaceName+"_"+arpAllowPolicySuffix,
+					nbdb.ACLDirectionToLport,
+					types.DefaultAllowPriority,
+					"outport == @"+pgHash+"_"+ingressDenyPG+" && "+staleArpAllowPolicyMatch,
+					nbdb.ACLActionAllow,
+					types.OvnACLLoggingMeter,
+					nbdb.ACLSeverityInfo,
+					false,
+					map[string]string{
+						defaultDenyPolicyTypeACLExtIdKey: string(knet.PolicyTypeIngress),
+					},
+				)
+				leftOverACL2FromUpgrade.UUID = *leftOverACL2FromUpgrade.Name + "-ingressAllowACL-UUID"
+
+				// ACL3: leftover arp allow ACL ingress with new match (arp || nd)
+				leftOverACL3FromUpgrade := libovsdbops.BuildACL(
+					longLeftOverNameSpaceName+"blah"+"_"+arpAllowPolicySuffix,
+					nbdb.ACLDirectionToLport,
+					types.DefaultAllowPriority,
+					"outport == @"+pgHash+"_"+ingressDenyPG+" && "+arpAllowPolicyMatch, // new match! this ACL should be left as is!
+					nbdb.ACLActionAllow,
+					types.OvnACLLoggingMeter,
+					nbdb.ACLSeverityInfo,
+					false,
+					map[string]string{
+						defaultDenyPolicyTypeACLExtIdKey: string(knet.PolicyTypeIngress),
+					},
+				)
+				leftOverACL3FromUpgrade.UUID = *leftOverACL3FromUpgrade.Name + "-ingressAllowACL-UUID1"
+				testOnlyIngressDenyPG := libovsdbops.BuildPortGroup(
+					pgHash+"_"+ingressDenyPG,
+					pgHash+"_"+ingressDenyPG,
+					nil,
+					[]*nbdb.ACL{leftOverACL2FromUpgrade, leftOverACL3FromUpgrade},
+				)
+				testOnlyIngressDenyPG.UUID = testOnlyIngressDenyPG.Name + "-UUID"
+
+				// ACL4: leftover default deny ACL egress with old name (namespace_policyname)
+				leftOverACL4FromUpgrade := libovsdbops.BuildACL(
+					longLeftOverNameSpaceName+"_"+networkPolicy2.Name, // we are ok here because test server doesn't impose restrictions
+					nbdb.ACLDirectionFromLport,
+					types.DefaultDenyPriority,
+					"inport == @"+pgHash+"_"+egressDenyPG,
+					nbdb.ACLActionDrop,
+					types.OvnACLLoggingMeter,
+					nbdb.ACLSeverityInfo,
+					false,
+					map[string]string{
+						defaultDenyPolicyTypeACLExtIdKey: string(knet.PolicyTypeEgress),
+					},
+				)
+				leftOverACL4FromUpgrade.UUID = *leftOverACL4FromUpgrade.Name + "-egressDenyACL-UUID"
+
+				// ACL5: leftover default deny ACL ingress with old name (namespace_policyname)
+				leftOverACL5FromUpgrade := libovsdbops.BuildACL(
+					longLeftOverNameSpaceName+"_"+networkPolicy2.Name, // we are ok here because test server doesn't impose restrictions
+					nbdb.ACLDirectionToLport,
+					types.DefaultDenyPriority,
+					"outport == @"+pgHash+"_"+ingressDenyPG,
+					nbdb.ACLActionDrop,
+					types.OvnACLLoggingMeter,
+					nbdb.ACLSeverityInfo,
+					false,
+					map[string]string{
+						defaultDenyPolicyTypeACLExtIdKey: string(knet.PolicyTypeIngress),
+					},
+				)
+				leftOverACL5FromUpgrade.UUID = *leftOverACL5FromUpgrade.Name + "-ingressDenyACL-UUID"
+
+				longLeftOverNameSpaceName62 := "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghij"
+				// ACL6: leftover default deny ACL ingress with old name (namespace_policyname) but namespace is 62 characters long
+				leftOverACL6FromUpgrade := libovsdbops.BuildACL(
+					longLeftOverNameSpaceName62+"_"+networkPolicy2.Name,
+					nbdb.ACLDirectionToLport,
+					types.DefaultDenyPriority,
+					"outport == @"+pgHash+"_"+ingressDenyPG,
+					nbdb.ACLActionDrop,
+					types.OvnACLLoggingMeter,
+					nbdb.ACLSeverityInfo,
+					false,
+					map[string]string{
+						defaultDenyPolicyTypeACLExtIdKey: string(knet.PolicyTypeIngress),
+					},
+				)
+				leftOverACL6FromUpgrade.UUID = *leftOverACL6FromUpgrade.Name + "-ingressDenyACL-UUID"
+
+				initialDB1 := libovsdb.TestSetup{
+					NBData: []libovsdb.TestData{
+						&nbdb.LogicalSwitch{
+							Name: "node1",
+						},
+						leftOverACL1FromUpgrade,
+						leftOverACL2FromUpgrade,
+						leftOverACL3FromUpgrade,
+						leftOverACL4FromUpgrade,
+						leftOverACL5FromUpgrade,
+						leftOverACL6FromUpgrade,
+						testOnlyIngressDenyPG,
+						testOnlyEgressDenyPG,
+					},
+				}
+
+				fakeOvn.startWithDBSetup(initialDB1,
+					&v1.NamespaceList{
+						Items: []v1.Namespace{longNamespace},
+					},
+					&v1.PodList{
+						Items: []v1.Pod{*nPod},
+					},
+					&knet.NetworkPolicyList{
+						Items: []knet.NetworkPolicy{*networkPolicy1},
+					},
+				)
+				nPodTest.populateLogicalSwitchCache(fakeOvn, getLogicalSwitchUUID(fakeOvn.controller.nbClient, "node1"))
+				fakeOvn.controller.WatchNamespaces()
+				fakeOvn.controller.WatchPods()
+				fakeOvn.controller.WatchNetworkPolicy()
+
+				ginkgo.By("Creating a network policy that applies to a pod")
+
+				_, err := fakeOvn.fakeClient.KubeClient.NetworkingV1().NetworkPolicies(networkPolicy1.Namespace).Get(context.TODO(), networkPolicy1.Name, metav1.GetOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				fakeOvn.asf.ExpectAddressSetWithIPs(longNamespace.Name, []string{nPodTest.podIP})
+				npTest := kNetworkPolicy{}
+				expectedData := []libovsdb.TestData{}
+				expectedData = append(expectedData, getExpectedDataPodsAndSwitches([]testPod{nPodTest}, []string{"node1"})...)
+				gressPolicy1ExpectedData := npTest.getPolicyData(networkPolicy1, []string{nPodTest.portUUID},
+					nil, []int32{portNum}, nbdb.ACLSeverityInfo, false)
+				defaultDeny1ExpectedData := npTest.getDefaultDenyData(networkPolicy1, []string{nPodTest.portUUID},
+					nbdb.ACLSeverityInfo, false)
+				expectedData = append(expectedData, gressPolicy1ExpectedData...)
+				expectedData = append(expectedData, defaultDeny1ExpectedData...)
+
+				// Create a second NP
+				ginkgo.By("Creating another policy that references that pod")
+				_, err = fakeOvn.fakeClient.KubeClient.NetworkingV1().NetworkPolicies(networkPolicy1.Namespace).
+					Create(context.TODO(), networkPolicy2, metav1.CreateOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				_, err = fakeOvn.fakeClient.KubeClient.NetworkingV1().NetworkPolicies(networkPolicy1.Namespace).Get(context.TODO(), networkPolicy2.Name, metav1.GetOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gressPolicy2ExpectedData := npTest.getPolicyData(networkPolicy2, []string{nPodTest.portUUID},
+					nil, []int32{portNum + 1}, nbdb.ACLSeverityInfo, false)
+				expectedData = append(expectedData, gressPolicy2ExpectedData...)
+				egressOptions = map[string]string{
+					"apply-after-lb": "true",
+				}
+				leftOverACL4FromUpgrade.Options = egressOptions
+				leftOverACL3FromUpgrade.Name = utilpointer.StringPtr(longLeftOverNameSpaceName + "blah_ARPall") // trims it according to RFC1123
+				leftOverACL4FromUpgrade.Name = utilpointer.StringPtr(longLeftOverNameSpaceName + "_egressDefa") // trims it according to RFC1123
+				leftOverACL5FromUpgrade.Name = utilpointer.StringPtr(longLeftOverNameSpaceName + "_ingressDef") // trims it according to RFC1123
+				leftOverACL6FromUpgrade.Name = utilpointer.StringPtr(longLeftOverNameSpaceName62 + "_")         // name stays the same here since its no-op
+				expectedData = append(expectedData, leftOverACL3FromUpgrade)
+				expectedData = append(expectedData, leftOverACL4FromUpgrade)
+				expectedData = append(expectedData, leftOverACL5FromUpgrade)
+				expectedData = append(expectedData, leftOverACL6FromUpgrade)
+				testOnlyIngressDenyPG.ACLs = []string{leftOverACL3FromUpgrade.UUID} // Sync Function should remove stale ACL from PGs and delete the ACL
+				testOnlyEgressDenyPG.ACLs = nil                                     // Sync Function should remove stale ACL from PGs and delete the ACL
+				expectedData = append(expectedData, testOnlyIngressDenyPG)
+				expectedData = append(expectedData, testOnlyEgressDenyPG)
+				gomega.Eventually(fakeOvn.nbClient).Should(libovsdb.HaveData(expectedData...))
+
+				// in stable state, after all stale acls were updated and cleanedup invoke sync again to re-enact a master restart
+				ginkgo.By("Trigger another syncNetworkPolicies run and ensure nothing has changed in the DB")
+				fakeOvn.controller.syncNetworkPolicies(nil)
+				gomega.Eventually(fakeOvn.nbClient).Should(libovsdb.HaveData(expectedData...))
+
+				ginkgo.By("Simulate the initial re-add of all network policies during upgrade and ensure we are stable")
+				nsInfo, nsUnlock, err := fakeOvn.controller.ensureNamespaceLocked(networkPolicy1.Namespace, false, nil)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				nsInfo.networkPolicies = map[string]*networkPolicy{} // reset cache so that we simulate the add that happens during upgrades
+				nsUnlock()
+				err = fakeOvn.controller.addNetworkPolicy(networkPolicy1)
+				// TODO: FIX ME
+				gomega.Expect(err).To(gomega.HaveOccurred())
+				gomega.Expect(err.Error()).To(gomega.ContainSubstring("failed to create default port groups and acls " +
+					"for policy: abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk/networkpolicy1, " +
+					"error: unexpectedly found multiple equivalent ACLs"))
 
 				return nil
 			}

--- a/go-controller/pkg/ovn/policy_test.go
+++ b/go-controller/pkg/ovn/policy_test.go
@@ -1824,7 +1824,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 
 				// ACL3: leftover default deny ACL egress with old name (namespace_policyname)
 				leftOverACL3FromUpgrade := libovsdbops.BuildACL(
-					"leftover1"+"_"+networkPolicy2.Name,
+					"youknownothingjonsnowyouknownothingjonsnowyouknownothingjonsnow"+"_"+networkPolicy2.Name,
 					nbdb.ACLDirectionFromLport,
 					types.DefaultDenyPriority,
 					"inport == @"+pgHash+"_"+egressDenyPG,
@@ -1900,7 +1900,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 					"apply-after-lb": "true",
 				}
 				leftOverACL3FromUpgrade.Options = egressOptions
-				newDefaultDenyEgressACLName := "leftover1_" + egressDefaultDenySuffix
+				newDefaultDenyEgressACLName := "youknownothingjonsnowyouknownothingjonsnowyouknownothingjonsnow" // trims it according to RFC1123
 				newDefaultDenyIngressACLName := "leftover1_" + ingressDefaultDenySuffix
 				leftOverACL3FromUpgrade.Name = &newDefaultDenyEgressACLName
 				leftOverACL4FromUpgrade.Name = &newDefaultDenyIngressACLName

--- a/go-controller/pkg/ovn/policy_test.go
+++ b/go-controller/pkg/ovn/policy_test.go
@@ -97,7 +97,7 @@ func (n kNetworkPolicy) getDefaultDenyData(networkPolicy *knet.NetworkPolicy, po
 		egressDirection = nbdb.ACLDirectionToLport
 	}
 	egressDenyACL := libovsdbops.BuildACL(
-		networkPolicy.Namespace+"_"+networkPolicy.Name,
+		networkPolicy.Namespace+"_"+egressDefaultDenySuffix,
 		egressDirection,
 		types.DefaultDenyPriority,
 		"inport == @"+pgHash+"_"+egressDenyPG,
@@ -112,7 +112,7 @@ func (n kNetworkPolicy) getDefaultDenyData(networkPolicy *knet.NetworkPolicy, po
 	egressDenyACL.UUID = libovsdbops.BuildNamedUUID()
 
 	egressAllowACL := libovsdbops.BuildACL(
-		networkPolicy.Namespace+"_ARPallowPolicy",
+		networkPolicy.Namespace+"_"+arpAllowPolicySuffix,
 		egressDirection,
 		types.DefaultAllowPriority,
 		"inport == @"+pgHash+"_"+egressDenyPG+" && (arp || nd)",
@@ -127,7 +127,7 @@ func (n kNetworkPolicy) getDefaultDenyData(networkPolicy *knet.NetworkPolicy, po
 	egressAllowACL.UUID = libovsdbops.BuildNamedUUID()
 
 	ingressDenyACL := libovsdbops.BuildACL(
-		networkPolicy.Namespace+"_"+networkPolicy.Name,
+		networkPolicy.Namespace+"_"+ingressDefaultDenySuffix,
 		nbdb.ACLDirectionToLport,
 		types.DefaultDenyPriority,
 		"outport == @"+pgHash+"_"+ingressDenyPG,
@@ -142,7 +142,7 @@ func (n kNetworkPolicy) getDefaultDenyData(networkPolicy *knet.NetworkPolicy, po
 	ingressDenyACL.UUID = libovsdbops.BuildNamedUUID()
 
 	ingressAllowACL := libovsdbops.BuildACL(
-		networkPolicy.Namespace+"_ARPallowPolicy",
+		networkPolicy.Namespace+"_"+arpAllowPolicySuffix,
 		nbdb.ACLDirectionToLport,
 		types.DefaultAllowPriority,
 		"outport == @"+pgHash+"_"+ingressDenyPG+" && (arp || nd)",
@@ -1632,10 +1632,10 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 
 				pgHash := hashedPortGroup(networkPolicy.Namespace)
 				leftOverACLFromUpgrade1 := libovsdbops.BuildACL(
-					networkPolicy.Namespace+"_ARPallowPolicy",
+					networkPolicy.Namespace+"_"+arpAllowPolicySuffix,
 					nbdb.ACLDirectionFromLport,
 					types.DefaultAllowPriority,
-					"inport == @"+pgHash+"_"+egressDenyPG+" && arp",
+					"inport == @"+pgHash+"_"+egressDenyPG+" && (arp)", // invalid ACL match; won't be cleaned up
 					nbdb.ACLActionAllow,
 					types.OvnACLLoggingMeter,
 					nbdb.ACLSeverityInfo,
@@ -1644,10 +1644,10 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 						defaultDenyPolicyTypeACLExtIdKey: string(knet.PolicyTypeEgress),
 					},
 				)
-				leftOverACLFromUpgrade1.UUID = *leftOverACLFromUpgrade1.Name + "-ingressAllowACL-UUID1"
+				leftOverACLFromUpgrade1.UUID = *leftOverACLFromUpgrade1.Name + "-egressAllowACL-UUID1"
 
 				leftOverACLFromUpgrade2 := libovsdbops.BuildACL(
-					networkPolicy.Namespace+"_ARPallowPolicy",
+					networkPolicy.Namespace+"_"+arpAllowPolicySuffix,
 					nbdb.ACLDirectionFromLport,
 					types.DefaultAllowPriority,
 					"inport == @"+pgHash+"_"+egressDenyPG+" && (arp || nd)",
@@ -1659,7 +1659,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 						defaultDenyPolicyTypeACLExtIdKey: string(knet.PolicyTypeEgress),
 					},
 				)
-				leftOverACLFromUpgrade2.UUID = *leftOverACLFromUpgrade2.Name + "-ingressAllowACL-UUID2"
+				leftOverACLFromUpgrade2.UUID = *leftOverACLFromUpgrade2.Name + "-egressAllowACL-UUID2"
 
 				initialDB1 := libovsdb.TestSetup{
 					NBData: []libovsdb.TestData{
@@ -1702,6 +1702,197 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				// I0623 policy.go:1285] Deleting network policy networkpolicy1 in namespace namespace1, np is nil: true
 				// W0623 policy.go:1315] Unable to delete network policy: namespace1/networkpolicy1 since its not found in cache
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+
+		ginkgo.It("older stale ACLs should be cleaned up or updated at startup via syncNetworkPolicies", func() {
+			app.Action = func(ctx *cli.Context) error {
+				namespace1 := *newNamespace(namespaceName1)
+				nPodTest := newTPod(
+					"node1",
+					"10.128.1.0/24",
+					"10.128.1.2",
+					"10.128.1.1",
+					"myPod",
+					"10.128.1.3",
+					"0a:58:0a:80:01:03",
+					namespace1.Name,
+				)
+				nPod := newPod(nPodTest.namespace, nPodTest.podName, nPodTest.nodeName, nPodTest.podIP)
+
+				const (
+					labelName string = "pod-name"
+					labelVal  string = "server"
+					portNum   int32  = 81
+				)
+				nPod.Labels[labelName] = labelVal
+
+				tcpProtocol := v1.Protocol(v1.ProtocolTCP)
+				networkPolicy1 := newNetworkPolicy("networkpolicy1", namespace1.Name,
+					metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							labelName: labelVal,
+						},
+					},
+					[]knet.NetworkPolicyIngressRule{{
+						Ports: []knet.NetworkPolicyPort{{
+							Port:     &intstr.IntOrString{IntVal: portNum},
+							Protocol: &tcpProtocol,
+						}},
+					}},
+					[]knet.NetworkPolicyEgressRule{{
+						Ports: []knet.NetworkPolicyPort{{
+							Port:     &intstr.IntOrString{IntVal: portNum},
+							Protocol: &tcpProtocol,
+						}},
+					}},
+				)
+				networkPolicy2 := newNetworkPolicy("networkpolicy2", namespace1.Name,
+					metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							labelName: labelVal,
+						},
+					},
+					[]knet.NetworkPolicyIngressRule{{
+						Ports: []knet.NetworkPolicyPort{{
+							Port:     &intstr.IntOrString{IntVal: portNum + 1},
+							Protocol: &tcpProtocol,
+						}},
+					}},
+					[]knet.NetworkPolicyEgressRule{{
+						Ports: []knet.NetworkPolicyPort{{
+							Port:     &intstr.IntOrString{IntVal: portNum + 1},
+							Protocol: &tcpProtocol,
+						}},
+					}},
+				)
+
+				egressOptions := map[string]string{
+					// older versions of ACLs don't have, should be added by syncNetworkPolicies on startup
+					//	"apply-after-lb": "true",
+				}
+				pgHash := hashedPortGroup("leftover1")
+				// ACL1: leftover arp allow ACL egress with old match (arp)
+				leftOverACL1FromUpgrade := libovsdbops.BuildACL(
+					"leftover1"+"_"+arpAllowPolicySuffix,
+					nbdb.ACLDirectionFromLport,
+					types.DefaultAllowPriority,
+					"inport == @"+pgHash+"_"+egressDenyPG+" && arp",
+					nbdb.ACLActionAllow,
+					types.OvnACLLoggingMeter,
+					nbdb.ACLSeverityInfo,
+					false,
+					map[string]string{
+						defaultDenyPolicyTypeACLExtIdKey: string(knet.PolicyTypeEgress),
+					},
+				)
+				leftOverACL1FromUpgrade.UUID = *leftOverACL1FromUpgrade.Name + "-egressAllowACL-UUID"
+				// ACL2: leftover arp allow ACL ingress with old match (arp)
+				leftOverACL2FromUpgrade := libovsdbops.BuildACL(
+					"leftover1"+"_"+arpAllowPolicySuffix,
+					nbdb.ACLDirectionToLport,
+					types.DefaultAllowPriority,
+					"outport == @"+pgHash+"_"+ingressDenyPG+" && arp",
+					nbdb.ACLActionAllow,
+					types.OvnACLLoggingMeter,
+					nbdb.ACLSeverityInfo,
+					false,
+					map[string]string{
+						defaultDenyPolicyTypeACLExtIdKey: string(knet.PolicyTypeIngress),
+					},
+				)
+				leftOverACL2FromUpgrade.UUID = *leftOverACL2FromUpgrade.Name + "-ingressAllowACL-UUID"
+
+				// ACL3: leftover default deny ACL egress with old name (namespace_policyname)
+				leftOverACL3FromUpgrade := libovsdbops.BuildACL(
+					"leftover1"+"_"+networkPolicy2.Name,
+					nbdb.ACLDirectionFromLport,
+					types.DefaultDenyPriority,
+					"inport == @"+pgHash+"_"+egressDenyPG,
+					nbdb.ACLActionDrop,
+					types.OvnACLLoggingMeter,
+					nbdb.ACLSeverityInfo,
+					false,
+					map[string]string{
+						defaultDenyPolicyTypeACLExtIdKey: string(knet.PolicyTypeEgress),
+					},
+				)
+				leftOverACL3FromUpgrade.UUID = *leftOverACL3FromUpgrade.Name + "-egressDenyACL-UUID"
+
+				// ACL4: leftover default deny ACL ingress with old name (namespace_policyname)
+				leftOverACL4FromUpgrade := libovsdbops.BuildACL(
+					"leftover1"+"_"+networkPolicy2.Name,
+					nbdb.ACLDirectionToLport,
+					types.DefaultDenyPriority,
+					"outport == @"+pgHash+"_"+ingressDenyPG,
+					nbdb.ACLActionDrop,
+					types.OvnACLLoggingMeter,
+					nbdb.ACLSeverityInfo,
+					false,
+					map[string]string{
+						defaultDenyPolicyTypeACLExtIdKey: string(knet.PolicyTypeIngress),
+					},
+				)
+				leftOverACL4FromUpgrade.UUID = *leftOverACL4FromUpgrade.Name + "-ingressDenyACL-UUID"
+
+				initialDB1 := libovsdb.TestSetup{
+					NBData: []libovsdb.TestData{
+						&nbdb.LogicalSwitch{
+							Name: "node1",
+						},
+						leftOverACL1FromUpgrade,
+						leftOverACL2FromUpgrade,
+						leftOverACL3FromUpgrade,
+						leftOverACL4FromUpgrade,
+					},
+				}
+
+				fakeOvn.startWithDBSetup(initialDB1,
+					&v1.NamespaceList{
+						Items: []v1.Namespace{namespace1},
+					},
+					&v1.PodList{
+						Items: []v1.Pod{*nPod},
+					},
+					&knet.NetworkPolicyList{
+						Items: []knet.NetworkPolicy{*networkPolicy1},
+					},
+				)
+				nPodTest.populateLogicalSwitchCache(fakeOvn, getLogicalSwitchUUID(fakeOvn.controller.nbClient, "node1"))
+				fakeOvn.controller.WatchNamespaces()
+				fakeOvn.controller.WatchPods()
+				fakeOvn.controller.WatchNetworkPolicy()
+
+				_, err := fakeOvn.fakeClient.KubeClient.NetworkingV1().NetworkPolicies(networkPolicy1.Namespace).Create(context.TODO(), networkPolicy2, metav1.CreateOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				npTest := kNetworkPolicy{}
+				expectedData := []libovsdb.TestData{}
+				expectedData = append(expectedData, getExpectedDataPodsAndSwitches([]testPod{nPodTest}, []string{"node1"})...)
+				gressPolicy1ExpectedData := npTest.getPolicyData(networkPolicy1, []string{nPodTest.portUUID}, nil, []int32{portNum}, nbdb.ACLSeverityInfo, false)
+				defaultDeny1ExpectedData := npTest.getDefaultDenyData(networkPolicy1, []string{nPodTest.portUUID}, nbdb.ACLSeverityInfo, false)
+				expectedData = append(expectedData, gressPolicy1ExpectedData...)
+				expectedData = append(expectedData, defaultDeny1ExpectedData...)
+				gressPolicy2ExpectedData := npTest.getPolicyData(networkPolicy2, []string{nPodTest.portUUID}, nil, []int32{portNum + 1}, nbdb.ACLSeverityInfo, false)
+				expectedData = append(expectedData, gressPolicy2ExpectedData...)
+				egressOptions = map[string]string{
+					"apply-after-lb": "true",
+				}
+				leftOverACL3FromUpgrade.Options = egressOptions
+				newDefaultDenyEgressACLName := "leftover1_" + egressDefaultDenySuffix
+				newDefaultDenyIngressACLName := "leftover1_" + ingressDefaultDenySuffix
+				leftOverACL3FromUpgrade.Name = &newDefaultDenyEgressACLName
+				leftOverACL4FromUpgrade.Name = &newDefaultDenyIngressACLName
+				expectedData = append(expectedData, leftOverACL3FromUpgrade)
+				expectedData = append(expectedData, leftOverACL4FromUpgrade)
+
+				fakeOvn.asf.ExpectAddressSetWithIPs(namespaceName1, []string{nPodTest.podIP})
+				gomega.Eventually(fakeOvn.nbClient).Should(libovsdb.HaveData(expectedData...))
 
 				return nil
 			}


### PR DESCRIPTION
Cherry-picked from https://github.com/openshift/ovn-kubernetes/pull/1259.
Conflicts are outlined in commit message for each commit.