### PR TITLE
[release-4.12] Bug OCPBUGS-4380: Hold lock when deleting completed pod during update event

### DIFF
--- a/go-controller/pkg/retry/obj_retry.go
+++ b/go-controller/pkg/retry/obj_retry.go
@@ -523,7 +523,9 @@ func (r *RetryFramework) WatchResourceFiltered(namespaceForFilteredHandler strin
 					if kerrors.IsNotFound(err) && r.ResourceHandler.IsObjectInTerminalState(newer) {
 						klog.Warningf("%s %s is in terminal state but no longer exists in informer cache, removing",
 							r.ResourceHandler.ObjType, newKey)
-						r.processObjectInTerminalState(newer, newKey, resourceEventUpdate)
+						r.DoWithLock(newKey, func(key string) {
+							r.processObjectInTerminalState(newer, newKey, resourceEventUpdate)
+						})
 					} else {
 						klog.Warningf("Unable to get %s %s from informer cache (perhaps it was already"+
 							" deleted?), skipping update: %v", r.ResourceHandler.ObjType, newKey, err)


### PR DESCRIPTION
Hold lock when deleting completed pod during update event

Original upstream PR: https://github.com/ovn-org/ovn-kubernetes/pull/3274


Closes #OCPBUGS-4380