### PR TITLE
egress ip: Skip mgmt ports that cannot have assignable IP addresses

### DIFF
--- a/go-controller/pkg/node/management-port-dpu.go
+++ b/go-controller/pkg/node/management-port-dpu.go
@@ -151,6 +151,11 @@ func (mp *managementPortRepresentor) CheckManagementPortHealth(cfg *managementPo
 		stopChan)
 }
 
+// Port representors should not have any IP address assignable to them, thus always return false.
+func (mp *managementPortRepresentor) HasIpAddr() bool {
+	return false
+}
+
 type managementPortNetdev struct {
 	hostSubnets []*net.IPNet
 	netdevName  string
@@ -237,4 +242,9 @@ func (mp *managementPortNetdev) CheckManagementPortHealth(cfg *managementPortCon
 		},
 		30*time.Second,
 		stopChan)
+}
+
+// Management port Netdev should have IP addresses assignable to them.
+func (mp *managementPortNetdev) HasIpAddr() bool {
+	return true
 }

--- a/go-controller/pkg/node/management-port.go
+++ b/go-controller/pkg/node/management-port.go
@@ -24,6 +24,13 @@ type ManagementPort interface {
 	// CheckManagementPortHealth checks periodically for management port health until stopChan is posted
 	// or closed and reports any warnings/errors to log
 	CheckManagementPortHealth(cfg *managementPortConfig, stopChan chan struct{})
+	// Not all management ports have an IP address. Some cases where a management port would not have an IP address
+	// are as follows:
+	//   - Full mode with HW backed device (e.g. Virtual Function Representor).
+	//   - DPU mode with Virtual Function Representor.
+	// It is up to the implementation of the ManagementPort to report whether an IP address can be assigned for the
+	// type of ManagementPort.
+	HasIpAddr() bool
 }
 
 // NewManagementPorts creates a new ManagementPorts
@@ -116,6 +123,11 @@ func (mp *managementPort) CheckManagementPortHealth(cfg *managementPortConfig, s
 		},
 		30*time.Second,
 		stopChan)
+}
+
+// OVS Internal Port Netdev should have IP addresses assignable to them.
+func (mp *managementPort) HasIpAddr() bool {
+	return true
 }
 
 func managementPortReady() (bool, error) {

--- a/go-controller/pkg/node/node.go
+++ b/go-controller/pkg/node/node.go
@@ -611,6 +611,10 @@ func (n *OvnNode) Start(ctx context.Context, wg *sync.WaitGroup) error {
 	// start management ports health check
 	for _, mgmtPort := range mgmtPorts {
 		mgmtPort.port.CheckManagementPortHealth(mgmtPort.config, n.stopChan)
+		// Start the health checking server used by egressip, if EgressIPNodeHealthCheckPort is specified
+		if err := n.startEgressIPHealthCheckingServer(wg, mgmtPort); err != nil {
+			return err
+		}
 	}
 
 	if config.OvnKubeNode.Mode != types.NodeModeDPUHost {
@@ -649,16 +653,11 @@ func (n *OvnNode) Start(ctx context.Context, wg *sync.WaitGroup) error {
 		}
 	}
 
-	// Start the health checking server used by egressip, if EgressIPNodeHealthCheckPort is specified
-	if err := n.startEgressIPHealthCheckingServer(wg, mgmtPortConfig); err != nil {
-		return err
-	}
-
 	klog.Infof("OVN Kube Node initialized and ready.")
 	return nil
 }
 
-func (n *OvnNode) startEgressIPHealthCheckingServer(wg *sync.WaitGroup, mgmtPortConfig *managementPortConfig) error {
+func (n *OvnNode) startEgressIPHealthCheckingServer(wg *sync.WaitGroup, mgmtPortEntry managementPortEntry) error {
 	healthCheckPort := config.OVNKubernetesFeature.EgressIPNodeHealthCheckPort
 	if healthCheckPort == 0 {
 		klog.Infof("Egress IP health check server skipped: no port specified")
@@ -666,16 +665,23 @@ func (n *OvnNode) startEgressIPHealthCheckingServer(wg *sync.WaitGroup, mgmtPort
 	}
 
 	var nodeMgmtIP net.IP
-	if mgmtPortConfig.ipv4 != nil {
-		nodeMgmtIP = mgmtPortConfig.ipv4.ifAddr.IP
-	} else if mgmtPortConfig.ipv6 != nil {
-		nodeMgmtIP = mgmtPortConfig.ipv6.ifAddr.IP
-		// Wait for IPv6 address to become usable.
-		if err := ip.SettleAddresses(mgmtPortConfig.ifName, 10); err != nil {
-			return fmt.Errorf("failed start health checking server due to unsettled IPv6: %w", err)
+	var mgmtPortConfig *managementPortConfig = mgmtPortEntry.config
+	// Not all management port interfaces can have IP addresses assignable to them.
+	if mgmtPortEntry.port.HasIpAddr() {
+		if mgmtPortConfig.ipv4 != nil {
+			nodeMgmtIP = mgmtPortConfig.ipv4.ifAddr.IP
+		} else if mgmtPortConfig.ipv6 != nil {
+			nodeMgmtIP = mgmtPortConfig.ipv6.ifAddr.IP
+			// Wait for IPv6 address to become usable.
+			if err := ip.SettleAddresses(mgmtPortConfig.ifName, 10); err != nil {
+				return fmt.Errorf("failed to start Egress IP health checking server due to unsettled IPv6: %w on interface %s", err, mgmtPortConfig.ifName)
+			}
+		} else {
+			return fmt.Errorf("unable to start Egress IP health checking server on interface %s: no mgmt ip", mgmtPortConfig.ifName)
 		}
 	} else {
-		return fmt.Errorf("unable to start health checking server: no mgmt ip")
+		klog.Infof("Skipping interface %s as it should not have an IP address", mgmtPortConfig.ifName)
+		return nil
 	}
 
 	healthServer, err := healthcheck.NewEgressIPHealthServer(nodeMgmtIP, healthCheckPort)


### PR DESCRIPTION
There can be multiple management ports. Currently in the case of Full mode with hardware backed mgmt port, the virtual function representor and virtual function netdev exists separately. However the management port config belongs to the virtual function representor in this case. This caused the Egress IP health check to fail to initialize since there won't be an IP address on the virtual function representor interface. Instead the code now iterates through all management port interfaces, skips the virtual function representor and finds the virtual function netdev management port with a valid IP address configuration.

In the case of DPU, there will be a DPU-Host mode node and DPU mode node. Also it will always use hardware backed mgmt ports. The DPU mode node will only have a virtual function representor, thus the Egress IP Health Check won't run on this node. The DPU-Host mode node will only have a virtual function netdev; thus the Egress IP Health Check will run on this node.

Also see discussion in: https://github.com/ovn-org/ovn-kubernetes/pull/3251

Signed-off-by: William Zhao <wizhao@redhat.com>