### PR TITLE
OCPBUGS-3908: [release-4.11] Support proper parsing of IPs with leading zeros

### DIFF
--- a/go-controller/hybrid-overlay/pkg/util/util.go
+++ b/go-controller/hybrid-overlay/pkg/util/util.go
@@ -11,6 +11,7 @@ import (
 	kapi "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	utilnet "k8s.io/utils/net"
 )
 
 // ParseHybridOverlayHostSubnet returns the parsed hybrid overlay hostsubnet if
@@ -54,7 +55,7 @@ func SameIPNet(a, b *net.IPNet) bool {
 func GetNodeInternalIP(node *kapi.Node) (string, error) {
 	for _, addr := range node.Status.Addresses {
 		if addr.Type == kapi.NodeInternalIP {
-			return addr.Address, nil
+			return utilnet.ParseIPSloppy(addr.Address).String(), nil
 		}
 	}
 	return "", fmt.Errorf("failed to read node %q InternalIP", node.Name)

--- a/go-controller/pkg/node/gateway_iptables.go
+++ b/go-controller/pkg/node/gateway_iptables.go
@@ -441,13 +441,8 @@ func getGatewayIPTRules(service *kapi.Service, svcHasLocalHostNetEndPnt bool) []
 				rules = append(rules, getNodePortIPTRules(svcPort, clusterIP, svcPort.Port, svcHasLocalHostNetEndPnt, false)...)
 			}
 		}
