### PR TITLE
[WIP] Netpol bundle db transactions

### DIFF
--- a/go-controller/cmd/ovnkube/ovnkube.go
+++ b/go-controller/cmd/ovnkube/ovnkube.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdb"
 	"io"
 	"io/ioutil"
 	"os"
@@ -22,6 +21,7 @@ import (
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdb"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/metrics"
 	ovnnode "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn"
@@ -232,7 +232,7 @@ func runOvnKube(ctx *cli.Context) error {
 			return fmt.Errorf("error when trying to initialize libovsdb SB client: %v", err)
 		}
 		// create factory and start the controllers asked for
-		masterWatchFactory, err = factory.NewMasterWatchFactory(ovnClientset, libovsdbOvnNBClient, &ovn.NetPolObjects)
+		masterWatchFactory, err = factory.NewMasterWatchFactory(ovnClientset, libovsdbOvnNBClient, &ovn.NetPolPodDelayedTxns)
 		if err != nil {
 			return err
 		}

--- a/go-controller/hybrid-overlay/pkg/util/util.go
+++ b/go-controller/hybrid-overlay/pkg/util/util.go
@@ -6,13 +6,11 @@ import (
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/hybrid-overlay/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
 
 	kapi "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/client-go/tools/cache"
 )
 
 // ParseHybridOverlayHostSubnet returns the parsed hybrid overlay hostsubnet if
@@ -60,25 +58,6 @@ func GetNodeInternalIP(node *kapi.Node) (string, error) {
 		}
 	}
 	return "", fmt.Errorf("failed to read node %q InternalIP", node.Name)
-}
-
-// StartNodeWatch starts a node event handler
-func StartNodeWatch(h types.NodeHandler, wf *factory.WatchFactory) {
-	wf.AddNodeHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
-			node := obj.(*kapi.Node)
-			h.Add(node)
-		},
-		UpdateFunc: func(oldObj, newObj interface{}) {
-			oldNode := oldObj.(*kapi.Node)
-			newNode := newObj.(*kapi.Node)
-			h.Update(oldNode, newNode)
-		},
-		DeleteFunc: func(obj interface{}) {
-			node := obj.(*kapi.Node)
-			h.Delete(node)
-		},
-	}, nil, wf.GetHandlerPriority(""))
 }
 
 // CopyNamespaceAnnotationsToPod copies annotations from a namespace to a pod

