### PR TITLE
OCPBUGS-1520: Prioritize adding events to handlers for shared resources

### DIFF
--- a/go-controller/pkg/factory/factory.go
+++ b/go-controller/pkg/factory/factory.go
@@ -78,6 +78,11 @@ const (
 
 	// namespace, node, and pod handlers
 	defaultNumEventQueues uint32 = 15
+
+	// default priorities for various handlers (also the highest priority)
+	defaultHandlerPriority uint32 = 0
+	// lowest priority among various handlers (See GetHandlerPriority for more information)
+	minHandlerPriority uint32 = 4
 )
 
 // types for dynamic handlers created when adding a network policy
@@ -394,7 +399,40 @@ func getObjectMeta(objType reflect.Type, obj interface{}) (*metav1.ObjectMeta, e
 
 type AddHandlerFuncType func(namespace string, sel labels.Selector, funcs cache.ResourceEventHandler, processExisting func([]interface{}) error) (*Handler, error)
 
+// GetHandlerPriority returns the priority of each objType's handler
+// Priority of the handler is what determine which handler would get an event first
+// This is relevant only for handlers that are sharing the same resources:
+// Pods: shared by PodType (0), EgressIPPodType (1), PeerPodSelectorType (2), PeerPodForNamespaceAndPodSelectorType (3), LocalPodSelectorType (4)
+// Namespaces: shared by NamespaceType (0), EgressIPNamespaceType (1), PeerNamespaceSelectorType (3), PeerNamespaceAndPodSelectorType (4)
+// Nodes: shared by NodeType (0), EgressNodeType (1)
+// By default handlers get the defaultHandlerPriority which is 0 (highest priority). Higher the number, lower the priority to get an event.
+// Example: EgressIPPodType will always get the pod event after PodType and PeerPodSelectorType will always get the event after PodType and EgressIPPodType
+// NOTE: If you are touching this function to add a new object type that uses shared objects, please make sure to update `minHandlerPriority` if needed
+func (wf *WatchFactory) GetHandlerPriority(objType reflect.Type) (priority uint32) {
+	switch objType {
+	case EgressIPPodType:
+		return 1
+	case PeerPodSelectorType:
+		return 2
+	case PeerPodForNamespaceAndPodSelectorType:
+		return 3
+	case LocalPodSelectorType:
+		return 4
+	case EgressIPNamespaceType:
+		return 1
+	case PeerNamespaceSelectorType:
+		return 2
+	case PeerNamespaceAndPodSelectorType:
+		return 3
+	case EgressNodeType:
+		return 1
+	default:
+		return defaultHandlerPriority
+	}
+}
+
 func (wf *WatchFactory) GetResourceHandlerFunc(objType reflect.Type) (AddHandlerFuncType, error) {
+	priority := wf.GetHandlerPriority(objType)
 	switch objType {
 	case NamespaceType:
 		return func(namespace string, sel labels.Selector,
@@ -411,7 +449,7 @@ func (wf *WatchFactory) GetResourceHandlerFunc(objType reflect.Type) (AddHandler
 	case NodeType, EgressNodeType:
 		return func(namespace string, sel labels.Selector,
 			funcs cache.ResourceEventHandler, processExisting func([]interface{}) error) (*Handler, error) {
-			return wf.AddNodeHandler(funcs, processExisting)
+			return wf.AddNodeHandler(funcs, processExisting, priority)
 		}, nil
 
 	case PeerServiceType:
@@ -420,22 +458,16 @@ func (wf *WatchFactory) GetResourceHandlerFunc(objType reflect.Type) (AddHandler
 			return wf.AddFilteredServiceHandler(namespace, funcs, processExisting)
 		}, nil
 
-	case PeerPodSelectorType, LocalPodSelectorType, PodType, EgressIPPodType:
+	case PeerPodSelectorType, LocalPodSelectorType, PodType, EgressIPPodType, PeerPodForNamespaceAndPodSelectorType:
 		return func(namespace string, sel labels.Selector,
 			funcs cache.ResourceEventHandler, processExisting func([]interface{}) error) (*Handler, error) {
-			return wf.AddFilteredPodHandler(namespace, sel, funcs, processExisting)
+			return wf.AddFilteredPodHandler(namespace, sel, funcs, processExisting, priority)
 		}, nil
 
 	case PeerNamespaceAndPodSelectorType, PeerNamespaceSelectorType, EgressIPNamespaceType:
 		return func(namespace string, sel labels.Selector,
 			funcs cache.ResourceEventHandler, processExisting func([]interface{}) error) (*Handler, error) {
-			return wf.AddFilteredNamespaceHandler(namespace, sel, funcs, processExisting)
-		}, nil
-
-	case PeerPodForNamespaceAndPodSelectorType:
-		return func(namespace string, sel labels.Selector,
-			funcs cache.ResourceEventHandler, processExisting func([]interface{}) error) (*Handler, error) {
-			return wf.AddFilteredPodHandler(namespace, sel, funcs, processExisting)
+			return wf.AddFilteredNamespaceHandler(namespace, sel, funcs, processExisting, priority)
 		}, nil
 
 	case EgressFirewallType:
@@ -459,7 +491,7 @@ func (wf *WatchFactory) GetResourceHandlerFunc(objType reflect.Type) (AddHandler
 	return nil, fmt.Errorf("cannot get ObjectMeta from type %v", objType)
 }
 
-func (wf *WatchFactory) addHandler(objType reflect.Type, namespace string, sel labels.Selector, funcs cache.ResourceEventHandler, processExisting func([]interface{}) error) (*Handler, error) {
+func (wf *WatchFactory) addHandler(objType reflect.Type, namespace string, sel labels.Selector, funcs cache.ResourceEventHandler, processExisting func([]interface{}) error, priority uint32) (*Handler, error) {
 	inf, ok := wf.informers[objType]
 	if !ok {
 		klog.Fatalf("Tried to add handler of unknown object type %v", objType)
@@ -510,7 +542,7 @@ func (wf *WatchFactory) addHandler(objType reflect.Type, namespace string, sel l
 	}
 
 	handlerID := atomic.AddUint64(&wf.handlerCounter, 1)
-	handler := inf.addHandler(handlerID, filterFunc, funcs, items)
+	handler := inf.addHandler(handlerID, priority, filterFunc, funcs, items)
 	klog.V(5).Infof("Added %v event handler %d", objType, handler.id)
 	return handler, nil
 }
@@ -521,12 +553,12 @@ func (wf *WatchFactory) removeHandler(objType reflect.Type, handler *Handler) {
 
 // AddPodHandler adds a handler function that will be executed on Pod object changes
 func (wf *WatchFactory) AddPodHandler(handlerFuncs cache.ResourceEventHandler, processExisting func([]interface{}) error) (*Handler, error) {
-	return wf.addHandler(PodType, "", nil, handlerFuncs, processExisting)
+	return wf.addHandler(PodType, "", nil, handlerFuncs, processExisting, defaultHandlerPriority)
 }
 
 // AddFilteredPodHandler adds a handler function that will be executed when Pod objects that match the given filters change
-func (wf *WatchFactory) AddFilteredPodHandler(namespace string, sel labels.Selector, handlerFuncs cache.ResourceEventHandler, processExisting func([]interface{}) error) (*Handler, error) {
-	return wf.addHandler(PodType, namespace, sel, handlerFuncs, processExisting)
+func (wf *WatchFactory) AddFilteredPodHandler(namespace string, sel labels.Selector, handlerFuncs cache.ResourceEventHandler, processExisting func([]interface{}) error, priority uint32) (*Handler, error) {
+	return wf.addHandler(PodType, namespace, sel, handlerFuncs, processExisting, priority)
 }
 
 // RemovePodHandler removes a Pod object event handler function
@@ -536,12 +568,12 @@ func (wf *WatchFactory) RemovePodHandler(handler *Handler) {
 
 // AddServiceHandler adds a handler function that will be executed on Service object changes
 func (wf *WatchFactory) AddServiceHandler(handlerFuncs cache.ResourceEventHandler, processExisting func([]interface{}) error) (*Handler, error) {
-	return wf.addHandler(ServiceType, "", nil, handlerFuncs, processExisting)
+	return wf.addHandler(ServiceType, "", nil, handlerFuncs, processExisting, defaultHandlerPriority)
 }
 
 // AddFilteredServiceHandler adds a handler function that will be executed on all Service object changes for a specific namespace
 func (wf *WatchFactory) AddFilteredServiceHandler(namespace string, handlerFuncs cache.ResourceEventHandler, processExisting func([]interface{}) error) (*Handler, error) {
-	return wf.addHandler(ServiceType, namespace, nil, handlerFuncs, processExisting)
+	return wf.addHandler(ServiceType, namespace, nil, handlerFuncs, processExisting, defaultHandlerPriority)
 }
 
 // RemoveServiceHandler removes a Service object event handler function
@@ -551,7 +583,7 @@ func (wf *WatchFactory) RemoveServiceHandler(handler *Handler) {
 
 // AddEndpointSliceHandler adds a handler function that will be executed on EndpointSlice object changes
 func (wf *WatchFactory) AddEndpointSliceHandler(handlerFuncs cache.ResourceEventHandler, processExisting func([]interface{}) error) (*Handler, error) {
-	return wf.addHandler(EndpointSliceType, "", nil, handlerFuncs, processExisting)
+	return wf.addHandler(EndpointSliceType, "", nil, handlerFuncs, processExisting, defaultHandlerPriority)
 }
 
 // RemoveEndpointSliceHandler removes a EndpointSlice object event handler function
@@ -561,7 +593,7 @@ func (wf *WatchFactory) RemoveEndpointSliceHandler(handler *Handler) {
 
 // AddPolicyHandler adds a handler function that will be executed on NetworkPolicy object changes
 func (wf *WatchFactory) AddPolicyHandler(handlerFuncs cache.ResourceEventHandler, processExisting func([]interface{}) error) (*Handler, error) {
-	return wf.addHandler(PolicyType, "", nil, handlerFuncs, processExisting)
+	return wf.addHandler(PolicyType, "", nil, handlerFuncs, processExisting, defaultHandlerPriority)
 }
 
 // RemovePolicyHandler removes a NetworkPolicy object event handler function
@@ -571,7 +603,7 @@ func (wf *WatchFactory) RemovePolicyHandler(handler *Handler) {
 
 // AddEgressFirewallHandler adds a handler function that will be executed on EgressFirewall object changes
 func (wf *WatchFactory) AddEgressFirewallHandler(handlerFuncs cache.ResourceEventHandler, processExisting func([]interface{}) error) (*Handler, error) {
-	return wf.addHandler(EgressFirewallType, "", nil, handlerFuncs, processExisting)
+	return wf.addHandler(EgressFirewallType, "", nil, handlerFuncs, processExisting, defaultHandlerPriority)
 }
 
 // RemoveEgressFirewallHandler removes an EgressFirewall object event handler function
@@ -586,7 +618,7 @@ func (wf *WatchFactory) RemoveEgressQoSHandler(handler *Handler) {
 
 // AddEgressIPHandler adds a handler function that will be executed on EgressIP object changes
 func (wf *WatchFactory) AddEgressIPHandler(handlerFuncs cache.ResourceEventHandler, processExisting func([]interface{}) error) (*Handler, error) {
-	return wf.addHandler(EgressIPType, "", nil, handlerFuncs, processExisting)
+	return wf.addHandler(EgressIPType, "", nil, handlerFuncs, processExisting, defaultHandlerPriority)
 }
 
 // RemoveEgressIPHandler removes an EgressIP object event handler function
@@ -596,7 +628,7 @@ func (wf *WatchFactory) RemoveEgressIPHandler(handler *Handler) {
 
 // AddCloudPrivateIPConfigHandler adds a handler function that will be executed on CloudPrivateIPConfig object changes
 func (wf *WatchFactory) AddCloudPrivateIPConfigHandler(handlerFuncs cache.ResourceEventHandler, processExisting func([]interface{}) error) (*Handler, error) {
-	return wf.addHandler(CloudPrivateIPConfigType, "", nil, handlerFuncs, processExisting)
+	return wf.addHandler(CloudPrivateIPConfigType, "", nil, handlerFuncs, processExisting, defaultHandlerPriority)
 }
 
 // RemoveCloudPrivateIPConfigHandler removes an CloudPrivateIPConfig object event handler function
@@ -606,12 +638,12 @@ func (wf *WatchFactory) RemoveCloudPrivateIPConfigHandler(handler *Handler) {
 
 // AddNamespaceHandler adds a handler function that will be executed on Namespace object changes
 func (wf *WatchFactory) AddNamespaceHandler(handlerFuncs cache.ResourceEventHandler, processExisting func([]interface{}) error) (*Handler, error) {
-	return wf.addHandler(NamespaceType, "", nil, handlerFuncs, processExisting)
+	return wf.addHandler(NamespaceType, "", nil, handlerFuncs, processExisting, defaultHandlerPriority)
 }
 
 // AddFilteredNamespaceHandler adds a handler function that will be executed when Namespace objects that match the given filters change
-func (wf *WatchFactory) AddFilteredNamespaceHandler(namespace string, sel labels.Selector, handlerFuncs cache.ResourceEventHandler, processExisting func([]interface{}) error) (*Handler, error) {
-	return wf.addHandler(NamespaceType, namespace, sel, handlerFuncs, processExisting)
+func (wf *WatchFactory) AddFilteredNamespaceHandler(namespace string, sel labels.Selector, handlerFuncs cache.ResourceEventHandler, processExisting func([]interface{}) error, priority uint32) (*Handler, error) {
+	return wf.addHandler(NamespaceType, namespace, sel, handlerFuncs, processExisting, priority)
 }
 
 // RemoveNamespaceHandler removes a Namespace object event handler function
@@ -620,13 +652,13 @@ func (wf *WatchFactory) RemoveNamespaceHandler(handler *Handler) {
 }
 
 // AddNodeHandler adds a handler function that will be executed on Node object changes
-func (wf *WatchFactory) AddNodeHandler(handlerFuncs cache.ResourceEventHandler, processExisting func([]interface{}) error) (*Handler, error) {
-	return wf.addHandler(NodeType, "", nil, handlerFuncs, processExisting)
+func (wf *WatchFactory) AddNodeHandler(handlerFuncs cache.ResourceEventHandler, processExisting func([]interface{}) error, priority uint32) (*Handler, error) {
+	return wf.addHandler(NodeType, "", nil, handlerFuncs, processExisting, priority)
 }
 
 // AddFilteredNodeHandler dds a handler function that will be executed when Node objects that match the given label selector
 func (wf *WatchFactory) AddFilteredNodeHandler(sel labels.Selector, handlerFuncs cache.ResourceEventHandler, processExisting func([]interface{}) error) (*Handler, error) {
-	return wf.addHandler(NodeType, "", sel, handlerFuncs, processExisting)
+	return wf.addHandler(NodeType, "", sel, handlerFuncs, processExisting, defaultHandlerPriority)
 }
 
 // RemoveNodeHandler removes a Node object event handler function

--- a/go-controller/pkg/factory/factory_test.go
+++ b/go-controller/pkg/factory/factory_test.go
@@ -379,7 +379,7 @@ var _ = Describe("Watch Factory Operations", func() {
 	})
 
 	Context("when a processExisting is given", func() {
-		testExisting := func(objType reflect.Type, namespace string, sel labels.Selector) {
+		testExisting := func(objType reflect.Type, namespace string, sel labels.Selector, priority uint32) {
 			if objType == EndpointSliceType {
 				wf, err = NewNodeWatchFactory(ovnClientset, nodeName)
 			} else {
@@ -394,57 +394,126 @@ var _ = Describe("Watch Factory Operations", func() {
 					defer GinkgoRecover()
 					Expect(len(objs)).To(Equal(1))
 					return nil
-				})
+				}, wf.GetHandlerPriority(objType))
 			Expect(h).NotTo(BeNil())
 			Expect(err).NotTo(HaveOccurred())
+			Expect(h.priority).To(Equal(priority))
+			wf.removeHandler(objType, h)
+		}
+
+		testExistingFilteredHandler := func(objType reflect.Type, realObj reflect.Type, namespace string, sel labels.Selector, priority uint32) {
+			if objType == EndpointSliceType {
+				wf, err = NewNodeWatchFactory(ovnClientset, nodeName)
+			} else {
+				wf, err = NewMasterWatchFactory(ovnClientset)
+			}
+			Expect(err).NotTo(HaveOccurred())
+			err = wf.Start()
+			Expect(err).NotTo(HaveOccurred())
+			h, err := wf.AddFilteredPodHandler(namespace, sel,
+				cache.ResourceEventHandlerFuncs{},
+				func(objs []interface{}) error {
+					defer GinkgoRecover()
+					Expect(len(objs)).To(Equal(1))
+					return nil
+				}, wf.GetHandlerPriority(realObj))
+			Expect(h).NotTo(BeNil())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(h.priority).To(Equal(priority))
 			wf.removeHandler(objType, h)
 		}
 
 		It("is called for each existing pod", func() {
 			pods = append(pods, newPod("pod1", "default"))
-			testExisting(PodType, "", nil)
+			testExisting(PodType, "", nil, defaultHandlerPriority)
 		})
 
 		It("is called for each existing namespace", func() {
 			namespaces = append(namespaces, newNamespace("default"))
-			testExisting(NamespaceType, "", nil)
+			testExisting(NamespaceType, "", nil, defaultHandlerPriority)
 		})
 
 		It("is called for each existing node", func() {
 			nodes = append(nodes, newNode("default"))
-			testExisting(NodeType, "", nil)
+			testExisting(NodeType, "", nil, defaultHandlerPriority)
 		})
 
 		It("is called for each existing policy", func() {
 			policies = append(policies, newPolicy("denyall", "default"))
-			testExisting(PolicyType, "", nil)
+			pods = append(pods, newPod("pod1", "default"))
+			testExisting(PolicyType, "", nil, defaultHandlerPriority)
+		})
+
+		It("is called for each existing policy: PeerPodSelectorType", func() {
+			policies = append(policies, newPolicy("denyall", "default"))
+			pods = append(pods, newPod("pod1", "default"))
+			testExistingFilteredHandler(PodType, PeerPodSelectorType, "default", nil, 2)
+		})
+
+		It("is called for each existing policy: LocalPodSelectorType", func() {
+			policies = append(policies, newPolicy("denyall", "default"))
+			pods = append(pods, newPod("pod1", "default"))
+			testExistingFilteredHandler(PodType, LocalPodSelectorType, "default", nil, 4)
+		})
+
+		It("is called for each existing policy: PeerPodForNamespaceAndPodSelectorType", func() {
+			policies = append(policies, newPolicy("denyall", "default"))
+			pods = append(pods, newPod("pod1", "default"))
+			testExistingFilteredHandler(PodType, PeerPodForNamespaceAndPodSelectorType, "default", nil, 3)
+		})
+
+		It("is called for each existing policy: PeerNamespaceAndPodSelectorType", func() {
+			policies = append(policies, newPolicy("denyall", "default"))
+			pods = append(pods, newPod("pod1", "default"))
+			testExistingFilteredHandler(NamespaceType, PeerNamespaceAndPodSelectorType, "default", nil, 3)
+		})
+
+		It("is called for each existing policy: PeerNamespaceSelectorType", func() {
+			policies = append(policies, newPolicy("denyall", "default"))
+			pods = append(pods, newPod("pod1", "default"))
+			testExistingFilteredHandler(NamespaceType, PeerNamespaceSelectorType, "default", nil, 2)
 		})
 
 		It("is called for each existing endpointSlice", func() {
 			endpointSlices = append(endpointSlices, newEndpointSlice("myEndpointSlice", "default", "myService"))
-			testExisting(EndpointSliceType, "", nil)
+			testExisting(EndpointSliceType, "", nil, defaultHandlerPriority)
 		})
 
 		It("is called for each existing service", func() {
 			services = append(services, newService("myservice", "default"))
-			testExisting(ServiceType, "", nil)
+			testExisting(ServiceType, "", nil, defaultHandlerPriority)
 		})
 
 		It("is called for each existing egressFirewall", func() {
 			egressFirewalls = append(egressFirewalls, newEgressFirewall("myEgressFirewall", "default"))
-			testExisting(EgressFirewallType, "", nil)
+			testExisting(EgressFirewallType, "", nil, defaultHandlerPriority)
 		})
+
 		It("is called for each existing egressIP", func() {
 			egressIPs = append(egressIPs, newEgressIP("myEgressIP", "default"))
-			testExisting(EgressIPType, "", nil)
+			pods = append(pods, newPod("pod1", "default"))
+			testExisting(EgressIPType, "", nil, defaultHandlerPriority)
 		})
+
+		It("is called for each existing egressIP: EgressIPPodType", func() {
+			egressIPs = append(egressIPs, newEgressIP("myEgressIP", "default"))
+			pods = append(pods, newPod("pod1", "default"))
+			testExistingFilteredHandler(PodType, EgressIPPodType, "default", nil, 1)
+		})
+
+		It("is called for each existing egressIP: EgressIPNamespaceType", func() {
+			egressIPs = append(egressIPs, newEgressIP("myEgressIP", "default"))
+			pods = append(pods, newPod("pod1", "default"))
+			testExistingFilteredHandler(NamespaceType, EgressIPNamespaceType, "default", nil, 1)
+		})
+
 		It("is called for each existing cloudPrivateIPConfig", func() {
 			cloudPrivateIPConfigs = append(cloudPrivateIPConfigs, newCloudPrivateIPConfig("192.168.176.25"))
-			testExisting(CloudPrivateIPConfigType, "", nil)
+			testExisting(CloudPrivateIPConfigType, "", nil, defaultHandlerPriority)
 		})
 		It("is called for each existing egressQoS", func() {
 			egressQoSes = append(egressQoSes, newEgressQoS("myEgressQoS", "default"))
-			testExisting(EgressQoSType, "", nil)
+			testExisting(EgressQoSType, "", nil, defaultHandlerPriority)
 		})
 
 		It("is called for each existing pod that matches a given namespace and label", func() {
@@ -459,7 +528,7 @@ var _ = Describe("Watch Factory Operations", func() {
 			)
 			Expect(err).NotTo(HaveOccurred())
 
-			testExisting(PodType, "default", sel)
+			testExisting(PodType, "default", sel, defaultHandlerPriority)
 		})
 	})
 
@@ -481,7 +550,7 @@ var _ = Describe("Watch Factory Operations", func() {
 					},
 					UpdateFunc: func(old, new interface{}) {},
 					DeleteFunc: func(obj interface{}) {},
-				}, nil)
+				}, nil, wf.GetHandlerPriority(objType))
 			Expect(int(addCalls)).To(Equal(2))
 			Expect(err).NotTo(HaveOccurred())
 			wf.removeHandler(objType, h)
@@ -585,7 +654,7 @@ var _ = Describe("Watch Factory Operations", func() {
 		})
 	})
 
-	addFilteredHandler := func(wf *WatchFactory, objType reflect.Type, namespace string, sel labels.Selector, funcs cache.ResourceEventHandlerFuncs) (*Handler, *handlerCalls) {
+	addFilteredHandler := func(wf *WatchFactory, objType reflect.Type, realObjType reflect.Type, namespace string, sel labels.Selector, funcs cache.ResourceEventHandlerFuncs) (*Handler, *handlerCalls) {
 		calls := handlerCalls{}
 		h, err := wf.addHandler(objType, namespace, sel, cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
@@ -603,14 +672,18 @@ var _ = Describe("Watch Factory Operations", func() {
 				atomic.AddInt32(&calls.deleted, 1)
 				funcs.DeleteFunc(obj)
 			},
-		}, nil)
+		}, nil, wf.GetHandlerPriority(realObjType))
 		Expect(h).NotTo(BeNil())
 		Expect(err).NotTo(HaveOccurred())
 		return h, &calls
 	}
 
 	addHandler := func(wf *WatchFactory, objType reflect.Type, funcs cache.ResourceEventHandlerFuncs) (*Handler, *handlerCalls) {
-		return addFilteredHandler(wf, objType, "", nil, funcs)
+		return addFilteredHandler(wf, objType, objType, "", nil, funcs)
+	}
+
+	addPriorityHandler := func(wf *WatchFactory, objType reflect.Type, realObjType reflect.Type, funcs cache.ResourceEventHandlerFuncs) (*Handler, *handlerCalls) {
+		return addFilteredHandler(wf, objType, realObjType, "", nil, funcs)
 	}
 
 	It("responds to pod add/update/delete events", func() {
@@ -1049,6 +1122,210 @@ var _ = Describe("Watch Factory Operations", func() {
 		wf.RemoveNamespaceHandler(h)
 	})
 
+	It("correctly orders add events across prioritized handlers sharing the same object type", func() {
+		type opTest struct {
+			mu                            sync.Mutex
+			namespace                     *v1.Namespace
+			added                         int
+			updated                       int
+			initialupdateBeforeEIPAdd     bool
+			initialupdateBeforePeerAdd    bool
+			initialupdateBeforePeerPodAdd bool
+		}
+		testNamespaces := make(map[string]*opTest)
+
+		for i := 0; i < 998; i++ {
+			name := fmt.Sprintf("mynamespace-%d", i)
+			namespace := newNamespace(name)
+			testNamespaces[name] = &opTest{namespace: namespace, initialupdateBeforeEIPAdd: false, initialupdateBeforePeerAdd: false, initialupdateBeforePeerPodAdd: false}
+			// Add all namespaces to the initial list
+			namespaces = append(namespaces, namespace)
+		}
+
+		wf, err = NewMasterWatchFactory(ovnClientset)
+		Expect(err).NotTo(HaveOccurred())
+		err = wf.Start()
+		Expect(err).NotTo(HaveOccurred())
+
+		startWg := sync.WaitGroup{}
+		startWg.Add(1)
+		doneWg := sync.WaitGroup{}
+		doneWg.Add(1)
+		go func() {
+			startWg.Done()
+			// Send an update event for each namespace
+			for _, n := range namespaces {
+				n.Status.Phase = v1.NamespaceTerminating
+				namespaceWatch.Modify(n)
+			}
+			doneWg.Done()
+		}()
+		startWg.Wait()
+
+		nsh, c1 := addPriorityHandler(wf, NamespaceType, NamespaceType, cache.ResourceEventHandlerFuncs{
+			AddFunc: func(obj interface{}) {
+				defer GinkgoRecover()
+				namespace := obj.(*v1.Namespace)
+				ot, ok := testNamespaces[namespace.Name]
+				Expect(ok).To(BeTrue())
+				ot.mu.Lock()
+				defer ot.mu.Unlock()
+				Expect(ot.added).To(Equal(0))
+				ot.added++
+			},
+			UpdateFunc: func(old, new interface{}) {
+				defer GinkgoRecover()
+				newNamespace := new.(*v1.Namespace)
+				ot, ok := testNamespaces[newNamespace.Name]
+				Expect(ok).To(BeTrue())
+				// Expect updates to be processed after Add
+				ot.mu.Lock()
+				defer ot.mu.Unlock()
+				if ot.added == 1 {
+					// we don't have control over order of update v/s add between the different priority handlers
+					ot.initialupdateBeforeEIPAdd = true
+				} else if ot.added == 10 {
+					ot.initialupdateBeforePeerAdd = true
+				} else if ot.added == 8 {
+					ot.initialupdateBeforePeerPodAdd = true
+				}
+				Expect(ot.updated).To(Equal(0))
+				ot.updated++
+				Expect(newNamespace.Status.Phase).To(Equal(v1.NamespaceTerminating))
+			},
+			DeleteFunc: func(obj interface{}) {},
+		})
+
+		eipnsh, c2 := addPriorityHandler(wf, NamespaceType, EgressIPNamespaceType, cache.ResourceEventHandlerFuncs{
+			AddFunc: func(obj interface{}) {
+				defer GinkgoRecover()
+				namespace := obj.(*v1.Namespace)
+				ot, ok := testNamespaces[namespace.Name]
+				Expect(ok).To(BeTrue())
+				ot.mu.Lock()
+				defer ot.mu.Unlock()
+				Expect(ot.added).To(Equal(1), "add for EIP namespace %s processed before initial namespace add!", namespace.Name)
+				ot.added = ot.added * 10
+			},
+			UpdateFunc: func(old, new interface{}) {
+				defer GinkgoRecover()
+				newNamespace := new.(*v1.Namespace)
+				ot, ok := testNamespaces[newNamespace.Name]
+				Expect(ok).To(BeTrue())
+				// Expect updates to be processed after Add
+				ot.mu.Lock()
+				defer ot.mu.Unlock()
+				Expect(ot.updated).To(Equal(1), "update for EIP namespace %s processed before initial namespace update!", newNamespace.Name)
+				ot.updated = ot.updated * 10
+				Expect(newNamespace.Status.Phase).To(Equal(v1.NamespaceTerminating))
+			},
+			DeleteFunc: func(obj interface{}) {},
+		})
+		peernsh, c3 := addPriorityHandler(wf, NamespaceType, PeerNamespaceSelectorType, cache.ResourceEventHandlerFuncs{
+			AddFunc: func(obj interface{}) {
+				defer GinkgoRecover()
+				namespace := obj.(*v1.Namespace)
+				ot, ok := testNamespaces[namespace.Name]
+				Expect(ok).To(BeTrue())
+				ot.mu.Lock()
+				defer ot.mu.Unlock()
+				Expect(ot.added).To(Equal(10), "add for peer namespace %s processed before EIP namespace add!", namespace.Name)
+				ot.added = ot.added - 2
+			},
+			UpdateFunc: func(old, new interface{}) {
+				defer GinkgoRecover()
+				newNamespace := new.(*v1.Namespace)
+				ot, ok := testNamespaces[newNamespace.Name]
+				Expect(ok).To(BeTrue())
+				// Expect updates to be processed after Add
+				ot.mu.Lock()
+				defer ot.mu.Unlock()
+				if ot.initialupdateBeforeEIPAdd {
+					Expect(ot.updated).To(Equal(1), "update for peer namespace %s processed before initial namespace update!", newNamespace.Name)
+				} else {
+					Expect(ot.updated).To(Equal(10), "update for peer namespace %s processed before EIP namespace update!", newNamespace.Name)
+				}
+				ot.updated = ot.updated - 2
+				Expect(newNamespace.Status.Phase).To(Equal(v1.NamespaceTerminating))
+			},
+			DeleteFunc: func(obj interface{}) {},
+		})
+		peerpodnsh, c4 := addPriorityHandler(wf, NamespaceType, PeerNamespaceAndPodSelectorType, cache.ResourceEventHandlerFuncs{
+			AddFunc: func(obj interface{}) {
+				defer GinkgoRecover()
+				namespace := obj.(*v1.Namespace)
+				ot, ok := testNamespaces[namespace.Name]
+				Expect(ok).To(BeTrue())
+				ot.mu.Lock()
+				defer ot.mu.Unlock()
+				Expect(ot.added).To(Equal(8), "add for peerPod namespace %s processed before peer namespace add!", namespace.Name)
+				ot.added = ot.added / 2
+			},
+			UpdateFunc: func(old, new interface{}) {
+				defer GinkgoRecover()
+				newNamespace := new.(*v1.Namespace)
+				ot, ok := testNamespaces[newNamespace.Name]
+				Expect(ok).To(BeTrue())
+				// Expect updates to be processed after Add
+				ot.mu.Lock()
+				defer ot.mu.Unlock()
+				Expect(ot.added).To(Equal(4), "update for peerPod namespace %s processed before peerPod namespace add!", newNamespace.Name)
+				if ot.initialupdateBeforeEIPAdd {
+					Expect(ot.updated).To(Equal(1), "update for peerPod namespace %s processed before initial namespace update!", newNamespace.Name)
+				} else if ot.initialupdateBeforePeerAdd {
+					Expect(ot.updated).To(Equal(10), "update for peerPod namespace %s processed before EIP namespace update!", newNamespace.Name)
+				} else {
+					Expect(ot.updated).To(Equal(8), "update for peerPod namespace %s processed before peer namespace update!", newNamespace.Name)
+				}
+				ot.updated = ot.updated / 2
+				Expect(newNamespace.Status.Phase).To(Equal(v1.NamespaceTerminating))
+			},
+			DeleteFunc: func(obj interface{}) {},
+		})
+		doneWg.Wait()
+		// Adds are done synchronously at handler addition time
+		for _, ot := range testNamespaces {
+			ot.mu.Lock()
+			// ((((0 + 1) * 10) - 2) / 2) = 4
+			Expect(ot.added).To(Equal(4), "missing add for namespace %s", ot.namespace.Name)
+			ot.mu.Unlock()
+		}
+		Expect(c1.getAdded()).To(Equal(len(testNamespaces)))
+		Eventually(c2.getAdded, 10).Should(Equal(len(testNamespaces)))
+		Eventually(c3.getAdded, 10).Should(Equal(len(testNamespaces)))
+
+		// Updates are async and may take a bit longer to finish
+		Eventually(c1.getUpdated, 10).Should(Equal(len(testNamespaces)))
+		eipUpdateCount := 0
+		peerUpdateCount := 0
+		peerPodUpdateCount := 0
+		for _, ot := range testNamespaces {
+			ot.mu.Lock()
+			if !ot.initialupdateBeforePeerAdd && !ot.initialupdateBeforeEIPAdd && !ot.initialupdateBeforePeerPodAdd {
+				peerUpdateCount++
+				eipUpdateCount++
+				peerPodUpdateCount++
+				Expect(ot.updated).To(Equal(4), "missing update for namespace %s", ot.namespace.Name)
+			} else if !ot.initialupdateBeforePeerAdd && !ot.initialupdateBeforeEIPAdd {
+				peerUpdateCount++
+				eipUpdateCount++
+				Expect(ot.updated).To(Equal(8), "missing update for namespace %s", ot.namespace.Name)
+			} else if !ot.initialupdateBeforeEIPAdd {
+				eipUpdateCount++
+				Expect(ot.updated).To(Equal(10), "missing update for namespace %s", ot.namespace.Name)
+			}
+			ot.mu.Unlock()
+		}
+		Eventually(c2.getUpdated, 10).Should(Equal(eipUpdateCount))
+		Eventually(c3.getUpdated, 10).Should(Equal(peerUpdateCount))
+		Eventually(c4.getUpdated, 10).Should(Equal(peerPodUpdateCount))
+
+		wf.RemoveNamespaceHandler(nsh)
+		wf.RemoveNamespaceHandler(eipnsh)
+		wf.RemoveNamespaceHandler(peernsh)
+		wf.RemoveNamespaceHandler(peerpodnsh)
+	})
+
 	It("responds to policy add/update/delete events", func() {
 		wf, err = NewMasterWatchFactory(ovnClientset)
 		Expect(err).NotTo(HaveOccurred())
@@ -1352,6 +1629,7 @@ var _ = Describe("Watch Factory Operations", func() {
 
 		_, c := addFilteredHandler(wf,
 			PodType,
+			PodType,
 			"default",
 			sel,
 			cache.ResourceEventHandlerFuncs{
@@ -1419,6 +1697,7 @@ var _ = Describe("Watch Factory Operations", func() {
 
 		equalPod := pod
 		h, c := addFilteredHandler(wf,
+			PodType,
 			PodType,
 			"default",
 			sel,

--- a/go-controller/pkg/factory/handler.go
+++ b/go-controller/pkg/factory/handler.go
@@ -35,6 +35,10 @@ type Handler struct {
 	// tombstone should only be set using atomic operations since it is
 	// used from multiple goroutines.
 	tombstone uint32
+	// priority is used to track the handler's priority of being invoked.
+	// example: a handler with priority 0 will process the received event first
+	// before a handler with priority 1.
+	priority uint32
 }
 
 func (h *Handler) OnAdd(obj interface{}) {
@@ -76,9 +80,14 @@ type queueMapEntry struct {
 
 type informer struct {
 	sync.RWMutex
-	oType    reflect.Type
-	inf      cache.SharedIndexInformer
-	handlers map[uint64]*Handler
+	oType reflect.Type
+	inf   cache.SharedIndexInformer
+	// keyed by priority - used to track the handler's priority of being invoked.
+	// example: a handler with priority 0 will process the received event first
+	// before a handler with priority 1, 0 being the higest priority.
+	// NOTE: we can have multiple handlers with the same priority hence the value
+	// is a map of handlers keyed by its unique id.
+	handlers map[uint32]map[uint64]*Handler
 	events   []chan *event
 	lister   listerInterface
 	// initialAddFunc will be called to deliver the initial list of objects
@@ -92,8 +101,11 @@ type informer struct {
 func (i *informer) forEachQueuedHandler(f func(h *Handler)) {
 	i.RLock()
 	defer i.RUnlock()
-	for _, handler := range i.handlers {
-		f(handler)
+
+	for priority := 0; uint32(priority) <= minHandlerPriority; priority++ { // loop over priority higest to lowest
+		for _, handler := range i.handlers[uint32(priority)] {
+			f(handler)
+		}
 	}
 }
 
@@ -107,12 +119,14 @@ func (i *informer) forEachHandler(obj interface{}, f func(h *Handler)) {
 		return
 	}
 
-	for _, handler := range i.handlers {
-		f(handler)
+	for priority := 0; uint32(priority) <= minHandlerPriority; priority++ { // loop over priority higest to lowest
+		for _, handler := range i.handlers[uint32(priority)] {
+			f(handler)
+		}
 	}
 }
 
-func (i *informer) addHandler(id uint64, filterFunc func(obj interface{}) bool, funcs cache.ResourceEventHandler, existingItems []interface{}) *Handler {
+func (i *informer) addHandler(id uint64, priority uint32, filterFunc func(obj interface{}) bool, funcs cache.ResourceEventHandler, existingItems []interface{}) *Handler {
 	handler := &Handler{
 		cache.FilteringResourceEventHandler{
 			FilterFunc: filterFunc,
@@ -120,6 +134,7 @@ func (i *informer) addHandler(id uint64, filterFunc func(obj interface{}) bool, 
 		},
 		id,
 		handlerAlive,
+		priority,
 	}
 
 	// Send existing items to the handler's add function; informers usually
@@ -127,7 +142,12 @@ func (i *informer) addHandler(id uint64, filterFunc func(obj interface{}) bool, 
 	// we must emulate that here
 	i.initialAddFunc(handler, existingItems)
 
-	i.handlers[id] = handler
+	_, ok := i.handlers[priority]
+	if !ok {
+		i.handlers[priority] = make(map[uint64]*Handler)
+	}
+	i.handlers[priority][id] = handler
+
 	return handler
 }
 
@@ -142,11 +162,19 @@ func (i *informer) removeHandler(handler *Handler) {
 	go func() {
 		i.Lock()
 		defer i.Unlock()
-		if _, ok := i.handlers[handler.id]; ok {
-			// Remove the handler
-			delete(i.handlers, handler.id)
-			klog.V(5).Infof("Removed %v event handler %d", i.oType, handler.id)
-		} else {
+		removed := 0
+		for priority := range i.handlers { // loop over priority
+			if _, ok := i.handlers[priority]; !ok {
+				continue // protection against nil map as value
+			}
+			if _, ok := i.handlers[priority][handler.id]; ok {
+				// Remove the handler
+				delete(i.handlers[priority], handler.id)
+				removed = 1
+				klog.V(5).Infof("Removed %v event handler %d", i.oType, handler.id)
+			}
+		}
+		if removed == 0 {
 			klog.Warningf("Tried to remove unknown object type %v event handler %d", i.oType, handler.id)
 		}
 	}()
@@ -344,8 +372,10 @@ func (i *informer) newFederatedHandler() cache.ResourceEventHandlerFuncs {
 func (i *informer) removeAllHandlers() {
 	i.Lock()
 	defer i.Unlock()
-	for _, handler := range i.handlers {
-		i.removeHandler(handler)
+	for _, handlers := range i.handlers {
+		for _, handler := range handlers {
+			i.removeHandler(handler)
+		}
 	}
 }
 
@@ -394,7 +424,7 @@ func newBaseInformer(oType reflect.Type, sharedInformer cache.SharedIndexInforme
 		oType:    oType,
 		inf:      sharedInformer,
 		lister:   lister,
-		handlers: make(map[uint64]*Handler),
+		handlers: make(map[uint32]map[uint64]*Handler),
 		queueMap: make(map[ktypes.NamespacedName]*queueMapEntry),
 	}, nil
 }


### PR DESCRIPTION
    Prioritize adding events to handlers for shared resources
    
    When handlers share the informer for the same type of objects - example
    egressIP feature also watches for Pods and creates a handler to receive
    events for any pod-related activities - it is better to prioritize the
    order in which a specific event for a pod will be processed. Pod
    creation should happen first, so addLogicalPort should go first before
    egressIP Pod handler. Similarly for network policies and other
    controllers.
    
    Today OVNK already handles the events serially, the only problem is we
    don't control which handler gets the event first, so this PR adds a
    priority system for the handlers where by we say all critical handlers
    get priority 0 - this is the highest priority and it applies to
    pods/namespaces/nodes and all the CRD objects. Then we start handing out
    priority to rest of the handlers, example egressIP pod handler will have
    priority 1 which means it will always get the event after the main pod
    handler has got it. Same for egressIP namespace handler which will
    always get the event after the main namespace handler has got it.
    
    Signed-off-by: Surya Seetharaman <suryaseetharaman.9@gmail.com>
    (cherry picked from commit c0f32f952c20bc4c9b90b50624b7303bbf65a8f2)

