### PR TITLE
[Release 4.12] OCPBUGS-3397: Avoid Remetric pods

### DIFF
--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -726,8 +726,10 @@ func (oc *Controller) addLogicalPort(pod *kapi.Pod) (err error) {
 			return err
 		}
 	}
-	// observe the pod creation latency metric.
-	metrics.RecordPodCreated(pod)
+	//observe the pod creation latency metric for newly created pods only
+	if needsIP && !lspExist {
+		metrics.RecordPodCreated(pod)
+	}
 	return nil
 }
 


### PR DESCRIPTION
Issue: When a new ovnkube master starts, or gains leadership through leaderelection, addLogicalPort is called for all existing pods to ensure they are set up correctly, which means we recollect the podCreated metrics on pods that may not need it, and we will set an incorrect creation latency for pods.

Solution: Do not record pod creation latency metric for pods with annotations or pods with existing logical switch ports when addLogicalPort is ran

Signed-off-by: Ben Pickard <bpickard@redhat.com>
(cherry picked from commit b481ef0cbd240eb3abd767c706f76f4727c5a44a)