### PR TITLE
OCPBUGS-3773: Adjust ovs bundle timeout

### DIFF
--- a/go-controller/pkg/node/node.go
+++ b/go-controller/pkg/node/node.go
@@ -196,6 +196,11 @@ func setupOVNNode(node *kapi.Node) error {
 			config.Default.InactivityProbe),
 		fmt.Sprintf("external_ids:ovn-openflow-probe-interval=%d",
 			config.Default.OpenFlowProbe),
+		// bundle-idle-timeout default value is 10s, it should be set
+		// as high as the ovn-openflow-probe-interval to allow ovn-controller
+		// to finish computation specially with complex acl configuration with port range.
+		fmt.Sprintf("other_config:bundle-idle-timeout=%d",
+			config.Default.OpenFlowProbe),
 		fmt.Sprintf("external_ids:hostname=\"%s\"", node.Name),
 		fmt.Sprintf("external_ids:ovn-monitor-all=%t", config.Default.MonitorAll),
 		fmt.Sprintf("external_ids:ovn-ofctrl-wait-before-clear=%d", config.Default.OfctrlWaitBeforeClear),

--- a/go-controller/pkg/node/node_test.go
+++ b/go-controller/pkg/node/node_test.go
@@ -211,11 +211,12 @@ var _ = Describe("Node", func() {
 						"external_ids:ovn-encap-ip=%s "+
 						"external_ids:ovn-remote-probe-interval=%d "+
 						"external_ids:ovn-openflow-probe-interval=%d "+
+						"other_config:bundle-idle-timeout=%d "+
 						"external_ids:hostname=\"%s\" "+
 						"external_ids:ovn-monitor-all=true "+
 						"external_ids:ovn-ofctrl-wait-before-clear=0 "+
 						"external_ids:ovn-enable-lflow-cache=true",
-						nodeIP, interval, ofintval, nodeName),
+						nodeIP, interval, ofintval, ofintval, nodeName),
 				})
 				fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 					Cmd: "ovs-vsctl --timeout=15 -- clear bridge br-int netflow" +
@@ -272,11 +273,12 @@ var _ = Describe("Node", func() {
 						"external_ids:ovn-encap-ip=%s "+
 						"external_ids:ovn-remote-probe-interval=%d "+
 						"external_ids:ovn-openflow-probe-interval=%d "+
+						"other_config:bundle-idle-timeout=%d "+
 						"external_ids:hostname=\"%s\" "+
 						"external_ids:ovn-monitor-all=true "+
 						"external_ids:ovn-ofctrl-wait-before-clear=0 "+
 						"external_ids:ovn-enable-lflow-cache=true",
-						nodeIP, interval, ofintval, nodeName),
+						nodeIP, interval, ofintval, ofintval, nodeName),
 				})
 				fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 					Cmd: fmt.Sprintf("ovs-vsctl --timeout=15 " +
@@ -346,13 +348,14 @@ var _ = Describe("Node", func() {
 						"external_ids:ovn-encap-ip=%s "+
 						"external_ids:ovn-remote-probe-interval=%d "+
 						"external_ids:ovn-openflow-probe-interval=%d "+
+						"other_config:bundle-idle-timeout=%d "+
 						"external_ids:hostname=\"%s\" "+
 						"external_ids:ovn-monitor-all=true "+
 						"external_ids:ovn-ofctrl-wait-before-clear=0 "+
 						"external_ids:ovn-enable-lflow-cache=false "+
 						"external_ids:ovn-limit-lflow-cache=1000 "+
 						"external_ids:ovn-memlimit-lflow-cache-kb=100000",
-						nodeIP, interval, ofintval, nodeName),
+						nodeIP, interval, ofintval, ofintval, nodeName),
 				})
 				fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 					Cmd: "ovs-vsctl --timeout=15 -- clear bridge br-int netflow" +
@@ -412,11 +415,12 @@ var _ = Describe("Node", func() {
 						"external_ids:ovn-encap-ip=%s "+
 						"external_ids:ovn-remote-probe-interval=%d "+
 						"external_ids:ovn-openflow-probe-interval=%d "+
+						"other_config:bundle-idle-timeout=%d "+
 						"external_ids:hostname=\"%s\" "+
 						"external_ids:ovn-monitor-all=true "+
 						"external_ids:ovn-ofctrl-wait-before-clear=0 "+
 						"external_ids:ovn-enable-lflow-cache=true",
-						nodeIP, interval, ofintval, nodeName),
+						nodeIP, interval, ofintval, ofintval, nodeName),
 				})
 
 				fexec.AddFakeCmd(&ovntest.ExpectedCmd{
@@ -484,11 +488,12 @@ var _ = Describe("Node", func() {
 						"external_ids:ovn-encap-ip=%s "+
 						"external_ids:ovn-remote-probe-interval=%d "+
 						"external_ids:ovn-openflow-probe-interval=%d "+
+						"other_config:bundle-idle-timeout=%d "+
 						"external_ids:hostname=\"%s\" "+
 						"external_ids:ovn-monitor-all=true "+
 						"external_ids:ovn-ofctrl-wait-before-clear=0 "+
 						"external_ids:ovn-enable-lflow-cache=true",
-						nodeIP, interval, ofintval, nodeName),
+						nodeIP, interval, ofintval, ofintval, nodeName),
 				})
 
 				fexec.AddFakeCmd(&ovntest.ExpectedCmd{
@@ -556,11 +561,12 @@ var _ = Describe("Node", func() {
 						"external_ids:ovn-encap-ip=%s "+
 						"external_ids:ovn-remote-probe-interval=%d "+
 						"external_ids:ovn-openflow-probe-interval=%d "+
+						"other_config:bundle-idle-timeout=%d "+
 						"external_ids:hostname=\"%s\" "+
 						"external_ids:ovn-monitor-all=true "+
 						"external_ids:ovn-ofctrl-wait-before-clear=0 "+
 						"external_ids:ovn-enable-lflow-cache=true",
-						nodeIP, interval, ofintval, nodeName),
+						nodeIP, interval, ofintval, ofintval, nodeName),
 				})
 
 				fexec.AddFakeCmd(&ovntest.ExpectedCmd{


### PR DESCRIPTION
with complex ACL configration ovn-controller
needs additional time to finish its computation
it was recommended by OVN team to set bundle timeout to match flowprobe setting since its default is 10s.

Signed-off-by: Mohamed Mahmoud <mmahmoud@redhat.com>
(cherry picked from commit 49ab185eed4db7e88abd189b241a65926bc2b105)

