### PR TITLE
[release-4.12] OCPBUGS-3378: Set the node as reachable only when it is being added as an egressip node

### DIFF
--- a/go-controller/pkg/ovn/egressip.go
+++ b/go-controller/pkg/ovn/egressip.go
@@ -2090,6 +2090,8 @@ type egressIPController struct {
 	watchFactory *factory.WatchFactory
 	// EgressIP Node reachability total timeout configuration
 	egressIPTotalTimeout int
+	// reachability check interval
+	reachabilityCheckInterval time.Duration
 	// EgressIP Node reachability gRPC port (0 means it should use dial instead)
 	egressIPNodeHealthCheckPort int
 }
@@ -2398,7 +2400,7 @@ func (e *egressIPController) deleteEgressIPStatusSetup(name string, status egres
 // is important because egress IP is based upon routing traffic to these nodes,
 // and if they aren't reachable we shouldn't be using them for egress IP.
 func (oc *Controller) checkEgressNodesReachability() {
-	timer := time.NewTicker(5 * time.Second)
+	timer := time.NewTicker(oc.eIPC.reachabilityCheckInterval)
 	defer timer.Stop()
 	for {
 		select {

--- a/go-controller/pkg/ovn/egressip_test.go
+++ b/go-controller/pkg/ovn/egressip_test.go
@@ -7798,6 +7798,112 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		})
 
+		ginkgo.It("egress node update should not mark the node as reachable if there was no label/readiness change", func() {
+			// When an egress node becomes reachable during a node update event and there is no changes to node labels/readiness
+			// unassigned egress IP should be eventually added by the periodic reachability check.
+			// Test steps:
+			//  - disable periodic check from running in background, so it can be called directly from the test
+			//  - assign egress IP to an available node
+			//  - make the node unreachable and verify that the egress IP was unassigned
+			//  - make the node reachable and update a node
+			//  - verify that the egress IP was assigned by calling the periodic reachability check
+			app.Action = func(ctx *cli.Context) error {
+				egressIP := "192.168.126.101"
+				nodeIPv4 := "192.168.126.51/24"
+				node := v1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: node1Name,
+						Annotations: map[string]string{
+							"k8s.ovn.org/node-primary-ifaddr": fmt.Sprintf("{\"ipv4\": \"%s\"}", nodeIPv4),
+							"k8s.ovn.org/node-subnets":        fmt.Sprintf("{\"default\":[\"%s\"]}", v4NodeSubnet),
+						},
+						Labels: map[string]string{
+							"k8s.ovn.org/egress-assignable": "",
+						},
+					},
+					Status: v1.NodeStatus{
+						Conditions: []v1.NodeCondition{
+							{
+								Type:   v1.NodeReady,
+								Status: v1.ConditionTrue,
+							},
+						},
+					},
+				}
+				eIP1 := egressipv1.EgressIP{
+					ObjectMeta: newEgressIPMeta(egressIPName),
+					Spec: egressipv1.EgressIPSpec{
+						EgressIPs: []string{egressIP},
+					},
+				}
+				fakeOvn.startWithDBSetup(
+					libovsdbtest.TestSetup{
+						NBData: []libovsdbtest.TestData{
+							&nbdb.LogicalRouter{
+								Name: ovntypes.OVNClusterRouter,
+								UUID: ovntypes.OVNClusterRouter + "-UUID",
+							},
+							&nbdb.LogicalRouter{
+								Name: ovntypes.GWRouterPrefix + node.Name,
+								UUID: ovntypes.GWRouterPrefix + node.Name + "-UUID",
+							},
+							&nbdb.LogicalRouterPort{
+								UUID:     ovntypes.GWRouterToJoinSwitchPrefix + ovntypes.GWRouterPrefix + node.Name + "-UUID",
+								Name:     ovntypes.GWRouterToJoinSwitchPrefix + ovntypes.GWRouterPrefix + node.Name,
+								Networks: []string{nodeLogicalRouterIfAddrV4},
+							},
+							&nbdb.LogicalSwitchPort{
+								UUID: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node.Name + "UUID",
+								Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node.Name,
+								Type: "router",
+								Options: map[string]string{
+									"router-port": types.GWRouterToExtSwitchPrefix + "GR_" + node.Name,
+								},
+							},
+						},
+					},
+					&egressipv1.EgressIPList{
+						Items: []egressipv1.EgressIP{eIP1},
+					},
+					&v1.NodeList{
+						Items: []v1.Node{node},
+					},
+				)
+
+				// Virtually disable background reachability check by using a huge interval
+				fakeOvn.controller.eIPC.reachabilityCheckInterval = time.Hour
+
+				err := fakeOvn.controller.WatchEgressNodes()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				gomega.Eventually(getEgressIPStatusLen(eIP1.Name)).Should(gomega.Equal(1))
+				egressIPs, _ := getEgressIPStatus(eIP1.Name)
+				gomega.Expect(egressIPs[0]).To(gomega.Equal(egressIP))
+
+				hcClient := fakeOvn.controller.eIPC.allocator.cache[node.Name].healthClient.(*fakeEgressIPHealthClient)
+				hcClient.FakeProbeFailure = true
+				// explicitly call check reachability, periodic checker is not active
+				checkEgressNodesReachabilityIterate(fakeOvn.controller)
+				gomega.Eventually(getEgressIPStatusLen(eIP1.Name)).Should(gomega.Equal(0))
+
+				hcClient.FakeProbeFailure = false
+				node.Annotations["test"] = "dummy"
+				_, err = fakeOvn.fakeClient.KubeClient.CoreV1().Nodes().Update(context.TODO(), &node, metav1.UpdateOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Eventually(hcClient.IsConnected()).Should(gomega.Equal(true))
+				// the node should not be marked as reachable in the update handler as it is not getting added
+				gomega.Consistently(func() bool { return fakeOvn.controller.eIPC.allocator.cache[node.Name].isReachable }).Should(gomega.Equal(false))
+
+				// egress IP should get assigned on the next checkEgressNodesReachabilityIterate call
+				// explicitly call check reachability, periodic checker is not active
+				checkEgressNodesReachabilityIterate(fakeOvn.controller)
+				gomega.Eventually(getEgressIPStatusLen(eIP1.Name)).Should(gomega.Equal(1))
+
+				return nil
+			}
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
 	})
 
 	ginkgo.Context("Dual-stack assignment", func() {

--- a/go-controller/pkg/ovn/obj_retry_master.go
+++ b/go-controller/pkg/ovn/obj_retry_master.go
@@ -499,10 +499,8 @@ func (h *masterEventHandler) AddResource(obj interface{}, fromRetryLoop bool) er
 			h.oc.setNodeEgressReady(node.Name, true)
 		}
 		isReachable := h.oc.isEgressNodeReachable(node)
-		if isReachable {
-			h.oc.setNodeEgressReachable(node.Name, true)
-		}
 		if hasEgressLabel && isReachable && isReady {
+			h.oc.setNodeEgressReachable(node.Name, true)
 			if err := h.oc.addEgressNode(node.Name); err != nil {
 				return err
 			}
@@ -631,11 +629,11 @@ func (h *masterEventHandler) UpdateResource(oldObj, newObj interface{}, inRetryC
 		isNewReady := h.oc.isEgressNodeReady(newNode)
 		isNewReachable := h.oc.isEgressNodeReachable(newNode)
 		h.oc.setNodeEgressReady(newNode.Name, isNewReady)
-		h.oc.setNodeEgressReachable(newNode.Name, isNewReachable)
 		if !oldHadEgressLabel && newHasEgressLabel {
 			klog.Infof("Node: %s has been labeled, adding it for egress assignment", newNode.Name)
 			h.oc.setNodeEgressAssignable(newNode.Name, true)
 			if isNewReady && isNewReachable {
+				h.oc.setNodeEgressReachable(newNode.Name, isNewReachable)
 				if err := h.oc.addEgressNode(newNode.Name); err != nil {
 					return err
 				}
@@ -655,6 +653,7 @@ func (h *masterEventHandler) UpdateResource(oldObj, newObj interface{}, inRetryC
 			}
 		} else if isNewReady && isNewReachable {
 			klog.Infof("Node: %s is ready and reachable, adding it for egress assignment", newNode.Name)
+			h.oc.setNodeEgressReachable(newNode.Name, isNewReachable)
 			if err := h.oc.addEgressNode(newNode.Name); err != nil {
 				return err
 			}

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -50,7 +50,8 @@ import (
 )
 
 const (
-	egressFirewallDNSDefaultDuration time.Duration = 30 * time.Minute
+	egressFirewallDNSDefaultDuration  = 30 * time.Minute
+	egressIPReachabilityCheckInterval = 5 * time.Second
 )
 
 // ACL logging severity levels
@@ -265,6 +266,7 @@ func NewOvnController(ovnClient *util.OVNClientset, wf *factory.WatchFactory, st
 			nbClient:                          libovsdbOvnNBClient,
 			watchFactory:                      wf,
 			egressIPTotalTimeout:              config.OVNKubernetesFeature.EgressIPReachabiltyTotalTimeout,
+			reachabilityCheckInterval:         egressIPReachabilityCheckInterval,
 			egressIPNodeHealthCheckPort:       config.OVNKubernetesFeature.EgressIPNodeHealthCheckPort,
 		},
 		loadbalancerClusterCache: make(map[kapi.Protocol]string),
@@ -648,12 +650,14 @@ func (oc *Controller) WatchNodes() error {
 // *) Valid values for "allow" and "deny" are  "alert", "warning", "notice", "info", "debug", "".
 // *) Invalid values will return an error, and logging will be disabled for the respective key.
 // *) In the following special cases, nsInfo.aclLogging.Deny and nsInfo.aclLogging.Allow. will both be reset to ""
-//    without logging an error, meaning that logging will be switched off:
-//    i) oc.aclLoggingEnabled == false
-//    ii) annotation == ""
-//    iii) annotation == "{}"
+// without logging an error, meaning that logging will be switched off:
+//
+//	i) oc.aclLoggingEnabled == false
+//	ii) annotation == ""
+//	iii) annotation == "{}"
+//
 // *) If one of "allow" or "deny" can be parsed and has a valid value, but the other key is not present in the
-//    annotation, then assume that this key should be disabled by setting its nsInfo value to "".
+// annotation, then assume that this key should be disabled by setting its nsInfo value to "".
 func (oc *Controller) aclLoggingUpdateNsInfo(annotation string, nsInfo *namespaceInfo) error {
 	var aclLevels ACLLoggingLevels
 	var errors []error


### PR DESCRIPTION
This is a cherry-pick of https://github.com/ovn-org/ovn-kubernetes/pull/3267.

There were conflicts caused by https://github.com/ovn-org/ovn-kubernetes/pull/3258 not being in 4.12.

/cc @flavio-fernandes @tssurya 
/assign @jcaamano 

Signed-off-by: Patryk Diak <pdiak@redhat.com>
(cherry picked from commit 2cf92683cc3d307d055ff17d93b90408cbf17c78)