### PR TITLE
Jira OCPBUGS-1318: Merge 9 23 22

### DIFF
--- a/go-controller/pkg/factory/factory.go
+++ b/go-controller/pkg/factory/factory.go
@@ -383,6 +383,12 @@ type AddHandlerFuncType func(namespace string, sel labels.Selector, funcs cache.
 
 func (wf *WatchFactory) GetResourceHandlerFunc(objType reflect.Type) (AddHandlerFuncType, error) {
 	switch objType {
+	case NamespaceType:
+		return func(namespace string, sel labels.Selector,
+			funcs cache.ResourceEventHandler, processExisting func([]interface{}) error) (*Handler, error) {
+			return wf.AddNamespaceHandler(funcs, processExisting)
+		}, nil
+
 	case PolicyType:
 		return func(namespace string, sel labels.Selector,
 			funcs cache.ResourceEventHandler, processExisting func([]interface{}) error) (*Handler, error) {

--- a/go-controller/pkg/metrics/master.go
+++ b/go-controller/pkg/metrics/master.go
@@ -843,7 +843,12 @@ type ConfigDurationRecorder struct {
 // global variable is needed because this functionality is accessed in many functions
 var cdr *ConfigDurationRecorder
 
+// lock for accessing the cdr global variable
+var cdrMutex sync.Mutex
+
 func GetConfigDurationRecorder() *ConfigDurationRecorder {
+	cdrMutex.Lock()
+	defer cdrMutex.Unlock()
 	if cdr == nil {
 		cdr = &ConfigDurationRecorder{}
 	}

--- a/go-controller/pkg/node/helper_linux_test.go
+++ b/go-controller/pkg/node/helper_linux_test.go
@@ -1,0 +1,176 @@
+package node
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/vishvananda/netlink"
+)
+
+func TestFilterRoutesByIfIndex(t *testing.T) {
+	tcs := []struct {
+		routesUnfiltered []netlink.Route
+		gwIfIdx          int
+		routesFiltered   []netlink.Route
+	}{
+		// tc0 - baseline.
+		{
+			routesUnfiltered: []netlink.Route{},
+			gwIfIdx:          0,
+			routesFiltered:   []netlink.Route{},
+		},
+		// tc1 - do not filter.
+		{
+			routesUnfiltered: []netlink.Route{
+				{
+					LinkIndex: 1,
+					Gw:        []byte{1, 1, 1, 1},
+				},
+				{
+					LinkIndex: 2,
+					Gw:        []byte{2, 2, 2, 2},
+				},
+				{
+					LinkIndex: 1,
+					Gw:        []byte{3, 3, 3, 3},
+				},
+			},
+			gwIfIdx: 0,
+			routesFiltered: []netlink.Route{
+				{
+					LinkIndex: 1,
+					Gw:        []byte{1, 1, 1, 1},
+				},
+				{
+					LinkIndex: 2,
+					Gw:        []byte{2, 2, 2, 2},
+				},
+				{
+					LinkIndex: 1,
+					Gw:        []byte{3, 3, 3, 3},
+				},
+			},
+		},
+		// tc2 - filter by link index.
+		{
+			routesUnfiltered: []netlink.Route{
+				{
+					LinkIndex: 1,
+					Gw:        []byte{1, 1, 1, 1},
+				},
+				{
+					LinkIndex: 2,
+					Gw:        []byte{2, 2, 2, 2},
+				},
+				{
+					LinkIndex: 1,
+					Gw:        []byte{3, 3, 3, 3},
+				},
+			},
+			gwIfIdx: 1,
+			routesFiltered: []netlink.Route{
+				{
+					LinkIndex: 1,
+					Gw:        []byte{1, 1, 1, 1},
+				},
+				{
+					LinkIndex: 1,
+					Gw:        []byte{3, 3, 3, 3},
+				},
+			},
+		},
+		// tc3 - filter by MultiPath index.
+		{
+			routesUnfiltered: []netlink.Route{
+				{
+					LinkIndex: 1,
+					Gw:        []byte{1, 1, 1, 1},
+				},
+				{
+					LinkIndex: 2,
+					Gw:        []byte{2, 2, 2, 2},
+				},
+				{
+					LinkIndex: 0,
+					MultiPath: []*netlink.NexthopInfo{
+						{
+							LinkIndex: 1,
+							Hops:      0,
+							Gw:        []byte{3, 3, 3, 3},
+						},
+						{
+							LinkIndex: 1,
+							Hops:      0,
+							Gw:        []byte{4, 4, 4, 4},
+						},
+					},
+				},
+			},
+			gwIfIdx: 1,
+			routesFiltered: []netlink.Route{
+				{
+					LinkIndex: 1,
+					Gw:        []byte{1, 1, 1, 1},
+				},
+				{
+					LinkIndex: 0,
+					MultiPath: []*netlink.NexthopInfo{
+						{
+							LinkIndex: 1,
+							Hops:      0,
+							Gw:        []byte{3, 3, 3, 3},
+						},
+						{
+							LinkIndex: 1,
+							Hops:      0,
+							Gw:        []byte{4, 4, 4, 4},
+						},
+					},
+				},
+			},
+		},
+		// tc4 - filter by MultiPath index - MultiPath with multiple interfaces.
+		{
+			routesUnfiltered: []netlink.Route{
+				{
+					LinkIndex: 1,
+					Gw:        []byte{1, 1, 1, 1},
+				},
+				{
+					LinkIndex: 2,
+					Gw:        []byte{2, 2, 2, 2},
+				},
+				{
+					LinkIndex: 0,
+					MultiPath: []*netlink.NexthopInfo{
+						{
+							LinkIndex: 1,
+							Hops:      0,
+							Gw:        []byte{3, 3, 3, 3},
+						},
+						{
+							LinkIndex: 2,
+							Hops:      0,
+							Gw:        []byte{4, 4, 4, 4},
+						},
+					},
+				},
+			},
+			gwIfIdx: 1,
+			routesFiltered: []netlink.Route{
+				{
+					LinkIndex: 1,
+					Gw:        []byte{1, 1, 1, 1},
+				},
+			},
+		},
+	}
+
+	for i, tc := range tcs {
+		routesFiltered := filterRoutesByIfIndex(tc.routesUnfiltered, tc.gwIfIdx)
+		if !reflect.DeepEqual(tc.routesFiltered, routesFiltered) {
+			t.Fatalf("TestFilterRoutesByIfIndex(%d): Filtering '%v' by index '%d' should have yielded '%v' but got '%v'",
+				i, tc.routesUnfiltered, tc.gwIfIdx, tc.routesFiltered, routesFiltered)
+		}
+	}
+}

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -664,6 +664,7 @@ func (oc *Controller) ensureNodeLogicalNetwork(node *kapi.Node, hostSubnets []*n
 	var v4Gateway, v6Gateway net.IP
 	var hostNetworkPolicyIPs []net.IP
 	logicalRouterPortNetwork := []string{}
+	logicalSwitch.OtherConfig = map[string]string{}
 	for _, hostSubnet := range hostSubnets {
 		gwIfAddr := util.GetNodeGatewayIfAddr(hostSubnet)
 		mgmtIfAddr := util.GetNodeManagementIfAddr(hostSubnet)
@@ -673,9 +674,8 @@ func (oc *Controller) ensureNodeLogicalNetwork(node *kapi.Node, hostSubnets []*n
 		if utilnet.IsIPv6CIDR(hostSubnet) {
 			v6Gateway = gwIfAddr.IP
 
-			logicalSwitch.OtherConfig = map[string]string{
-				"ipv6_prefix": hostSubnet.IP.String(),
-			}
+			logicalSwitch.OtherConfig["ipv6_prefix"] =
+				hostSubnet.IP.String()
 		} else {
 			v4Gateway = gwIfAddr.IP
 			excludeIPs := mgmtIfAddr.IP.String()
@@ -683,10 +683,8 @@ func (oc *Controller) ensureNodeLogicalNetwork(node *kapi.Node, hostSubnets []*n
 				hybridOverlayIfAddr := util.GetNodeHybridOverlayIfAddr(hostSubnet)
 				excludeIPs += ".." + hybridOverlayIfAddr.IP.String()
 			}
-			logicalSwitch.OtherConfig = map[string]string{
-				"subnet":      hostSubnet.String(),
-				"exclude_ips": excludeIPs,
-			}
+			logicalSwitch.OtherConfig["subnet"] = hostSubnet.String()
+			logicalSwitch.OtherConfig["exclude_ips"] = excludeIPs
 		}
 	}
 

--- a/go-controller/pkg/ovn/namespace.go
+++ b/go-controller/pkg/ovn/namespace.go
@@ -7,13 +7,13 @@ import (
 	"time"
 
 	"github.com/ovn-org/libovsdb/ovsdb"
-	hotypes "github.com/ovn-org/ovn-kubernetes/go-controller/hybrid-overlay/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	addressset "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/address_set"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 
 	kapi "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
 )
@@ -142,15 +142,15 @@ func isNamespaceMulticastEnabled(annotations map[string]string) bool {
 // Creates an explicit "allow" policy for multicast traffic within the
 // namespace if multicast is enabled. Otherwise, removes the "allow" policy.
 // Traffic will be dropped by the default multicast deny ACL.
-func (oc *Controller) multicastUpdateNamespace(ns *kapi.Namespace, nsInfo *namespaceInfo) {
+func (oc *Controller) multicastUpdateNamespace(ns *kapi.Namespace, nsInfo *namespaceInfo) error {
 	if !oc.multicastSupport {
-		return
+		return nil
 	}
 
 	enabled := isNamespaceMulticastEnabled(ns.Annotations)
 	enabledOld := nsInfo.multicastEnabled
 	if enabledOld == enabled {
-		return
+		return nil
 	}
 
 	var err error
@@ -161,24 +161,25 @@ func (oc *Controller) multicastUpdateNamespace(ns *kapi.Namespace, nsInfo *names
 		err = deleteMulticastAllowPolicy(oc.nbClient, ns.Name)
 	}
 	if err != nil {
-		klog.Errorf(err.Error())
-		return
+		return err
 	}
+	return nil
 }
 
 // Cleans up the multicast policy for this namespace if multicast was
 // previously allowed.
-func (oc *Controller) multicastDeleteNamespace(ns *kapi.Namespace, nsInfo *namespaceInfo) {
+func (oc *Controller) multicastDeleteNamespace(ns *kapi.Namespace, nsInfo *namespaceInfo) error {
 	if nsInfo.multicastEnabled {
 		nsInfo.multicastEnabled = false
 		if err := deleteMulticastAllowPolicy(oc.nbClient, ns.Name); err != nil {
-			klog.Errorf(err.Error())
+			return err
 		}
 	}
+	return nil
 }
 
 // AddNamespace creates corresponding addressset in ovn db
-func (oc *Controller) AddNamespace(ns *kapi.Namespace) {
+func (oc *Controller) AddNamespace(ns *kapi.Namespace) error {
 	klog.Infof("[%s] adding namespace", ns.Name)
 	// Keep track of how long syncs take.
 	start := time.Now()
@@ -186,46 +187,27 @@ func (oc *Controller) AddNamespace(ns *kapi.Namespace) {
 		klog.Infof("[%s] adding namespace took %v", ns.Name, time.Since(start))
 	}()
 
-	nsInfo, nsUnlock, err := oc.ensureNamespaceLocked(ns.Name, false, ns)
+	_, nsUnlock, err := oc.ensureNamespaceLocked(ns.Name, false, ns)
 	if err != nil {
-		klog.Errorf("Failed to ensure namespace locked: %v", err)
-		return
+		return fmt.Errorf("failed to ensure namespace locked: %v", err)
 	}
-
 	defer nsUnlock()
-
-	annotation := ns.Annotations[hotypes.HybridOverlayExternalGw]
-	if annotation != "" {
-		parsedAnnotation := net.ParseIP(annotation)
-		if parsedAnnotation == nil {
-			klog.Errorf("Could not parse hybrid overlay external gw annotation")
-		} else {
-			nsInfo.hybridOverlayExternalGW = parsedAnnotation
-		}
-	}
-	annotation = ns.Annotations[hotypes.HybridOverlayVTEP]
-	if annotation != "" {
-		parsedAnnotation := net.ParseIP(annotation)
-		if parsedAnnotation == nil {
-			klog.Errorf("Could not parse hybrid overlay VTEP annotation")
-		} else {
-			nsInfo.hybridOverlayVTEP = parsedAnnotation
-		}
-	}
+	return nil
 }
 
 // configureNamespace ensures internal structures are updated based on namespace
 // must be called with nsInfo lock
-func (oc *Controller) configureNamespace(nsInfo *namespaceInfo, ns *kapi.Namespace) {
+func (oc *Controller) configureNamespace(nsInfo *namespaceInfo, ns *kapi.Namespace) error {
+	var errors []error
 	if annotation, ok := ns.Annotations[util.RoutingExternalGWsAnnotation]; ok {
 		exGateways, err := util.ParseRoutingExternalGWAnnotation(annotation)
 		if err != nil {
-			klog.Errorf(err.Error())
+			errors = append(errors, fmt.Errorf("failed to parse external gateway annotation (%v)", err))
 		} else {
 			_, bfdEnabled := ns.Annotations[util.BfdAnnotation]
 			err = oc.addExternalGWsForNamespace(gatewayInfo{gws: exGateways, bfdEnabled: bfdEnabled}, nsInfo, ns.Name)
 			if err != nil {
-				klog.Error(err.Error())
+				errors = append(errors, fmt.Errorf("failed to add external gateway for namespace %s (%v)", ns.Name, err))
 			}
 		}
 		if _, ok := ns.Annotations[util.BfdAnnotation]; ok {
@@ -249,16 +231,20 @@ func (oc *Controller) configureNamespace(nsInfo *namespaceInfo, ns *kapi.Namespa
 	// created
 
 	// If multicast enabled, adds all current pods in the namespace to the allow policy
-	oc.multicastUpdateNamespace(ns, nsInfo)
+	if err := oc.multicastUpdateNamespace(ns, nsInfo); err != nil {
+		errors = append(errors, fmt.Errorf("failed to update multicast (%v)", err))
+	}
+	return kerrors.NewAggregate(errors)
 }
 
-func (oc *Controller) updateNamespace(old, newer *kapi.Namespace) {
+func (oc *Controller) updateNamespace(old, newer *kapi.Namespace) error {
+	var errors []error
 	klog.Infof("[%s] updating namespace", old.Name)
 
 	nsInfo, nsUnlock := oc.getNamespaceLocked(old.Name, false)
 	if nsInfo == nil {
 		klog.Warningf("Update event for unknown namespace %q", old.Name)
-		return
+		return nil
 	}
 	defer nsUnlock()
 
@@ -273,7 +259,7 @@ func (oc *Controller) updateNamespace(old, newer *kapi.Namespace) {
 			if config.Gateway.DisableSNATMultipleGWs {
 				existingPods, err := oc.watchFactory.GetPods(old.Name)
 				if err != nil {
-					klog.Errorf("Failed to get all the pods (%v)", err)
+					errors = append(errors, fmt.Errorf("failed to get all the pods (%v)", err))
 				}
 				for _, pod := range existingPods {
 					logicalPort := util.GetLogicalPortName(pod.Namespace, pod.Name)
@@ -282,7 +268,7 @@ func (oc *Controller) updateNamespace(old, newer *kapi.Namespace) {
 					}
 					podIPs, err := util.GetAllPodIPs(pod)
 					if err != nil {
-						klog.Warningf("Unable to get pod %q IPs for SNAT rule removal", logicalPort)
+						errors = append(errors, fmt.Errorf("unable to get pod %q IPs for SNAT rule removal err (%v)", logicalPort, err))
 					}
 					ips := make([]*net.IPNet, 0, len(podIPs))
 					for _, podIP := range podIPs {
@@ -290,26 +276,26 @@ func (oc *Controller) updateNamespace(old, newer *kapi.Namespace) {
 					}
 					if len(ips) > 0 {
 						if extIPs, err := getExternalIPsGRSNAT(oc.watchFactory, pod.Spec.NodeName); err != nil {
-							klog.Error(err.Error())
+							errors = append(errors, err)
 						} else if err = deletePerPodGRSNAT(oc.nbClient, pod.Spec.NodeName, extIPs, ips); err != nil {
-							klog.Error(err.Error())
+							errors = append(errors, err)
 						}
 					}
 				}
 			}
 		} else {
 			if err := oc.deleteGWRoutesForNamespace(old.Name, nil); err != nil {
-				klog.Error(err.Error())
+				errors = append(errors, err)
 			}
 			nsInfo.routingExternalGWs = gatewayInfo{}
 		}
 		exGateways, err := util.ParseRoutingExternalGWAnnotation(gwAnnotation)
 		if err != nil {
-			klog.Error(err.Error())
+			errors = append(errors, err)
 		} else {
 			err = oc.addExternalGWsForNamespace(gatewayInfo{gws: exGateways, bfdEnabled: newBFDEnabled}, nsInfo, old.Name)
 			if err != nil {
-				klog.Error(err.Error())
+				errors = append(errors, err)
 			}
 		}
 		// if new annotation is empty, exgws were removed, may need to add SNAT per pod
@@ -317,17 +303,17 @@ func (oc *Controller) updateNamespace(old, newer *kapi.Namespace) {
 		if gwAnnotation == "" && len(nsInfo.routingExternalPodGWs) == 0 && config.Gateway.DisableSNATMultipleGWs {
 			existingPods, err := oc.watchFactory.GetPods(old.Name)
 			if err != nil {
-				klog.Errorf("Failed to get all the pods (%v)", err)
+				errors = append(errors, fmt.Errorf("failed to get all the pods (%v)", err))
 			}
 			for _, pod := range existingPods {
 				podAnnotation, err := util.UnmarshalPodAnnotation(pod.Annotations)
 				if err != nil {
-					klog.Error(err.Error())
+					errors = append(errors, err)
 				} else {
 					if extIPs, err := getExternalIPsGRSNAT(oc.watchFactory, pod.Spec.NodeName); err != nil {
-						klog.Error(err.Error())
+						errors = append(errors, err)
 					} else if err = addOrUpdatePerPodGRSNAT(oc.nbClient, pod.Spec.NodeName, extIPs, podAnnotation.IPs); err != nil {
-						klog.Error(err.Error())
+						errors = append(errors, err)
 					}
 				}
 			}
@@ -347,7 +333,7 @@ func (oc *Controller) updateNamespace(old, newer *kapi.Namespace) {
 		if len(nsInfo.networkPolicies) > 0 {
 			// deny rules are all one per namespace
 			if err := oc.setNetworkPolicyACLLoggingForNamespace(old.Name, nsInfo); err != nil {
-				klog.Warningf(err.Error())
+				errors = append(errors, err)
 			} else {
 				klog.Infof("Namespace %s: NetworkPolicy ACL logging setting updated to deny=%s allow=%s",
 					old.Name, nsInfo.aclLogging.Deny, nsInfo.aclLogging.Allow)
@@ -357,44 +343,25 @@ func (oc *Controller) updateNamespace(old, newer *kapi.Namespace) {
 		// this will not do anything.
 		updated, err := oc.updateACLLoggingForEgressFirewall(old.Name, nsInfo)
 		if err != nil {
-			klog.Warningf(err.Error())
+			errors = append(errors, err)
 		} else if updated {
 			klog.Infof("Namespace %s: EgressFirewall ACL logging setting updated to deny=%s allow=%s",
 				old.Name, nsInfo.aclLogging.Deny, nsInfo.aclLogging.Allow)
 		}
 	}
 
-	annotation := newer.Annotations[hotypes.HybridOverlayExternalGw]
-	if annotation != "" {
-		parsedAnnotation := net.ParseIP(annotation)
-		if parsedAnnotation == nil {
-			klog.Errorf("Could not parse hybrid overlay external gw annotation")
-		} else {
-			nsInfo.hybridOverlayExternalGW = parsedAnnotation
-		}
-	} else {
-		nsInfo.hybridOverlayExternalGW = nil
+	if err := oc.multicastUpdateNamespace(newer, nsInfo); err != nil {
+		errors = append(errors, err)
 	}
-	annotation = newer.Annotations[hotypes.HybridOverlayVTEP]
-	if annotation != "" {
-		parsedAnnotation := net.ParseIP(annotation)
-		if parsedAnnotation == nil {
-			klog.Errorf("Could not parse hybrid overlay VTEP annotation")
-		} else {
-			nsInfo.hybridOverlayVTEP = parsedAnnotation
-		}
-	} else {
-		nsInfo.hybridOverlayVTEP = nil
-	}
-	oc.multicastUpdateNamespace(newer, nsInfo)
+	return kerrors.NewAggregate(errors)
 }
 
-func (oc *Controller) deleteNamespace(ns *kapi.Namespace) {
+func (oc *Controller) deleteNamespace(ns *kapi.Namespace) error {
 	klog.Infof("[%s] deleting namespace", ns.Name)
 
 	nsInfo := oc.deleteNamespaceLocked(ns.Name)
 	if nsInfo == nil {
-		return
+		return nil
 	}
 	defer nsInfo.Unlock()
 
@@ -415,9 +382,12 @@ func (oc *Controller) deleteNamespace(ns *kapi.Namespace) {
 		})
 	}
 	if err := oc.deleteGWRoutesForNamespace(ns.Name, nil); err != nil {
-		klog.Errorf("Failed to delete GW routes for namespace: %s, error: %v", ns.Name, err)
+		return fmt.Errorf("failed to delete GW routes for namespace: %s, error: %v", ns.Name, err)
 	}
-	oc.multicastDeleteNamespace(ns, nsInfo)
+	if err := oc.multicastDeleteNamespace(ns, nsInfo); err != nil {
+		return fmt.Errorf("failed to delete multicast nameosace error %v", err)
+	}
+	return nil
 }
 
 // getNamespaceLocked locks namespacesMutex, looks up ns, and (if found), returns it with
@@ -518,7 +488,9 @@ func (oc *Controller) ensureNamespaceLocked(ns string, readOnly bool, namespace 
 
 	if namespace != nil {
 		// if we have the namespace, attempt to configure nsInfo with it
-		oc.configureNamespace(nsInfo, namespace)
+		if err := oc.configureNamespace(nsInfo, namespace); err != nil {
+			return nil, nil, fmt.Errorf("failed to configure namespace %s: %v", ns, err)
+		}
 	}
 
 	return nsInfo, unlockFunc, nil

--- a/go-controller/pkg/ovn/obj_retry.go
+++ b/go-controller/pkg/ovn/obj_retry.go
@@ -227,7 +227,8 @@ func hasResourceAnUpdateFunc(objType reflect.Type) bool {
 		factory.EgressIPPodType,
 		factory.EgressNodeType,
 		factory.CloudPrivateIPConfigType,
-		factory.LocalPodSelectorType:
+		factory.LocalPodSelectorType,
+		factory.NamespaceType:
 		return true
 	}
 	return false
@@ -317,6 +318,9 @@ func areResourcesEqual(objType reflect.Type, obj1, obj2 interface{}) (bool, erro
 		// force update path for EgressIP resource.
 		return false, nil
 
+	case factory.NamespaceType:
+		// force update path for Namespace resource.
+		return false, nil
 	}
 
 	return false, fmt.Errorf("no object comparison for type %s", objType)
@@ -362,7 +366,8 @@ func getResourceKey(objType reflect.Type, obj interface{}) (string, error) {
 
 	case factory.PeerNamespaceAndPodSelectorType,
 		factory.PeerNamespaceSelectorType,
-		factory.EgressIPNamespaceType:
+		factory.EgressIPNamespaceType,
+		factory.NamespaceType:
 		namespace, ok := obj.(*kapi.Namespace)
 		if !ok {
 			return "", fmt.Errorf("could not cast %T object to *kapi.Namespace", obj)
@@ -453,7 +458,8 @@ func (oc *Controller) getResourceFromInformerCache(objType reflect.Type, key str
 
 	case factory.PeerNamespaceAndPodSelectorType,
 		factory.PeerNamespaceSelectorType,
-		factory.EgressIPNamespaceType:
+		factory.EgressIPNamespaceType,
+		factory.NamespaceType:
 		obj, err = oc.watchFactory.GetNamespace(key)
 
 	case factory.EgressFirewallType:
@@ -559,7 +565,8 @@ func resourceNeedsUpdate(objType reflect.Type) bool {
 		factory.EgressIPType,
 		factory.EgressIPPodType,
 		factory.EgressIPNamespaceType,
-		factory.CloudPrivateIPConfigType:
+		factory.CloudPrivateIPConfigType,
+		factory.NamespaceType:
 		return true
 	}
 	return false
@@ -746,6 +753,13 @@ func (oc *Controller) addResource(objectsToRetry *RetryObjs, obj interface{}, fr
 		cloudPrivateIPConfig := obj.(*ocpcloudnetworkapi.CloudPrivateIPConfig)
 		return oc.reconcileCloudPrivateIPConfig(nil, cloudPrivateIPConfig)
 
+	case factory.NamespaceType:
+		ns, ok := obj.(*kapi.Namespace)
+		if !ok {
+			return fmt.Errorf("could not cast %T object to *kapi.Namespace", obj)
+		}
+		return oc.AddNamespace(ns)
+
 	default:
 		return fmt.Errorf("no add function for object type %s", objectsToRetry.oType)
 	}
@@ -885,6 +899,10 @@ func (oc *Controller) updateResource(objectsToRetry *RetryObjs, oldObj, newObj i
 		oldCloudPrivateIPConfig := oldObj.(*ocpcloudnetworkapi.CloudPrivateIPConfig)
 		newCloudPrivateIPConfig := newObj.(*ocpcloudnetworkapi.CloudPrivateIPConfig)
 		return oc.reconcileCloudPrivateIPConfig(oldCloudPrivateIPConfig, newCloudPrivateIPConfig)
+
+	case factory.NamespaceType:
+		oldNs, newNs := oldObj.(*kapi.Namespace), newObj.(*kapi.Namespace)
+		return oc.updateNamespace(oldNs, newNs)
 	}
 
 	return fmt.Errorf("no update function for object type %s", objectsToRetry.oType)
@@ -1023,6 +1041,10 @@ func (oc *Controller) deleteResource(objectsToRetry *RetryObjs, obj, cachedObj i
 	case factory.CloudPrivateIPConfigType:
 		cloudPrivateIPConfig := obj.(*ocpcloudnetworkapi.CloudPrivateIPConfig)
 		return oc.reconcileCloudPrivateIPConfig(cloudPrivateIPConfig, nil)
+
+	case factory.NamespaceType:
+		ns := obj.(*kapi.Namespace)
+		return oc.deleteNamespace(ns)
 
 	default:
 		return fmt.Errorf("object type %s not supported", objectsToRetry.oType)
@@ -1258,6 +1280,9 @@ func (oc *Controller) getSyncResourcesFunc(r *RetryObjs) (func([]interface{}) er
 		factory.EgressIPNamespaceType,
 		factory.CloudPrivateIPConfigType:
 		syncFunc = nil
+
+	case factory.NamespaceType:
+		syncFunc = oc.syncNamespaces
 
 	default:
 		return nil, fmt.Errorf("no sync function for object type %s", r.oType)

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -228,6 +228,8 @@ type Controller struct {
 	retryNodes *RetryObjs
 	// Objects for Cloud private IP config that need to be retried
 	retryCloudPrivateIPConfig *RetryObjs
+	// Objects for namespaces that need to be retried
+	retryNamespaces *RetryObjs
 	// Node-specific syncMap used by node event handler
 	gatewaysFailed              sync.Map
 	mgmtPortFailed              sync.Map
@@ -329,6 +331,7 @@ func NewOvnController(ovnClient *util.OVNClientset, wf *factory.WatchFactory, st
 		retryEgressIPPods:         NewRetryObjs(factory.EgressIPPodType, "", nil, nil, nil),
 		retryEgressNodes:          NewRetryObjs(factory.EgressNodeType, "", nil, nil, nil),
 		retryCloudPrivateIPConfig: NewRetryObjs(factory.CloudPrivateIPConfigType, "", nil, nil, nil),
+		retryNamespaces:           NewRetryObjs(factory.NamespaceType, "", nil, nil, nil),
 		recorder:                  recorder,
 		nbClient:                  libovsdbOvnNBClient,
 		sbClient:                  libovsdbOvnSBClient,
@@ -631,39 +634,8 @@ func (oc *Controller) WatchEgressIPPods() error {
 // WatchNamespaces starts the watching of namespace resource and calls
 // back the appropriate handler logic
 func (oc *Controller) WatchNamespaces() error {
-	start := time.Now()
-	_, err := oc.watchFactory.AddNamespaceHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
-			ns := obj.(*kapi.Namespace)
-			if config.HybridOverlay.Enabled && hasHybridAnnotation(ns.ObjectMeta) {
-				if err := oc.addNamespaceICNIv1(ns); err != nil {
-					klog.Errorf("Unable to handle legacy ICNIv1 check for namespace %q add, error: %v",
-						ns.Name, err)
-				}
-			}
-			oc.AddNamespace(ns)
-		},
-		UpdateFunc: func(old, newer interface{}) {
-			oldNs, newNs := old.(*kapi.Namespace), newer.(*kapi.Namespace)
-			if config.HybridOverlay.Enabled && nsHybridAnnotationChanged(oldNs, newNs) {
-				if err := oc.addNamespaceICNIv1(newNs); err != nil {
-					klog.Errorf("Unable to handle legacy ICNIv1 check for namespace %q during update, error: %v",
-						newNs.Name, err)
-				}
-			}
-			oc.updateNamespace(oldNs, newNs)
-		},
-		DeleteFunc: func(obj interface{}) {
-			ns := obj.(*kapi.Namespace)
-			oc.deleteNamespace(ns)
-		},
-	}, oc.syncNamespaces)
-	klog.Infof("Bootstrapping existing namespaces and cleaning stale namespaces took %v", time.Since(start))
-	if err != nil {
-		klog.Errorf("Failed to watch namespaces err: %v", err)
-		return err
-	}
-	return nil
+	_, err := oc.WatchResource(oc.retryNamespaces)
+	return err
 }
 
 // syncNodeGateway ensures a node's gateway router is configured

--- a/test/e2e/external_gateways.go
+++ b/test/e2e/external_gateways.go
@@ -65,31 +65,30 @@ type gatewayTestIPs struct {
 
 // Validate pods can reach a network running in a container's looback address via
 // an external gateway running on eth0 of the container without any tunnel encap.
-// The traffic will get proxied through an annotated pod in the default namespace.
+// The traffic will get proxied through an annotated pod in the serving namespace.
 var _ = ginkgo.Describe("e2e non-vxlan external gateway through a gateway pod", func() {
 	const (
-		svcname          string = "externalgw-pod-novxlan"
-		gwContainer1     string = "ex-gw-container1"
-		gwContainer2     string = "ex-gw-container2"
-		defaultNamespace string = "default"
-		srcPingPodName   string = "e2e-exgw-src-ping-pod"
-		gatewayPodName1  string = "e2e-gateway-pod1"
-		gatewayPodName2  string = "e2e-gateway-pod2"
-		externalTCPPort         = 91
-		externalUDPPort         = 90
-		ecmpRetry        int    = 20
-		testTimeout      string = "20"
+		svcname         string = "externalgw-pod-novxlan"
+		gwContainer1    string = "ex-gw-container1"
+		gwContainer2    string = "ex-gw-container2"
+		srcPingPodName  string = "e2e-exgw-src-ping-pod"
+		gatewayPodName1 string = "e2e-gateway-pod1"
+		gatewayPodName2 string = "e2e-gateway-pod2"
+		externalTCPPort        = 91
+		externalUDPPort        = 90
+		ecmpRetry       int    = 20
+		testTimeout     string = "20"
 	)
 
 	var (
 		sleepCommand             = []string{"bash", "-c", "sleep 20000"}
 		addressesv4, addressesv6 gatewayTestIPs
 		clientSet                kubernetes.Interface
+		servingNamespace         string
 	)
 
 	var (
 		gwContainers []string
-		gwPods       []string
 	)
 
 	f := wrappedTestFramework(svcname)
@@ -105,12 +104,16 @@ var _ = ginkgo.Describe("e2e non-vxlan external gateway through a gateway pod", 
 				len(nodes.Items))
 		}
 
+		ns, err := f.CreateNamespace("exgw-serving", nil)
+		framework.ExpectNoError(err)
+		servingNamespace = ns.Name
+
 		gwContainers, addressesv4, addressesv6 = setupGatewayContainers(f, nodes, gwContainer1, gwContainer2, srcPingPodName, externalUDPPort, externalTCPPort, ecmpRetry)
-		gwPods = setupGatewayPods(f, nodes, gatewayPodName1, gatewayPodName2, defaultNamespace, sleepCommand, addressesv4, addressesv6, false)
+		setupGatewayPods(f, nodes, gatewayPodName1, gatewayPodName2, servingNamespace, sleepCommand, addressesv4, addressesv6, false)
 	})
 
 	ginkgo.AfterEach(func() {
-		cleanExGWContainersAndPods(clientSet, []string{gwContainer1, gwContainer2}, gwPods, defaultNamespace, addressesv4, addressesv6)
+		cleanExGWContainers(clientSet, []string{gwContainer1, gwContainer2}, addressesv4, addressesv6)
 	})
 
 	ginkgotable.DescribeTable("Should validate ICMP connectivity to an external gateway's loopback address via a pod with external gateway annotations enabled",
@@ -126,24 +129,15 @@ var _ = ginkgo.Describe("e2e non-vxlan external gateway through a gateway pod", 
 			}
 
 			tcpDumpSync := sync.WaitGroup{}
-			checkPingOnContainer := func(container string) error {
-				defer ginkgo.GinkgoRecover()
-				defer tcpDumpSync.Done()
-				_, err := runCommand(containerRuntime, "exec", container, "timeout", "60", "tcpdump", "-c", "1", "-i", "any", icmpCommand)
-				framework.ExpectNoError(err, "Failed to detect icmp messages from %s on gateway %s", srcPingPodName, container)
-				framework.Logf("ICMP packet successfully detected on gateway %s", container)
-				return nil
-			}
-
 			tcpDumpSync.Add(len(gwContainers))
 
 			for _, gwContainer := range gwContainers {
-				go checkPingOnContainer(gwContainer)
+				go checkPingOnContainer(gwContainer, srcPingPodName, icmpCommand, &tcpDumpSync)
 			}
 
 			pingSync := sync.WaitGroup{}
 			// Verify the external gateway loopback address running on the external container is reachable and
-			// that traffic from the source ping pod is proxied through the pod in the default namespace
+			// that traffic from the source ping pod is proxied through the pod in the serving namespace
 			ginkgo.By("Verifying connectivity via the gateway namespace to the remote addresses")
 			for _, t := range addresses.targetIPs {
 				pingSync.Add(1)
@@ -306,19 +300,9 @@ var _ = ginkgo.Describe("e2e multiple external gateway validation", func() {
 		// If an ICMP packet is never detected, return the error via the specified chanel.
 
 		tcpDumpSync := sync.WaitGroup{}
-
-		checkPingOnContainer := func(container string) error {
-			defer ginkgo.GinkgoRecover()
-			defer tcpDumpSync.Done()
-			_, err := runCommand(containerRuntime, "exec", container, "timeout", "60", "tcpdump", "-c", "1", "-i", "any", icmpToDump)
-			framework.ExpectNoError(err, "Failed to detect icmp messages from %s on gateway %s", srcPodName, container)
-			framework.Logf("ICMP packet successfully detected on gateway %s", container)
-			return nil
-		}
-
 		tcpDumpSync.Add(len(gwContainers))
 		for _, gwContainer := range gwContainers {
-			go checkPingOnContainer(gwContainer)
+			go checkPingOnContainer(gwContainer, srcPodName, icmpToDump, &tcpDumpSync)
 		}
 
 		pingSync := sync.WaitGroup{}
@@ -388,13 +372,16 @@ var _ = ginkgo.Describe("e2e multiple external gateway validation", func() {
 
 var _ = ginkgo.Describe("e2e multiple external gateway stale conntrack entry deletion validation", func() {
 	const (
-		svcname          string = "novxlan-externalgw-ecmp"
-		gwContainer1     string = "gw-test-container1"
-		gwContainer2     string = "gw-test-container2"
-		srcPodName       string = "e2e-exgw-src-pod"
-		gatewayPodName1  string = "e2e-gateway-pod1"
-		gatewayPodName2  string = "e2e-gateway-pod2"
-		defaultNamespace string = "default"
+		svcname         string = "novxlan-externalgw-ecmp"
+		gwContainer1    string = "gw-test-container1"
+		gwContainer2    string = "gw-test-container2"
+		srcPodName      string = "e2e-exgw-src-pod"
+		gatewayPodName1 string = "e2e-gateway-pod1"
+		gatewayPodName2 string = "e2e-gateway-pod2"
+	)
+
+	var (
+		servingNamespace string
 	)
 
 	f := wrappedTestFramework(svcname)
@@ -422,11 +409,15 @@ var _ = ginkgo.Describe("e2e multiple external gateway stale conntrack entry del
 			skipper.Skipf("Skipping as host network doesn't support multiple external gateways")
 		}
 
+		ns, err := f.CreateNamespace("exgw-conntrack-serving", nil)
+		framework.ExpectNoError(err)
+		servingNamespace = ns.Name
+
 		addressesv4, addressesv6 = setupGatewayContainersForConntrackTest(f, nodes, gwContainer1, gwContainer2, srcPodName)
 		sleepCommand = []string{"bash", "-c", "sleep 20000"}
-		_, err = createGenericPod(f, gatewayPodName1, nodes.Items[0].Name, defaultNamespace, sleepCommand)
+		_, err = createGenericPod(f, gatewayPodName1, nodes.Items[0].Name, servingNamespace, sleepCommand)
 		framework.ExpectNoError(err, "Create and annotate the external gw pods to manage the src app pod namespace, failed: %v", err)
-		_, err = createGenericPod(f, gatewayPodName2, nodes.Items[1].Name, defaultNamespace, sleepCommand)
+		_, err = createGenericPod(f, gatewayPodName2, nodes.Items[1].Name, servingNamespace, sleepCommand)
 		framework.ExpectNoError(err, "Create and annotate the external gw pods to manage the src app pod namespace, failed: %v", err)
 
 		// remove the routing external annotation
@@ -445,9 +436,6 @@ var _ = ginkgo.Describe("e2e multiple external gateway stale conntrack entry del
 		ginkgo.By("Deleting the gateway containers")
 		deleteClusterExternalContainer(gwContainer1)
 		deleteClusterExternalContainer(gwContainer2)
-		ginkgo.By("Deleting the gateway pods")
-		deletePodSyncNS(clientSet, defaultNamespace, gatewayPodName1)
-		deletePodSyncNS(clientSet, defaultNamespace, gatewayPodName2)
 	})
 
 	ginkgotable.DescribeTable("Namespace annotation: Should validate conntrack entry deletion for TCP/UDP traffic via multiple external gateways a.k.a ECMP routes", func(addresses *gatewayTestIPs, protocol string) {
@@ -525,7 +513,7 @@ var _ = ginkgo.Describe("e2e multiple external gateway stale conntrack entry del
 			if addresses.srcPodIP != "" && addresses.nodeIP != "" {
 				networkIPs = fmt.Sprintf("\"%s\", \"%s\"", addresses.gatewayIPs[i], addresses.gatewayIPs[i])
 			}
-			annotatePodForGateway(gwPod, f.Namespace.Name, networkIPs, false)
+			annotatePodForGateway(gwPod, servingNamespace, f.Namespace.Name, networkIPs, false)
 		}
 
 		// ensure the conntrack deletion tracker annotation is updated
@@ -561,7 +549,7 @@ var _ = ginkgo.Describe("e2e multiple external gateway stale conntrack entry del
 		gomega.Expect(totalPodConnEntries).To(gomega.Equal(6)) // total conntrack entries for this pod/protocol
 
 		ginkgo.By("Remove second external gateway pod's routing-namespace annotation")
-		annotatePodForGateway(gatewayPodName2, "", addresses.gatewayIPs[1], false)
+		annotatePodForGateway(gatewayPodName2, servingNamespace, "", addresses.gatewayIPs[1], false)
 
 		// ensure the conntrack deletion tracker annotation is updated
 		ginkgo.By("Check if the k8s.ovn.org/external-gw-pod-ips got updated for the app namespace")
@@ -583,7 +571,7 @@ var _ = ginkgo.Describe("e2e multiple external gateway stale conntrack entry del
 		}
 
 		ginkgo.By("Remove first external gateway pod's routing-namespace annotation")
-		annotatePodForGateway(gatewayPodName1, "", addresses.gatewayIPs[0], false)
+		annotatePodForGateway(gatewayPodName1, servingNamespace, "", addresses.gatewayIPs[0], false)
 
 		// ensure the conntrack deletion tracker annotation is updated
 		ginkgo.By("Check if the k8s.ovn.org/external-gw-pod-ips got updated for the app namespace")
@@ -617,28 +605,27 @@ var _ = ginkgo.Describe("e2e multiple external gateway stale conntrack entry del
 var _ = ginkgo.Context("BFD", func() {
 	var _ = ginkgo.Describe("e2e non-vxlan external gateway through a gateway pod", func() {
 		const (
-			svcname          string = "externalgw-pod-novxlan"
-			gwContainer1     string = "ex-gw-container1"
-			gwContainer2     string = "ex-gw-container2"
-			defaultNamespace string = "default"
-			srcPingPodName   string = "e2e-exgw-src-ping-pod"
-			gatewayPodName1  string = "e2e-gateway-pod1"
-			gatewayPodName2  string = "e2e-gateway-pod2"
-			externalTCPPort         = 91
-			externalUDPPort         = 90
-			ecmpRetry        int    = 20
-			testTimeout      string = "20"
+			svcname         string = "externalgw-pod-novxlan"
+			gwContainer1    string = "ex-gw-container1"
+			gwContainer2    string = "ex-gw-container2"
+			srcPingPodName  string = "e2e-exgw-src-ping-pod"
+			gatewayPodName1 string = "e2e-gateway-pod1"
+			gatewayPodName2 string = "e2e-gateway-pod2"
+			externalTCPPort        = 91
+			externalUDPPort        = 90
+			ecmpRetry       int    = 20
+			testTimeout     string = "20"
 		)
 
 		var (
 			sleepCommand             = []string{"bash", "-c", "sleep 20000"}
 			addressesv4, addressesv6 gatewayTestIPs
 			clientSet                kubernetes.Interface
+			servingNamespace         string
 		)
 
 		var (
 			gwContainers []string
-			gwPods       []string
 		)
 
 		f := wrappedTestFramework(svcname)
@@ -654,13 +641,17 @@ var _ = ginkgo.Context("BFD", func() {
 					len(nodes.Items))
 			}
 
+			ns, err := f.CreateNamespace("exgw-bfd-serving", nil)
+			framework.ExpectNoError(err)
+			servingNamespace = ns.Name
+
 			setupBFD := setupBFDOnContainer(nodes.Items)
 			gwContainers, addressesv4, addressesv6 = setupGatewayContainers(f, nodes, gwContainer1, gwContainer2, srcPingPodName, externalUDPPort, externalTCPPort, ecmpRetry, setupBFD)
-			gwPods = setupGatewayPods(f, nodes, gatewayPodName1, gatewayPodName2, defaultNamespace, sleepCommand, addressesv4, addressesv6, true)
+			setupGatewayPods(f, nodes, gatewayPodName1, gatewayPodName2, servingNamespace, sleepCommand, addressesv4, addressesv6, true)
 		})
 
 		ginkgo.AfterEach(func() {
-			cleanExGWContainersAndPods(clientSet, []string{gwContainer1, gwContainer2}, gwPods, defaultNamespace, addressesv4, addressesv6)
+			cleanExGWContainers(clientSet, []string{gwContainer1, gwContainer2}, addressesv4, addressesv6)
 		})
 
 		ginkgotable.DescribeTable("Should validate ICMP connectivity to an external gateway's loopback address via a pod with external gateway annotations enabled",
@@ -683,22 +674,13 @@ var _ = ginkgo.Context("BFD", func() {
 				}
 
 				tcpDumpSync := sync.WaitGroup{}
-				checkPingOnContainer := func(container string, wg *sync.WaitGroup) error {
-					defer ginkgo.GinkgoRecover()
-					defer tcpDumpSync.Done()
-					_, err := runCommand(containerRuntime, "exec", container, "timeout", "60", "tcpdump", "-c", "1", "-i", "any", icmpCommand)
-					framework.ExpectNoError(err, "Failed to detect icmp messages from %s on gateway %s", srcPingPodName, container)
-					framework.Logf("ICMP packet successfully detected on gateway %s", container)
-					return nil
-				}
-
 				tcpDumpSync.Add(len(gwContainers))
 				for _, gwContainer := range gwContainers {
-					go checkPingOnContainer(gwContainer, &tcpDumpSync)
+					go checkPingOnContainer(gwContainer, srcPingPodName, icmpCommand, &tcpDumpSync)
 				}
 
 				// Verify the external gateway loopback address running on the external container is reachable and
-				// that traffic from the source ping pod is proxied through the pod in the default namespace
+				// that traffic from the source ping pod is proxied through the pod in the serving namespace
 				ginkgo.By("Verifying connectivity via the gateway namespace to the remote addresses")
 
 				pingSync := sync.WaitGroup{}
@@ -726,10 +708,10 @@ var _ = ginkgo.Context("BFD", func() {
 
 					tcpDumpSync = sync.WaitGroup{}
 					tcpDumpSync.Add(1)
-					go checkPingOnContainer(gwContainers[0], &tcpDumpSync)
+					go checkPingOnContainer(gwContainers[0], srcPingPodName, icmpCommand, &tcpDumpSync)
 
 					// Verify the external gateway loopback address running on the external container is reachable and
-					// that traffic from the source ping pod is proxied through the pod in the default namespace
+					// that traffic from the source ping pod is proxied through the pod in the serving namespace
 					ginkgo.By("Verifying connectivity via the gateway namespace to the remote addresses")
 					pingSync = sync.WaitGroup{}
 
@@ -904,18 +886,9 @@ var _ = ginkgo.Context("BFD", func() {
 			// If an ICMP packet is never detected, return the error via the specified chanel.
 
 			tcpDumpSync := sync.WaitGroup{}
-			checkPingOnContainer := func(container string, wg *sync.WaitGroup) error {
-				defer ginkgo.GinkgoRecover()
-				defer tcpDumpSync.Done()
-				_, err := runCommand(containerRuntime, "exec", container, "timeout", "60", "tcpdump", "-c", "1", "-i", "any", icmpToDump)
-				framework.ExpectNoError(err, "Failed to detect icmp messages from %s on gateway %s", srcPodName, container)
-				framework.Logf("ICMP packet successfully detected on gateway %s", container)
-				return nil
-			}
-
 			tcpDumpSync.Add(len(gwContainers))
 			for _, gwContainer := range gwContainers {
-				go checkPingOnContainer(gwContainer, &tcpDumpSync)
+				go checkPingOnContainer(gwContainer, srcPodName, icmpToDump, &tcpDumpSync)
 			}
 
 			// spawn a goroutine to asynchronously (to speed up the test)
@@ -948,7 +921,7 @@ var _ = ginkgo.Context("BFD", func() {
 			tcpDumpSync = sync.WaitGroup{}
 
 			tcpDumpSync.Add(1)
-			go checkPingOnContainer(gwContainers[0], &tcpDumpSync)
+			go checkPingOnContainer(gwContainers[0], srcPodName, icmpToDump, &tcpDumpSync)
 
 			// spawn a goroutine to asynchronously (to speed up the test)
 			// to ping the gateway loopbacks on both containers via ECMP.
@@ -1191,13 +1164,13 @@ func setupGatewayPods(f *framework.Framework, nodes *v1.NodeList, pod1, pod2, ns
 		if addressesv6.srcPodIP != "" && addressesv6.nodeIP != "" {
 			networkIPs = fmt.Sprintf("\"%s\", \"%s\"", addressesv4.gatewayIPs[i], addressesv6.gatewayIPs[i])
 		}
-		annotatePodForGateway(gwPod, f.Namespace.Name, networkIPs, bfd)
+		annotatePodForGateway(gwPod, ns, f.Namespace.Name, networkIPs, bfd)
 	}
 
 	return gwPods
 }
 
-func cleanExGWContainersAndPods(clientSet kubernetes.Interface, gwContainers, gwPods []string, ns string, addressesv4, addressesv6 gatewayTestIPs) {
+func cleanExGWContainers(clientSet kubernetes.Interface, gwContainers []string, addressesv4, addressesv6 gatewayTestIPs) {
 	ginkgo.By("Deleting the gateway containers")
 	if externalContainerNetwork == "host" {
 		cleanRoutesAndIPs(gwContainers[0], addressesv4, addressesv6)
@@ -1206,12 +1179,6 @@ func cleanExGWContainersAndPods(clientSet kubernetes.Interface, gwContainers, gw
 		for _, container := range gwContainers {
 			deleteClusterExternalContainer(container)
 		}
-	}
-
-	ginkgo.By("Deleting the gateway pods")
-
-	for _, gwPod := range gwPods {
-		deletePodSyncNS(clientSet, ns, gwPod)
 	}
 }
 
@@ -1293,7 +1260,7 @@ func reachPodFromContainer(targetAddress, targetPort, targetPodName, srcContaine
 	framework.ExpectEqual(strings.Trim(res, "\n"), targetPodName)
 }
 
-func annotatePodForGateway(podName, namespace, networkIPs string, bfd bool) {
+func annotatePodForGateway(podName, podNS, namespace, networkIPs string, bfd bool) {
 	// add the annotations to the pod to enable the gateway forwarding.
 	// this fakes out the multus annotation so that the pod IP is
 	// actually an IP of an external container for testing purposes
@@ -1312,7 +1279,7 @@ func annotatePodForGateway(podName, namespace, networkIPs string, bfd bool) {
 		annotateArgs = append(annotateArgs, "k8s.ovn.org/bfd-enabled=\"\"")
 	}
 	framework.Logf("Annotating the external gateway pod with annotation %s", annotateArgs)
-	framework.RunKubectlOrDie("default", annotateArgs...)
+	framework.RunKubectlOrDie(podNS, annotateArgs...)
 }
 
 func annotateNamespaceForGateway(namespace string, bfd bool, gateways ...string) {
@@ -1468,4 +1435,12 @@ func cleanRoutesAndIPsForFamily(containerName string, family int, addresses gate
 	ginkgo.By(fmt.Sprintf("Removing the route from %s to the src pod (IPv%d)", containerName, family))
 	_, err = runCommand(containerRuntime, "exec", containerName, "ip", addressSelector, "route", "del", addresses.srcPodIP, "via", addresses.nodeIP)
 	framework.ExpectNoError(err, "failed to del the pod host route on the test container %s", containerName)
+}
+
+func checkPingOnContainer(container string, srcPodName string, icmpCmd string, wg *sync.WaitGroup) {
+	defer ginkgo.GinkgoRecover()
+	defer wg.Done()
+	_, err := runCommand(containerRuntime, "exec", container, "timeout", "60", "tcpdump", "-c", "1", "-i", "any", icmpCmd)
+	framework.ExpectNoError(err, "Failed to detect icmp messages from %s on gateway %s", srcPodName, container)
+	framework.Logf("ICMP packet successfully detected on gateway %s", container)
 }

--- a/test/e2e/service.go
+++ b/test/e2e/service.go
@@ -172,7 +172,7 @@ var _ = ginkgo.Describe("Services", func() {
 		framework.ExpectNoError(err)
 
 		ginkgo.By("Adding this IP as a manual endpoint")
-		f.ClientSet.CoreV1().Endpoints(namespace).Create(context.TODO(),
+		_, err = f.ClientSet.CoreV1().Endpoints(namespace).Create(context.TODO(),
 			&v1.Endpoints{
 				ObjectMeta: metav1.ObjectMeta{Name: service.Name},
 				Subsets: []v1.EndpointSubset{


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**

Conflicts were just about removing the "HEAD" section for a 3 minor conflicts, mainly git just throwing its hands up.

The merge seems clean otherwise:
~~~
[akaris@linux go-controller (merge_9_23_22)]$ git show
commit b11f90f33c1943f02004ff25e7e194fd454c95c4 (HEAD -> merge_9_23_22)
Merge: c4cc1f287 ebd3caeee
Author: Andreas Karis <ak.karis@gmail.com>
Date:   Fri Sep 23 12:42:43 2022 +0200

    Merge remote-tracking branch 'upstream/master' into merge_9_23_22
    
    Signed-off-by: Andreas Karis <ak.karis@gmail.com>
    
    Conflicts:
      go-controller/pkg/ovn/namespace.go
      go-controller/pkg/ovn/ovn.go
~~~

And diffing upstream/downstream shows diffs for hybrid overlay only:
~~~
[akaris@linux go-controller (merge_9_23_22)]$ git diff upstream/master -- pkg/ovn/ovn.go
diff --git a/go-controller/pkg/ovn/ovn.go b/go-controller/pkg/ovn/ovn.go
index 3c39a666a..fcee85392 100644
--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -77,6 +77,9 @@ type namespaceInfo struct {
        // the policy itself.
        networkPolicies map[string]*networkPolicy
 
+       hybridOverlayExternalGW net.IP
+       hybridOverlayVTEP       net.IP
+
        // routingExternalGWs is a slice of net.IP containing the values parsed from
        // annotation k8s.ovn.org/routing-external-gws
        routingExternalGWs gatewayInfo
[akaris@linux go-controller (merge_9_23_22)]$ git diff upstream/master -- pkg/ovn/namespace.go
diff --git a/go-controller/pkg/ovn/namespace.go b/go-controller/pkg/ovn/namespace.go
index 4b23cf4c9..f89738657 100644
--- a/go-controller/pkg/ovn/namespace.go
+++ b/go-controller/pkg/ovn/namespace.go
@@ -86,21 +86,21 @@ func (oc *Controller) getRoutingPodGWs(nsInfo *namespaceInfo) map[string]gateway
 
 // addPodToNamespace returns pod's routing gateway info and the ops needed
 // to add pod's IP to the namespace's address set.
-func (oc *Controller) addPodToNamespace(ns string, ips []*net.IPNet) (*gatewayInfo, map[string]gatewayInfo, []ovsdb.Operation, error) {
+func (oc *Controller) addPodToNamespace(ns string, ips []*net.IPNet) (*gatewayInfo, map[string]gatewayInfo, net.IP, []ovsdb.Operation, error) {
        var ops []ovsdb.Operation
        var err error
        nsInfo, nsUnlock, err := oc.ensureNamespaceLocked(ns, true, nil)
        if err != nil {
-               return nil, nil, nil, fmt.Errorf("failed to ensure namespace locked: %v", err)
+               return nil, nil, nil, nil, fmt.Errorf("failed to ensure namespace locked: %v", err)
        }
 
        defer nsUnlock()
 
        if ops, err = nsInfo.addressSet.AddIPsReturnOps(createIPAddressSlice(ips)); err != nil {
-               return nil, nil, nil, err
+               return nil, nil, nil, nil, err
        }
 
-       return oc.getRoutingExternalGWs(nsInfo), oc.getRoutingPodGWs(nsInfo), ops, nil
+       return oc.getRoutingExternalGWs(nsInfo), oc.getRoutingPodGWs(nsInfo), nsInfo.hybridOverlayExternalGW, ops, nil
 }
 
 func (oc *Controller) deletePodFromNamespace(ns string, podIfAddrs []*net.IPNet, portUUID string) ([]ovsdb.Operation, error) {
~~~


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->