### PR TITLE
OCPBUGS-3798: [4.12] Dockerfile: bump OVS to 2.17.0-62.el8fdp

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -12,8 +12,8 @@ RUN yum install -y  \
 	selinux-policy && \
 	yum clean all
 
-ARG ovsver=2.17.0-37.4.el8fdp
-ARG ovnver=22.06.0-27.el8fdp
+ARG ovsver=2.17.0-62.el8fdp
+ARG ovnver=22.09.0-5.el8fdp
 RUN echo $ovsver > /ovs-version && echo $ovnver > /ovn-version
 
 RUN mkdir -p /var/run/openvswitch && \

--- a/Dockerfile.microshift
+++ b/Dockerfile.microshift
@@ -29,7 +29,7 @@ ENV PYTHONDONTWRITEBYTECODE yes
 RUN export ovsver=$(cat /ovs-version) && \
 	export ovnver=$(cat /ovn-version) && \
 	yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False "openvswitch2.17 = $ovsver" "python3-openvswitch2.17 = $ovsver" && \
-        yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False "ovn22.06 = $ovnver" "ovn22.06-central = $ovnver" "ovn22.06-host = $ovnver" && \
+        yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False "ovn22.09 = $ovnver" "ovn22.09-central = $ovnver" "ovn22.09-host = $ovnver" && \
         yum clean all && rm -rf /var/cache/*
 
 COPY --from=builder /go/src/github.com/openshift/ovn-kubernetes/go-controller/_output/go/bin/ovnkube /usr/bin/


### PR DESCRIPTION
Mainly to get:
"ovsdb/transaction.c: Refactor assess_weak_refs."
http://patchwork.ozlabs.org/project/openvswitch/list/?series=325800&state=%2A&archive=both

which fixes a memory leak in ovsdb-server.

4.12 cherry-pick of https://github.com/openshift/ovn-kubernetes/pull/1362