### PR TITLE
[release-4.12] OCPBUGS-3390: Handle k8s watcher restart scenario

### DIFF
--- a/go-controller/pkg/factory/factory.go
+++ b/go-controller/pkg/factory/factory.go
@@ -857,3 +857,29 @@ func noAlternateProxySelector() func(options *metav1.ListOptions) {
 		options.LabelSelector = labelSelector.String()
 	}
 }
+
+// WithUpdateHandlingForObjReplace decorates given cache.ResourceEventHandler with checking object
+// replace case in the update event. when old and new object have different UIDs, then consider it
+// as a replace and invoke delete handler for old object followed by add handler for new object.
+func WithUpdateHandlingForObjReplace(funcs cache.ResourceEventHandler) cache.ResourceEventHandlerFuncs {
+	return cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			funcs.OnAdd(obj)
+		},
+		UpdateFunc: func(old, new interface{}) {
+			oldObj := old.(metav1.Object)
+			newObj := new.(metav1.Object)
+			if oldObj.GetUID() == newObj.GetUID() {
+				funcs.OnUpdate(old, new)
+				return
+			}
+			// This occurs not so often, so log this occurance.
+			klog.Infof("Object %s/%s is replaced, invoking delete followed by add handler", newObj.GetNamespace(), newObj.GetName())
+			funcs.OnDelete(old)
+			funcs.OnAdd(new)
+		},
+		DeleteFunc: func(obj interface{}) {
+			funcs.OnDelete(obj)
+		},
+	}
+}

--- a/go-controller/pkg/ovn/controller/egress_services/egress_services_controller.go
+++ b/go-controller/pkg/ovn/controller/egress_services/egress_services_controller.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	libovsdbclient "github.com/ovn-org/libovsdb/client"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdbops"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/healthcheck"
@@ -118,19 +119,19 @@ func NewController(
 		workqueue.NewItemFastSlowRateLimiter(1*time.Second, 5*time.Second, 5),
 		"egressservices",
 	)
-	serviceInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	serviceInformer.Informer().AddEventHandler(factory.WithUpdateHandlingForObjReplace(cache.ResourceEventHandlerFuncs{
 		AddFunc:    c.onServiceAdd,
 		UpdateFunc: c.onServiceUpdate,
 		DeleteFunc: c.onServiceDelete,
-	})
+	}))
 
 	c.endpointSliceLister = endpointSliceInformer.Lister()
 	c.endpointSlicesSynced = endpointSliceInformer.Informer().HasSynced
-	endpointSliceInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	endpointSliceInformer.Informer().AddEventHandler(factory.WithUpdateHandlingForObjReplace(cache.ResourceEventHandlerFuncs{
 		AddFunc:    c.onEndpointSliceAdd,
 		UpdateFunc: c.onEndpointSliceUpdate,
 		DeleteFunc: c.onEndpointSliceDelete,
-	})
+	}))
 
 	c.nodeLister = nodeInformer.Lister()
 	c.nodesSynced = nodeInformer.Informer().HasSynced
@@ -138,11 +139,11 @@ func NewController(
 		workqueue.NewItemFastSlowRateLimiter(1*time.Second, 5*time.Second, 5),
 		"egressservicenodes",
 	)
-	nodeInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	nodeInformer.Informer().AddEventHandler(factory.WithUpdateHandlingForObjReplace(cache.ResourceEventHandlerFuncs{
 		AddFunc:    c.onNodeAdd,
 		UpdateFunc: c.onNodeUpdate,
 		DeleteFunc: c.onNodeDelete,
-	})
+	}))
 
 	return c
 }

--- a/go-controller/pkg/ovn/controller/services/node_tracker.go
+++ b/go-controller/pkg/ovn/controller/services/node_tracker.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	globalconfig "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 
 	v1 "k8s.io/api/core/v1"
@@ -69,7 +70,7 @@ func newNodeTracker(nodeInformer coreinformers.NodeInformer) *nodeTracker {
 		nodes: map[string]nodeInfo{},
 	}
 
