### PR TITLE
[release-4.12] OCPBUGS-3977: Handle expired entry while handling dns update

### DIFF
--- a/go-controller/pkg/ovn/egressfirewall_dns.go
+++ b/go-controller/pkg/ovn/egressfirewall_dns.go
@@ -200,10 +200,14 @@ func (e *EgressDNS) Run(defaultInterval time.Duration) {
 			// find the domain name whose DNS entry will expire first and calculate when it will expire,
 			// set timer to what's sooner: default update interval or next expiration time
 			ttl, domainNameExpiringNext, timeSet = e.dns.GetNextQueryTime()
-			if time.Until(ttl) > defaultInterval || !timeSet {
+			ttlDuration := time.Until(ttl)
+			if ttlDuration > defaultInterval || !timeSet {
 				durationTillNextQuery = defaultInterval
+			} else if ttlDuration.Seconds() > 0 {
+				durationTillNextQuery = ttlDuration
 			} else {
-				durationTillNextQuery = time.Until(ttl)
+				// DNS entry is already expired, so trigger tick as soon as possible.
+				durationTillNextQuery = 1 * time.Millisecond
 			}
 			timer.Reset(durationTillNextQuery)
 		}


### PR DESCRIPTION
When nextQueryTime for dns entry is already expired and update goroutine is trying to use negative duration to reset ticker. This causes process crash on the ovnk master. This change avoids proces crash and ensures to trigger ticker in shortest possible time (1 ms) so that update happens immediately on expired dns entry.

Signed-off-by: Periyasamy Palanisamy <pepalani@redhat.com>
(cherry picked from commit 378425472307e08f238deef8eb72ea498852d287)