### PR TITLE
OCPBUGS-2569: Fix netpol races

### DIFF
--- a/go-controller/pkg/ovn/egressfirewall.go
+++ b/go-controller/pkg/ovn/egressfirewall.go
@@ -364,13 +364,13 @@ func (oc *Controller) createEgressFirewallRules(priority int, match, action, ext
 
 	egressFirewallACL := BuildACL(
 		aclName,
-		nbdb.ACLDirectionToLport,
 		priority,
 		match,
 		action,
 		aclLogging,
+		// since egressFirewall has direction to-lport, set type to ingress
+		lportIngress,
 		map[string]string{egressFirewallACLExtIdKey: externalID},
-		nil,
 	)
 	ops, err := libovsdbops.CreateOrUpdateACLsOps(oc.nbClient, nil, egressFirewallACL)
 	if err != nil {

--- a/go-controller/pkg/ovn/gress_policy.go
+++ b/go-controller/pkg/ovn/gress_policy.go
@@ -3,8 +3,10 @@ package ovn
 import (
 	"fmt"
 	"net"
+	"sort"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/ovn-org/libovsdb/client"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
@@ -17,7 +19,6 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	knet "k8s.io/api/networking/v1"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
 	utilnet "k8s.io/utils/net"
 )
@@ -28,14 +29,20 @@ type gressPolicy struct {
 	policyType      knet.PolicyType
 	idx             int
 
-	// peerAddressSet points to the addressSet that holds all peer pod
+	// peerAddressSet points to the addressSet that holds all peer pod or peer service
 	// IP addresess.
+	// used for pod, pod with namespace, and svc peer selectors
+	// This addressSet is synced by networkPolicy lock:
+	// ensurePeerAddressSet and destroy functions need to hold networkPolicy write lock,
+	// and function that modify addressSet need to hold networkPolicy read lock.
+	// Adding/deleting ips to/from address set is safe for concurrent use.
 	peerAddressSet addressset.AddressSet
 
+	// peerVxAddressSets includes gressPolicy.peerAddressSet, and address sets for selected namespaces
 	// peerV4AddressSets has Address sets for all namespaces and pod selectors for IPv4
-	peerV4AddressSets sets.String
+	peerV4AddressSets *sync.Map
 	// peerV6AddressSets has Address sets for all namespaces and pod selectors for IPv6
-	peerV6AddressSets sets.String
+	peerV6AddressSets *sync.Map
 
 	// portPolicies represents all the ports to which traffic is allowed for
 	// the rule in question.
@@ -77,12 +84,38 @@ func newGressPolicy(policyType knet.PolicyType, idx int, namespace, name string)
 		policyName:        name,
 		policyType:        policyType,
 		idx:               idx,
-		peerV4AddressSets: sets.String{},
-		peerV6AddressSets: sets.String{},
+		peerV4AddressSets: &sync.Map{},
+		peerV6AddressSets: &sync.Map{},
 		portPolicies:      make([]*portPolicy, 0),
 	}
 }
 
+type sortableSlice []string
+
+func (s sortableSlice) Len() int           { return len(s) }
+func (s sortableSlice) Less(i, j int) bool { return s[i] < s[j] }
+func (s sortableSlice) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+
+func syncMapToSortedList(m *sync.Map) []string {
+	result := sortableSlice{}
+	m.Range(func(key, _ interface{}) bool {
+		result = append(result, key.(string))
+		return true
+	})
+	sort.Sort(result)
+	return result
+}
+
+func syncMapLen(m *sync.Map) int {
+	result := 0
+	m.Range(func(_, _ interface{}) bool {
+		result++
+		return true
+	})
+	return result
+}
+
+// must be called with network policy write lock
 func (gp *gressPolicy) ensurePeerAddressSet(factory addressset.AddressSetFactory) error {
 	if gp.peerAddressSet != nil {
 		return nil
@@ -98,14 +131,15 @@ func (gp *gressPolicy) ensurePeerAddressSet(factory addressset.AddressSetFactory
 	gp.peerAddressSet = as
 	ipv4HashedAS, ipv6HashedAS := as.GetASHashNames()
 	if ipv4HashedAS != "" {
-		gp.peerV4AddressSets.Insert("$" + ipv4HashedAS)
+		gp.peerV4AddressSets.Store("$"+ipv4HashedAS, true)
 	}
 	if ipv6HashedAS != "" {
-		gp.peerV6AddressSets.Insert("$" + ipv6HashedAS)
+		gp.peerV6AddressSets.Store("$"+ipv6HashedAS, true)
 	}
 	return nil
 }
 
+// must be called with network policy read lock
 func (gp *gressPolicy) addPeerSvcVip(nbClient client.Client, service *v1.Service) error {
 	if gp.peerAddressSet == nil {
 		return fmt.Errorf("peer AddressSet is nil, cannot add peer Service: %s for gressPolicy: %s",
@@ -119,6 +153,7 @@ func (gp *gressPolicy) addPeerSvcVip(nbClient client.Client, service *v1.Service
 	return gp.peerAddressSet.AddIPs(ips)
 }
 
+// must be called with network policy read lock
 func (gp *gressPolicy) deletePeerSvcVip(nbClient client.Client, service *v1.Service) error {
 	if gp.peerAddressSet == nil {
 		return fmt.Errorf("peer AddressSet is nil, cannot add peer Service: %s for gressPolicy: %s",
@@ -132,6 +167,9 @@ func (gp *gressPolicy) deletePeerSvcVip(nbClient client.Client, service *v1.Serv
 	return gp.peerAddressSet.DeleteIPs(ips)
 }
 
+// addPeerPods will get all currently assigned ips for given pods, and add them to the address set.
+// If pod ips change, this function should be called again.
+// must be called with network policy read lock
 func (gp *gressPolicy) addPeerPods(pods ...*v1.Pod) error {
 	if gp.peerAddressSet == nil {
 		return fmt.Errorf("peer AddressSet is nil, cannot add peer pod(s): for gressPolicy: %s",
@@ -154,6 +192,7 @@ func (gp *gressPolicy) addPeerPods(pods ...*v1.Pod) error {
 	return gp.peerAddressSet.AddIPs(ips)
 }
 
+// must be called with network policy read lock
 func (gp *gressPolicy) deletePeerPod(pod *v1.Pod) error {
 	ips, err := util.GetAllPodIPs(pod)
 	if err != nil {
@@ -183,12 +222,15 @@ func (gp *gressPolicy) addIPBlock(ipblockJSON *knet.IPBlock) {
 
 func (gp *gressPolicy) getL3MatchFromAddressSet() string {
 	var l3Match string
-	if len(gp.peerV4AddressSets) == 0 && len(gp.peerV6AddressSets) == 0 {
+	v4List := syncMapToSortedList(gp.peerV4AddressSets)
+	v6List := syncMapToSortedList(gp.peerV6AddressSets)
+
+	if len(v4List) == 0 && len(v6List) == 0 {
 		l3Match = constructEmptyMatchString()
 	} else {
-		// List() method on the set will return the sorted strings
-		// Hence we'll be constructing the sorted adress set string here
-		l3Match = gp.constructMatchString(gp.peerV4AddressSets.List(), gp.peerV6AddressSets.List())
+		// We sort address slice,
+		// Hence we'll be constructing the sorted address set string here
+		l3Match = gp.constructMatchString(v4List, v6List)
 	}
 	return l3Match
 }
@@ -232,7 +274,7 @@ func (gp *gressPolicy) constructMatchString(v4AddressSets, v6AddressSets []strin
 }
 
 func (gp *gressPolicy) sizeOfAddressSet() int {
-	return gp.peerV4AddressSets.Len() + gp.peerV6AddressSets.Len()
+	return syncMapLen(gp.peerV4AddressSets) + syncMapLen(gp.peerV6AddressSets)
 }
 
 func (gp *gressPolicy) getMatchFromIPBlock(lportMatch, l4Match string) []string {
@@ -248,62 +290,57 @@ func (gp *gressPolicy) getMatchFromIPBlock(lportMatch, l4Match string) []string 
 // addNamespaceAddressSet adds a namespace address set to the gress policy
 // if the address set does not exist and returns `true`;  if the address set already exists,
 // it returns `false`.
+// This function is safe for concurrent use, doesn't require additional synchronization
 func (gp *gressPolicy) addNamespaceAddressSet(name string) bool {
 	v4HashName, v6HashName := addressset.MakeAddressSetHashNames(name)
 	v4HashName = "$" + v4HashName
 	v6HashName = "$" + v6HashName
 
-	if gp.peerV4AddressSets.Has(v4HashName) || gp.peerV6AddressSets.Has(v6HashName) {
-		return false
-	}
+	v4NoUpdate := true
+	v6NoUpdate := true
+	// only update vXNoUpdate if value was stored and not loaded
 	if config.IPv4Mode {
-		gp.peerV4AddressSets.Insert(v4HashName)
+		_, v4NoUpdate = gp.peerV4AddressSets.LoadOrStore(v4HashName, true)
 	}
 	if config.IPv6Mode {
-		gp.peerV6AddressSets.Insert(v6HashName)
+		_, v6NoUpdate = gp.peerV6AddressSets.LoadOrStore(v6HashName, true)
 	}
-
+	if v4NoUpdate && v6NoUpdate {
+		// no changes were applied, return false
+		return false
+	}
 	return true
-}
-
-// addNamespaceAddressSets adds namespace address sets to the gress policy.
-func (gp *gressPolicy) addNamespaceAddressSets(namespaces []interface{}) {
-	if len(namespaces) <= 0 {
-		return
-	}
-	for _, nsInterface := range namespaces {
-		namespace, ok := nsInterface.(*v1.Namespace)
-		if !ok {
-			klog.Errorf("Spurious object in addNamespaceAddressSets: %v", nsInterface)
-			continue
-		}
-		gp.addNamespaceAddressSet(namespace.Name)
-	}
 }
 
 // delNamespaceAddressSet removes a namespace address set from the gress policy
 // and returns whether the address set was in the policy or not.
+// This function is safe for concurrent use, doesn't require additional synchronization
 func (gp *gressPolicy) delNamespaceAddressSet(name string) bool {
 	v4HashName, v6HashName := addressset.MakeAddressSetHashNames(name)
 	v4HashName = "$" + v4HashName
 	v6HashName = "$" + v6HashName
 
-	if !gp.peerV4AddressSets.Has(v4HashName) && !gp.peerV6AddressSets.Has(v6HashName) {
-		return false
-	}
+	v4Update := false
+	v6Update := false
+	// only update vXUpdate if value was loaded
 	if config.IPv4Mode {
-		gp.peerV4AddressSets.Delete(v4HashName)
+		_, v4Update = gp.peerV4AddressSets.LoadAndDelete(v4HashName)
 	}
 	if config.IPv6Mode {
-		gp.peerV6AddressSets.Delete(v6HashName)
+		_, v6Update = gp.peerV6AddressSets.LoadAndDelete(v6HashName)
 	}
-
-	return true
+	if v4Update || v6Update {
+		// at least 1 address set was updated, return true
+		return true
+	}
+	return false
 }
 
 // buildLocalPodACLs builds the ACLs that implement the gress policy's rules to the
 // given Port Group (which should contain all pod logical switch ports selected
 // by the parent NetworkPolicy)
+// buildLocalPodACLs is safe for concurrent use, since it only uses gressPolicy fields that don't change
+// since creation, or are safe for concurrent use like peerVXAddressSets
 func (gp *gressPolicy) buildLocalPodACLs(portGroupName string, aclLogging *ACLLoggingLevels) []*nbdb.ACL {
 	l3Match := gp.getL3MatchFromAddressSet()
 	var lportMatch string
@@ -422,11 +459,13 @@ func constructIPBlockStringsForACL(direction string, ipBlocks []*knet.IPBlock, l
 	return matchStrings
 }
 
+// must be called with network policy write lock
 func (gp *gressPolicy) destroy() error {
 	if gp.peerAddressSet != nil {
 		if err := gp.peerAddressSet.Destroy(); err != nil {
 			return err
 		}
+		gp.peerAddressSet = nil
 	}
 	return nil
 }

--- a/go-controller/pkg/ovn/namespace.go
+++ b/go-controller/pkg/ovn/namespace.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"sync"
 	"time"
 
 	"github.com/ovn-org/libovsdb/ovsdb"
@@ -18,6 +19,45 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
 )
+
+// namespaceInfo contains information related to a Namespace. Use oc.getNamespaceLocked()
+// or oc.waitForNamespaceLocked() to get a locked namespaceInfo for a Namespace, and call
+// nsInfo.Unlock() on it when you are done with it. (No code outside of the code that
+// manages the oc.namespaces map is ever allowed to hold an unlocked namespaceInfo.)
+type namespaceInfo struct {
+	sync.RWMutex
+
+	// addressSet is an address set object that holds the IP addresses
+	// of all pods in the namespace.
+	addressSet addressset.AddressSet
+
+	// map from NetworkPolicy name to networkPolicy. You must hold the
+	// namespaceInfo's mutex to add/delete/lookup policies, but must hold the
+	// networkPolicy's mutex (and not necessarily the namespaceInfo's) to work with
+	// the policy itself.
+	networkPolicies map[string]*networkPolicy
+
+	hybridOverlayExternalGW net.IP
+	hybridOverlayVTEP       net.IP
+
+	// routingExternalGWs is a slice of net.IP containing the values parsed from
+	// annotation k8s.ovn.org/routing-external-gws
+	routingExternalGWs gatewayInfo
+
+	// routingExternalPodGWs contains a map of all pods serving as exgws as well as their
+	// exgw IPs
+	// key is <namespace>_<pod name>
+	routingExternalPodGWs map[string]gatewayInfo
+
+	multicastEnabled bool
+
+	// If not empty, then it has to be set to a logging a severity level, e.g. "notice", "alert", etc
+	aclLogging ACLLoggingLevels
+
+	// Per-namespace port group default deny UUIDs
+	portGroupIngressDenyName string // Port group Name for ingress deny rule
+	portGroupEgressDenyName  string // Port group Name for egress deny rule
+}
 
 // This function implements the main body of work of syncNamespaces.
 // Upon failure, it may be invoked multiple times in order to avoid a pod restart.

--- a/go-controller/pkg/ovn/namespace.go
+++ b/go-controller/pkg/ovn/namespace.go
@@ -53,10 +53,6 @@ type namespaceInfo struct {
 
 	// If not empty, then it has to be set to a logging a severity level, e.g. "notice", "alert", etc
 	aclLogging ACLLoggingLevels
-
-	// Per-namespace port group default deny UUIDs
-	portGroupIngressDenyName string // Port group Name for ingress deny rule
-	portGroupEgressDenyName  string // Port group Name for egress deny rule
 }
 
 // This function implements the main body of work of syncNamespaces.
@@ -453,13 +449,12 @@ func (oc *Controller) deleteNamespace(ns *kapi.Namespace) error {
 
 	klog.V(5).Infof("Deleting Namespace's NetworkPolicy entities")
 	for _, np := range nsInfo.networkPolicies {
-		key := getPolicyNamespacedName(np.policy)
+		key := getPolicyKey(np.policy)
 		oc.retryNetworkPolicies.DoWithLock(key, func(key string) {
 			// add the full np object to the retry entry, since the namespace is going to be removed
 			// along with any mappings of nsInfo -> network policies
 			oc.retryNetworkPolicies.initRetryObjWithDelete(np.policy, key, np, false)
-			isLastPolicyInNamespace := len(nsInfo.networkPolicies) == 1
-			if err := oc.destroyNetworkPolicy(np, isLastPolicyInNamespace); err != nil {
+			if err := oc.destroyNetworkPolicy(np); err != nil {
 				klog.Errorf("Failed to delete network policy: %s, error: %v", key, err)
 			} else {
 				oc.retryNetworkPolicies.deleteRetryObj(key)

--- a/go-controller/pkg/ovn/obj_retry.go
+++ b/go-controller/pkg/ovn/obj_retry.go
@@ -655,11 +655,14 @@ func (oc *Controller) addResource(objectsToRetry *RetryObjs, obj interface{}, fr
 		}
 
 		// start watching pods in this namespace and selected by the label selector in extraParameters.podSelector
+		syncFunc := func(objs []interface{}) error {
+			return oc.handlePeerPodSelectorAddUpdate(extraParameters.gp, objs...)
+		}
 		retryPeerPods := NewRetryObjs(
 			factory.PeerPodForNamespaceAndPodSelectorType,
 			namespace.Name,
 			extraParameters.podSelector,
-			nil,
+			syncFunc,
 			&NetworkPolicyExtraParameters{gp: extraParameters.gp},
 		)
 		// The AddFilteredPodHandler call might call handlePeerPodSelectorAddUpdate
@@ -1243,39 +1246,12 @@ func (oc *Controller) getSyncResourcesFunc(r *RetryObjs) (func([]interface{}) er
 	case factory.NodeType:
 		syncFunc = oc.syncNodes
 
-	case factory.PeerServiceType,
-		factory.PeerNamespaceAndPodSelectorType:
-		syncFunc = nil
-
-	case factory.PeerPodSelectorType:
-		extraParameters := r.extraParameters.(*NetworkPolicyExtraParameters)
-		syncFunc = func(objs []interface{}) error {
-			return oc.handlePeerPodSelectorAddUpdate(extraParameters.gp, objs...)
-		}
-
-	case factory.PeerPodForNamespaceAndPodSelectorType:
-		extraParameters := r.extraParameters.(*NetworkPolicyExtraParameters)
-		syncFunc = func(objs []interface{}) error {
-			return oc.handlePeerPodSelectorAddUpdate(extraParameters.gp, objs...)
-		}
-
-	case factory.PeerNamespaceSelectorType:
-		extraParameters := r.extraParameters.(*NetworkPolicyExtraParameters)
-		// the function below will never fail, so there's no point in making it retriable...
-		syncFunc = func(i []interface{}) error {
-			// This needs to be a write lock because there's no locking around 'gress policies
-			extraParameters.np.Lock()
-			defer extraParameters.np.Unlock()
-			// We load the existing address set into the 'gress policy.
-			// Notice that this will make the AddFunc for this initial
-			// address set a noop.
-			// The ACL must be set explicitly after setting up this handler
-			// for the address set to be considered.
-			extraParameters.gp.addNamespaceAddressSets(i)
-			return nil
-		}
-
-	case factory.LocalPodSelectorType:
+	case factory.LocalPodSelectorType,
+		factory.PeerServiceType,
+		factory.PeerNamespaceAndPodSelectorType,
+		factory.PeerPodSelectorType,
+		factory.PeerPodForNamespaceAndPodSelectorType,
+		factory.PeerNamespaceSelectorType:
 		syncFunc = r.syncFunc
 
 	case factory.EgressFirewallType:

--- a/go-controller/pkg/ovn/obj_retry.go
+++ b/go-controller/pkg/ovn/obj_retry.go
@@ -97,7 +97,7 @@ func (r *RetryObjs) DoWithLock(key string, f func(key string)) {
 
 func (r *RetryObjs) initRetryObjWithAddBackoff(obj interface{}, lockedKey string, backoff time.Duration) *retryObjEntry {
 	// even if the object was loaded and changed before with the same lock, LoadOrStore will return reference to the same object
-	entry := r.retryEntries.LoadOrStore(lockedKey, &retryObjEntry{backoffSec: backoff})
+	entry, _ := r.retryEntries.LoadOrStore(lockedKey, &retryObjEntry{backoffSec: backoff})
 	entry.timeStamp = time.Now()
 	entry.newObj = obj
 	entry.failedAttempts = 0
@@ -113,7 +113,7 @@ func (r *RetryObjs) initRetryObjWithAdd(obj interface{}, lockedKey string) *retr
 
 // initRetryObjWithUpdate tracks objects that failed to be updated to potentially retry later
 func (r *RetryObjs) initRetryObjWithUpdate(oldObj, newObj interface{}, lockedKey string) *retryObjEntry {
-	entry := r.retryEntries.LoadOrStore(lockedKey, &retryObjEntry{config: oldObj, backoffSec: initialBackoff})
+	entry, _ := r.retryEntries.LoadOrStore(lockedKey, &retryObjEntry{config: oldObj, backoffSec: initialBackoff})
 	// even if the object was loaded and changed before with the same lock, LoadOrStore will return reference to the same object
 	entry.timeStamp = time.Now()
 	entry.newObj = newObj
@@ -133,7 +133,7 @@ func (r *RetryObjs) initRetryObjWithUpdate(oldObj, newObj interface{}, lockedKey
 // The noRetryAdd boolean argument is to indicate whether to retry for addition
 func (r *RetryObjs) initRetryObjWithDelete(obj interface{}, lockedKey string, config interface{}, noRetryAdd bool) *retryObjEntry {
 	// even if the object was loaded and changed before with the same lock, LoadOrStore will return reference to the same object
-	entry := r.retryEntries.LoadOrStore(lockedKey, &retryObjEntry{config: config, backoffSec: initialBackoff})
+	entry, _ := r.retryEntries.LoadOrStore(lockedKey, &retryObjEntry{config: config, backoffSec: initialBackoff})
 	entry.timeStamp = time.Now()
 	entry.oldObj = obj
 	if entry.config == nil {
@@ -337,7 +337,7 @@ func getResourceKey(objType reflect.Type, obj interface{}) (string, error) {
 		if !ok {
 			return "", fmt.Errorf("could not cast %T object to *knet.NetworkPolicy", obj)
 		}
-		return getPolicyNamespacedName(np), nil
+		return getPolicyKey(np), nil
 
 	case factory.NodeType,
 		factory.EgressNodeType:
@@ -697,10 +697,8 @@ func (oc *Controller) addResource(objectsToRetry *RetryObjs, obj interface{}, fr
 	case factory.LocalPodSelectorType:
 		extraParameters := objectsToRetry.extraParameters.(*NetworkPolicyExtraParameters)
 		return oc.handleLocalPodSelectorAddFunc(
-			extraParameters.policy,
 			extraParameters.np,
-			extraParameters.portGroupIngressDenyName,
-			extraParameters.portGroupEgressDenyName,
+			false,
 			obj)
 
 	case factory.EgressFirewallType:
@@ -829,10 +827,8 @@ func (oc *Controller) updateResource(objectsToRetry *RetryObjs, oldObj, newObj i
 	case factory.LocalPodSelectorType:
 		extraParameters := objectsToRetry.extraParameters.(*NetworkPolicyExtraParameters)
 		return oc.handleLocalPodSelectorAddFunc(
-			extraParameters.policy,
 			extraParameters.np,
-			extraParameters.portGroupIngressDenyName,
-			extraParameters.portGroupEgressDenyName,
+			false,
 			newObj)
 
 	case factory.EgressIPType:
@@ -1011,10 +1007,7 @@ func (oc *Controller) deleteResource(objectsToRetry *RetryObjs, obj, cachedObj i
 	case factory.LocalPodSelectorType:
 		extraParameters := objectsToRetry.extraParameters.(*NetworkPolicyExtraParameters)
 		return oc.handleLocalPodSelectorDelFunc(
-			extraParameters.policy,
 			extraParameters.np,
-			extraParameters.portGroupIngressDenyName,
-			extraParameters.portGroupEgressDenyName,
 			obj)
 
 	case factory.EgressFirewallType:

--- a/go-controller/pkg/ovn/obj_retry.go
+++ b/go-controller/pkg/ovn/obj_retry.go
@@ -634,11 +634,11 @@ func (oc *Controller) addResource(objectsToRetry *RetryObjs, obj interface{}, fr
 			return fmt.Errorf("could not cast peer service of type %T to *kapi.Service", obj)
 		}
 		extraParameters := objectsToRetry.extraParameters.(*NetworkPolicyExtraParameters)
-		return oc.handlePeerServiceAdd(extraParameters.gp, service)
+		return oc.handlePeerServiceAdd(extraParameters.np, extraParameters.gp, service)
 
 	case factory.PeerPodSelectorType:
 		extraParameters := objectsToRetry.extraParameters.(*NetworkPolicyExtraParameters)
-		return oc.handlePeerPodSelectorAddUpdate(extraParameters.gp, obj)
+		return oc.handlePeerPodSelectorAddUpdate(extraParameters.np, extraParameters.gp, obj)
 
 	case factory.PeerNamespaceAndPodSelectorType:
 		extraParameters := objectsToRetry.extraParameters.(*NetworkPolicyExtraParameters)
@@ -647,7 +647,7 @@ func (oc *Controller) addResource(objectsToRetry *RetryObjs, obj interface{}, fr
 
 	case factory.PeerPodForNamespaceAndPodSelectorType:
 		extraParameters := objectsToRetry.extraParameters.(*NetworkPolicyExtraParameters)
-		return oc.handlePeerPodSelectorAddUpdate(extraParameters.gp, obj)
+		return oc.handlePeerPodSelectorAddUpdate(extraParameters.np, extraParameters.gp, obj)
 
 	case factory.PeerNamespaceSelectorType:
 		extraParameters := objectsToRetry.extraParameters.(*NetworkPolicyExtraParameters)
@@ -657,7 +657,6 @@ func (oc *Controller) addResource(objectsToRetry *RetryObjs, obj interface{}, fr
 		extraParameters := objectsToRetry.extraParameters.(*NetworkPolicyExtraParameters)
 		return oc.handleLocalPodSelectorAddFunc(
 			extraParameters.np,
-			false,
 			obj)
 
 	case factory.EgressFirewallType:
@@ -777,17 +776,16 @@ func (oc *Controller) updateResource(objectsToRetry *RetryObjs, oldObj, newObj i
 
 	case factory.PeerPodSelectorType:
 		extraParameters := objectsToRetry.extraParameters.(*NetworkPolicyExtraParameters)
-		return oc.handlePeerPodSelectorAddUpdate(extraParameters.gp, newObj)
+		return oc.handlePeerPodSelectorAddUpdate(extraParameters.np, extraParameters.gp, newObj)
 
 	case factory.PeerPodForNamespaceAndPodSelectorType:
 		extraParameters := objectsToRetry.extraParameters.(*NetworkPolicyExtraParameters)
-		return oc.handlePeerPodSelectorAddUpdate(extraParameters.gp, newObj)
+		return oc.handlePeerPodSelectorAddUpdate(extraParameters.np, extraParameters.gp, newObj)
 
 	case factory.LocalPodSelectorType:
 		extraParameters := objectsToRetry.extraParameters.(*NetworkPolicyExtraParameters)
 		return oc.handleLocalPodSelectorAddFunc(
 			extraParameters.np,
-			false,
 			newObj)
 
 	case factory.EgressIPType:
@@ -921,19 +919,19 @@ func (oc *Controller) deleteResource(objectsToRetry *RetryObjs, obj, cachedObj i
 			return fmt.Errorf("could not cast peer service of type %T to *kapi.Service", obj)
 		}
 		extraParameters := objectsToRetry.extraParameters.(*NetworkPolicyExtraParameters)
-		return oc.handlePeerServiceDelete(extraParameters.gp, service)
+		return oc.handlePeerServiceDelete(extraParameters.np, extraParameters.gp, service)
 
 	case factory.PeerPodSelectorType:
 		extraParameters := objectsToRetry.extraParameters.(*NetworkPolicyExtraParameters)
-		return oc.handlePeerPodSelectorDelete(extraParameters.gp, obj)
+		return oc.handlePeerPodSelectorDelete(extraParameters.np, extraParameters.gp, obj)
 
 	case factory.PeerNamespaceAndPodSelectorType:
 		extraParameters := objectsToRetry.extraParameters.(*NetworkPolicyExtraParameters)
-		return oc.handlePeerNamespaceAndPodDel(extraParameters.gp, obj)
+		return oc.handlePeerNamespaceAndPodDel(extraParameters.np, extraParameters.gp, obj)
 
 	case factory.PeerPodForNamespaceAndPodSelectorType:
 		extraParameters := objectsToRetry.extraParameters.(*NetworkPolicyExtraParameters)
-		return oc.handlePeerPodSelectorDelete(extraParameters.gp, obj)
+		return oc.handlePeerPodSelectorDelete(extraParameters.np, extraParameters.gp, obj)
 
 	case factory.PeerNamespaceSelectorType:
 		extraParameters := objectsToRetry.extraParameters.(*NetworkPolicyExtraParameters)
@@ -1133,7 +1131,7 @@ func (oc *Controller) iterateRetryResources(r *RetryObjs) {
 	}
 	klog.V(5).Infof("Waiting for all the %s retry setup to complete in iterateRetryResources", r.oType)
 	wg.Wait()
-	klog.V(5).Infof("Function iterateRetryResources ended (in %v)", time.Since(now))
+	klog.V(5).Infof("Function iterateRetryResources for %s ended (in %v)", r.oType, time.Since(now))
 }
 
 // periodicallyRetryResources tracks RetryObjs and checks if any object needs to be retried for add or delete every
@@ -1281,7 +1279,7 @@ func (oc *Controller) WatchResource(objectsToRetry *RetryObjs) (*factory.Handler
 					klog.Errorf("Upon add event: %v", err)
 					return
 				}
-				klog.V(5).Infof("Add event received for %s, key=%s", objectsToRetry.oType, key)
+				klog.V(5).Infof("Add event received for %s %s", objectsToRetry.oType, key)
 
 				objectsToRetry.DoWithLock(key, func(key string) {
 					// This only applies to pod watchers (pods + dynamic network policy handlers watching pods):

--- a/go-controller/pkg/ovn/obj_retry.go
+++ b/go-controller/pkg/ovn/obj_retry.go
@@ -125,10 +125,7 @@ func (r *RetryObjs) initRetryObjWithUpdate(oldObj, newObj interface{}, lockedKey
 // initRetryObjWithDelete creates a retry entry for an object that is being deleted,
 // so that, if it fails, the delete can be potentially retried later.
 // When applied to pods, we include the config object as well in case the namespace is removed
-// and the object is orphaned from the namespace. Similarly, when applied to network policies,
-// we include in config the networkPolicy struct used internally, for the same scenario where
-// a namespace is being deleted along with its network policies and, in case of a delete retry of
-// one such network policy, we wouldn't be able to get to the networkPolicy struct from nsInfo.
+// and the object is orphaned from the namespace.
 //
 // The noRetryAdd boolean argument is to indicate whether to retry for addition
 func (r *RetryObjs) initRetryObjWithDelete(obj interface{}, lockedKey string, config interface{}, noRetryAdd bool) *retryObjEntry {
@@ -929,7 +926,7 @@ func (oc *Controller) updateResource(objectsToRetry *RetryObjs, oldObj, newObj i
 
 // Given a *RetryObjs instance, an object and optionally a cachedObj, deleteResource deletes the object from the cluster
 // according to the delete logic of its resource type. cachedObj is the internal cache entry for this object,
-// used for now for pods and network policies.
+// used for now only for pods.
 func (oc *Controller) deleteResource(objectsToRetry *RetryObjs, obj, cachedObj interface{}) error {
 	switch objectsToRetry.oType {
 	case factory.PodType:
@@ -943,18 +940,11 @@ func (oc *Controller) deleteResource(objectsToRetry *RetryObjs, obj, cachedObj i
 		return oc.removePod(pod, portInfo)
 
 	case factory.PolicyType:
-		var cachedNP *networkPolicy
 		knp, ok := obj.(*knet.NetworkPolicy)
 		if !ok {
 			return fmt.Errorf("could not cast obj of type %T to *knet.NetworkPolicy", obj)
 		}
-
-		if cachedObj != nil {
-			if cachedNP, ok = cachedObj.(*networkPolicy); !ok {
-				cachedNP = nil
-			}
-		}
-		return oc.deleteNetworkPolicy(knp, cachedNP)
+		return oc.deleteNetworkPolicy(knp)
 
 	case factory.NodeType:
 		node, ok := obj.(*kapi.Node)

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -58,45 +58,6 @@ type ACLLoggingLevels struct {
 	Deny  string `json:"deny,omitempty"`
 }
 
-// namespaceInfo contains information related to a Namespace. Use oc.getNamespaceLocked()
-// or oc.waitForNamespaceLocked() to get a locked namespaceInfo for a Namespace, and call
-// nsInfo.Unlock() on it when you are done with it. (No code outside of the code that
-// manages the oc.namespaces map is ever allowed to hold an unlocked namespaceInfo.)
-type namespaceInfo struct {
-	sync.RWMutex
-
-	// addressSet is an address set object that holds the IP addresses
-	// of all pods in the namespace.
-	addressSet addressset.AddressSet
-
-	// map from NetworkPolicy name to networkPolicy. You must hold the
-	// namespaceInfo's mutex to add/delete/lookup policies, but must hold the
-	// networkPolicy's mutex (and not necessarily the namespaceInfo's) to work with
-	// the policy itself.
-	networkPolicies map[string]*networkPolicy
-
-	hybridOverlayExternalGW net.IP
-	hybridOverlayVTEP       net.IP
-
-	// routingExternalGWs is a slice of net.IP containing the values parsed from
-	// annotation k8s.ovn.org/routing-external-gws
-	routingExternalGWs gatewayInfo
-
-	// routingExternalPodGWs contains a map of all pods serving as exgws as well as their
-	// exgw IPs
-	// key is <namespace>_<pod name>
-	routingExternalPodGWs map[string]gatewayInfo
-
-	multicastEnabled bool
-
-	// If not empty, then it has to be set to a logging a severity level, e.g. "notice", "alert", etc
-	aclLogging ACLLoggingLevels
-
-	// Per-namespace port group default deny UUIDs
-	portGroupIngressDenyName string // Port group Name for ingress deny rule
-	portGroupEgressDenyName  string // Port group Name for egress deny rule
-}
-
 // Controller structure is the object which holds the controls for starting
 // and reacting upon the watched resources (e.g. pods, endpoints)
 type Controller struct {

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -112,6 +112,13 @@ type Controller struct {
 	// An address set factory that creates address sets
 	addressSetFactory addressset.AddressSetFactory
 
+	// network policies map, key should be retrieved with getPolicyKey(policy *knet.NetworkPolicy).
+	// network policies that failed to be created will also be added here, and can be retried or cleaned up later.
+	// network policy is only deleted from this map after successful cleanup.
+	// Allowed order of locking is namespace Lock -> oc.networkPolicies key Lock -> networkPolicy.Lock
+	// Don't take namespace Lock while holding networkPolicy key lock to avoid deadlock.
+	networkPolicies *syncmap.SyncMap[*networkPolicy]
+
 	// map of existing shared port groups for network policies
 	// port group exists in the db if and only if port group key is present in this map
 	// key is namespace
@@ -248,6 +255,7 @@ func NewOvnController(ovnClient *util.OVNClientset, wf *factory.WatchFactory, st
 		externalGWCache:              make(map[ktypes.NamespacedName]*externalRouteInfo),
 		exGWCacheMutex:               sync.RWMutex{},
 		addressSetFactory:            addressSetFactory,
+		networkPolicies:              syncmap.NewSyncMap[*networkPolicy](),
 		sharedNetpolPortGroups:       syncmap.NewSyncMap[*defaultDenyPortGroups](),
 		eIPC: egressIPController{
 			egressIPAssignmentMutex:           &sync.Mutex{},

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -414,6 +414,9 @@ func (oc *Controller) addRoutesGatewayIP(pod *kapi.Pod, podAnnotation *util.PodA
 	return nil
 }
 
+// podExpectedInLogicalCache returns true if pod should be added to oc.logicalPortCache.
+// For some pods, like hostNetwork pods, overlay node pods, or completed pods waiting for them to be added
+// to oc.logicalPortCache will never succeed.
 func (oc *Controller) podExpectedInLogicalCache(pod *kapi.Pod) bool {
 	return util.PodWantsNetwork(pod) && !oc.lsManager.IsNonHostSubnetSwitch(pod.Spec.NodeName) && !util.PodCompleted(pod)
 }

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -414,6 +414,10 @@ func (oc *Controller) addRoutesGatewayIP(pod *kapi.Pod, podAnnotation *util.PodA
 	return nil
 }
 
+func (oc *Controller) podExpectedInLogicalCache(pod *kapi.Pod) bool {
+	return util.PodWantsNetwork(pod) && !oc.lsManager.IsNonHostSubnetSwitch(pod.Spec.NodeName) && !util.PodCompleted(pod)
+}
+
 func (oc *Controller) addLogicalPort(pod *kapi.Pod) (err error) {
 	// If a node does node have an assigned hostsubnet don't wait for the logical switch to appear
 	if oc.lsManager.IsNonHostSubnetSwitch(pod.Spec.NodeName) {

--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -1509,7 +1509,7 @@ func (oc *Controller) addNetworkPolicy(policy *knet.NetworkPolicy) error {
 	// Run handleNetPolNamespaceUpdate sequence, but only for 1 newly added policy.
 	if nsInfo.aclLogging.Deny != aclLogging.Deny {
 		if err := oc.updateACLLoggingForDefaultACLs(policy.Namespace, nsInfo); err != nil {
-			klog.Warningf(err.Error())
+			return fmt.Errorf("network policy %s failed to be created: update default deny ACLs failed: %v", npKey, err)
 		} else {
 			klog.Infof("Policy %s: ACL logging setting updated to deny=%s allow=%s",
 				npKey, nsInfo.aclLogging.Deny, nsInfo.aclLogging.Allow)
@@ -1517,7 +1517,7 @@ func (oc *Controller) addNetworkPolicy(policy *knet.NetworkPolicy) error {
 	}
 	if nsInfo.aclLogging.Allow != aclLogging.Allow {
 		if err := oc.updateACLLoggingForPolicy(np, &nsInfo.aclLogging); err != nil {
-			klog.Warningf(err.Error())
+			return fmt.Errorf("network policy %s failed to be created: update policy ACLs failed: %v", npKey, err)
 		} else {
 			klog.Infof("Policy %s: ACL logging setting updated to deny=%s allow=%s",
 				npKey, nsInfo.aclLogging.Deny, nsInfo.aclLogging.Allow)

--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -1,7 +1,6 @@
 package ovn
 
 import (
-	"errors"
 	"fmt"
 	"net"
 	"strings"
@@ -134,19 +133,57 @@ func (sharedPGs *defaultDenyPortGroups) deletePortsForPolicy(np *networkPolicy,
 }
 
 type networkPolicy struct {
-	// RWMutex synchronizes operations on the policy.
-	// Operations that change local and peer pods take a RLock,
-	// whereas operations that affect the policy take a Lock.
+	// For now networkPolicy has
+	// 3 types of global events (those use oc.networkPolicies to get networkPolicy object)
+	// 1. Create network policy - create networkPolicy resources,
+	// enable local events, and Update namespace loglevel event
+	// 2. Update namespace loglevel - update ACLs for defaultDenyPortGroups and portGroup
+	// 3. Delete network policy - disable local events, and Update namespace loglevel event,
+	// send deletion signal to already running event handlers, delete resources
+	//
+	// 5 types of local events (those use the same networkPolicy object there were created for):
+	// 1. localPod events - update portGroup, defaultDenyPortGroups and localPods
+	// 2. peerNamespaceAndPod events - update namespacedPodHandlers
+	// 3. peerNamespace events - add/delete gressPolicy address set, update ACLs for portGroup
+	// 4. peerPod events - update gressPolicy address set
+	// 5. peerSvc events - update gressPolicy address set
+	//
+	// Delete network policy conflict with all other handlers, therefore we need to make sure it only runs
+	// when no other handlers are executing, and that no other handlers will try to work with networkPolicy after
+	// Delete network policy was called. This can be done with RWLock, if Delete network policy takes Write lock
+	// and sets deleted field to true, and all other handlers take RLock and return immediately if deleted is true.
+	// Create network Policy can also take Write lock while it is creating required resources.
+	//
+	// The only other conflict between handlers here is Update namespace loglevel and peerNamespace, since they both update
+	// portGroup ACLs, but this conflict is handled with namespace lock, because both these functions need to lock
+	// namespace to create/update ACLs with correct loglevel.
+	//
+	// We also need to make sure handlers of the same type can be executed in parallel, if this is not true, every
+	// event handler can have it own additional lock to sync handlers of the same type.
+	//
+	// Allowed order of locking is namespace Lock -> oc.networkPolicies key Lock -> networkPolicy.Lock
+	// Don't take namespace Lock while holding networkPolicy key lock to avoid deadlock.
+	// Don't take RLock from the same goroutine twice, it can lead to deadlock.
 	sync.RWMutex
+
 	name            string
 	namespace       string
 	ingressPolicies []*gressPolicy
 	egressPolicies  []*gressPolicy
 	isIngress       bool
 	isEgress        bool
-	podHandlerList  []*factory.Handler
-	svcHandlerList  []*factory.Handler
-	nsHandlerList   []*factory.Handler
+	// handlers that don't require synchronization, since they are updated sequentially during network policy creation.
+	// local and peer pod handlers
+	podHandlerList []*factory.Handler
+	// peer service handlers
+	svcHandlerList []*factory.Handler
+	// peer namespace handlers
+	nsHandlerList []*factory.Handler
+	// peer namespaced pod handlers, the only type of handler that can be dynamically deleted without deleting the whole
+	// networkPolicy. When namespace is deleted, podHandler for that namespace should be deleted too.
+	// Can be used by multiple PeerNamespace handlers in parallel for different keys
+	// namespace(string): *factory.Handler
+	namespacedPodHandlers sync.Map
 
 	// localPods is a map of pods affected by this policy.
 	// It is used to update defaultDeny port group port counters, when deleting network policy.
@@ -158,22 +195,28 @@ type networkPolicy struct {
 	localPods sync.Map
 
 	portGroupName string
-	deleted       bool //deleted policy
+	// this is a signal for related event handlers that they are/should be stopped.
+	// it will be set to true before any networkPolicy infrastructure is deleted,
+	// therefore every handler can either do its work and be sure all required resources are there,
+	// or this value will be set to true and handler can't proceed.
+	// Use networkPolicy.RLock to read this field and hold it for the whole event handling.
+	deleted bool
 }
 
 func NewNetworkPolicy(policy *knet.NetworkPolicy) *networkPolicy {
 	policyTypeIngress, policyTypeEgress := getPolicyType(policy)
 	np := &networkPolicy{
-		name:            policy.Name,
-		namespace:       policy.Namespace,
-		ingressPolicies: make([]*gressPolicy, 0),
-		egressPolicies:  make([]*gressPolicy, 0),
-		isIngress:       policyTypeIngress,
-		isEgress:        policyTypeEgress,
-		podHandlerList:  make([]*factory.Handler, 0),
-		svcHandlerList:  make([]*factory.Handler, 0),
-		nsHandlerList:   make([]*factory.Handler, 0),
-		localPods:       sync.Map{},
+		name:                  policy.Name,
+		namespace:             policy.Namespace,
+		ingressPolicies:       make([]*gressPolicy, 0),
+		egressPolicies:        make([]*gressPolicy, 0),
+		isIngress:             policyTypeIngress,
+		isEgress:              policyTypeEgress,
+		podHandlerList:        make([]*factory.Handler, 0),
+		svcHandlerList:        make([]*factory.Handler, 0),
+		nsHandlerList:         make([]*factory.Handler, 0),
+		namespacedPodHandlers: sync.Map{},
+		localPods:             sync.Map{},
 	}
 	return np
 }
@@ -496,6 +539,8 @@ func (oc *Controller) delPolicyFromDefaultPortGroups(np *networkPolicy) error {
 	})
 }
 
+// createDefaultDenyPGAndACLs creates the default port groups and acls for a namespace
+// must be called with defaultDenyPortGroups lock
 func (oc *Controller) createDefaultDenyPGAndACLs(namespace, policy string, aclLogging *ACLLoggingLevels) error {
 	ingressPGName := defaultDenyPortGroupName(namespace, ingressDefaultDenySuffix)
 	ingressDenyACL, ingressAllowACL := buildDenyACLs(namespace, ingressPGName, aclLogging, lportIngress)
@@ -528,7 +573,8 @@ func (oc *Controller) createDefaultDenyPGAndACLs(namespace, policy string, aclLo
 	return nil
 }
 
-// deleteDefaultDenyPGAndACLs deletes the default port groups and acls for a ns/policy
+// deleteDefaultDenyPGAndACLs deletes the default port groups and acls for a namespace
+// must be called with defaultDenyPortGroups lock
 func (oc *Controller) deleteDefaultDenyPGAndACLs(namespace, policy string) error {
 	var aclsToBeDeleted []*nbdb.ACL
 
@@ -557,10 +603,10 @@ func (oc *Controller) deleteDefaultDenyPGAndACLs(namespace, policy string) error
 	return nil
 }
 
+// must be called with namespace lock
 func (oc *Controller) updateACLLoggingForPolicy(np *networkPolicy, aclLogging *ACLLoggingLevels) error {
-	np.Lock()
-	defer np.Unlock()
-
+	np.RLock()
+	defer np.RUnlock()
 	if np.deleted {
 		return nil
 	}
@@ -873,19 +919,20 @@ func (oc *Controller) getNewLocalPolicyPorts(np *networkPolicy,
 	for _, obj := range objs {
 		pod := obj.(*kapi.Pod)
 
-		if util.PodCompleted(pod) {
-			// if pod is completed, do not add it to NP port group
+		logicalPortName := util.GetLogicalPortName(pod.Namespace, pod.Name)
+		if _, ok := np.localPods.Load(logicalPortName); ok {
+			// port is already added for this policy
 			continue
 		}
+
 		if pod.Spec.NodeName == "" {
 			// pod is not yet scheduled, will receive update event for it
 			continue
 		}
 
-		logicalPortName := util.GetLogicalPortName(pod.Namespace, pod.Name)
-
-		if _, ok := np.localPods.Load(logicalPortName); ok {
-			// port is already added for this policy
+		// Skip pods that will never be present in logicalPortCache,
+		// e.g. hostNetwork pods, overlay node pods, or completed pods
+		if !oc.podExpectedInLogicalCache(pod) {
 			continue
 		}
 
@@ -934,7 +981,8 @@ func (oc *Controller) getExistingLocalPolicyPorts(np *networkPolicy,
 			// port is already deleted for this policy
 			continue
 		}
-
+		// lsp is deleted from oc.logicalPortCache with 60 sec delay to make sure all other handlers
+		// were able to get required information
 		portInfo, err := oc.logicalPortCache.get(logicalPortName)
 		if err != nil {
 			klog.Warningf("Failed to get LSP for pod %s/%s for networkPolicy %s refetching err: %v",
@@ -1054,8 +1102,7 @@ func (oc *Controller) denyPGDeletePorts(np *networkPolicy, portNamesToUUIDs map[
 }
 
 // handleLocalPodSelectorAddFunc adds a new pod to an existing NetworkPolicy, should be retriable.
-// ignoreErr=true should only be used for initial objects handling, relying on per-object handlers to retry.
-func (oc *Controller) handleLocalPodSelectorAddFunc(np *networkPolicy, ignoreErr bool, objs ...interface{}) error {
+func (oc *Controller) handleLocalPodSelectorAddFunc(np *networkPolicy, objs ...interface{}) error {
 	np.RLock()
 	defer np.RUnlock()
 	if np.deleted {
@@ -1063,7 +1110,8 @@ func (oc *Controller) handleLocalPodSelectorAddFunc(np *networkPolicy, ignoreErr
 	}
 	// get info for new pods that are not listed in np.localPods
 	portNamesToUUIDs, policyPortUUIDs, errPods := oc.getNewLocalPolicyPorts(np, objs...)
-
+	// for multiple objects, try to update the ones that were fetched successfully
+	// return error for errPods in the end
 	if len(portNamesToUUIDs) > 0 {
 		var err error
 		// add pods to policy port group
@@ -1089,11 +1137,14 @@ func (oc *Controller) handleLocalPodSelectorAddFunc(np *networkPolicy, ignoreErr
 		}
 	}
 
-	if !ignoreErr && len(errPods) > 0 {
-		pod := errPods[0].(*kapi.Pod)
-		return fmt.Errorf("unable to get port info for pod %s/%s", pod.Namespace, pod.Name)
+	if len(errPods) > 0 {
+		var errs []error
+		for _, errPod := range errPods {
+			pod := errPod.(*kapi.Pod)
+			errs = append(errs, fmt.Errorf("unable to get port info for pod %s/%s", pod.Namespace, pod.Name))
+		}
+		return kerrorsutil.NewAggregate(errs)
 	}
-
 	return nil
 }
 
@@ -1138,9 +1189,11 @@ func (oc *Controller) handleLocalPodSelectorDelFunc(np *networkPolicy, objs ...i
 	return nil
 }
 
-func (oc *Controller) addLocalPodHandler(policy *knet.NetworkPolicy, np *networkPolicy,
-	handleInitialItems func([]interface{}) error) error {
-
+// This function starts a watcher for local pods. Sync function and add event for every existing pod
+// will be executed sequentially first, and an error will be returned if something fails.
+// LocalPodSelectorType uses handleLocalPodSelectorAddFunc on Add and Update,
+// and handleLocalPodSelectorDelFunc on Delete.
+func (oc *Controller) addLocalPodHandler(policy *knet.NetworkPolicy, np *networkPolicy) error {
 	// NetworkPolicy is validated by the apiserver
 	sel, err := metav1.LabelSelectorAsSelector(&policy.Spec.PodSelector)
 	if err != nil {
@@ -1148,11 +1201,17 @@ func (oc *Controller) addLocalPodHandler(policy *knet.NetworkPolicy, np *network
 		return err
 	}
 
+	// Add all local pods in a syncFunction to minimize db ops.
+	syncFunc := func(objs []interface{}) error {
+		// ignore returned error, since any pod that wasn't properly handled will be retried individually.
+		_ = oc.handleLocalPodSelectorAddFunc(np, objs...)
+		return nil
+	}
 	retryLocalPods := NewRetryObjs(
 		factory.LocalPodSelectorType,
 		policy.Namespace,
 		sel,
-		handleInitialItems,
+		syncFunc,
 		&NetworkPolicyExtraParameters{
 			np: np,
 		})
@@ -1163,8 +1222,6 @@ func (oc *Controller) addLocalPodHandler(policy *knet.NetworkPolicy, np *network
 		return err
 	}
 
-	np.Lock()
-	defer np.Unlock()
 	np.podHandlerList = append(np.podHandlerList, podHandler)
 	return nil
 }
@@ -1183,19 +1240,39 @@ type policyHandler struct {
 	gress             *gressPolicy
 	namespaceSelector *metav1.LabelSelector
 	podSelector       *metav1.LabelSelector
+	// service handlers don't use selectors
+	serviceSelector bool
 }
 
-// createNetworkPolicy creates a network policy, should be retriable
-// if network policy with given key exists, it will try to clean it up first, and return an error if it fails
+// createNetworkPolicy creates a network policy, should be retriable.
+// If network policy with given key exists, it will try to clean it up first, and return an error if it fails.
+// No need to log network policy key here, because caller of createNetworkPolicy should prepend error message with
+// that information.
 func (oc *Controller) createNetworkPolicy(policy *knet.NetworkPolicy, aclLogging *ACLLoggingLevels) (*networkPolicy, error) {
+	// To avoid existing connections disruption, make sure to apply allow ACLs before applying deny ACLs.
+	// This requires to start peer handlers before local pod handlers.
+	// 1. Cleanup old policy if it failed to be created
+	// 2. Build gress policies, create addressSets for peers
+	// 3. Add policy to default deny port group.
+	// 4. Build policy ACLs and port group. All the local pods that this policy
+	// selects will be eventually added to this port group.
+	// Pods are not added to default deny port groups yet, this is just a preparation step
+	// 5. Unlock networkPolicy before starting pod handlers to avoid deadlock
+	// since pod handlers take np.RLock
+	// 6. Start peer handlers to update all allow rules first
+	// 7. Start local pod handlers, that will update networkPolicy and default deny port groups with selected pods.
+
 	npKey := getPolicyKey(policy)
 	var np *networkPolicy
+	var policyHandlers []policyHandler
 
 	err := oc.networkPolicies.DoWithLock(npKey, func(npKey string) error {
 		oldNP, found := oc.networkPolicies.Load(npKey)
 		if found {
-			cleanupErr := oc.cleanupNetworkPolicy(oldNP)
-			return fmt.Errorf("cleanup for retrying network policy create failed: %v", cleanupErr)
+			// 1. Cleanup old policy if it failed to be created
+			if cleanupErr := oc.cleanupNetworkPolicy(oldNP); cleanupErr != nil {
+				return fmt.Errorf("cleanup for retrying network policy create failed: %v", cleanupErr)
+			}
 		}
 		np, found = oc.networkPolicies.LoadOrStore(npKey, NewNetworkPolicy(policy))
 		if found {
@@ -1204,13 +1281,23 @@ func (oc *Controller) createNetworkPolicy(policy *knet.NetworkPolicy, aclLogging
 				"while it should've been cleaned up, obj: %+v", np)
 		}
 		np.Lock()
+		npLocked := true
+		// we unlock np in the middle of this function, use npLocked to track if it was already unlocked explicitly
+		defer func() {
+			if npLocked {
+				np.Unlock()
+			}
+		}()
+		// no need to check np.deleted, since the object has just been created
+		// now we have a new np stored in oc.networkPolicies
+		var err error
 
 		if aclLogging.Deny != "" || aclLogging.Allow != "" {
 			klog.Infof("ACL logging for network policy %s in namespace %s set to deny=%s, allow=%s",
 				policy.Name, policy.Namespace, aclLogging.Deny, aclLogging.Allow)
 		}
 
-		var policyHandlers []policyHandler
+		// 2. Build gress policies, create addressSets for peers
 
 		// Consider both ingress and egress rules of the policy regardless of this
 		// policy type. A pod is isolated as long as as it is selected by any
@@ -1226,25 +1313,25 @@ func (oc *Controller) createNetworkPolicy(policy *knet.NetworkPolicy, aclLogging
 			klog.V(5).Infof("Network policy ingress is %+v", ingressJSON)
 
 			ingress := newGressPolicy(knet.PolicyTypeIngress, i, policy.Namespace, policy.Name)
+			// append ingress policy to be able to cleanup created address set
+			// see cleanupNetworkPolicy for details
+			np.ingressPolicies = append(np.ingressPolicies, ingress)
 
 			// Each ingress rule can have multiple ports to which we allow traffic.
 			for _, portJSON := range ingressJSON.Ports {
 				ingress.addPortPolicy(&portJSON)
 			}
-
 			if hasAnyLabelSelector(ingressJSON.From) {
-				klog.V(5).Infof("Network policy %s with ingress rule %s has a selector", policy.Name, ingress.policyName)
-				if err := ingress.ensurePeerAddressSet(oc.addressSetFactory); err != nil {
-					np.Unlock()
+				klog.V(5).Infof("Network policy %s with ingress rule %s has a selector", npKey, ingress.policyName)
+				if err = ingress.ensurePeerAddressSet(oc.addressSetFactory); err != nil {
 					return err
 				}
 				// Start service handlers ONLY if there's an ingress Address Set
-				if err := oc.addPeerServiceHandler(policy, ingress, np); err != nil {
-					np.Unlock()
-					return err
-				}
+				policyHandlers = append(policyHandlers, policyHandler{
+					gress:           ingress,
+					serviceSelector: true,
+				})
 			}
-
 			for _, fromJSON := range ingressJSON.From {
 				// Add IPBlock to ingress network policy
 				if fromJSON.IPBlock != nil {
@@ -1257,7 +1344,6 @@ func (oc *Controller) createNetworkPolicy(policy *knet.NetworkPolicy, aclLogging
 					podSelector:       fromJSON.PodSelector,
 				})
 			}
-			np.ingressPolicies = append(np.ingressPolicies, ingress)
 		}
 
 		// Go through each egress rule.  For each egress rule, create an
@@ -1266,6 +1352,9 @@ func (oc *Controller) createNetworkPolicy(policy *knet.NetworkPolicy, aclLogging
 			klog.V(5).Infof("Network policy egress is %+v", egressJSON)
 
 			egress := newGressPolicy(knet.PolicyTypeEgress, i, policy.Namespace, policy.Name)
+			// append ingress policy to be able to cleanup created address set
+			// see cleanupNetworkPolicy for details
+			np.egressPolicies = append(np.egressPolicies, egress)
 
 			// Each egress rule can have multiple ports to which we allow traffic.
 			for _, portJSON := range egressJSON.Ports {
@@ -1273,13 +1362,11 @@ func (oc *Controller) createNetworkPolicy(policy *knet.NetworkPolicy, aclLogging
 			}
 
 			if hasAnyLabelSelector(egressJSON.To) {
-				klog.V(5).Infof("Network policy %s with egress rule %s has a selector", policy.Name, egress.policyName)
-				if err := egress.ensurePeerAddressSet(oc.addressSetFactory); err != nil {
-					np.Unlock()
+				klog.V(5).Infof("Network policy %s with egress rule %s has a selector", npKey, egress.policyName)
+				if err = egress.ensurePeerAddressSet(oc.addressSetFactory); err != nil {
 					return err
 				}
 			}
-
 			for _, toJSON := range egressJSON.To {
 				// Add IPBlock to egress network policy
 				if toJSON.IPBlock != nil {
@@ -1292,12 +1379,55 @@ func (oc *Controller) createNetworkPolicy(policy *knet.NetworkPolicy, aclLogging
 					podSelector:       toJSON.PodSelector,
 				})
 			}
-			np.egressPolicies = append(np.egressPolicies, egress)
 		}
-		np.Unlock()
 
+		// 3. Add policy to default deny port group
+		// Pods are not added to default deny port groups yet, this is just a preparation step
+		err = oc.addPolicyToDefaultPortGroups(np, aclLogging)
+		if err != nil {
+			return err
+		}
+
+		// 4. Build policy ACLs and port group. All the local pods that this policy
+		// selects will be eventually added to this port group.
+		readableGroupName := fmt.Sprintf("%s_%s", policy.Namespace, policy.Name)
+		np.portGroupName = hashedPortGroup(readableGroupName)
+		ops := []ovsdb.Operation{}
+
+		acls := oc.buildNetworkPolicyACLs(np, aclLogging)
+		ops, err = libovsdbops.CreateOrUpdateACLsOps(oc.nbClient, ops, acls...)
+		if err != nil {
+			return fmt.Errorf("failed to create ACL ops: %v", err)
+		}
+
+		pg := libovsdbops.BuildPortGroup(np.portGroupName, readableGroupName, nil, acls)
+		ops, err = libovsdbops.CreateOrUpdatePortGroupsOps(oc.nbClient, ops, pg)
+		if err != nil {
+			return fmt.Errorf("failed to create ops to add port to a port group: %v", err)
+		}
+
+		var recordOps []ovsdb.Operation
+		var txOkCallBack func()
+		recordOps, txOkCallBack, _, err = metrics.GetConfigDurationRecorder().AddOVN(oc.nbClient, "networkpolicy",
+			policy.Namespace, policy.Name)
+		if err != nil {
+			klog.Errorf("Failed to record config duration: %v", err)
+		}
+		ops = append(ops, recordOps...)
+
+		_, err = libovsdbops.TransactAndCheck(oc.nbClient, ops)
+		if err != nil {
+			return fmt.Errorf("failed to run ovsdb txn to add ports to port group: %v", err)
+		}
+		txOkCallBack()
+
+		// 5. Unlock network policy before starting pod handlers to avoid deadlock,
+		// since pod handlers take np.RLock
+		np.Unlock()
+		npLocked = false
+
+		// 6. Start peer handlers to update all allow rules first
 		for _, handler := range policyHandlers {
-			var err error
 			if handler.namespaceSelector != nil && handler.podSelector != nil {
 				// For each rule that contains both peer namespace selector and
 				// peer pod selector, we create a watcher for each matching namespace
@@ -1310,87 +1440,21 @@ func (oc *Controller) createNetworkPolicy(policy *knet.NetworkPolicy, aclLogging
 			} else if handler.podSelector != nil {
 				// For each peer pod selector, we create a watcher that
 				// populates the addressSet
-				err = oc.addPeerPodHandler(policy, handler.podSelector,
-					handler.gress, np)
+				err = oc.addPeerPodHandler(handler.podSelector, handler.gress, np)
+			} else if handler.serviceSelector {
+				err = oc.addPeerServiceHandler(policy, handler.gress, np)
 			}
 			if err != nil {
-				return fmt.Errorf("failed to handle policy handler selector: %v", err)
+				return fmt.Errorf("failed to start peer handler: %v", err)
 			}
 		}
 
-		readableGroupName := fmt.Sprintf("%s_%s", policy.Namespace, policy.Name)
-		np.portGroupName = hashedPortGroup(readableGroupName)
-		ops := []ovsdb.Operation{}
-
-		// Build policy ACLs
-		acls := oc.buildNetworkPolicyACLs(np, aclLogging)
-		ops, err := libovsdbops.CreateOrUpdateACLsOps(oc.nbClient, ops, acls...)
+		// 7. Start local pod handlers, that will update networkPolicy and default deny port groups with selected pods.
+		err = oc.addLocalPodHandler(policy, np)
 		if err != nil {
-			return fmt.Errorf("failed to create ACL ops: %v", err)
+			return fmt.Errorf("failed to start local pod handler: %v", err)
 		}
 
-		// Build a port group for the policy. All the pods that this policy
-		// selects will be eventually added to this port group.
-		pg := libovsdbops.BuildPortGroup(np.portGroupName, readableGroupName, nil, acls)
-
-		// Add policy to defaultDeny port groups
-		// Create port groups if they don't exist for given namespace
-		err = oc.addPolicyToDefaultPortGroups(np, aclLogging)
-		if err != nil {
-			return err
-		}
-
-		// Add a handler to update the policy and deny port groups with the pods
-		// this policy applies to.
-		// Handle initial items locally to minimize DB ops.
-		handleInitialSelectedPods := func(objs []interface{}) error {
-			// get info for new pods that are not listed in np.localPods
-			portNamesToUUIDs, policyPortUUIDs, _ := oc.getNewLocalPolicyPorts(np, objs...)
-			pg.Ports = append(pg.Ports, policyPortUUIDs...)
-			// add pods to default deny port group
-			// make sure to only pass newly added pods
-			if err = oc.denyPGAddPorts(np, portNamesToUUIDs); err != nil {
-				// we don't need to delete policy ports from policy port group,
-				// because adding ports to port group is idempotent and can be retried
-				return fmt.Errorf("unable to add new pod to default deny port group: %v", err)
-			}
-			// all operations were successful, update np.localPods
-			for portName, portUUID := range portNamesToUUIDs {
-				np.localPods.Store(portName, portUUID)
-			}
-			return nil
-		}
-		err = oc.addLocalPodHandler(policy, np, handleInitialSelectedPods)
-		if err != nil {
-			return fmt.Errorf("failed to handle local pod selector: %v", err)
-		}
-
-		np.Lock()
-		defer np.Unlock()
-		if np.deleted {
-			_ = oc.denyPGDeletePorts(np, nil, true)
-			return nil
-		}
-
-		ops, err = libovsdbops.CreateOrUpdatePortGroupsOps(oc.nbClient, ops, pg)
-		if err != nil {
-			_ = oc.denyPGDeletePorts(np, nil, true)
-			return fmt.Errorf("failed to create ops to add port to a port group: %v", err)
-		}
-
-		recordOps, txOkCallBack, _, err := metrics.GetConfigDurationRecorder().AddOVN(oc.nbClient, "networkpolicy",
-			policy.Namespace, policy.Name)
-		if err != nil {
-			klog.Errorf("Failed to record config duration: %v", err)
-		}
-		ops = append(ops, recordOps...)
-
-		_, err = libovsdbops.TransactAndCheck(oc.nbClient, ops)
-		if err != nil {
-			_ = oc.denyPGDeletePorts(np, nil, true)
-			return fmt.Errorf("failed to run ovsdb txn to add ports to port group: %v", err)
-		}
-		txOkCallBack()
 		return nil
 	})
 	return np, err
@@ -1400,8 +1464,7 @@ func (oc *Controller) createNetworkPolicy(policy *knet.NetworkPolicy, aclLogging
 // ports from Kubernetes NetworkPolicy objects using OVN Port Groups
 // if addNetworkPolicy fails, create or delete operation can be retried
 func (oc *Controller) addNetworkPolicy(policy *knet.NetworkPolicy) error {
-	klog.Infof("Adding network policy %s in namespace %s", policy.Name,
-		policy.Namespace)
+	klog.Infof("Adding network policy %s", getPolicyKey(policy))
 
 	// To not hold nsLock for the whole process on network policy creation, we do the following:
 	// 1. save required namespace information to use for netpol create
@@ -1412,42 +1475,42 @@ func (oc *Controller) addNetworkPolicy(policy *knet.NetworkPolicy) error {
 	// 6. unlock namespace
 
 	// 1. save required namespace information to use for netpol create,
+	npKey := getPolicyKey(policy)
 	nsInfo, nsUnlock := oc.getNamespaceLocked(policy.Namespace, true)
 	if nsInfo == nil {
-		return fmt.Errorf("unable to get namespace %s for network policy %s: namespace doesn't exist",
-			policy.Namespace, policy.Name)
+		return fmt.Errorf("unable to get namespace for network policy %s: namespace doesn't exist", npKey)
 	}
 	aclLogging := nsInfo.aclLogging
 	nsUnlock()
 
 	// 2. create network policy without ns Lock, cleanup on failure
-	npKey := getPolicyKey(policy)
 	var np *networkPolicy
 	var err error
 
 	np, err = oc.createNetworkPolicy(policy, &aclLogging)
 	defer func() {
 		if err != nil {
+			klog.Infof("Create network policy %s failed, try to cleanup", npKey)
 			// try to cleanup network policy straight away
 			// it will be retried later with add/delete network policy handlers if it fails
 			cleanupErr := oc.networkPolicies.DoWithLock(npKey, func(npKey string) error {
 				np, ok := oc.networkPolicies.Load(npKey)
 				if !ok {
-					klog.Infof("Deleting policy %s/%s that is already deleted", policy.Namespace, policy.Name)
+					klog.Infof("Deleting policy %s that is already deleted", npKey)
 					return nil
 				}
 				return oc.cleanupNetworkPolicy(np)
 			})
 			if cleanupErr != nil {
-				klog.Infof("Cleanup for failed create network policy %s/%s returned an error: %v",
-					policy.Namespace, policy.Name, cleanupErr)
+				klog.Infof("Cleanup for failed create network policy %s returned an error: %v",
+					npKey, cleanupErr)
 			}
 		}
 	}()
 	if err != nil {
-		return fmt.Errorf("failed to create Network Policy %s/%s: %v",
-			policy.Namespace, policy.Name, err)
+		return fmt.Errorf("failed to create Network Policy %s: %v", npKey, err)
 	}
+	klog.Infof("Create network policy %s resources completed, update namespace loglevel", npKey)
 
 	// 3. lock namespace
 	nsInfo, nsUnlock = oc.getNamespaceLocked(policy.Namespace, false)
@@ -1455,8 +1518,7 @@ func (oc *Controller) addNetworkPolicy(policy *knet.NetworkPolicy) error {
 		// namespace was deleted while we were adding network policy,
 		// try to cleanup network policy
 		// expect retry to be handled by delete event that should come
-		err = fmt.Errorf("unable to get namespace %s at the end of network policy %s creation: %v",
-			policy.Namespace, policy.Name, err)
+		err = fmt.Errorf("unable to get namespace at the end of network policy %s creation: %v", npKey, err)
 		return err
 	}
 	// 6. defer unlock namespace
@@ -1470,7 +1532,7 @@ func (oc *Controller) addNetworkPolicy(policy *knet.NetworkPolicy) error {
 			klog.Warningf(err.Error())
 		} else {
 			klog.Infof("Policy %s: ACL logging setting updated to deny=%s allow=%s",
-				getPolicyKey(policy), nsInfo.aclLogging.Deny, nsInfo.aclLogging.Allow)
+				npKey, nsInfo.aclLogging.Deny, nsInfo.aclLogging.Allow)
 		}
 	}
 	if nsInfo.aclLogging.Allow != aclLogging.Allow {
@@ -1478,7 +1540,7 @@ func (oc *Controller) addNetworkPolicy(policy *knet.NetworkPolicy) error {
 			klog.Warningf(err.Error())
 		} else {
 			klog.Infof("Policy %s: ACL logging setting updated to deny=%s allow=%s",
-				getPolicyKey(policy), nsInfo.aclLogging.Deny, nsInfo.aclLogging.Allow)
+				npKey, nsInfo.aclLogging.Deny, nsInfo.aclLogging.Allow)
 		}
 	}
 
@@ -1506,9 +1568,9 @@ func (oc *Controller) buildNetworkPolicyACLs(np *networkPolicy, aclLogging *ACLL
 // deleteNetworkPolicy removes a network policy
 // It only uses Namespace and Name from given network policy
 func (oc *Controller) deleteNetworkPolicy(policy *knet.NetworkPolicy) error {
-	klog.Infof("Deleting network policy %s in namespace %s", policy.Name, policy.Namespace)
-
 	npKey := getPolicyKey(policy)
+	klog.Infof("Deleting network policy %s", npKey)
+
 	// First lock and update namespace
 	nsInfo, nsUnlock := oc.getNamespaceLocked(policy.Namespace, false)
 	if nsInfo != nil {
@@ -1520,21 +1582,31 @@ func (oc *Controller) deleteNetworkPolicy(policy *knet.NetworkPolicy) error {
 	err := oc.networkPolicies.DoWithLock(npKey, func(npKey string) error {
 		np, ok := oc.networkPolicies.Load(npKey)
 		if !ok {
-			klog.Infof("Deleting policy that is already deleted")
+			klog.Infof("Deleting policy %s that is already deleted", npKey)
 			return nil
 		}
-		return oc.cleanupNetworkPolicy(np)
+		if err := oc.cleanupNetworkPolicy(np); err != nil {
+			return fmt.Errorf("deleting policy %s failed: %v", npKey, err)
+		}
+		return nil
 	})
 	return err
 }
 
 // cleanupNetworkPolicy should be retriable
-// it takes and releases networkPolicy lock
-// it updates oc.networkPolicies on success, should be called with oc.networkPolicies key locked
+// It takes and releases networkPolicy lock.
+// It updates oc.networkPolicies on success, should be called with oc.networkPolicies key locked.
+// No need to log network policy key here, because caller of cleanupNetworkPolicy should prepend error message with
+// that information.
 func (oc *Controller) cleanupNetworkPolicy(np *networkPolicy) error {
+	klog.Infof("Cleanup network policy %s", np.getKey())
 	np.Lock()
 	defer np.Unlock()
+
+	// signal to local pod/peer handlers to ignore new events
 	np.deleted = true
+
+	// stop handlers, retriable
 	oc.shutdownHandlers(np)
 	var err error
 
@@ -1551,8 +1623,7 @@ func (oc *Controller) cleanupNetworkPolicy(np *networkPolicy) error {
 	// Delete the port group, idempotent
 	ops, err := libovsdbops.DeletePortGroupsOps(oc.nbClient, nil, np.portGroupName)
 	if err != nil {
-		return fmt.Errorf("failed to make delete network policy port group ops, policy: %s/%s, group name: %s,"+
-			" error: %v", np.namespace, np.name, np.portGroupName, err)
+		return fmt.Errorf("failed to get delete network policy port group %s ops: %v", np.portGroupName, err)
 	}
 	recordOps, txOkCallBack, _, err := metrics.GetConfigDurationRecorder().AddOVN(oc.nbClient, "networkpolicy",
 		np.namespace, np.name)
@@ -1568,21 +1639,25 @@ func (oc *Controller) cleanupNetworkPolicy(np *networkPolicy) error {
 	}
 	txOkCallBack()
 
-	// Delete ingress/egress address sets
-	for _, policy := range np.ingressPolicies {
+	// Delete ingress/egress address sets, idempotent
+	for i, policy := range np.ingressPolicies {
 		err = policy.destroy()
 		if err != nil {
-			return fmt.Errorf("failed to delete network policy ingress address sets, policy: %s/%s, error: %v",
-				np.namespace, np.name, err)
+			// remove deleted policies from the list
+			np.ingressPolicies = np.ingressPolicies[i:]
+			return fmt.Errorf("failed to delete network policy ingress address sets: %v", err)
 		}
 	}
-	for _, policy := range np.egressPolicies {
+	np.ingressPolicies = make([]*gressPolicy, 0)
+	for i, policy := range np.egressPolicies {
 		err = policy.destroy()
 		if err != nil {
-			return fmt.Errorf("failed to delete network policy egress address sets, policy: %s/%s, error: %v",
-				np.namespace, np.name, err)
+			// remove deleted policies from the list
+			np.egressPolicies = np.egressPolicies[i:]
+			return fmt.Errorf("failed to delete network policy egress address sets: %v", err)
 		}
 	}
+	np.egressPolicies = make([]*gressPolicy, 0)
 
 	// finally, delete netpol from existing networkPolicies
 	// this is the signal that cleanup was successful
@@ -1593,33 +1668,40 @@ func (oc *Controller) cleanupNetworkPolicy(np *networkPolicy) error {
 // handlePeerPodSelectorAddUpdate adds the IP address of a pod that has been
 // selected as a peer by a NetworkPolicy's ingress/egress section to that
 // ingress/egress address set
-func (oc *Controller) handlePeerPodSelectorAddUpdate(gp *gressPolicy, objs ...interface{}) error {
+func (oc *Controller) handlePeerPodSelectorAddUpdate(np *networkPolicy, gp *gressPolicy, objs ...interface{}) error {
+	np.RLock()
+	defer np.RUnlock()
+	if np.deleted {
+		return nil
+	}
 	pods := make([]*kapi.Pod, 0, len(objs))
 	for _, obj := range objs {
 		pod := obj.(*kapi.Pod)
 		if pod.Spec.NodeName == "" {
+			// update event will be received for this pod later, no ips should be assigned yet
 			continue
 		}
 		pods = append(pods, pod)
 	}
-	// If no IP is found, the pod handler may not have added it by the time the network policy handler
-	// processed this pod event. It will grab it during the pod update event to add the annotation,
-	// so don't log an error here.
-	if err := gp.addPeerPods(pods...); err != nil && !errors.Is(err, util.ErrNoPodIPFound) {
-		return err
-	}
-	return nil
+	// gressPolicy.addPeerPods must be called with networkPolicy RLock.
+	return gp.addPeerPods(pods...)
 }
 
 // handlePeerPodSelectorDelete removes the IP address of a pod that no longer
 // matches a NetworkPolicy ingress/egress section's selectors from that
 // ingress/egress address set
-func (oc *Controller) handlePeerPodSelectorDelete(gp *gressPolicy, obj interface{}) error {
+func (oc *Controller) handlePeerPodSelectorDelete(np *networkPolicy, gp *gressPolicy, obj interface{}) error {
+	np.RLock()
+	defer np.RUnlock()
+	if np.deleted {
+		return nil
+	}
 	pod := obj.(*kapi.Pod)
 	if pod.Spec.NodeName == "" {
 		klog.Infof("Pod %s/%s not scheduled on any node, skipping it", pod.Namespace, pod.Name)
 		return nil
 	}
+	// gressPolicy.deletePeerPod must be called with networkPolicy RLock.
 	if err := gp.deletePeerPod(pod); err != nil {
 		return err
 	}
@@ -1628,14 +1710,26 @@ func (oc *Controller) handlePeerPodSelectorDelete(gp *gressPolicy, obj interface
 
 // handlePeerServiceSelectorAddUpdate adds the VIP of a service that selects
 // pods that are selected by the Network Policy
-func (oc *Controller) handlePeerServiceAdd(gp *gressPolicy, service *kapi.Service) error {
+func (oc *Controller) handlePeerServiceAdd(np *networkPolicy, gp *gressPolicy, service *kapi.Service) error {
 	klog.V(5).Infof("A Service: %s matches the namespace as the gress policy: %s", service.Name, gp.policyName)
+	np.RLock()
+	defer np.RUnlock()
+	if np.deleted {
+		return nil
+	}
+	// gressPolicy.addPeerSvcVip must be called with networkPolicy RLock.
 	return gp.addPeerSvcVip(oc.nbClient, service)
 }
 
 // handlePeerServiceDelete removes the VIP of a service that selects
 // pods that are selected by the Network Policy
-func (oc *Controller) handlePeerServiceDelete(gp *gressPolicy, service *kapi.Service) error {
+func (oc *Controller) handlePeerServiceDelete(np *networkPolicy, gp *gressPolicy, service *kapi.Service) error {
+	np.RLock()
+	defer np.RUnlock()
+	if np.deleted {
+		return nil
+	}
+	// gressPolicy.deletePeerSvcVip must be called with networkPolicy RLock.
 	return gp.deletePeerSvcVip(oc.nbClient, service)
 }
 
@@ -1645,8 +1739,11 @@ type NetworkPolicyExtraParameters struct {
 	podSelector labels.Selector
 }
 
-// Watch services that are in the same Namespace as the NP
-// To account for hairpined traffic
+// addPeerServiceHandler starts a watcher for PeerServiceType.
+// It watches services that are in the same Namespace as the NP to account for hairpinned traffic
+// Add event for every existing namespace will be executed sequentially first, and an error will be
+// returned if something fails.
+// PeerServiceType uses handlePeerServiceAdd on Add, and handlePeerServiceDelete on Delete.
 func (oc *Controller) addPeerServiceHandler(
 	policy *knet.NetworkPolicy, gp *gressPolicy, np *networkPolicy) error {
 	// start watching services in the same namespace as the network policy
@@ -1654,7 +1751,10 @@ func (oc *Controller) addPeerServiceHandler(
 		factory.PeerServiceType,
 		policy.Namespace,
 		nil, nil,
-		&NetworkPolicyExtraParameters{gp: gp})
+		&NetworkPolicyExtraParameters{
+			gp: gp,
+			np: np,
+		})
 
 	serviceHandler, err := oc.WatchResource(retryPeerServices)
 	if err != nil {
@@ -1666,8 +1766,12 @@ func (oc *Controller) addPeerServiceHandler(
 	return nil
 }
 
-func (oc *Controller) addPeerPodHandler(
-	policy *knet.NetworkPolicy, podSelector *metav1.LabelSelector,
+// addPeerPodHandler starts a watcher for PeerPodSelectorType.
+// Sync function and Add event for every existing namespace will be executed sequentially first, and an error will be
+// returned if something fails.
+// PeerPodSelectorType uses handlePeerPodSelectorAddUpdate on Add and Update,
+// and handlePeerPodSelectorDelete on Delete.
+func (oc *Controller) addPeerPodHandler(podSelector *metav1.LabelSelector,
 	gp *gressPolicy, np *networkPolicy) error {
 
 	// NetworkPolicy is validated by the apiserver; this can't fail.
@@ -1676,13 +1780,18 @@ func (oc *Controller) addPeerPodHandler(
 	// start watching pods in the same namespace as the network policy and selected by the
 	// label selector
 	syncFunc := func(objs []interface{}) error {
-		return oc.handlePeerPodSelectorAddUpdate(gp, objs...)
+		// ignore returned error, since any pod that wasn't properly handled will be retried individually.
+		_ = oc.handlePeerPodSelectorAddUpdate(np, gp, objs...)
+		return nil
 	}
 	retryPeerPods := NewRetryObjs(
 		factory.PeerPodSelectorType,
-		policy.Namespace,
+		np.namespace,
 		sel, syncFunc,
-		&NetworkPolicyExtraParameters{gp: gp})
+		&NetworkPolicyExtraParameters{
+			np: np,
+			gp: gp,
+		})
 
 	podHandler, err := oc.WatchResource(retryPeerPods)
 	if err != nil {
@@ -1698,62 +1807,92 @@ func (oc *Controller) handlePeerNamespaceAndPodAdd(np *networkPolicy, gp *gressP
 	podSelector labels.Selector, obj interface{}) error {
 	namespace := obj.(*kapi.Namespace)
 	np.RLock()
-	alreadyDeleted := np.deleted
-	np.RUnlock()
-	if alreadyDeleted {
+	locked := true
+	defer func() {
+		if locked {
+			np.RUnlock()
+		}
+	}()
+	if np.deleted {
 		return nil
 	}
 
 	// start watching pods in this namespace and selected by the label selector in extraParameters.podSelector
 	syncFunc := func(objs []interface{}) error {
-		return oc.handlePeerPodSelectorAddUpdate(gp, objs...)
+		// ignore returned error, since any pod that wasn't properly handled will be retried individually.
+		_ = oc.handlePeerPodSelectorAddUpdate(np, gp, objs...)
+		return nil
 	}
 	retryPeerPods := NewRetryObjs(
 		factory.PeerPodForNamespaceAndPodSelectorType,
 		namespace.Name,
 		podSelector,
 		syncFunc,
-		&NetworkPolicyExtraParameters{gp: gp},
+		&NetworkPolicyExtraParameters{
+			gp: gp,
+			np: np,
+		},
 	)
-	// The AddFilteredPodHandler call might call handlePeerPodSelectorAddUpdate
-	// on existing pods so we can't be holding the lock at this point
+	// syncFunc and factory.PeerPodForNamespaceAndPodSelectorType add event handler also take np.RLock,
+	// and will be called form the same thread. The same thread shouldn't take the same rlock twice.
+	// unlock
+	np.RUnlock()
+	locked = false
 	podHandler, err := oc.WatchResource(retryPeerPods)
 	if err != nil {
 		klog.Errorf("Failed WatchResource for PeerNamespaceAndPodSelectorType: %v", err)
 		return err
 	}
-
-	np.Lock()
-	defer np.Unlock()
+	// lock networkPolicy again to update namespacedPodHandlers
+	np.RLock()
+	locked = true
 	if np.deleted {
 		oc.watchFactory.RemovePodHandler(podHandler)
 		return nil
 	}
-	np.podHandlerList = append(np.podHandlerList, podHandler)
+	np.namespacedPodHandlers.Store(namespace.Name, podHandler)
 	return nil
 }
 
-func (oc *Controller) handlePeerNamespaceAndPodDel(gp *gressPolicy, obj interface{}) error {
+func (oc *Controller) handlePeerNamespaceAndPodDel(np *networkPolicy, gp *gressPolicy, obj interface{}) error {
+	np.RLock()
+	defer np.RUnlock()
+	if np.deleted {
+		return nil
+	}
+
 	// when the namespace labels no longer apply
+	// stop pod handler,
 	// remove the namespaces pods from the address_set
 	var errs []error
 	namespace := obj.(*kapi.Namespace)
-	pods, _ := oc.watchFactory.GetPods(namespace.Name)
 
+	if handler, ok := np.namespacedPodHandlers.Load(namespace.Name); ok {
+		oc.watchFactory.RemovePodHandler(handler.(*factory.Handler))
+		np.namespacedPodHandlers.Delete(namespace.Name)
+	}
+
+	pods, err := oc.watchFactory.GetPods(namespace.Name)
+	if err != nil {
+		return fmt.Errorf("failed to get namespace %s pods: %v", namespace.Namespace, err)
+	}
 	for _, pod := range pods {
-		if err := oc.handlePeerPodSelectorDelete(gp, pod); err != nil {
+		// call functions from handlePeerPodSelectorDelete
+		// gressPolicy.deletePeerPod must be called with networkPolicy RLock.
+		if err = gp.deletePeerPod(pod); err != nil {
 			errs = append(errs, err)
 		}
 	}
 	return kerrorsutil.NewAggregate(errs)
 }
 
-func (oc *Controller) addPeerNamespaceAndPodHandler(
-	namespaceSelector *metav1.LabelSelector,
-	podSelector *metav1.LabelSelector,
-	gp *gressPolicy,
-	np *networkPolicy) error {
-
+// addPeerNamespaceAndPodHandler starts a watcher for PeerNamespaceAndPodSelectorType.
+// Add event for every existing namespace will be executed sequentially first, and an error will be
+// returned if something fails.
+// PeerNamespaceAndPodSelectorType uses handlePeerNamespaceAndPodAdd on Add,
+// and handlePeerNamespaceAndPodDel on Delete.
+func (oc *Controller) addPeerNamespaceAndPodHandler(namespaceSelector *metav1.LabelSelector,
+	podSelector *metav1.LabelSelector, gp *gressPolicy, np *networkPolicy) error {
 	// NetworkPolicy is validated by the apiserver; this can't fail.
 	nsSel, _ := metav1.LabelSelectorAsSelector(namespaceSelector)
 	podSel, _ := metav1.LabelSelectorAsSelector(podSelector)
@@ -1780,11 +1919,21 @@ func (oc *Controller) addPeerNamespaceAndPodHandler(
 	return nil
 }
 
-func (oc *Controller) handlePeerNamespaceSelectorAdd(np *networkPolicy, gp *gressPolicy, obj interface{}) error {
-	namespace := obj.(*kapi.Namespace)
-	np.Lock()
-	updated := gp.addNamespaceAddressSet(namespace.Name)
-	np.Unlock()
+func (oc *Controller) handlePeerNamespaceSelectorAdd(np *networkPolicy, gp *gressPolicy, objs ...interface{}) error {
+	np.RLock()
+	if np.deleted {
+		np.RUnlock()
+		return nil
+	}
+	updated := false
+	for _, obj := range objs {
+		namespace := obj.(*kapi.Namespace)
+		// addNamespaceAddressSet is safe for concurrent use, doesn't require additional synchronization
+		if gp.addNamespaceAddressSet(namespace.Name) {
+			updated = true
+		}
+	}
+	np.RUnlock()
 	// unlock networkPolicy, before calling peerNamespaceUpdate
 	if updated {
 		return oc.peerNamespaceUpdate(np, gp)
@@ -1792,11 +1941,21 @@ func (oc *Controller) handlePeerNamespaceSelectorAdd(np *networkPolicy, gp *gres
 	return nil
 }
 
-func (oc *Controller) handlePeerNamespaceSelectorDel(np *networkPolicy, gp *gressPolicy, obj interface{}) error {
-	namespace := obj.(*kapi.Namespace)
-	np.Lock()
-	updated := gp.delNamespaceAddressSet(namespace.Name)
-	np.Unlock()
+func (oc *Controller) handlePeerNamespaceSelectorDel(np *networkPolicy, gp *gressPolicy, objs ...interface{}) error {
+	np.RLock()
+	if np.deleted {
+		np.RUnlock()
+		return nil
+	}
+	updated := false
+	for _, obj := range objs {
+		namespace := obj.(*kapi.Namespace)
+		// delNamespaceAddressSet is safe for concurrent use, doesn't require additional synchronization
+		if gp.delNamespaceAddressSet(namespace.Name) {
+			updated = true
+		}
+	}
+	np.RUnlock()
 	// unlock networkPolicy, before calling peerNamespaceUpdate
 	if updated {
 		return oc.peerNamespaceUpdate(np, gp)
@@ -1804,29 +1963,47 @@ func (oc *Controller) handlePeerNamespaceSelectorDel(np *networkPolicy, gp *gres
 	return nil
 }
 
+// peerNamespaceUpdate updates gress ACLs, for this purpose it need to take nsInfo lock and np.RLock
+// make sure to pass unlocked networkPolicy
 func (oc *Controller) peerNamespaceUpdate(np *networkPolicy, gp *gressPolicy) error {
-	aclLoggingLevels := oc.GetNamespaceACLLogging(np.namespace)
-	np.Lock()
-	defer np.Unlock()
-	// This needs to be a write lock because there's no locking around 'gress policies
-	if !np.deleted {
-		acls := gp.buildLocalPodACLs(np.portGroupName, aclLoggingLevels)
-		ops, err := libovsdbops.CreateOrUpdateACLsOps(oc.nbClient, nil, acls...)
-		if err != nil {
-			return err
+	// Lock namespace before locking np
+	// this is to make sure we don't miss update acl loglevel event for namespace.
+	// The order of locking is strict: namespace first, then network policy, otherwise deadlock may happen
+	nsInfo, nsUnlock := oc.getNamespaceLocked(np.namespace, true)
+	var aclLogging *ACLLoggingLevels
+	if nsInfo == nil {
+		aclLogging = &ACLLoggingLevels{
+			Allow: "",
+			Deny:  "",
 		}
-		ops, err = libovsdbops.AddACLsToPortGroupOps(oc.nbClient, ops, np.portGroupName, acls...)
-		if err != nil {
-			return err
-		}
-		_, err = libovsdbops.TransactAndCheck(oc.nbClient, ops)
-		if err != nil {
-			return err
-		}
+	} else {
+		defer nsUnlock()
+		aclLogging = &nsInfo.aclLogging
 	}
-	return nil
+	np.RLock()
+	defer np.RUnlock()
+	if np.deleted {
+		return nil
+	}
+	// buildLocalPodACLs is safe for concurrent use, see function comment for details
+	acls := gp.buildLocalPodACLs(np.portGroupName, aclLogging)
+	ops, err := libovsdbops.CreateOrUpdateACLsOps(oc.nbClient, nil, acls...)
+	if err != nil {
+		return err
+	}
+	ops, err = libovsdbops.AddACLsToPortGroupOps(oc.nbClient, ops, np.portGroupName, acls...)
+	if err != nil {
+		return err
+	}
+	_, err = libovsdbops.TransactAndCheck(oc.nbClient, ops)
+	return err
 }
 
+// addPeerNamespaceHandler starts a watcher for PeerNamespaceSelectorType.
+// Sync function and Add event for every existing namespace will be executed sequentially first, and an error will be
+// returned if something fails.
+// PeerNamespaceSelectorType uses handlePeerNamespaceSelectorAdd on Add,
+// and handlePeerNamespaceSelectorDel on Delete.
 func (oc *Controller) addPeerNamespaceHandler(
 	namespaceSelector *metav1.LabelSelector,
 	gress *gressPolicy, np *networkPolicy) error {
@@ -1835,16 +2012,9 @@ func (oc *Controller) addPeerNamespaceHandler(
 	sel, _ := metav1.LabelSelectorAsSelector(namespaceSelector)
 
 	// start watching namespaces selected by the namespace selector
-	syncFunc := func(i []interface{}) error {
-		// This needs to be a write lock because there's no locking around 'gress policies
-		np.Lock()
-		defer np.Unlock()
-		// We load the existing address set into the 'gress policy.
-		// Notice that this will make the AddFunc for this initial
-		// address set a noop.
-		// The ACL must be set explicitly after setting up this handler
-		// for the address set to be considered.
-		gress.addNamespaceAddressSets(i)
+	syncFunc := func(objs []interface{}) error {
+		// ignore returned error, since any namespace that wasn't properly handled will be retried individually.
+		_ = oc.handlePeerNamespaceSelectorAdd(np, gress, objs...)
 		return nil
 	}
 	retryPeerNamespaces := NewRetryObjs(
@@ -1867,15 +2037,23 @@ func (oc *Controller) shutdownHandlers(np *networkPolicy) {
 	for _, handler := range np.podHandlerList {
 		oc.watchFactory.RemovePodHandler(handler)
 	}
+	np.podHandlerList = make([]*factory.Handler, 0)
 	for _, handler := range np.nsHandlerList {
 		oc.watchFactory.RemoveNamespaceHandler(handler)
 	}
+	np.nsHandlerList = make([]*factory.Handler, 0)
 	for _, handler := range np.svcHandlerList {
 		oc.watchFactory.RemoveServiceHandler(handler)
 	}
+	np.svcHandlerList = make([]*factory.Handler, 0)
+	np.namespacedPodHandlers.Range(func(_, value interface{}) bool {
+		oc.watchFactory.RemovePodHandler(value.(*factory.Handler))
+		return true
+	})
+	np.namespacedPodHandlers = sync.Map{}
 }
 
-// The following 2 function should return the same key for network policy based on k8s on internal networkPolicy object
+// The following 2 functions should return the same key for network policy based on k8s on internal networkPolicy object
 func getPolicyKey(policy *knet.NetworkPolicy) string {
 	return fmt.Sprintf("%v/%v", policy.Namespace, policy.Name)
 }

--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -977,22 +977,15 @@ func (oc *Controller) getExistingLocalPolicyPorts(np *networkPolicy,
 		pod := obj.(*kapi.Pod)
 
 		logicalPortName := util.GetLogicalPortName(pod.Namespace, pod.Name)
-		if _, ok := np.localPods.Load(logicalPortName); !ok {
+		loadedPortUUID, ok := np.localPods.Load(logicalPortName)
+		if !ok {
 			// port is already deleted for this policy
 			continue
 		}
-		// lsp is deleted from oc.logicalPortCache with 60 sec delay to make sure all other handlers
-		// were able to get required information
-		portInfo, err := oc.logicalPortCache.get(logicalPortName)
-		if err != nil {
-			klog.Warningf("Failed to get LSP for pod %s/%s for networkPolicy %s refetching err: %v",
-				pod.Namespace, pod.Name, np.name, err)
-			errObjs = append(errObjs, pod)
-			return
-		}
+		portUUID := loadedPortUUID.(string)
 
-		policyPortsToUUIDs[portInfo.name] = portInfo.uuid
-		policyPortUUIDs = append(policyPortUUIDs, portInfo.uuid)
+		policyPortsToUUIDs[logicalPortName] = portUUID
+		policyPortUUIDs = append(policyPortUUIDs, portUUID)
 	}
 	return
 }

--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -6,7 +6,6 @@ import (
 	"net"
 	"strings"
 	"sync"
-	"time"
 
 	libovsdbclient "github.com/ovn-org/libovsdb/client"
 	ovsdb "github.com/ovn-org/libovsdb/ovsdb"
@@ -15,15 +14,14 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdbops"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/metrics"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
-
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+
 	kapi "k8s.io/api/core/v1"
 	knet "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	kerrorsutil "k8s.io/apimachinery/pkg/util/errors"
-	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
 	utilnet "k8s.io/utils/net"
 )
@@ -57,6 +55,83 @@ const (
 	staleArpAllowPolicyMatch = "arp"
 )
 
+// defaultDenyPortGroups is a shared object and should be used by only 1 thread at a time
+type defaultDenyPortGroups struct {
+	// portName: map[portName]sets.String(policyNames)
+	// store policies that are using every port in the map
+	// these maps should be atomically updated with db operations
+	// if adding a port to db for a policy fails, map shouldn't be changed
+	ingressPortToPolicies map[string]sets.String
+	egressPortToPolicies  map[string]sets.String
+	// policies is a map of policies that use this port group
+	// policy keys must be unique, and it can be retrieved with (np *networkPolicy) getKey()
+	policies map[string]bool
+}
+
+// addPortsForPolicy adds port-policy association for default deny port groups and
+// returns lists of new ports to add to the default deny port groups.
+// If port should be added to ingress and/or egress default deny port group depends on policy spec.
+func (sharedPGs *defaultDenyPortGroups) addPortsForPolicy(np *networkPolicy,
+	portNamesToUUIDs map[string]string) (ingressDenyPorts, egressDenyPorts []string) {
+	ingressDenyPorts = []string{}
+	egressDenyPorts = []string{}
+
+	if np.isIngress {
+		for portName, portUUID := range portNamesToUUIDs {
+			// if this is the first NP referencing this pod, then we
+			// need to add it to the port group.
+			if sharedPGs.ingressPortToPolicies[portName].Len() == 0 {
+				ingressDenyPorts = append(ingressDenyPorts, portUUID)
+				sharedPGs.ingressPortToPolicies[portName] = sets.String{}
+			}
+			// increment the reference count.
+			sharedPGs.ingressPortToPolicies[portName].Insert(np.getKey())
+		}
+	}
+	if np.isEgress {
+		for portName, portUUID := range portNamesToUUIDs {
+			if sharedPGs.egressPortToPolicies[portName].Len() == 0 {
+				// again, reference count is 0, so add to port
+				egressDenyPorts = append(egressDenyPorts, portUUID)
+				sharedPGs.egressPortToPolicies[portName] = sets.String{}
+			}
+			// bump reference count
+			sharedPGs.egressPortToPolicies[portName].Insert(np.getKey())
+		}
+	}
+	return
+}
+
+// deletePortsForPolicy deletes port-policy association for default deny port groups,
+// and returns lists of port UUIDs to delete from the default deny port groups.
+// If port should be deleted from ingress and/or egress default deny port group depends on policy spec.
+func (sharedPGs *defaultDenyPortGroups) deletePortsForPolicy(np *networkPolicy,
+	portNamesToUUIDs map[string]string) (ingressDenyPorts, egressDenyPorts []string) {
+	ingressDenyPorts = []string{}
+	egressDenyPorts = []string{}
+
+	if np.isIngress {
+		for portName, portUUID := range portNamesToUUIDs {
+			// Delete and Len can be used for zero-value nil set
+			sharedPGs.ingressPortToPolicies[portName].Delete(np.getKey())
+			if sharedPGs.ingressPortToPolicies[portName].Len() == 0 {
+				ingressDenyPorts = append(ingressDenyPorts, portUUID)
+				delete(sharedPGs.ingressPortToPolicies, portName)
+			}
+		}
+	}
+	if np.isEgress {
+		for portName, portUUID := range portNamesToUUIDs {
+			sharedPGs.egressPortToPolicies[portName].Delete(np.getKey())
+			if sharedPGs.egressPortToPolicies[portName].Len() == 0 {
+				egressDenyPorts = append(egressDenyPorts, portUUID)
+				delete(sharedPGs.egressPortToPolicies, portName)
+			}
+		}
+	}
+	return
+}
+
 type networkPolicy struct {
 	// RWMutex synchronizes operations on the policy.
 	// Operations that change local and peer pods take a RLock,
@@ -67,13 +142,19 @@ type networkPolicy struct {
 	policy          *knet.NetworkPolicy
 	ingressPolicies []*gressPolicy
 	egressPolicies  []*gressPolicy
+	isIngress       bool
+	isEgress        bool
 	podHandlerList  []*factory.Handler
 	svcHandlerList  []*factory.Handler
 	nsHandlerList   []*factory.Handler
 
-	// localPods is a list of pods affected by this policy
-	// this is a sync map so we can handle multiple pods at once
-	// map of string -> *lpInfo
+	// localPods is a map of pods affected by this policy.
+	// It is used to update defaultDeny port group port counters, when deleting network policy.
+	// Port should only be added here if it was successfully added to default deny port group,
+	// and local port group in db.
+	// localPods may be updated by multiple pod handlers at the same time,
+	// therefore it uses a sync map to handle simultaneous access.
+	// map of portName(string): portUUID(string)
 	localPods sync.Map
 
 	portGroupName string
@@ -81,12 +162,15 @@ type networkPolicy struct {
 }
 
 func NewNetworkPolicy(policy *knet.NetworkPolicy) *networkPolicy {
+	policyTypeIngress, policyTypeEgress := getPolicyType(policy)
 	np := &networkPolicy{
 		name:            policy.Name,
 		namespace:       policy.Namespace,
 		policy:          policy,
 		ingressPolicies: make([]*gressPolicy, 0),
 		egressPolicies:  make([]*gressPolicy, 0),
+		isIngress:       policyTypeIngress,
+		isEgress:        policyTypeEgress,
 		podHandlerList:  make([]*factory.Handler, 0),
 		svcHandlerList:  make([]*factory.Handler, 0),
 		nsHandlerList:   make([]*factory.Handler, 0),
@@ -143,8 +227,8 @@ func (oc *Controller) updateStaleDefaultDenyACLNames(npType knet.PolicyType, gre
 		newName := namespacePortGroupACLName(namespace, "", gressSuffix)
 		if len(aclList) > 1 {
 			// this should never be the case but delete everything except 1st ACL
-			ingressPGName := defaultDenyPortGroup(namespace, ingressDefaultDenySuffix)
-			egressPGName := defaultDenyPortGroup(namespace, egressDefaultDenySuffix)
+			ingressPGName := defaultDenyPortGroupName(namespace, ingressDefaultDenySuffix)
+			egressPGName := defaultDenyPortGroupName(namespace, egressDefaultDenySuffix)
 			err := libovsdbops.DeleteACLs(oc.nbClient, []string{ingressPGName, egressPGName}, nil, aclList[1:]...)
 			if err != nil {
 				return err
@@ -363,7 +447,7 @@ func buildACL(namespace, portGroup, name, direction string, priority int, match,
 	return BuildACL(aclName, direction, priority, match, action, logLevels, externalIds, options)
 }
 
-func defaultDenyPortGroup(namespace, gressSuffix string) string {
+func defaultDenyPortGroupName(namespace, gressSuffix string) string {
 	return hashedPortGroup(namespace) + "_" + gressSuffix
 }
 
@@ -384,14 +468,50 @@ func buildDenyACLs(namespace, policy, pg string, aclLogging *ACLLoggingLevels, p
 	return
 }
 
-// must be called with a write lock on nsInfo
-func (oc *Controller) createDefaultDenyPGAndACLs(namespace, policy string, nsInfo *namespaceInfo) error {
-	aclLogging := nsInfo.aclLogging
+func (oc *Controller) addPolicyToDefaultPortGroups(np *networkPolicy, aclLogging *ACLLoggingLevels) error {
+	return oc.sharedNetpolPortGroups.DoWithLock(np.namespace, func(pgKey string) error {
+		sharedPGs, loaded := oc.sharedNetpolPortGroups.LoadOrStore(pgKey, &defaultDenyPortGroups{
+			ingressPortToPolicies: map[string]sets.String{},
+			egressPortToPolicies:  map[string]sets.String{},
+			policies:              map[string]bool{},
+		})
+		if !loaded {
+			// create port groups with acls
+			err := oc.createDefaultDenyPGAndACLs(np.namespace, np.name, aclLogging)
+			if err != nil {
+				oc.sharedNetpolPortGroups.Delete(pgKey)
+				return fmt.Errorf("failed to create default deny port groups: %v", err)
+			}
+		}
+		sharedPGs.policies[np.getKey()] = true
+		return nil
+	})
+}
 
-	ingressPGName := defaultDenyPortGroup(namespace, ingressDefaultDenySuffix)
-	ingressDenyACL, ingressAllowACL := buildDenyACLs(namespace, policy, ingressPGName, &aclLogging, knet.PolicyTypeIngress)
-	egressPGName := defaultDenyPortGroup(namespace, egressDefaultDenySuffix)
-	egressDenyACL, egressAllowACL := buildDenyACLs(namespace, policy, egressPGName, &aclLogging, knet.PolicyTypeEgress)
+func (oc *Controller) delPolicyFromDefaultPortGroups(np *networkPolicy) error {
+	return oc.sharedNetpolPortGroups.DoWithLock(np.namespace, func(pgKey string) error {
+		sharedPGs, found := oc.sharedNetpolPortGroups.Load(pgKey)
+		if !found {
+			return nil
+		}
+		delete(sharedPGs.policies, np.getKey())
+		if len(sharedPGs.policies) == 0 {
+			// last policy was deleted, delete port group
+			err := oc.deleteDefaultDenyPGAndACLs(np.namespace, np.name)
+			if err != nil {
+				return fmt.Errorf("failed to delete defaul deny port group: %v", err)
+			}
+			oc.sharedNetpolPortGroups.Delete(pgKey)
+		}
+		return nil
+	})
+}
+
+func (oc *Controller) createDefaultDenyPGAndACLs(namespace, policy string, aclLogging *ACLLoggingLevels) error {
+	ingressPGName := defaultDenyPortGroupName(namespace, ingressDefaultDenySuffix)
+	ingressDenyACL, ingressAllowACL := buildDenyACLs(namespace, policy, ingressPGName, aclLogging, knet.PolicyTypeIngress)
+	egressPGName := defaultDenyPortGroupName(namespace, egressDefaultDenySuffix)
+	egressDenyACL, egressAllowACL := buildDenyACLs(namespace, policy, egressPGName, aclLogging, knet.PolicyTypeEgress)
 	ops, err := libovsdbops.CreateOrUpdateACLsOps(oc.nbClient, nil, ingressDenyACL, ingressAllowACL, egressDenyACL, egressAllowACL)
 	if err != nil {
 		return err
@@ -416,23 +536,18 @@ func (oc *Controller) createDefaultDenyPGAndACLs(namespace, policy string, nsInf
 	}
 	txOkCallBack()
 
-	nsInfo.portGroupEgressDenyName = egressPGName
-	nsInfo.portGroupIngressDenyName = ingressPGName
-
 	return nil
 }
 
 // deleteDefaultDenyPGAndACLs deletes the default port groups and acls for a ns/policy
-// must be called with a write lock on nsInfo
-func (oc *Controller) deleteDefaultDenyPGAndACLs(namespace, policy string, nsInfo *namespaceInfo) error {
-	aclLogging := nsInfo.aclLogging
+func (oc *Controller) deleteDefaultDenyPGAndACLs(namespace, policy string) error {
 	var aclsToBeDeleted []*nbdb.ACL
 
-	ingressPGName := defaultDenyPortGroup(namespace, ingressDefaultDenySuffix)
-	ingressDenyACL, ingressAllowACL := buildDenyACLs(namespace, policy, ingressPGName, &aclLogging, knet.PolicyTypeIngress)
+	ingressPGName := defaultDenyPortGroupName(namespace, ingressDefaultDenySuffix)
+	ingressDenyACL, ingressAllowACL := buildDenyACLs(namespace, policy, ingressPGName, nil, knet.PolicyTypeIngress)
 	aclsToBeDeleted = append(aclsToBeDeleted, ingressDenyACL, ingressAllowACL)
-	egressPGName := defaultDenyPortGroup(namespace, egressDefaultDenySuffix)
-	egressDenyACL, egressAllowACL := buildDenyACLs(namespace, policy, egressPGName, &aclLogging, knet.PolicyTypeEgress)
+	egressPGName := defaultDenyPortGroupName(namespace, egressDefaultDenySuffix)
+	egressDenyACL, egressAllowACL := buildDenyACLs(namespace, policy, egressPGName, nil, knet.PolicyTypeEgress)
 	aclsToBeDeleted = append(aclsToBeDeleted, egressDenyACL, egressAllowACL)
 
 	ops, err := libovsdbops.DeletePortGroupsOps(oc.nbClient, nil, ingressPGName, egressPGName)
@@ -449,8 +564,6 @@ func (oc *Controller) deleteDefaultDenyPGAndACLs(namespace, policy string, nsInf
 	if err != nil {
 		return fmt.Errorf("failed to transact deleteDefaultDenyPGAndACLs: %v", err)
 	}
-	nsInfo.portGroupEgressDenyName = ""
-	nsInfo.portGroupIngressDenyName = ""
 
 	return nil
 }
@@ -471,15 +584,21 @@ func (oc *Controller) updateACLLoggingForPolicy(np *networkPolicy, aclLogging *A
 }
 
 func (oc *Controller) updateACLLoggingForDefaultACLs(ns string, nsInfo *namespaceInfo) error {
-	// update namespace-scoped default deny ACLs
-	denyEgressACL, _ := buildDenyACLs(ns, "", defaultDenyPortGroup(ns, egressDefaultDenySuffix),
-		&nsInfo.aclLogging, knet.PolicyTypeEgress)
-	denyIngressACL, _ := buildDenyACLs(ns, "", defaultDenyPortGroup(ns, ingressDefaultDenySuffix),
-		&nsInfo.aclLogging, knet.PolicyTypeIngress)
-	if err := UpdateACLLogging(oc.nbClient, []*nbdb.ACL{denyIngressACL, denyEgressACL}, &nsInfo.aclLogging); err != nil {
-		return fmt.Errorf("unable to update ACL logging for namespace %s: %w", ns, err)
-	}
-	return nil
+	return oc.sharedNetpolPortGroups.DoWithLock(ns, func(pgKey string) error {
+		_, loaded := oc.sharedNetpolPortGroups.Load(pgKey)
+		if !loaded {
+			// shared port group doesn't exist
+			return fmt.Errorf("shared port group doesn't exist for ns %s", ns)
+		}
+		denyEgressACL, _ := buildDenyACLs(ns, "", defaultDenyPortGroupName(ns, egressDefaultDenySuffix),
+			&nsInfo.aclLogging, knet.PolicyTypeEgress)
+		denyIngressACL, _ := buildDenyACLs(ns, "", defaultDenyPortGroupName(ns, ingressDefaultDenySuffix),
+			&nsInfo.aclLogging, knet.PolicyTypeIngress)
+		if err := UpdateACLLogging(oc.nbClient, []*nbdb.ACL{denyIngressACL, denyEgressACL}, &nsInfo.aclLogging); err != nil {
+			return fmt.Errorf("unable to update ACL logging for namespace %s: %w", ns, err)
+		}
+		return nil
+	})
 }
 
 func (oc *Controller) setNetworkPolicyACLLoggingForNamespace(ns string, nsInfo *namespaceInfo) error {
@@ -712,8 +831,8 @@ func podDeleteAllowMulticastPolicy(nbClient libovsdbclient.Client, ns string, po
 	return libovsdbops.DeletePortsFromPortGroup(nbClient, hashedPortGroup(ns), portUUID)
 }
 
-// policyType returns whether the policy is of type ingress and/or egress
-func policyType(policy *knet.NetworkPolicy) (bool, bool) {
+// getPolicyType returns whether the policy is of type ingress and/or egress
+func getPolicyType(policy *knet.NetworkPolicy) (bool, bool) {
 	var policyTypeIngress bool
 	var policyTypeEgress bool
 
@@ -728,160 +847,15 @@ func policyType(policy *knet.NetworkPolicy) (bool, bool) {
 	return policyTypeIngress, policyTypeEgress
 }
 
-// localPodAddDefaultDeny ensures ports (i.e. pods) are in the correct
-// default-deny portgroups. Whether or not pods are in default-deny depends
-// on whether or not any policies select this pod, so there is a reference
-// count to ensure we don't accidentally open up a pod.
-func (oc *Controller) localPodAddDefaultDeny(policy *knet.NetworkPolicy,
-	ports ...*lpInfo) (ingressDenyPorts, egressDenyPorts []string) {
-	oc.lspMutex.Lock()
+// getNewLocalPolicyPorts will find and return port info for every given pod obj, that is not found in
+// np.localPods.
+// if there are problems with fetching port info from logicalPortCache, pod will be added to errObjs.
+func (oc *Controller) getNewLocalPolicyPorts(np *networkPolicy,
+	objs ...interface{}) (policyPortsToUUIDs map[string]string, policyPortUUIDs []string, errObjs []interface{}) {
 
-	ingressDenyPorts = []string{}
-	egressDenyPorts = []string{}
-
-	policyTypeIngress, policyTypeEgress := policyType(policy)
-
-	if policyTypeIngress {
-		for _, portInfo := range ports {
-			// if this is the first NP referencing this pod, then we
-			// need to add it to the port group.
-			if oc.lspIngressDenyCache[portInfo.name] == 0 {
-				ingressDenyPorts = append(ingressDenyPorts, portInfo.uuid)
-			}
-
-			// increment the reference count.
-			oc.lspIngressDenyCache[portInfo.name]++
-		}
-	}
-
-	// Handle condition 2 above.
-	if policyTypeEgress {
-		for _, portInfo := range ports {
-			if oc.lspEgressDenyCache[portInfo.name] == 0 {
-				// again, reference count is 0, so add to port
-				egressDenyPorts = append(egressDenyPorts, portInfo.uuid)
-			}
-
-			// bump reference count
-			oc.lspEgressDenyCache[portInfo.name]++
-		}
-	}
-	oc.lspMutex.Unlock()
-
-	return
-}
-
-// localPodDelDefaultDeny decrements a pod's policy reference count and removes a pod
-// from the default-deny portgroups if the reference count for the pod is 0
-func (oc *Controller) localPodDelDefaultDeny(
-	np *networkPolicy, ports ...*lpInfo) (ingressDenyPorts, egressDenyPorts []string) {
-	oc.lspMutex.Lock()
-
-	ingressDenyPorts = []string{}
-	egressDenyPorts = []string{}
-
-	policyTypeIngress, policyTypeEgress := policyType(np.policy)
-
-	// Remove port from ingress deny port-group for [Ingress] and [ingress,egress] PolicyTypes
-	// If NOT [egress] PolicyType
-	if policyTypeIngress {
-		for _, portInfo := range ports {
-			if oc.lspIngressDenyCache[portInfo.name] > 0 {
-				oc.lspIngressDenyCache[portInfo.name]--
-				if oc.lspIngressDenyCache[portInfo.name] == 0 {
-					ingressDenyPorts = append(ingressDenyPorts, portInfo.uuid)
-					delete(oc.lspIngressDenyCache, portInfo.name)
-				}
-			}
-		}
-	}
-
-	// Remove port from egress deny port group for [egress] and [ingress,egress] PolicyTypes
-	// if [egress] PolicyType OR there are any egress rules OR [ingress,egress] PolicyType
-	if policyTypeEgress {
-		for _, portInfo := range ports {
-			if oc.lspEgressDenyCache[portInfo.name] > 0 {
-				oc.lspEgressDenyCache[portInfo.name]--
-				if oc.lspEgressDenyCache[portInfo.name] == 0 {
-					egressDenyPorts = append(egressDenyPorts, portInfo.uuid)
-					delete(oc.lspEgressDenyCache, portInfo.name)
-				}
-			}
-		}
-	}
-	oc.lspMutex.Unlock()
-
-	return
-}
-
-func (oc *Controller) processLocalPodSelectorSetPods(policy *knet.NetworkPolicy,
-	np *networkPolicy, objs ...interface{}) (policyPorts, ingressDenyPorts, egressDenyPorts []string) {
 	klog.Infof("Processing NetworkPolicy %s/%s to have %d local pods...", np.namespace, np.name, len(objs))
-
-	// get list of pods and their logical ports to add
-	// theoretically this should never filter any pods but it's always good to be
-	// paranoid.
-	policyPorts = make([]string, 0, len(objs))
-	policyPortsInfo := make([]*lpInfo, 0, len(objs))
-
-	// thread safe helper vars used by the `getPortInfo` go-routine
-	getPortsInfoMap := sync.Map{}
-	getPolicyPortsWg := &sync.WaitGroup{}
-
-	getPortInfo := func(pod *kapi.Pod) {
-		defer getPolicyPortsWg.Done()
-
-		if pod.Spec.NodeName == "" {
-			return
-		}
-
-		logicalPort := util.GetLogicalPortName(pod.Namespace, pod.Name)
-		var portInfo *lpInfo
-
-		// Get the logical port info from the cache, if that fails, retry.
-		// If the gotten LSP is scheduled for removal, retry (stateful-sets).
-		//
-		// 24ms is chosen because gomega.Eventually default timeout is 50ms
-		// libovsdb transactions take less than 50ms usually as well so pod create
-		// should be done within a couple iterations
-		retryErr := wait.PollImmediate(24*time.Millisecond, 1*time.Second, func() (bool, error) {
-			var err error
-
-			// Retry if getting pod LSP from the cache fails
-			portInfo, err = oc.logicalPortCache.get(logicalPort)
-			if err != nil {
-				klog.Warningf("Failed to get LSP for pod %s/%s for networkPolicy %s refetching err: %v",
-					pod.Namespace, pod.Name, policy.Name, err)
-				return false, nil
-			}
-
-			// Retry if LSP is scheduled for deletion
-			if !portInfo.expires.IsZero() {
-				klog.Warningf("Stale LSP %s for network policy %s found in cache refetching",
-					portInfo.name, policy.Name)
-				return false, nil
-			}
-
-			// LSP get succeeded and LSP is up to fresh, exit and continue
-			klog.V(5).Infof("Fresh LSP %s for network policy %s found in cache",
-				portInfo.name, policy.Name)
-			return true, nil
-
-		})
-		if retryErr != nil {
-			// Failed to get an up to date version of the LSP from the cache
-			klog.Warningf("Failed to get LSP after multiple retries for pod %s/%s for networkPolicy %s err: %v",
-				pod.Namespace, pod.Name, policy.Name, retryErr)
-			return
-		}
-
-		// if this pod is somehow already added to this policy, then skip
-		if _, ok := np.localPods.LoadOrStore(portInfo.name, portInfo); ok {
-			return
-		}
-
-		getPortsInfoMap.Store(portInfo.uuid, portInfo)
-	}
+	policyPortUUIDs = make([]string, 0, len(objs))
+	policyPortsToUUIDs = map[string]string{}
 
 	for _, obj := range objs {
 		pod := obj.(*kapi.Pod)
@@ -890,140 +864,268 @@ func (oc *Controller) processLocalPodSelectorSetPods(policy *knet.NetworkPolicy,
 			// if pod is completed, do not add it to NP port group
 			continue
 		}
+		if pod.Spec.NodeName == "" {
+			// pod is not yet scheduled, will receive update event for it
+			continue
+		}
 
-		getPolicyPortsWg.Add(1)
-		go getPortInfo(pod)
+		logicalPortName := util.GetLogicalPortName(pod.Namespace, pod.Name)
+
+		if _, ok := np.localPods.Load(logicalPortName); ok {
+			// port is already added for this policy
+			continue
+		}
+
+		// Add pod to errObjs for retry if
+		// 1. getting pod LSP from the cache fails,
+		// 2. the gotten LSP is scheduled for removal (stateful-sets).
+		portInfo, err := oc.logicalPortCache.get(logicalPortName)
+		if err != nil {
+			klog.Warningf("Failed to get LSP for pod %s/%s for networkPolicy %s, err: %v",
+				pod.Namespace, pod.Name, np.name, err)
+			errObjs = append(errObjs, pod)
+			continue
+		}
+
+		// Add pod to errObjs if LSP is scheduled for deletion
+		if !portInfo.expires.IsZero() {
+			klog.Warningf("Stale LSP %s for network policy %s found in cache",
+				portInfo.name, np.name)
+			errObjs = append(errObjs, pod)
+			continue
+		}
+
+		// LSP get succeeded and LSP is up to fresh
+		klog.V(5).Infof("Fresh LSP %s for network policy %s found in cache",
+			portInfo.name, np.name)
+
+		policyPortUUIDs = append(policyPortUUIDs, portInfo.uuid)
+		policyPortsToUUIDs[portInfo.name] = portInfo.uuid
 	}
-
-	getPolicyPortsWg.Wait()
-
-	// build usable atomic structures from the sync.Map() populated by the getPortInfo threads
-	// add to backup policyPorts array
-	getPortsInfoMap.Range(func(key interface{}, value interface{}) bool {
-		policyPorts = append(policyPorts, key.(string))
-		policyPortsInfo = append(policyPortsInfo, value.(*lpInfo))
-		return true
-	})
-
-	ingressDenyPorts, egressDenyPorts = oc.localPodAddDefaultDeny(policy, policyPortsInfo...)
-
 	return
 }
 
-func (oc *Controller) processLocalPodSelectorDelPods(np *networkPolicy,
-	objs ...interface{}) (policyPorts, ingressDenyPorts, egressDenyPorts []string) {
+// getExistingLocalPolicyPorts will find and return port info for every given pod obj, that is present in np.localPods.
+// if there are problems with fetching port info from logicalPortCache, pod will be added to errObjs.
+func (oc *Controller) getExistingLocalPolicyPorts(np *networkPolicy,
+	objs ...interface{}) (policyPortsToUUIDs map[string]string, policyPortUUIDs []string, errObjs []interface{}) {
 	klog.Infof("Processing NetworkPolicy %s/%s to delete %d local pods...", np.namespace, np.name, len(objs))
 
-	policyPorts = make([]string, 0, len(objs))
-	policyPortsInfo := make([]*lpInfo, 0, len(objs))
+	policyPortUUIDs = make([]string, 0, len(objs))
+	policyPortsToUUIDs = map[string]string{}
 	for _, obj := range objs {
 		pod := obj.(*kapi.Pod)
 
-		if pod.Spec.NodeName == "" {
+		logicalPortName := util.GetLogicalPortName(pod.Namespace, pod.Name)
+		if _, ok := np.localPods.Load(logicalPortName); !ok {
+			// port is already deleted for this policy
 			continue
 		}
 
-		logicalPort := util.GetLogicalPortName(pod.Namespace, pod.Name)
-		portInfo, err := oc.logicalPortCache.get(logicalPort)
+		portInfo, err := oc.logicalPortCache.get(logicalPortName)
 		if err != nil {
-			klog.Errorf(err.Error())
+			klog.Warningf("Failed to get LSP for pod %s/%s for networkPolicy %s refetching err: %v",
+				pod.Namespace, pod.Name, np.name, err)
+			errObjs = append(errObjs, pod)
 			return
 		}
 
-		// If we never saw this pod, short-circuit
-		if _, ok := np.localPods.LoadAndDelete(logicalPort); !ok {
-			continue
-		}
-
-		policyPortsInfo = append(policyPortsInfo, portInfo)
-		policyPorts = append(policyPorts, portInfo.uuid)
+		policyPortsToUUIDs[portInfo.name] = portInfo.uuid
+		policyPortUUIDs = append(policyPortUUIDs, portInfo.uuid)
 	}
-
-	ingressDenyPorts, egressDenyPorts = oc.localPodDelDefaultDeny(np, policyPortsInfo...)
-
 	return
 }
 
-// handleLocalPodSelectorAddFunc adds a new pod to an existing NetworkPolicy
-func (oc *Controller) handleLocalPodSelectorAddFunc(policy *knet.NetworkPolicy, np *networkPolicy,
-	portGroupIngressDenyName, portGroupEgressDenyName string, obj interface{}) error {
+// denyPGAddPorts adds ports to default deny port groups.
+func (oc *Controller) denyPGAddPorts(np *networkPolicy, portNamesToUUIDs map[string]string) error {
+	var err error
+	var ops []ovsdb.Operation
+	ingressDenyPGName := defaultDenyPortGroupName(np.namespace, ingressDefaultDenySuffix)
+	egressDenyPGName := defaultDenyPortGroupName(np.namespace, egressDefaultDenySuffix)
+
+	pgKey := np.namespace
+	// this lock guarantees that sharedPortGroup counters will be updated atomically
+	// with adding port to port group in db.
+	oc.sharedNetpolPortGroups.LockKey(pgKey)
+	defer oc.sharedNetpolPortGroups.UnlockKey(pgKey)
+	sharedPGs, ok := oc.sharedNetpolPortGroups.Load(pgKey)
+	if !ok {
+		// Port group doesn't exist
+		return fmt.Errorf("port groups for ns %s don't exist", np.namespace)
+	}
+
+	ingressDenyPorts, egressDenyPorts := sharedPGs.addPortsForPolicy(np, portNamesToUUIDs)
+	// counters were updated, update back to initial values on error
+	defer func() {
+		if err != nil {
+			sharedPGs.deletePortsForPolicy(np, portNamesToUUIDs)
+		}
+	}()
+
+	if len(ingressDenyPorts) != 0 || len(egressDenyPorts) != 0 {
+		// db changes required
+		ops, err = libovsdbops.AddPortsToPortGroupOps(oc.nbClient, ops, ingressDenyPGName, ingressDenyPorts...)
+		if err != nil {
+			return fmt.Errorf("unable to get add ports to %s port group ops: %v", ingressDenyPGName, err)
+		}
+
+		ops, err = libovsdbops.AddPortsToPortGroupOps(oc.nbClient, ops, egressDenyPGName, egressDenyPorts...)
+		if err != nil {
+			return fmt.Errorf("unable to get add ports to %s port group ops: %v", egressDenyPGName, err)
+		}
+
+		_, err = libovsdbops.TransactAndCheck(oc.nbClient, ops)
+		if err != nil {
+			return fmt.Errorf("unable to transact add ports to default deny port groups: %v", err)
+		}
+	}
+	return nil
+}
+
+// denyPGDeletePorts deletes ports from default deny port groups.
+// Set useLocalPods = true, when deleting networkPolicy to remove all its ports from defaultDeny port groups.
+func (oc *Controller) denyPGDeletePorts(np *networkPolicy, portNamesToUUIDs map[string]string, useLocalPods bool) error {
+	var err error
+	var ops []ovsdb.Operation
+	if useLocalPods {
+		portNamesToUUIDs = map[string]string{}
+		np.localPods.Range(func(key, value interface{}) bool {
+			portNamesToUUIDs[key.(string)] = value.(string)
+			return true
+		})
+	}
+	if len(portNamesToUUIDs) == 0 {
+		return nil
+	}
+
+	ingressDenyPGName := defaultDenyPortGroupName(np.namespace, ingressDefaultDenySuffix)
+	egressDenyPGName := defaultDenyPortGroupName(np.namespace, egressDefaultDenySuffix)
+
+	pgKey := np.namespace
+	// this lock guarantees that sharedPortGroup counters will be updated atomically
+	// with adding port to port group in db.
+	oc.sharedNetpolPortGroups.LockKey(pgKey)
+	defer oc.sharedNetpolPortGroups.UnlockKey(pgKey)
+	sharedPGs, ok := oc.sharedNetpolPortGroups.Load(pgKey)
+	if !ok {
+		// Port group doesn't exist, nothing to clean up
+		klog.Infof("Skip delete ports from default deny port group: port group doesn't exist")
+		return nil
+	}
+
+	ingressDenyPorts, egressDenyPorts := sharedPGs.deletePortsForPolicy(np, portNamesToUUIDs)
+	// counters were updated, update back to initial values on error
+	defer func() {
+		if err != nil {
+			sharedPGs.addPortsForPolicy(np, portNamesToUUIDs)
+		}
+	}()
+
+	if len(ingressDenyPorts) != 0 || len(egressDenyPorts) != 0 {
+		// db changes required
+		ops, err = libovsdbops.DeletePortsFromPortGroupOps(oc.nbClient, ops, ingressDenyPGName, ingressDenyPorts...)
+		if err != nil {
+			return fmt.Errorf("unable to get del ports from %s port group ops: %v", ingressDenyPGName, err)
+		}
+
+		ops, err = libovsdbops.DeletePortsFromPortGroupOps(oc.nbClient, ops, egressDenyPGName, egressDenyPorts...)
+		if err != nil {
+			return fmt.Errorf("unable to get del ports from %s port group ops: %v", egressDenyPGName, err)
+		}
+		_, err = libovsdbops.TransactAndCheck(oc.nbClient, ops)
+		if err != nil {
+			return fmt.Errorf("unable to transact del ports from default deny port groups: %v", err)
+		}
+	}
+	return nil
+}
+
+// handleLocalPodSelectorAddFunc adds a new pod to an existing NetworkPolicy, should be retriable.
+// ignoreErr=true should only be used for initial objects handling, relying on per-object handlers to retry.
+func (oc *Controller) handleLocalPodSelectorAddFunc(np *networkPolicy, ignoreErr bool, objs ...interface{}) error {
+	np.RLock()
+	defer np.RUnlock()
+	if np.deleted {
+		return nil
+	}
+	// get info for new pods that are not listed in np.localPods
+	portNamesToUUIDs, policyPortUUIDs, errPods := oc.getNewLocalPolicyPorts(np, objs...)
+
+	if len(portNamesToUUIDs) > 0 {
+		var err error
+		// add pods to policy port group
+		var ops []ovsdb.Operation
+		ops, err = libovsdbops.AddPortsToPortGroupOps(oc.nbClient, nil, np.portGroupName, policyPortUUIDs...)
+		if err != nil {
+			return fmt.Errorf("unable to get ops to add new pod to policy port group: %v", err)
+		}
+		_, err = libovsdbops.TransactAndCheck(oc.nbClient, ops)
+		if err != nil {
+			return fmt.Errorf("unable to transact add new pod to policy port group: %v", err)
+		}
+		// add pods to default deny port group
+		// make sure to only pass newly added pods
+		if err = oc.denyPGAddPorts(np, portNamesToUUIDs); err != nil {
+			// we don't need to delete policy ports from policy port group,
+			// because adding ports to port group is idempotent and can be retried
+			return fmt.Errorf("unable to add new pod to default deny port group: %v", err)
+		}
+		// all operations were successful, update np.localPods
+		for portName, portUUID := range portNamesToUUIDs {
+			np.localPods.Store(portName, portUUID)
+		}
+	}
+
+	if !ignoreErr && len(errPods) > 0 {
+		pod := errPods[0].(*kapi.Pod)
+		return fmt.Errorf("unable to get port info for pod %s/%s", pod.Namespace, pod.Name)
+	}
+
+	return nil
+}
+
+// handleLocalPodSelectorDelFunc handles delete event for local pod, should be retriable
+func (oc *Controller) handleLocalPodSelectorDelFunc(np *networkPolicy, objs ...interface{}) error {
 	np.RLock()
 	defer np.RUnlock()
 	if np.deleted {
 		return nil
 	}
 
-	policyPorts, ingressDenyPorts, egressDenyPorts := oc.processLocalPodSelectorSetPods(policy, np, obj)
+	portNamesToUUIDs, policyPortUUIDs, errPods := oc.getExistingLocalPolicyPorts(np, objs...)
 
-	var errs []error
-
-	ops, err := libovsdbops.AddPortsToPortGroupOps(oc.nbClient, nil, portGroupIngressDenyName, ingressDenyPorts...)
-	if err != nil {
-		oc.processLocalPodSelectorDelPods(np, obj)
-		errs = append(errs, err)
+	if len(portNamesToUUIDs) > 0 {
+		var err error
+		// del pods from policy port group
+		var ops []ovsdb.Operation
+		ops, err = libovsdbops.DeletePortsFromPortGroupOps(oc.nbClient, nil, np.portGroupName, policyPortUUIDs...)
+		if err != nil {
+			return fmt.Errorf("unable to get ops to add new pod to policy port group: %v", err)
+		}
+		_, err = libovsdbops.TransactAndCheck(oc.nbClient, ops)
+		if err != nil {
+			return fmt.Errorf("unable to transact add new pod to policy port group: %v", err)
+		}
+		// delete pods from default deny port group
+		if err = oc.denyPGDeletePorts(np, portNamesToUUIDs, false); err != nil {
+			// we don't need to add policy ports back to policy port group,
+			// because delete ports from port group is idempotent and can be retried
+			return fmt.Errorf("unable to add new pod to default deny port group: %v", err)
+		}
+		// all operations were successful, update np.localPods
+		for portName := range portNamesToUUIDs {
+			np.localPods.Delete(portName)
+		}
 	}
 
-	ops, err = libovsdbops.AddPortsToPortGroupOps(oc.nbClient, ops, portGroupEgressDenyName, egressDenyPorts...)
-	if err != nil {
-		oc.processLocalPodSelectorDelPods(np, obj)
-		errs = append(errs, err)
+	if len(errPods) > 0 {
+		pod := errPods[0].(*kapi.Pod)
+		return fmt.Errorf("unable to get port info for pod %s/%s", pod.Namespace, pod.Name)
 	}
-
-	ops, err = libovsdbops.AddPortsToPortGroupOps(oc.nbClient, ops, np.portGroupName, policyPorts...)
-	if err != nil {
-		oc.processLocalPodSelectorDelPods(np, obj)
-		errs = append(errs, err)
-	}
-
-	_, err = libovsdbops.TransactAndCheck(oc.nbClient, ops)
-	if err != nil {
-		oc.processLocalPodSelectorDelPods(np, obj)
-		errs = append(errs, err)
-	}
-	return kerrorsutil.NewAggregate(errs)
+	return nil
 }
 
-func (oc *Controller) handleLocalPodSelectorDelFunc(policy *knet.NetworkPolicy, np *networkPolicy,
-	portGroupIngressDenyName, portGroupEgressDenyName string, obj interface{}) error {
-	np.RLock()
-	defer np.RUnlock()
-	if np.deleted {
-		return nil
-	}
-
-	policyPorts, ingressDenyPorts, egressDenyPorts := oc.processLocalPodSelectorDelPods(np, obj)
-
-	ops, err := libovsdbops.DeletePortsFromPortGroupOps(oc.nbClient, nil, portGroupIngressDenyName, ingressDenyPorts...)
-	if err != nil {
-		oc.processLocalPodSelectorSetPods(policy, np, obj)
-		return err
-	}
-
-	ops, err = libovsdbops.DeletePortsFromPortGroupOps(oc.nbClient, ops, portGroupEgressDenyName, egressDenyPorts...)
-	if err != nil {
-		oc.processLocalPodSelectorSetPods(policy, np, obj)
-		return err
-	}
-
-	var errs []error
-
-	ops, err = libovsdbops.DeletePortsFromPortGroupOps(oc.nbClient, ops, np.portGroupName, policyPorts...)
-	if err != nil {
-		oc.processLocalPodSelectorSetPods(policy, np, obj)
-		errs = append(errs, err)
-	}
-
-	_, err = libovsdbops.TransactAndCheck(oc.nbClient, ops)
-	if err != nil {
-		oc.processLocalPodSelectorSetPods(policy, np, obj)
-		errs = append(errs, err)
-	}
-
-	return kerrorsutil.NewAggregate(errs)
-}
-
-func (oc *Controller) addLocalPodHandler(
-	policy *knet.NetworkPolicy, np *networkPolicy, portGroupIngressDenyName, portGroupEgressDenyName string,
+func (oc *Controller) addLocalPodHandler(policy *knet.NetworkPolicy, np *networkPolicy,
 	handleInitialItems func([]interface{}) error) error {
 
 	// NetworkPolicy is validated by the apiserver
@@ -1039,10 +1141,7 @@ func (oc *Controller) addLocalPodHandler(
 		sel,
 		handleInitialItems,
 		&NetworkPolicyExtraParameters{
-			policy:                   policy,
-			np:                       np,
-			portGroupIngressDenyName: portGroupIngressDenyName,
-			portGroupEgressDenyName:  portGroupEgressDenyName,
+			np: np,
 		})
 
 	podHandler, err := oc.WatchResource(retryLocalPods)
@@ -1068,8 +1167,7 @@ func hasAnyLabelSelector(peers []knet.NetworkPolicyPeer) bool {
 }
 
 // createNetworkPolicy creates a network policy
-func (oc *Controller) createNetworkPolicy(np *networkPolicy, policy *knet.NetworkPolicy, aclLogging *ACLLoggingLevels,
-	portGroupIngressDenyName, portGroupEgressDenyName string) error {
+func (oc *Controller) createNetworkPolicy(np *networkPolicy, policy *knet.NetworkPolicy, aclLogging *ACLLoggingLevels) error {
 
 	np.Lock()
 
@@ -1210,25 +1308,24 @@ func (oc *Controller) createNetworkPolicy(np *networkPolicy, policy *knet.Networ
 	// Add a handler to update the policy and deny port groups with the pods
 	// this policy applies to.
 	// Handle initial items locally to minimize DB ops.
-	var selectedPods []interface{}
 	handleInitialSelectedPods := func(objs []interface{}) error {
-		var errs []error
-		selectedPods = objs
-		policyPorts, ingressDenyPorts, egressDenyPorts := oc.processLocalPodSelectorSetPods(policy, np, selectedPods...)
-		pg.Ports = append(pg.Ports, policyPorts...)
-		ops, err = libovsdbops.AddPortsToPortGroupOps(oc.nbClient, ops, portGroupIngressDenyName, ingressDenyPorts...)
-		if err != nil {
-			oc.processLocalPodSelectorDelPods(np, selectedPods...)
-			errs = append(errs, err)
+		// get info for new pods that are not listed in np.localPods
+		portNamesToUUIDs, policyPortUUIDs, _ := oc.getNewLocalPolicyPorts(np, objs...)
+		pg.Ports = append(pg.Ports, policyPortUUIDs...)
+		// add pods to default deny port group
+		// make sure to only pass newly added pods
+		if err = oc.denyPGAddPorts(np, portNamesToUUIDs); err != nil {
+			// we don't need to delete policy ports from policy port group,
+			// because adding ports to port group is idempotent and can be retried
+			return fmt.Errorf("unable to add new pod to default deny port group: %v", err)
 		}
-		ops, err = libovsdbops.AddPortsToPortGroupOps(oc.nbClient, ops, portGroupEgressDenyName, egressDenyPorts...)
-		if err != nil {
-			oc.processLocalPodSelectorDelPods(np, selectedPods...)
-			errs = append(errs, err)
+		// all operations were successful, update np.localPods
+		for portName, portUUID := range portNamesToUUIDs {
+			np.localPods.Store(portName, portUUID)
 		}
-		return kerrorsutil.NewAggregate(errs)
+		return nil
 	}
-	err = oc.addLocalPodHandler(policy, np, portGroupIngressDenyName, portGroupEgressDenyName, handleInitialSelectedPods)
+	err = oc.addLocalPodHandler(policy, np, handleInitialSelectedPods)
 	if err != nil {
 		return fmt.Errorf("failed to handle local pod selector: %v", err)
 	}
@@ -1236,13 +1333,13 @@ func (oc *Controller) createNetworkPolicy(np *networkPolicy, policy *knet.Networ
 	np.Lock()
 	defer np.Unlock()
 	if np.deleted {
-		oc.processLocalPodSelectorDelPods(np, selectedPods...)
+		_ = oc.denyPGDeletePorts(np, nil, true)
 		return nil
 	}
 
 	ops, err = libovsdbops.CreateOrUpdatePortGroupsOps(oc.nbClient, ops, pg)
 	if err != nil {
-		oc.processLocalPodSelectorDelPods(np, selectedPods...)
+		_ = oc.denyPGDeletePorts(np, nil, true)
 		return fmt.Errorf("failed to create ops to add port to a port group: %v", err)
 	}
 
@@ -1255,7 +1352,7 @@ func (oc *Controller) createNetworkPolicy(np *networkPolicy, policy *knet.Networ
 
 	_, err = libovsdbops.TransactAndCheck(oc.nbClient, ops)
 	if err != nil {
-		oc.processLocalPodSelectorDelPods(np, selectedPods...)
+		_ = oc.denyPGDeletePorts(np, nil, true)
 		return fmt.Errorf("failed to run ovsdb txn to add ports to port group: %v", err)
 	}
 	txOkCallBack()
@@ -1286,40 +1383,26 @@ func (oc *Controller) addNetworkPolicy(policy *knet.NetworkPolicy) error {
 	np := NewNetworkPolicy(policy)
 
 	if len(nsInfo.networkPolicies) == 0 {
-		err = oc.createDefaultDenyPGAndACLs(policy.Namespace, policy.Name, nsInfo)
+		err := oc.addPolicyToDefaultPortGroups(np, &nsInfo.aclLogging)
 		if err != nil {
 			nsUnlock()
-			return fmt.Errorf("failed to create default port groups and acls for policy: %s/%s, error: %v",
+			return fmt.Errorf("adding network policy %s/%s failed: %v",
 				policy.Namespace, policy.Name, err)
 		}
 		defer func() {
 			if err != nil {
-				nsInfo, nsUnlock, errDelete := oc.ensureNamespaceLocked(policy.Namespace, false, nil)
+				errDelete := oc.delPolicyFromDefaultPortGroups(np)
 				// rollback failed, best effort cleanup; won't add to retry mechanism since item doesn't exist in cache yet.
 				if errDelete != nil {
 					klog.Warningf("Rollback of default port groups and acls for policy: %s/%s failed, Unable to ensure namespace for network policy: error %v", policy.Namespace, policy.Name, errDelete)
 					return
 				}
-				if len(nsInfo.networkPolicies) == 0 {
-					// try rolling-back since creation of default acls/pgs failed
-					errDelete = oc.deleteDefaultDenyPGAndACLs(policy.Namespace, policy.Name, nsInfo)
-					nsUnlock()
-					if errDelete != nil {
-						// rollback failed, best effort cleanup; won't add to retry mechanism since item doesn't exist in cache yet.
-						klog.Warningf("Rollback of default port groups and acls for policy: %s/%s failed: error %v", policy.Namespace, policy.Name, errDelete)
-					}
-				} else {
-					nsUnlock()
-				}
 			}
 		}()
 	}
 	aclLogging := nsInfo.aclLogging
-	portGroupIngressDenyName := nsInfo.portGroupIngressDenyName
-	portGroupEgressDenyName := nsInfo.portGroupEgressDenyName
 	nsUnlock()
-	if err := oc.createNetworkPolicy(np, policy, &aclLogging,
-		portGroupIngressDenyName, portGroupEgressDenyName); err != nil {
+	if err := oc.createNetworkPolicy(np, policy, &aclLogging); err != nil {
 		return fmt.Errorf("failed to create Network Policy: %s/%s, error: %v",
 			policy.Namespace, policy.Name, err)
 	}
@@ -1330,7 +1413,7 @@ func (oc *Controller) addNetworkPolicy(policy *knet.NetworkPolicy) error {
 		// rollback network policy
 		if err := oc.deleteNetworkPolicy(policy, np); err != nil {
 			// rollback failed, add to retry to cleanup
-			key := getPolicyNamespacedName(policy)
+			key := getPolicyKey(policy)
 			oc.retryNetworkPolicies.DoWithLock(key, func(key string) {
 				oc.retryNetworkPolicies.initRetryObjWithDelete(policy, key, np, false)
 			})
@@ -1346,7 +1429,7 @@ func (oc *Controller) addNetworkPolicy(policy *knet.NetworkPolicy) error {
 			klog.Warningf(err.Error())
 		} else {
 			klog.Infof("Policy %s: ACL logging setting updated to deny=%s allow=%s",
-				getPolicyNamespacedName(policy), nsInfo.aclLogging.Deny, nsInfo.aclLogging.Allow)
+				getPolicyKey(policy), nsInfo.aclLogging.Deny, nsInfo.aclLogging.Allow)
 		}
 	}
 	// The allow logging level was updated while we were creating the policy if
@@ -1358,7 +1441,7 @@ func (oc *Controller) addNetworkPolicy(policy *knet.NetworkPolicy) error {
 			klog.Warningf(err.Error())
 		} else {
 			klog.Infof("Policy %s: ACL logging setting updated to deny=%s allow=%s",
-				getPolicyNamespacedName(policy), nsInfo.aclLogging.Deny, nsInfo.aclLogging.Allow)
+				getPolicyKey(policy), nsInfo.aclLogging.Deny, nsInfo.aclLogging.Allow)
 		}
 	}
 	nsInfo.networkPolicies[policy.Name] = np
@@ -1396,7 +1479,7 @@ func (oc *Controller) deleteNetworkPolicy(policy *knet.NetworkPolicy, np *networ
 			return nil
 		}
 
-		if err := oc.destroyNetworkPolicy(np, false); err != nil {
+		if err := oc.destroyNetworkPolicy(np); err != nil {
 			return fmt.Errorf("failed to destroy network policy: %s/%s", policy.Namespace, policy.Name)
 		}
 		return nil
@@ -1407,18 +1490,15 @@ func (oc *Controller) deleteNetworkPolicy(policy *knet.NetworkPolicy, np *networ
 	// try to use the more official np found in nsInfo
 	// also, if this is called during the process of the policy creation, the current network policy
 	// may not be added to nsInfo.networkPolicies yet.
-	expectedLastPolicyNum := 0
 	foundNp, ok := nsInfo.networkPolicies[policy.Name]
 	if ok {
-		expectedLastPolicyNum = 1
 		np = foundNp
 	}
 	if np == nil {
 		klog.Warningf("Unable to delete network policy: %s/%s since its not found in cache", policy.Namespace, policy.Name)
 		return nil
 	}
-	isLastPolicyInNamespace := len(nsInfo.networkPolicies) == expectedLastPolicyNum
-	if err := oc.destroyNetworkPolicy(np, isLastPolicyInNamespace); err != nil {
+	if err := oc.destroyNetworkPolicy(np); err != nil {
 		return fmt.Errorf("failed to destroy network policy: %s/%s", policy.Namespace, policy.Name)
 	}
 
@@ -1429,58 +1509,19 @@ func (oc *Controller) deleteNetworkPolicy(policy *knet.NetworkPolicy, np *networ
 // destroys a particular network policy
 // if nsInfo is provided, the entire port group will be deleted for ingress/egress directions
 // lastPolicy indicates if no other policies are using the respective portgroup anymore
-func (oc *Controller) destroyNetworkPolicy(np *networkPolicy, lastPolicy bool) error {
+func (oc *Controller) destroyNetworkPolicy(np *networkPolicy) error {
 	np.Lock()
 	defer np.Unlock()
 	np.deleted = true
 	oc.shutdownHandlers(np)
-
-	ports := []*lpInfo{}
-	np.localPods.Range(func(_, value interface{}) bool {
-		portInfo := value.(*lpInfo)
-		ports = append(ports, portInfo)
-		return true
-	})
-
 	var err error
-	ingressPGName := defaultDenyPortGroup(np.namespace, ingressDefaultDenySuffix)
-	egressPGName := defaultDenyPortGroup(np.namespace, egressDefaultDenySuffix)
 
-	ingressDenyPorts, egressDenyPorts := oc.localPodDelDefaultDeny(np, ports...)
-	defer func() {
-		// In case of error, undo localPodDelDefaultDeny() and restore lspIngressDenyCache/lspEgressDenyCache refcnt.
-		// Deletion will be retried.
-		if err != nil {
-			oc.localPodAddDefaultDeny(np.policy, ports...)
-		}
-	}()
+	err = oc.denyPGDeletePorts(np, nil, true)
+	if err != nil {
+		return fmt.Errorf("unable to delete ports from defaultDeny port group: %v", err)
+	}
 
 	ops := []ovsdb.Operation{}
-	// we haven't deleted our np from the namespace yet so there should be 1 policy
-	// if there are no more policies left on the namespace
-	if lastPolicy {
-		ops, err = libovsdbops.DeletePortGroupsOps(oc.nbClient, ops, ingressPGName)
-		if err != nil {
-			return fmt.Errorf("failed to make ops for delete ingress port group: %s, for policy: %s/%s, error: %v",
-				ingressPGName, np.namespace, np.name, err)
-		}
-		ops, err = libovsdbops.DeletePortGroupsOps(oc.nbClient, ops, egressPGName)
-		if err != nil {
-			return fmt.Errorf("failed to make ops for delete egress port group: %s, for policy: %s/%s, error: %v",
-				egressPGName, np.namespace, np.name, err)
-		}
-	} else {
-		ops, err = libovsdbops.DeletePortsFromPortGroupOps(oc.nbClient, ops, ingressPGName, ingressDenyPorts...)
-		if err != nil {
-			return fmt.Errorf("failed to make ops for ingress port group: %s, for policy: %s/%s, to remove ports: %#v,"+
-				" error: %v", ingressPGName, np.namespace, np.name, ingressDenyPorts, err)
-		}
-		ops, err = libovsdbops.DeletePortsFromPortGroupOps(oc.nbClient, ops, egressPGName, egressDenyPorts...)
-		if err != nil {
-			return fmt.Errorf("failed to make ops for egress port group: %s, for policy: %s/%s, to remove ports: %#v,"+
-				" error: %v", egressPGName, np.namespace, np.name, egressDenyPorts, err)
-		}
-	}
 
 	// Delete the port group
 	ops, err = libovsdbops.DeletePortGroupsOps(oc.nbClient, ops, np.portGroupName)
@@ -1518,6 +1559,12 @@ func (oc *Controller) destroyNetworkPolicy(np *networkPolicy, lastPolicy bool) e
 				np.namespace, np.name, err)
 		}
 	}
+
+	err = oc.delPolicyFromDefaultPortGroups(np)
+	if err != nil {
+		return fmt.Errorf("unable to delete policy from default deny port groups: %v", err)
+	}
+
 	return nil
 }
 
@@ -1571,12 +1618,9 @@ func (oc *Controller) handlePeerServiceDelete(gp *gressPolicy, service *kapi.Ser
 }
 
 type NetworkPolicyExtraParameters struct {
-	policy                   *knet.NetworkPolicy
-	np                       *networkPolicy
-	gp                       *gressPolicy
-	podSelector              labels.Selector
-	portGroupIngressDenyName string
-	portGroupEgressDenyName  string
+	np          *networkPolicy
+	gp          *gressPolicy
+	podSelector labels.Selector
 }
 
 // Watch services that are in the same Namespace as the NP
@@ -1731,6 +1775,11 @@ func (oc *Controller) shutdownHandlers(np *networkPolicy) {
 	}
 }
 
-func getPolicyNamespacedName(policy *knet.NetworkPolicy) string {
+// The following 2 function should return the same key for network policy based on k8s on internal networkPolicy object
+func getPolicyKey(policy *knet.NetworkPolicy) string {
 	return fmt.Sprintf("%v/%v", policy.Namespace, policy.Name)
+}
+
+func (np *networkPolicy) getKey() string {
+	return fmt.Sprintf("%v/%v", np.namespace, np.name)
 }

--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -998,9 +998,9 @@ func (oc *Controller) getExistingLocalPolicyPorts(np *networkPolicy,
 }
 
 // denyPGAddPorts adds ports to default deny port groups.
-func (oc *Controller) denyPGAddPorts(np *networkPolicy, portNamesToUUIDs map[string]string) error {
+// It also can take existing ops e.g. to add port to network policy port group and transact it.
+func (oc *Controller) denyPGAddPorts(np *networkPolicy, portNamesToUUIDs map[string]string, ops []ovsdb.Operation) error {
 	var err error
-	var ops []ovsdb.Operation
 	ingressDenyPGName := defaultDenyPortGroupName(np.namespace, ingressDefaultDenySuffix)
 	egressDenyPGName := defaultDenyPortGroupName(np.namespace, egressDefaultDenySuffix)
 
@@ -1034,20 +1034,20 @@ func (oc *Controller) denyPGAddPorts(np *networkPolicy, portNamesToUUIDs map[str
 		if err != nil {
 			return fmt.Errorf("unable to get add ports to %s port group ops: %v", egressDenyPGName, err)
 		}
-
-		_, err = libovsdbops.TransactAndCheck(oc.nbClient, ops)
-		if err != nil {
-			return fmt.Errorf("unable to transact add ports to default deny port groups: %v", err)
-		}
+	}
+	_, err = libovsdbops.TransactAndCheck(oc.nbClient, ops)
+	if err != nil {
+		return fmt.Errorf("unable to transact add ports to default deny port groups: %v", err)
 	}
 	return nil
 }
 
 // denyPGDeletePorts deletes ports from default deny port groups.
 // Set useLocalPods = true, when deleting networkPolicy to remove all its ports from defaultDeny port groups.
-func (oc *Controller) denyPGDeletePorts(np *networkPolicy, portNamesToUUIDs map[string]string, useLocalPods bool) error {
+// It also can take existing ops e.g. to delete ports from network policy port group and transact it.
+func (oc *Controller) denyPGDeletePorts(np *networkPolicy, portNamesToUUIDs map[string]string, useLocalPods bool,
+	ops []ovsdb.Operation) error {
 	var err error
-	var ops []ovsdb.Operation
 	if useLocalPods {
 		portNamesToUUIDs = map[string]string{}
 		np.localPods.Range(func(key, value interface{}) bool {
@@ -1055,49 +1055,47 @@ func (oc *Controller) denyPGDeletePorts(np *networkPolicy, portNamesToUUIDs map[
 			return true
 		})
 	}
-	if len(portNamesToUUIDs) == 0 {
-		return nil
-	}
+	if len(portNamesToUUIDs) != 0 {
+		ingressDenyPGName := defaultDenyPortGroupName(np.namespace, ingressDefaultDenySuffix)
+		egressDenyPGName := defaultDenyPortGroupName(np.namespace, egressDefaultDenySuffix)
 
-	ingressDenyPGName := defaultDenyPortGroupName(np.namespace, ingressDefaultDenySuffix)
-	egressDenyPGName := defaultDenyPortGroupName(np.namespace, egressDefaultDenySuffix)
+		pgKey := np.namespace
+		// this lock guarantees that sharedPortGroup counters will be updated atomically
+		// with adding port to port group in db.
+		oc.sharedNetpolPortGroups.LockKey(pgKey)
+		defer oc.sharedNetpolPortGroups.UnlockKey(pgKey)
+		sharedPGs, ok := oc.sharedNetpolPortGroups.Load(pgKey)
+		if !ok {
+			// Port group doesn't exist, nothing to clean up
+			klog.Infof("Skip delete ports from default deny port group: port group doesn't exist")
+		} else {
+			ingressDenyPorts, egressDenyPorts := sharedPGs.deletePortsForPolicy(np, portNamesToUUIDs)
+			// counters were updated, update back to initial values on error
+			defer func() {
+				if err != nil {
+					sharedPGs.addPortsForPolicy(np, portNamesToUUIDs)
+				}
+			}()
 
-	pgKey := np.namespace
-	// this lock guarantees that sharedPortGroup counters will be updated atomically
-	// with adding port to port group in db.
-	oc.sharedNetpolPortGroups.LockKey(pgKey)
-	defer oc.sharedNetpolPortGroups.UnlockKey(pgKey)
-	sharedPGs, ok := oc.sharedNetpolPortGroups.Load(pgKey)
-	if !ok {
-		// Port group doesn't exist, nothing to clean up
-		klog.Infof("Skip delete ports from default deny port group: port group doesn't exist")
-		return nil
-	}
+			if len(ingressDenyPorts) != 0 || len(egressDenyPorts) != 0 {
+				// db changes required
+				ops, err = libovsdbops.DeletePortsFromPortGroupOps(oc.nbClient, ops, ingressDenyPGName, ingressDenyPorts...)
+				if err != nil {
+					return fmt.Errorf("unable to get del ports from %s port group ops: %v", ingressDenyPGName, err)
+				}
 
-	ingressDenyPorts, egressDenyPorts := sharedPGs.deletePortsForPolicy(np, portNamesToUUIDs)
-	// counters were updated, update back to initial values on error
-	defer func() {
-		if err != nil {
-			sharedPGs.addPortsForPolicy(np, portNamesToUUIDs)
-		}
-	}()
-
-	if len(ingressDenyPorts) != 0 || len(egressDenyPorts) != 0 {
-		// db changes required
-		ops, err = libovsdbops.DeletePortsFromPortGroupOps(oc.nbClient, ops, ingressDenyPGName, ingressDenyPorts...)
-		if err != nil {
-			return fmt.Errorf("unable to get del ports from %s port group ops: %v", ingressDenyPGName, err)
-		}
-
-		ops, err = libovsdbops.DeletePortsFromPortGroupOps(oc.nbClient, ops, egressDenyPGName, egressDenyPorts...)
-		if err != nil {
-			return fmt.Errorf("unable to get del ports from %s port group ops: %v", egressDenyPGName, err)
-		}
-		_, err = libovsdbops.TransactAndCheck(oc.nbClient, ops)
-		if err != nil {
-			return fmt.Errorf("unable to transact del ports from default deny port groups: %v", err)
+				ops, err = libovsdbops.DeletePortsFromPortGroupOps(oc.nbClient, ops, egressDenyPGName, egressDenyPorts...)
+				if err != nil {
+					return fmt.Errorf("unable to get del ports from %s port group ops: %v", egressDenyPGName, err)
+				}
+			}
 		}
 	}
+	_, err = libovsdbops.TransactAndCheck(oc.nbClient, ops)
+	if err != nil {
+		return fmt.Errorf("unable to transact del ports from default deny port groups: %v", err)
+	}
+
 	return nil
 }
 
@@ -1120,15 +1118,10 @@ func (oc *Controller) handleLocalPodSelectorAddFunc(np *networkPolicy, objs ...i
 		if err != nil {
 			return fmt.Errorf("unable to get ops to add new pod to policy port group: %v", err)
 		}
-		_, err = libovsdbops.TransactAndCheck(oc.nbClient, ops)
-		if err != nil {
-			return fmt.Errorf("unable to transact add new pod to policy port group: %v", err)
-		}
 		// add pods to default deny port group
 		// make sure to only pass newly added pods
-		if err = oc.denyPGAddPorts(np, portNamesToUUIDs); err != nil {
-			// we don't need to delete policy ports from policy port group,
-			// because adding ports to port group is idempotent and can be retried
+		// ops will be transacted by denyPGAddPorts
+		if err = oc.denyPGAddPorts(np, portNamesToUUIDs, ops); err != nil {
 			return fmt.Errorf("unable to add new pod to default deny port group: %v", err)
 		}
 		// all operations were successful, update np.localPods
@@ -1166,14 +1159,8 @@ func (oc *Controller) handleLocalPodSelectorDelFunc(np *networkPolicy, objs ...i
 		if err != nil {
 			return fmt.Errorf("unable to get ops to add new pod to policy port group: %v", err)
 		}
-		_, err = libovsdbops.TransactAndCheck(oc.nbClient, ops)
-		if err != nil {
-			return fmt.Errorf("unable to transact add new pod to policy port group: %v", err)
-		}
 		// delete pods from default deny port group
-		if err = oc.denyPGDeletePorts(np, portNamesToUUIDs, false); err != nil {
-			// we don't need to add policy ports back to policy port group,
-			// because delete ports from port group is idempotent and can be retried
+		if err = oc.denyPGDeletePorts(np, portNamesToUUIDs, false, ops); err != nil {
 			return fmt.Errorf("unable to add new pod to default deny port group: %v", err)
 		}
 		// all operations were successful, update np.localPods
@@ -1610,16 +1597,6 @@ func (oc *Controller) cleanupNetworkPolicy(np *networkPolicy) error {
 	oc.shutdownHandlers(np)
 	var err error
 
-	err = oc.denyPGDeletePorts(np, nil, true)
-	if err != nil {
-		return fmt.Errorf("unable to delete ports from defaultDeny port group: %v", err)
-	}
-
-	err = oc.delPolicyFromDefaultPortGroups(np)
-	if err != nil {
-		return fmt.Errorf("unable to delete policy from default deny port groups: %v", err)
-	}
-
 	// Delete the port group, idempotent
 	ops, err := libovsdbops.DeletePortGroupsOps(oc.nbClient, nil, np.portGroupName)
 	if err != nil {
@@ -1632,12 +1609,19 @@ func (oc *Controller) cleanupNetworkPolicy(np *networkPolicy) error {
 	}
 	ops = append(ops, recordOps...)
 
-	_, err = libovsdbops.TransactAndCheck(oc.nbClient, ops)
+	err = oc.denyPGDeletePorts(np, nil, true, ops)
 	if err != nil {
-		return fmt.Errorf("failed to execute ovsdb txn to delete network policy: %s/%s, error: %v",
-			np.namespace, np.name, err)
+		return fmt.Errorf("unable to delete ports from defaultDeny port group: %v", err)
 	}
+	// transaction was successful, exec callback
 	txOkCallBack()
+	// cleanup local pods, since they were deleted from port groups
+	np.localPods = sync.Map{}
+
+	err = oc.delPolicyFromDefaultPortGroups(np)
+	if err != nil {
+		return fmt.Errorf("unable to delete policy from default deny port groups: %v", err)
+	}
 
 	// Delete ingress/egress address sets, idempotent
 	for i, policy := range np.ingressPolicies {

--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -1022,7 +1022,7 @@ func (oc *Controller) handleLocalPodSelectorDelFunc(policy *knet.NetworkPolicy, 
 	return kerrorsutil.NewAggregate(errs)
 }
 
-func (oc *Controller) handleLocalPodSelector(
+func (oc *Controller) addLocalPodHandler(
 	policy *knet.NetworkPolicy, np *networkPolicy, portGroupIngressDenyName, portGroupEgressDenyName string,
 	handleInitialItems func([]interface{}) error) error {
 
@@ -1047,7 +1047,7 @@ func (oc *Controller) handleLocalPodSelector(
 
 	podHandler, err := oc.WatchResource(retryLocalPods)
 	if err != nil {
-		klog.Errorf("Failed WatchResource for handleLocalPodSelector: %v", err)
+		klog.Errorf("Failed WatchResource for addLocalPodHandler: %v", err)
 		return err
 	}
 
@@ -1112,7 +1112,7 @@ func (oc *Controller) createNetworkPolicy(np *networkPolicy, policy *knet.Networ
 				return err
 			}
 			// Start service handlers ONLY if there's an ingress Address Set
-			if err := oc.handlePeerService(policy, ingress, np); err != nil {
+			if err := oc.addPeerServiceHandler(policy, ingress, np); err != nil {
 				np.Unlock()
 				return err
 			}
@@ -1176,15 +1176,15 @@ func (oc *Controller) createNetworkPolicy(np *networkPolicy, policy *knet.Networ
 			// For each rule that contains both peer namespace selector and
 			// peer pod selector, we create a watcher for each matching namespace
 			// that populates the addressSet
-			err = oc.handlePeerNamespaceAndPodSelector(handler.namespaceSelector, handler.podSelector, handler.gress, np)
+			err = oc.addPeerNamespaceAndPodHandler(handler.namespaceSelector, handler.podSelector, handler.gress, np)
 		} else if handler.namespaceSelector != nil {
 			// For each peer namespace selector, we create a watcher that
 			// populates ingress.peerAddressSets
-			err = oc.handlePeerNamespaceSelector(handler.namespaceSelector, handler.gress, np)
+			err = oc.addPeerNamespaceHandler(handler.namespaceSelector, handler.gress, np)
 		} else if handler.podSelector != nil {
 			// For each peer pod selector, we create a watcher that
 			// populates the addressSet
-			err = oc.handlePeerPodSelector(policy, handler.podSelector,
+			err = oc.addPeerPodHandler(policy, handler.podSelector,
 				handler.gress, np)
 		}
 		if err != nil {
@@ -1228,7 +1228,7 @@ func (oc *Controller) createNetworkPolicy(np *networkPolicy, policy *knet.Networ
 		}
 		return kerrorsutil.NewAggregate(errs)
 	}
-	err = oc.handleLocalPodSelector(policy, np, portGroupIngressDenyName, portGroupEgressDenyName, handleInitialSelectedPods)
+	err = oc.addLocalPodHandler(policy, np, portGroupIngressDenyName, portGroupEgressDenyName, handleInitialSelectedPods)
 	if err != nil {
 		return fmt.Errorf("failed to handle local pod selector: %v", err)
 	}
@@ -1581,7 +1581,7 @@ type NetworkPolicyExtraParameters struct {
 
 // Watch services that are in the same Namespace as the NP
 // To account for hairpined traffic
-func (oc *Controller) handlePeerService(
+func (oc *Controller) addPeerServiceHandler(
 	policy *knet.NetworkPolicy, gp *gressPolicy, np *networkPolicy) error {
 	// start watching services in the same namespace as the network policy
 	retryPeerServices := NewRetryObjs(
@@ -1592,7 +1592,7 @@ func (oc *Controller) handlePeerService(
 
 	serviceHandler, err := oc.WatchResource(retryPeerServices)
 	if err != nil {
-		klog.Errorf("Failed WatchResource for handlePeerService: %v", err)
+		klog.Errorf("Failed WatchResource for addPeerServiceHandler: %v", err)
 		return err
 	}
 
@@ -1600,7 +1600,7 @@ func (oc *Controller) handlePeerService(
 	return nil
 }
 
-func (oc *Controller) handlePeerPodSelector(
+func (oc *Controller) addPeerPodHandler(
 	policy *knet.NetworkPolicy, podSelector *metav1.LabelSelector,
 	gp *gressPolicy, np *networkPolicy) error {
 
@@ -1609,15 +1609,18 @@ func (oc *Controller) handlePeerPodSelector(
 
 	// start watching pods in the same namespace as the network policy and selected by the
 	// label selector
+	syncFunc := func(objs []interface{}) error {
+		return oc.handlePeerPodSelectorAddUpdate(gp, objs...)
+	}
 	retryPeerPods := NewRetryObjs(
 		factory.PeerPodSelectorType,
 		policy.Namespace,
-		sel, nil,
+		sel, syncFunc,
 		&NetworkPolicyExtraParameters{gp: gp})
 
 	podHandler, err := oc.WatchResource(retryPeerPods)
 	if err != nil {
-		klog.Errorf("Failed WatchResource for handlePeerPodSelector: %v", err)
+		klog.Errorf("Failed WatchResource for addPeerPodHandler: %v", err)
 		return err
 	}
 
@@ -1625,7 +1628,7 @@ func (oc *Controller) handlePeerPodSelector(
 	return nil
 }
 
-func (oc *Controller) handlePeerNamespaceAndPodSelector(
+func (oc *Controller) addPeerNamespaceAndPodHandler(
 	namespaceSelector *metav1.LabelSelector,
 	podSelector *metav1.LabelSelector,
 	gp *gressPolicy,
@@ -1649,7 +1652,7 @@ func (oc *Controller) handlePeerNamespaceAndPodSelector(
 
 	namespaceHandler, err := oc.WatchResource(retryPeerNamespaces)
 	if err != nil {
-		klog.Errorf("Failed WatchResource for handlePeerNamespaceAndPodSelector: %v", err)
+		klog.Errorf("Failed WatchResource for addPeerNamespaceAndPodHandler: %v", err)
 		return err
 	}
 
@@ -1680,7 +1683,7 @@ func (oc *Controller) handlePeerNamespaceSelectorOnUpdate(np *networkPolicy, gp 
 	return nil
 }
 
-func (oc *Controller) handlePeerNamespaceSelector(
+func (oc *Controller) addPeerNamespaceHandler(
 	namespaceSelector *metav1.LabelSelector,
 	gress *gressPolicy, np *networkPolicy) error {
 
@@ -1688,15 +1691,27 @@ func (oc *Controller) handlePeerNamespaceSelector(
 	sel, _ := metav1.LabelSelectorAsSelector(namespaceSelector)
 
 	// start watching namespaces selected by the namespace selector
+	syncFunc := func(i []interface{}) error {
+		// This needs to be a write lock because there's no locking around 'gress policies
+		np.Lock()
+		defer np.Unlock()
+		// We load the existing address set into the 'gress policy.
+		// Notice that this will make the AddFunc for this initial
+		// address set a noop.
+		// The ACL must be set explicitly after setting up this handler
+		// for the address set to be considered.
+		gress.addNamespaceAddressSets(i)
+		return nil
+	}
 	retryPeerNamespaces := NewRetryObjs(
 		factory.PeerNamespaceSelectorType,
-		"", sel, nil,
+		"", sel, syncFunc,
 		&NetworkPolicyExtraParameters{gp: gress, np: np},
 	)
 
 	namespaceHandler, err := oc.WatchResource(retryPeerNamespaces)
 	if err != nil {
-		klog.Errorf("Failed WatchResource for handlePeerNamespaceSelector: %v", err)
+		klog.Errorf("Failed WatchResource for addPeerNamespaceHandler: %v", err)
 		return err
 	}
 

--- a/go-controller/pkg/ovn/policy_test.go
+++ b/go-controller/pkg/ovn/policy_test.go
@@ -102,7 +102,7 @@ const (
 
 func (n kNetworkPolicy) getDefaultDenyData(networkPolicy *knet.NetworkPolicy, ports []string, logSeverity nbdb.ACLSeverity, oldEgress bool) []libovsdb.TestData {
 	pgHash := hashedPortGroup(networkPolicy.Namespace)
-	policyTypeIngress, policyTypeEgress := policyType(networkPolicy)
+	policyTypeIngress, policyTypeEgress := getPolicyType(networkPolicy)
 	shouldBeLogged := logSeverity != ""
 	egressDirection := nbdb.ACLDirectionFromLport
 	egressOptions := map[string]string{
@@ -1331,7 +1331,6 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				acls := []libovsdb.TestData{}
 				acls = append(acls, gressPolicy1ExpectedData[:len(gressPolicy1ExpectedData)-1]...)
 				acls = append(acls, gressPolicy2ExpectedData[:len(gressPolicy2ExpectedData)-1]...)
-				acls = append(acls, defaultDenyExpectedData[:len(defaultDenyExpectedData)-2]...)
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdb.HaveData(append(acls, getExpectedDataPodsAndSwitches([]testPod{nPodTest}, []string{"node1"})...)))
 
 				return nil
@@ -1451,7 +1450,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				// sleep long enough for TransactWithRetry to fail, causing NP Add to fail
 				time.Sleep(types.OVSDBTimeout + time.Second)
 				// check to see if the retry cache has an entry for this policy
-				key := getPolicyNamespacedName(networkPolicy2)
+				key := getPolicyKey(networkPolicy2)
 				checkRetryObjectEventually(key, true, fakeOvn.controller.retryNetworkPolicies)
 
 				connCtx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout)
@@ -1582,7 +1581,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				// sleep long enough for TransactWithRetry to fail, causing NP Add to fail
 				time.Sleep(types.OVSDBTimeout + time.Second)
 				// check to see if the retry cache has an entry for this policy
-				key := getPolicyNamespacedName(networkPolicy2)
+				key := getPolicyKey(networkPolicy2)
 				checkRetryObjectEventually(key, true, fakeOvn.controller.retryNetworkPolicies)
 				if retryEntry, found := getRetryObj(key, fakeOvn.controller.retryNetworkPolicies); found {
 					ginkgo.By("retry entry new policy should be nil")
@@ -1612,7 +1611,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				expectedData = append(expectedData, getExpectedDataPodsAndSwitches([]testPod{nPodTest}, []string{"node1"})...)
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdb.HaveData(expectedData...))
 				// check the cache no longer has the entry
-				key = getPolicyNamespacedName(networkPolicy)
+				key = getPolicyKey(networkPolicy)
 				checkRetryObjectEventually(key, false, fakeOvn.controller.retryNetworkPolicies)
 				return nil
 			}
@@ -1729,9 +1728,9 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 
 				err = fakeOvn.controller.addNetworkPolicy(networkPolicy)
 				gomega.Expect(err).To(gomega.HaveOccurred())
-				gomega.Expect(err.Error()).To(gomega.ContainSubstring("failed to create default port groups and acls " +
-					"for policy: abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk/networkpolicy1, " +
-					"error: unexpectedly found multiple results for provided predicate"))
+				gomega.Expect(err.Error()).To(gomega.ContainSubstring("adding network policy " +
+					"abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk/networkpolicy1 failed: " +
+					"failed to create default deny port groups: unexpectedly found multiple results for provided predicate"))
 
 				//ensure the default PGs and ACLs were removed via rollback from add failure
 				expectedData := []libovsdb.TestData{}
@@ -2244,12 +2243,13 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				nsInfo.networkPolicies = map[string]*networkPolicy{} // reset cache so that we simulate the add that happens during upgrades
 				nsUnlock()
+				fakeOvn.controller.sharedNetpolPortGroups.Delete(networkPolicy1.Namespace)
 				err = fakeOvn.controller.addNetworkPolicy(networkPolicy1)
 				// TODO: FIX ME
 				gomega.Expect(err).To(gomega.HaveOccurred())
-				gomega.Expect(err.Error()).To(gomega.ContainSubstring("failed to create default port groups and acls " +
-					"for policy: abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk/networkpolicy1, " +
-					"error: unexpectedly found multiple results for provided predicate"))
+				gomega.Expect(err.Error()).To(gomega.ContainSubstring("adding network policy " +
+					"abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk/networkpolicy1 failed: " +
+					"failed to create default deny port groups: unexpectedly found multiple results for provided predicate"))
 
 				return nil
 			}
@@ -2857,7 +2857,6 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 
 				acls := []libovsdb.TestData{}
 				acls = append(acls, gressPolicyExpectedData[:len(gressPolicyExpectedData)-1]...)
-				acls = append(acls, defaultDenyExpectedData[:len(defaultDenyExpectedData)-2]...)
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdb.HaveData(append(acls, getExpectedDataPodsAndSwitches([]testPod{nPodTest}, []string{"node1"})...)))
 
 				return nil
@@ -2961,7 +2960,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				// sleep long enough for TransactWithRetry to fail, causing NP Add to fail
 				time.Sleep(types.OVSDBTimeout + time.Second)
 				// check to see if the retry cache has an entry for this policy
-				key := getPolicyNamespacedName(networkPolicy)
+				key := getPolicyKey(networkPolicy)
 				checkRetryObjectEventually(key, true, fakeOvn.controller.retryNetworkPolicies)
 				connCtx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout)
 				defer cancel()
@@ -2973,7 +2972,6 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 
 				acls := []libovsdb.TestData{}
 				acls = append(acls, gressPolicyExpectedData[:len(gressPolicyExpectedData)-1]...)
-				acls = append(acls, defaultDenyExpectedData[:len(defaultDenyExpectedData)-2]...)
 				gomega.Eventually(fakeOvn.controller.nbClient).Should(libovsdb.HaveData(append(acls, getExpectedDataPodsAndSwitches([]testPod{nPodTest}, []string{"node1"})...)))
 
 				// check the cache no longer has the entry
@@ -3067,7 +3065,6 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				// TODO: test server does not garbage collect ACLs, so we just expect policy & deny portgroups to be removed
 				acls := []libovsdb.TestData{}
 				acls = append(acls, gressPolicy1ExpectedData[:len(gressPolicy1ExpectedData)-1]...)
-				acls = append(acls, defaultDenyExpectedData[:len(defaultDenyExpectedData)-2]...)
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdb.HaveData(append(acls, getExpectedDataPodsAndSwitches([]testPod{nPodTest}, []string{"node1"})...)))
 
 				return nil
@@ -3159,7 +3156,6 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				// TODO: test server does not garbage collect ACLs, so we just expect policy & deny portgroups to be removed
 				acls := []libovsdb.TestData{}
 				acls = append(acls, gressPolicy1ExpectedData[:len(gressPolicy1ExpectedData)-1]...)
-				acls = append(acls, defaultDenyExpectedData[:len(defaultDenyExpectedData)-2]...)
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdb.HaveData(append(acls, getExpectedDataPodsAndSwitches([]testPod{nPodTest}, []string{"node1"})...)))
 
 				return nil

--- a/go-controller/pkg/ovn/port_cache.go
+++ b/go-controller/pkg/ovn/port_cache.go
@@ -70,7 +70,7 @@ func (c *portCache) remove(logicalPort string) {
 	info.expires = time.Now().Add(time.Minute)
 	klog.V(5).Infof("port-cache(%s): scheduling port for removal at %v", logicalPort, info.expires)
 
-	// Removal must be deferred since, for example, NetworkPolicy pod handlers
+	// Removal must be deferred, since some handlers
 	// may run after the main pod handler and look for items in the cache
 	// on delete events.
 	go func() {


### PR DESCRIPTION
This a downstream cherry-pick for network policy fixes, some of the bugs that are fixed listed in the linked bug
https://github.com/ovn-org/ovn-kubernetes/pull/3146
https://github.com/ovn-org/ovn-kubernetes/pull/3161
https://github.com/ovn-org/ovn-kubernetes/pull/3191
https://github.com/ovn-org/ovn-kubernetes/pull/3205

There were 2 merge conflicts:
1. downstream-only fields https://github.com/openshift/ovn-kubernetes/blob/master/go-controller/pkg/ovn/ovn.go#L80-L81 were moved together with `namespaceInfo` struct to namespace
2. https://github.com/openshift/ovn-kubernetes/pull/1300 is merged between commits in this PR upstream, but was cherry-picked downstream before. Therefore some changes for `policy_test.go` were reapplied in correct order, see commit messages for more info on conflict resolution.

