### PR TITLE
[release-4.12] OCPBUGS-4505: pods: deleteLogicalPort should not fail when node is gone

### DIFF
--- a/go-controller/pkg/ovn/obj_retry_master.go
+++ b/go-controller/pkg/ovn/obj_retry_master.go
@@ -840,7 +840,7 @@ func (h *masterEventHandler) SyncFunc(objs []interface{}) error {
 	return syncFunc(objs)
 }
 
-// Given an object and its type, IsObjectInTerminalState returns true if the object is a in terminal state.
+// IsObjectInTerminalState returns true if the object is in a terminal state.
 // This is used now for pods that are either in a PodSucceeded or in a PodFailed state.
 func (h *masterEventHandler) IsObjectInTerminalState(obj interface{}) bool {
 	switch h.objType {

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/metrics"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/ipallocator"
+	logicalswitchmanager "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/logical_switch_manager"
 	util "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 	"github.com/pkg/errors"
 	kapi "k8s.io/api/core/v1"
@@ -294,11 +295,15 @@ func (oc *Controller) deleteLogicalPort(pod *kapi.Pod, portInfo *lpInfo) (err er
 	// Releasing IPs needs to happen last so that we can deterministically know that if delete failed that
 	// the IP of the pod needs to be released. Otherwise we could have a completed pod failed to be removed
 	// and we dont know if the IP was released or not, and subsequently could accidentally release the IP
-	// while it is now on another pod
+	// while it is now on another pod. Releasing IPs may fail at this point if cache knows nothing about it,
+	// which is okay since node may have been deleted.
 	klog.Infof("Attempting to release IPs for pod: %s/%s, ips: %s", pod.Namespace, pod.Name,
 		util.JoinIPNetIPs(podIfAddrs, " "))
 	if err := oc.lsManager.ReleaseIPs(nodeName, podIfAddrs); err != nil {
-		return fmt.Errorf("cannot release IPs for pod %s: %w", podDesc, err)
+		if !errors.Is(err, logicalswitchmanager.SwitchNotFound) {
+			return fmt.Errorf("cannot release IPs for pod %s on node %s: %w", podDesc, nodeName, err)
+		}
+		klog.Warningf("Ignoring release IPs failure for pod %s on node %s: %w", podDesc, nodeName, err)
 	}
 
 	return nil

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -13,6 +13,7 @@ import (
 	util "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 	"github.com/pkg/errors"
 	kapi "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	ktypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
@@ -20,7 +21,7 @@ import (
 
 	libovsdbclient "github.com/ovn-org/libovsdb/client"
 	"github.com/ovn-org/libovsdb/ovsdb"
-	libovsdbops "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdbops"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdbops"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
 )
 
@@ -43,8 +44,23 @@ func (oc *Controller) syncPods(pods []interface{}) error {
 			}
 			logicalPort := util.GetLogicalPortName(pod.Namespace, pod.Name)
 			expectedLogicalPorts[logicalPort] = true
+			// it is possible to try to add a pod here that has no node. For example if a pod was deleted with
+			// a finalizer, and then the node was removed. In this case the pod will still exist in a running state.
+			// Terminating pods should still have network connectivity for pre-stop hooks or termination grace period
+			if _, err := oc.watchFactory.GetNode(pod.Spec.NodeName); kerrors.IsNotFound(err) &&
+				oc.lsManager.GetSwitchSubnets(pod.Spec.NodeName) == nil {
+				if util.PodTerminating(pod) {
+					klog.Infof("Ignoring IP allocation for terminating pod: %s/%s, on deleted "+
+						"node: %s", pod.Namespace, pod.Name, pod.Spec.NodeName)
+					continue
+				} else {
+					// unknown condition how we are getting a non-terminating pod without a node here
+					klog.Errorf("Pod IP allocation found for a non-existent node in API with unknown "+
+						"condition. Pod: %s/%s, node: %s", pod.Namespace, pod.Name, pod.Spec.NodeName)
+				}
+			}
 			if err = oc.waitForNodeLogicalSwitchInCache(pod.Spec.NodeName); err != nil {
-				return fmt.Errorf("failed to wait for node %s to be added to cache. IP allocation may fail!",
+				return fmt.Errorf("failed to wait for node %s to be added to cache. IP allocation may fail",
 					pod.Spec.NodeName)
 			}
 			if err = oc.lsManager.AllocateIPs(pod.Spec.NodeName, annotations.IPs); err != nil {
@@ -440,6 +456,20 @@ func (oc *Controller) addLogicalPort(pod *kapi.Pod) (err error) {
 		klog.Infof("[%s/%s] addLogicalPort took %v, libovsdb time %v, annotation time: %v",
 			pod.Namespace, pod.Name, time.Since(start), libovsdbExecuteTime, podAnnoTime)
 	}()
+
+	// it is possible to try to add a pod here that has no node. For example if a pod was deleted with
+	// a finalizer, and then the node was removed. In this case the pod will still exist in a running state.
+	// Terminating pods should still have network connectivity for pre-stop hooks or termination grace period
+	// We cannot wire a pod that has no node/switch, so retry again later
+	if _, err := oc.watchFactory.GetNode(pod.Spec.NodeName); kerrors.IsNotFound(err) &&
+		oc.lsManager.GetSwitchSubnets(pod.Spec.NodeName) == nil {
+		podState := "unknown"
+		if util.PodTerminating(pod) {
+			podState = "terminating"
+		}
+		return fmt.Errorf("[%s/%s] Non-existent node: %s in API for pod with %s state",
+			pod.Namespace, pod.Name, pod.Spec.NodeName, podState)
+	}
 
 	logicalSwitch := pod.Spec.NodeName
 	ls, err := oc.waitForNodeLogicalSwitch(logicalSwitch)

--- a/go-controller/pkg/ovn/pods_test.go
+++ b/go-controller/pkg/ovn/pods_test.go
@@ -1823,5 +1823,60 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 			err := app.Run([]string{app.Name})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		})
+
+		ginkgo.It("reconciles a terminating pod with no node", func() {
+			app.Action = func(ctx *cli.Context) error {
+
+				namespaceT := *newNamespace("namespace1")
+				t := newTPod(
+					"node1",
+					"10.128.1.0/24",
+					"10.128.1.2",
+					"10.128.1.1",
+					"myPod",
+					"10.128.1.3",
+					"0a:58:0a:80:01:03",
+					namespaceT.Name,
+				)
+
+				p := newPod(t.namespace, t.podName, t.nodeName, t.podIP)
+				now := metav1.Now()
+				p.SetDeletionTimestamp(&now)
+
+				fakeOvn.startWithDBSetup(initialDB,
+					&v1.NamespaceList{
+						Items: []v1.Namespace{
+							namespaceT,
+						},
+					},
+					&v1.PodList{
+						Items: []v1.Pod{
+							*p,
+						},
+					},
+				)
+				// pod exists, networks annotations don't
+				pod, err := fakeOvn.fakeClient.KubeClient.CoreV1().Pods(t.namespace).Get(context.TODO(), t.podName, metav1.GetOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				_, ok := pod.Annotations[util.OvnPodAnnotationName]
+				gomega.Expect(ok).To(gomega.BeFalse())
+
+				err = fakeOvn.controller.WatchNamespaces()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				err = fakeOvn.controller.WatchPods()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				// port should not be in cache, because it should never have been added
+				logicalPort := util.GetLogicalPortName(t.namespace, t.podName)
+				_, err = fakeOvn.controller.logicalPortCache.get(logicalPort)
+				gomega.Expect(err).NotTo(gomega.BeNil())
+				myPod1Key, err := retry.GetResourceKey(pod)
+				retry.CheckRetryObjectEventually(myPod1Key, true, fakeOvn.controller.retryPods)
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
 	})
 })

--- a/go-controller/pkg/ovn/pods_test.go
+++ b/go-controller/pkg/ovn/pods_test.go
@@ -1568,6 +1568,9 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 					},
 				)
 
+				// we don't know the real switch UUID in the db, but it can be found by name
+				swUUID := getLogicalSwitchUUID(fakeOvn.controller.nbClient, testNode.Name)
+				fakeOvn.controller.lsManager.AddNode(testNode.Name, swUUID, []*net.IPNet{ovntest.MustParseIPNet(v4NodeSubnet)})
 				err := fakeOvn.controller.WatchNamespaces()
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				err = fakeOvn.controller.WatchPods()
@@ -1739,6 +1742,74 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 				t3.routes = []util.PodRoute{}
 				gomega.Expect(annotations).To(gomega.MatchJSON(t3.getAnnotationsJson()))
 
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+
+		ginkgo.It("cleans stale LSPs and ignore cleanup of stale ports on nodes with no LS", func() {
+			// may occur if sync nodes runs out of host subnets to assign therefore a logical switch for a node never gets created.
+			// expect reconciliation not to fail and to continue reconciliation for existing pods.
+			// this test proves reconciliation continues for existing pods by checking a pod that doesn't exist in kapi
+			// is cleaned up in OVN.
+			app.Action = func(ctx *cli.Context) error {
+				initialDB := libovsdbtest.TestSetup{
+					NBData: []libovsdbtest.TestData{
+						&nbdb.LogicalSwitchPort{
+							UUID:      "namespace1_non-existing-pod-UUID",
+							Name:      "namespace1_non-existing-pod",
+							Addresses: []string{"0a:58:0a:80:02:03", "10.128.2.3"},
+							ExternalIDs: map[string]string{
+								"pod": "true",
+							},
+						},
+						&nbdb.LogicalSwitch{
+							UUID:  "ls-uuid",
+							Name:  "node1",
+							Ports: []string{"namespace1_non-existing-pod-UUID"},
+						},
+					},
+				}
+				testNodeWithLS := v1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node1",
+					},
+				}
+				testNodeWithoutLS := v1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node2",
+					},
+				}
+				fakeOvn.startWithDBSetup(initialDB,
+					&v1.NodeList{
+						Items: []v1.Node{
+							testNodeWithLS,
+							testNodeWithoutLS,
+						},
+					},
+					// no pods - we want to test that cleanup of pod LSP is successful within OVN DB despite one node having
+					// no logical switch
+					&v1.PodList{
+						Items: []v1.Pod{},
+					},
+				)
+				// we don't know the real switch UUID in the db, but it can be found by name
+				swUUID := getLogicalSwitchUUID(fakeOvn.controller.nbClient, testNodeWithLS.Name)
+				fakeOvn.controller.lsManager.AddNode(testNodeWithLS.Name, swUUID, []*net.IPNet{ovntest.MustParseIPNet(v4NodeSubnet)})
+				err := fakeOvn.controller.WatchPods()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				// expect stale logical switch port removed if reconciliation is successful
+				expectData := []libovsdbtest.TestData{
+					&nbdb.LogicalSwitch{
+						UUID:  "ls-uuid",
+						Name:  testNodeWithLS.Name,
+						Ports: []string{},
+					},
+				}
+				gomega.Eventually(fakeOvn.nbClient).Should(
+					libovsdbtest.HaveData(expectData))
 				return nil
 			}
 

