### PR TITLE
OCPBUGS-799: Bump OVN to 22.09.0-22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN yum install -y  \
 	yum clean all
 
 ARG ovsver=2.17.0-62.el8fdp
-ARG ovnver=22.09.0-5.el8fdp
+ARG ovnver=22.09.0-22.el8fdp
 
 RUN INSTALL_PKGS=" \
 	openssl python3-pyOpenSSL firewalld-filesystem \

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -13,7 +13,7 @@ RUN yum install -y  \
 	yum clean all
 
 ARG ovsver=2.17.0-62.el8fdp
-ARG ovnver=22.09.0-5.el8fdp
+ARG ovnver=22.09.0-22.el8fdp
 RUN echo $ovsver > /ovs-version && echo $ovnver > /ovn-version
 
 RUN mkdir -p /var/run/openvswitch && \


### PR DESCRIPTION
This is being done to get:

* Tue Nov 15 2022 Mark Michelson <mmichels@redhat.com> - 22.09.0-13
- ovn-controller: Fix some issues with CT zone assignment. (#2126406) [Upstream: 0fc041667031da20cd03c0b76de8de3dbe502d50]

for the corresponding bug I have in OVNK. Side effect is I also get the lb session affinity fixes from OVN which are cherry-picked downstream only even if its not yet release for main OVN upstream rpms.

Other changes coming in are: 
https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2282903


```


* Tue Nov 29 2022 Lorenzo Bianconi <lorenzo.bianconi@redhat.com> - 22.09.0-22 
* - northd: rely on new actions for lb affinity [Upstream: 5b6223dcb6060205c6e9d4e8c092e96134bb032a]  

* Tue Nov 29 2022 Lorenzo Bianconi <lorenzo.bianconi@redhat.com> - 22.09.0-21 
* - actions: introduce chk_lb_aff action [Upstream: f74c418e3cd2079e7cae4d3ec293ffc387f5a660]  

* Tue Nov 29 2022 Lorenzo Bianconi <lorenzo.bianconi@redhat.com> - 22.09.0-20 
* - actions: introduce commit_lb_aff action [Upstream: 2d190e5c69c9440c720ab8412cc04e4096d4114a]  

* Fri Nov 25 2022 Xavier Simonart <xsimonar@redhat.com> - 22.09.0-19 
* - controller: Fixed ovs/ovn(features) connection lost when running more than 120 seconds (#2144084) [Upstream: db61b2e4f166092e5bc93f4cba7696a72037a069]  

* Thu Nov 24 2022 Dumitru Ceara <dceara@redhat.com> - 22.09.0-18 
* - ovs: Bump submodule to include latest fixes. [Upstream: d62dde642879ffb7ff1eb8f4077b6224f977c6d7]  

* Tue Nov 22 2022 Xavier Simonart <xsimonar@redhat.com> - 22.09.0-17 
* - ovn-controller: Fixed missing flows after interface deletion (#2129866) [Upstream: 90c165fa5a6ecdd9bac606cf259ae88228b96208]  

* Tue Nov 22 2022 Xavier Simonart <xsimonar@redhat.com> - 22.09.0-16 
* - ovn-controller: Fix releasing wrong vif [Upstream: 4da7a269c9eb055b2cfa27d67593a77167b8c9a6]  

* Tue Nov 22 2022 Xavier Simonart <xsimonar@redhat.com> - 22.09.0-15 
* - tests: Fix flaky test "multi-vtep SB Chassis encap updates" [Upstream: ef15d5c22fa2255db69be2d6da822cefb099327c]  

* Fri Nov 18 2022 Ilya Maximets <i.maximets@ovn.org> - 22.09.0-14 
* - controller: Fix QoS for ports with undetected or too low link speed. (#2136716) [Upstream: ae96d5d753ccbee9b239178f56460e05169ac9f7]  

* Tue Nov 15 2022 Mark Michelson <mmichels@redhat.com> - 22.09.0-13 
* - ovn-controller: Fix some issues with CT zone assignment. (#2126406) [Upstream: 0fc041667031da20cd03c0b76de8de3dbe502d50]  

* Thu Nov 03 2022 Ales Musil <amusil@redhat.com> - 22.09.0-12 
* - ci: Update jobs to use numbers instead of test flags [Upstream: bc609bf148be3a38a0b8f38f049f30eb7e9b55f8]  

* Thu Oct 20 2022 Xavier Simonart <xsimonar@redhat.com> - 22.09.0-11 
* - ovs: Bump submodule to tip of branch-3.0 and add related test (#2126450) [Upstream: c18415d5ae7273c633190df4ac9e872a0a0f9709]  

* Wed Oct 05 2022 Lorenzo Bianconi <lorenzo.bianconi@redhat.com> - 22.09.0-10 
* - controller: fix ipv6 prefix delegation in gw router mode (#2129244 2129247) [Upstream: f2042a2e6aeb1a7fe266316337545331f5186dd0]  

* Wed Oct 05 2022 Vladislav Odintsov <odivlad@gmail.com> - 22.09.0-9 
* - spec: require python3-openvswitch for ovn-detrace [Upstream: 29e4d43966fbf34d9707e31880c455f22a643bb3]  

* Mon Oct 03 2022 Mark Michelson <mmichels@redhat.com> - 22.09.0-8 
* - northd: Use separate SNAT for already-DNATted traffic. [Upstream: 51044dbfdba234a3f50d8c9c952335e41b72a39b]  

* Fri Sep 30 2022 Ales Musil <amusil@redhat.com> - 22.09.0-7 
* - controller: Restore MAC and vlan for DVR scenario (#2123837) [Upstream: 86e99bf95a2191ebdcd5d03335ff8add2a636f55]  

* Fri Sep 30 2022 Xavier Simonart <xsimonar@redhat.com> - 22.09.0-6 
* - northd: Fix multicast table full (#2094710) [Upstream: 40dd85eb8d2d2d88f9000b6be6fb263b4bd1a27f]
--

```