### PR TITLE
OCPBUGS-4503: Support LB Session Affinity TimeOut

### DIFF
--- a/go-controller/pkg/libovsdbops/loadbalancer.go
+++ b/go-controller/pkg/libovsdbops/loadbalancer.go
@@ -47,14 +47,13 @@ func getNonZeroLoadBalancerMutableFields(lb *nbdb.LoadBalancer) []interface{} {
 }
 
 // BuildLoadBalancer builds a load balancer
-func BuildLoadBalancer(name string, protocol nbdb.LoadBalancerProtocol, selectionFields []nbdb.LoadBalancerSelectionFields, vips, options, externalIds map[string]string) *nbdb.LoadBalancer {
+func BuildLoadBalancer(name string, protocol nbdb.LoadBalancerProtocol, vips, options, externalIds map[string]string) *nbdb.LoadBalancer {
 	return &nbdb.LoadBalancer{
-		Name:            name,
-		Protocol:        &protocol,
-		SelectionFields: selectionFields,
-		Vips:            vips,
-		Options:         options,
-		ExternalIDs:     externalIds,
+		Name:        name,
+		Protocol:    &protocol,
+		Vips:        vips,
+		Options:     options,
+		ExternalIDs: externalIds,
 	}
 }
 

--- a/go-controller/pkg/ovn/controller/services/load_balancer.go
+++ b/go-controller/pkg/ovn/controller/services/load_balancer.go
@@ -475,13 +475,29 @@ func configsByProto(configs []lbConfig) map[v1.Protocol][]lbConfig {
 	return out
 }
 
+func getSessionAffinityTimeOut(service *v1.Service) int32 {
+	// NOTE: This if condition is actually not needed, present only for protection against nil value as good coding practice,
+	// The API always puts the default value of 10800 whenever sessionAffinity == ClientIP if timeout is not explicitly set
+	// There is no ClientIP session affinity without a timeout set.
+	if service.Spec.SessionAffinityConfig == nil ||
+		service.Spec.SessionAffinityConfig.ClientIP == nil ||
+		service.Spec.SessionAffinityConfig.ClientIP.TimeoutSeconds == nil {
+		return 10800 // default value
+	}
+	return *service.Spec.SessionAffinityConfig.ClientIP.TimeoutSeconds
+}
+
 // lbOpts generates the OVN load balancer options from the kubernetes Service.
 func lbOpts(service *v1.Service) ovnlb.LBOpts {
-	return ovnlb.LBOpts{
+	affinity := service.Spec.SessionAffinity == v1.ServiceAffinityClientIP
+	lbOptions := ovnlb.LBOpts{
 		Unidling: svcNeedsIdling(service.GetAnnotations()),
-		Affinity: service.Spec.SessionAffinity == v1.ServiceAffinityClientIP,
 		SkipSNAT: false, // never service-wide, ExternalTrafficPolicy-specific
 	}
+	if affinity {
+		lbOptions.AffinityTimeOut = getSessionAffinityTimeOut(service)
+	}
+	return lbOptions
 }
 
 // mergeLBs joins two LBs together if it is safe to do so.

--- a/go-controller/pkg/ovn/loadbalancer/loadbalancer.go
+++ b/go-controller/pkg/ovn/loadbalancer/loadbalancer.go
@@ -258,20 +258,16 @@ func buildLB(lb *LB) *nbdb.LoadBalancer {
 	}
 
 	// Session affinity
-	// If enabled, then bucket flows by 3-tuple (proto, srcip, dstip)
+	// If enabled, then bucket flows by 3-tuple (proto, srcip, dstip) for the specific timeout value
 	// otherwise, use default ovn value
-	selectionFields := []nbdb.LoadBalancerSelectionFields{}
-	if lb.Opts.Affinity {
-		selectionFields = []string{
-			nbdb.LoadBalancerSelectionFieldsIPSrc,
-			nbdb.LoadBalancerSelectionFieldsIPDst,
-		}
+	if lb.Opts.AffinityTimeOut > 0 {
+		options["affinity_timeout"] = fmt.Sprintf("%d", lb.Opts.AffinityTimeOut)
 	}
 
 	// vipMap
 	vips := buildVipMap(lb.Rules)
 
-	return libovsdbops.BuildLoadBalancer(lb.Name, strings.ToLower(lb.Protocol), selectionFields, vips, options, lb.ExternalIDs)
+	return libovsdbops.BuildLoadBalancer(lb.Name, strings.ToLower(lb.Protocol), vips, options, lb.ExternalIDs)
 }
 
 // buildVipMap returns a viups map from a set of rules

--- a/go-controller/pkg/ovn/loadbalancer/types.go
+++ b/go-controller/pkg/ovn/loadbalancer/types.go
@@ -22,8 +22,8 @@ type LBOpts struct {
 	// if true, then enable unidling. Otherwise, generate reject
 	Unidling bool
 
-	// If true, then enable per-client-IP affinity.
-	Affinity bool
+	// If greater than 0, then enable per-client-IP affinity.
+	AffinityTimeOut int32
 
 	// If true, then disable SNAT entirely
 	SkipSNAT bool

--- a/test/scripts/e2e-kind.sh
+++ b/test/scripts/e2e-kind.sh
@@ -26,9 +26,6 @@ kube-proxy
 should set TCP CLOSE_WAIT timeout
 \[Feature:ProxyTerminatingEndpoints\]
 
-# not implemented - OVN doesn't support time
-should have session affinity timeout work
-
 # NOT IMPLEMENTED; SEE DISCUSSION IN https://github.com/ovn-org/ovn-kubernetes/pull/1225
 named port.+\[Feature:NetworkPolicy\]
 


### PR DESCRIPTION
This PR adds support for session affinity
timeout which is required for OVNK plugin to
become CNCF complaint and pass the conformance
tests around this feature.

NOTE: Most of the work has been done in OVN,
only bit OVNK does is to enable this in the
right manner as an option on the load balancer
if a service with session affinity is created.
OVN version bump is being done in the fedora
image used to the build.

NOTE2: We used to use the selectionFields option
before, this is no longer needed because there can never be a session affinity without a timeout set
(defaults to 3hrs), so if affinity-timeout is set
then OVN does the rest of the logic to determin
stickyness.

NOTE3: Is the stickness timeout calculated for
packets or sessions? (can't remember what IPVS
does and OVN does) :( so do we timeout after
the last packet ?

Signed-off-by: Surya Seetharaman <suryaseetharaman.9@gmail.com>
(cherry picked from commit 898d2f8f10c496c35b4891eb5f6665f76daa99a4)