### PR TITLE
OCPBUGS-3615: [4.10] CARRY: client: don't construct transaction log string when it's not needed

### DIFF
--- a/go-controller/vendor/github.com/ovn-org/libovsdb/client/client.go
+++ b/go-controller/vendor/github.com/ovn-org/libovsdb/client/client.go
@@ -778,7 +778,10 @@ func (o *ovsdbClient) transact(ctx context.Context, dbName string, operation ...
 	if o.rpcClient == nil {
 		return nil, ErrNotConnected
 	}
-	o.logger.V(4).Info("transacting operations", "database", dbName, "operations", fmt.Sprintf("%+v", operation))
+	dbgLogger := o.logger.WithValues("database", dbName).V(4)
+	if dbgLogger.Enabled() {
+		dbgLogger.Info("transacting operations", "operations", fmt.Sprintf("%+v", operation))
+	}
 	err := o.rpcClient.CallWithContext(ctx, "transact", args, &reply)
 	if err != nil {
 		if err == rpc2.ErrShutdown {


### PR DESCRIPTION
https://github.com/ovn-org/libovsdb/pull/342 (see also 4.12 version https://github.com/openshift/ovn-kubernetes/pull/1348 and 4.11 version https://github.com/openshift/ovn-kubernetes/pull/1374)

fmt.Sprintf() will be evaluated before the logging function is called, which means that even if the logging level is less than V(4) we'll still construct the whole string for the operation, just to discard it. That can be pretty expensive.