--- a/go-controller/pkg/factory/factory.go
+++ b/go-controller/pkg/factory/factory.go
@@ -2,12 +2,12 @@ package factory
 
 import (
 	"fmt"
-	"github.com/ovn-org/libovsdb/client"
 	"reflect"
 	"sync"
 	"sync/atomic"
 	"time"
 
+	"github.com/ovn-org/libovsdb/client"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 

--- a/go-controller/pkg/factory/factory_test.go
+++ b/go-controller/pkg/factory/factory_test.go
@@ -327,7 +327,7 @@ var _ = Describe("Watch Factory Operations", func() {
 
 	Context("when a processExisting is given", func() {
 		testExisting := func(objType reflect.Type, namespace string, sel labels.Selector, priority uint32) {
-			wf, err = NewMasterWatchFactory(ovnClientset)
+			wf, err = NewMasterWatchFactory(ovnClientset, nil, &sync.Map{})
 			Expect(err).NotTo(HaveOccurred())
 			err = wf.Start()
 			Expect(err).NotTo(HaveOccurred())
@@ -344,7 +344,7 @@ var _ = Describe("Watch Factory Operations", func() {
 		}
 
 		testExistingFilteredHandler := func(objType reflect.Type, realObj string, namespace string, sel labels.Selector, priority uint32) {
-			wf, err = NewMasterWatchFactory(ovnClientset)
+			wf, err = NewMasterWatchFactory(ovnClientset, nil, &sync.Map{})
 			Expect(err).NotTo(HaveOccurred())
 			err = wf.Start()
 			Expect(err).NotTo(HaveOccurred())
@@ -467,7 +467,7 @@ var _ = Describe("Watch Factory Operations", func() {
 
 	Context("when existing items are known to the informer", func() {
 		testExisting := func(objType reflect.Type) {
-			wf, err = NewMasterWatchFactory(ovnClientset)
+			wf, err = NewMasterWatchFactory(ovnClientset, nil, &sync.Map{})
 			Expect(err).NotTo(HaveOccurred())
 			err = wf.Start()
 			Expect(err).NotTo(HaveOccurred())
@@ -538,7 +538,7 @@ var _ = Describe("Watch Factory Operations", func() {
 
 	Context("when EgressIP is disabled", func() {
 		testExisting := func(objType reflect.Type) {
-			wf, err = NewMasterWatchFactory(ovnClientset)
+			wf, err = NewMasterWatchFactory(ovnClientset, nil, &sync.Map{})
 			Expect(err).NotTo(HaveOccurred())
 			err = wf.Start()
 			Expect(err).NotTo(HaveOccurred())
@@ -551,7 +551,7 @@ var _ = Describe("Watch Factory Operations", func() {
 	})
 	Context("when EgressFirewall is disabled", func() {
 		testExisting := func(objType reflect.Type) {
-			wf, err = NewMasterWatchFactory(ovnClientset)
+			wf, err = NewMasterWatchFactory(ovnClientset, nil, &sync.Map{})
 			Expect(err).NotTo(HaveOccurred())
 			err = wf.Start()
 			Expect(err).NotTo(HaveOccurred())
@@ -595,7 +595,7 @@ var _ = Describe("Watch Factory Operations", func() {
 	}
 
 	It("responds to pod add/update/delete events", func() {
-		wf, err = NewMasterWatchFactory(ovnClientset)
+		wf, err = NewMasterWatchFactory(ovnClientset, nil, &sync.Map{})
 		Expect(err).NotTo(HaveOccurred())
 		err = wf.Start()
 		Expect(err).NotTo(HaveOccurred())
@@ -631,7 +631,7 @@ var _ = Describe("Watch Factory Operations", func() {
 	})
 
 	It("responds to multiple pod add/update/delete events", func() {
-		wf, err = NewMasterWatchFactory(ovnClientset)
+		wf, err = NewMasterWatchFactory(ovnClientset, nil, &sync.Map{})
 		Expect(err).NotTo(HaveOccurred())
 		err = wf.Start()
 		Expect(err).NotTo(HaveOccurred())
@@ -714,7 +714,7 @@ var _ = Describe("Watch Factory Operations", func() {
 	})
 
 	It("responds to namespace add/update/delete events", func() {
-		wf, err = NewMasterWatchFactory(ovnClientset)
+		wf, err = NewMasterWatchFactory(ovnClientset, nil, &sync.Map{})
 		Expect(err).NotTo(HaveOccurred())
 		err = wf.Start()
 		Expect(err).NotTo(HaveOccurred())
@@ -750,7 +750,7 @@ var _ = Describe("Watch Factory Operations", func() {
 	})
 
 	It("responds to node add/update/delete events", func() {
-		wf, err = NewMasterWatchFactory(ovnClientset)
+		wf, err = NewMasterWatchFactory(ovnClientset, nil, &sync.Map{})
 		Expect(err).NotTo(HaveOccurred())
 		err = wf.Start()
 		Expect(err).NotTo(HaveOccurred())
@@ -786,7 +786,7 @@ var _ = Describe("Watch Factory Operations", func() {
 	})
 
 	It("responds to multiple node add/update/delete events", func() {
-		wf, err = NewMasterWatchFactory(ovnClientset)
+		wf, err = NewMasterWatchFactory(ovnClientset, nil, &sync.Map{})
 		Expect(err).NotTo(HaveOccurred())
 		err = wf.Start()
 		Expect(err).NotTo(HaveOccurred())
@@ -884,7 +884,7 @@ var _ = Describe("Watch Factory Operations", func() {
 			nodes = append(nodes, node)
 		}
 
-		wf, err = NewMasterWatchFactory(ovnClientset)
+		wf, err = NewMasterWatchFactory(ovnClientset, nil, &sync.Map{})
 		Expect(err).NotTo(HaveOccurred())
 		err = wf.Start()
 		Expect(err).NotTo(HaveOccurred())
@@ -963,7 +963,7 @@ var _ = Describe("Watch Factory Operations", func() {
 			namespaces = append(namespaces, namespace)
 		}
 
-		wf, err = NewMasterWatchFactory(ovnClientset)
+		wf, err = NewMasterWatchFactory(ovnClientset, nil, &sync.Map{})
 		Expect(err).NotTo(HaveOccurred())
 		err = wf.Start()
 		Expect(err).NotTo(HaveOccurred())
@@ -1047,7 +1047,7 @@ var _ = Describe("Watch Factory Operations", func() {
 			namespaces = append(namespaces, namespace)
 		}
 
-		wf, err = NewMasterWatchFactory(ovnClientset)
+		wf, err = NewMasterWatchFactory(ovnClientset, nil, &sync.Map{})
 		Expect(err).NotTo(HaveOccurred())
 		err = wf.Start()
 		Expect(err).NotTo(HaveOccurred())
@@ -1199,7 +1199,7 @@ var _ = Describe("Watch Factory Operations", func() {
 	})
 
 	It("responds to policy add/update/delete events", func() {
-		wf, err = NewMasterWatchFactory(ovnClientset)
+		wf, err = NewMasterWatchFactory(ovnClientset, nil, &sync.Map{})
 		Expect(err).NotTo(HaveOccurred())
 		err = wf.Start()
 		Expect(err).NotTo(HaveOccurred())
@@ -1235,7 +1235,7 @@ var _ = Describe("Watch Factory Operations", func() {
 	})
 
 	It("responds to endpoints add/update/delete events", func() {
-		wf, err = NewMasterWatchFactory(ovnClientset)
+		wf, err = NewMasterWatchFactory(ovnClientset, nil, &sync.Map{})
 		Expect(err).NotTo(HaveOccurred())
 		err = wf.Start()
 		Expect(err).NotTo(HaveOccurred())
@@ -1278,7 +1278,7 @@ var _ = Describe("Watch Factory Operations", func() {
 	})
 
 	It("responds to service add/update/delete events", func() {
-		wf, err = NewMasterWatchFactory(ovnClientset)
+		wf, err = NewMasterWatchFactory(ovnClientset, nil, &sync.Map{})
 		Expect(err).NotTo(HaveOccurred())
 		err = wf.Start()
 		Expect(err).NotTo(HaveOccurred())
@@ -1314,7 +1314,7 @@ var _ = Describe("Watch Factory Operations", func() {
 	})
 
 	It("responds to egressFirewall add/update/delete events", func() {
-		wf, err = NewMasterWatchFactory(ovnClientset)
+		wf, err = NewMasterWatchFactory(ovnClientset, nil, &sync.Map{})
 		Expect(err).NotTo(HaveOccurred())
 		err = wf.Start()
 		Expect(err).NotTo(HaveOccurred())
@@ -1349,7 +1349,7 @@ var _ = Describe("Watch Factory Operations", func() {
 		wf.RemoveEgressFirewallHandler(h)
 	})
 	It("responds to egressIP add/update/delete events", func() {
-		wf, err = NewMasterWatchFactory(ovnClientset)
+		wf, err = NewMasterWatchFactory(ovnClientset, nil, &sync.Map{})
 		Expect(err).NotTo(HaveOccurred())
 		err = wf.Start()
 		Expect(err).NotTo(HaveOccurred())
@@ -1384,7 +1384,7 @@ var _ = Describe("Watch Factory Operations", func() {
 		wf.RemoveEgressIPHandler(h)
 	})
 	It("responds to cloudPrivateIPConfig add/update/delete events", func() {
-		wf, err = NewMasterWatchFactory(ovnClientset)
+		wf, err = NewMasterWatchFactory(ovnClientset, nil, &sync.Map{})
 		Expect(err).NotTo(HaveOccurred())
 		err = wf.Start()
 		Expect(err).NotTo(HaveOccurred())
@@ -1419,7 +1419,7 @@ var _ = Describe("Watch Factory Operations", func() {
 		wf.RemoveCloudPrivateIPConfigHandler(h)
 	})
 	It("stops processing events after the handler is removed", func() {
-		wf, err = NewMasterWatchFactory(ovnClientset)
+		wf, err = NewMasterWatchFactory(ovnClientset, nil, &sync.Map{})
 		Expect(err).NotTo(HaveOccurred())
 		err = wf.Start()
 		Expect(err).NotTo(HaveOccurred())
@@ -1450,7 +1450,7 @@ var _ = Describe("Watch Factory Operations", func() {
 	})
 
 	It("filters correctly by label and namespace", func() {
-		wf, err = NewMasterWatchFactory(ovnClientset)
+		wf, err = NewMasterWatchFactory(ovnClientset, nil, &sync.Map{})
 		Expect(err).NotTo(HaveOccurred())
 		err = wf.Start()
 		Expect(err).NotTo(HaveOccurred())
@@ -1522,7 +1522,7 @@ var _ = Describe("Watch Factory Operations", func() {
 	})
 
 	It("correctly handles object updates that cause filter changes", func() {
-		wf, err = NewMasterWatchFactory(ovnClientset)
+		wf, err = NewMasterWatchFactory(ovnClientset, nil, &sync.Map{})
 		Expect(err).NotTo(HaveOccurred())
 		err = wf.Start()
 		Expect(err).NotTo(HaveOccurred())

--- a/go-controller/pkg/factory/types.go
+++ b/go-controller/pkg/factory/types.go
@@ -45,7 +45,7 @@ type NodeWatchFactory interface {
 	AddNamespaceHandler(handlerFuncs cache.ResourceEventHandler, processExisting func([]interface{}), priority uint32) *Handler
 	RemoveNamespaceHandler(handler *Handler)
 
-	GetHandlerPriority(objType string) (uint32)
+	GetHandlerPriority(objType string) uint32
 
 	NodeInformer() cache.SharedIndexInformer
 	LocalPodInformer() cache.SharedIndexInformer

--- a/go-controller/pkg/ovn/gress_policy.go
+++ b/go-controller/pkg/ovn/gress_policy.go
@@ -2,7 +2,6 @@ package ovn
 
 import (
 	"fmt"
-	"github.com/ovn-org/libovsdb/ovsdb"
 	ktypes "k8s.io/apimachinery/pkg/types"
 	"net"
 	"strconv"
@@ -161,10 +160,7 @@ func (gp *gressPolicy) addPeerPods(transact bool, pods ...*v1.Pod) error {
 	ops, err := gp.peerAddressSet.AddIPsReturnOps(ips)
 	if err == nil {
 		namespacedName := ktypes.NamespacedName{Namespace: pods[0].Namespace, Name: pods[0].Name}
-		if existingOps, loaded := NetPolObjects.LoadOrStore(namespacedName, ops); loaded {
-			newOps := append(existingOps.([]ovsdb.Operation), ops...)
-			NetPolObjects.Store(namespacedName, newOps)
-		}
+		addNetPolDelayedTxn(namespacedName, ops, nil)
 	}
 	return err
 }
@@ -177,10 +173,7 @@ func (gp *gressPolicy) deletePeerPod(pod *v1.Pod) error {
 	ops, err := gp.peerAddressSet.DeleteIPsReturnOps(ips)
 	if err == nil {
 		namespacedName := ktypes.NamespacedName{Namespace: pod.Namespace, Name: pod.Name}
-		if existingOps, loaded := NetPolObjects.LoadOrStore(namespacedName, ops); loaded {
-			newOps := append(existingOps.([]ovsdb.Operation), ops...)
-			NetPolObjects.Store(namespacedName, newOps)
-		}
+		addNetPolDelayedTxn(namespacedName, ops, nil)
 	}
 	return err
 }

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -924,7 +924,7 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 			hostAddrs, err := util.ParseNodeHostAddresses(updatedNode)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			f, err = factory.NewMasterWatchFactory(fakeClient)
+			f, err = factory.NewMasterWatchFactory(fakeClient, nil, &sync.Map{})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			err = f.Start()
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -1112,7 +1112,7 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 			hostAddrs, err := util.ParseNodeHostAddresses(updatedNode)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			f, err = factory.NewMasterWatchFactory(fakeClient)
+			f, err = factory.NewMasterWatchFactory(fakeClient, nil, &sync.Map{})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			err = f.Start()
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -1437,7 +1437,7 @@ func TestController_allocateNodeSubnets(t *testing.T) {
 				EgressIPClient:       egressIPFakeClient,
 				EgressFirewallClient: egressFirewallFakeClient,
 			}
-			f, err := factory.NewMasterWatchFactory(fakeClient)
+			f, err := factory.NewMasterWatchFactory(fakeClient, nil, &sync.Map{})
 			if err != nil {
 				t.Fatalf("Error creating master watch factory: %v", err)
 			}
@@ -1539,7 +1539,7 @@ func TestController_syncNodesRetriable(t *testing.T) {
 				EgressIPClient:       egressIPFakeClient,
 				EgressFirewallClient: egressFirewallFakeClient,
 			}
-			f, err := factory.NewMasterWatchFactory(fakeClient)
+			f, err := factory.NewMasterWatchFactory(fakeClient, nil, &sync.Map{})
 			if err != nil {
 				t.Fatalf("%s: Error creating master watch factory: %v", tt.name, err)
 			}

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -550,7 +550,7 @@ func networkStatusAnnotationsChanged(oldPod, newPod *kapi.Pod) bool {
 func (oc *Controller) ensurePod(oldPod, pod *kapi.Pod, addPort bool) error {
 	// Try unscheduled pods later
 	if !util.PodScheduled(pod) {
-		return fmt.Errorf("failed to ensurePod %s/%s since it is not yet scheduled", pod.Namespace, pod.Name)
+		return nil
 	}
 
 	if oldPod != nil && (exGatewayAnnotationsChanged(oldPod, pod) || networkStatusAnnotationsChanged(oldPod, pod)) {
@@ -722,7 +722,7 @@ func (oc *Controller) WatchPods() {
 				return
 			}
 
-			if err := oc.ensurePod(oldPod, pod, oc.checkAndSkipRetryPod(pod)); err != nil {
+			if err := oc.ensurePod(oldPod, pod, oc.checkAndSkipRetryPod(pod) || util.PodScheduled(oldPod) != util.PodScheduled(newerPod)); err != nil {
 				oc.recordPodEvent(err, pod)
 				klog.Errorf("Failed to update pod %s, error: %v",
 					getPodNamespacedName(pod), err)

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -245,6 +245,8 @@ const (
 	SCTP = "SCTP"
 )
 
+var NetPolObjects sync.Map
+
 // NewOvnController creates a new OVN controller for creating logical network
 // infrastructure and policy
 func NewOvnController(ovnClient *util.OVNClientset, wf *factory.WatchFactory, stopChan <-chan struct{}, addressSetFactory addressset.AddressSetFactory,

--- a/go-controller/pkg/ovn/ovn_test.go
+++ b/go-controller/pkg/ovn/ovn_test.go
@@ -90,11 +90,11 @@ func (o *FakeOVN) shutdown() {
 
 func (o *FakeOVN) init() {
 	var err error
-	o.watcher, err = factory.NewMasterWatchFactory(o.fakeClient)
+	o.nbClient, o.sbClient, o.nbsbCleanup, err = libovsdbtest.NewNBSBTestHarness(o.dbSetup)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	o.watcher, err = factory.NewMasterWatchFactory(o.fakeClient, o.nbClient, &NetPolPodDelayedTxns)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	err = o.watcher.Start()
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-	o.nbClient, o.sbClient, o.nbsbCleanup, err = libovsdbtest.NewNBSBTestHarness(o.dbSetup)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 	o.stopChan = make(chan struct{})

--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -881,6 +881,12 @@ func (oc *Controller) processLocalPodSelectorSetPods(policy *knet.NetworkPolicy,
 		}
 
 		logicalPort := util.GetLogicalPortName(pod.Namespace, pod.Name)
+
+		// if this pod is somehow already added to this policy, skip
+		if _, ok := np.localPods.Load(logicalPort); ok {
+			return
+		}
+
 		var portInfo *lpInfo
 
 		// Get the logical port info from the cache, if that fails, retry


### PR DESCRIPTION
Apply all db changes caused by the same event within 1 transaction as a part of `(i *informer) forEachQueuedHandler`.
Error handling with delayed transaction is safe, since the same key for pod can't be handled at the same time by another thread.
unit tests don't work on 4.10, but I still added some changes to make if fail less.

That is a follow up from https://github.com/openshift/ovn-kubernetes/pull/1394