### PR TITLE
[release-4.10] OCPBUGS-1568: pods: deleteLogicalPort should not fail when node is gone

### DIFF
--- a/go-controller/pkg/ovn/logical_switch_manager/logical_switch_manager.go
+++ b/go-controller/pkg/ovn/logical_switch_manager/logical_switch_manager.go
@@ -1,6 +1,7 @@
 package logicalswitchmanager
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"reflect"
@@ -14,6 +15,9 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 	"k8s.io/klog/v2"
 )
+
+// SwitchNotFound is used to inform the logical switch was not found in the cache
+var SwitchNotFound = errors.New("switch not found")
 
 // logicalSwitchInfo contains information corresponding to the node. It holds the
 // subnet allocations (v4 and v6) as well as the IPAM allocator instances for each
@@ -177,9 +181,9 @@ func (manager *LogicalSwitchManager) AllocateUntilFull(nodeName string) error {
 	defer manager.RUnlock()
 	lsi, ok := manager.cache[nodeName]
 	if !ok {
-		return fmt.Errorf("unable to allocate ips, node: %s does not exist in logical switch manager", nodeName)
+		return fmt.Errorf("unable to allocate IPs for node: %s: %w", nodeName, SwitchNotFound)
 	} else if len(lsi.ipams) == 0 {
-		return fmt.Errorf("unable to allocate ips for node: %s. logical switch manager has no IPAM", nodeName)
+		return fmt.Errorf("unable to allocate IPs for node: %s because logical switch manager has no IPAM", nodeName)
 	}
 	var err error
 	for err != ipam.ErrFull {
@@ -200,10 +204,9 @@ func (manager *LogicalSwitchManager) AllocateIPs(nodeName string, ipnets []*net.
 	defer manager.RUnlock()
 	lsi, ok := manager.cache[nodeName]
 	if !ok {
-		return fmt.Errorf("unable to allocate ips: %v, node: %s does not exist in logical switch manager",
-			ipnets, nodeName)
+		return fmt.Errorf("unable to allocate IPs: %v for node %s: %w", ipnets, nodeName, SwitchNotFound)
 	} else if len(lsi.ipams) == 0 {
-		return fmt.Errorf("unable to allocate ips %v for node: %s. logical switch manager has no IPAM",
+		return fmt.Errorf("unable to allocate IPs: %v for node: %s: logical switch manager has no IPAM",
 			ipnets, nodeName)
 
 	}
@@ -253,7 +256,7 @@ func (manager *LogicalSwitchManager) AllocateNextIPs(nodeName string) ([]*net.IP
 	lsi, ok := manager.cache[nodeName]
 
 	if !ok {
-		return nil, fmt.Errorf("node %s not found in the logical switch manager cache", nodeName)
+		return nil, fmt.Errorf("failed to allocate IPs for node %s: %w", nodeName, SwitchNotFound)
 	}
 
 	if len(lsi.ipams) == 0 {
@@ -303,8 +306,7 @@ func (manager *LogicalSwitchManager) ReleaseIPs(nodeName string, ipnets []*net.I
 	}
 	lsi, ok := manager.cache[nodeName]
 	if !ok {
-		return fmt.Errorf("node %s not found in the logical switch manager cache",
-			nodeName)
+		return fmt.Errorf("unable to release ips for node %s: %w", nodeName, SwitchNotFound)
 	}
 	if len(lsi.ipams) == 0 {
 		return fmt.Errorf("failed to release IPs for node %s because there is no IPAM instance", nodeName)

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -15,6 +15,7 @@ import (
 	util "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 	"github.com/pkg/errors"
 	kapi "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	ktypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
@@ -23,7 +24,7 @@ import (
 	libovsdbclient "github.com/ovn-org/libovsdb/client"
 	"github.com/ovn-org/libovsdb/model"
 	"github.com/ovn-org/libovsdb/ovsdb"
-	libovsdbops "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdbops"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdbops"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
 )
 
@@ -53,8 +54,23 @@ func (oc *Controller) syncPodsRetriable(pods []interface{}) error {
 			}
 			logicalPort := util.GetLogicalPortName(pod.Namespace, pod.Name)
 			expectedLogicalPorts[logicalPort] = true
+			// it is possible to try to add a pod here that has no node. For example if a pod was deleted with
+			// a finalizer, and then the node was removed. In this case the pod will still exist in a running state.
+			// Terminating pods should still have network connectivity for pre-stop hooks or termination grace period
+			if _, err := oc.watchFactory.GetNode(pod.Spec.NodeName); kerrors.IsNotFound(err) &&
+				oc.lsManager.GetSwitchSubnets(pod.Spec.NodeName) == nil {
+				if util.PodTerminating(pod) {
+					klog.Infof("Ignoring IP allocation for terminating pod: %s/%s, on deleted "+
+						"node: %s", pod.Namespace, pod.Name, pod.Spec.NodeName)
+					continue
+				} else {
+					// unknown condition how we are getting a non-terminating pod without a node here
+					klog.Errorf("Pod IP allocation found for a non-existent node in API with unknown "+
+						"condition. Pod: %s/%s, node: %s", pod.Namespace, pod.Name, pod.Spec.NodeName)
+				}
+			}
 			if err = oc.waitForNodeLogicalSwitchInCache(pod.Spec.NodeName); err != nil {
-				return fmt.Errorf("failed to wait for node %s to be added to cache. IP allocation may fail!",
+				return fmt.Errorf("failed to wait for node %s to be added to cache. IP allocation may fail",
 					pod.Spec.NodeName)
 			}
 			if err = oc.lsManager.AllocateIPs(pod.Spec.NodeName, annotations.IPs); err != nil {
@@ -446,6 +462,20 @@ func (oc *Controller) addLogicalPort(pod *kapi.Pod) (err error) {
 	defer func() {
 		klog.Infof("[%s/%s] addLogicalPort took %v", pod.Namespace, pod.Name, time.Since(start))
 	}()
+
+	// it is possible to try to add a pod here that has no node. For example if a pod was deleted with
+	// a finalizer, and then the node was removed. In this case the pod will still exist in a running state.
+	// Terminating pods should still have network connectivity for pre-stop hooks or termination grace period
+	// We cannot wire a pod that has no node/switch, so retry again later
+	if _, err := oc.watchFactory.GetNode(pod.Spec.NodeName); kerrors.IsNotFound(err) &&
+		oc.lsManager.GetSwitchSubnets(pod.Spec.NodeName) == nil {
+		podState := "unknown"
+		if util.PodTerminating(pod) {
+			podState = "terminating"
+		}
+		return fmt.Errorf("[%s/%s] Non-existent node: %s in API for pod with %s state",
+			pod.Namespace, pod.Name, pod.Spec.NodeName, podState)
+	}
 
 	logicalSwitch := pod.Spec.NodeName
 	ls, err := oc.waitForNodeLogicalSwitch(logicalSwitch)

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/metrics"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/ipallocator"
+	logicalswitchmanager "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/logical_switch_manager"
 	util "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 	"github.com/pkg/errors"
 	kapi "k8s.io/api/core/v1"
@@ -297,11 +298,15 @@ func (oc *Controller) deleteLogicalPort(pod *kapi.Pod, portInfo *lpInfo) (err er
 	// Releasing IPs needs to happen last so that we can deterministically know that if delete failed that
 	// the IP of the pod needs to be released. Otherwise we could have a completed pod failed to be removed
 	// and we dont know if the IP was released or not, and subsequently could accidentally release the IP
-	// while it is now on another pod
+	// while it is now on another pod. Releasing IPs may fail at this point if cache knows nothing about it,
+	// which is okay since node may have been deleted.
 	klog.Infof("Attempting to release IPs for pod: %s/%s, ips: %s", pod.Namespace, pod.Name,
 		util.JoinIPNetIPs(podIfAddrs, " "))
 	if err := oc.lsManager.ReleaseIPs(nodeName, podIfAddrs); err != nil {
-		return fmt.Errorf("cannot release IPs for pod %s: %w", podDesc, err)
+		if !errors.Is(err, logicalswitchmanager.SwitchNotFound) {
+			return fmt.Errorf("cannot release IPs for pod %s on node %s: %w", podDesc, nodeName, err)
+		}
+		klog.Warningf("Ignoring release IPs failure for pod %s on node %s: %w", podDesc, nodeName, err)
 	}
 
 	return nil

--- a/go-controller/pkg/ovn/pods_test.go
+++ b/go-controller/pkg/ovn/pods_test.go
@@ -1434,6 +1434,60 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 			err := app.Run([]string{app.Name})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		})
+
+		ginkgo.It("reconciles a terminating pod with no node", func() {
+			app.Action = func(ctx *cli.Context) error {
+
+				namespaceT := *newNamespace("namespace1")
+				t := newTPod(
+					"node1",
+					"10.128.1.0/24",
+					"10.128.1.2",
+					"10.128.1.1",
+					"myPod",
+					"10.128.1.3",
+					"0a:58:0a:80:01:03",
+					namespaceT.Name,
+				)
+
+				p := newPod(t.namespace, t.podName, t.nodeName, t.podIP)
+				now := metav1.Now()
+				p.SetDeletionTimestamp(&now)
+
+				fakeOvn.startWithDBSetup(initialDB,
+					&v1.NamespaceList{
+						Items: []v1.Namespace{
+							namespaceT,
+						},
+					},
+					&v1.PodList{
+						Items: []v1.Pod{
+							*p,
+						},
+					},
+				)
+				// pod exists, networks annotations don't
+				pod, err := fakeOvn.fakeClient.KubeClient.CoreV1().Pods(t.namespace).Get(context.TODO(), t.podName, metav1.GetOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				_, ok := pod.Annotations[util.OvnPodAnnotationName]
+				gomega.Expect(ok).To(gomega.BeFalse())
+
+				fakeOvn.controller.WatchNamespaces()
+				fakeOvn.controller.WatchPods()
+				// port should not be in cache, because it should never have been added
+				logicalPort := util.GetLogicalPortName(t.namespace, t.podName)
+				_, err = fakeOvn.controller.logicalPortCache.get(logicalPort)
+				gomega.Expect(err).NotTo(gomega.BeNil())
+				gomega.Eventually(func() *retryEntry {
+					return fakeOvn.controller.getPodRetryEntry(pod)
+				}).ShouldNot(gomega.BeNil())
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
 	})
 
 	ginkgo.Context("with hybrid overlay gw mode", func() {

--- a/go-controller/pkg/ovn/pods_test.go
+++ b/go-controller/pkg/ovn/pods_test.go
@@ -944,6 +944,10 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				gomega.Expect(fakeOvn.controller.deleteLogicalPort(pod, nil)).To(gomega.Succeed(), "Deleting port from switch that no longer exists should be okay")
 
+				// Delete cache from lsManager and make sure deleteLogicalPort will not fail
+				fakeOvn.controller.lsManager.DeleteNode(pod.Spec.NodeName)
+				gomega.Expect(fakeOvn.controller.deleteLogicalPort(pod, nil)).To(gomega.Succeed(), "Deleting port from node that no longer exists should be okay")
+
 				return nil
 			}
 

--- a/go-controller/pkg/util/kube.go
+++ b/go-controller/pkg/util/kube.go
@@ -245,6 +245,11 @@ func PodScheduled(pod *kapi.Pod) bool {
 	return pod.Spec.NodeName != ""
 }
 
+// PodTerminating checks if the pod has been deleted via API but still in the process of terminating
+func PodTerminating(pod *kapi.Pod) bool {
+	return pod.DeletionTimestamp != nil
+}
+
 // EventRecorder returns an EventRecorder type that can be
 // used to post Events to different object's lifecycles.
 func EventRecorder(kubeClient kubernetes.Interface) record.EventRecorder {


### PR DESCRIPTION
deleteLogicalPort should not fail when node is already deleted from lsManager's cache.

Cherry pick from https://github.com/openshift/ovn-kubernetes/pull/1422

Also back porting fixes from the following jiras here, which are all related to similar issues:

[OCPBUGS-4622](https://issues.redhat.com/browse/OCPBUGS-4622)
[OCPBUGS-4623](https://issues.redhat.com/browse/OCPBUGS-4623)
