### PR TITLE
OCPBUGS-4598: Bumps libovsdb to pick up fixes for optional values

### DIFF
--- a/go-controller/go.mod
+++ b/go-controller/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/onsi/gomega v1.14.0
 	github.com/openshift/api v0.0.0-20211201215911-5a82bae32e46
 	github.com/openshift/client-go v0.0.0-20211202194848-d3f186f2d366
-	github.com/ovn-org/libovsdb v0.6.1-0.20220603151050-98c0bad3cff1
+	github.com/ovn-org/libovsdb v0.6.1-0.20220817162549-75c4d774187a
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.11.0
 	github.com/prometheus/client_model v0.2.0 // indirect

--- a/go-controller/go.sum
+++ b/go-controller/go.sum
@@ -356,6 +356,8 @@ github.com/openshift/client-go v0.0.0-20211202194848-d3f186f2d366/go.mod h1:HJeH
 github.com/ory/dockertest/v3 v3.8.0/go.mod h1:9zPATATlWQru+ynXP+DytBQrsXV7Tmlx7K86H6fQaDo=
 github.com/ovn-org/libovsdb v0.6.1-0.20220603151050-98c0bad3cff1 h1:ZXVHrW4b7RK/emoqTNL58IWUuK0dD8PVb93fbfh9cMs=
 github.com/ovn-org/libovsdb v0.6.1-0.20220603151050-98c0bad3cff1/go.mod h1:BQPdnSM2QOKxPwxl7wHJDSPP4B/CDKq3+vzgFW3J5gE=
+github.com/ovn-org/libovsdb v0.6.1-0.20220817162549-75c4d774187a h1:bOj7SK9txWcv0Bnnf6f37K77B2X2dnowX/eUZE6SMA4=
+github.com/ovn-org/libovsdb v0.6.1-0.20220817162549-75c4d774187a/go.mod h1:BQPdnSM2QOKxPwxl7wHJDSPP4B/CDKq3+vzgFW3J5gE=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/go-controller/vendor/github.com/ovn-org/libovsdb/server/mutate.go
+++ b/go-controller/vendor/github.com/ovn-org/libovsdb/server/mutate.go
@@ -164,7 +164,7 @@ func mutateDelete(current, value interface{}) (interface{}, interface{}) {
 			vvk := iter.Key()
 			vvv := iter.Value()
 			vcv := vc.MapIndex(vvk)
-			if reflect.DeepEqual(vcv.Interface(), vvv.Interface()) {
+			if vcv.IsValid() && reflect.DeepEqual(vcv.Interface(), vvv.Interface()) {
 				diff.SetMapIndex(vvk, vcv)
 				vc.SetMapIndex(vvk, reflect.Value{})
 			}

--- a/go-controller/vendor/modules.txt
+++ b/go-controller/vendor/modules.txt
@@ -185,7 +185,7 @@ github.com/openshift/client-go/cloudnetwork/informers/externalversions/cloudnetw
 github.com/openshift/client-go/cloudnetwork/informers/externalversions/cloudnetwork/v1
 github.com/openshift/client-go/cloudnetwork/informers/externalversions/internalinterfaces
 github.com/openshift/client-go/cloudnetwork/listers/cloudnetwork/v1
-# github.com/ovn-org/libovsdb v0.6.1-0.20220603151050-98c0bad3cff1
+# github.com/ovn-org/libovsdb v0.6.1-0.20220817162549-75c4d774187a
 github.com/ovn-org/libovsdb/cache
 github.com/ovn-org/libovsdb/client
 github.com/ovn-org/libovsdb/mapper


### PR DESCRIPTION
panic: reflect: call of reflect.Value.Len on ptr Value

ovn-org/libovsdb@75c4d77

(cherry picked from commit 8d63443)
Signed-off-by: Tim Rozet <trozet@redhat.com>

