### PR TITLE
[release-4.10]  OCPBUGS-3858: Adjust ovs bundle timeout

### DIFF
--- a/go-controller/pkg/node/node.go
+++ b/go-controller/pkg/node/node.go
@@ -200,6 +200,11 @@ func setupOVNNode(node *kapi.Node) error {
 			config.Default.InactivityProbe),
 		fmt.Sprintf("external_ids:ovn-openflow-probe-interval=%d",
 			config.Default.OpenFlowProbe),
+		// bundle-idle-timeout default value is 10s, it should be set
+		// as high as the ovn-openflow-probe-interval to allow ovn-controller
+		// to finish computation specially with complex acl configuration with port range.
+		fmt.Sprintf("other_config:bundle-idle-timeout=%d",
+			config.Default.OpenFlowProbe),
 		fmt.Sprintf("external_ids:hostname=\"%s\"", node.Name),
 		fmt.Sprintf("external_ids:ovn-monitor-all=%t", config.Default.MonitorAll),
 		fmt.Sprintf("external_ids:ovn-enable-lflow-cache=%t", config.Default.LFlowCacheEnable),

--- a/go-controller/pkg/node/node_test.go
+++ b/go-controller/pkg/node/node_test.go
@@ -226,10 +226,11 @@ var _ = Describe("Node", func() {
 						"external_ids:ovn-encap-ip=%s "+
 						"external_ids:ovn-remote-probe-interval=%d "+
 						"external_ids:ovn-openflow-probe-interval=%d "+
+						"other_config:bundle-idle-timeout=%d "+
 						"external_ids:hostname=\"%s\" "+
 						"external_ids:ovn-monitor-all=true "+
 						"external_ids:ovn-enable-lflow-cache=true",
-						nodeIP, interval, ofintval, nodeName),
+						nodeIP, interval, ofintval, ofintval, nodeName),
 				})
 				fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 					Cmd: "ovs-vsctl --timeout=15 -- clear bridge br-int netflow" +
@@ -286,10 +287,11 @@ var _ = Describe("Node", func() {
 						"external_ids:ovn-encap-ip=%s "+
 						"external_ids:ovn-remote-probe-interval=%d "+
 						"external_ids:ovn-openflow-probe-interval=%d "+
+						"other_config:bundle-idle-timeout=%d "+
 						"external_ids:hostname=\"%s\" "+
 						"external_ids:ovn-monitor-all=true "+
 						"external_ids:ovn-enable-lflow-cache=true",
-						nodeIP, interval, ofintval, nodeName),
+						nodeIP, interval, ofintval, ofintval, nodeName),
 				})
 				fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 					Cmd: fmt.Sprintf("ovs-vsctl --timeout=15 " +
@@ -359,12 +361,13 @@ var _ = Describe("Node", func() {
 						"external_ids:ovn-encap-ip=%s "+
 						"external_ids:ovn-remote-probe-interval=%d "+
 						"external_ids:ovn-openflow-probe-interval=%d "+
+						"other_config:bundle-idle-timeout=%d "+
 						"external_ids:hostname=\"%s\" "+
 						"external_ids:ovn-monitor-all=true "+
 						"external_ids:ovn-enable-lflow-cache=false "+
 						"external_ids:ovn-limit-lflow-cache=1000 "+
-						"external_ids:ovn-limit-lflow-cache-kb=100000",
-						nodeIP, interval, ofintval, nodeName),
+						"external_ids:ovn-memlimit-lflow-cache-kb=100000",
+						nodeIP, interval, ofintval, ofintval, nodeName),
 				})
 				fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 					Cmd: "ovs-vsctl --timeout=15 -- clear bridge br-int netflow" +
@@ -424,10 +427,11 @@ var _ = Describe("Node", func() {
 						"external_ids:ovn-encap-ip=%s "+
 						"external_ids:ovn-remote-probe-interval=%d "+
 						"external_ids:ovn-openflow-probe-interval=%d "+
+						"other_config:bundle-idle-timeout=%d "+
 						"external_ids:hostname=\"%s\" "+
 						"external_ids:ovn-monitor-all=true "+
 						"external_ids:ovn-enable-lflow-cache=true",
-						nodeIP, interval, ofintval, nodeName),
+						nodeIP, interval, ofintval, ofintval, nodeName),
 				})
 
 				fexec.AddFakeCmd(&ovntest.ExpectedCmd{
@@ -495,10 +499,11 @@ var _ = Describe("Node", func() {
 						"external_ids:ovn-encap-ip=%s "+
 						"external_ids:ovn-remote-probe-interval=%d "+
 						"external_ids:ovn-openflow-probe-interval=%d "+
+						"other_config:bundle-idle-timeout=%d "+
 						"external_ids:hostname=\"%s\" "+
 						"external_ids:ovn-monitor-all=true "+
 						"external_ids:ovn-enable-lflow-cache=true",
-						nodeIP, interval, ofintval, nodeName),
+						nodeIP, interval, ofintval, ofintval, nodeName),
 				})
 
 				fexec.AddFakeCmd(&ovntest.ExpectedCmd{
@@ -566,10 +571,11 @@ var _ = Describe("Node", func() {
 						"external_ids:ovn-encap-ip=%s "+
 						"external_ids:ovn-remote-probe-interval=%d "+
 						"external_ids:ovn-openflow-probe-interval=%d "+
+						"other_config:bundle-idle-timeout=%d "+
 						"external_ids:hostname=\"%s\" "+
 						"external_ids:ovn-monitor-all=true "+
 						"external_ids:ovn-enable-lflow-cache=true",
-						nodeIP, interval, ofintval, nodeName),
+						nodeIP, interval, ofintval, ofintval, nodeName),
 				})
 
 				fexec.AddFakeCmd(&ovntest.ExpectedCmd{


### PR DESCRIPTION
with complex ACL configration ovn-controller
needs additional time to finish its computation
it was recommended by OVN team to set bundle timeout to match flowprobe setting since its default is 10s.

Signed-off-by: Mohamed Mahmoud <mmahmoud@redhat.com>
(cherry picked from commit 49ab185eed4db7e88abd189b241a65926bc2b105) (cherry picked from commit d245a090b323dd0cb8e074d7c9e6710633df3f30)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->