### PR TITLE
OCPBUGS-3908: Changed all ParseIP and ParseCIDR functions of net package to ParseIP…

### DIFF
--- a/go-controller/cmd/ovnkube-trace/ovnkube-trace.go
+++ b/go-controller/cmd/ovnkube-trace/ovnkube-trace.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/remotecommand"
 	"k8s.io/klog/v2"
+	utilnet "k8s.io/utils/net"
 )
 
 const (
@@ -344,12 +345,13 @@ func getSvcInfo(coreclient *corev1client.CoreV1Client, restconfig *rest.Config, 
 	if clusterIP == "" || clusterIP == "None" {
 		return nil, fmt.Errorf("ClusterIP for service %s in namespace %s not available", svcName, namespace)
 	}
-	klog.V(5).Infof("==> Got service %s ClusterIP is %s\n", svcName, clusterIP)
+	clusterIPStr := utilnet.ParseIPSloppy(clusterIP).String()
+	klog.V(5).Infof("==> Got service %s ClusterIP is %s\n", svcName, clusterIPStr)
 
 	svcInfo = &SvcInfo{
 		SvcName:      svcName,
 		SvcNamespace: namespace,
-		ClusterIP:    svc.Spec.ClusterIP,
+		ClusterIP:    clusterIPStr,
 	}
 
 	ep, err := coreclient.Endpoints(namespace).Get(context.TODO(), svcName, metav1.GetOptions{})
@@ -404,7 +406,7 @@ func extractSubsetInfo(subsets []kapi.EndpointSubset, svcInfo *SvcInfo) error {
 			// At this point, we should have found valid pod information + a port, so set them and return nil.
 			svcInfo.PodName = epAddress.TargetRef.Name
 			svcInfo.PodNamespace = epAddress.TargetRef.Namespace
-			svcInfo.PodIP = epAddress.IP
+			svcInfo.PodIP = utilnet.ParseIPSloppy(epAddress.IP).String()
 			svcInfo.PodPort = podPort
 			klog.V(5).Infof("==> Got address and port information for service endpoint. podName: %s, podNamespace: %s, podIP: %s, podPort: %s",
 				svcInfo.PodName, svcInfo.PodNamespace, svcInfo.PodIP, svcInfo.PodPort)
@@ -425,7 +427,7 @@ func getPodInfo(coreclient *corev1client.CoreV1Client, restconfig *rest.Config, 
 		return nil, err
 	}
 	podInfo = &PodInfo{
-		IP:            pod.Status.PodIP,
+		IP:            utilnet.ParseIPSloppy(pod.Status.PodIP).String(),
 		PodName:       pod.Name,
 		ContainerName: pod.Spec.Containers[0].Name,
 		HostNetwork:   pod.Spec.HostNetwork,
@@ -931,19 +933,21 @@ func displayNodeInfo(coreclient *corev1client.CoreV1Client) {
 		if foundMaster || foundControlPlane {
 			klog.V(5).Infof("  Name: %s is a master", node.Name)
 			for _, s := range node.Status.Addresses {
-				klog.V(5).Infof("  Address Type: %s - Address: %s", s.Type, s.Address)
+				addrStr := utilnet.ParseIPSloppy(s.Address).String()
+				klog.V(5).Infof("  Address Type: %s - Address: %s", s.Type, addrStr)
 				//if s.Type == corev1client.NodeInternalIP {
 				if s.Type == "InternalIP" {
-					masters[node.Name] = s.Address
+					masters[node.Name] = addrStr
 				}
 			}
 		} else {
 			klog.V(5).Infof("  Name: %s is a worker", node.Name)
 			for _, s := range node.Status.Addresses {
-				klog.V(5).Infof("  Address Type: %s - Address: %s", s.Type, s.Address)
+				addrStr := utilnet.ParseIPSloppy(s.Address).String()
+				klog.V(5).Infof("  Address Type: %s - Address: %s", s.Type, addrStr)
 				//if s.Type == corev1client.NodeInternalIP {
 				if s.Type == "InternalIP" {
-					workers[node.Name] = s.Address
+					workers[node.Name] = addrStr
 				}
 			}
 		}

--- a/go-controller/hybrid-overlay/pkg/util/util.go
+++ b/go-controller/hybrid-overlay/pkg/util/util.go
@@ -11,6 +11,7 @@ import (
 	kapi "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	utilnet "k8s.io/utils/net"
 )
 
 // ParseHybridOverlayHostSubnet returns the parsed hybrid overlay hostsubnet if
@@ -54,7 +55,7 @@ func SameIPNet(a, b *net.IPNet) bool {
 func GetNodeInternalIP(node *kapi.Node) (string, error) {
 	for _, addr := range node.Status.Addresses {
 		if addr.Type == kapi.NodeInternalIP {
-			return addr.Address, nil
+			return utilnet.ParseIPSloppy(addr.Address).String(), nil
 		}
 	}
 	return "", fmt.Errorf("failed to read node %q InternalIP", node.Name)

--- a/go-controller/pkg/node/gateway_iptables.go
+++ b/go-controller/pkg/node/gateway_iptables.go
@@ -453,13 +453,8 @@ func getGatewayIPTRules(service *kapi.Service, svcHasLocalHostNetEndPnt bool) []
 				rules = append(rules, getNodePortIPTRules(svcPort, clusterIP, svcPort.Port, svcHasLocalHostNetEndPnt, false)...)
 			}
 		}
-		externalIPs := make([]string, 0, len(service.Spec.ExternalIPs)+len(service.Status.LoadBalancer.Ingress))
-		externalIPs = append(externalIPs, service.Spec.ExternalIPs...)
-		for _, ingress := range service.Status.LoadBalancer.Ingress {
-			if len(ingress.IP) > 0 {
-				externalIPs = append(externalIPs, ingress.IP)
-			}
-		}
+
+		externalIPs := util.GetExternalAndLBIPs(service)
 
 		for _, externalIP := range externalIPs {
 			err := util.ValidatePort(svcPort.Protocol, svcPort.Port)
@@ -494,7 +489,8 @@ func egressSVCIPTRulesForEndpoints(svc *kapi.Service, v4Eps, v6Eps []string) []i
 
 	comment, _ := cache.MetaNamespaceKeyFunc(svc)
 	for _, lb := range svc.Status.LoadBalancer.Ingress {
-		lbProto := getIPTablesProtocol(lb.IP)
+		lbIPStr := utilnet.ParseIPSloppy(lb.IP).String()
+		lbProto := getIPTablesProtocol(lbIPStr)
 		epsForProto := v4Eps
 		if lbProto == iptables.ProtocolIPv6 {
 			epsForProto = v6Eps
@@ -508,7 +504,7 @@ func egressSVCIPTRulesForEndpoints(svc *kapi.Service, v4Eps, v6Eps []string) []i
 					"-s", ep,
 					"-m", "comment", "--comment", comment,
 					"-j", "SNAT",
-					"--to-source", lb.IP,
+					"--to-source", lbIPStr,
 				},
 				protocol: lbProto,
 			})

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -201,7 +201,7 @@ func (npw *nodePortWatcher) updateServiceFlowCache(service *kapi.Service, add, h
 		// NodePort/Ingress access in the OVS bridge will only ever come from outside of the host
 		for _, ing := range service.Status.LoadBalancer.Ingress {
 			if len(ing.IP) > 0 {
-				err = npw.createLbAndExternalSvcFlows(service, &svcPort, add, hasLocalHostNetworkEp, protocol, actions, ing.IP, "Ingress")
+				err = npw.createLbAndExternalSvcFlows(service, &svcPort, add, hasLocalHostNetworkEp, protocol, actions, utilnet.ParseIPSloppy(ing.IP).String(), "Ingress")
 				if err != nil {
 					klog.Errorf(err.Error())
 				}
@@ -209,7 +209,7 @@ func (npw *nodePortWatcher) updateServiceFlowCache(service *kapi.Service, add, h
 		}
 		// flows for externalIPs
 		for _, externalIP := range service.Spec.ExternalIPs {
-			err = npw.createLbAndExternalSvcFlows(service, &svcPort, add, hasLocalHostNetworkEp, protocol, actions, externalIP, "External")
+			err = npw.createLbAndExternalSvcFlows(service, &svcPort, add, hasLocalHostNetworkEp, protocol, actions, utilnet.ParseIPSloppy(externalIP).String(), "External")
 			if err != nil {
 				klog.Errorf(err.Error())
 			}
@@ -658,8 +658,9 @@ func (npw *nodePortWatcher) SyncServices(services []interface{}) error {
 
 				for _, ep := range epSlice.Endpoints {
 					for _, ip := range ep.Addresses {
-						if !isHostEndpoint(ip) {
-							epsToInsert.Insert(ip)
+						ipStr := utilnet.ParseIPSloppy(ip).String()
+						if !isHostEndpoint(ipStr) {
+							epsToInsert.Insert(ipStr)
 						}
 					}
 				}
@@ -762,7 +763,9 @@ func getEndpointAddresses(endpointSlice *discovery.EndpointSlice) []string {
 	endpointsAddress := make([]string, 0)
 	for _, endpoint := range endpointSlice.Endpoints {
 		if isEndpointReady(endpoint) {
-			endpointsAddress = append(endpointsAddress, endpoint.Addresses...)
+			for _, ip := range endpoint.Addresses {
+				endpointsAddress = append(endpointsAddress, utilnet.ParseIPSloppy(ip).String())
+			}
 		}
 	}
 	return endpointsAddress

--- a/go-controller/pkg/node/gateway_shared_intf_linux.go
+++ b/go-controller/pkg/node/gateway_shared_intf_linux.go
@@ -15,6 +15,7 @@ import (
 	ktypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
+	utilnet "k8s.io/utils/net"
 )
 
 // deletes the local bridge used for DGP and removes the corresponding iface, as well as OVS bridge mappings
@@ -109,8 +110,9 @@ func updateEgressSVCIptRules(svc *kapi.Service, npw *nodePortWatcher) {
 
 		for _, ep := range epSlice.Endpoints {
 			for _, ip := range ep.Addresses {
-				if !isHostEndpoint(ip) {
-					epsToInsert.Insert(ip)
+				ipStr := utilnet.ParseIPSloppy(ip).String()
+				if !isHostEndpoint(ipStr) {
+					epsToInsert.Insert(ipStr)
 				}
 			}
 		}

--- a/go-controller/pkg/node/healthcheck.go
+++ b/go-controller/pkg/node/healthcheck.go
@@ -19,6 +19,7 @@ import (
 	ktypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
+	utilnet "k8s.io/utils/net"
 )
 
 // initLoadBalancerHealthChecker initializes the health check server for
@@ -171,7 +172,7 @@ func hasLocalHostNetworkEndpoints(epSlices []*discovery.EndpointSlice, nodeAddre
 			}
 			for _, ip := range endpoint.Addresses {
 				for _, nodeIP := range nodeAddresses {
-					if nodeIP.String() == ip {
+					if nodeIP.String() == utilnet.ParseIPSloppy(ip).String() {
 						return true
 					}
 				}

--- a/go-controller/pkg/node/node.go
+++ b/go-controller/pkg/node/node.go
@@ -638,7 +638,8 @@ func (n *OvnNode) WatchEndpointSlices() error {
 			for _, oldPort := range oldEndpointSlice.Ports {
 				for _, oldEndpoint := range oldEndpointSlice.Endpoints {
 					for _, oldIP := range oldEndpoint.Addresses {
-						if doesEPSliceContainReadyEndpoint(newEndpointSlice, oldIP, *oldPort.Port, *oldPort.Protocol) {
+						oldIPStr := utilnet.ParseIPSloppy(oldIP).String()
+						if doesEPSliceContainReadyEndpoint(newEndpointSlice, oldIPStr, *oldPort.Port, *oldPort.Protocol) {
 							continue
 						}
 						if *oldPort.Protocol == kapi.ProtocolUDP { // flush conntrack only for UDP
@@ -656,10 +657,11 @@ func (n *OvnNode) WatchEndpointSlices() error {
 			for _, port := range endpointSlice.Ports {
 				for _, endpoint := range endpointSlice.Endpoints {
 					for _, ip := range endpoint.Addresses {
+						ipStr := utilnet.ParseIPSloppy(ip).String()
 						if *port.Protocol == kapi.ProtocolUDP { // flush conntrack only for UDP
-							err := util.DeleteConntrack(ip, *port.Port, *port.Protocol, netlink.ConntrackReplyAnyIP, nil)
+							err := util.DeleteConntrack(ipStr, *port.Port, *port.Protocol, netlink.ConntrackReplyAnyIP, nil)
 							if err != nil {
-								klog.Errorf("Failed to delete conntrack entry for %s: %v", ip, err)
+								klog.Errorf("Failed to delete conntrack entry for %s: %v", ipStr, err)
 							}
 						}
 					}
@@ -816,7 +818,7 @@ func doesEPSliceContainReadyEndpoint(epSlice *discovery.EndpointSlice,
 				continue
 			}
 			for _, ip := range endpoint.Addresses {
-				if ip == epIP && *port.Port == epPort && *port.Protocol == protocol {
+				if utilnet.ParseIPSloppy(ip).String() == epIP && *port.Port == epPort && *port.Protocol == protocol {
 					return true
 				}
 			}

--- a/go-controller/pkg/node/port_claim.go
+++ b/go-controller/pkg/node/port_claim.go
@@ -188,7 +188,7 @@ func handleService(svc *kapi.Service, handler handler) []error {
 		}
 		for _, externalIP := range svc.Spec.ExternalIPs {
 			klog.V(5).Infof("Handle ExternalIPs service %s external IP %s port %d", svc.Name, externalIP, svcPort.Port)
-			if err := handlePort(getDescription(svcPort.Name, svc, false), svc, externalIP, svcPort.Port, svcPort.Protocol, handler); err != nil {
+			if err := handlePort(getDescription(svcPort.Name, svc, false), svc, utilnet.ParseIPSloppy(externalIP).String(), svcPort.Port, svcPort.Protocol, handler); err != nil {
 				errors = append(errors, err)
 			}
 		}

--- a/go-controller/pkg/ovn/controller/egress_services/egress_services_service.go
+++ b/go-controller/pkg/ovn/controller/egress_services/egress_services_service.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
+	utilnet "k8s.io/utils/net"
 )
 
 func (c *Controller) onServiceAdd(obj interface{}) {
@@ -408,8 +409,9 @@ func (c *Controller) allEndpointsFor(svc *corev1.Service) (sets.String, sets.Str
 
 		for _, ep := range eps.Endpoints {
 			for _, ip := range ep.Addresses {
-				if !services.IsHostEndpoint(ip) {
-					epsToInsert.Insert(ip)
+				ipStr := utilnet.ParseIPSloppy(ip).String()
+				if !services.IsHostEndpoint(ipStr) {
+					epsToInsert.Insert(ipStr)
 				}
 			}
 			if ep.NodeName != nil {

--- a/go-controller/pkg/ovn/controller/services/load_balancer.go
+++ b/go-controller/pkg/ovn/controller/services/load_balancer.go
@@ -85,21 +85,9 @@ func buildServiceLBConfigs(service *v1.Service, endpointSlices []*discovery.Endp
 			perNodeConfigs = append(perNodeConfigs, nodePortLBConfig)
 		}
 
-		// Build up list of vips
-		vips := append([]string{}, service.Spec.ClusterIPs...)
-		// Handle old clusters w/o v6 support
-		if len(vips) == 0 {
-			vips = []string{service.Spec.ClusterIP}
-		}
-		externalVips := []string{}
-		// ExternalIP
-		externalVips = append(externalVips, service.Spec.ExternalIPs...)
-		// LoadBalancer status
-		for _, ingress := range service.Status.LoadBalancer.Ingress {
-			if ingress.IP != "" {
-				externalVips = append(externalVips, ingress.IP)
-			}
-		}
+		// Build up list of vips and externalVips
+		vips := util.GetClusterIPs(service)
+		externalVips := util.GetExternalAndLBIPs(service)
 
 		// if ETP=Local, then treat ExternalIPs and LoadBalancer IPs specially
 		// otherwise, they're just cluster IPs

--- a/go-controller/pkg/ovn/controller/services/load_balancer_test.go
+++ b/go-controller/pkg/ovn/controller/services/load_balancer_test.go
@@ -387,7 +387,7 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 				service: &v1.Service{
 					ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: ns},
 					Spec: v1.ServiceSpec{
-						Type:       v1.ServiceTypeClusterIP,
+						Type:       v1.ServiceTypeLoadBalancer,
 						ClusterIP:  "192.168.1.1",
 						ClusterIPs: []string{"192.168.1.1", "2002::1"},
 						Ports: []v1.ServicePort{{

--- a/go-controller/pkg/ovn/controller/services/utils.go
+++ b/go-controller/pkg/ovn/controller/services/utils.go
@@ -23,14 +23,8 @@ func deleteServiceFromLegacyLBs(nbClient libovsdbclient.Client, service *v1.Serv
 	vipPortsPerProtocol := map[v1.Protocol]sets.String{}
 
 	// Generate list of vip:port by proto
-	ips := append([]string{}, service.Spec.ClusterIPs...)
-	if len(ips) == 0 {
-		ips = append(ips, service.Spec.ClusterIP)
-	}
-	ips = append(ips, service.Spec.ExternalIPs...)
-	for _, ingress := range service.Status.LoadBalancer.Ingress {
-		ips = append(ips, ingress.IP)
-	}
+	ips := util.GetClusterIPs(service)
+	ips = append(ips, util.GetExternalAndLBIPs(service)...)
 	for _, svcPort := range service.Spec.Ports {
 		proto := svcPort.Protocol
 		ipPorts := make([]string, 0, len(ips))

--- a/go-controller/pkg/ovn/egressip.go
+++ b/go-controller/pkg/ovn/egressip.go
@@ -2566,7 +2566,7 @@ func getNodeInternalAddrs(node *v1.Node) (net.IP, net.IP) {
 	var v4Addr, v6Addr net.IP
 	for _, nodeAddr := range node.Status.Addresses {
 		if nodeAddr.Type == v1.NodeInternalIP {
-			ip := net.ParseIP(nodeAddr.Address)
+			ip := utilnet.ParseIPSloppy(nodeAddr.Address)
 			if !utilnet.IsIPv6(ip) && v4Addr == nil {
 				v4Addr = ip
 			} else if utilnet.IsIPv6(ip) && v6Addr == nil {

--- a/go-controller/pkg/ovn/gress_policy.go
+++ b/go-controller/pkg/ovn/gress_policy.go
@@ -505,7 +505,7 @@ func getSvcVips(nbClient client.Client, service *v1.Service) []net.IP {
 		for _, ipStr := range ipStrs {
 			ip := net.ParseIP(ipStr)
 			if ip == nil {
-				klog.Errorf("Failed to parse cluster IP %q", service.Spec.ClusterIP)
+				klog.Errorf("Failed to parse cluster IP %q", ipStr)
 				continue
 			}
 			ips = append(ips, ip)
@@ -514,13 +514,13 @@ func getSvcVips(nbClient client.Client, service *v1.Service) []net.IP {
 		for _, ing := range service.Status.LoadBalancer.Ingress {
 			if ing.IP != "" {
 				klog.V(5).Infof("Adding ingress IPs: %s from Service: %s to VIP set", ing.IP, service.Name)
-				ips = append(ips, net.ParseIP(ing.IP))
+				ips = append(ips, utilnet.ParseIPSloppy(ing.IP))
 			}
 		}
 
 		if len(service.Spec.ExternalIPs) > 0 {
 			for _, extIP := range service.Spec.ExternalIPs {
-				ip := net.ParseIP(extIP)
+				ip := utilnet.ParseIPSloppy(extIP)
 				if ip == nil {
 					klog.Errorf("Failed to parse external IP %q", extIP)
 					continue

--- a/go-controller/pkg/ovndbmanager/ovndbmanager.go
+++ b/go-controller/pkg/ovndbmanager/ovndbmanager.go
@@ -252,7 +252,7 @@ func ensureClusterRaftMembership(db *util.OvsDbProperties, kclient kube.Interfac
 		if !memberFound {
 			for _, dbPod := range dbPods.Items {
 				for _, ip := range dbPod.Status.PodIPs {
-					if ip.IP == matchedServer {
+					if ip.IP == matchedServer || utilnet.ParseIPSloppy(ip.IP).String() == matchedServer {
 						memberFound = true
 						break
 					}

--- a/go-controller/pkg/util/kube_test.go
+++ b/go-controller/pkg/util/kube_test.go
@@ -296,12 +296,12 @@ func TestGetNodePrimaryIP(t *testing.T) {
 				Status: v1.NodeStatus{
 					Addresses: []v1.NodeAddress{
 						{Type: v1.NodeHostName, Address: "HN"},
-						{Type: v1.NodeInternalIP, Address: "IntIP"},
-						{Type: v1.NodeExternalIP, Address: "ExtIP"},
+						{Type: v1.NodeInternalIP, Address: "192.168.1.1"},
+						{Type: v1.NodeExternalIP, Address: "90.90.90.90"},
 					},
 				},
 			},
-			expOut: "IntIP",
+			expOut: "192.168.1.1",
 		},
 		{
 			desc: "success: node's external IP returned",
@@ -309,11 +309,11 @@ func TestGetNodePrimaryIP(t *testing.T) {
 				Status: v1.NodeStatus{
 					Addresses: []v1.NodeAddress{
 						{Type: v1.NodeHostName, Address: "HN"},
-						{Type: v1.NodeExternalIP, Address: "ExtIP"},
+						{Type: v1.NodeExternalIP, Address: "90.90.90.90"},
 					},
 				},
 			},
-			expOut: "ExtIP",
+			expOut: "90.90.90.90",
 		},
 	}
 	for i, tc := range tests {

--- a/go-controller/pkg/util/pod_annotation.go
+++ b/go-controller/pkg/util/pod_annotation.go
@@ -264,7 +264,7 @@ func GetAllPodIPs(pod *v1.Pod) ([]net.IP, error) {
 	// Otherwise if the annotation is not valid try to use Kube API pod IPs
 	ips := make([]net.IP, 0, len(pod.Status.PodIPs))
 	for _, podIP := range pod.Status.PodIPs {
-		ip := net.ParseIP(podIP.IP)
+		ip := utilnet.ParseIPSloppy(podIP.IP)
 		if ip == nil {
 			klog.Warningf("Failed to parse pod IP %q", podIP)
 			continue
@@ -278,7 +278,7 @@ func GetAllPodIPs(pod *v1.Pod) ([]net.IP, error) {
 
 	// Fallback check pod.Status.PodIP
 	// Kubelet < 1.16 only set podIP
-	ip := net.ParseIP(pod.Status.PodIP)
+	ip := utilnet.ParseIPSloppy(pod.Status.PodIP)
 	if ip == nil {
 		return nil, fmt.Errorf("pod %s/%s: %w ", pod.Namespace, pod.Name, ErrNoPodIPFound)
 	}


### PR DESCRIPTION
…Sloppy and ParseCIDRSloppy of k8s.io/utils/net package respectively for k8s API objects. This is done to allow IPs and CIDRs with leading zeros to be parsed without any error. Additionally have added conversion of any IP in string format to net.IP format and then conversion to string format again to remove any leading zeros.

Signed-off-by: arkadeepsen <arsen@redhat.com>
(cherry picked from commit dbe0a9137698088b0516acdafba9e38a9853d699)


Not a clean cherry-pick:
Files that needed modifications:
```
  go-controller/pkg/node/gateway_shared_intf.go
  go-controller/pkg/node/node.go
  go-controller/pkg/ovn/egressgw.go
```

# git diff of lines that needed small alterations
```
diff --cc go-controller/pkg/node/gateway_shared_intf.go
index 5a92cce43,6bdc78e88..000000000
--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@@ -761,8 -755,8 +762,13 @@@ func (npw *nodePortWatcher) DeleteEndpo
  func getEndpointAddresses(endpointSlice *discovery.EndpointSlice) []string {
        endpointsAddress := make([]string, 0)
        for _, endpoint := range endpointSlice.Endpoints {
++<<<<<<< HEAD
 +              if isEndpointReady(endpoint) {
 +                      endpointsAddress = append(endpointsAddress, endpoint.Addresses...)
++=======
+               for _, ip := range endpoint.Addresses {
+                       endpointsAddress = append(endpointsAddress, utilnet.ParseIPSloppy(ip).String())
++>>>>>>> dbe0a9137 (Changed all ParseIP and ParseCIDR functions of net package to ParseIPSloppy and ParseCIDRSloppy of k8s.io/utils/net package respectively for k8s API objects. This is done to allow IPs and CIDRs with leading zeros to be parsed without any error. Additionally have added conversion of any IP in string format to net.IP format and then conversion to string format again to remove any leading zeros.)
                }
        }
        return endpointsAddress
diff --cc go-controller/pkg/node/node.go
index 4edd49655,93cf5ac57..000000000
--- a/go-controller/pkg/node/node.go
+++ b/go-controller/pkg/node/node.go
@@@ -635,16 -676,17 +635,30 @@@ func (n *OvnNode) WatchEndpointSlices(
                UpdateFunc: func(old, new interface{}) {
                        newEndpointSlice := new.(*discovery.EndpointSlice)
                        oldEndpointSlice := old.(*discovery.EndpointSlice)
++<<<<<<< HEAD
 +                      for _, oldPort := range oldEndpointSlice.Ports {
 +                              for _, oldEndpoint := range oldEndpointSlice.Endpoints {
 +                                      for _, oldIP := range oldEndpoint.Addresses {
 +                                              if doesEPSliceContainReadyEndpoint(newEndpointSlice, oldIP, *oldPort.Port, *oldPort.Protocol) {
 +                                                      continue
 +                                              }
 +                                              if *oldPort.Protocol == kapi.ProtocolUDP { // flush conntrack only for UDP
 +                                                      err := util.DeleteConntrack(oldIP, *oldPort.Port, *oldPort.Protocol, netlink.ConntrackReplyAnyIP, nil)
 +                                                      if err != nil {
 +                                                              klog.Errorf("Failed to delete conntrack entry for %s: %v", oldIP, err)
++=======
+                       for _, port := range oldEndpointSlice.Ports {
+                               for _, endpoint := range oldEndpointSlice.Endpoints {
+                                       for _, ip := range endpoint.Addresses {
+                                               ipStr := utilnet.ParseIPSloppy(ip).String()
+                                               if doesEPSliceContainEndpoint(newEndpointSlice, ipStr, *port.Port, *port.Protocol) {
+                                                       continue
+                                               }
+                                               if *port.Protocol == kapi.ProtocolUDP { // flush conntrack only for UDP
+                                                       err := util.DeleteConntrack(ipStr, *port.Port, *port.Protocol, netlink.ConntrackReplyAnyIP, nil)
+                                                       if err != nil {
+                                                               klog.Errorf("Failed to delete conntrack entry for %s: %v", ipStr, err)
++>>>>>>> dbe0a9137 (Changed all ParseIP and ParseCIDR functions of net package to ParseIPSloppy and ParseCIDRSloppy of k8s.io/utils/net package respectively for k8s API objects. This is done to allow IPs and CIDRs with leading zeros to be parsed without any error. Additionally have added conversion of any IP in string format to net.IP format and then conversion to string format again to remove any leading zeros.)
                                                        }
                                                }
                                        }
@@@ -812,11 -856,8 +827,11 @@@ func doesEPSliceContainReadyEndpoint(ep
        epIP string, epPort int32, protocol kapi.Protocol) bool {
        for _, port := range epSlice.Ports {
                for _, endpoint := range epSlice.Endpoints {
 +                      if !isEndpointReady(endpoint) {
 +                              continue
 +                      }
                        for _, ip := range endpoint.Addresses {
-                               if ip == epIP && *port.Port == epPort && *port.Protocol == protocol {
+                               if utilnet.ParseIPSloppy(ip).String() == epIP && *port.Port == epPort && *port.Protocol == protocol {
                                        return true
                                }
                        }
diff --cc go-controller/pkg/ovn/egressgw.go
index c17486ba0,fa2fa97bb..000000000
--- a/go-controller/pkg/ovn/egressgw.go
+++ b/go-controller/pkg/ovn/egressgw.go
@@@ -230,7 -230,8 +230,12 @@@ func (oc *Controller) addGWRoutesForNam
                }
                podIPs := make([]*net.IPNet, 0)
                for _, podIP := range pod.Status.PodIPs {
++<<<<<<< HEAD
 +                      cidr := podIP.IP + util.GetIPFullMask(podIP.IP)
++=======
+                       podIPStr := utilnet.ParseIPSloppy(podIP.IP).String()
+                       cidr := podIPStr + GetIPFullMask(podIPStr)
++>>>>>>> dbe0a9137 (Changed all ParseIP and ParseCIDR functions of net package to ParseIPSloppy and ParseCIDRSloppy of k8s.io/utils/net package respectively for k8s API objects. This is done to allow IPs and CIDRs with leading zeros to be parsed without any error. Additionally have added conversion of any IP in string format to net.IP format and then conversion to string format again to remove any leading zeros.)
                        _, ipNet, err := net.ParseCIDR(cidr)
                        if err != nil {
                                return fmt.Errorf("failed to parse CIDR: %s, error: %v", cidr, err)

```