### PR TITLE
[release-4.11] OCPBUGS-2554: Fix UpdateService healthport checks

### DIFF
--- a/go-controller/pkg/node/gateway_init.go
+++ b/go-controller/pkg/node/gateway_init.go
@@ -266,7 +266,7 @@ func (n *OvnNode) initGateway(subnets []*net.IPNet, nodeAnnotator kube.Annotator
 	var portClaimWatcher *portClaimWatcher
 
 	if config.Gateway.NodeportEnable && config.OvnKubeNode.Mode == types.NodeModeFull {
-		loadBalancerHealthChecker = newLoadBalancerHealthChecker(n.name)
+		loadBalancerHealthChecker = newLoadBalancerHealthChecker(n.name, n.watchFactory)
 		portClaimWatcher, err = newPortClaimWatcher(n.recorder)
 		if err != nil {
 			return err
@@ -424,7 +424,7 @@ func (n *OvnNode) initGatewayDPUHost(kubeNodeIP net.IP) error {
 			return err
 		}
 		gw.nodePortWatcherIptables = newNodePortWatcherIptables()
-		gw.loadBalancerHealthChecker = newLoadBalancerHealthChecker(n.name)
+		gw.loadBalancerHealthChecker = newLoadBalancerHealthChecker(n.name, n.watchFactory)
 		portClaimWatcher, err := newPortClaimWatcher(n.recorder)
 		if err != nil {
 			return err


### PR DESCRIPTION
We were not creating healthchecks for service updates when the etp changed from local to cluster or back. This PR fixes this.

Signed-off-by: Surya Seetharaman <suryaseetharaman.9@gmail.com>
(cherry picked from commit 4c7add6a642689b7429babf1761c13942c3a9577)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->