### PR TITLE
[release-4.12] Bug OCPBUGS-4383: Don't log in iterateRetryResources when there are no retry entries

### DIFF
--- a/go-controller/pkg/retry/obj_retry.go
+++ b/go-controller/pkg/retry/obj_retry.go
@@ -341,10 +341,13 @@ func (r *RetryFramework) resourceRetry(objKey string, now time.Time) {
 // Deleted entries will be ignored, and all the updates will be reflected with key Lock.
 // Keys added after the snapshot was done won't be retried during this run.
 func (r *RetryFramework) iterateRetryResources() {
+	entriesKeys := r.retryEntries.GetKeys()
+	if len(entriesKeys) == 0 {
+		return
+	}
 	now := time.Now()
 	wg := &sync.WaitGroup{}
 
-	entriesKeys := r.retryEntries.GetKeys()
 	// Process the above list of objects that need retry by holding the lock for each one of them.
 	klog.V(5).Infof("Going to retry %v resource setup for %d objects: %s", r.ResourceHandler.ObjType, len(entriesKeys), entriesKeys)
 


### PR DESCRIPTION
Don't log in iterateRetryResources when there are no retry entries

Original upstream PR: https://github.com/ovn-org/ovn-kubernetes/pull/3270

Signed-off-by: Riccardo Ravaioli <rravaiol@redhat.com>
(cherry picked from commit 3ca6336a0e0c749568ba22ad8e6a8a80f25baf87)

Closes #OCPBUGS-4383
