### PR TITLE
OCPBUGS-2660: Add logging verbosity to configuring OVN logs

### DIFF
--- a/go-controller/pkg/libovsdbops/transact.go
+++ b/go-controller/pkg/libovsdbops/transact.go
@@ -38,7 +38,7 @@ func TransactAndCheck(c client.Client, ops []ovsdb.Operation) ([]ovsdb.Operation
 		return []ovsdb.OperationResult{{}}, nil
 	}
 
-	klog.Infof("Configuring OVN: %+v", ops)
+	klog.V(5).Infof("Configuring OVN: %+v", ops)
 
 	ctx, cancel := context.WithTimeout(context.TODO(), types.OVSDBTimeout)
 	defer cancel()


### PR DESCRIPTION
When updating a large number of address_set, logs get flooded with "Configuring OVN" which cannot be reduced.
Also klog shows up in the profiling data as a source of CPU consumption of ovnkube-master.

We make it configurable and assign it a verbosity of 5. Default on OpenShift is 4, however this log is redundant with the "transacting operations" that is already logged with level 4.

Reported-at: https://issues.redhat.com/browse/OCPBUGS-1643
Signed-off-by: François Rigault <frigo@amadeus.com>
Signed-off-by: Jamo Luhrsen <jluhrsen@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->