### PR TITLE
[WIP] make sure fix doesn't break windows 

### DIFF
--- a/go-controller/pkg/ovn/hybrid.go
+++ b/go-controller/pkg/ovn/hybrid.go
@@ -337,17 +337,19 @@ func (oc *Controller) allocateHybridOverlayDRIP(node *kapi.Node) error {
 		return fmt.Errorf("cannot allocate hybrid overlay distributed router ip for nodes until all initial pods are processed")
 	}
 
-	var ips []string
-	// check if there is a hybrid distributed router IP set as an annotation
-	nodeHybridOverlayDRIP := node.Annotations[hotypes.HybridOverlayDRIP]
-	if len(nodeHybridOverlayDRIP) > 0 {
-		ips = strings.Split(nodeHybridOverlayDRIP, ",")
-	}
-
-	allocatedHybridOverlayDRIPs, err := oc.lsManager.AllocateHybridOverlay(node.Name, ips)
+	allocatedHybridOverlayDRIPs, err := oc.lsManager.AllocateHybridOverlay(node.Name)
 	if err != nil {
 		return fmt.Errorf("cannot allocate hybrid overlay interface addresses on node %s: %v", node.Name, err)
 	}
+	defer func() {
+		if err != nil {
+			err = oc.lsManager.ReleaseIPs(node.Name, allocatedHybridOverlayDRIPs)
+			if err != nil {
+				klog.Infof("Failed to cleanup hybrid overlay address for node %s on error (%v)", node.Name, err)
+
+			}
+		}
+	}()
 
 	var sliceHybridOverlayDRIP []string
 	for _, ip := range allocatedHybridOverlayDRIPs {

--- a/go-controller/pkg/ovn/logical_switch_manager/logical_switch_manager.go
+++ b/go-controller/pkg/ovn/logical_switch_manager/logical_switch_manager.go
@@ -283,19 +283,7 @@ func (manager *LogicalSwitchManager) AllocateNextIPs(nodeName string) ([]*net.IP
 	return ipnets, nil
 }
 
-func (manager *LogicalSwitchManager) AllocateHybridOverlay(nodeName string, hybridOverlayAnnotation []string) ([]*net.IPNet, error) {
-	if len(hybridOverlayAnnotation) > 0 {
-		var allocateAddresses []*net.IPNet
-		for _, ip := range hybridOverlayAnnotation {
-			allocateAddresses = append(allocateAddresses, &net.IPNet{IP: net.ParseIP(ip).To4(), Mask: net.CIDRMask(32, 32)})
-		}
-		err := manager.AllocateIPs(nodeName, allocateAddresses)
-		if err != nil {
-			return nil, err
-		}
-		return allocateAddresses, nil
-	}
-	// if we are not provided with any addresses
+func (manager *LogicalSwitchManager) AllocateHybridOverlay(nodeName string) ([]*net.IPNet, error) {
 	manager.RLock()
 	defer manager.RUnlock()
 
@@ -313,6 +301,7 @@ func (manager *LogicalSwitchManager) AllocateHybridOverlay(nodeName string, hybr
 	var allocatedAddresses []*net.IPNet
 	for _, ipv4IPAM := range ipv4IPAMS {
 		hostSubnet := ipv4IPAM.CIDR()
+		// try the .3 address of the hostSubnet as that was the old default
 		potentialHybridIFAddress := util.GetNodeHybridOverlayIfAddr(&hostSubnet)
 		err := ipv4IPAM.Allocate(potentialHybridIFAddress.IP)
 		if err == ipam.ErrAllocated {

--- a/go-controller/pkg/ovn/logical_switch_manager/logical_switch_manager_test.go
+++ b/go-controller/pkg/ovn/logical_switch_manager/logical_switch_manager_test.go
@@ -106,30 +106,6 @@ var _ = ginkgo.Describe("OVN Logical Switch Manager operations", func() {
 			err := app.Run([]string{app.Name})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		})
-		ginkgo.It("creates IPAM for each subnet and reserves IPs correctly when HybridOverlay is enabled and address is passed", func() {
-			app.Action = func(ctx *cli.Context) error {
-				_, err := config.InitConfig(ctx, fexec, nil)
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-				testNode := testNodeSubnetData{
-					nodeName: "testNode1",
-					subnets: []string{
-						"10.1.1.0/24",
-						"2000::/64",
-					},
-				}
-				err = lsManager.AddNode(testNode.nodeName, "", ovntest.MustParseIPNets(testNode.subnets...))
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				allocatedHybridOverlayDRIP, err := lsManager.AllocateHybridOverlay(testNode.nodeName, []string{"10.1.1.53"})
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				gomega.Expect(net.ParseIP("10.1.1.53").To4()).To(gomega.Equal(allocatedHybridOverlayDRIP[0].IP))
-				gomega.Expect(true).To(gomega.Equal(lsManager.isAllocatedIP(testNode.nodeName, "10.1.1.53")))
-
-				return nil
-			}
-			err := app.Run([]string{app.Name})
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		})
 		ginkgo.It("creates IPAM for each subnet and reserves the .3 address for Hybrid Overlay by default", func() {
 			app.Action = func(ctx *cli.Context) error {
 				_, err := config.InitConfig(ctx, fexec, nil)
@@ -145,7 +121,7 @@ var _ = ginkgo.Describe("OVN Logical Switch Manager operations", func() {
 
 				err = lsManager.AddNode(testNode.nodeName, "", ovntest.MustParseIPNets(testNode.subnets...))
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				allocatedHybridOverlayDRIP, err := lsManager.AllocateHybridOverlay(testNode.nodeName, []string{})
+				allocatedHybridOverlayDRIP, err := lsManager.AllocateHybridOverlay(testNode.nodeName)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				gomega.Expect(net.ParseIP("10.1.1.3").To4()).To(gomega.Equal(allocatedHybridOverlayDRIP[0].IP))
 
@@ -175,7 +151,7 @@ var _ = ginkgo.Describe("OVN Logical Switch Manager operations", func() {
 					{net.ParseIP("10.1.1.3").To4(), net.CIDRMask(32, 32)},
 				})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				allocatedHybridOverlayDRIP, err := lsManager.AllocateHybridOverlay(testNode.nodeName, []string{})
+				allocatedHybridOverlayDRIP, err := lsManager.AllocateHybridOverlay(testNode.nodeName)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				// 10.1.1.4 is the next ip address
 				gomega.Expect(net.ParseIP("10.1.1.4").To4()).To(gomega.Equal(allocatedHybridOverlayDRIP[0].IP))


### PR DESCRIPTION
before this fix the hybrid overlay tried to resuse the allocated hybrid overlay distributed router ip address between restarts. This caused a race condition when we waited for all pods to finish processing, a pod add event could allocate the address before we allocated it for the hybrid overlay distributed router ip address.

Change the allocation to allocate a new IP address every time, there is no specific benifit to using the same ip address between restarts, there is a negligable amount of node side action that needs to take place when the address changes

Signed-off-by: Jacob Tanenbaum <jtanenba@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->