### PR TITLE
OCPBUGS-3656: Fixes dualstack clusterIPs for network policy svc handler

### DIFF
--- a/go-controller/pkg/ovn/gress_policy.go
+++ b/go-controller/pkg/ovn/gress_policy.go
@@ -464,10 +464,12 @@ func getSvcVips(nbClient client.Client, service *v1.Service) []net.IP {
 		}
 	}
 	if util.ServiceTypeHasClusterIP(service) {
-		if util.IsClusterIPSet(service) {
-			ip := net.ParseIP(service.Spec.ClusterIP)
+		ipStrs := util.GetClusterIPs(service)
+		for _, ipStr := range ipStrs {
+			ip := net.ParseIP(ipStr)
 			if ip == nil {
 				klog.Errorf("Failed to parse cluster IP %q", service.Spec.ClusterIP)
+				continue
 			}
 			ips = append(ips, ip)
 		}

--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -1581,11 +1581,12 @@ func (oc *Controller) handlePeerService(
 				newSvc := newObj.(*kapi.Service)
 				if reflect.DeepEqual(newSvc.Spec.ExternalIPs, oldSvc.Spec.ExternalIPs) &&
 					reflect.DeepEqual(newSvc.Spec.ClusterIP, oldSvc.Spec.ClusterIP) &&
+					reflect.DeepEqual(newSvc.Spec.ClusterIPs, oldSvc.Spec.ClusterIPs) &&
 					reflect.DeepEqual(newSvc.Spec.Type, oldSvc.Spec.Type) &&
 					reflect.DeepEqual(newSvc.Status.LoadBalancer.Ingress, oldSvc.Status.LoadBalancer.Ingress) {
 
-					klog.V(5).Infof("Skipping service update for: %s as change does not apply to any of .Spec.Ports, "+
-						".Spec.ExternalIP, .Spec.ClusterIP, .Spec.Type, .Status.LoadBalancer.Ingress", newSvc.Name)
+					klog.V(5).Infof("Skipping service update for: %s as change does not apply to any of "+
+						".Spec.ExternalIP, .Spec.ClusterIP, .Spec.ClusterIPs, .Spec.Type, .Status.LoadBalancer.Ingress", newSvc.Name)
 					return
 				}
 


### PR DESCRIPTION
Signed-off-by: Tim Rozet <trozet@redhat.com>

clean cherry-pick of: 1ff6e794c0597d72ff7576722e7fb4016383bfb6