### PR TITLE
[release-4.12] OCPBUGS-3346: vendor: bump libovsdb to 8f21d188c3a50d0ce378bd66ec68215967aaad77

### DIFF
--- a/go-controller/go.mod
+++ b/go-controller/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/onsi/gomega v1.15.0
 	github.com/openshift/api v0.0.0-20220525145417-ee5b62754c68
 	github.com/openshift/client-go v0.0.0-20220525160904-9e1acff93e4a
-	github.com/ovn-org/libovsdb v0.6.1-0.20220901025242-999ca1972a3a
+	github.com/ovn-org/libovsdb v0.6.1-0.20221101143603-8f21d188c3a5
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.12.1
 	github.com/prometheus/client_model v0.2.0

--- a/go-controller/go.sum
+++ b/go-controller/go.sum
@@ -616,8 +616,8 @@ github.com/openshift/build-machinery-go v0.0.0-20211213093930-7e33a7eb4ce3/go.mo
 github.com/openshift/client-go v0.0.0-20220525160904-9e1acff93e4a h1:ylsEgoC8Dlg4A0C1TLH0A4x/TZao7k1YveLwROhRUdk=
 github.com/openshift/client-go v0.0.0-20220525160904-9e1acff93e4a/go.mod h1:eDO5QeVi2IiXmDwB0e2z1DpAznWroZKe978pzZwFBzg=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
