### PR TITLE
[release-4.10] [WIP] Bug 2080060: Make sure VXLAN interface is up when setting up VXLAN tunnel

### DIFF
--- a/go-controller/hybrid-overlay/pkg/controller/node_linux.go
+++ b/go-controller/hybrid-overlay/pkg/controller/node_linux.go
@@ -25,8 +25,9 @@ import (
 )
 
 const (
-	extBridgeName string = "br-ext"
-	extVXLANName  string = "ext-vxlan"
+	extBridgeName          string = "br-ext"
+	extVXLANName           string = "ext-vxlan"
+	OVSVXLANDeviceTemplate string = "vxlan_sys_%d"
 )
 
 type flowCacheEntry struct {
@@ -470,6 +471,15 @@ func (n *NodeController) EnsureHybridOverlayBridge(node *kapi.Node) error {
 	if err != nil {
 		return fmt.Errorf("failed to add VXLAN port for ovs bridge %s"+
 			", stderr:%s: %v", extBridgeName, stderr, err)
+	}
+
+	// bring VXLAN interface up if ever it was brought down by multiple network manager restarts
+	// in ovs-configure.sh
+	vxlan_interface := fmt.Sprintf(OVSVXLANDeviceTemplate, n.vxlanPort)
+	if _, err = util.LinkSetUpWithPolling(vxlan_interface, 50*time.Millisecond, time.Second); err != nil {
+		return fmt.Errorf("failed to bring up VXLAN interface %s: %v", vxlan_interface, err)
+	} else {
+		klog.Infof("successfully brought up VXLAN interface %s", vxlan_interface) // TODO remove this
 	}
 
 	flows := make([]string, 0, 10)

--- a/go-controller/hybrid-overlay/pkg/controller/node_linux_test.go
+++ b/go-controller/hybrid-overlay/pkg/controller/node_linux_test.go
@@ -207,7 +207,7 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 		_ = netns.Do(func(ns.NetNS) error {
 			defer GinkgoRecover()
 			ovntest.AddLink(extBridgeName)
-
+			ovntest.AddLink(fmt.Sprintf(OVSVXLANDeviceTemplate, config.HybridOverlay.VXLANPort))
 			// Set up management interface with its address
 			link := ovntest.AddLink(types.K8sMgmtIntfName)
 			_, thisNet, err := net.ParseCIDR(thisSubnet)


### PR DESCRIPTION
When running ovs-configure, if network manager is restarted more than once, it will bring down the VXLAN interface for hybrid overlay. Let's bring the interface up systematically when setting up the VXLAN tunnel.

Fixes #2080060

Signed-off-by: Riccardo Ravaioli [rravaiol@redhat.com](mailto:rravaiol@redhat.com)