### PR TITLE
OCPBUGS-3262: Don't warn on failure to create pod when it isn't scheduled

### DIFF
--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -534,7 +534,7 @@ func networkStatusAnnotationsChanged(oldPod, newPod *kapi.Pod) bool {
 func (oc *Controller) ensurePod(oldPod, pod *kapi.Pod, addPort bool) error {
 	// Try unscheduled pods later
 	if !util.PodScheduled(pod) {
-		return fmt.Errorf("failed to ensurePod %s/%s since it is not yet scheduled", pod.Namespace, pod.Name)
+		return nil
 	}
 
 	if oldPod != nil && (exGatewayAnnotationsChanged(oldPod, pod) || networkStatusAnnotationsChanged(oldPod, pod)) {
@@ -706,7 +706,7 @@ func (oc *Controller) WatchPods() {
 				return
 			}
 
-			if err := oc.ensurePod(oldPod, pod, oc.checkAndSkipRetryPod(pod)); err != nil {
+			if err := oc.ensurePod(oldPod, pod, oc.checkAndSkipRetryPod(pod) || util.PodScheduled(oldPod) != util.PodScheduled(pod)); err != nil {
 				oc.recordPodEvent(err, pod)
 				klog.Errorf("Failed to update pod %s, error: %v",
 					getPodNamespacedName(pod), err)


### PR DESCRIPTION
If the pod isn't yet scheduled, we should just ignore the event and try again later when we get the update event as we do in 4.11+.

Signed-off-by: Ori Braunshtein <obraunsh@redhat.com>

**- Special notes for reviewers**
This is similar to 28fc798a72f469c2fa4deec3236bfb41f56402c9 but could not be cherry-picked since obj_retry is since 4.11