### PR TITLE
[release-4.10] OCPBUGS-2208: getDefaultGatewayInterfaceByFamily: custom filter for MultiHop

### DIFF
--- a/go-controller/pkg/node/helper_linux_test.go
+++ b/go-controller/pkg/node/helper_linux_test.go
@@ -1,0 +1,176 @@
+package node
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/vishvananda/netlink"
+)
+
+func TestFilterRoutesByIfIndex(t *testing.T) {
+	tcs := []struct {
+		routesUnfiltered []netlink.Route
+		gwIfIdx          int
+		routesFiltered   []netlink.Route
+	}{
+		// tc0 - baseline.
+		{
+			routesUnfiltered: []netlink.Route{},
+			gwIfIdx:          0,
+			routesFiltered:   []netlink.Route{},
+		},
+		// tc1 - do not filter.
+		{
+			routesUnfiltered: []netlink.Route{
+				{
+					LinkIndex: 1,
+					Gw:        []byte{1, 1, 1, 1},
+				},
+				{
+					LinkIndex: 2,
+					Gw:        []byte{2, 2, 2, 2},
+				},
+				{
+					LinkIndex: 1,
+					Gw:        []byte{3, 3, 3, 3},
+				},
+			},
+			gwIfIdx: 0,
+			routesFiltered: []netlink.Route{
+				{
+					LinkIndex: 1,
+					Gw:        []byte{1, 1, 1, 1},
+				},
+				{
+					LinkIndex: 2,
+					Gw:        []byte{2, 2, 2, 2},
+				},
+				{
+					LinkIndex: 1,
+					Gw:        []byte{3, 3, 3, 3},
+				},
+			},
+		},
+		// tc2 - filter by link index.
+		{
+			routesUnfiltered: []netlink.Route{
+				{
+					LinkIndex: 1,
+					Gw:        []byte{1, 1, 1, 1},
+				},
+				{
+					LinkIndex: 2,
+					Gw:        []byte{2, 2, 2, 2},
+				},
+				{
+					LinkIndex: 1,
+					Gw:        []byte{3, 3, 3, 3},
+				},
+			},
+			gwIfIdx: 1,
+			routesFiltered: []netlink.Route{
+				{
+					LinkIndex: 1,
+					Gw:        []byte{1, 1, 1, 1},
+				},
+				{
+					LinkIndex: 1,
+					Gw:        []byte{3, 3, 3, 3},
+				},
+			},
+		},
+		// tc3 - filter by MultiPath index.
+		{
+			routesUnfiltered: []netlink.Route{
+				{
+					LinkIndex: 1,
+					Gw:        []byte{1, 1, 1, 1},
+				},
+				{
+					LinkIndex: 2,
+					Gw:        []byte{2, 2, 2, 2},
+				},
+				{
+					LinkIndex: 0,
+					MultiPath: []*netlink.NexthopInfo{
+						{
+							LinkIndex: 1,
+							Hops:      0,
+							Gw:        []byte{3, 3, 3, 3},
+						},
+						{
+							LinkIndex: 1,
+							Hops:      0,
+							Gw:        []byte{4, 4, 4, 4},
+						},
+					},
+				},
+			},
+			gwIfIdx: 1,
+			routesFiltered: []netlink.Route{
+				{
+					LinkIndex: 1,
+					Gw:        []byte{1, 1, 1, 1},
+				},
+				{
+					LinkIndex: 0,
+					MultiPath: []*netlink.NexthopInfo{
+						{
+							LinkIndex: 1,
+							Hops:      0,
+							Gw:        []byte{3, 3, 3, 3},
+						},
+						{
+							LinkIndex: 1,
+							Hops:      0,
+							Gw:        []byte{4, 4, 4, 4},
+						},
+					},
+				},
+			},
+		},
+		// tc4 - filter by MultiPath index - MultiPath with multiple interfaces.
+		{
+			routesUnfiltered: []netlink.Route{
+				{
+					LinkIndex: 1,
+					Gw:        []byte{1, 1, 1, 1},
+				},
+				{
+					LinkIndex: 2,
+					Gw:        []byte{2, 2, 2, 2},
+				},
+				{
+					LinkIndex: 0,
+					MultiPath: []*netlink.NexthopInfo{
+						{
+							LinkIndex: 1,
+							Hops:      0,
+							Gw:        []byte{3, 3, 3, 3},
+						},
+						{
+							LinkIndex: 2,
+							Hops:      0,
+							Gw:        []byte{4, 4, 4, 4},
+						},
+					},
+				},
+			},
+			gwIfIdx: 1,
+			routesFiltered: []netlink.Route{
+				{
+					LinkIndex: 1,
+					Gw:        []byte{1, 1, 1, 1},
+				},
+			},
+		},
+	}
+
+	for i, tc := range tcs {
+		routesFiltered := filterRoutesByIfIndex(tc.routesUnfiltered, tc.gwIfIdx)
+		if !reflect.DeepEqual(tc.routesFiltered, routesFiltered) {
+			t.Fatalf("TestFilterRoutesByIfIndex(%d): Filtering '%v' by index '%d' should have yielded '%v' but got '%v'",
+				i, tc.routesUnfiltered, tc.gwIfIdx, tc.routesFiltered, routesFiltered)
+		}
+	}
+}


### PR DESCRIPTION
Due to the way how IPv6 multipath is implemented, it is not possible to filter by ifindex as the ifindex for multihop routes will always be 0. Instead, implement a custom filter.

Reported-at: https://issues.redhat.com/browse/OCPBUGS-1318
Signed-off-by: Andreas Karis <ak.karis@gmail.com>
(cherry picked from commit 980694d38b56b73b5ffe821d3521061a55e600a2) (cherry picked from commit 9353ff60cd9abe7cf8de78629ecf892e0981de21)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->