### PR TITLE
OCPBUGS-4503: [release-4.12] Dockerfile: bump OVN to 22.09.0-25

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN yum install -y  \
 	yum clean all
 
 ARG ovsver=2.17.0-62.el8fdp
-ARG ovnver=22.09.0-22.el8fdp
+ARG ovnver=22.09.0-25.el8fdp
 
 RUN INSTALL_PKGS=" \
 	openssl python3-pyOpenSSL firewalld-filesystem \

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -13,7 +13,7 @@ RUN yum install -y  \
 	yum clean all
 
 ARG ovsver=2.17.0-62.el8fdp
-ARG ovnver=22.09.0-22.el8fdp
+ARG ovnver=22.09.0-25.el8fdp
 RUN echo $ovsver > /ovs-version && echo $ovnver > /ovn-version
 
 RUN mkdir -p /var/run/openvswitch && \


### PR DESCRIPTION
* Tue Dec 06 2022 Dumitru Ceara <dceara@redhat.com> - 22.09.0-24
- northd: Include VIP port in LB affinity learn flow matches. (#2150533)
[Upstream: cc037c7538d635e7d014e98935a83bc15140674f]
