### PR TITLE
OCBUGS-4502: Dockerfile: bump OVN to 22.09.0-25

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -13,7 +13,7 @@ RUN yum install -y  \
 	yum clean all
 
 ARG ovsver=2.17.0-62.el8fdp
-ARG ovnver=22.09.0-22.el8fdp
+ARG ovnver=22.09.0-25.el8fdp
 
 RUN \
     yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False "openvswitch2.17 = $ovsver" "python3-openvswitch2.17 = $ovsver" && \


### PR DESCRIPTION
* Tue Dec 06 2022 Dumitru Ceara <dceara@redhat.com> - 22.09.0-24
- northd: Include VIP port in LB affinity learn flow matches. (#2150533)
[Upstream: cc037c7538d635e7d014e98935a83bc15140674f]

@tssurya 