### PR TITLE
OCPBUGS-2085: CARRY: Dockerfile.base: bump to openvswitch2.17.0-37.4.el8fdp

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -12,7 +12,7 @@ RUN yum install -y  \
 	selinux-policy && \
 	yum clean all
 
-ARG ovsver=2.17.0-22.el8fdp
+ARG ovsver=2.17.0-37.4.el8fdp
 ARG ovnver=22.06.0-27.el8fdp
 RUN echo $ovsver > /ovs-version && echo $ovnver > /ovn-version
 


### PR DESCRIPTION
This is a continuation of commit
https://github.com/openshift/ovn-kubernetes/pull/1273/commits/2c797c4c791a0a0c11a612d4d0103a349ad64ea5

In particular, this bump includes fixes for AVX512 runtime checks:
- dpif-netdev: Refactor AVX512 runtime checks. (#2100393)
- dpif-netdev: Fix leak of AVX512 DPIF scratch pad
- dpif-netdev-extract-avx512: Protect GCC builtin usage

All other changes can be obtained here:
https://access.redhat.com/downloads/content/rhel---8/x86_64/7816/openvswitch2.17/2.17.0-37.4.el8fdp/x86_64/fd431d51/package-changelog

Signed-off-by: Flavio Fernandes <flaviof@redhat.com>