-github.com/ovn-org/libovsdb v0.6.1-0.20220901025242-999ca1972a3a h1:fcKT5QPXQfNURcy4QddDFnI8f2GTNVlJrQMwJ+pZbI8=
-github.com/ovn-org/libovsdb v0.6.1-0.20220901025242-999ca1972a3a/go.mod h1:S/+Hux9//oB7yLaPsUKnXTzZc6S1C4a9HP0UifXfKz0=
+github.com/ovn-org/libovsdb v0.6.1-0.20221101143603-8f21d188c3a5 h1:Cw0JXIHSGp8etz5/P7zNQ0tCMmTljBGBr8Rn2P1PuzQ=
+github.com/ovn-org/libovsdb v0.6.1-0.20221101143603-8f21d188c3a5/go.mod h1:S/+Hux9//oB7yLaPsUKnXTzZc6S1C4a9HP0UifXfKz0=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.8.1/go.mod h1:T2/BmBdy8dvIRq1a/8aqjN41wvWlN4lrapLU/GW4pbc=

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -708,7 +708,11 @@ func (npw *nodePortWatcher) AddEndpointSlice(epSlice *discovery.EndpointSlice) {
 	// Here we make sure the correct rules are programmed whenever an AddEndpointSlice
 	// event is received, only alter flows if we need to, i.e if cache wasn't
 	// set or if it was and hasLocalHostNetworkEp state changed, to prevent flow churn
-	namespacedName := namespacedNameFromEPSlice(epSlice)
+	namespacedName, err := namespacedNameFromEPSlice(epSlice)
+	if err != nil {
+		klog.Errorf("Skipping %s/%s: %v", epSlice.Namespace, epSlice.Name, err)
+		return
+	}
 	out, exists := npw.getAndSetServiceInfo(namespacedName, svc, hasLocalHostNetworkEp)
 	if !exists {
 		klog.V(5).Infof("Endpointslice %s ADD event in namespace %s is creating rules", epSlice.Name, epSlice.Namespace)
@@ -738,7 +742,11 @@ func (npw *nodePortWatcher) DeleteEndpointSlice(epSlice *discovery.EndpointSlice
 
 	klog.V(5).Infof("Deleting endpointslice %s in namespace %s", epSlice.Name, epSlice.Namespace)
 	// remove rules for endpoints and add back normal ones
-	namespacedName := namespacedNameFromEPSlice(epSlice)
+	namespacedName, err := namespacedNameFromEPSlice(epSlice)
+	if err != nil {
+		klog.Errorf("Skipping %s/%s: %v", epSlice.Namespace, epSlice.Name, err)
+		return
+	}
 	if svcConfig, exists := npw.updateServiceInfo(namespacedName, nil, &hasLocalHostNetworkEp); exists {
 		// Lock the cache mutex here so we don't miss a service delete during an endpoint delete
 		// we have to do this because deleting and adding iptables rules is slow.
@@ -753,7 +761,9 @@ func (npw *nodePortWatcher) DeleteEndpointSlice(epSlice *discovery.EndpointSlice
 func getEndpointAddresses(endpointSlice *discovery.EndpointSlice) []string {
 	endpointsAddress := make([]string, 0)
 	for _, endpoint := range endpointSlice.Endpoints {
-		endpointsAddress = append(endpointsAddress, endpoint.Addresses...)
+		if isEndpointReady(endpoint) {
+			endpointsAddress = append(endpointsAddress, endpoint.Addresses...)
+		}
 	}
 	return endpointsAddress
 }
@@ -765,7 +775,11 @@ func (npw *nodePortWatcher) UpdateEndpointSlice(oldEpSlice, newEpSlice *discover
 		return
 	}
 
-	namespacedName := namespacedNameFromEPSlice(oldEpSlice)
+	namespacedName, err := namespacedNameFromEPSlice(newEpSlice)
+	if err != nil {
+		klog.Errorf("Skipping %s/%s: %v", newEpSlice.Namespace, newEpSlice.Name, err)
+		return
+	}
 
 	if _, exists := npw.getServiceInfo(namespacedName); !exists {
 		// When a service is updated from externalName to nodeport type, it won't be

--- a/go-controller/pkg/node/healthcheck.go
+++ b/go-controller/pkg/node/healthcheck.go
@@ -1,6 +1,7 @@
 package node
 
 import (
+	"fmt"
 	"net"
 	"os"
 	"strings"
@@ -65,7 +66,7 @@ func (l *loadBalancerHealthChecker) UpdateService(old, new *kapi.Service) {
 		}
 		namespacedName := ktypes.NamespacedName{Namespace: new.Namespace, Name: new.Name}
 		l.Lock()
-		l.endpoints[namespacedName] = l.GetLocalEndpointAddressesCount(epSlices)
+		l.endpoints[namespacedName] = l.CountLocalEndpointAddresses(epSlices)
 		_ = l.server.SyncEndpoints(l.endpoints)
 		l.Unlock()
 	}
@@ -91,23 +92,33 @@ func (l *loadBalancerHealthChecker) SyncServices(svcs []interface{}) error {
 }
 
 func (l *loadBalancerHealthChecker) SyncEndPointSlices(epSlice *discovery.EndpointSlice) {
-	namespacedName := namespacedNameFromEPSlice(epSlice)
+	namespacedName, err := namespacedNameFromEPSlice(epSlice)
+	if err != nil {
+		klog.Errorf("Skipping %s/%s: %v", epSlice.Namespace, epSlice.Name, err)
+		return
+	}
 	epSlices, err := l.watchFactory.GetEndpointSlices(epSlice.Namespace, epSlice.Labels[discovery.LabelServiceName])
 	if err != nil {
 		// should be a rare occurence
-		klog.V(4).Infof("Could not fetch endpointslices for %v during health check", namespacedName)
+		klog.V(4).Infof("Could not fetch endpointslices for %s during health check", namespacedName.String())
 	}
+
+	localEndpointAddressCount := l.CountLocalEndpointAddresses(epSlices)
 	if len(epSlices) == 0 {
 		// let's delete it from cache and wait for the next update; this will show as 0 endpoints for health checks
 		delete(l.endpoints, namespacedName)
 	} else {
-		l.endpoints[namespacedName] = l.GetLocalEndpointAddressesCount(epSlices)
+		l.endpoints[namespacedName] = localEndpointAddressCount
 	}
 	_ = l.server.SyncEndpoints(l.endpoints)
 }
 
 func (l *loadBalancerHealthChecker) AddEndpointSlice(epSlice *discovery.EndpointSlice) {
-	namespacedName := namespacedNameFromEPSlice(epSlice)
+	namespacedName, err := namespacedNameFromEPSlice(epSlice)
+	if err != nil {
+		klog.Errorf("Skipping %s/%s: %v", epSlice.Namespace, epSlice.Name, err)
+		return
+	}
 	l.Lock()
 	defer l.Unlock()
 	if _, exists := l.services[namespacedName]; exists {
@@ -116,7 +127,11 @@ func (l *loadBalancerHealthChecker) AddEndpointSlice(epSlice *discovery.Endpoint
 }
 
 func (l *loadBalancerHealthChecker) UpdateEndpointSlice(oldEpSlice, newEpSlice *discovery.EndpointSlice) {
-	namespacedName := namespacedNameFromEPSlice(newEpSlice)
+	namespacedName, err := namespacedNameFromEPSlice(newEpSlice)
+	if err != nil {
+		klog.Errorf("Skipping %s/%s: %v", newEpSlice.Namespace, newEpSlice.Name, err)
+		return
+	}
 	l.Lock()
 	defer l.Unlock()
 	if _, exists := l.services[namespacedName]; exists {
@@ -130,17 +145,19 @@ func (l *loadBalancerHealthChecker) DeleteEndpointSlice(epSlice *discovery.Endpo
 	l.SyncEndPointSlices(epSlice)
 }
 
-// GetLocalEndpointAddresses returns the number of endpoints that are local to the node for a service
-func (l *loadBalancerHealthChecker) GetLocalEndpointAddressesCount(endpointSlices []*discovery.EndpointSlice) int {
-	localEndpoints := sets.NewString()
+// CountLocalEndpointAddresses returns the number of IP addresses from ready endpoints that are local
+// to the node for a service
+func (l *loadBalancerHealthChecker) CountLocalEndpointAddresses(endpointSlices []*discovery.EndpointSlice) int {
+	localEndpointAddresses := sets.NewString()
 	for _, endpointSlice := range endpointSlices {
 		for _, endpoint := range endpointSlice.Endpoints {
-			if endpoint.NodeName != nil && *endpoint.NodeName == l.nodeName {
-				localEndpoints.Insert(endpoint.Addresses...)
+			isLocal := endpoint.NodeName != nil && *endpoint.NodeName == l.nodeName
+			if isEndpointReady(endpoint) && isLocal {
+				localEndpointAddresses.Insert(endpoint.Addresses...)
 			}
 		}
 	}
-	return len(localEndpoints)
+	return len(localEndpointAddresses)
 }
 
 // hasLocalHostNetworkEndpoints returns true if there is at least one host-networked endpoint
@@ -149,6 +166,9 @@ func (l *loadBalancerHealthChecker) GetLocalEndpointAddressesCount(endpointSlice
 func hasLocalHostNetworkEndpoints(epSlices []*discovery.EndpointSlice, nodeAddresses []net.IP) bool {
 	for _, epSlice := range epSlices {
 		for _, endpoint := range epSlice.Endpoints {
+			if !isEndpointReady(endpoint) {
+				continue
+			}
 			for _, ip := range endpoint.Addresses {
 				for _, nodeIP := range nodeAddresses {
 					if nodeIP.String() == ip {
@@ -169,6 +189,13 @@ func isHostEndpoint(endpointIP string) bool {
 		}
 	}
 	return true
+}
+
+// discovery.EndpointSlice reports in the same slice all endpoints along with their status.
+// isEndpointReady takes an endpoint from an endpoint slice and returns true if the endpoint is
+// to be considered ready.
+func isEndpointReady(endpoint discovery.Endpoint) bool {
+	return endpoint.Conditions.Ready == nil || *endpoint.Conditions.Ready
 }
 
 // checkForStaleOVSInternalPorts checks for OVS internal ports without any ofport assigned,
@@ -432,7 +459,15 @@ func checkPorts(patchIntf, ofPortPatch, physIntf, ofPortPhys string) error {
 	return nil
 }
 
-func namespacedNameFromEPSlice(epSlice *discovery.EndpointSlice) ktypes.NamespacedName {
+func namespacedNameFromEPSlice(epSlice *discovery.EndpointSlice) (ktypes.NamespacedName, error) {
+	// Return the namespaced name of the corresponding service
+	var serviceNamespacedName ktypes.NamespacedName
 	svcName := epSlice.Labels[discovery.LabelServiceName]
-	return ktypes.NamespacedName{Namespace: epSlice.Namespace, Name: svcName}
+	if svcName == "" {
+		// should not happen, since the informer already filters out endpoint slices with an empty service label
+		return serviceNamespacedName,
+			fmt.Errorf("endpointslice %s/%s: empty value for label %s",
+				epSlice.Namespace, epSlice.Name, discovery.LabelServiceName)
+	}
+	return ktypes.NamespacedName{Namespace: epSlice.Namespace, Name: svcName}, nil
 }

--- a/go-controller/pkg/node/node.go
+++ b/go-controller/pkg/node/node.go
@@ -630,16 +630,16 @@ func (n *OvnNode) WatchEndpointSlices() error {
 		UpdateFunc: func(old, new interface{}) {
 			newEndpointSlice := new.(*discovery.EndpointSlice)
 			oldEndpointSlice := old.(*discovery.EndpointSlice)
-			for _, port := range oldEndpointSlice.Ports {
-				for _, endpoint := range oldEndpointSlice.Endpoints {
-					for _, ip := range endpoint.Addresses {
-						if doesEPSliceContainEndpoint(newEndpointSlice, ip, *port.Port, *port.Protocol) {
+			for _, oldPort := range oldEndpointSlice.Ports {
+				for _, oldEndpoint := range oldEndpointSlice.Endpoints {
+					for _, oldIP := range oldEndpoint.Addresses {
+						if doesEPSliceContainReadyEndpoint(newEndpointSlice, oldIP, *oldPort.Port, *oldPort.Protocol) {
 							continue
 						}
-						if *port.Protocol == kapi.ProtocolUDP { // flush conntrack only for UDP
-							err := util.DeleteConntrack(ip, *port.Port, *port.Protocol, netlink.ConntrackReplyAnyIP, nil)
+						if *oldPort.Protocol == kapi.ProtocolUDP { // flush conntrack only for UDP
+							err := util.DeleteConntrack(oldIP, *oldPort.Port, *oldPort.Protocol, netlink.ConntrackReplyAnyIP, nil)
 							if err != nil {
-								klog.Errorf("Failed to delete conntrack entry for %s: %v", ip, err)
+								klog.Errorf("Failed to delete conntrack entry for %s: %v", oldIP, err)
 							}
 						}
 					}
@@ -802,11 +802,14 @@ func (n *OvnNode) validateVTEPInterfaceMTU() error {
 }
 
 // doesEPSliceContainEndpoint checks whether the endpointslice
-// contains a specific endpoint with IP/Port/Protocol
-func doesEPSliceContainEndpoint(epSlice *discovery.EndpointSlice,
+// contains a specific endpoint with IP/Port/Protocol and this endpoint is ready
+func doesEPSliceContainReadyEndpoint(epSlice *discovery.EndpointSlice,
 	epIP string, epPort int32, protocol kapi.Protocol) bool {
 	for _, port := range epSlice.Ports {
 		for _, endpoint := range epSlice.Endpoints {
+			if !isEndpointReady(endpoint) {
+				continue
+			}
 			for _, ip := range endpoint.Addresses {
 				if ip == epIP && *port.Port == epPort && *port.Protocol == protocol {
 					return true

--- a/go-controller/vendor/github.com/ovn-org/libovsdb/client/client.go
+++ b/go-controller/vendor/github.com/ovn-org/libovsdb/client/client.go
@@ -778,7 +778,10 @@ func (o *ovsdbClient) transact(ctx context.Context, dbName string, operation ...
 	if o.rpcClient == nil {
 		return nil, ErrNotConnected
 	}
-	o.logger.V(4).Info("transacting operations", "database", dbName, "operations", fmt.Sprintf("%+v", operation))
+	dbgLogger := o.logger.WithValues("database", dbName).V(4)
+	if dbgLogger.Enabled() {
+		dbgLogger.Info("transacting operations", "operations", fmt.Sprintf("%+v", operation))
+	}
 	err := o.rpcClient.CallWithContext(ctx, "transact", args, &reply)
 	if err != nil {
 		if err == rpc2.ErrShutdown {

--- a/go-controller/vendor/github.com/ovn-org/libovsdb/ovsdb/serverdb/database.go
+++ b/go-controller/vendor/github.com/ovn-org/libovsdb/ovsdb/serverdb/database.go
@@ -5,6 +5,8 @@ package serverdb
 
 import "github.com/ovn-org/libovsdb/model"
 
+const DatabaseTable = "Database"
+
 type (
 	DatabaseModel = string
 )

--- a/go-controller/vendor/modules.txt
+++ b/go-controller/vendor/modules.txt
@@ -269,7 +269,7 @@ github.com/openshift/client-go/cloudnetwork/informers/externalversions/cloudnetw
 github.com/openshift/client-go/cloudnetwork/informers/externalversions/cloudnetwork/v1
 github.com/openshift/client-go/cloudnetwork/informers/externalversions/internalinterfaces
 github.com/openshift/client-go/cloudnetwork/listers/cloudnetwork/v1
-# github.com/ovn-org/libovsdb v0.6.1-0.20220901025242-999ca1972a3a
+# github.com/ovn-org/libovsdb v0.6.1-0.20221101143603-8f21d188c3a5
 ## explicit; go 1.18
 github.com/ovn-org/libovsdb/cache
 github.com/ovn-org/libovsdb/client


### PR DESCRIPTION
Pulls in the following commits, for which we really just care about the client logging one for performance.

```
64a1543b16 client: don't construct transaction log string when it's not needed
14b9f5b67b Make table name a const above generated model
```

(cherry picked from commit 3b56eb09a6a0fca6ad7e9d2361adf77f2b468120)