-		externalIPs := make([]string, 0, len(service.Spec.ExternalIPs)+len(service.Status.LoadBalancer.Ingress))
-		externalIPs = append(externalIPs, service.Spec.ExternalIPs...)
-		for _, ingress := range service.Status.LoadBalancer.Ingress {
-			if len(ingress.IP) > 0 {
-				externalIPs = append(externalIPs, ingress.IP)
-			}
-		}
+
+		externalIPs := util.GetExternalAndLBIPs(service)
 
 		for _, externalIP := range externalIPs {
 			err := util.ValidatePort(svcPort.Protocol, svcPort.Port)

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -191,7 +191,7 @@ func (npw *nodePortWatcher) updateServiceFlowCache(service *kapi.Service, add, h
 		// NodePort/Ingress access in the OVS bridge will only ever come from outside of the host
 		for _, ing := range service.Status.LoadBalancer.Ingress {
 			if len(ing.IP) > 0 {
-				err = npw.createLbAndExternalSvcFlows(service, &svcPort, add, hasLocalHostNetworkEp, protocol, actions, ing.IP, "Ingress")
+				err = npw.createLbAndExternalSvcFlows(service, &svcPort, add, hasLocalHostNetworkEp, protocol, actions, utilnet.ParseIPSloppy(ing.IP).String(), "Ingress")
 				if err != nil {
 					klog.Errorf(err.Error())
 				}
@@ -199,7 +199,7 @@ func (npw *nodePortWatcher) updateServiceFlowCache(service *kapi.Service, add, h
 		}
 		// flows for externalIPs
 		for _, externalIP := range service.Spec.ExternalIPs {
-			err = npw.createLbAndExternalSvcFlows(service, &svcPort, add, hasLocalHostNetworkEp, protocol, actions, externalIP, "External")
+			err = npw.createLbAndExternalSvcFlows(service, &svcPort, add, hasLocalHostNetworkEp, protocol, actions, utilnet.ParseIPSloppy(externalIP).String(), "External")
 			if err != nil {
 				klog.Errorf(err.Error())
 			}

--- a/go-controller/pkg/node/healthcheck.go
+++ b/go-controller/pkg/node/healthcheck.go
@@ -15,6 +15,7 @@ import (
 	kapi "k8s.io/api/core/v1"
 	ktypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
+	utilnet "k8s.io/utils/net"
 )
 
 // initLoadBalancerHealthChecker initializes the health check server for
@@ -118,7 +119,7 @@ func hasLocalHostNetworkEndpoints(ep *kapi.Endpoints, nodeAddresses []net.IP) bo
 		for i := range ss.Addresses {
 			addr := &ss.Addresses[i]
 			for _, nodeIP := range nodeAddresses {
-				if nodeIP.String() == addr.IP {
+				if nodeIP.String() == utilnet.ParseIPSloppy(addr.IP).String() {
 					return true
 				}
 			}

--- a/go-controller/pkg/node/node.go
+++ b/go-controller/pkg/node/node.go
@@ -763,7 +763,7 @@ func buildEndpointAddressMap(epSubsets []kapi.EndpointSubset) map[epAddressItem]
 			for _, port := range subset.Ports {
 				if port.Protocol == kapi.ProtocolUDP || port.Protocol == kapi.ProtocolSCTP {
 					epMap[epAddressItem{
-						ip:       address.IP,
+						ip:       utilnet.ParseIPSloppy(address.IP).String(),
 						port:     port.Port,
 						protocol: port.Protocol,
 					}] = struct{}{}

--- a/go-controller/pkg/node/port_claim.go
+++ b/go-controller/pkg/node/port_claim.go
@@ -188,7 +188,7 @@ func handleService(svc *kapi.Service, handler handler) []error {
 		}
 		for _, externalIP := range svc.Spec.ExternalIPs {
 			klog.V(5).Infof("Handle ExternalIPs service %s external IP %s port %d", svc.Name, externalIP, svcPort.Port)
-			if err := handlePort(getDescription(svcPort.Name, svc, false), svc, externalIP, svcPort.Port, svcPort.Protocol, handler); err != nil {
+			if err := handlePort(getDescription(svcPort.Name, svc, false), svc, utilnet.ParseIPSloppy(externalIP).String(), svcPort.Port, svcPort.Protocol, handler); err != nil {
 				errors = append(errors, err)
 			}
 		}

--- a/go-controller/pkg/ovn/controller/services/load_balancer.go
+++ b/go-controller/pkg/ovn/controller/services/load_balancer.go
@@ -85,21 +85,9 @@ func buildServiceLBConfigs(service *v1.Service, endpointSlices []*discovery.Endp
 			perNodeConfigs = append(perNodeConfigs, nodePortLBConfig)
 		}
 
-		// Build up list of vips
-		vips := append([]string{}, service.Spec.ClusterIPs...)
-		// Handle old clusters w/o v6 support
-		if len(vips) == 0 {
-			vips = []string{service.Spec.ClusterIP}
-		}
-		externalVips := []string{}
-		// ExternalIP
-		externalVips = append(externalVips, service.Spec.ExternalIPs...)
-		// LoadBalancer status
-		for _, ingress := range service.Status.LoadBalancer.Ingress {
-			if ingress.IP != "" {
-				externalVips = append(externalVips, ingress.IP)
-			}
-		}
+		// Build up list of vips and externalVips
+		vips := util.GetClusterIPs(service)
+		externalVips := util.GetExternalAndLBIPs(service)
 
 		// if ETP=Local, then treat ExternalIPs and LoadBalancer IPs specially
 		// otherwise, they're just cluster IPs

--- a/go-controller/pkg/ovn/controller/services/load_balancer_test.go
+++ b/go-controller/pkg/ovn/controller/services/load_balancer_test.go
@@ -387,7 +387,7 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 				service: &v1.Service{
 					ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: ns},
 					Spec: v1.ServiceSpec{
-						Type:       v1.ServiceTypeClusterIP,
+						Type:       v1.ServiceTypeLoadBalancer,
 						ClusterIP:  "192.168.1.1",
 						ClusterIPs: []string{"192.168.1.1", "2002::1"},
 						Ports: []v1.ServicePort{{

--- a/go-controller/pkg/ovn/controller/services/utils.go
+++ b/go-controller/pkg/ovn/controller/services/utils.go
@@ -23,14 +23,8 @@ func deleteServiceFromLegacyLBs(nbClient libovsdbclient.Client, service *v1.Serv
 	vipPortsPerProtocol := map[v1.Protocol]sets.String{}
 
 	// Generate list of vip:port by proto
-	ips := append([]string{}, service.Spec.ClusterIPs...)
-	if len(ips) == 0 {
-		ips = append(ips, service.Spec.ClusterIP)
-	}
-	ips = append(ips, service.Spec.ExternalIPs...)
-	for _, ingress := range service.Status.LoadBalancer.Ingress {
-		ips = append(ips, ingress.IP)
-	}
+	ips := util.GetClusterIPs(service)
+	ips = append(ips, util.GetExternalAndLBIPs(service)...)
 	for _, svcPort := range service.Spec.Ports {
 		proto := svcPort.Protocol
 		ipPorts := make([]string, 0, len(ips))

--- a/go-controller/pkg/ovn/egressgw.go
+++ b/go-controller/pkg/ovn/egressgw.go
@@ -230,7 +230,8 @@ func (oc *Controller) addGWRoutesForNamespace(namespace string, egress gatewayIn
 		}
 		podIPs := make([]*net.IPNet, 0)
 		for _, podIP := range pod.Status.PodIPs {
-			cidr := podIP.IP + util.GetIPFullMask(podIP.IP)
+			podIPStr := utilnet.ParseIPSloppy(podIP.IP).String()
+			cidr := podIPStr + util.GetIPFullMask(podIPStr)
 			_, ipNet, err := net.ParseCIDR(cidr)
 			if err != nil {
 				return fmt.Errorf("failed to parse CIDR: %s, error: %v", cidr, err)
@@ -1003,7 +1004,7 @@ func getExGwPodIPs(gatewayPod *kapi.Pod) (sets.String, error) {
 		}
 	} else if gatewayPod.Spec.HostNetwork {
 		for _, podIP := range gatewayPod.Status.PodIPs {
-			ip := net.ParseIP(podIP.IP)
+			ip := utilnet.ParseIPSloppy(podIP.IP)
 			if ip != nil {
 				foundGws.Insert(ip.String())
 			}
@@ -1046,10 +1047,11 @@ func (oc *Controller) buildClusterECMPCacheFromNamespaces(clusterRouteCache map[
 					continue
 				}
 				for _, podIP := range nsPod.Status.PodIPs {
-					if utilnet.IsIPv6String(gwIP) != utilnet.IsIPv6String(podIP.IP) {
+					podIPStr := utilnet.ParseIPSloppy(podIP.IP).String()
+					if utilnet.IsIPv6String(gwIP) != utilnet.IsIPv6String(podIPStr) {
 						continue
 					}
-					if val, ok := clusterRouteCache[podIP.IP]; ok {
+					if val, ok := clusterRouteCache[podIPStr]; ok {
 						// add gwIP to cache only if buildClusterECMPCacheFromPods hasn't already added it
 						gwIPexists := false
 						for _, existingGwIP := range val {
@@ -1059,10 +1061,10 @@ func (oc *Controller) buildClusterECMPCacheFromNamespaces(clusterRouteCache map[
 							}
 						}
 						if !gwIPexists {
-							clusterRouteCache[podIP.IP] = append(clusterRouteCache[podIP.IP], gwIP)
+							clusterRouteCache[podIPStr] = append(clusterRouteCache[podIPStr], gwIP)
 						}
 					} else {
-						clusterRouteCache[podIP.IP] = []string{gwIP}
+						clusterRouteCache[podIPStr] = []string{gwIP}
 					}
 				}
 			}
@@ -1103,10 +1105,11 @@ func (oc *Controller) buildClusterECMPCacheFromPods(clusterRouteCache map[string
 					continue
 				}
 				for _, podIP := range nsPod.Status.PodIPs {
-					if utilnet.IsIPv6String(gwIP) != utilnet.IsIPv6String(podIP.IP) {
+					podIPStr := utilnet.ParseIPSloppy(podIP.IP).String()
+					if utilnet.IsIPv6String(gwIP) != utilnet.IsIPv6String(podIPStr) {
 						continue
 					}
-					clusterRouteCache[podIP.IP] = append(clusterRouteCache[podIP.IP], gwIP)
+					clusterRouteCache[podIPStr] = append(clusterRouteCache[podIPStr], gwIP)
 				}
 			}
 		}

--- a/go-controller/pkg/ovn/egressip.go
+++ b/go-controller/pkg/ovn/egressip.go
@@ -2401,7 +2401,7 @@ func getNodeInternalAddrs(node *v1.Node) (net.IP, net.IP) {
 	var v4Addr, v6Addr net.IP
 	for _, nodeAddr := range node.Status.Addresses {
 		if nodeAddr.Type == v1.NodeInternalIP {
-			ip := net.ParseIP(nodeAddr.Address)
+			ip := utilnet.ParseIPSloppy(nodeAddr.Address)
 			if !utilnet.IsIPv6(ip) && v4Addr == nil {
 				v4Addr = ip
 			} else if utilnet.IsIPv6(ip) && v6Addr == nil {

--- a/go-controller/pkg/ovn/gress_policy.go
+++ b/go-controller/pkg/ovn/gress_policy.go
@@ -471,7 +471,7 @@ func getSvcVips(nbClient client.Client, service *v1.Service) []net.IP {
 		for _, ipStr := range ipStrs {
 			ip := net.ParseIP(ipStr)
 			if ip == nil {
-				klog.Errorf("Failed to parse cluster IP %q", service.Spec.ClusterIP)
+				klog.Errorf("Failed to parse cluster IP %q", ipStr)
 				continue
 			}
 			ips = append(ips, ip)
@@ -480,13 +480,13 @@ func getSvcVips(nbClient client.Client, service *v1.Service) []net.IP {
 		for _, ing := range service.Status.LoadBalancer.Ingress {
 			if ing.IP != "" {
 				klog.V(5).Infof("Adding ingress IPs: %s from Service: %s to VIP set", ing.IP, service.Name)
-				ips = append(ips, net.ParseIP(ing.IP))
+				ips = append(ips, utilnet.ParseIPSloppy(ing.IP))
 			}
 		}
 
 		if len(service.Spec.ExternalIPs) > 0 {
 			for _, extIP := range service.Spec.ExternalIPs {
-				ip := net.ParseIP(extIP)
+				ip := utilnet.ParseIPSloppy(extIP)
 				if ip == nil {
 					klog.Errorf("Failed to parse external IP %q", extIP)
 					continue

--- a/go-controller/pkg/ovndbmanager/ovndbmanager.go
+++ b/go-controller/pkg/ovndbmanager/ovndbmanager.go
@@ -252,7 +252,7 @@ func ensureClusterRaftMembership(db *util.OvsDbProperties, kclient kube.Interfac
 		if !memberFound {
 			for _, dbPod := range dbPods.Items {
 				for _, ip := range dbPod.Status.PodIPs {
-					if ip.IP == matchedServer {
+					if ip.IP == matchedServer || utilnet.ParseIPSloppy(ip.IP).String() == matchedServer {
 						memberFound = true
 						break
 					}

--- a/go-controller/pkg/util/kube_test.go
+++ b/go-controller/pkg/util/kube_test.go
@@ -296,12 +296,12 @@ func TestGetNodePrimaryIP(t *testing.T) {
 				Status: v1.NodeStatus{
 					Addresses: []v1.NodeAddress{
 						{Type: v1.NodeHostName, Address: "HN"},
-						{Type: v1.NodeInternalIP, Address: "IntIP"},
-						{Type: v1.NodeExternalIP, Address: "ExtIP"},
+						{Type: v1.NodeInternalIP, Address: "192.168.1.1"},
+						{Type: v1.NodeExternalIP, Address: "90.90.90.90"},
 					},
 				},
 			},
-			expOut: "IntIP",
+			expOut: "192.168.1.1",
 		},
 		{
 			desc: "success: node's external IP returned",
@@ -309,11 +309,11 @@ func TestGetNodePrimaryIP(t *testing.T) {
 				Status: v1.NodeStatus{
 					Addresses: []v1.NodeAddress{
 						{Type: v1.NodeHostName, Address: "HN"},
-						{Type: v1.NodeExternalIP, Address: "ExtIP"},
+						{Type: v1.NodeExternalIP, Address: "90.90.90.90"},
 					},
 				},
 			},
-			expOut: "ExtIP",
+			expOut: "90.90.90.90",
 		},
 	}
 	for i, tc := range tests {

--- a/go-controller/pkg/util/pod_annotation.go
+++ b/go-controller/pkg/util/pod_annotation.go
@@ -264,7 +264,7 @@ func GetAllPodIPs(pod *v1.Pod) ([]net.IP, error) {
 	// Otherwise if the annotation is not valid try to use Kube API pod IPs
 	ips := make([]net.IP, 0, len(pod.Status.PodIPs))
 	for _, podIP := range pod.Status.PodIPs {
-		ip := net.ParseIP(podIP.IP)
+		ip := utilnet.ParseIPSloppy(podIP.IP)
 		if ip == nil {
 			klog.Warningf("Failed to parse pod IP %q", podIP)
 			continue
@@ -278,7 +278,7 @@ func GetAllPodIPs(pod *v1.Pod) ([]net.IP, error) {
 
 	// Fallback check pod.Status.PodIP
 	// Kubelet < 1.16 only set podIP
-	ip := net.ParseIP(pod.Status.PodIP)
+	ip := utilnet.ParseIPSloppy(pod.Status.PodIP)
 	if ip == nil {
 		return nil, fmt.Errorf("pod %s/%s: %w ", pod.Namespace, pod.Name, ErrNoPodIPFound)
 	}


### PR DESCRIPTION
Cherry picked from commit b0efc6b31d72437cd576a8f60eb6e13e3195ca85

Merge conflicts:

- cmd/ovnkube-trace/ovnkube-race.go
- pkg/node/gateway_iptables.go
- pkg/node/gateway_shared_intf_linux.go (resolving merge conflict resulted in no change)
- pkg/node/gateway_shared_intf.go
- pkg/node/healthcheck.go
- pkg/node/node.go
- pkg/ovn/controller/egress_services/egress_services_service.go (not present in 4.11)
