### PR TITLE
OCPBUGS-3291: Disable packet MTU check when OVS HW Offload is enabled

### DIFF
--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -120,6 +120,10 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 			Output: "Check pkt length action: Yes",
 		})
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+			Cmd:    "ovs-vsctl --timeout=15 --if-exists get Open_vSwitch . other_config:hw-offload",
+			Output: "false",
+		})
+		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 			Cmd:    "ovs-vsctl --timeout=15 get Interface patch-breth0_node1-to-br-int ofport",
 			Output: "5",
 		})
@@ -401,6 +405,11 @@ func shareGatewayInterfaceDPUTest(app *cli.App, testNS ns.NetNS,
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 			Cmd:    "ovs-appctl --timeout=15 dpif/show-dp-features " + brphys,
 			Output: "Check pkt length action: Yes",
+		})
+		// IsOvsHwOffloadEnabled
+		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+			Cmd:    "ovs-vsctl --timeout=15 --if-exists get Open_vSwitch . other_config:hw-offload",
+			Output: "false",
 		})
 		// GetDPUHostInterface
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
@@ -729,6 +738,10 @@ func localGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 			Cmd:    "ovs-appctl --timeout=15 dpif/show-dp-features breth0",
 			Output: "Check pkt length action: Yes",
+		})
+		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+			Cmd:    "ovs-vsctl --timeout=15 --if-exists get Open_vSwitch . other_config:hw-offload",
+			Output: "false",
 		})
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 			Cmd:    "ovs-vsctl --timeout=15 get Interface patch-breth0_node1-to-br-int ofport",

--- a/go-controller/pkg/util/ovs.go
+++ b/go-controller/pkg/util/ovs.go
@@ -880,6 +880,23 @@ func DetectCheckPktLengthSupport(bridge string) (bool, error) {
 	return false, nil
 }
 
+// IsOvsHwOffloadEnabled checks if OvS Hardware Offload is enabled.
+func IsOvsHwOffloadEnabled() (bool, error) {
+	stdout, stderr, err := RunOVSVsctl("--if-exists", "get",
+		"Open_vSwitch", ".", "other_config:hw-offload")
+	if err != nil {
+		klog.Errorf("Failed to get output from ovs-vsctl --if-exists get Open_vSwitch . "+
+			"other_config:hw-offload stderr(%s) : %v", stderr, err)
+		return false, err
+	}
+
+	// For the case if the hw-offload key doesn't exist, we check for empty output.
+	if len(stdout) == 0 || stdout == "false" {
+		return false, nil
+	}
+	return true, nil
+}
+
 type OvsDbProperties struct {
 	AppCtl        func(timeout int, args ...string) (string, string, error)
 	DbAlias       string


### PR DESCRIPTION
This is a OVS dependent work around fix. If we detect that OVS HW Offload is enabled, we are aware that the offloading of packet MTU check support in OVS is not supported. This support will not be available until the offload support for sFlow is added.

In order to have the most optimal performance, the packet MTU check support should be disabled when OVS HW Offload is enabled on the node.

Backport of upstream https://github.com/ovn-org/ovn-kubernetes/pull/3227
(cherry picked from commit 70e0e13bb1bf15a6c5d2b2ca36988ddf74bd5d13)