### PR TITLE
OCPBUGS-1486: Avoid re-metricing pods

### DIFF
--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -727,7 +727,10 @@ func (oc *Controller) addLogicalPort(pod *kapi.Pod) (err error) {
 		}
 	}
 	// observe the pod creation latency metric.
-	metrics.RecordPodCreated(pod)
+	// if pod was annotated (needs IP will be false) or had an lsp when addLogicalPort was called do not record pod metrics
+	if needsIP && !lspExist {
+		metrics.RecordPodCreated(pod)
+	}
 	return nil
 }
 


### PR DESCRIPTION
Issue: When a new ovnkube master starts, or gains leadership through leaderelection, addLogicalPort is called for all existing pods to ensure they are set up correctly, which means we recollect the podCreated metrics on pods that may not need it, and we will set an incorrect creation latency for pods.

Solution: Do not record pod creation latency metric for pods with annotations or pods with existing logical switch ports when addLogicalPort is ran

Signed-off-by: Ben Pickard <bpickard@redhat.com>