### PR TITLE
OCPBUGS-1705: Trim ACL names according to RFC1123

### DIFF
--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -115,7 +115,7 @@ func (oc *Controller) updateStaleDefaultDenyACLNames(npType knet.PolicyType, gre
 		return item.ExternalIDs[defaultDenyPolicyTypeACLExtIdKey] == string(npType) && // default-deny-policy-type:Egress or default-deny-policy-type:Ingress
 			strings.Contains(item.Match, gressSuffix) && // Match:inport ==	@ablah80448_egressDefaultDeny or Match:inport == @ablah80448_ingressDefaultDeny
 			!strings.Contains(*item.Name, arpAllowPolicySuffix) && // != name: namespace_ARPallowPolicy
-			!strings.Contains(*item.Name, gressSuffix) // filter out already converted ACLs
+			!strings.Contains(*item.Name, gressSuffix) // filter out already converted ACLs (we still continue to pick the cases where names were >45 chars)
 	}
 	gressACLs, err := libovsdbops.FindACLsWithPredicate(oc.nbClient, p)
 	if err != nil {
@@ -138,8 +138,17 @@ func (oc *Controller) updateStaleDefaultDenyACLNames(npType knet.PolicyType, gre
 				return err
 			}
 		}
-		aclList[0].Name = &newName
-		err := libovsdbops.CreateOrUpdateACLs(oc.nbClient, aclList[0])
+		newACL := BuildACL(
+			newName, // this is the only thing we need to change, keep the rest same
+			aclList[0].Direction,
+			aclList[0].Priority,
+			aclList[0].Match,
+			aclList[0].Action,
+			oc.GetNamespaceACLLogging(namespace),
+			aclList[0].ExternalIDs,
+			aclList[0].Options,
+		)
+		err := libovsdbops.CreateOrUpdateACLs(oc.nbClient, newACL)
 		if err != nil {
 			return fmt.Errorf("cannot update old NetworkPolicy ACLs for namespace %s: %v", namespace, err)
 		}

--- a/go-controller/pkg/ovn/policy_test.go
+++ b/go-controller/pkg/ovn/policy_test.go
@@ -1846,7 +1846,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 
 				// ACL3: leftover default deny ACL egress with old name (namespace_policyname)
 				leftOverACL3FromUpgrade := libovsdbops.BuildACL(
-					"leftover1"+"_"+networkPolicy2.Name,
+					"youknownothingjonsnowyouknownothingjonsnowyouknownothingjonsnow"+"_"+networkPolicy2.Name,
 					nbdb.ACLDirectionFromLport,
 					types.DefaultDenyPriority,
 					"inport == @"+pgHash+"_"+egressDenyPG,
@@ -1929,7 +1929,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 					"apply-after-lb": "true",
 				}
 				leftOverACL3FromUpgrade.Options = egressOptions
-				newDefaultDenyEgressACLName := "leftover1_" + egressDefaultDenySuffix
+				newDefaultDenyEgressACLName := "youknownothingjonsnowyouknownothingjonsnowyouknownothingjonsnow" // trims it according to RFC1123
 				newDefaultDenyIngressACLName := "leftover1_" + ingressDefaultDenySuffix
 				leftOverACL3FromUpgrade.Name = &newDefaultDenyEgressACLName
 				leftOverACL4FromUpgrade.Name = &newDefaultDenyIngressACLName


### PR DESCRIPTION
We didn't consider this tiny hack that we do
https://github.com/openshift/ovn-kubernetes/blob/44ad75466e486cce605e39513a3ecd9e0b306e7d/go-controller/pkg/libovsdbops/acl.go#L60 there when we wrote https://github.com/openshift/ovn-kubernetes/pull/1259 and unit tests don't actually scream loudly for longer names.

Without this PR we break users who have namespace names longer than 45 characters.

Signed-off-by: Surya Seetharaman <suryaseetharaman.9@gmail.com>
Co-authored-by: Patryk Diak <pdiak@redhat.com>
(cherry picked from commit b10ed7bcc2fe486e6cb8b1a06024227b06abaa71)

/cc @trozet and @jcaamano 