### PR TITLE
OCPBUGS-3798: [4.12] Dockerfile: bump regular image to OVS 2.17.0-62

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN yum install -y  \
 	selinux-policy && \
 	yum clean all
 
-ARG ovsver=2.17.0-37.4.el8fdp
+ARG ovsver=2.17.0-62.el8fdp
 ARG ovnver=22.09.0-22.el8fdp
 
 RUN INSTALL_PKGS=" \


### PR DESCRIPTION
https://github.com/openshift/ovn-kubernetes/pull/1387 was supposed to do this but due to some refactors/rebases, ended up only doing it for microshift.

Mainly to get:
"ovsdb/transaction.c: Refactor assess_weak_refs."
http://patchwork.ozlabs.org/project/openvswitch/list/?series=325800&state=%2A&archive=both

which fixes a memory leak in ovsdb-server.

4.12 cherry-pick of https://github.com/openshift/ovn-kubernetes/pull/1362