### PR TITLE
OCPBUGS-1552: Dockerfile: bump to openvswitch2.17.0-37.4.el8fdp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN yum install -y  \
 	selinux-policy && \
 	yum clean all
 
-ARG ovsver=2.17.0-22.el8fdp
+ARG ovsver=2.17.0-37.4.el8fdp
 ARG ovnver=22.06.0-27.el8fdp
 
 RUN INSTALL_PKGS=" \


### PR DESCRIPTION
In particular, this bump includes fixes for AVX512 runtime checks:
- dpif-netdev: Refactor AVX512 runtime checks. (#2100393)
- dpif-netdev: Fix leak of AVX512 DPIF scratch pad
- dpif-netdev-extract-avx512: Protect GCC builtin usage

All other changes can be obtained here:
https://access.redhat.com/downloads/content/rhel---8/x86_64/7816/openvswitch2.17/2.17.0-37.4.el8fdp/x86_64/fd431d51/package-changelog

Signed-off-by: Flavio Fernandes <flaviof@redhat.com>