### PR TITLE
OCPBUGS-3778: [release-4.10] Netpol races partial fixes

### DIFF
--- a/go-controller/pkg/factory/factory.go
+++ b/go-controller/pkg/factory/factory.go
@@ -376,7 +376,7 @@ func (wf *WatchFactory) GetHandlerPriority(objType string) (priority uint32) {
 	}
 }
 
-func (wf *WatchFactory) addHandler(objType reflect.Type, namespace string, sel labels.Selector, funcs cache.ResourceEventHandler, processExisting func([]interface{}),  priority uint32) *Handler {
+func (wf *WatchFactory) addHandler(objType reflect.Type, namespace string, sel labels.Selector, funcs cache.ResourceEventHandler, processExisting func([]interface{}), priority uint32) *Handler {
 	inf, ok := wf.informers[objType]
 	if !ok {
 		klog.Fatalf("Tried to add handler of unknown object type %v", objType)

--- a/go-controller/pkg/factory/types.go
+++ b/go-controller/pkg/factory/types.go
@@ -45,7 +45,7 @@ type NodeWatchFactory interface {
 	AddNamespaceHandler(handlerFuncs cache.ResourceEventHandler, processExisting func([]interface{}), priority uint32) *Handler
 	RemoveNamespaceHandler(handler *Handler)
 
-	GetHandlerPriority(objType string) (uint32)
+	GetHandlerPriority(objType string) uint32
 
 	NodeInformer() cache.SharedIndexInformer
 	LocalPodInformer() cache.SharedIndexInformer

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -534,7 +534,7 @@ func networkStatusAnnotationsChanged(oldPod, newPod *kapi.Pod) bool {
 func (oc *Controller) ensurePod(oldPod, pod *kapi.Pod, addPort bool) error {
 	// Try unscheduled pods later
 	if !util.PodScheduled(pod) {
-		return fmt.Errorf("failed to ensurePod %s/%s since it is not yet scheduled", pod.Namespace, pod.Name)
+		return nil
 	}
 
 	if oldPod != nil && (exGatewayAnnotationsChanged(oldPod, pod) || networkStatusAnnotationsChanged(oldPod, pod)) {
@@ -706,7 +706,7 @@ func (oc *Controller) WatchPods() {
 				return
 			}
 
-			if err := oc.ensurePod(oldPod, pod, oc.checkAndSkipRetryPod(pod)); err != nil {
+			if err := oc.ensurePod(oldPod, pod, oc.checkAndSkipRetryPod(pod) || util.PodScheduled(oldPod) != util.PodScheduled(newerPod)); err != nil {
 				oc.recordPodEvent(err, pod)
 				klog.Errorf("Failed to update pod %s, error: %v",
 					getPodNamespacedName(pod), err)

--- a/go-controller/pkg/ovn/pods_test.go
+++ b/go-controller/pkg/ovn/pods_test.go
@@ -1272,14 +1272,6 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 
 				initialDB = libovsdbtest.TestSetup{
 					NBData: []libovsdbtest.TestData{
-						&nbdb.LogicalSwitch{
-							Name:  "node1",
-							Ports: []string{t1.portUUID},
-						},
-						&nbdb.LogicalSwitch{
-							Name:  "node2",
-							Ports: []string{t2.portUUID},
-						},
 						&nbdb.LogicalSwitchPort{
 							UUID:      t1.portUUID,
 							Name:      util.GetLogicalPortName(t1.namespace, t1.podName),
@@ -1309,6 +1301,14 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 								//"iface-id-ver": is empty to check that it won't be set on update
 							},
 							PortSecurity: []string{fmt.Sprintf("%s %s", t2.podMAC, t2.podIP)},
+						},
+						&nbdb.LogicalSwitch{
+							Name:  "node1",
+							Ports: []string{t1.portUUID},
+						},
+						&nbdb.LogicalSwitch{
+							Name:  "node2",
+							Ports: []string{t2.portUUID},
 						},
 					},
 				}

--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -1335,7 +1335,7 @@ func (oc *Controller) deleteNetworkPolicy(policy *knet.NetworkPolicy, np *networ
 		}
 
 		if err := oc.destroyNetworkPolicy(np, false); err != nil {
-			return fmt.Errorf("failed to destroy network policy: %s/%s", policy.Namespace, policy.Name)
+			return fmt.Errorf("failed to destroy network policy %s/%s: %v", policy.Namespace, policy.Name, err)
 		}
 		return nil
 	}
@@ -1357,7 +1357,7 @@ func (oc *Controller) deleteNetworkPolicy(policy *knet.NetworkPolicy, np *networ
 	}
 	isLastPolicyInNamespace := len(nsInfo.networkPolicies) == expectedLastPolicyNum
 	if err := oc.destroyNetworkPolicy(np, isLastPolicyInNamespace); err != nil {
-		return fmt.Errorf("failed to destroy network policy: %s/%s", policy.Namespace, policy.Name)
+		return fmt.Errorf("failed to destroy network policy %s/%s: %v", policy.Namespace, policy.Name, err)
 	}
 
 	delete(nsInfo.networkPolicies, policy.Name)

--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -880,6 +880,12 @@ func (oc *Controller) processLocalPodSelectorSetPods(policy *knet.NetworkPolicy,
 		}
 
 		logicalPort := util.GetLogicalPortName(pod.Namespace, pod.Name)
+
+		// if this pod is somehow already added to this policy, skip
+		if _, ok := np.localPods.Load(logicalPort); ok {
+			return
+		}
+
 		var portInfo *lpInfo
 
 		// Get the logical port info from the cache, if that fails, retry


### PR DESCRIPTION
The problems that are fixed, and perf improvement:
1. don't retry unscheduled pod, wait for update event instead. 
2.  Cleanup pod handler for namespaceAndPod handler on namespace delete
event.
3. Only update localPods after successful db transaction, 
return fast from localPod handlers based on `np.localPods`
4. Don't retry fetching lsp from the lspCache, that "stops" the handler for 1 second
5.  Use stored portUUID to delete local pods instead of getting that info
from lspCache