### PR TITLE
OCPBUGS-1568: pods: deleteLogicalPort should not fail when ls is gone

### DIFF
--- a/go-controller/pkg/libovsdbops/switch.go
+++ b/go-controller/pkg/libovsdbops/switch.go
@@ -149,6 +149,20 @@ func FindSwitchByName(nbClient libovsdbclient.Client, name string) (*nbdb.Logica
 	return &switches[0], nil
 }
 
+// DeleteLogicalSwitch deletes the provided logical switch
+func DeleteLogicalSwitch(nbClient libovsdbclient.Client, swName string) error {
+	sw, err := FindSwitchByName(nbClient, swName)
+	if err != nil {
+		return err
+	}
+	var ops []libovsdb.Operation
+	if ops, err = nbClient.Where(sw).Delete(); err != nil {
+		return err
+	}
+	_, err = TransactAndCheck(nbClient, ops)
+	return err
+}
+
 func AddLoadBalancersToSwitchOps(nbClient libovsdbclient.Client, ops []libovsdb.Operation, lswitch *nbdb.LogicalSwitch, lbs ...*nbdb.LoadBalancer) ([]libovsdb.Operation, error) {
 	if ops == nil {
 		ops = []libovsdb.Operation{}


### PR DESCRIPTION
deleteLogicalPort should not fail when its logical switch is already gone. This is needed when handling situations where node has been removed from cluster, but a completed pod remained present after ovnkube master restarts.

https://github.com/ovn-org/ovn-kubernetes/issues/3168

Conflicts:
  go-controller/pkg/ovn/pods.go
  go-controller/pkg/ovn/pods_test.go
  go-controller/pkg/libovsdbops/switch.go (adding DeleteLogicalSwitch)

Closes #3168: ovnkube fails to restart after node deletion Reported-at: https://issues.redhat.com/browse/OCPBUGS-1568
Signed-off-by: Flavio Fernandes <flaviof@redhat.com>
(cherry picked from commit b328345fe57f6310550202664d87e2a4317879d5)

**NOTE:** For this backport, the unit test exercises invoking `deleteLogicalPort`after removing the logical switch. Since DeleteLogicalSwitch did not exist in 4.10, this PR adds it to `libovsdbops/switch.go`
