### PR TITLE
[release-4.13] Update images to be consistent with ART

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@
 # are built in this Dockerfile and included in the image (instead of the rpm)
 #
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.18-openshift-4.12 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-4.12 AS builder
 
 WORKDIR /go/src/github.com/openshift/ovn-kubernetes
 COPY . .

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -13,7 +13,7 @@ RUN yum install -y  \
 	yum clean all
 
 ARG ovsver=2.17.0-37.4.el8fdp
-ARG ovnver=22.06.0-27.el8fdp
+ARG ovnver=22.09.0-5.el8fdp
 RUN echo $ovsver > /ovs-version && echo $ovnver > /ovn-version
 
 RUN mkdir -p /var/run/openvswitch && \

--- a/Dockerfile.microshift
+++ b/Dockerfile.microshift
@@ -12,7 +12,7 @@
 # openvswitch-devel, openvswitch-ipsec, libpcap, iproute etc
 # ovn-kube-util, hybrid-overlay-node.exe, ovndbchecker and ovnkube-trace
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.18-openshift-4.12 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-4.12 AS builder
 
 WORKDIR /go/src/github.com/openshift/ovn-kubernetes
 COPY . .
@@ -29,7 +29,7 @@ ENV PYTHONDONTWRITEBYTECODE yes
 RUN export ovsver=$(cat /ovs-version) && \
 	export ovnver=$(cat /ovn-version) && \
 	yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False "openvswitch2.17 = $ovsver" "python3-openvswitch2.17 = $ovsver" && \
-        yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False "ovn22.06 = $ovnver" "ovn22.06-central = $ovnver" "ovn22.06-host = $ovnver" && \
+        yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False "ovn22.09 = $ovnver" "ovn22.09-central = $ovnver" "ovn22.09-host = $ovnver" && \
         yum clean all && rm -rf /var/cache/*
 
 COPY --from=builder /go/src/github.com/openshift/ovn-kubernetes/go-controller/_output/go/bin/ovnkube /usr/bin/


### PR DESCRIPTION
Bump base image to Go 1.19, and make sure Microshift uses the same OVN version as the regular image.

We'll use this as the 4.13 change that will unblock:

https://github.com/openshift/ovn-kubernetes/pull/1286
https://github.com/openshift/ovn-kubernetes/pull/1288
https://github.com/openshift/ovn-kubernetes/pull/1287
