### PR TITLE
OCPBUGS-3614: [4.11] CARRY: client: don't construct transaction log string when it's not needed

### DIFF
--- a/go-controller/go.mod
+++ b/go-controller/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/onsi/gomega v1.14.0
 	github.com/openshift/api v0.0.0-20211201215911-5a82bae32e46
 	github.com/openshift/client-go v0.0.0-20211202194848-d3f186f2d366
-	github.com/ovn-org/libovsdb v0.6.1-0.20220826133223-e4d2d8648be7
+	github.com/ovn-org/libovsdb v0.6.1-0.20221101143603-8f21d188c3a5
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.12.1
 	github.com/prometheus/client_model v0.2.0

--- a/go-controller/go.sum
+++ b/go-controller/go.sum
@@ -375,8 +375,8 @@ github.com/openshift/api v0.0.0-20211201215911-5a82bae32e46/go.mod h1:RsQCVJu4qh
 github.com/openshift/build-machinery-go v0.0.0-20210712174854-1bb7fd1518d3/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20211202194848-d3f186f2d366 h1:/llKlbXC7F6rqTkAl2GE//9GDR0iDsqJEFvvJ1kLJXg=
 github.com/openshift/client-go v0.0.0-20211202194848-d3f186f2d366/go.mod h1:HJeHsH6mPyrrOVS/2j1zcztGAJG9ETKbqtlyohs84yY=
-github.com/ovn-org/libovsdb v0.6.1-0.20220826133223-e4d2d8648be7 h1:5QygTHBNvCe3A78OAl9UqllaIGX4TL00te/OIBiHHEo=
-github.com/ovn-org/libovsdb v0.6.1-0.20220826133223-e4d2d8648be7/go.mod h1:j6GV+8zVENVmWFxHg5nNcn88ge67sq35yyoAEso7TD8=
+github.com/ovn-org/libovsdb v0.6.1-0.20221101143603-8f21d188c3a5 h1:Cw0JXIHSGp8etz5/P7zNQ0tCMmTljBGBr8Rn2P1PuzQ=
+github.com/ovn-org/libovsdb v0.6.1-0.20221101143603-8f21d188c3a5/go.mod h1:S/+Hux9//oB7yLaPsUKnXTzZc6S1C4a9HP0UifXfKz0=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/go-controller/vendor/github.com/ovn-org/libovsdb/client/client.go
+++ b/go-controller/vendor/github.com/ovn-org/libovsdb/client/client.go
@@ -778,7 +778,10 @@ func (o *ovsdbClient) transact(ctx context.Context, dbName string, operation ...
 	if o.rpcClient == nil {
 		return nil, ErrNotConnected
 	}
-	o.logger.V(4).Info("transacting operations", "database", dbName, "operations", fmt.Sprintf("%+v", operation))
+	dbgLogger := o.logger.WithValues("database", dbName).V(4)
+	if dbgLogger.Enabled() {
+		dbgLogger.Info("transacting operations", "operations", fmt.Sprintf("%+v", operation))
+	}
 	err := o.rpcClient.CallWithContext(ctx, "transact", args, &reply)
 	if err != nil {
 		if err == rpc2.ErrShutdown {

--- a/go-controller/vendor/github.com/ovn-org/libovsdb/client/metrics.go
+++ b/go-controller/vendor/github.com/ovn-org/libovsdb/client/metrics.go
@@ -13,9 +13,8 @@ type metrics struct {
 	numTableUpdates *prometheus.CounterVec
 	numDisconnects  prometheus.Counter
 	numMonitors     prometheus.Gauge
+	registerOnce    sync.Once
 }
-
-var regMetricsOnce sync.Once
 
 func (m *metrics) init(modelName string, namespace, subsystem string) {
 	// labels that are the same across all metrics
@@ -70,7 +69,7 @@ func (m *metrics) init(modelName string, namespace, subsystem string) {
 }
 
 func (m *metrics) register(r prometheus.Registerer) {
-	regMetricsOnce.Do(func() {
+	m.registerOnce.Do(func() {
 		r.MustRegister(
 			m.numUpdates,
 			m.numTableUpdates,

--- a/go-controller/vendor/github.com/ovn-org/libovsdb/ovsdb/serverdb/database.go
+++ b/go-controller/vendor/github.com/ovn-org/libovsdb/ovsdb/serverdb/database.go
@@ -5,6 +5,8 @@ package serverdb
 
 import "github.com/ovn-org/libovsdb/model"
 
+const DatabaseTable = "Database"
+
 type (
 	DatabaseModel = string
 )

--- a/go-controller/vendor/modules.txt
+++ b/go-controller/vendor/modules.txt
@@ -235,7 +235,7 @@ github.com/openshift/client-go/cloudnetwork/informers/externalversions/cloudnetw
 github.com/openshift/client-go/cloudnetwork/informers/externalversions/cloudnetwork/v1
 github.com/openshift/client-go/cloudnetwork/informers/externalversions/internalinterfaces
 github.com/openshift/client-go/cloudnetwork/listers/cloudnetwork/v1
-# github.com/ovn-org/libovsdb v0.6.1-0.20220826133223-e4d2d8648be7
+# github.com/ovn-org/libovsdb v0.6.1-0.20221101143603-8f21d188c3a5
 ## explicit; go 1.18
 github.com/ovn-org/libovsdb/cache
 github.com/ovn-org/libovsdb/client


### PR DESCRIPTION
Backport of https://github.com/ovn-org/libovsdb/pull/342 (see also 4.12 version https://github.com/openshift/ovn-kubernetes/pull/1348)

fmt.Sprintf() will be evaluated before the logging function is called, which means that even if the logging level is less than V(4) we'll still construct the whole string for the operation, just to discard it. That can be pretty expensive.