### PR TITLE
OCPBUGS-4611: egress ip: Skip mgmt ports that cannot have assignable IP addresses

### DIFF
--- a/go-controller/pkg/node/management-port-dpu.go
+++ b/go-controller/pkg/node/management-port-dpu.go
@@ -151,6 +151,11 @@ func (mp *managementPortRepresentor) CheckManagementPortHealth(cfg *managementPo
 		stopChan)
 }
 
+// Port representors should not have any IP address assignable to them, thus always return false.
+func (mp *managementPortRepresentor) HasIpAddr() bool {
+	return false
+}
+
 type managementPortNetdev struct {
 	hostSubnets []*net.IPNet
 	netdevName  string
@@ -237,4 +242,9 @@ func (mp *managementPortNetdev) CheckManagementPortHealth(cfg *managementPortCon
 		},
 		30*time.Second,
 		stopChan)
+}
+
+// Management port Netdev should have IP addresses assignable to them.
+func (mp *managementPortNetdev) HasIpAddr() bool {
+	return true
 }

--- a/go-controller/pkg/node/management-port.go
+++ b/go-controller/pkg/node/management-port.go
@@ -24,6 +24,12 @@ type ManagementPort interface {
 	// CheckManagementPortHealth checks periodically for management port health until stopChan is posted
 	// or closed and reports any warnings/errors to log
 	CheckManagementPortHealth(cfg *managementPortConfig, stopChan chan struct{})
+	// Currently, the management port(s) that doesn't have an assignable IP address are the following cases:
+	//   - Full mode with HW backed device (e.g. Virtual Function Representor).
+	//   - DPU mode with Virtual Function Representor.
+	// It is up to the implementation of the ManagementPort to report whether an IP address can be assigned for the
+	// type of ManagementPort.
+	HasIpAddr() bool
 }
 
 // NewManagementPorts creates a new ManagementPorts
@@ -116,6 +122,11 @@ func (mp *managementPort) CheckManagementPortHealth(cfg *managementPortConfig, s
 		},
 		30*time.Second,
 		stopChan)
+}
+
+// OVS Internal Port Netdev should have IP addresses assignable to them.
+func (mp *managementPort) HasIpAddr() bool {
+	return true
 }
 
 func managementPortReady() (bool, error) {


### PR DESCRIPTION
There can be multiple management ports. Currently in the case of Full mode with hardware backed mgmt port, the virtual function representor and virtual function netdev exists separately. However the management port config belongs to the virtual function representor in this case. This caused the Egress IP health check to fail to initialize since there won't be an IP address on the virtual function representor interface. Instead the code now iterates through all management port interfaces, skips the virtual function representor and finds the virtual function netdev management port with a valid IP address configuration.

In the case of DPU, there will be a DPU-Host mode node and DPU mode node. Also it will always use hardware backed mgmt ports. The DPU mode node will only have a virtual function representor, thus the Egress IP Health Check won't run on this node. The DPU-Host mode node will only have a virtual function netdev; thus the Egress IP Health Check will run on this node.

Signed-off-by: William Zhao <wizhao@redhat.com>
[Upstream cherry picked from commit 8dd825c5cf5a0deca58a3f0c059b6c4259c29a07]