### PR TITLE
OCPBUGS-1427: Ignore non-ready endpoints when processing endpointslices

### DIFF
--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -708,7 +708,11 @@ func (npw *nodePortWatcher) AddEndpointSlice(epSlice *discovery.EndpointSlice) {
 	// Here we make sure the correct rules are programmed whenever an AddEndpointSlice
 	// event is received, only alter flows if we need to, i.e if cache wasn't
 	// set or if it was and hasLocalHostNetworkEp state changed, to prevent flow churn
-	namespacedName := namespacedNameFromEPSlice(epSlice)
+	namespacedName, err := namespacedNameFromEPSlice(epSlice)
+	if err != nil {
+		klog.Errorf("Skipping %s/%s: %v", epSlice.Namespace, epSlice.Name, err)
+		return
+	}
 	out, exists := npw.getAndSetServiceInfo(namespacedName, svc, hasLocalHostNetworkEp)
 	if !exists {
 		klog.V(5).Infof("Endpointslice %s ADD event in namespace %s is creating rules", epSlice.Name, epSlice.Namespace)
@@ -738,7 +742,11 @@ func (npw *nodePortWatcher) DeleteEndpointSlice(epSlice *discovery.EndpointSlice
 
 	klog.V(5).Infof("Deleting endpointslice %s in namespace %s", epSlice.Name, epSlice.Namespace)
 	// remove rules for endpoints and add back normal ones
-	namespacedName := namespacedNameFromEPSlice(epSlice)
+	namespacedName, err := namespacedNameFromEPSlice(epSlice)
+	if err != nil {
+		klog.Errorf("Skipping %s/%s: %v", epSlice.Namespace, epSlice.Name, err)
+		return
+	}
 	if svcConfig, exists := npw.updateServiceInfo(namespacedName, nil, &hasLocalHostNetworkEp); exists {
 		// Lock the cache mutex here so we don't miss a service delete during an endpoint delete
 		// we have to do this because deleting and adding iptables rules is slow.
@@ -753,7 +761,9 @@ func (npw *nodePortWatcher) DeleteEndpointSlice(epSlice *discovery.EndpointSlice
 func getEndpointAddresses(endpointSlice *discovery.EndpointSlice) []string {
 	endpointsAddress := make([]string, 0)
 	for _, endpoint := range endpointSlice.Endpoints {
-		endpointsAddress = append(endpointsAddress, endpoint.Addresses...)
+		if isEndpointReady(endpoint) {
+			endpointsAddress = append(endpointsAddress, endpoint.Addresses...)
+		}
 	}
 	return endpointsAddress
 }
@@ -765,7 +775,11 @@ func (npw *nodePortWatcher) UpdateEndpointSlice(oldEpSlice, newEpSlice *discover
 		return
 	}
 
-	namespacedName := namespacedNameFromEPSlice(oldEpSlice)
+	namespacedName, err := namespacedNameFromEPSlice(newEpSlice)
+	if err != nil {
+		klog.Errorf("Skipping %s/%s: %v", newEpSlice.Namespace, newEpSlice.Name, err)
+		return
+	}
 
 	if _, exists := npw.getServiceInfo(namespacedName); !exists {
 		// When a service is updated from externalName to nodeport type, it won't be

--- a/go-controller/pkg/node/healthcheck.go
+++ b/go-controller/pkg/node/healthcheck.go
@@ -1,6 +1,7 @@
 package node
 
 import (
+	"fmt"
 	"net"
 	"os"
 	"strings"
@@ -65,7 +66,7 @@ func (l *loadBalancerHealthChecker) UpdateService(old, new *kapi.Service) {
 		}
 		namespacedName := ktypes.NamespacedName{Namespace: new.Namespace, Name: new.Name}
 		l.Lock()
-		l.endpoints[namespacedName] = l.GetLocalEndpointAddressesCount(epSlices)
+		l.endpoints[namespacedName] = l.CountLocalEndpointAddresses(epSlices)
 		_ = l.server.SyncEndpoints(l.endpoints)
 		l.Unlock()
 	}
@@ -91,23 +92,33 @@ func (l *loadBalancerHealthChecker) SyncServices(svcs []interface{}) error {
 }
 
 func (l *loadBalancerHealthChecker) SyncEndPointSlices(epSlice *discovery.EndpointSlice) {
-	namespacedName := namespacedNameFromEPSlice(epSlice)
+	namespacedName, err := namespacedNameFromEPSlice(epSlice)
+	if err != nil {
+		klog.Errorf("Skipping %s/%s: %v", epSlice.Namespace, epSlice.Name, err)
+		return
+	}
 	epSlices, err := l.watchFactory.GetEndpointSlices(epSlice.Namespace, epSlice.Labels[discovery.LabelServiceName])
 	if err != nil {
 		// should be a rare occurence
-		klog.V(4).Infof("Could not fetch endpointslices for %v during health check", namespacedName)
+		klog.V(4).Infof("Could not fetch endpointslices for %s during health check", namespacedName.String())
 	}
+
+	localEndpointAddressCount := l.CountLocalEndpointAddresses(epSlices)
 	if len(epSlices) == 0 {
 		// let's delete it from cache and wait for the next update; this will show as 0 endpoints for health checks
 		delete(l.endpoints, namespacedName)
 	} else {
-		l.endpoints[namespacedName] = l.GetLocalEndpointAddressesCount(epSlices)
+		l.endpoints[namespacedName] = localEndpointAddressCount
 	}
 	_ = l.server.SyncEndpoints(l.endpoints)
 }
 
 func (l *loadBalancerHealthChecker) AddEndpointSlice(epSlice *discovery.EndpointSlice) {
-	namespacedName := namespacedNameFromEPSlice(epSlice)
+	namespacedName, err := namespacedNameFromEPSlice(epSlice)
+	if err != nil {
+		klog.Errorf("Skipping %s/%s: %v", epSlice.Namespace, epSlice.Name, err)
+		return
+	}
 	l.Lock()
 	defer l.Unlock()
 	if _, exists := l.services[namespacedName]; exists {
@@ -116,7 +127,11 @@ func (l *loadBalancerHealthChecker) AddEndpointSlice(epSlice *discovery.Endpoint
 }
 
 func (l *loadBalancerHealthChecker) UpdateEndpointSlice(oldEpSlice, newEpSlice *discovery.EndpointSlice) {
-	namespacedName := namespacedNameFromEPSlice(newEpSlice)
+	namespacedName, err := namespacedNameFromEPSlice(newEpSlice)
+	if err != nil {
+		klog.Errorf("Skipping %s/%s: %v", newEpSlice.Namespace, newEpSlice.Name, err)
+		return
+	}
 	l.Lock()
 	defer l.Unlock()
 	if _, exists := l.services[namespacedName]; exists {
@@ -130,17 +145,19 @@ func (l *loadBalancerHealthChecker) DeleteEndpointSlice(epSlice *discovery.Endpo
 	l.SyncEndPointSlices(epSlice)
 }
 
-// GetLocalEndpointAddresses returns the number of endpoints that are local to the node for a service
-func (l *loadBalancerHealthChecker) GetLocalEndpointAddressesCount(endpointSlices []*discovery.EndpointSlice) int {
-	localEndpoints := sets.NewString()
+// CountLocalEndpointAddresses returns the number of IP addresses from ready endpoints that are local
+// to the node for a service
+func (l *loadBalancerHealthChecker) CountLocalEndpointAddresses(endpointSlices []*discovery.EndpointSlice) int {
+	localEndpointAddresses := sets.NewString()
 	for _, endpointSlice := range endpointSlices {
 		for _, endpoint := range endpointSlice.Endpoints {
-			if endpoint.NodeName != nil && *endpoint.NodeName == l.nodeName {
-				localEndpoints.Insert(endpoint.Addresses...)
+			isLocal := endpoint.NodeName != nil && *endpoint.NodeName == l.nodeName
+			if isEndpointReady(endpoint) && isLocal {
+				localEndpointAddresses.Insert(endpoint.Addresses...)
 			}
 		}
 	}
-	return len(localEndpoints)
+	return len(localEndpointAddresses)
 }
 
 // hasLocalHostNetworkEndpoints returns true if there is at least one host-networked endpoint
@@ -149,6 +166,9 @@ func (l *loadBalancerHealthChecker) GetLocalEndpointAddressesCount(endpointSlice
 func hasLocalHostNetworkEndpoints(epSlices []*discovery.EndpointSlice, nodeAddresses []net.IP) bool {
 	for _, epSlice := range epSlices {
 		for _, endpoint := range epSlice.Endpoints {
+			if !isEndpointReady(endpoint) {
+				continue
+			}
 			for _, ip := range endpoint.Addresses {
 				for _, nodeIP := range nodeAddresses {
 					if nodeIP.String() == ip {
@@ -169,6 +189,13 @@ func isHostEndpoint(endpointIP string) bool {
 		}
 	}
 	return true
+}
+
+// discovery.EndpointSlice reports in the same slice all endpoints along with their status.
+// isEndpointReady takes an endpoint from an endpoint slice and returns true if the endpoint is
+// to be considered ready.
+func isEndpointReady(endpoint discovery.Endpoint) bool {
+	return endpoint.Conditions.Ready == nil || *endpoint.Conditions.Ready
 }
 
 // checkForStaleOVSInternalPorts checks for OVS internal ports without any ofport assigned,
@@ -432,7 +459,15 @@ func checkPorts(patchIntf, ofPortPatch, physIntf, ofPortPhys string) error {
 	return nil
 }
 
-func namespacedNameFromEPSlice(epSlice *discovery.EndpointSlice) ktypes.NamespacedName {
+func namespacedNameFromEPSlice(epSlice *discovery.EndpointSlice) (ktypes.NamespacedName, error) {
+	// Return the namespaced name of the corresponding service
+	var serviceNamespacedName ktypes.NamespacedName
 	svcName := epSlice.Labels[discovery.LabelServiceName]
-	return ktypes.NamespacedName{Namespace: epSlice.Namespace, Name: svcName}
+	if svcName == "" {
+		// should not happen, since the informer already filters out endpoint slices with an empty service label
+		return serviceNamespacedName,
+			fmt.Errorf("endpointslice %s/%s: empty value for label %s",
+				epSlice.Namespace, epSlice.Name, discovery.LabelServiceName)
+	}
+	return ktypes.NamespacedName{Namespace: epSlice.Namespace, Name: svcName}, nil
 }

--- a/go-controller/pkg/node/node.go
+++ b/go-controller/pkg/node/node.go
@@ -630,16 +630,16 @@ func (n *OvnNode) WatchEndpointSlices() error {
 		UpdateFunc: func(old, new interface{}) {
 			newEndpointSlice := new.(*discovery.EndpointSlice)
 			oldEndpointSlice := old.(*discovery.EndpointSlice)
-			for _, port := range oldEndpointSlice.Ports {
-				for _, endpoint := range oldEndpointSlice.Endpoints {
-					for _, ip := range endpoint.Addresses {
-						if doesEPSliceContainEndpoint(newEndpointSlice, ip, *port.Port, *port.Protocol) {
+			for _, oldPort := range oldEndpointSlice.Ports {
+				for _, oldEndpoint := range oldEndpointSlice.Endpoints {
+					for _, oldIP := range oldEndpoint.Addresses {
+						if doesEPSliceContainReadyEndpoint(newEndpointSlice, oldIP, *oldPort.Port, *oldPort.Protocol) {
 							continue
 						}
-						if *port.Protocol == kapi.ProtocolUDP { // flush conntrack only for UDP
-							err := util.DeleteConntrack(ip, *port.Port, *port.Protocol, netlink.ConntrackReplyAnyIP, nil)
+						if *oldPort.Protocol == kapi.ProtocolUDP { // flush conntrack only for UDP
+							err := util.DeleteConntrack(oldIP, *oldPort.Port, *oldPort.Protocol, netlink.ConntrackReplyAnyIP, nil)
 							if err != nil {
-								klog.Errorf("Failed to delete conntrack entry for %s: %v", ip, err)
+								klog.Errorf("Failed to delete conntrack entry for %s: %v", oldIP, err)
 							}
 						}
 					}
@@ -802,11 +802,14 @@ func (n *OvnNode) validateVTEPInterfaceMTU() error {
 }
 
 // doesEPSliceContainEndpoint checks whether the endpointslice
-// contains a specific endpoint with IP/Port/Protocol
-func doesEPSliceContainEndpoint(epSlice *discovery.EndpointSlice,
+// contains a specific endpoint with IP/Port/Protocol and this endpoint is ready
+func doesEPSliceContainReadyEndpoint(epSlice *discovery.EndpointSlice,
 	epIP string, epPort int32, protocol kapi.Protocol) bool {
 	for _, port := range epSlice.Ports {
 		for _, endpoint := range epSlice.Endpoints {
+			if !isEndpointReady(endpoint) {
+				continue
+			}
 			for _, ip := range endpoint.Addresses {
 				if ip == epIP && *port.Port == epPort && *port.Protocol == protocol {
 					return true


### PR DESCRIPTION
Ignore non-ready endpoints when processing endpointslices

In ovn-k node we introduced a regression when replacing endpoints with endpointslices, causing 10x higher disruption times in ingress-to-console/oauth/image-registry new connections in CI upgrade jobs, as reported in #OCPBUGS-1427

Previously we were processing Endpoints from `k8s.io/api/core/v1`, where we get the current list of _ready_ endpoint addresses from  `EndpointSubset.Addresses` and the list of non-ready addresses from `EndpointSubset.NotReadyAddresses`:  https://github.com/openshift/ovn-kubernetes/blob/da6ac5b78ff34d10201edbadb37e7b658b3ea991/go-controller/vendor/k8s.io/api/core/v1/types.go#L4711-L4724

However, endpointslices are defined differently and offer a more fine-grained view of each endpoint, reporting its status with respect to the endpoint being `ready`, `serving` and `terminating`: https://github.com/openshift/ovn-kubernetes/blob/ac9909dadf452a27153ee7f983f935a1992f365b/go-controller/vendor/k8s.io/api/discovery/v1/types.go#L117-L141

 All endpoints inside an endpointslice, regardless of their current status, are in the same slice:
 https://github.com/openshift/ovn-kubernetes/blob/ac9909dadf452a27153ee7f983f935a1992f365b/go-controller/vendor/k8s.io/api/discovery/v1/types.go#L43-L46

Our code didn't filter out non-ready endpoints, which explains why we were getting 10x the disruption times we previously had: throughout the upgrade, we were always considering all endpoints as being ready, while they were not.


Signed-off-by: Riccardo Ravaioli [rravaiol@redhat.com](mailto:rravaiol@redhat.com)

Fixes #OCPBUGS-1427