-	nodeInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	nodeInformer.Informer().AddEventHandler(factory.WithUpdateHandlingForObjReplace(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			node, ok := obj.(*v1.Node)
 			if !ok {
@@ -114,7 +115,7 @@ func newNodeTracker(nodeInformer coreinformers.NodeInformer) *nodeTracker {
 			}
 			nt.removeNodeWithServiceReSync(node.Name)
 		},
-	})
+	}))
 
 	return nt
 

--- a/go-controller/pkg/ovn/controller/services/services_controller.go
+++ b/go-controller/pkg/ovn/controller/services/services_controller.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	libovsdbclient "github.com/ovn-org/libovsdb/client"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/metrics"
 	ovnlb "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/loadbalancer"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
@@ -65,21 +66,21 @@ func NewController(client clientset.Interface,
 
 	// services
 	klog.Info("Setting up event handlers for services")
-	serviceInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	serviceInformer.Informer().AddEventHandler(factory.WithUpdateHandlingForObjReplace(cache.ResourceEventHandlerFuncs{
 		AddFunc:    c.onServiceAdd,
 		UpdateFunc: c.onServiceUpdate,
 		DeleteFunc: c.onServiceDelete,
-	})
+	}))
 	c.serviceLister = serviceInformer.Lister()
 	c.servicesSynced = serviceInformer.Informer().HasSynced
 
 	// endpoints slices
 	klog.Info("Setting up event handlers for endpoint slices")
-	endpointSliceInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	endpointSliceInformer.Informer().AddEventHandler(factory.WithUpdateHandlingForObjReplace(cache.ResourceEventHandlerFuncs{
 		AddFunc:    c.onEndpointSliceAdd,
 		UpdateFunc: c.onEndpointSliceUpdate,
 		DeleteFunc: c.onEndpointSliceDelete,
-	})
+	}))
 
 	c.endpointSliceLister = endpointSliceInformer.Lister()
 	c.endpointSlicesSynced = endpointSliceInformer.Informer().HasSynced

--- a/go-controller/pkg/ovn/egressqos.go
+++ b/go-controller/pkg/ovn/egressqos.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	egressqosapi "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressqos/v1"
 	egressqosinformer "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressqos/v1/apis/informers/externalversions/egressqos/v1"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdbops"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
 	addressset "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/address_set"
@@ -170,11 +171,11 @@ func (oc *Controller) initEgressQoSController(
 		workqueue.NewItemFastSlowRateLimiter(1*time.Second, 5*time.Second, 5),
 		"egressqos",
 	)
-	eqInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	eqInformer.Informer().AddEventHandler(factory.WithUpdateHandlingForObjReplace(cache.ResourceEventHandlerFuncs{
 		AddFunc:    oc.onEgressQoSAdd,
 		UpdateFunc: oc.onEgressQoSUpdate,
 		DeleteFunc: oc.onEgressQoSDelete,
-	})
+	}))
 
 	oc.egressQoSPodLister = podInformer.Lister()
 	oc.egressQoSPodSynced = podInformer.Informer().HasSynced
@@ -182,11 +183,11 @@ func (oc *Controller) initEgressQoSController(
 		workqueue.NewItemFastSlowRateLimiter(1*time.Second, 5*time.Second, 5),
 		"egressqospods",
 	)
-	podInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	podInformer.Informer().AddEventHandler(factory.WithUpdateHandlingForObjReplace(cache.ResourceEventHandlerFuncs{
 		AddFunc:    oc.onEgressQoSPodAdd,
 		UpdateFunc: oc.onEgressQoSPodUpdate,
 		DeleteFunc: oc.onEgressQoSPodDelete,
-	})
+	}))
 
 	oc.egressQoSNodeLister = nodeInformer.Lister()
 	oc.egressQoSNodeSynced = nodeInformer.Informer().HasSynced


### PR DESCRIPTION
Sometimes k8s watcher getting restarted and for this condition update events are sent for all updated resources. If the object was recreated with same namespace and name while the watcher was off, ovnk gets update event where old and new objects have different UIDs.

Hence this commit handles such scenario by comparing object UIDs, deleting resources for old object followed by adding resources for new object.

Signed-off-by: Periyasamy Palanisamy <pepalani@redhat.com>
(cherry picked from commit bcd6124549e2e9ced9a397dc21c02f26f651bedd)