### PR TITLE
[release-4.11] OCPBUGS-2859: node, route update: generic way to filter routes

### DIFF
--- a/go-controller/pkg/util/net_linux.go
+++ b/go-controller/pkg/util/net_linux.go
@@ -299,7 +299,7 @@ func LinkRoutesAdd(link netlink.Link, gwIP net.IP, subnets []*net.IPNet, mtu int
 
 func LinkRoutesAddOrUpdateMTU(link netlink.Link, gwIP net.IP, subnets []*net.IPNet, mtu int) error {
 	for _, subnet := range subnets {
-		route, err := LinkRouteGet(link, gwIP, subnet)
+		route, err := LinkRouteGetFilteredRoute(filterRouteByDst(link, subnet))
 		if err != nil {
 			return err
 		}
@@ -319,26 +319,23 @@ func LinkRoutesAddOrUpdateMTU(link netlink.Link, gwIP net.IP, subnets []*net.IPN
 	return nil
 }
 
-// LinkRouteGet gets a route for the given subnet with the specified gwIPStr
+// LinkRouteGetFilteredRoute gets a route for the given route filter.
 // returns nil if route is not found
-func LinkRouteGet(link netlink.Link, gwIP net.IP, subnet *net.IPNet) (*netlink.Route, error) {
-	routeFilter := &netlink.Route{Dst: subnet, LinkIndex: link.Attrs().Index}
-	filterMask := netlink.RT_FILTER_DST | netlink.RT_FILTER_OIF
-	routes, err := netLinkOps.RouteListFiltered(getFamily(gwIP), routeFilter, filterMask)
+func LinkRouteGetFilteredRoute(routeFilter *netlink.Route, filterMask uint64) (*netlink.Route, error) {
+	routes, err := netLinkOps.RouteListFiltered(getFamily(routeFilter.Dst.IP), routeFilter, filterMask)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get routes for subnet %s", subnet.String())
+		return nil, fmt.Errorf(
+			"failed to get routes for filter %v with mask %d: %v", *routeFilter, filterMask, err)
 	}
-	for _, route := range routes {
-		if route.Gw.Equal(gwIP) {
-			return &route, nil
-		}
+	if len(routes) == 0 {
+		return nil, nil
 	}
-	return nil, nil
+	return &routes[0], nil
 }
 
 // LinkRouteExists checks for existence of routes for the given subnet through gwIPStr
 func LinkRouteExists(link netlink.Link, gwIP net.IP, subnet *net.IPNet) (bool, error) {
-	route, err := LinkRouteGet(link, gwIP, subnet)
+	route, err := LinkRouteGetFilteredRoute(filterRouteByDstAndGw(link, subnet, gwIP))
 	return route != nil, err
 }
 
@@ -524,4 +521,21 @@ func GetIFNameAndMTUForAddress(ifAddress net.IP) (string, int, error) {
 	}
 
 	return "", 0, fmt.Errorf("couldn't not find a link associated with the given OVN Encap IP (%s)", ifAddress)
+}
+
+func filterRouteByDst(link netlink.Link, subnet *net.IPNet) (*netlink.Route, uint64) {
+	return &netlink.Route{
+			Dst:       subnet,
+			LinkIndex: link.Attrs().Index,
+		},
+		netlink.RT_FILTER_DST | netlink.RT_FILTER_OIF
+}
+
+func filterRouteByDstAndGw(link netlink.Link, subnet *net.IPNet, gw net.IP) (*netlink.Route, uint64) {
+	return &netlink.Route{
+			Dst:       subnet,
+			LinkIndex: link.Attrs().Index,
+			Gw:        gw,
+		},
+		netlink.RT_FILTER_DST | netlink.RT_FILTER_OIF | netlink.RT_FILTER_GW
 }

--- a/go-controller/pkg/util/net_linux_unit_test.go
+++ b/go-controller/pkg/util/net_linux_unit_test.go
@@ -590,6 +590,7 @@ func TestLinkRoutesAddOrUpdateMTU(t *testing.T) {
 				{OnCallMethodName: "RouteListFiltered", OnCallMethodArgType: []string{"int", "*netlink.Route", "uint64"}, RetArgList: []interface{}{[]netlink.Route{
 					{
 						Gw:  ovntest.MustParseIP("192.168.0.1"),
+						Dst: ovntest.MustParseIPNet("10.18.20.0/24"),
 						MTU: 1400,
 					},
 				}, nil}},
@@ -607,9 +608,33 @@ func TestLinkRoutesAddOrUpdateMTU(t *testing.T) {
 			errExp:       false,
 			onRetArgsNetLinkLibOpers: []ovntest.TestifyMockHelper{
 				{OnCallMethodName: "RouteListFiltered", OnCallMethodArgType: []string{"int", "*netlink.Route", "uint64"}, RetArgList: []interface{}{[]netlink.Route{
-					{Gw: ovntest.MustParseIP("192.168.0.1")},
+					{
+						Gw:  ovntest.MustParseIP("192.168.0.1"),
+						Dst: ovntest.MustParseIPNet("10.18.20.0/24"),
+					},
 				}, nil}},
 				{OnCallMethodName: "RouteReplace", OnCallMethodArgType: []string{"*netlink.Route"}, RetArgList: []interface{}{nil}},
+			},
+			onRetArgsLinkIfaceOpers: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "Attrs", OnCallMethodArgType: []string{}, RetArgList: []interface{}{&netlink.LinkAttrs{Name: "testIfaceName", Index: 1}}},
+			},
+		},
+		{
+			desc:         "Route exists, has the same mtu and is not updated",
+			inputLink:    mockLink,
+			inputGwIP:    nil,
+			inputSubnets: ovntest.MustParseIPNets("10.18.20.0/24"),
+			inputMTU:     1400,
+			errExp:       false,
+			onRetArgsNetLinkLibOpers: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "RouteListFiltered", OnCallMethodArgType: []string{"int", "*netlink.Route", "uint64"}, RetArgList: []interface{}{[]netlink.Route{
+					{
+						Gw:  ovntest.MustParseIP("192.168.0.1"),
+						Dst: ovntest.MustParseIPNet("10.18.20.0/24"),
+						MTU: 1400,
+						Src: ovntest.MustParseIP("192.168.0.10"),
+					},
+				}, nil}},
 			},
 			onRetArgsLinkIfaceOpers: []ovntest.TestifyMockHelper{
 				{OnCallMethodName: "Attrs", OnCallMethodArgType: []string{}, RetArgList: []interface{}{&netlink.LinkAttrs{Name: "testIfaceName", Index: 1}}},


### PR DESCRIPTION
This PR is required in 4.11 to allow for rollbacks from 4.12: https://issues.redhat.com/browse/OCPBUGS-2517?focusedCommentId=21154727&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-21154727

Currently the rollback fails because 4.11 ovnkube-node is trying to add a route with a different destination which fails with the following error:
```
F1106 04:48:21.166135  193616 ovnkube.go:133] unable to add/update route for service via br-ex, error: file exists
```
https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.12-upgrade-from-stable-4.11-e2e-aws-ovn-upgrade-rollback/1589046338517995520/artifacts/e2e-aws-ovn-upgrade-rollback/gather-extra/artifacts/pods/openshift-ovn-kubernetes_ovnkube-node-z8ljm_ovnkube-node.log

With 69d5d7d3cf434dfa7e864b7a9f19b1c81f4333d8 backported the route will get updated.


(cherry picked from commit 69d5d7d3cf434dfa7e864b7a9f19b1c81f4333d8)