### PR TITLE
OCPBUGS-1739: pods: deleteLogicalPort should not fail when ls is gone

### DIFF
--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/metrics"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/ipallocator"
 	util "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	"github.com/pkg/errors"
 	kapi "k8s.io/api/core/v1"
 	ktypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -225,7 +226,8 @@ func (oc *Controller) deleteLogicalPort(pod *kapi.Pod, portInfo *lpInfo) (err er
 		allOps = append(allOps, ops...)
 	}
 	ops, err = oc.delLSPOps(logicalPort, nodeName, portUUID)
-	if err != nil {
+	// Tolerate cases where logical switch of the logical port no longer exist in OVN.
+	if err != nil && !errors.Is(err, libovsdbclient.ErrNotFound) {
 		return fmt.Errorf("failed to create delete ops for the lsp: %s: %s", logicalPort, err)
 	}
 	allOps = append(allOps, ops...)
@@ -763,7 +765,7 @@ func (oc *Controller) delLSPOps(logicalPort, logicalSwitch, lspUUID string) ([]o
 	}
 	ops, err := libovsdbops.DeleteLogicalSwitchPortsOps(oc.nbClient, nil, &lsw, &lsp)
 	if err != nil {
-		return nil, fmt.Errorf("error deleting logical switch port %+v from switch %+v: %v", lsp, lsw, err)
+		return nil, fmt.Errorf("error deleting logical switch port %+v from switch %+v: %w", lsp, lsw, err)
 	}
 
 	return ops, nil

--- a/go-controller/pkg/ovn/pods_test.go
+++ b/go-controller/pkg/ovn/pods_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/urfave/cli/v2"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdbops"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/ipallocator"
 	ovstypes "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 
@@ -955,7 +956,6 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 				pod, err = fakeOvn.fakeClient.KubeClient.CoreV1().Pods(podTest.namespace).Get(context.TODO(), podTest.podName, metav1.GetOptions{})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-				// Deleting port that no longer exists should be okay!
 				gomega.Expect(fakeOvn.controller.deleteLogicalPort(pod, nil)).To(gomega.Succeed(), "Deleting port that no longer exists should be okay")
 
 				err = fakeOvn.fakeClient.KubeClient.CoreV1().Pods(pod.Namespace).Delete(context.TODO(), pod.Name, *metav1.NewDeleteOptions(0))
@@ -965,6 +965,12 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 				gomega.Eventually(func() *retryObjEntry {
 					return fakeOvn.controller.retryPods.getObjRetryEntry(key)
 				}).Should(gomega.BeNil())
+
+				// Remove Logical Switch created on behalf of node and make sure deleteLogicalPort will not fail
+				err = libovsdbops.DeleteLogicalSwitch(fakeOvn.controller.nbClient, pod.Spec.NodeName)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Expect(fakeOvn.controller.deleteLogicalPort(pod, nil)).To(gomega.Succeed(), "Deleting port from switch that no longer exists should be okay")
+
 				return nil
 			}
 


### PR DESCRIPTION
deleteLogicalPort should not fail when its logical switch is already gone. This is needed when handling situations where node has been removed from cluster, but a completed pod remained present after ovnkube master restarts.

https://github.com/ovn-org/ovn-kubernetes/issues/3168

Conflicts:
  go-controller/pkg/ovn/pods_test.go

Closes #3168: ovnkube fails to restart after node deletion Reported-at: https://issues.redhat.com/browse/OCPBUGS-1568
Signed-off-by: Flavio Fernandes <flaviof@redhat.com>
(cherry picked from commit b328345fe57f6310550202664d87e2a4317879d5)