--- a/go-controller/pkg/ovn/pods_test.go
+++ b/go-controller/pkg/ovn/pods_test.go
@@ -1204,6 +1204,10 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				gomega.Expect(fakeOvn.controller.deleteLogicalPort(pod, nil)).To(gomega.Succeed(), "Deleting port from switch that no longer exists should be okay")
 
+				// Delete cache from lsManager and make sure deleteLogicalPort will not fail
+				fakeOvn.controller.lsManager.DeleteNode(pod.Spec.NodeName)
+				gomega.Expect(fakeOvn.controller.deleteLogicalPort(pod, nil)).To(gomega.Succeed(), "Deleting port from node that no longer exists should be okay")
+
 				return nil
 			}
 

--- a/go-controller/pkg/util/kube.go
+++ b/go-controller/pkg/util/kube.go
@@ -265,6 +265,11 @@ func PodScheduled(pod *kapi.Pod) bool {
 	return pod.Spec.NodeName != ""
 }
 
+// PodTerminating checks if the pod has been deleted via API but still in the process of terminating
+func PodTerminating(pod *kapi.Pod) bool {
+	return pod.DeletionTimestamp != nil
+}
+
 // EventRecorder returns an EventRecorder type that can be
 // used to post Events to different object's lifecycles.
 func EventRecorder(kubeClient kubernetes.Interface) record.EventRecorder {


### PR DESCRIPTION
deleteLogicalPort should not fail when node is already deleted from lsManager's cache.

Cherry pick from DS merge: https://github.com/openshift/ovn-kubernetes/pull/1410

https://github.com/openshift/ovn-kubernetes/pull/1410/commits/b489b145a7bf794a8c256483e8a1e284c12d3c64

Also back porting fixes from the following jiras here, which are all related to similar issues:
-  https://github.com/openshift/ovn-kubernetes/pull/1400/commits/a1b961d5ee5b544c138fad9c863ef56933bf0515 -- tracked via [OCPBUGS-4554](https://issues.redhat.com/browse/OCPBUGS-4554)
-  https://github.com/openshift/ovn-kubernetes/pull/1410/commits/719fe895c2fad9509f208b2813847e432ad4ddac -- tracked via [OCPBUGS-4553](https://issues.redhat.com/browse/OCPBUGS-4553)