### PR TITLE
[release-4.11] OCPBUGS-1720: Backport changes to ovnkube-trace

### DIFF
--- a/go-controller/cmd/ovnkube-trace/ovnkube-trace.go
+++ b/go-controller/cmd/ovnkube-trace/ovnkube-trace.go
@@ -1,9 +1,9 @@
 package main
 
 import (
+	"bufio"
 	"bytes"
 	"context"
-	"encoding/json"
 	"flag"
 	"fmt"
 	"io"
@@ -27,16 +27,9 @@ import (
 	utilnet "k8s.io/utils/net"
 )
 
-type AddrInfo struct {
-	Family    string `json:"family,omitempty"`
-	Local     string `json:"local,omitempty"`
-	Prefixlen int    `json:"prefixlen,omitempty"`
-}
-type IpAddrReq struct {
-	IfIndex   int        `json:"ifindex,omitempty"`
-	IfName    string     `json:"ifname,omitempty"`
-	LinkIndex int        `json:"link_index,omitempty"`
-	AInfo     []AddrInfo `json:"addr_info,omitempty"`
+type OvsInterface struct {
+	Name   string
+	Ofport string
 }
 
 type SvcInfo struct {
@@ -161,6 +154,53 @@ func getPodMAC(client *corev1client.CoreV1Client, pod *kapi.Pod) (podMAC string,
 	return podMAC, nil
 }
 
+// getPodOvsInterfaceNameAndOfport searches the node's OVS database for information
+// about this pod's OVS interface and returns the name and ofport fields.
+// It will run `ovs-vsctl --columns name,ofport find interface external_ids:iface-id=%s` with the given `$namespace-$pod` tuple and it will then parse the
+// result into a map[string]string that maps the keys to their values.
+func getPodOvsInterfaceNameAndOfport(coreclient *corev1client.CoreV1Client, restconfig *rest.Config, ovnNamespace, ovnkubePodName, fullyQualifiedPodName string) (*OvsInterface, error) {
+	var interfaceInfo OvsInterface
+
+	findInterfaceCmd := fmt.Sprintf("ovs-vsctl --columns name,ofport find interface external_ids:iface-id=%s", fullyQualifiedPodName)
+	findInterfaceStdout, findInterfaceStderr, err := execInPod(coreclient, restconfig, ovnNamespace, ovnkubePodName, "ovnkube-node", findInterfaceCmd, "")
+	if err != nil {
+		return nil, err
+	}
+
+	var key string
+	var value string
+	scanner := bufio.NewScanner(strings.NewReader(findInterfaceStdout))
+	for scanner.Scan() {
+		splitLine := strings.Split(scanner.Text(), ":")
+		if len(splitLine) != 2 {
+			continue
+		}
+		key = strings.TrimSpace(splitLine[0])
+		value = strings.TrimSpace(splitLine[1])
+		switch key {
+		case "name":
+			interfaceInfo.Name = strings.Trim(value, "\"")
+		case "ofport":
+			interfaceInfo.Ofport = value
+		default:
+		}
+	}
+
+	if interfaceInfo.Name == "" || interfaceInfo.Ofport == "" {
+		return nil, fmt.Errorf("could not find interface info for: "+
+			"fullyQualifiedPodName: %s, ovnNamespace: %s, ovnkubePodName: %s, cmd: %s. Got: %s, %s, parsed interface info: %v",
+			fullyQualifiedPodName,
+			ovnNamespace,
+			ovnkubePodName,
+			findInterfaceCmd,
+			findInterfaceStdout,
+			findInterfaceStderr,
+			interfaceInfo,
+		)
+	}
+	return &interfaceInfo, nil
+}
+
 func getSvcInfo(coreclient *corev1client.CoreV1Client, restconfig *rest.Config, svcName string, ovnNamespace string, namespace string, cmd string) (svcInfo *SvcInfo, err error) {
 
 	// Get service with the name supplied by svcName
@@ -254,48 +294,6 @@ func getPodInfo(coreclient *corev1client.CoreV1Client, restconfig *rest.Config, 
 	podInfo.MAC = podMAC
 	podInfo.ContainerName = pod.Spec.Containers[0].Name
 
-	var linkIndex int
-
-	// The interface name used depends on what network namespasce the pod uses
-	if pod.Spec.HostNetwork {
-		ethName = util.GetLegacyK8sMgmtIntfName(node.Name)
-		podInfo.HostNetwork = true
-		linkIndex = 0
-	} else {
-		ethName = "eth0"
-		podInfo.HostNetwork = false
-
-		// Find index used for pod interface
-		klog.V(5).Infof("Reading interface index from /sys/class/net/...")
-
-		sysCmd := "cat /sys/class/net/" + ethName + "/iflink"
-		klog.V(5).Infof("The command is %s", sysCmd)
-
-		linkOutput, linkError, err := execInPod(coreclient, restconfig, namespace, podName, podInfo.ContainerName, sysCmd, "")
-		if err != nil {
-			klog.V(1).Infof("The command error %v stdOut: %s\n stdErr: %s", err, linkOutput, linkError)
-			// Give up, unknown error
-			return nil, err
-		}
-
-		linkIndex, err = strconv.Atoi(strings.TrimSuffix(linkOutput, "\n"))
-		if err != nil {
-			klog.Error("Error converting string to int", err)
-			return nil, err
-		}
-		klog.V(5).Infof("Using '%s' - linkIndex is %d", sysCmd, linkIndex)
-	}
-	klog.V(5).Infof("Using interface name of %s with MAC of %s", ethName, podMAC)
-
-	if !pod.Spec.HostNetwork && linkIndex == 0 {
-		klog.V(0).Infof("Fatal: Pod Network used and linkIndex is zero")
-		return nil, err
-	}
-	if pod.Spec.HostNetwork && linkIndex != 0 {
-		klog.V(1).Infof("Fatal: Host Network used and linkIndex is non-zero")
-		return nil, err
-	}
-
 	// Get pods in the openshift-ovn-kubernetes namespace
 	podsOvn, errOvn := coreclient.Pods(ovnNamespace).List(context.TODO(), metav1.ListOptions{})
 	if errOvn != nil {
@@ -326,6 +324,22 @@ func getPodInfo(coreclient *corev1client.CoreV1Client, restconfig *rest.Config, 
 	podInfo.OvnKubeContainerPodName = ovnkubePod.Name
 	podInfo.NodeName = ovnkubePod.Spec.NodeName
 
+	// The interface name used depends on what network namespasce the pod uses
+	if pod.Spec.HostNetwork {
+		ethName = util.GetLegacyK8sMgmtIntfName(node.Name)
+		podInfo.HostNetwork = true
+	} else {
+		ethName = "eth0"
+		podInfo.HostNetwork = false
+		ovsInterfaceInformation, err := getPodOvsInterfaceNameAndOfport(coreclient, restconfig, ovnNamespace, podInfo.OvnKubeContainerPodName, namespace+"_"+podInfo.PodName)
+		if err != nil {
+			return nil, err
+		}
+		podInfo.VethName = ovsInterfaceInformation.Name
+		podInfo.PortNum = ovsInterfaceInformation.Ofport
+	}
+	klog.V(5).Infof("Using interface name of %s with MAC of %s", ethName, podMAC)
+
 	// Find rtos MAC
 	klog.V(5).Infof("Command is: %s", "ovn-nbctl "+cmd+" --bare --no-heading --column=mac list logical-router-port "+"rtos-"+ovnkubePod.Spec.NodeName)
 	lspCmd := "ovn-nbctl " + cmd + " --bare --no-heading --column=mac list logical-router-port " + "rtos-" + ovnkubePod.Spec.NodeName
@@ -342,44 +356,6 @@ func getPodInfo(coreclient *corev1client.CoreV1Client, restconfig *rest.Config, 
 		podInfo.OVNName = types.K8sPrefix + ovnkubePod.Spec.NodeName
 		podInfo.VethName = "ovn-k8s-mp0"
 		klog.V(5).Infof("hostInterface on host stack OVN name is %s\n", podInfo.OVNName)
-	} else {
-
-		// obnkube-node-xxx uses host network.  Find host end of veth matching pod eth0 index
-
-		var hostInterface string
-
-		ipCmd := "ip -j addr show"
-		klog.V(5).Infof("Command is: %s", ipCmd)
-
-		hostOutput, hostError, err := execInPod(coreclient, restconfig, ovnNamespace, ovnkubePod.Name, "ovnkube-node", ipCmd, "")
-		if err != nil {
-			fmt.Printf("execInPod() failed with %s stderr %s stdout %s \n", err, hostError, hostOutput)
-			klog.V(5).Infof("execInPod() failed err %s - podInfo %v - ovnkubePod Name %s", err, podInfo, ovnkubePod.Name)
-			return nil, err
-		}
-
-		klog.V(5).Infof("==>ovnkubePod %s: ip addr show: %q", ovnkubePod.Name, hostOutput)
-
-		var data []IpAddrReq
-		hostOutput = strings.Replace(hostOutput, "\n", "", -1)
-		klog.V(5).Infof("==> host %s NOW: %s", ovnkubePod.Name, hostOutput)
-		err = json.Unmarshal([]byte(hostOutput), &data)
-		if err != nil {
-			klog.V(1).Infof("JSON ERR: couldn't get stuff from data %v; json parse error: %v", data, err)
-			return nil, err
-		}
-		klog.V(5).Infof("Size of IpAddrReq array: %v", len(data))
-		klog.V(5).Infof("IpAddrReq: %v", data)
-
-		for _, addr := range data {
-			if addr.IfIndex == linkIndex {
-				hostInterface = addr.IfName
-				klog.V(5).Infof("ifName: %v\n", addr.IfName)
-				break
-			}
-		}
-		klog.V(5).Infof("hostInterface name is %s\n", hostInterface)
-		podInfo.VethName = hostInterface
 	}
 
 	// ovs-vsctl get Interface [vethname] ofport

--- a/go-controller/cmd/ovnkube-trace/ovnkube-trace.go
+++ b/go-controller/cmd/ovnkube-trace/ovnkube-trace.go
@@ -883,7 +883,8 @@ func getOfprotoIPFamilyArgs(protocol string, ip net.IP) (string, string, string)
 }
 
 // installOvnDetraceDependencies installs dependencies for ovn-detrace with pip3 in case they are missing (for older images).
-func installOvnDetraceDependencies(coreclient *corev1client.CoreV1Client, restconfig *rest.Config, podName, ovnNamespace string) {
+// Returns error if dependencies are missing but cannot be installed.
+func installOvnDetraceDependencies(coreclient *corev1client.CoreV1Client, restconfig *rest.Config, podName, ovnNamespace string) error {
 	dependencies := map[string]string{
 		"ovs":       "if type -p ovn-detrace >/dev/null 2>&1; then echo 'true' ; fi",
 		"pyOpenSSL": "if rpm -qa | egrep -q python3-pyOpenSSL; then echo 'true'; fi",
@@ -891,7 +892,8 @@ func installOvnDetraceDependencies(coreclient *corev1client.CoreV1Client, restco
 	for dependency, dependencyCmd := range dependencies {
 		depVerifyOut, depVerifyErr, err := execInPod(coreclient, restconfig, ovnNamespace, podName, "ovnkube-node", dependencyCmd, "")
 		if err != nil {
-			klog.Exitf("Dependency verification error in pod %s, container %s. Error '%v', stdOut: '%s'\n stdErr: %s", podName, "ovnkube-node", err, depVerifyOut, depVerifyErr)
+			return fmt.Errorf("dependency verification error in pod %s, container %s. Error '%v', stdOut: '%s'\n stdErr: %s",
+				podName, "ovnkube-node", err, depVerifyOut, depVerifyErr)
 		}
 		trueFalse := strings.TrimSuffix(depVerifyOut, "\n")
 		klog.V(10).Infof("Dependency check '%s' in pod '%s', container '%s' yielded '%s'", dependencyCmd, podName, "ovnkube-node", trueFalse)
@@ -899,15 +901,28 @@ func installOvnDetraceDependencies(coreclient *corev1client.CoreV1Client, restco
 			installCmd := "pip3 install " + dependency
 			depInstallOut, depInstallErr, err := execInPod(coreclient, restconfig, ovnNamespace, podName, "ovnkube-node", installCmd, "")
 			if err != nil {
-				klog.Exitf("ovn-detrace error in pod %s, container %s. Error '%v', stdOut: '%s'\n stdErr: %s", podName, "ovnkube-node", err, depInstallOut, depInstallErr)
+				return fmt.Errorf("ovn-detrace error in pod %s, container %s. Error '%v', stdOut: '%s'\n stdErr: %s",
+					podName, "ovnkube-node", err, depInstallOut, depInstallErr)
 			}
-			klog.V(1).Infof("Install ovn-detrace Output: %s\n", depInstallOut)
+			klog.V(1).Infof("Install ovn-detrace dependencies output: %s\n", depInstallOut)
 		}
 	}
+	return nil
 }
 
 // runOvnDetrace runs an ovn-detrace command for the given input.
-func runOvnDetrace(coreclient *corev1client.CoreV1Client, restconfig *rest.Config, direction string, srcPodInfo *PodInfo, dstName string, appSrcDstOut, ovnNamespace, nbURI, sbURI, sslCertKeys string) {
+// Returns error if dependencies are not met (allows for graceful handling of those issues).
+func runOvnDetrace(coreclient *corev1client.CoreV1Client, restconfig *rest.Config, direction string, srcPodInfo *PodInfo,
+	dstName string, appSrcDstOut, ovnNamespace, nbURI, sbURI, sslCertKeys, nbcmd string) error {
+	// If NBDB connectivity is not available do not run ovn-detrace.
+	if _, stdErr, err := execInPod(coreclient, restconfig, ovnNamespace, srcPodInfo.OvnKubePodName, "ovnkube-node", fmt.Sprintf("ovn-nbctl %s get-connection", nbcmd), ""); err != nil {
+		return fmt.Errorf("nbdb is not available %q", stdErr)
+	}
+	// If dependencies aren't satisfied do not run ovn-detrace.
+	if err := installOvnDetraceDependencies(coreclient, restconfig, srcPodInfo.OvnKubePodName, ovnNamespace); err != nil {
+		return fmt.Errorf("dependencies check failed: %q", err)
+	}
+
 	cmd := fmt.Sprintf(`ovn-detrace --ovnnb=%[1]s --ovnsb=%[2]s %[3]s --ovsdb=unix:/var/run/openvswitch/db.sock`,
 		nbURI,       // 1
 		sbURI,       // 2
@@ -917,6 +932,8 @@ func runOvnDetrace(coreclient *corev1client.CoreV1Client, restconfig *rest.Confi
 
 	dtraceSrcDstOut, dtraceSrcDstErr, err := execInPod(coreclient, restconfig, ovnNamespace, srcPodInfo.OvnKubePodName, "ovnkube-node", cmd, appSrcDstOut)
 	printSuccessOrFailure("ovn-detrace "+direction, srcPodInfo.PodName, dstName, dtraceSrcDstOut, dtraceSrcDstErr, err, "")
+
+	return nil
 }
 
 // displayNodeInfo shows a summary about nodes in this cluster.
@@ -1106,7 +1123,10 @@ func main() {
 		klog.V(5).Infof("Running a trace to an IP address")
 		egressNodeName, egressBridgeName := runOvnTraceToIP(coreclient, restconfig, srcPodInfo, parsedDstIP, sbcmd, ovnNamespace, protocol, *dstPort)
 		appSrcDstOut := runOfprotoTraceToIP(coreclient, restconfig, srcPodInfo, parsedDstIP, ovnNamespace, protocol, *dstPort, egressNodeName, egressBridgeName)
-		runOvnDetrace(coreclient, restconfig, "pod to external IP", srcPodInfo, parsedDstIP.String(), appSrcDstOut, ovnNamespace, nbURI, sbURI, sslCertKeys)
+		err = runOvnDetrace(coreclient, restconfig, "pod to external IP", srcPodInfo, parsedDstIP.String(), appSrcDstOut, ovnNamespace, nbURI, sbURI, sslCertKeys, nbcmd)
+		if err != nil {
+			klog.Infof("Skipped ovn-detrace due to: %q", err)
+		}
 		return
 	}
 
@@ -1149,16 +1169,15 @@ func main() {
 	appSrcDstOut := runOfprotoTraceToPod(coreclient, restconfig, "source pod to destination pod", srcPodInfo, dstPodInfo, ovnNamespace, protocol, *dstPort)
 	appDstSrcOut := runOfprotoTraceToPod(coreclient, restconfig, "destination pod to source pod", dstPodInfo, srcPodInfo, ovnNamespace, protocol, *dstPort)
 
-	// If NBDB connectivity is not available do not run ovn-dtrace
-	_, stdErr, err := execInPod(coreclient, restconfig, ovnNamespace, srcPodInfo.OvnKubePodName, "ovnkube-node", fmt.Sprintf("ovn-nbctl %s get-connection", nbcmd), "")
+	// ovn-detrace commands below
+	err = runOvnDetrace(coreclient, restconfig, "source pod to destination pod", srcPodInfo, dstPodInfo.PodName, appSrcDstOut, ovnNamespace, nbURI, sbURI, sslCertKeys, nbcmd)
 	if err != nil {
-		klog.V(4).Infof("Skip ovn-dtrace, nbdb is not available %s", stdErr)
+		klog.Infof("Skipped ovn-detrace due to: %q", err)
 		return
 	}
-	// ovn-detrace commands below
-	// Install dependencies with pip3 in case they are missing (for older images)
-	installOvnDetraceDependencies(coreclient, restconfig, srcPodInfo.OvnKubePodName, ovnNamespace)
-	installOvnDetraceDependencies(coreclient, restconfig, dstPodInfo.OvnKubePodName, ovnNamespace)
-	runOvnDetrace(coreclient, restconfig, "source pod to destination pod", srcPodInfo, dstPodInfo.PodName, appSrcDstOut, ovnNamespace, nbURI, sbURI, sslCertKeys)
-	runOvnDetrace(coreclient, restconfig, "destination pod to source pod", dstPodInfo, srcPodInfo.PodName, appDstSrcOut, ovnNamespace, nbURI, sbURI, sslCertKeys)
+	err = runOvnDetrace(coreclient, restconfig, "destination pod to source pod", dstPodInfo, srcPodInfo.PodName, appDstSrcOut, ovnNamespace, nbURI, sbURI, sslCertKeys, nbcmd)
+	if err != nil {
+		klog.Infof("Skipped ovn-detrace due to: %q", err)
+		return
+	}
 }

--- a/go-controller/cmd/ovnkube-trace/ovnkube-trace.go
+++ b/go-controller/cmd/ovnkube-trace/ovnkube-trace.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"io"
@@ -13,6 +14,8 @@ import (
 	"strconv"
 	"strings"
 
+	types "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
+	util "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 	kapi "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -21,11 +24,28 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/remotecommand"
 	"k8s.io/klog/v2"
-
-	types "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
-	util "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 	utilnet "k8s.io/utils/net"
 )
+
+const (
+	// Colors for bash highlighting.
+	reset  = "\033[0m"
+	red    = "\033[31m"
+	green  = "\033[32m"
+	italic = "\033[3m"
+	bold   = "\033[1m"
+
+	// OVN related.
+	ovnNodeL3GatewayConfig = "k8s.ovn.org/l3-gateway-config"
+)
+
+var (
+	level klog.Level
+)
+
+type l3GatewayConfig struct {
+	Mode string
+}
 
 type OvsInterface struct {
 	Name   string
@@ -33,30 +53,59 @@ type OvsInterface struct {
 }
 
 type SvcInfo struct {
-	IP           string
-	PodName      string
-	PodNamespace string
-	PodIP        string
-	PodPort      string
+	SvcName      string // The service's name
+	SvcNamespace string // The service's namespace
+	ClusterIP    string // The service's cluster IP address
+	PodName      string // The first Endpoint subset.Addresses[].TargetRef.Name that can be found (a pod name)
+	PodNamespace string // The namespace of the selected pod
+	PodIP        string // The IP address of the selected pod
+	PodPort      string // Endpoint target port used to reach the pod in PodName
+}
+
+type NodeInfo struct {
+	NodeExternalBridgeName string // The name of the node's bridge, e.g. breth0 or br-ex
+	OvnK8sMp0PortName      string // ovn-k8s-mp0
+	OvnK8sMp0OfportNum     string // ofport num of ovn-k8s-mp0
+	K8sNodeNamePort        string // k8s-<nodeName>, e.g. k8s-ovn-worker, only useful for host networked pods
+	NodeName               string // The name of the node that the pod runs on
+	OvnKubePodName         string // The OvnKube pod on the same node as this pod
+	RoutingViaHost         bool   // The gateway mode, true for 'routingViaHost' or false for 'routingViaOVN'
 }
 
 type PodInfo struct {
-	IP                      string
-	MAC                     string
-	VethName                string
-	PortNum                 string
-	LocalNum                string
-	OVNName                 string
-	PodName                 string
-	ContainerName           string
-	OvnKubeContainerPodName string
-	NodeName                string
-	RtosMAC                 string
-	HostNetwork             bool
+	NodeInfo
+	PrimaryInterfaceName string // primary pod interface name inside the pod
+	IP                   string // the primary interface's primary IP address
+	MAC                  string // the primary interface's MAC address
+	VethName             string // veth peer of the primary interface of the pod
+	OfportNum            string // ofport number of veth interface or for host net pods of ovn-k8s-mp0
+	PodName              string // name of the pod
+	PodNamespace         string // the pod's namespace
+	ContainerName        string // the pod's principal container name (the first container found atm)
+	RtosMAC              string // router to switch mac address, the L2 address of the first hop router of the pod
+	HostNetwork          bool   // if this pod is host networked or not
+}
+
+// String returns a JSON representation of the SvcInfo object, or "" on failure.
+func (si *SvcInfo) String() string {
+	b, err := json.Marshal(*si)
+	if err != nil {
+		return ""
+	}
+	return string(b)
+}
+
+// String returns a JSON representation of the PodInfo object, or "" on failure.
+func (pi *PodInfo) String() string {
+	b, err := json.Marshal(*pi)
+	if err != nil {
+		return ""
+	}
+	return string(b)
 }
 
 func (si SvcInfo) getL3Ver() string {
-	if net.ParseIP(si.IP).To4() != nil {
+	if net.ParseIP(si.ClusterIP).To4() != nil {
 		return "ip4"
 	}
 	return "ip6"
@@ -69,12 +118,28 @@ func (si PodInfo) getL3Ver() string {
 	return "ip6"
 }
 
+func (si *SvcInfo) FullyQualifiedPodName() string {
+	return fmt.Sprintf("%s_%s", si.PodNamespace, si.PodName)
+}
+
+func (pi *PodInfo) FullyQualifiedPodName() string {
+	return fmt.Sprintf("%s_%s", pi.PodNamespace, pi.PodName)
+}
+
+// execInPod runs a command inside the given container. Requires bash. Returns Stdout, Stderr, err.
 func execInPod(coreclient *corev1client.CoreV1Client, restconfig *rest.Config, namespace string, podName string, containerName string, cmd string, in string) (string, string, error) {
+	klog.V(5).Infof(
+		"Running command inside container: namespace: %s, podName: %s, containerName: %s, cmd: %s, stdin: %s%s%s",
+		namespace,
+		podName,
+		containerName,
+		cmd,
+		italic, in, reset,
+	)
 
 	scheme := runtime.NewScheme()
 	if err := kapi.AddToScheme(scheme); err != nil {
-		fmt.Printf("error adding to scheme: %v", err)
-		os.Exit(-1)
+		klog.Exitf("Error adding to scheme: %v", err)
 	}
 	parameterCodec := runtime.NewParameterCodec(scheme)
 
@@ -126,8 +191,47 @@ func execInPod(coreclient *corev1client.CoreV1Client, restconfig *rest.Config, n
 	return stdout.String(), stderr.String(), err
 }
 
-func getPodMAC(client *corev1client.CoreV1Client, pod *kapi.Pod) (podMAC string, err error) {
+// isRoutingViaHost returns the gateway mode, either 'true' for 'routingViaHost' or 'false' for 'routingViaOVN'.
+// In order to do so, it looks for annotation 'k8s.ovn.org/l3-gateway-config' on the provided node.
+// That annotation should contain a JSON string like: '{"default":{"mode":"shared", ...}}'.
+// It will then determine the routing mode from that annotation if it is valid or return error otherwise.
+func isRoutingViaHost(coreclient *corev1client.CoreV1Client, restconfig *rest.Config, ovnNamespace, ovnKubePodName, nodeName string) (bool, error) {
+	node, err := coreclient.Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
+	if err != nil {
+		return false, err
+	}
 
+	l3GwConfigParsed := make(map[string]l3GatewayConfig)
+	var l3GwConfig string
+	var ok bool
+	var defaultL3GwConfigParsed l3GatewayConfig
+
+	annotations := node.GetAnnotations()
+	l3GwConfig, ok = annotations[ovnNodeL3GatewayConfig]
+	if !ok {
+		return false, fmt.Errorf("could not find l3GwConfig annotation '%s' on node '%s'", ovnNodeL3GatewayConfig, nodeName)
+	}
+	err = json.Unmarshal([]byte(l3GwConfig), &l3GwConfigParsed)
+	if err != nil {
+		return false, fmt.Errorf("could not determine gateway mode from annotations on node %s, err: %q", node.Name, err)
+	}
+	defaultL3GwConfigParsed, ok = l3GwConfigParsed["default"]
+	if !ok {
+		return false, fmt.Errorf("could not determine gateway mode from annotations on node %s, no default entry in l3GwConfig: %v", node.Name, l3GwConfigParsed)
+	}
+	if defaultL3GwConfigParsed.Mode == "local" {
+		klog.V(5).Infof("Cluster gateway mode is routingViaHost according to annotation on node %s, %s", node.Name, l3GwConfig)
+		return true, nil
+	} else if defaultL3GwConfigParsed.Mode == "shared" {
+		klog.V(5).Infof("Cluster gateway mode is routingViaOVN according to annotation on node %s, %s", node.Name, l3GwConfig)
+		return false, nil
+	}
+
+	return false, fmt.Errorf("could not determine gateway mode from annotations on node %s, unknown mode in l3GwConfig: %s", node.Name, defaultL3GwConfigParsed.Mode)
+}
+
+// getPodMAC returns the pod's MAC address.
+func getPodMAC(client *corev1client.CoreV1Client, pod *kapi.Pod) (podMAC string, err error) {
 	if pod.Spec.HostNetwork {
 		node, err := client.Nodes().Get(context.TODO(), pod.Spec.NodeName, metav1.GetOptions{})
 		if err != nil {
@@ -152,6 +256,33 @@ func getPodMAC(client *corev1client.CoreV1Client, pod *kapi.Pod) (podMAC string,
 	}
 
 	return podMAC, nil
+}
+
+// getOvnKubePodOnNode returns the name of the ovnkube-node pod that is running on a given node.
+func getOvnKubePodOnNode(coreclient *corev1client.CoreV1Client, ovnNamespace string, nodeName string) (string, error) {
+	// Get pods in the openshift-ovn-kubernetes namespace
+	podsOvn, errOvn := coreclient.Pods(ovnNamespace).List(context.TODO(), metav1.ListOptions{})
+	if errOvn != nil {
+		klog.Infof("Cannot find pods in %s namespace, err: %v", ovnNamespace, errOvn)
+		return "", errOvn
+	}
+	var ovnkubePod *kapi.Pod
+	// Find ovnkube-node-xxx pod running on the same node as Pod
+	for _, podOvn := range podsOvn.Items {
+		podOvn := podOvn
+		if podOvn.Spec.NodeName == nodeName {
+			if appLabel, ok := podOvn.Labels["app"]; ok && appLabel == "ovnkube-node" {
+				klog.V(5).Infof("==> pod %s is running on node %s", podOvn.Name, nodeName)
+				ovnkubePod = &podOvn
+				break
+			}
+		}
+	}
+	if ovnkubePod == nil {
+		err := fmt.Errorf("cannot find ovnkube-node pod on node %s in namespace %s", nodeName, ovnNamespace)
+		return "", err
+	}
+	return ovnkubePod.Name, nil
 }
 
 // getPodOvsInterfaceNameAndOfport searches the node's OVS database for information
@@ -201,188 +332,195 @@ func getPodOvsInterfaceNameAndOfport(coreclient *corev1client.CoreV1Client, rest
 	return &interfaceInfo, nil
 }
 
+// getSvcInfo builds the SvcInfo object for this service. PodName/PodNamespace/PodIP are for the first valid endpoint pod that can be found for this service.
 func getSvcInfo(coreclient *corev1client.CoreV1Client, restconfig *rest.Config, svcName string, ovnNamespace string, namespace string, cmd string) (svcInfo *SvcInfo, err error) {
-
 	// Get service with the name supplied by svcName
 	svc, err := coreclient.Services(namespace).Get(context.TODO(), svcName, metav1.GetOptions{})
 	if err != nil {
-		klog.V(1).Infof("Service %s in namespace %s not found\n", svcName, namespace)
-		return nil, err
+		return nil, fmt.Errorf("service %s in namespace %s not found, err: %v", svcName, namespace, err)
 	}
-	klog.V(5).Infof("==>Got service %s in namespace %s\n", svcName, namespace)
+	klog.V(5).Infof("==> Got service %s in namespace %s\n", svcName, namespace)
 
 	clusterIP := svc.Spec.ClusterIP
 	if clusterIP == "" || clusterIP == "None" {
-		klog.V(1).Infof("ClusterIP for service %s in namespace %s not available\n", svcName, namespace)
-		return nil, err
+		return nil, fmt.Errorf("ClusterIP for service %s in namespace %s not available", svcName, namespace)
 	}
 	clusterIPStr := utilnet.ParseIPSloppy(clusterIP).String()
-	klog.V(5).Infof("==>Got service %s ClusterIP is %s\n", svcName, clusterIPStr)
+	klog.V(5).Infof("==> Got service %s ClusterIP is %s\n", svcName, clusterIPStr)
 
 	svcInfo = &SvcInfo{
-		IP: clusterIPStr,
+		SvcName:      svcName,
+		SvcNamespace: namespace,
+		ClusterIP:    clusterIPStr,
 	}
 
 	ep, err := coreclient.Endpoints(namespace).Get(context.TODO(), svcName, metav1.GetOptions{})
 	if err != nil {
-		klog.V(1).Infof("Endpoints for service %s in namespace %s not found\n", svcName, namespace)
-		return nil, err
+		return nil, fmt.Errorf("endpoints for service %s in namespace %s not found, err: %v", svcName, namespace, err)
 	}
-	klog.V(5).Infof("==>Got Endpoint %v for service %s in namespace %s\n", ep, svcName, namespace)
+	klog.V(5).Infof("==> Got Endpoint %v for service %s in namespace %s\n", ep, svcName, namespace)
 
-	addrFound := false
-	portFound := false
-	for _, subset := range ep.Subsets {
-		klog.V(5).Infof("==>Got subset %v for service %s in namespace %s\n", subset, svcName, namespace)
-		for _, epAddress := range subset.Addresses {
-			klog.V(5).Infof("==>Got Address %v for service %s in namespace %s\n", epAddress, svcName, namespace)
-			svcInfo.PodName = epAddress.TargetRef.Name
-			svcInfo.PodNamespace = epAddress.TargetRef.Namespace
-			svcInfo.PodIP = utilnet.ParseIPSloppy(epAddress.IP).String()
-			addrFound = true
-			break
-		}
-		for _, port := range subset.Ports {
-			klog.V(5).Infof("==>Got Port %v for service %s in namespace %s\n", port, svcName, namespace)
-			svcInfo.PodPort = strconv.Itoa(int(port.Port))
-			portFound = true
-			break
-		}
-		if addrFound && portFound {
-			break
-		}
-	}
-	if svcInfo.PodName == "" {
-		klog.V(0).Infof("Cannot find pods in Endpoints for service %s in namespace %s", svcName, namespace)
-		err := fmt.Errorf("cannot find pods in Endpoints for service %s in namespace %s", svcName, namespace)
+	err = extractSubsetInfo(ep.Subsets, svcInfo)
+	if err != nil {
 		return nil, err
 	}
 
 	return svcInfo, err
 }
 
+// extractSubsetInfo copies information from the endpoint subsets into the SvcInfo object.
+// Modifies the svcInfo object the pointer of which is passed to it.
+func extractSubsetInfo(subsets []kapi.EndpointSubset, svcInfo *SvcInfo) error {
+	for _, subset := range subsets {
+		klog.V(5).Infof("==> Trying to extract information for service %s in namespace %s from subset %v",
+			svcInfo.SvcName, svcInfo.SvcNamespace, subset)
+
+		// Find a port for the subset.
+		var podPort string
+		for _, port := range subset.Ports {
+			podPort = strconv.Itoa(int(port.Port))
+			if podPort == "" {
+				klog.V(5).Infof("==> Could not parse port %d, skipping.", port)
+				continue // with the next port
+			}
+		}
+		// Continue with the next subset if podPort is empty.
+		if podPort == "" {
+			continue // with the next subset
+		}
+
+		// Parse pod information from the subset addresses. One of the subsets must have a valid address which does not belong
+		// to a host networked pod.
+		for _, epAddress := range subset.Addresses {
+			// This is nil for host networked services.
+			if epAddress.TargetRef == nil {
+				klog.V(5).Infof("Address %v belongs to a host networked pod. Skipping.", epAddress)
+				continue // with the next address
+			}
+			if epAddress.TargetRef.Name == "" || epAddress.TargetRef.Namespace == "" || epAddress.IP == "" {
+				klog.V(5).Infof("Address %v contains invalid data. podName %s, podNamespace %s, podIP %s. Skipping.",
+					epAddress, epAddress.TargetRef.Name, epAddress.TargetRef.Namespace, epAddress.IP)
+				continue // with the next address
+			}
+
+			// At this point, we should have found valid pod information + a port, so set them and return nil.
+			svcInfo.PodName = epAddress.TargetRef.Name
+			svcInfo.PodNamespace = epAddress.TargetRef.Namespace
+			svcInfo.PodIP = utilnet.ParseIPSloppy(epAddress.IP).String()
+			svcInfo.PodPort = podPort
+			klog.V(5).Infof("==> Got address and port information for service endpoint. podName: %s, podNamespace: %s, podIP: %s, podPort: %s",
+				svcInfo.PodName, svcInfo.PodNamespace, svcInfo.PodIP, svcInfo.PodPort)
+			return nil
+		}
+	}
+
+	return fmt.Errorf("could not extract pod and port information from endpoints for service %s in namespace %s.", svcInfo.SvcName, svcInfo.SvcNamespace)
+}
+
+// getPodInfo returns a pointer to a fully populated PodInfo struct, or error on failure.
 func getPodInfo(coreclient *corev1client.CoreV1Client, restconfig *rest.Config, podName string, ovnNamespace string, namespace string, cmd string) (podInfo *PodInfo, err error) {
-
-	var ethName string
-
-	// Get pod with the name supplied by srcPodName
+	// Create a PodInfo object with the base information already added, such as
+	// IP, PodName, ContainerName, NodeName, HostNetwork, Namespace, PrimaryInterfaceName
 	pod, err := coreclient.Pods(namespace).Get(context.TODO(), podName, metav1.GetOptions{})
 	if err != nil {
 		klog.V(1).Infof("Pod %s in namespace %s not found\n", podName, namespace)
 		return nil, err
 	}
-
 	podInfo = &PodInfo{
-		IP: utilnet.ParseIPSloppy(pod.Status.PodIP).String(),
+		IP:            utilnet.ParseIPSloppy(pod.Status.PodIP).String(),
+		PodName:       pod.Name,
+		ContainerName: pod.Spec.Containers[0].Name,
+		HostNetwork:   pod.Spec.HostNetwork,
+		PodNamespace:  pod.Namespace,
 	}
+	podInfo.NodeName = pod.Spec.NodeName
 
-	// Get the node on which the pod runs on
-	node, err := coreclient.Nodes().Get(context.TODO(), pod.Spec.NodeName, metav1.GetOptions{})
+	// Get the pod's ovnkubePod.
+	podInfo.OvnKubePodName, err = getOvnKubePodOnNode(coreclient, ovnNamespace, podInfo.NodeName)
 	if err != nil {
-		klog.V(1).Infof("Pod %s in namespace %s node not found\n", podName, namespace)
+		klog.V(1).Infof("Problem obtaining ovnkube pod name of Pod %s in namespace %s\n", podName, namespace)
 		return nil, err
 	}
-	klog.V(5).Infof("==>Got pod %s which is running on node %s\n", podName, node.Name)
 
-	podMAC, err := getPodMAC(coreclient, pod)
+	// Get the node's gateway mode
+	podInfo.RoutingViaHost, err = isRoutingViaHost(coreclient, restconfig, ovnNamespace, podInfo.OvnKubePodName, podInfo.NodeName)
+	if err != nil {
+		return nil, err
+	}
+
+	// Get the pod's MAC address.
+	podInfo.MAC, err = getPodMAC(coreclient, pod)
 	if err != nil {
 		klog.V(1).Infof("Problem obtaining Ethernet address of Pod %s in namespace %s\n", podName, namespace)
 		return nil, err
 	}
 
-	podInfo.PodName = pod.Name
-	podInfo.MAC = podMAC
-	podInfo.ContainerName = pod.Spec.Containers[0].Name
+	// Find rtos MAC (this is the pod's first hop router).
+	lspCmd := "ovn-nbctl " + cmd + " --bare --no-heading --column=mac list logical-router-port " + types.RouterToSwitchPrefix + podInfo.NodeName
+	ipOutput, ipError, err := execInPod(coreclient, restconfig, ovnNamespace, podInfo.OvnKubePodName, "ovnkube-node", lspCmd, "")
 
-	// Get pods in the openshift-ovn-kubernetes namespace
-	podsOvn, errOvn := coreclient.Pods(ovnNamespace).List(context.TODO(), metav1.ListOptions{})
-	if errOvn != nil {
-		klog.V(0).Infof("Cannot find pods in %s namespace", ovnNamespace)
-		return nil, errOvn
-	}
-
-	var ovnkubePod *kapi.Pod
-	// Find ovnkube-node-xxx pod running on the same node as Pod
-	for index := 0; index < len(podsOvn.Items); index++ {
-		podOvn := podsOvn.Items[index]
-		if podOvn.Spec.NodeName == node.Name {
-			if !strings.HasPrefix(podOvn.Name, "ovnkube-node-metrics") {
-				if strings.HasPrefix(podOvn.Name, "ovnkube-node") {
-					klog.V(5).Infof("==> pod %s is running on node %s", podOvn.Name, node.Name)
-					ovnkubePod = &podOvn
-					break
-				}
-			}
-		}
-	}
-	if ovnkubePod == nil {
-		klog.V(0).Infof("Cannot find ovnkube-node pod on node %s in namespace %s", node.Name, ovnNamespace)
-		err := fmt.Errorf("cannot find ovnkube-node pod on node %s in namespace %s", node.Name, ovnNamespace)
-		return nil, err
-	}
-
-	podInfo.OvnKubeContainerPodName = ovnkubePod.Name
-	podInfo.NodeName = ovnkubePod.Spec.NodeName
-
-	// The interface name used depends on what network namespasce the pod uses
-	if pod.Spec.HostNetwork {
-		ethName = util.GetLegacyK8sMgmtIntfName(node.Name)
-		podInfo.HostNetwork = true
-	} else {
-		ethName = "eth0"
-		podInfo.HostNetwork = false
-		ovsInterfaceInformation, err := getPodOvsInterfaceNameAndOfport(coreclient, restconfig, ovnNamespace, podInfo.OvnKubeContainerPodName, namespace+"_"+podInfo.PodName)
-		if err != nil {
-			return nil, err
-		}
-		podInfo.VethName = ovsInterfaceInformation.Name
-		podInfo.PortNum = ovsInterfaceInformation.Ofport
-	}
-	klog.V(5).Infof("Using interface name of %s with MAC of %s", ethName, podMAC)
-
-	// Find rtos MAC
-	klog.V(5).Infof("Command is: %s", "ovn-nbctl "+cmd+" --bare --no-heading --column=mac list logical-router-port "+"rtos-"+ovnkubePod.Spec.NodeName)
-	lspCmd := "ovn-nbctl " + cmd + " --bare --no-heading --column=mac list logical-router-port " + "rtos-" + ovnkubePod.Spec.NodeName
-	ipOutput, ipError, err := execInPod(coreclient, restconfig, ovnNamespace, ovnkubePod.Name, "ovnkube-node", lspCmd, "")
 	if err != nil {
-		fmt.Printf("execInPod() failed with %s stderr %s stdout %s \n", err, ipError, ipOutput)
-		klog.V(5).Infof("execInPod() failed err %s - podInfo %v - ovnkubePod Name %s", err, podInfo, ovnkubePod.Name)
-		return nil, err
+		return nil, fmt.Errorf("execInPod() failed. err: %s, stderr: %s, stdout: %s, podInfo: %v", err, ipError, ipOutput, podInfo)
 	}
 	podInfo.RtosMAC = strings.Replace(ipOutput, "\n", "", -1)
 
-	k8sMgmtIntfName := util.GetLegacyK8sMgmtIntfName(podInfo.NodeName)
-	if ethName == k8sMgmtIntfName {
-		podInfo.OVNName = types.K8sPrefix + ovnkubePod.Spec.NodeName
-		podInfo.VethName = "ovn-k8s-mp0"
-		klog.V(5).Infof("hostInterface on host stack OVN name is %s\n", podInfo.OVNName)
+	// Set information specific to ovn-k8s-mp0. This info is required for routingViaHost gateway mode traffic to an external IP
+	// destination.
+	podInfo.OvnK8sMp0PortName = types.K8sMgmtIntfName
+	portCmd := fmt.Sprintf("ovs-vsctl get Interface %s ofport", podInfo.OvnK8sMp0PortName)
+	localOutput, localError, err := execInPod(coreclient, restconfig, ovnNamespace, podInfo.OvnKubePodName, "ovnkube-node", portCmd, "")
+	if err != nil {
+		return nil, fmt.Errorf("execInPod() failed. err: %s, stderr: %s, stdout: %s, podInfo: %v", err, localError, localOutput, podInfo)
+	}
+	podInfo.OvnK8sMp0OfportNum = strings.Replace(localOutput, "\n", "", -1)
+
+	// Set information specific to host networked pods or non-host networked pods.
+	if podInfo.HostNetwork {
+		podInfo.PrimaryInterfaceName = util.GetLegacyK8sMgmtIntfName(podInfo.NodeName)
+		podInfo.K8sNodeNamePort = types.K8sPrefix + podInfo.NodeName
+		podInfo.VethName = podInfo.OvnK8sMp0PortName
+		podInfo.OfportNum = podInfo.OvnK8sMp0OfportNum
+	} else {
+		// Get the pod's interface information
+		ovsInterfaceInformation, err := getPodOvsInterfaceNameAndOfport(coreclient, restconfig, ovnNamespace, podInfo.OvnKubePodName, podInfo.FullyQualifiedPodName())
+		if err != nil {
+			return nil, err
+		}
+		podInfo.PrimaryInterfaceName = "eth0"
+		podInfo.VethName = ovsInterfaceInformation.Name
+		podInfo.OfportNum = ovsInterfaceInformation.Ofport
 	}
 
-	// ovs-vsctl get Interface [vethname] ofport
-	portCmd := "ovs-vsctl get Interface " + podInfo.VethName + " ofport"
-	klog.V(5).Infof("Command is: %s", portCmd)
-	portOutput, portError, err := execInPod(coreclient, restconfig, ovnNamespace, ovnkubePod.Name, "ovnkube-node", portCmd, "")
+	podInfo.NodeExternalBridgeName, err = getNodeExternalBridgeName(coreclient, restconfig, ovnNamespace, podInfo.OvnKubePodName, cmd, podInfo.NodeName)
 	if err != nil {
-		fmt.Printf("execInPod() failed with %s stderr %s stdout %s \n", err, portError, portOutput)
-		klog.V(5).Infof("execInPod() failed err %s - podInfo %v - ovnkubePod Name %s", err, podInfo, ovnkubePod.Name)
 		return nil, err
 	}
-	podInfo.PortNum = strings.Replace(portOutput, "\n", "", -1)
-
-	// ovs-vsctl get Interface ovn-k8s-mp0 ofport
-	portCmd = "ovs-vsctl get Interface " + "ovn-k8s-mp0" + " ofport"
-	klog.V(5).Infof("Command is: %s", portCmd)
-	localOutput, localError, err := execInPod(coreclient, restconfig, ovnNamespace, ovnkubePod.Name, "ovnkube-node", portCmd, "")
-	if err != nil {
-		fmt.Printf("execInPod() failed with %s stderr %s stdout %s \n", err, localError, localOutput)
-		klog.V(5).Infof("execInPod() failed err %s - podInfo %v - ovnkubePod Name %s", err, podInfo, ovnkubePod.Name)
-		return nil, err
-	}
-	podInfo.LocalNum = strings.Replace(localOutput, "\n", "", -1)
 
 	return podInfo, err
 }
 
+// getNodeExternalBridgeName gets the name of the external bridge of this node, e.g. breth0 or br-ex.
+func getNodeExternalBridgeName(coreclient *corev1client.CoreV1Client, restconfig *rest.Config, ovnNamespace, podName, nbcmd, nodeName string) (string, error) {
+	cmd := "ovn-nbctl " + nbcmd + " --bare --no-heading --column=name find Logical_Switch_Port options:network_name=" + types.PhysicalNetworkName
+	stdout, stderr, err := execInPod(coreclient, restconfig, ovnNamespace, podName, "ovnkube-node", cmd, "")
+	if err != nil {
+		return "", fmt.Errorf("execInPod() failed with %s stderr %s stdout %s \n", err, stderr, stdout)
+	}
+	scanner := bufio.NewScanner(strings.NewReader(stdout))
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.Contains(line, "_"+nodeName) {
+			splitLine := strings.Split(scanner.Text(), "_")
+			if len(splitLine) == 2 {
+				return splitLine[0], nil
+			}
+		}
+	}
+	return "", fmt.Errorf("could not find external bridge for node %s in getNodeBridgeName()", nodeName)
+}
+
+// getOvnNamespace searches all namespaces for pods with the label selector app=ovnkube-node.
+// If it can find such pods, it returns the namespace that they reside in, or error otherwise.
 func getOvnNamespace(coreclient *corev1client.CoreV1Client, override string) (string, error) {
 	if override != "" {
 		return override, nil
@@ -393,7 +531,7 @@ func getOvnNamespace(coreclient *corev1client.CoreV1Client, override string) (st
 	}
 	pods, err := coreclient.Pods("").List(context.TODO(), listOptions)
 	if err != nil || len(pods.Items) == 0 {
-		klog.V(0).Infof("Cannot find ovnkube pods in any namespace")
+		klog.Infof("Cannot find ovnkube pods in any namespace")
 		return "", err
 	}
 
@@ -458,130 +596,190 @@ func getDatabaseURIs(coreclient *corev1client.CoreV1Client, restconfig *rest.Con
 	return nbAddress, sbAddress, protocol == "ssl", nil
 }
 
-var (
-	level klog.Level
-)
-
-func main() {
-	var pcfgNamespace *string
-	var psrcNamespace *string
-	var pdstNamespace *string
-	var protocol string
-	var ovnNamespace string
-	var err error
-
-	pcfgNamespace = flag.String("ovn-config-namespace", "", "namespace used by ovn-config itself")
-	psrcNamespace = flag.String("src-namespace", "default", "k8s namespace of source pod")
-	pdstNamespace = flag.String("dst-namespace", "default", "k8s namespace of dest pod")
-
-	cliConfig := flag.String("kubeconfig", "", "absolute path to the kubeconfig file")
-
-	srcPodName := flag.String("src", "", "src: source pod name")
-	dstPodName := flag.String("dst", "", "dest: destination pod name")
-	dstSvcName := flag.String("service", "", "service: destination service name")
-	dstPort := flag.String("dst-port", "80", "dst-port: destination port")
-	tcp := flag.Bool("tcp", false, "use tcp transport protocol")
-	udp := flag.Bool("udp", false, "use udp transport protocol")
-	loglevel := flag.String("loglevel", "0", "loglevel: klog level")
-
-	flag.Parse()
-
-	klog.InitFlags(nil)
-	klog.SetOutput(os.Stderr)
-	err = level.Set(*loglevel)
+// printSuccessOrFailure will print a success or failure message. If searchString is set, then we expect to find a match for the
+// regexp given in searchString.
+func printSuccessOrFailure(commandDescription, src, dst, commandStdout, commandStderr string, err error, searchString string) {
 	if err != nil {
-		fmt.Printf("fatal: cannot set logging level\n")
-		os.Exit(-1)
+		klog.Exitf("%s error %v stdOut: %s\n stdErr: %s", commandDescription, err, commandStdout, commandStderr)
 	}
-	klog.V(0).Infof("Log level set to: %s", *loglevel)
+	klog.V(2).Infof("%s Output:\n%s%s%s\n", commandDescription, italic, commandStdout, reset)
 
-	srcNamespace := *psrcNamespace
-	dstNamespace := *pdstNamespace
-
-	if *srcPodName == "" {
-		fmt.Printf("Usage: source pod must be specified\n")
-		klog.V(1).Infof("Usage: source pod must be specified")
-		os.Exit(-1)
-	}
-	if !*tcp && !*udp {
-		fmt.Printf("Usage: either tcp or udp must be specified\n")
-		klog.V(1).Infof("Usage: either tcp or udp must be specified")
-		os.Exit(-1)
-	}
-	if *udp && *tcp {
-		fmt.Printf("Usage: Both tcp or udp cannot be specified\n")
-		klog.V(1).Infof("Usage: Both tcp or udp cannot be specified")
-		os.Exit(-1)
-	}
-	if *tcp {
-		if *dstSvcName == "" && *dstPodName == "" {
-			fmt.Printf("Usage: destination pod or destination service must be specified for tcp\n")
-			klog.V(1).Infof("Usage: destination pod or destination service must be specified for tcp")
-			os.Exit(-1)
-		} else {
-			protocol = "tcp"
-		}
-	}
-	if *udp {
-		if *dstPodName == "" {
-			fmt.Printf("Usage: destination pod must be specified for udp\n")
-			klog.V(1).Infof("Usage: destination pod must be specified for udp")
-			os.Exit(-1)
-		} else {
-			protocol = "udp"
-		}
-	}
-
-	var restconfig *rest.Config
-
-	// This might work better?  https://godoc.org/sigs.k8s.io/controller-runtime/pkg/client/config
-
-	// When supplied the kubeconfig supplied via cli takes precedence
-	if *cliConfig != "" {
-
-		// use the current context in kubeconfig
-		restconfig, err = clientcmd.BuildConfigFromFlags("", *cliConfig)
+	if searchString != "" {
+		match, err := regexp.MatchString(searchString, commandStdout)
 		if err != nil {
-			klog.V(1).Infof(" Unexpected error: %v", err)
+			klog.Exitf("Unexpected failure matching regex '%s' to commandStdout '%s', err: %s", searchString, commandStdout, err)
+		}
+		if match {
+			// Write the result to stdout.
+			fmt.Printf("%s%s%s indicates success from %s to %s%s\n", green, bold, commandDescription, src, dst, reset)
+			// Log further info on log level 1.
+			klog.V(1).Infof("%sSearch string matched:\n%s%s\n", green, searchString, reset)
+		} else {
+			// Write the result to stdout.
+			fmt.Printf("%s%s%s indicates failure from %s to %s%s\n", red, bold, commandDescription, src, dst, reset)
+			// Log further info on log level 1.
+			klog.V(1).Infof("%sSearch string not matched:\n%s%s\n", red, searchString, reset)
 			os.Exit(-1)
 		}
 	} else {
+		// Write the result to stdout.
+		fmt.Printf("%s%s%s indicates success from %s to %s%s\n", green, bold, commandDescription, src, dst, reset)
+	}
+}
 
-		// Instantiate loader for kubeconfig file.
-		kubeconfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
-			clientcmd.NewDefaultClientConfigLoadingRules(),
-			&clientcmd.ConfigOverrides{},
-		)
+// runOvnTraceToService runs an ovntrace from src pod to dst service. If dstSvcInfo == nil, then skip all steps.
+func runOvnTraceToService(coreclient *corev1client.CoreV1Client, restconfig *rest.Config, srcPodInfo *PodInfo, dstSvcInfo *SvcInfo, sbcmd, ovnNamespace, protocol, dstPort string) {
+	var inport string
+	inport = srcPodInfo.FullyQualifiedPodName()
+	if srcPodInfo.HostNetwork {
+		inport = srcPodInfo.K8sNodeNamePort
+	}
+	cmd := fmt.Sprintf(`ovn-trace %[1]s %[2]s --ct=new `+
+		`'inport=="%[3]s" && eth.src==%[4]s && eth.dst==%[5]s && %[6]s.src==%[7]s && %[8]s.dst==%[9]s && ip.ttl==64 && %[10]s.dst==%[11]s && %[10]s.src==52888' --lb-dst %[12]s:%[13]s`,
+		sbcmd,                 // 1
+		srcPodInfo.NodeName,   // 2
+		inport,                // 3
+		srcPodInfo.MAC,        // 4
+		srcPodInfo.RtosMAC,    // 5
+		srcPodInfo.getL3Ver(), // 6
+		srcPodInfo.IP,         // 7
+		dstSvcInfo.getL3Ver(), // 8
+		dstSvcInfo.ClusterIP,  // 9
+		protocol,              // 10
+		dstPort,               // 11
+		dstSvcInfo.PodIP,      // 12
+		dstSvcInfo.PodPort,    // 13
+	)
+	klog.V(4).Infof("ovn-trace command from src to service clusterIP is %s", cmd)
 
-		// Get a rest.Config from the kubeconfig file.  This will be passed into all
-		// the client objects we create.
-		restconfig, err = kubeconfig.ClientConfig()
+	ovnSrcDstOut, ovnSrcDstErr, err := execInPod(coreclient, restconfig, ovnNamespace, srcPodInfo.OvnKubePodName, "ovnkube-node", cmd, "")
+	successString := fmt.Sprintf(`output to "%s"`, dstSvcInfo.FullyQualifiedPodName())
+	printSuccessOrFailure("ovn-trace from source pod to service clusterIP", srcPodInfo.PodName, dstSvcInfo.SvcName, ovnSrcDstOut, ovnSrcDstErr, err, successString)
+}
+
+// runOvnTraceToPod runs an ovntrace from src pod to dst pod.
+func runOvnTraceToPod(coreclient *corev1client.CoreV1Client, restconfig *rest.Config, direction string, srcPodInfo, dstPodInfo *PodInfo, sbcmd, ovnNamespace, protocol, dstPort string) {
+	var inport string
+	inport = srcPodInfo.FullyQualifiedPodName()
+	if srcPodInfo.HostNetwork {
+		inport = srcPodInfo.K8sNodeNamePort
+	}
+	cmd := fmt.Sprintf(`ovn-trace %[1]s %[2]s `+
+		`'inport=="%[3]s" && eth.src==%[4]s && eth.dst==%[5]s && %[6]s.src==%[7]s && %[8]s.dst==%[9]s && ip.ttl==64 && %[10]s.dst==%[11]s && %[10]s.src==52888'`,
+		sbcmd,                 // 1
+		srcPodInfo.NodeName,   // 2
+		inport,                // 3
+		srcPodInfo.MAC,        // 4
+		srcPodInfo.RtosMAC,    // 5
+		srcPodInfo.getL3Ver(), // 6
+		srcPodInfo.IP,         // 7
+		dstPodInfo.getL3Ver(), // 8
+		dstPodInfo.IP,         // 9
+		protocol,              // 10
+		dstPort,               // 11
+	)
+	klog.V(4).Infof("ovn-trace command from %s is %s", direction, cmd)
+
+	var successString string
+	if dstPodInfo.HostNetwork {
+		// OVN will get as far as this sending node (the src node).
+		// routingViaHost gateway mode or if both pods are on the same node example: k8s-ovn-worker.
+		// routingViaOVN gateway mode example: "breth0_ovn-worker2.
+		if srcPodInfo.RoutingViaHost || srcPodInfo.NodeName == dstPodInfo.NodeName {
+			successString = fmt.Sprintf(`output to "%s%s"`, types.K8sPrefix, srcPodInfo.NodeName)
+		} else {
+			successString = fmt.Sprintf(`output to "%s_%s"`, srcPodInfo.NodeExternalBridgeName, srcPodInfo.NodeName)
+		}
+	} else {
+		successString = fmt.Sprintf(`output to "%s"`, dstPodInfo.FullyQualifiedPodName())
+	}
+	ovnSrcDstOut, ovnSrcDstErr, err := execInPod(coreclient, restconfig, ovnNamespace, srcPodInfo.OvnKubePodName, "ovnkube-node", cmd, "")
+	printSuccessOrFailure("ovn-trace "+direction, srcPodInfo.PodName, dstPodInfo.PodName, ovnSrcDstOut, ovnSrcDstErr, err, successString)
+}
+
+// runOfprotoTraceToPod runs an ofproto/trace command from the src to the destination pod.
+func runOfprotoTraceToPod(coreclient *corev1client.CoreV1Client, restconfig *rest.Config, direction string, srcPodInfo, dstPodInfo *PodInfo, ovnNamespace, protocol, dstPort string) string {
+	cmd := fmt.Sprintf(`ovs-appctl ofproto/trace br-int `+
+		`"in_port=%[1]s, %[2]s, dl_src=%[3]s, dl_dst=%[4]s, nw_src=%[5]s, nw_dst=%[6]s, nw_ttl=64, %[7]s_dst=%[8]s, %[7]s_src=12345"`,
+		srcPodInfo.VethName, // 1
+		protocol,            // 2
+		srcPodInfo.MAC,      // 3
+		srcPodInfo.RtosMAC,  // 4
+		srcPodInfo.IP,       // 5
+		dstPodInfo.IP,       // 6
+		protocol,            // 7
+		dstPort,             // 8
+	)
+	klog.V(4).Infof("ovs-appctl ofproto/trace command from %s is %s", direction, cmd)
+
+	var successString string
+	if srcPodInfo.NodeName == dstPodInfo.NodeName {
+		klog.V(5).Infof("Pods are on the same node %s", dstPodInfo.NodeName)
+		// trace will end at the ovs port number of the dest pod
+		successString = "output:" + dstPodInfo.OfportNum + "\n\nFinal flow:"
+	} else if dstPodInfo.HostNetwork {
+		klog.V(5).Infof("Pod %s is on host network on node %s", dstPodInfo.PodName, dstPodInfo.NodeName)
+		// Different paths for routingViaHost gateway mode and routingViaOVN gateway mode.
+		// Trace will end at the ovs port number of the management port of this sending node for routingViaHost gateway mode.
+		// For routingViaOVN gateway mode, we will simply look for an SNAT.
+		if !srcPodInfo.RoutingViaHost {
+			successString = `ct\(.*,nat`
+		} else {
+			successString = fmt.Sprintf(`output:%s\n\nFinal flow:`, srcPodInfo.OvnK8sMp0OfportNum)
+		}
+	} else {
+		klog.V(5).Infof("Pods are on node: %s and node %s", srcPodInfo.NodeName, dstPodInfo.NodeName)
+		successString = "-> output to kernel tunnel"
+	}
+	appSrcDstOut, appSrcDstErr, err := execInPod(coreclient, restconfig, ovnNamespace, srcPodInfo.OvnKubePodName, "ovnkube-node", cmd, "")
+	printSuccessOrFailure("ovs-appctl ofproto/trace "+direction, srcPodInfo.PodName, dstPodInfo.PodName, appSrcDstOut, appSrcDstErr, err, successString)
+
+	return appSrcDstOut
+}
+
+// installOvnDetraceDependencies installs dependencies for ovn-detrace with pip3 in case they are missing (for older images).
+func installOvnDetraceDependencies(coreclient *corev1client.CoreV1Client, restconfig *rest.Config, podName, ovnNamespace string) {
+	dependencies := map[string]string{
+		"ovs":       "if type -p ovn-detrace >/dev/null 2>&1; then echo 'true' ; fi",
+		"pyOpenSSL": "if rpm -qa | egrep -q python3-pyOpenSSL; then echo 'true'; fi",
+	}
+	for dependency, dependencyCmd := range dependencies {
+		depVerifyOut, depVerifyErr, err := execInPod(coreclient, restconfig, ovnNamespace, podName, "ovnkube-node", dependencyCmd, "")
 		if err != nil {
-			klog.V(1).Infof(" Unexpected error: %v", err)
-			os.Exit(-1)
+			klog.Exitf("Dependency verification error in pod %s, container %s. Error '%v', stdOut: '%s'\n stdErr: %s", podName, "ovnkube-node", err, depVerifyOut, depVerifyErr)
+		}
+		trueFalse := strings.TrimSuffix(depVerifyOut, "\n")
+		klog.V(10).Infof("Dependency check '%s' in pod '%s', container '%s' yielded '%s'", dependencyCmd, podName, "ovnkube-node", trueFalse)
+		if trueFalse != "true" {
+			installCmd := "pip3 install " + dependency
+			depInstallOut, depInstallErr, err := execInPod(coreclient, restconfig, ovnNamespace, podName, "ovnkube-node", installCmd, "")
+			if err != nil {
+				klog.Exitf("ovn-detrace error in pod %s, container %s. Error '%v', stdOut: '%s'\n stdErr: %s", podName, "ovnkube-node", err, depInstallOut, depInstallErr)
+			}
+			klog.V(1).Infof("Install ovn-detrace Output: %s\n", depInstallOut)
 		}
 	}
+}
 
-	// Create a Kubernetes core/v1 client.
-	coreclient, err := corev1client.NewForConfig(restconfig)
-	if err != nil {
-		klog.V(1).Infof(" Unexpected error: %v", err)
-		os.Exit(-1)
-	}
+// runOvnDetrace runs an ovn-detrace command for the given input.
+func runOvnDetrace(coreclient *corev1client.CoreV1Client, restconfig *rest.Config, direction string, srcPodInfo *PodInfo, dstName string, appSrcDstOut, ovnNamespace, nbUri, sbUri, sslCertKeys string) {
+	cmd := fmt.Sprintf(`ovn-detrace --ovnnb=%[1]s --ovnsb=%[2]s %[3]s --ovsdb=unix:/var/run/openvswitch/db.sock`,
+		nbUri,       // 1
+		sbUri,       // 2
+		sslCertKeys, // 3
+	)
+	klog.V(4).Infof("ovn-detrace command from %s is %s", direction, cmd)
 
-	// Get OVN Namespace
-	ovnNamespace, err = getOvnNamespace(coreclient, *pcfgNamespace)
-	if err != nil {
-		klog.V(1).Infof(" Unexpected error: %v", err)
-		os.Exit(-1)
-	}
-	klog.V(5).Infof("OVN Kubernetes namespace is %s", ovnNamespace)
+	dtraceSrcDstOut, dtraceSrcDstErr, err := execInPod(coreclient, restconfig, ovnNamespace, srcPodInfo.OvnKubePodName, "ovnkube-node", cmd, appSrcDstOut)
+	printSuccessOrFailure("ovn-detrace "+direction, srcPodInfo.PodName, dstName, dtraceSrcDstOut, dtraceSrcDstErr, err, "")
+}
 
+// displayNodeInfo shows a summary about nodes in this cluster.
+func displayNodeInfo(coreclient *corev1client.CoreV1Client) {
 	// List all Nodes.
 	nodes, err := coreclient.Nodes().List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
-		klog.V(1).Infof(" Unexpected error: %v", err)
-		os.Exit(-1)
+		klog.Exitf(" Unexpected error: %v", err)
 	}
 
 	masters := make(map[string]string)
@@ -593,7 +791,6 @@ func main() {
 		// https://github.com/kubernetes/kubernetes/pull/107533
 		_, foundMaster := node.Labels["node-role.kubernetes.io/master"]
 		_, foundControlPlane := node.Labels["node-role.kubernetes.io/control-plane"]
-
 		if foundMaster || foundControlPlane {
 			klog.V(5).Infof("  Name: %s is a master", node.Name)
 			for _, s := range node.Status.Addresses {
@@ -620,345 +817,178 @@ func main() {
 	if len(masters) < 3 {
 		klog.V(5).Infof("Cluster does not have 3 masters, found %d", len(masters))
 	}
+}
+
+// setLogLevel sets the log level for this application.
+func setLogLevel(loglevel string) {
+	klog.InitFlags(nil)
+	klog.SetOutput(os.Stderr)
+	err := level.Set(loglevel)
+	if err != nil {
+		klog.Exitf("fatal: cannot set logging level\n")
+	}
+	klog.V(1).Infof("Log level set to: %s", loglevel)
+}
+
+func main() {
+	var protocol string
+	var err error
+
+	// Parse CLI flags.
+	cliConfig := flag.String("kubeconfig", "", "absolute path to the kubeconfig file")
+	cfgNamespace := flag.String("ovn-config-namespace", "", "namespace used by ovn-config itself")
+	srcNamespace := flag.String("src-namespace", "default", "k8s namespace of source pod")
+	dstNamespace := flag.String("dst-namespace", "default", "k8s namespace of dest pod")
+	srcPodName := flag.String("src", "", "src: source pod name")
+	dstPodName := flag.String("dst", "", "dest: destination pod name")
+	dstSvcName := flag.String("service", "", "service: destination service name")
+	dstPort := flag.String("dst-port", "80", "dst-port: destination port")
+	tcp := flag.Bool("tcp", false, "use tcp transport protocol")
+	udp := flag.Bool("udp", false, "use udp transport protocol")
+	loglevel := flag.String("loglevel", "0", "loglevel: klog level")
+	flag.Parse()
+
+	// Set the application's log level.
+	setLogLevel(*loglevel)
+
+	// Verify CLI flags.
+	if *srcPodName == "" {
+		klog.Exitf("Usage: source pod must be specified")
+	}
+	if !*tcp && !*udp {
+		klog.Exitf("Usage: either tcp or udp must be specified")
+	}
+	if *udp && *tcp {
+		klog.Exitf("Usage: Both tcp and udp cannot be specified at the same time")
+	}
+	if *tcp {
+		protocol = "tcp"
+	}
+	if *udp {
+		if *dstSvcName != "" {
+			klog.Exitf("Usage: udp option is not compatible with destination service trace")
+		}
+		protocol = "udp"
+	}
+	targetOptions := 0
+	if *dstPodName != "" {
+		targetOptions++
+	}
+	if *dstSvcName != "" {
+		targetOptions++
+	}
+	if targetOptions != 1 {
+		klog.Exitf("Usage: exactly one of -dst, -service must be set")
+	}
+
+	// Get the ClientConfig.
+	// This might work better?  https://godoc.org/sigs.k8s.io/controller-runtime/pkg/client/config
+	// When supplied the kubeconfig supplied via cli takes precedence
+	var restconfig *rest.Config
+	if *cliConfig != "" {
+		// use the current context in kubeconfig
+		restconfig, err = clientcmd.BuildConfigFromFlags("", *cliConfig)
+		if err != nil {
+			klog.Exitf(" Unexpected error: %v", err)
+		}
+	} else {
+		// Instantiate loader for kubeconfig file.
+		kubeconfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+			clientcmd.NewDefaultClientConfigLoadingRules(),
+			&clientcmd.ConfigOverrides{},
+		)
+
+		// Get a rest.Config from the kubeconfig file.  This will be passed into all
+		// the client objects we create.
+		restconfig, err = kubeconfig.ClientConfig()
+		if err != nil {
+			klog.Exitf(" Unexpected error: %v", err)
+		}
+	}
+
+	// Create a Kubernetes core/v1 client.
+	coreclient, err := corev1client.NewForConfig(restconfig)
+	if err != nil {
+		klog.Exitf(" Unexpected error: %v", err)
+	}
+
+	// Get the namespace that OVN pods reside in.
+	ovnNamespace, err := getOvnNamespace(coreclient, *cfgNamespace)
+	if err != nil {
+		klog.Exitf(" Unexpected error: %v", err)
+	}
+	klog.V(5).Infof("OVN Kubernetes namespace is %s", ovnNamespace)
+
+	// Show some information about the nodes in this cluster - only if log level 5 or higher.
+	if lvl, err := strconv.Atoi(*loglevel); err == nil && lvl >= 5 {
+		displayNodeInfo(coreclient)
+	}
 
 	// Common ssl parameters
 	var sslCertKeys string
 	nbUri, sbUri, useSSL, err := getDatabaseURIs(coreclient, restconfig, ovnNamespace)
 	if err != nil {
-		fmt.Printf("Failed to get database URIs: %v\n", err)
-		os.Exit(-1)
+		klog.Exitf("Failed to get database URIs: %v\n", err)
 	}
-
 	if useSSL {
 		sslCertKeys = "-p /ovn-cert/tls.key -c /ovn-cert/tls.crt -C /ovn-ca/ca-bundle.crt "
 	} else {
 		sslCertKeys = " "
 	}
-
 	nbcmd := sslCertKeys + "--db " + nbUri
 	klog.V(5).Infof("The nbcmd is %s", nbcmd)
-
 	sbcmd := sslCertKeys + "--db " + sbUri
 	klog.V(5).Infof("The sbcmd is %s", sbcmd)
 
 	// Get info needed for the src Pod
-	srcPodInfo, err := getPodInfo(coreclient, restconfig, *srcPodName, ovnNamespace, srcNamespace, nbcmd)
+	srcPodInfo, err := getPodInfo(coreclient, restconfig, *srcPodName, ovnNamespace, *srcNamespace, nbcmd)
 	if err != nil {
-		fmt.Printf("Failed to get information from pod %s: %v\n", *srcPodName, err)
-		klog.V(1).Infof("Failed to get information from pod %s: %v", *srcPodName, err)
-		os.Exit(-1)
+		klog.Exitf("Failed to get information from pod %s: %v", *srcPodName, err)
 	}
-	klog.V(5).Infof("srcPodInfo is %v", srcPodInfo)
+	klog.V(5).Infof("srcPodInfo is %s\n", srcPodInfo)
 
+	// Get destination service information if a destination service name was provided.
+	klog.V(5).Infof("Running a trace to a cluster local svc or to another pod")
 	var dstSvcInfo *SvcInfo
-
-	// Get destination service if there is one
 	if *dstSvcName != "" {
-		//Get dst servcie
-		dstSvcInfo, err = getSvcInfo(coreclient, restconfig, *dstSvcName, ovnNamespace, dstNamespace, nbcmd)
+		// Get dst service
+		dstSvcInfo, err = getSvcInfo(coreclient, restconfig, *dstSvcName, ovnNamespace, *dstNamespace, nbcmd)
 		if err != nil {
-			fmt.Printf("Failed to get information from service %s: %v\n", *dstSvcName, err)
-			klog.V(1).Infof("Failed to get information from service %s: %v", *dstSvcName, err)
-			os.Exit(-1)
+			klog.Exitf("Failed to get information from service %s: %v", *dstSvcName, err)
 		}
-
-		// ovn-trace from src pod to clusterIP of ther service
-
-		var fromSrc string
-
-		if srcPodInfo.HostNetwork {
-			fromSrc = " 'inport==\"" + srcPodInfo.OVNName + "\""
-		} else {
-			fromSrc = " 'inport==\"" + srcNamespace + "_" + *srcPodName + "\""
-		}
-		fromSrc += " && eth.dst==" + srcPodInfo.RtosMAC
-		fromSrc += " && eth.src==" + srcPodInfo.MAC
-		fromSrc += fmt.Sprintf(" && %s.dst==%s", dstSvcInfo.getL3Ver(), dstSvcInfo.IP)
-		fromSrc += fmt.Sprintf(" && %s.src==%s", srcPodInfo.getL3Ver(), srcPodInfo.IP)
-		fromSrc += " && ip.ttl==64"
-		fromSrc += " && " + protocol + ".dst==" + *dstPort + " && " + protocol + ".src==52888'"
-		fromSrc += " --lb-dst " + dstSvcInfo.PodIP + ":" + dstSvcInfo.PodPort
-
-		fromSrcCmd := "ovn-trace " + sbcmd + " " + srcPodInfo.NodeName + " " + "--ct=new " + fromSrc
-
-		klog.V(5).Infof("ovn-trace command from src to service cluserIP is %s", fromSrcCmd)
-		ovnSrcDstOut, ovnSrcDstErr, err := execInPod(coreclient, restconfig, ovnNamespace, srcPodInfo.OvnKubeContainerPodName, "ovnkube-node", fromSrcCmd, "")
-		if err != nil {
-			klog.V(1).Infof("Source to Destination ovn-trace error %v stdOut: %s\n stdErr: %s", err, ovnSrcDstOut, ovnSrcDstErr)
-			os.Exit(-1)
-		}
-		klog.V(2).Infof("Source to service clusterIP  ovn-trace Output: %s\n", ovnSrcDstOut)
-
-		successString := "output to \"" + dstSvcInfo.PodNamespace + "_" + dstSvcInfo.PodName + "\""
-		if strings.Contains(ovnSrcDstOut, successString) {
-			fmt.Printf("ovn-trace indicates success from %s to %s - matched on %s\n", *srcPodName, *dstSvcName, successString)
-			klog.V(0).Infof("ovn-trace indicates success from %s to %s - matched on %s\n", *srcPodName, *dstSvcName, successString)
-		} else {
-			fmt.Printf("ovn-trace indicates failure from %s to %s - %s not matched\n", *srcPodName, *dstSvcName, successString)
-			klog.V(0).Infof("ovn-trace indicates failure from %s to %s - %s not matched\n", *srcPodName, *dstSvcName, successString)
-			os.Exit(-1)
-		}
-
-		// set dst pod name, we'll use this to run through pod-pod tests as if use supplied this pod
+		klog.V(5).Infof("dstSvcInfo is %s\n", dstSvcInfo)
+		// Set dst pod name, we'll use this to run through pod-pod tests as if use supplied this pod
 		*dstPodName = dstSvcInfo.PodName
-		fmt.Printf("using pod %s in service %s to test against\n", dstSvcInfo.PodName, *dstSvcName)
-		klog.V(1).Infof("Using pod %s in service %s to test against\n", dstSvcInfo.PodName, *dstSvcName)
+		klog.V(1).Infof("Using pod %s in service %s to test against", dstSvcInfo.PodName, *dstSvcName)
 	}
 
-	//Now get info needed for the dst Pod
-	dstPodInfo, err := getPodInfo(coreclient, restconfig, *dstPodName, ovnNamespace, dstNamespace, nbcmd)
+	// Now get info needed for the dst Pod
+	dstPodInfo, err := getPodInfo(coreclient, restconfig, *dstPodName, ovnNamespace, *dstNamespace, nbcmd)
 	if err != nil {
-		fmt.Printf("Failed to get information from pod %s: %v\n", *dstPodName, err)
-		klog.V(1).Infof("Failed to get information from pod %s: %v", *dstPodName, err)
-		os.Exit(-1)
+		klog.Exitf("Failed to get information from pod %s: %v", *dstPodName, err)
 	}
-	klog.V(5).Infof("dstPodInfo is %v\n", dstPodInfo)
-
-	podsOnSameNode := false
-	if srcPodInfo.NodeName == dstPodInfo.NodeName {
-		podsOnSameNode = true
-	}
+	klog.V(5).Infof("dstPodInfo is %s\n", dstPodInfo)
 
 	// At least one pod must not be on the Host Network
 	if srcPodInfo.HostNetwork && dstPodInfo.HostNetwork {
-		fmt.Printf("Both pods cannot be on Host Network; use ping\n")
-		os.Exit(-1)
+		klog.Exitf("Both pods cannot be on Host Network; use ping")
 	}
 
-	// ovn-trace from src pod to dst pod
-
-	var fromSrc string
-
-	if srcPodInfo.HostNetwork {
-		fromSrc = " 'inport==\"" + srcPodInfo.OVNName + "\""
-	} else {
-		fromSrc = " 'inport==\"" + srcNamespace + "_" + *srcPodName + "\""
+	// ovn-trace commands
+	if dstSvcInfo != nil {
+		runOvnTraceToService(coreclient, restconfig, srcPodInfo, dstSvcInfo, sbcmd, ovnNamespace, protocol, *dstPort)
 	}
-	fromSrc += " && eth.dst==" + srcPodInfo.RtosMAC
-	fromSrc += " && eth.src==" + srcPodInfo.MAC
-	fromSrc += fmt.Sprintf(" && %s.dst==%s", dstPodInfo.getL3Ver(), dstPodInfo.IP)
-	fromSrc += fmt.Sprintf(" && %s.src==%s", srcPodInfo.getL3Ver(), srcPodInfo.IP)
-	fromSrc += " && ip.ttl==64"
-	fromSrc += " && " + protocol + ".dst==" + *dstPort + " && " + protocol + ".src==52888'"
+	runOvnTraceToPod(coreclient, restconfig, "source pod to destination pod", srcPodInfo, dstPodInfo, sbcmd, ovnNamespace, protocol, *dstPort)
+	runOvnTraceToPod(coreclient, restconfig, "destination pod to source pod", dstPodInfo, srcPodInfo, sbcmd, ovnNamespace, protocol, *dstPort)
 
-	fromSrcCmd := "ovn-trace " + sbcmd + " " + srcPodInfo.NodeName + " " + fromSrc
+	// ovs-appctl ofproto/trace commands
+	appSrcDstOut := runOfprotoTraceToPod(coreclient, restconfig, "source pod to destination pod", srcPodInfo, dstPodInfo, ovnNamespace, protocol, *dstPort)
+	appDstSrcOut := runOfprotoTraceToPod(coreclient, restconfig, "destination pod to source pod", dstPodInfo, srcPodInfo, ovnNamespace, protocol, *dstPort)
 
-	klog.V(5).Infof("ovn-trace command from src to dst is %s", fromSrcCmd)
-	ovnSrcDstOut, ovnSrcDstErr, err := execInPod(coreclient, restconfig, ovnNamespace, srcPodInfo.OvnKubeContainerPodName, "ovnkube-node", fromSrcCmd, "")
-	if err != nil {
-		klog.V(1).Infof("Source to Destination ovn-trace error %v stdOut: %s\n stdErr: %s", err, ovnSrcDstOut, ovnSrcDstErr)
-		os.Exit(-1)
-	}
-	klog.V(2).Infof("Source to Destination ovn-trace Output: %s\n", ovnSrcDstOut)
-
-	var successString string
-	if dstPodInfo.HostNetwork {
-		// OVN will get as far as this sending node (the src node)
-		successString = "output to \"" + types.K8sPrefix + srcPodInfo.NodeName + "\""
-	} else {
-		successString = "output to \"" + dstNamespace + "_" + *dstPodName + "\""
-	}
-	if strings.Contains(ovnSrcDstOut, successString) {
-		fmt.Printf("ovn-trace indicates success from %s to %s - matched on %s\n", *srcPodName, *dstPodName, successString)
-		klog.V(0).Infof("ovn-trace indicates success from %s to %s - matched on %s\n", *srcPodName, *dstPodName, successString)
-	} else {
-		fmt.Printf("ovn-trace indicates failure from %s to %s - %s not matched\n", *srcPodName, *dstPodName, successString)
-		klog.V(0).Infof("ovn-trace indicates failure from %s to %s - %s not matched\n", *srcPodName, *dstPodName, successString)
-		os.Exit(-1)
-	}
-
-	// Trace from dst pod to src pod
-
-	var fromDst string
-
-	//fromDst := " 'inport==\"" + namespace + "_" + *dstPodName + "\""
-	if dstPodInfo.HostNetwork {
-		fromDst = " 'inport==\"" + dstPodInfo.OVNName + "\""
-	} else {
-		fromDst = " 'inport==\"" + dstNamespace + "_" + *dstPodName + "\""
-	}
-	fromDst += " && eth.dst==" + dstPodInfo.RtosMAC
-	fromDst += " && eth.src==" + dstPodInfo.MAC
-	fromDst += fmt.Sprintf(" && %s.dst==%s", srcPodInfo.getL3Ver(), srcPodInfo.IP)
-	fromDst += fmt.Sprintf(" && %s.src==%s", dstPodInfo.getL3Ver(), dstPodInfo.IP)
-	fromDst += " && ip.ttl==64"
-	fromDst += " && " + protocol + ".src==" + *dstPort + " && " + protocol + ".dst==52888'"
-
-	fromDstCmd := "ovn-trace " + sbcmd + " " + dstPodInfo.NodeName + " " + fromDst
-
-	klog.V(5).Infof("ovn-trace command from dst to src is %s", fromDstCmd)
-	ovnDstSrcOut, ovnDstSrcErr, err := execInPod(coreclient, restconfig, ovnNamespace, srcPodInfo.OvnKubeContainerPodName, "ovnkube-node", fromDstCmd, "")
-	if err != nil {
-		klog.V(1).Infof("Source to Destination ovn-trace error %v stdOut: %s\n stdErr: %s", err, ovnDstSrcOut, ovnDstSrcErr)
-		os.Exit(-1)
-	}
-	klog.V(2).Infof("Destination to Source ovn-trace Output: %s\n", ovnDstSrcOut)
-
-	if srcPodInfo.HostNetwork {
-		// OVN will get as far as this sending node (the dst node)
-		successString = "output to \"" + types.K8sPrefix + dstPodInfo.NodeName + "\""
-	} else {
-		successString = "output to \"" + srcNamespace + "_" + *srcPodName + "\""
-	}
-	if strings.Contains(ovnDstSrcOut, successString) {
-		fmt.Printf("ovn-trace indicates success from %s to %s - matched on %s\n", *dstPodName, *srcPodName, successString)
-		klog.V(0).Infof("ovn-trace indicates success from %s to %s - matched on %s\n", *dstPodName, *srcPodName, successString)
-	} else {
-		fmt.Printf("ovn-trace indicates failure from %s to %s - %s not matched\n", *dstPodName, *srcPodName, successString)
-		klog.V(0).Infof("ovn-trace indicates failure from %s to %s - %s not matched\n", *dstPodName, *srcPodName, successString)
-		os.Exit(-1)
-	}
-
-	// ovs-appctl ofproto/trace: src pod to dst pod
-
-	fromSrc = "ofproto/trace br-int"
-	fromSrc += " \"in_port=" + srcPodInfo.VethName + ", " + protocol + ","
-	fromSrc += " dl_dst=" + srcPodInfo.RtosMAC + ","
-	fromSrc += " dl_src=" + srcPodInfo.MAC + ","
-	fromSrc += " nw_dst=" + dstPodInfo.IP + ","
-	fromSrc += " nw_src=" + srcPodInfo.IP + ","
-	fromSrc += " nw_ttl=64" + ","
-	fromSrc += " " + protocol + "_dst=" + *dstPort + ","
-	fromSrc += " " + protocol + "_src=" + "12345\""
-
-	fromSrcCmd = "ovs-appctl " + fromSrc
-
-	klog.V(5).Infof("ovs-appctl ofproto/trace command from src to dst is %s", fromSrcCmd)
-	appSrcDstOut, appSrcDstErr, err := execInPod(coreclient, restconfig, ovnNamespace, srcPodInfo.OvnKubeContainerPodName, "ovnkube-node", fromSrcCmd, "")
-	if err != nil {
-		klog.V(1).Infof("Source to Destination ovs-appctl error %v stdOut: %s\n stdErr: %s", err, appSrcDstOut, appSrcDstErr)
-		os.Exit(-1)
-	}
-	klog.V(2).Infof("Source to Destination ovs-appctl Output: %s\n", appSrcDstOut)
-
-	if podsOnSameNode {
-		klog.V(5).Infof("Pods are on the same node %s", dstPodInfo.NodeName)
-		// trace will end at the ovs port number of the dest pod
-		successString = "output:" + dstPodInfo.PortNum + "\n\nFinal flow:"
-	} else if dstPodInfo.HostNetwork {
-		klog.V(5).Infof("Dst pod %s is on host network  %s", dstPodInfo.PodName, dstPodInfo.NodeName)
-		// trace will end at the ovs port number of the management port of this sending node
-		successString = "output:" + srcPodInfo.LocalNum + "\n\nFinal flow:"
-	} else {
-		klog.V(5).Infof("Pods are on srcNode: %s and dstNode %s", srcPodInfo.NodeName, dstPodInfo.NodeName)
-		successString = "-> output to kernel tunnel"
-	}
-
-	if strings.Contains(appSrcDstOut, successString) {
-		fmt.Printf("ovs-appctl ofproto/trace indicates success from %s to %s - matched on %s\n", *srcPodName, *dstPodName, successString)
-		klog.V(0).Infof("ovs-appctl ofproto/trace indicates success from %s to %s - matched on %s\n", *srcPodName, *dstPodName, successString)
-	} else {
-		fmt.Printf("ovs-appctl ofproto/trace indicates failure from %s to %s - %s not matched\n", *srcPodName, *dstPodName, successString)
-		klog.V(0).Infof("ovs-appctl ofproto/trace indicates failure from %s to %s - %s not matched\n", *srcPodName, *dstPodName, successString)
-		os.Exit(-1)
-	}
-
-	// ovs-appctl ofproto/trace: dst pod to src pod
-
-	fromDst = "ofproto/trace br-int"
-	fromDst += " \"in_port=" + dstPodInfo.VethName + ", " + protocol + ","
-	fromDst += " dl_dst=" + dstPodInfo.RtosMAC + ","
-	fromDst += " dl_src=" + dstPodInfo.MAC + ","
-	fromDst += " nw_dst=" + srcPodInfo.IP + ","
-	fromDst += " nw_src=" + dstPodInfo.IP + ","
-	fromDst += " nw_ttl=64" + ","
-	fromDst += " " + protocol + "_src=" + *dstPort + ","
-	fromDst += " " + protocol + "_dst=" + "12345\""
-
-	fromDstCmd = "ovs-appctl " + fromDst
-
-	klog.V(5).Infof("ovs-appctl ofproto/trace command from dst to src is %s", fromDstCmd)
-	appDstSrcOut, appDstSrcErr, err := execInPod(coreclient, restconfig, ovnNamespace, dstPodInfo.OvnKubeContainerPodName, "ovnkube-node", fromDstCmd, "")
-	if err != nil {
-		klog.V(1).Infof("Destination to Source ovs-appctl error %v stdOut: %s\n stdErr: %s", err, appDstSrcOut, appDstSrcErr)
-		os.Exit(-1)
-	}
-	klog.V(2).Infof("Destination to Source ovs-appctl Output: %s\n", appDstSrcOut)
-
-	if podsOnSameNode {
-		klog.V(5).Infof("Pods are on the same node %s", srcPodInfo.NodeName)
-		// trace will end at the ovs port number of the dest pod in this test, which is srcPod
-		successString = "output:" + srcPodInfo.PortNum + "\n\nFinal flow:"
-	} else if srcPodInfo.HostNetwork {
-		klog.V(5).Infof("Src pod %s is on host network  %s", srcPodInfo.PodName, srcPodInfo.NodeName)
-		// trace will end at the ovs port number of the management port of the sending node, which is dstPod
-		successString = "output:" + dstPodInfo.LocalNum + "\n\nFinal flow:"
-	} else {
-		klog.V(5).Infof("Pods are on dstNode: %s and srcNode %s", dstPodInfo.NodeName, srcPodInfo.NodeName)
-		successString = "-> output to kernel tunnel"
-	}
-
-	if strings.Contains(appDstSrcOut, successString) {
-		fmt.Printf("ovs-appctl ofproto/trace indicates success from %s to %s - matched on %s\n", *dstPodName, *srcPodName, successString)
-		klog.V(0).Infof("ovs-appctl ofproto/trace indicates success from %s to %s - matched on %s\n", *dstPodName, *srcPodName, successString)
-	} else {
-		fmt.Printf("ovs-appctl ofproto/trace indicates failure from %s to %s - %s not matched\n", *dstPodName, *srcPodName, successString)
-		klog.V(0).Infof("ovs-appctl ofproto/trace indicates failure from %s to %s - %s not matched\n", *dstPodName, *srcPodName, successString)
-		os.Exit(-1)
-	}
-
+	// ovn-detrace commands below
 	// Install dependencies with pip3 in case they are missing (for older images)
-	podList := []string{
-		srcPodInfo.OvnKubeContainerPodName,
-		dstPodInfo.OvnKubeContainerPodName,
-	}
-	dependencies := map[string]string{
-		"ovs":       "if type -p ovn-detrace >/dev/null 2>&1; then echo 'true' ; fi",
-		"pyOpenSSL": "if rpm -qa | egrep -q python3-pyOpenSSL; then echo 'true'; fi",
-	}
-	for _, podName := range podList {
-		for dependency, dependencyCmd := range dependencies {
-			depVerifyOut, depVerifyErr, err := execInPod(coreclient, restconfig, ovnNamespace, podName, "ovnkube-node", dependencyCmd, "")
-			if err != nil {
-				klog.V(0).Infof("Dependency verification error in pod %s, container %s. Error '%v', stdOut: '%s'\n stdErr: %s", podName, "ovnkube-node", err, depVerifyOut, depVerifyErr)
-				os.Exit(-1)
-			}
-			trueFalse := strings.TrimSuffix(depVerifyOut, "\n")
-			klog.V(10).Infof("Dependency check '%s' in pod '%s', container '%s' yielded '%s'", dependencyCmd, podName, "ovnkube-node", trueFalse)
-			if trueFalse != "true" {
-				installCmd := "pip3 install " + dependency
-				depInstallOut, depInstallErr, err := execInPod(coreclient, restconfig, ovnNamespace, podName, "ovnkube-node", installCmd, "")
-				if err != nil {
-					klog.V(0).Infof("ovn-detrace error in pod %s, container %s. Error '%v', stdOut: '%s'\n stdErr: %s", podName, "ovnkube-node", err, depInstallOut, depInstallErr)
-					os.Exit(-1)
-				}
-				fmt.Printf("install ovn-detrace Output: %s\n", depInstallOut)
-			}
-		}
-	}
-
-	// ovn-detrace src - dst
-	fromSrc = "--ovnnb=" + nbUri + " "
-	fromSrc += "--ovnsb=" + sbUri + " "
-	fromSrc += sslCertKeys + " "
-	//fromSrc += "--ovs --ovsdb=unix:/var/run/openvswitch/db.sock "
-	fromSrc += "--ovsdb=unix:/var/run/openvswitch/db.sock "
-
-	fromSrcCmd = "ovn-detrace " + fromSrc
-
-	klog.V(5).Infof("ovn-detrace command from src to dst is %s", fromSrcCmd)
-	dtraceSrcDstOut, dtraceSrcDstErr, err := execInPod(coreclient, restconfig, ovnNamespace, srcPodInfo.OvnKubeContainerPodName, "ovnkube-node", fromSrcCmd, appSrcDstOut)
-	if err != nil {
-		klog.V(1).Infof("Source to Destination ovn-detrace error %v stdOut: %s\n stdErr: %s", err, dtraceSrcDstOut, dtraceSrcDstErr)
-		os.Exit(-1)
-	}
-	klog.V(2).Infof("Source to Destination ovn-detrace Completed - Output: %s\n", dtraceSrcDstOut)
-
-	fromDst = "--ovnnb=" + nbUri + " "
-	fromDst += "--ovnsb=" + sbUri + " "
-	fromDst += sslCertKeys + " "
-	//fromDst += "--ovs --ovsdb=unix:/var/run/openvswitch/db.sock "
-	fromDst += "--ovsdb=unix:/var/run/openvswitch/db.sock "
-
-	fromDstCmd = "ovn-detrace " + fromDst
-
-	klog.V(5).Infof("ovn-detrace command from dst to src is %s", fromDstCmd)
-	dtraceDstSrcOut, dtraceDstSrcErr, err := execInPod(coreclient, restconfig, ovnNamespace, dstPodInfo.OvnKubeContainerPodName, "ovnkube-node", fromDstCmd, appDstSrcOut)
-	if err != nil {
-		klog.V(1).Infof("Destination to Source ovn-detrace error %v stdOut: %s\n stdErr: %s", err, dtraceDstSrcOut, dtraceDstSrcErr)
-		os.Exit(-1)
-	}
-	klog.V(2).Infof("Destination to Source detrace Completed - Output: %s\n", appDstSrcOut)
-
-	fmt.Println("ovn-trace command Completed normally")
+	installOvnDetraceDependencies(coreclient, restconfig, srcPodInfo.OvnKubePodName, ovnNamespace)
+	installOvnDetraceDependencies(coreclient, restconfig, dstPodInfo.OvnKubePodName, ovnNamespace)
+	runOvnDetrace(coreclient, restconfig, "source pod to destination pod", srcPodInfo, dstPodInfo.PodName, appSrcDstOut, ovnNamespace, nbUri, sbUri, sslCertKeys)
+	runOvnDetrace(coreclient, restconfig, "destination pod to source pod", dstPodInfo, srcPodInfo.PodName, appDstSrcOut, ovnNamespace, nbUri, sbUri, sslCertKeys)
 }

--- a/go-controller/cmd/ovnkube-trace/ovnkube-trace.go
+++ b/go-controller/cmd/ovnkube-trace/ovnkube-trace.go
@@ -613,9 +613,12 @@ func main() {
 
 	klog.V(5).Infof(" Nodes: ")
 	for _, node := range nodes.Items {
+		// look for both labels until master label is removed in kubernetes 1.25
+		// https://github.com/kubernetes/kubernetes/pull/107533
+		_, foundMaster := node.Labels["node-role.kubernetes.io/master"]
+		_, foundControlPlane := node.Labels["node-role.kubernetes.io/control-plane"]
 
-		_, found := node.Labels["node-role.kubernetes.io/master"]
-		if found {
+		if foundMaster || foundControlPlane {
 			klog.V(5).Infof("  Name: %s is a master", node.Name)
 			for _, s := range node.Status.Addresses {
 				addrStr := utilnet.ParseIPSloppy(s.Address).String()

--- a/go-controller/cmd/ovnkube-trace/ovnkube-trace.go
+++ b/go-controller/cmd/ovnkube-trace/ovnkube-trace.go
@@ -772,8 +772,9 @@ func runOvnTraceToPod(coreclient *corev1client.CoreV1Client, restconfig *rest.Co
 
 // runOfprotoTraceToPod runs an ofproto/trace command from the src to the destination pod.
 func runOfprotoTraceToPod(coreclient *corev1client.CoreV1Client, restconfig *rest.Config, direction string, srcPodInfo, dstPodInfo *PodInfo, ovnNamespace, protocol, dstPort string) string {
+	protocolSelector, nwSrc, nwDst := getOfprotoIPFamilyArgs(protocol, net.ParseIP(dstPodInfo.IP))
 	cmd := fmt.Sprintf(`ovs-appctl ofproto/trace br-int `+
-		`"in_port=%[1]s, %[2]s, dl_src=%[3]s, dl_dst=%[4]s, nw_src=%[5]s, nw_dst=%[6]s, nw_ttl=64, %[7]s_dst=%[8]s, %[7]s_src=12345"`,
+		`"in_port=%[1]s, %[9]s, dl_src=%[3]s, dl_dst=%[4]s, %[10]s=%[5]s, %[11]s=%[6]s, nw_ttl=64, %[7]s_dst=%[8]s, %[7]s_src=12345"`,
 		srcPodInfo.VethName, // 1
 		protocol,            // 2
 		srcPodInfo.MAC,      // 3
@@ -782,6 +783,9 @@ func runOfprotoTraceToPod(coreclient *corev1client.CoreV1Client, restconfig *res
 		dstPodInfo.IP,       // 6
 		protocol,            // 7
 		dstPort,             // 8
+		protocolSelector,    // 9
+		nwSrc,               // 10
+		nwDst,               // 11
 	)
 	klog.V(4).Infof("ovs-appctl ofproto/trace command from %s is %s", direction, cmd)
 
@@ -816,8 +820,9 @@ func runOfprotoTraceToPod(coreclient *corev1client.CoreV1Client, restconfig *res
 // egressBridgeName is the name of the exit bridge (for EgressIPs, EgressGW and also for routingViaOVN mode).
 // If egressBridgeName == "", then this is routingViaHost Gateway mode without an EgressIP / EgressGW.
 func runOfprotoTraceToIP(coreclient *corev1client.CoreV1Client, restconfig *rest.Config, srcPodInfo *PodInfo, dstIP net.IP, ovnNamespace, protocol, dstPort, egressNodeName, egressBridgeName string) string {
+	protocolSelector, nwSrc, nwDst := getOfprotoIPFamilyArgs(protocol, dstIP)
 	cmd := fmt.Sprintf(`ovs-appctl ofproto/trace br-int `+
-		`"in_port=%[1]s, %[2]s, dl_src=%[3]s, dl_dst=%[4]s, nw_src=%[5]s, nw_dst=%[6]s, nw_ttl=64, %[2]s_dst=%[7]s, %[2]s_src=12345"`,
+		`"in_port=%[1]s, %[8]s, dl_src=%[3]s, dl_dst=%[4]s, %[9]s=%[5]s, %[10]s=%[6]s, nw_ttl=64, %[2]s_dst=%[7]s, %[2]s_src=12345"`,
 		srcPodInfo.VethName, // 1
 		protocol,            // 2
 		srcPodInfo.MAC,      // 3
@@ -825,6 +830,9 @@ func runOfprotoTraceToIP(coreclient *corev1client.CoreV1Client, restconfig *rest
 		srcPodInfo.IP,       // 5
 		dstIP.String(),      // 6
 		dstPort,             // 7
+		protocolSelector,    // 8
+		nwSrc,               // 9
+		nwDst,               // 10
 	)
 	direction := "pod to IP"
 	klog.V(4).Infof("ovs-appctl ofproto/trace command from %s is %s", direction, cmd)
@@ -848,6 +856,20 @@ func runOfprotoTraceToIP(coreclient *corev1client.CoreV1Client, restconfig *rest
 	printSuccessOrFailure(fmt.Sprintf("ovs-appctl ofproto/trace %s", direction), srcPodInfo.PodName, dstIP.String(), appSrcDstOut, appSrcDstErr, err, successString)
 
 	return appSrcDstOut
+}
+
+// getOfprotoIPFamilyArgs generates the protocol parameter name and the src and dst parameter names.
+// We must do this as syntax for ofproto/trace with IPv6 is slightly different.
+func getOfprotoIPFamilyArgs(protocol string, ip net.IP) (string, string, string) {
+	protocolSelector := protocol
+	nwSrc := "nw_src"
+	nwDst := "nw_dst"
+	if ip.To4() == nil {
+		protocolSelector += "6"
+		nwSrc = "ipv6_src"
+		nwDst = "ipv6_dst"
+	}
+	return protocolSelector, nwSrc, nwDst
 }
 
 // installOvnDetraceDependencies installs dependencies for ovn-detrace with pip3 in case they are missing (for older images).

--- a/go-controller/cmd/ovnkube-trace/ovnkube-trace.go
+++ b/go-controller/cmd/ovnkube-trace/ovnkube-trace.go
@@ -47,11 +47,13 @@ type l3GatewayConfig struct {
 	Mode string
 }
 
+// OvsInterface describes an OVS interface.
 type OvsInterface struct {
 	Name   string
 	Ofport string
 }
 
+// SvcInfo contains information about a service.
 type SvcInfo struct {
 	SvcName      string // The service's name
 	SvcNamespace string // The service's namespace
@@ -62,6 +64,7 @@ type SvcInfo struct {
 	PodPort      string // Endpoint target port used to reach the pod in PodName
 }
 
+// NodeInfo contains node information.
 type NodeInfo struct {
 	NodeExternalBridgeName string // The name of the node's bridge, e.g. breth0 or br-ex
 	OvnK8sMp0PortName      string // ovn-k8s-mp0
@@ -72,6 +75,7 @@ type NodeInfo struct {
 	RoutingViaHost         bool   // The gateway mode, true for 'routingViaHost' or false for 'routingViaOVN'
 }
 
+// PodInfo contains pod information.
 type PodInfo struct {
 	NodeInfo
 	PrimaryInterfaceName string // primary pod interface name inside the pod
@@ -111,17 +115,19 @@ func (si SvcInfo) getL3Ver() string {
 	return "ip6"
 }
 
-func (si PodInfo) getL3Ver() string {
-	if net.ParseIP(si.IP).To4() != nil {
+func (pi PodInfo) getL3Ver() string {
+	if net.ParseIP(pi.IP).To4() != nil {
 		return "ip4"
 	}
 	return "ip6"
 }
 
+// FullyQualifiedPodName returns the full name of the pod, <namespace>_<pod>.
 func (si *SvcInfo) FullyQualifiedPodName() string {
 	return fmt.Sprintf("%s_%s", si.PodNamespace, si.PodName)
 }
 
+// FullyQualifiedPodName returns the full name of the pod, <namespace>_<pod>.
 func (pi *PodInfo) FullyQualifiedPodName() string {
 	return fmt.Sprintf("%s_%s", pi.PodNamespace, pi.PodName)
 }
@@ -414,7 +420,7 @@ func extractSubsetInfo(subsets []kapi.EndpointSubset, svcInfo *SvcInfo) error {
 		}
 	}
 
-	return fmt.Errorf("could not extract pod and port information from endpoints for service %s in namespace %s.", svcInfo.SvcName, svcInfo.SvcNamespace)
+	return fmt.Errorf("could not extract pod and port information from endpoints for service %s in namespace %s", svcInfo.SvcName, svcInfo.SvcNamespace)
 }
 
 // getPodInfo returns a pointer to a fully populated PodInfo struct, or error on failure.
@@ -508,7 +514,7 @@ func getNodeExternalBridgeName(coreclient *corev1client.CoreV1Client, restconfig
 	cmd := "ovn-sbctl " + sbcmd + " --bare --no-heading --column=logical_port find Port_Binding options:network_name=" + types.PhysicalNetworkName
 	stdout, stderr, err := execInPod(coreclient, restconfig, ovnNamespace, podName, "ovnkube-node", cmd, "")
 	if err != nil {
-		return "", fmt.Errorf("execInPod() failed with %s stderr %s stdout %s \n", err, stderr, stdout)
+		return "", fmt.Errorf("execInPod() failed with %s stderr %s stdout %s", err, stderr, stdout)
 	}
 	scanner := bufio.NewScanner(strings.NewReader(stdout))
 	for scanner.Scan() {
@@ -901,10 +907,10 @@ func installOvnDetraceDependencies(coreclient *corev1client.CoreV1Client, restco
 }
 
 // runOvnDetrace runs an ovn-detrace command for the given input.
-func runOvnDetrace(coreclient *corev1client.CoreV1Client, restconfig *rest.Config, direction string, srcPodInfo *PodInfo, dstName string, appSrcDstOut, ovnNamespace, nbUri, sbUri, sslCertKeys string) {
+func runOvnDetrace(coreclient *corev1client.CoreV1Client, restconfig *rest.Config, direction string, srcPodInfo *PodInfo, dstName string, appSrcDstOut, ovnNamespace, nbURI, sbURI, sslCertKeys string) {
 	cmd := fmt.Sprintf(`ovn-detrace --ovnnb=%[1]s --ovnsb=%[2]s %[3]s --ovsdb=unix:/var/run/openvswitch/db.sock`,
-		nbUri,       // 1
-		sbUri,       // 2
+		nbURI,       // 1
+		sbURI,       // 2
 		sslCertKeys, // 3
 	)
 	klog.V(4).Infof("ovn-detrace command from %s is %s", direction, cmd)
@@ -1074,7 +1080,7 @@ func main() {
 
 	// Common ssl parameters
 	var sslCertKeys string
-	nbUri, sbUri, useSSL, err := getDatabaseURIs(coreclient, restconfig, ovnNamespace)
+	nbURI, sbURI, useSSL, err := getDatabaseURIs(coreclient, restconfig, ovnNamespace)
 	if err != nil {
 		klog.Exitf("Failed to get database URIs: %v\n", err)
 	}
@@ -1083,9 +1089,9 @@ func main() {
 	} else {
 		sslCertKeys = " "
 	}
-	nbcmd := sslCertKeys + "--db " + nbUri
+	nbcmd := sslCertKeys + "--db " + nbURI
 	klog.V(5).Infof("The nbcmd is %s", nbcmd)
-	sbcmd := sslCertKeys + "--db " + sbUri
+	sbcmd := sslCertKeys + "--db " + sbURI
 	klog.V(5).Infof("The sbcmd is %s", sbcmd)
 
 	// Get info needed for the src Pod
@@ -1100,7 +1106,7 @@ func main() {
 		klog.V(5).Infof("Running a trace to an IP address")
 		egressNodeName, egressBridgeName := runOvnTraceToIP(coreclient, restconfig, srcPodInfo, parsedDstIP, sbcmd, ovnNamespace, protocol, *dstPort)
 		appSrcDstOut := runOfprotoTraceToIP(coreclient, restconfig, srcPodInfo, parsedDstIP, ovnNamespace, protocol, *dstPort, egressNodeName, egressBridgeName)
-		runOvnDetrace(coreclient, restconfig, "pod to external IP", srcPodInfo, parsedDstIP.String(), appSrcDstOut, ovnNamespace, nbUri, sbUri, sslCertKeys)
+		runOvnDetrace(coreclient, restconfig, "pod to external IP", srcPodInfo, parsedDstIP.String(), appSrcDstOut, ovnNamespace, nbURI, sbURI, sslCertKeys)
 		return
 	}
 
@@ -1153,6 +1159,6 @@ func main() {
 	// Install dependencies with pip3 in case they are missing (for older images)
 	installOvnDetraceDependencies(coreclient, restconfig, srcPodInfo.OvnKubePodName, ovnNamespace)
 	installOvnDetraceDependencies(coreclient, restconfig, dstPodInfo.OvnKubePodName, ovnNamespace)
-	runOvnDetrace(coreclient, restconfig, "source pod to destination pod", srcPodInfo, dstPodInfo.PodName, appSrcDstOut, ovnNamespace, nbUri, sbUri, sslCertKeys)
-	runOvnDetrace(coreclient, restconfig, "destination pod to source pod", dstPodInfo, srcPodInfo.PodName, appDstSrcOut, ovnNamespace, nbUri, sbUri, sslCertKeys)
+	runOvnDetrace(coreclient, restconfig, "source pod to destination pod", srcPodInfo, dstPodInfo.PodName, appSrcDstOut, ovnNamespace, nbURI, sbURI, sslCertKeys)
+	runOvnDetrace(coreclient, restconfig, "destination pod to source pod", dstPodInfo, srcPodInfo.PodName, appDstSrcOut, ovnNamespace, nbURI, sbURI, sslCertKeys)
 }

--- a/go-controller/cmd/ovnkube-trace/ovnkube-trace.go
+++ b/go-controller/cmd/ovnkube-trace/ovnkube-trace.go
@@ -333,7 +333,7 @@ func getPodOvsInterfaceNameAndOfport(coreclient *corev1client.CoreV1Client, rest
 }
 
 // getSvcInfo builds the SvcInfo object for this service. PodName/PodNamespace/PodIP are for the first valid endpoint pod that can be found for this service.
-func getSvcInfo(coreclient *corev1client.CoreV1Client, restconfig *rest.Config, svcName string, ovnNamespace string, namespace string, cmd string) (svcInfo *SvcInfo, err error) {
+func getSvcInfo(coreclient *corev1client.CoreV1Client, restconfig *rest.Config, svcName string, ovnNamespace string, namespace string) (svcInfo *SvcInfo, err error) {
 	// Get service with the name supplied by svcName
 	svc, err := coreclient.Services(namespace).Get(context.TODO(), svcName, metav1.GetOptions{})
 	if err != nil {
@@ -456,13 +456,17 @@ func getPodInfo(coreclient *corev1client.CoreV1Client, restconfig *rest.Config, 
 	}
 
 	// Find rtos MAC (this is the pod's first hop router).
-	lspCmd := "ovn-nbctl " + cmd + " --bare --no-heading --column=mac list logical-router-port " + types.RouterToSwitchPrefix + podInfo.NodeName
+	lspCmd := "ovn-sbctl " + cmd + " --bare --no-heading --column=mac list Port_Binding " + types.RouterToSwitchPrefix + podInfo.NodeName
 	ipOutput, ipError, err := execInPod(coreclient, restconfig, ovnNamespace, podInfo.OvnKubePodName, "ovnkube-node", lspCmd, "")
 
 	if err != nil {
 		return nil, fmt.Errorf("execInPod() failed. err: %s, stderr: %s, stdout: %s, podInfo: %v", err, ipError, ipOutput, podInfo)
 	}
-	podInfo.RtosMAC = strings.Replace(ipOutput, "\n", "", -1)
+	macIP := strings.Split(strings.Replace(ipOutput, "\n", "", -1), " ")
+	if len(macIP) != 2 {
+		return nil, fmt.Errorf("invalid output %s", ipOutput)
+	}
+	podInfo.RtosMAC = macIP[0]
 
 	// Set information specific to ovn-k8s-mp0. This info is required for routingViaHost gateway mode traffic to an external IP
 	// destination.
@@ -500,8 +504,8 @@ func getPodInfo(coreclient *corev1client.CoreV1Client, restconfig *rest.Config, 
 }
 
 // getNodeExternalBridgeName gets the name of the external bridge of this node, e.g. breth0 or br-ex.
-func getNodeExternalBridgeName(coreclient *corev1client.CoreV1Client, restconfig *rest.Config, ovnNamespace, podName, nbcmd, nodeName string) (string, error) {
-	cmd := "ovn-nbctl " + nbcmd + " --bare --no-heading --column=name find Logical_Switch_Port options:network_name=" + types.PhysicalNetworkName
+func getNodeExternalBridgeName(coreclient *corev1client.CoreV1Client, restconfig *rest.Config, ovnNamespace, podName, sbcmd, nodeName string) (string, error) {
+	cmd := "ovn-sbctl " + sbcmd + " --bare --no-heading --column=logical_port find Port_Binding options:network_name=" + types.PhysicalNetworkName
 	stdout, stderr, err := execInPod(coreclient, restconfig, ovnNamespace, podName, "ovnkube-node", cmd, "")
 	if err != nil {
 		return "", fmt.Errorf("execInPod() failed with %s stderr %s stdout %s \n", err, stderr, stdout)
@@ -538,10 +542,10 @@ func getOvnNamespace(coreclient *corev1client.CoreV1Client, override string) (st
 	return pods.Items[0].Namespace, nil
 }
 
-// Get the OVN Database URIs from the first container found in any pod in the ovn-kubernetes namespace with name "ovnkube-master"
+// Get the OVN Database URIs from the first container found in any pod in the ovn-kubernetes namespace with name "ovnkube-node"
 // Returns nbAddress, sbAddress, protocol == "ssl", nil
 func getDatabaseURIs(coreclient *corev1client.CoreV1Client, restconfig *rest.Config, ovnNamespace string) (string, string, bool, error) {
-	containerName := "ovnkube-master"
+	containerName := "ovnkube-node"
 	var err error
 
 	found := false
@@ -1085,7 +1089,7 @@ func main() {
 	klog.V(5).Infof("The sbcmd is %s", sbcmd)
 
 	// Get info needed for the src Pod
-	srcPodInfo, err := getPodInfo(coreclient, restconfig, *srcPodName, ovnNamespace, *srcNamespace, nbcmd)
+	srcPodInfo, err := getPodInfo(coreclient, restconfig, *srcPodName, ovnNamespace, *srcNamespace, sbcmd)
 	if err != nil {
 		klog.Exitf("Failed to get information from pod %s: %v", *srcPodName, err)
 	}
@@ -1106,7 +1110,7 @@ func main() {
 	var dstSvcInfo *SvcInfo
 	if *dstSvcName != "" {
 		// Get dst service
-		dstSvcInfo, err = getSvcInfo(coreclient, restconfig, *dstSvcName, ovnNamespace, *dstNamespace, nbcmd)
+		dstSvcInfo, err = getSvcInfo(coreclient, restconfig, *dstSvcName, ovnNamespace, *dstNamespace)
 		if err != nil {
 			klog.Exitf("Failed to get information from service %s: %v", *dstSvcName, err)
 		}
@@ -1117,7 +1121,7 @@ func main() {
 	}
 
 	// Now get info needed for the dst Pod
-	dstPodInfo, err := getPodInfo(coreclient, restconfig, *dstPodName, ovnNamespace, *dstNamespace, nbcmd)
+	dstPodInfo, err := getPodInfo(coreclient, restconfig, *dstPodName, ovnNamespace, *dstNamespace, sbcmd)
 	if err != nil {
 		klog.Exitf("Failed to get information from pod %s: %v", *dstPodName, err)
 	}
@@ -1139,6 +1143,12 @@ func main() {
 	appSrcDstOut := runOfprotoTraceToPod(coreclient, restconfig, "source pod to destination pod", srcPodInfo, dstPodInfo, ovnNamespace, protocol, *dstPort)
 	appDstSrcOut := runOfprotoTraceToPod(coreclient, restconfig, "destination pod to source pod", dstPodInfo, srcPodInfo, ovnNamespace, protocol, *dstPort)
 
+	// If NBDB connectivity is not available do not run ovn-dtrace
+	_, stdErr, err := execInPod(coreclient, restconfig, ovnNamespace, srcPodInfo.OvnKubePodName, "ovnkube-node", fmt.Sprintf("ovn-nbctl %s get-connection", nbcmd), "")
+	if err != nil {
+		klog.V(4).Infof("Skip ovn-dtrace, nbdb is not available %s", stdErr)
+		return
+	}
 	// ovn-detrace commands below
 	// Install dependencies with pip3 in case they are missing (for older images)
 	installOvnDetraceDependencies(coreclient, restconfig, srcPodInfo.OvnKubePodName, ovnNamespace)

--- a/go-controller/cmd/ovnkube-trace/ovnkube-trace.go
+++ b/go-controller/cmd/ovnkube-trace/ovnkube-trace.go
@@ -657,6 +657,79 @@ func runOvnTraceToService(coreclient *corev1client.CoreV1Client, restconfig *res
 	printSuccessOrFailure("ovn-trace from source pod to service clusterIP", srcPodInfo.PodName, dstSvcInfo.SvcName, ovnSrcDstOut, ovnSrcDstErr, err, successString)
 }
 
+// runOvnTraceToIP runs an ovntrace from src pod to dst IP address (should be external to the cluster).
+// Returns the node that the trace will exit on.
+func runOvnTraceToIP(coreclient *corev1client.CoreV1Client, restconfig *rest.Config, srcPodInfo *PodInfo, parsedDstIP net.IP, sbcmd, ovnNamespace, protocol, dstPort string) (string, string) {
+	if srcPodInfo.HostNetwork {
+		klog.Exitf("Pod cannot be on Host Network when tracing to an IP address; use ping\n")
+	}
+
+	l3ver := "ip6"
+	if parsedDstIP.To4() != nil {
+		l3ver = "ip4"
+	}
+	if srcPodInfo.getL3Ver() != l3ver {
+		klog.Exitf("Pod src IP address family (address: %s) and destination IP address family (address: %s) do not match",
+			srcPodInfo.IP, parsedDstIP)
+	}
+
+	cmd := fmt.Sprintf(`ovn-trace %[1]s %[2]s `+
+		`'inport=="%[3]s" && eth.src==%[4]s && eth.dst==%[5]s && %[6]s.src==%[7]s && %[8]s.dst==%[9]s && ip.ttl==64 && %[10]s.dst==%[11]s && %[10]s.src==52888'`,
+		sbcmd,                              // 1
+		srcPodInfo.NodeName,                // 2
+		srcPodInfo.FullyQualifiedPodName(), // 3
+		srcPodInfo.MAC,                     // 4
+		srcPodInfo.RtosMAC,                 // 5
+		l3ver,                              // 6
+		srcPodInfo.IP,                      // 7
+		l3ver,                              // 8
+		parsedDstIP,                        // 9
+		protocol,                           // 10
+		dstPort,                            // 11
+	)
+	klog.V(4).Infof("ovn-trace command from pod to IP is %s", cmd)
+
+	// This is different depending on:
+	// a) if this is routingViaHost gateway mode, output to "k8s-<nodename>"
+	// b) for routingViaHost gateway egressip and routingViaOVN gateway mode, go out of <bridge name>_<node name>
+	successString := fmt.Sprintf(`output to "(.*)_(.*)", type "localnet"|output to "k8s-%s"`, srcPodInfo.NodeName)
+	// Run the command and check if succesString was found.
+	ovnSrcDstOut, ovnSrcDstErr, err := execInPod(coreclient, restconfig, ovnNamespace, srcPodInfo.OvnKubePodName, "ovnkube-node", cmd, "")
+	printSuccessOrFailure("ovn-trace from pod to IP", srcPodInfo.PodName, parsedDstIP.String(), ovnSrcDstOut, ovnSrcDstErr, err, successString)
+
+	// Print some additional information about the node where this request leaves from as well
+	// as the SNAT IP address.
+	snatString := `ct_snat\((.*)\)`
+	re := regexp.MustCompile(snatString)
+	subMatches := re.FindSubmatch([]byte(ovnSrcDstOut))
+	if len(subMatches) >= 2 {
+		klog.V(5).Infof("Could find SNAT for this trace command, this must be routingViaOVN gateway mode, any mode with EgressIP or any mode with EgressGW.")
+		snat := subMatches[len(subMatches)-1]
+		re = regexp.MustCompile(successString)
+		subMatches = re.FindSubmatch([]byte(ovnSrcDstOut))
+		// We should never hit this (printSuccessOrFailure checks the same already above).
+		if len(subMatches) < 3 {
+			klog.Exitf("Could not determine the output port for this trace command, subMatches: %q\n", subMatches)
+		}
+		node := subMatches[len(subMatches)-1]
+		bridgeName := subMatches[len(subMatches)-2]
+		klog.V(1).Infof("%sout on node %s via Logical_Switch_Port %s with SNAT %s%s\n", green, node, bridgeName, snat, reset)
+
+		return string(node), string(bridgeName)
+	}
+
+	klog.V(5).Infof("Could not find SNAT for this trace command, this must be routingViaHost gateway mode without EgressIP.")
+	nodeNameRegex := `output to "k8s-(.*)",`
+	re = regexp.MustCompile(nodeNameRegex)
+	subMatches = re.FindSubmatch([]byte(ovnSrcDstOut))
+	if len(subMatches) < 2 {
+		klog.Exitf("Could not determine node name / bridge name of egress node in runOvnTraceToIP()")
+	}
+	node := subMatches[len(subMatches)-1]
+	klog.V(1).Infof("%sout on node %s%s\n", green, node, reset)
+	return string(node), ""
+}
+
 // runOvnTraceToPod runs an ovntrace from src pod to dst pod.
 func runOvnTraceToPod(coreclient *corev1client.CoreV1Client, restconfig *rest.Config, direction string, srcPodInfo, dstPodInfo *PodInfo, sbcmd, ovnNamespace, protocol, dstPort string) {
 	var inport string
@@ -715,7 +788,8 @@ func runOfprotoTraceToPod(coreclient *corev1client.CoreV1Client, restconfig *res
 	var successString string
 	if srcPodInfo.NodeName == dstPodInfo.NodeName {
 		klog.V(5).Infof("Pods are on the same node %s", dstPodInfo.NodeName)
-		// trace will end at the ovs port number of the dest pod
+		// Trace will end at the ovs port number of the dest pod.
+		// For host networked pods, getPodInfo sets OfportNum to the number of OvnK8sMp0OfportNum, see getPodInfo.
 		successString = "output:" + dstPodInfo.OfportNum + "\n\nFinal flow:"
 	} else if dstPodInfo.HostNetwork {
 		klog.V(5).Infof("Pod %s is on host network on node %s", dstPodInfo.PodName, dstPodInfo.NodeName)
@@ -733,6 +807,45 @@ func runOfprotoTraceToPod(coreclient *corev1client.CoreV1Client, restconfig *res
 	}
 	appSrcDstOut, appSrcDstErr, err := execInPod(coreclient, restconfig, ovnNamespace, srcPodInfo.OvnKubePodName, "ovnkube-node", cmd, "")
 	printSuccessOrFailure("ovs-appctl ofproto/trace "+direction, srcPodInfo.PodName, dstPodInfo.PodName, appSrcDstOut, appSrcDstErr, err, successString)
+
+	return appSrcDstOut
+}
+
+// runOfprotoTraceToIP runs an ofproto/trace command from the src to the destination pod.
+// egressNodeName is the exit node, as determined by an ovn-trace command that was run earlier.
+// egressBridgeName is the name of the exit bridge (for EgressIPs, EgressGW and also for routingViaOVN mode).
+// If egressBridgeName == "", then this is routingViaHost Gateway mode without an EgressIP / EgressGW.
+func runOfprotoTraceToIP(coreclient *corev1client.CoreV1Client, restconfig *rest.Config, srcPodInfo *PodInfo, dstIP net.IP, ovnNamespace, protocol, dstPort, egressNodeName, egressBridgeName string) string {
+	cmd := fmt.Sprintf(`ovs-appctl ofproto/trace br-int `+
+		`"in_port=%[1]s, %[2]s, dl_src=%[3]s, dl_dst=%[4]s, nw_src=%[5]s, nw_dst=%[6]s, nw_ttl=64, %[2]s_dst=%[7]s, %[2]s_src=12345"`,
+		srcPodInfo.VethName, // 1
+		protocol,            // 2
+		srcPodInfo.MAC,      // 3
+		srcPodInfo.RtosMAC,  // 4
+		srcPodInfo.IP,       // 5
+		dstIP.String(),      // 6
+		dstPort,             // 7
+	)
+	direction := "pod to IP"
+	klog.V(4).Infof("ovs-appctl ofproto/trace command from %s is %s", direction, cmd)
+
+	var successString string
+	if srcPodInfo.NodeName != egressNodeName {
+		klog.V(5).Infof("Pod is on node %s and traffic egress via node %s", srcPodInfo.NodeName, egressNodeName)
+		successString = "-> output to kernel tunnel"
+	} else {
+		if egressBridgeName != "" {
+			// routingViaOVN gateway mode or EgressIP matched traffic, or ICNI traffic.
+			klog.V(5).Infof("Pod is on node %s and traffic egress via the same node's bridge %s", srcPodInfo.NodeName, egressBridgeName)
+			successString = fmt.Sprintf(`bridge\("%s"\)`, egressBridgeName)
+		} else {
+			// routingViaHost gateway mode and no EgressIP matched traffic.
+			klog.V(5).Infof("Pod is on node %s and traffic egress via the same node's port %s (%s)", srcPodInfo.NodeName, srcPodInfo.OvnK8sMp0PortName, srcPodInfo.OvnK8sMp0OfportNum)
+			successString = fmt.Sprintf(`output:%s`, srcPodInfo.OvnK8sMp0OfportNum)
+		}
+	}
+	appSrcDstOut, appSrcDstErr, err := execInPod(coreclient, restconfig, ovnNamespace, srcPodInfo.OvnKubePodName, "ovnkube-node", cmd, "")
+	printSuccessOrFailure(fmt.Sprintf("ovs-appctl ofproto/trace %s", direction), srcPodInfo.PodName, dstIP.String(), appSrcDstOut, appSrcDstErr, err, successString)
 
 	return appSrcDstOut
 }
@@ -832,6 +945,7 @@ func setLogLevel(loglevel string) {
 
 func main() {
 	var protocol string
+	var parsedDstIP net.IP
 	var err error
 
 	// Parse CLI flags.
@@ -842,6 +956,7 @@ func main() {
 	srcPodName := flag.String("src", "", "src: source pod name")
 	dstPodName := flag.String("dst", "", "dest: destination pod name")
 	dstSvcName := flag.String("service", "", "service: destination service name")
+	dstIP := flag.String("dst-ip", "", "destination IP address (meant for tests to external targets)")
 	dstPort := flag.String("dst-port", "80", "dst-port: destination port")
 	tcp := flag.Bool("tcp", false, "use tcp transport protocol")
 	udp := flag.Bool("udp", false, "use udp transport protocol")
@@ -877,8 +992,15 @@ func main() {
 	if *dstSvcName != "" {
 		targetOptions++
 	}
+	if *dstIP != "" {
+		targetOptions++
+		parsedDstIP = net.ParseIP(*dstIP)
+		if parsedDstIP == nil {
+			klog.Exitf("Usage: cannot parse IP address provided in -dst-ip")
+		}
+	}
 	if targetOptions != 1 {
-		klog.Exitf("Usage: exactly one of -dst, -service must be set")
+		klog.Exitf("Usage: exactly one of -dst, -service or -dst-ip must be set")
 	}
 
 	// Get the ClientConfig.
@@ -947,6 +1069,16 @@ func main() {
 	}
 	klog.V(5).Infof("srcPodInfo is %s\n", srcPodInfo)
 
+	// 1) Either run a trace from source pod to destination IP and return ...
+	if parsedDstIP != nil {
+		klog.V(5).Infof("Running a trace to an IP address")
+		egressNodeName, egressBridgeName := runOvnTraceToIP(coreclient, restconfig, srcPodInfo, parsedDstIP, sbcmd, ovnNamespace, protocol, *dstPort)
+		appSrcDstOut := runOfprotoTraceToIP(coreclient, restconfig, srcPodInfo, parsedDstIP, ovnNamespace, protocol, *dstPort, egressNodeName, egressBridgeName)
+		runOvnDetrace(coreclient, restconfig, "pod to external IP", srcPodInfo, parsedDstIP.String(), appSrcDstOut, ovnNamespace, nbUri, sbUri, sslCertKeys)
+		return
+	}
+
+	// 2) ... or run a trace to destination service / destination pod.
 	// Get destination service information if a destination service name was provided.
 	klog.V(5).Infof("Running a trace to a cluster local svc or to another pod")
 	var dstSvcInfo *SvcInfo

--- a/go-controller/cmd/ovnkube-trace/ovnkube-trace.go
+++ b/go-controller/cmd/ovnkube-trace/ovnkube-trace.go
@@ -1009,6 +1009,7 @@ func main() {
 	dstPort := flag.String("dst-port", "80", "dst-port: destination port")
 	tcp := flag.Bool("tcp", false, "use tcp transport protocol")
 	udp := flag.Bool("udp", false, "use udp transport protocol")
+	skipOvnDetrace := flag.Bool("skip-detrace", false, "skip ovn-detrace command")
 	loglevel := flag.String("loglevel", "0", "loglevel: klog level")
 	flag.Parse()
 
@@ -1123,6 +1124,9 @@ func main() {
 		klog.V(5).Infof("Running a trace to an IP address")
 		egressNodeName, egressBridgeName := runOvnTraceToIP(coreclient, restconfig, srcPodInfo, parsedDstIP, sbcmd, ovnNamespace, protocol, *dstPort)
 		appSrcDstOut := runOfprotoTraceToIP(coreclient, restconfig, srcPodInfo, parsedDstIP, ovnNamespace, protocol, *dstPort, egressNodeName, egressBridgeName)
+		if *skipOvnDetrace {
+			return
+		}
 		err = runOvnDetrace(coreclient, restconfig, "pod to external IP", srcPodInfo, parsedDstIP.String(), appSrcDstOut, ovnNamespace, nbURI, sbURI, sslCertKeys, nbcmd)
 		if err != nil {
 			klog.Infof("Skipped ovn-detrace due to: %q", err)
@@ -1170,6 +1174,9 @@ func main() {
 	appDstSrcOut := runOfprotoTraceToPod(coreclient, restconfig, "destination pod to source pod", dstPodInfo, srcPodInfo, ovnNamespace, protocol, *dstPort)
 
 	// ovn-detrace commands below
+	if *skipOvnDetrace {
+		return
+	}
 	err = runOvnDetrace(coreclient, restconfig, "source pod to destination pod", srcPodInfo, dstPodInfo.PodName, appSrcDstOut, ovnNamespace, nbURI, sbURI, sslCertKeys, nbcmd)
 	if err != nil {
 		klog.Infof("Skipped ovn-detrace due to: %q", err)

--- a/test/scripts/test-ovnkube-trace.sh
+++ b/test/scripts/test-ovnkube-trace.sh
@@ -1,0 +1,502 @@
+#!/usr/bin/env bash
+# This script will run a bunch of ovnkube-trace commands to make rudimentary
+# testing easier and to provide a bunch of example pods, services and parameters
+# for testing. This should help verify that ovnkube-trace still works well when changes
+# are made to that binary.
+# Note: Some commands are run in double, but this shouldn't do any arm besides
+# having this script run for a bit longer.
+
+# always exit on errors
+set -e
+
+if [ "${KUBECONFIG}" == "" ]; then
+  export KUBECONFIG=${HOME}/ovn.conf
+fi
+export OVN_IMAGE=${OVN_IMAGE:-ovn-daemonset-f:pr}
+
+DIR=$(dirname "${BASH_SOURCE[0]}")
+
+# Get the kubectl or oc binary. Always lean towards using oc if
+# that binary can be found.
+KUBECTL=""
+for cmd in kubectl oc ; do
+  if command -v $cmd &> /dev/null; then
+      KUBECTL=$(which $cmd)
+  fi
+done
+if [ "$KUBECTL" == "" ]; then
+  echo "Cannot find kubectl or oc binary, please install at least one or the other."
+  exit 1
+fi
+
+LOGLEVEL=0
+POST_CLEANUP=true
+SETUP=true
+RUN_DEST_IP_TESTS=true
+OVNKUBE_TRACE=${DIR}/../../go-controller/_output/go/bin/ovnkube-trace
+CONTAINER_IMAGE=alpine
+EGRESS_IP=172.18.0.10
+parse_args() {
+    while [ "$1" != "" ]; do
+        case $1 in
+            --skip-post-cleanup )               POST_CLEANUP=false
+                                                ;;
+            --skip-setup )                      SETUP=false
+                                                ;;
+            --skip-dst-ip-tests )               RUN_DEST_IP_TESTS=false
+                                                ;;
+            --loglevel )                          shift
+                                                LOGLEVEL=$1
+                                                ;;
+            --binary )                          shift
+                                                OVNKUBE_TRACE=$1
+                                                ;;
+            --container-image )                 shift
+                                                CONTAINER_IMAGE=$1
+                                                ;;
+            --egress-ip )                       shift
+                                                EGRESS_IP=$1
+                                                ;;
+            --kubectl)                          shift
+                                                kubectl_override=$1
+                                                ;;
+            -h | --help )                       usage
+                                                exit
+                                                ;;
+            * )                                 usage
+                                                exit 1
+        esac
+        shift
+    done
+    if [ "${kubectl_override}" != "" ]; then
+        if command -v ${kubectl_override} &> /dev/null; then
+            KUBECTL=$(which ${kubectl_override})
+        else
+            echo "Cannot find kubectl binary ${kubectl_override}."
+            exit 1
+        fi
+    fi
+}
+
+usage() {
+    echo "usage: test-ovnkube-trace.sh [--kubectl <binary name>] [--loglevel <level>] [--skip-post-cleanup] [--skip-setup] [--skip-dst-ip-tests]"
+    echo "                             [--binary <location of ovnkube-trace binary>] [--container-image <image name>] [--egress-ip <egress IP, default 172.18.0.10>]"
+}
+
+# wait for deployment ready replicas count == desired replicas count
+# parameters: <namespace> <deployment>
+kubectl_wait_deployment(){
+  # takes one deployment and makes sure its replicas and readyReplicas are equal
+  local retries=0
+  local attempts=30
+  while true; do
+    sleep 10
+    run_kubectl get deployments.apps $2 -n $1
+    DESIRED_REPLICAS=$(run_kubectl get deployments.apps $2 -n $1 -o=jsonpath='{.status.replicas}')
+    READY_REPLICAS=$(run_kubectl get deployments.apps $2 -n $1 -o=jsonpath='{.status.readyReplicas}')
+    echo "CURRENT READY REPLICAS: $READY_REPLICAS, CURRENT DESIRED REPLICAS: $DESIRED_REPLICAS for the Deployment $1/$2"
+    if [[ $READY_REPLICAS -eq $DESIRED_REPLICAS ]]; then
+      break
+    fi
+    ((retries += 1))
+    if [[ "${retries}" -gt ${attempts} ]]; then
+      echo "error: deployment did not succeed, failing"
+      exit 1
+    fi
+  done
+}
+
+# wrapper around the kubectl command
+run_kubectl() {
+  local retries=0
+  local attempts=10
+  while true; do
+    if ${KUBECTL} "$@"; then
+      break
+    fi
+
+    ((retries += 1))
+    if [[ "${retries}" -gt ${attempts} ]]; then
+      echo "error: 'kubectl $*' did not succeed, failing"
+      exit 1
+    fi
+    echo "info: waiting for 'kubectl $*' to succeed..."
+    sleep 1
+  done
+}
+
+get_worker_nodes() {
+  local worker_nodes=$(${KUBECTL} get nodes --show-labels | awk '!/node-role.kubernetes.io\/master=|node-role.kubernetes.io\/control-plane=/ && $1!="NAME" {print $1}')
+  echo "${worker_nodes}"
+}
+
+# add_scc adds an SCC to the default user of the given namespace.
+# If the oc binary cannot be found and/or if this is not OpenShift, simply
+# continue without failing. This way, this will work for both OCP and kind.
+add_scc() {
+  namespace=$1
+  scc=$2
+  # Simply return if oc cannot be found
+  if ! command -v oc &> /dev/null; then
+    return
+  fi
+  oc adm policy add-scc-to-user ${scc} -z default -n ${namespace} 2>/dev/null
+}
+
+# Spawn a test deployment named 'pod-test' with 2 replicas in namespace 
+# named 'ovn-kubetrace-pod-test'
+spawn_deployment() {
+  local namespace="ovn-kubetrace-pod-test"
+  local name="pod-test"
+  local replicas="2"
+
+  file=$(mktemp)
+  cat <<EOF >| $file
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ${namespace}
+EOF
+  run_kubectl apply -f ${file}
+
+  file=$(mktemp)
+  cat <<EOF >| $file
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: ${name}
+  name: ${name}
+  namespace: ${namespace}
+spec:
+  replicas: ${replicas}
+  selector:
+    matchLabels:
+      app: ${name}
+  template:
+    metadata:
+      labels:
+        app: ${name}
+    spec:
+      containers:
+      - command:
+        - sleep
+        - "3600"
+        image: ${CONTAINER_IMAGE}
+        name: ${name}
+EOF
+  run_kubectl apply -f ${file}
+  kubectl_wait_deployment ${namespace} ${name}
+}
+
+# Spawn a test deployment named 'pod-test-hostnetwork' with 2 replicas in namespace
+# named 'ovn-kubetrace-pod-test-hostnetwork'. The pods of this deployment use hostNetwork=true
+spawn_hostnetwork_deployment() {
+  local namespace="ovn-kubetrace-pod-test-hostnetwork"
+  local name="pod-test-hostnetwork"
+  local replicas="2"
+
+  file=$(mktemp)
+  cat <<EOF >| $file
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ${namespace}
+EOF
+  run_kubectl apply -f ${file}
+  add_scc ${namespace} hostnetwork
+
+  file=$(mktemp)
+  cat <<EOF >| $file
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: ${name}
+  name: ${name}
+  namespace: ${namespace}
+spec:
+  replicas: ${replicas}
+  selector:
+    matchLabels:
+      app: ${name}
+  template:
+    metadata:
+      labels:
+        app: ${name}
+    spec:
+      hostNetwork: true
+      containers:
+      - command:
+        - sleep
+        - "3600"
+        image: ${CONTAINER_IMAGE}
+        name: ${name}
+EOF
+  run_kubectl apply -f ${file}
+  kubectl_wait_deployment ${namespace} ${name}
+}
+
+# Spawn a test service named 'service-test' with a test deployment named 'service-test'
+# with 1 replica in namespace named 'ovn-kubetrace-service-test'
+spawn_service() {
+  local namespace="ovn-kubetrace-service-test"
+  local name="service-test"
+  local replicas="1"
+
+  file=$(mktemp)
+  cat <<EOF >| $file
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ${namespace}
+EOF
+  run_kubectl apply -f ${file}
+
+  file=$(mktemp)
+cat <<EOF >| $file
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ${name}
+  namespace: ${namespace}
+  labels:
+    app: ${name}
+spec:
+  replicas: ${replicas}
+  selector:
+    matchLabels:
+      app: ${name}
+  template:
+    metadata:
+      labels:
+        app: ${name}
+    spec:
+      containers:
+      - name: ${name}
+        image: ${CONTAINER_IMAGE}
+        command:
+        - sleep
+        - "3600"
+EOF
+  run_kubectl apply -f ${file}
+  kubectl_wait_deployment ${namespace} ${name}
+
+file=$(mktemp)
+cat <<EOF >| $file
+apiVersion: v1
+kind: Service
+metadata:
+  name: ${name}
+  namespace: ${namespace}
+spec:
+  type: ClusterIP
+  selector:
+    app: ${name}
+  ports:
+    - port: 80
+      targetPort: 80
+EOF
+  run_kubectl apply -f ${file}
+}
+
+# Create a test egressip named 'egressip-pod-test' with a test deployment
+# with 2 replica in namespace named 'egressip-kubetrace-pod-test'
+spawn_egressip() {
+  local namespace="egressip-kubetrace-pod-test"
+  local name="egressip-pod-test"
+  local replicas="2"
+  local egressip="$1"
+
+  local worker_nodes=$(get_worker_nodes)
+  if [ "${worker_nodes}" == "" ]; then
+    echo "Could not find worker nodes for EgressIP. Exiting."
+    exit 1
+  fi
+  for n in ${worker_nodes}; do
+    ${KUBECTL} label node/$n k8s.ovn.org/egress-assignable="" --overwrite
+  done
+
+  file=$(mktemp)
+  cat <<EOF >| $file
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ${namespace}
+  labels:
+    env: ${namespace}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: ${name}
+  name: ${name}
+  namespace: ${namespace}
+spec:
+  replicas: ${replicas}
+  selector:
+    matchLabels:
+      app: ${name}
+  template:
+    metadata:
+      labels:
+        app: ${name}
+    spec:
+      nodeSelector:
+        k8s.ovn.org/egress-assignable: ""
+      containers:
+      - command:
+        - "sleep"
+        - "3600"
+        image: ${CONTAINER_IMAGE}
+        name: ${name}
+EOF
+  run_kubectl apply -f ${file}
+  kubectl_wait_deployment ${namespace} ${name}
+
+  file=$(mktemp)
+  cat <<EOF >| ${file}
+apiVersion: k8s.ovn.org/v1
+kind: EgressIP
+metadata:
+  name: ${name}
+spec:
+  egressIPs: [ "${egressip}" ]
+  namespaceSelector:
+    matchLabels:
+      env: ${namespace}
+EOF
+  run_kubectl apply -f ${file}
+}
+
+# Clean up all namespaces that we created and remove egress assignable labels
+cleanup() {
+  echo "Cleaning up namespaces"
+  ${KUBECTL} delete ns ovn-kubetrace-pod-test             2>/dev/null || true
+  ${KUBECTL} delete ns ovn-kubetrace-pod-test-hostnetwork 2>/dev/null || true
+  ${KUBECTL} delete ns ovn-kubetrace-service-test         2>/dev/null || true
+  ${KUBECTL} delete ns egressip-kubetrace-pod-test        2>/dev/null || true
+  ${KUBECTL} delete egressip egressip-pod-test            2>/dev/null || true
+  local worker_nodes=$(get_worker_nodes)
+  if [ "${worker_nodes}" == "" ]; then
+    echo "Could not find worker nodes for EgressIP. Exiting."
+    exit 1
+  fi
+  for n in ${worker_nodes}; do
+    ${KUBECTL} label node/$n k8s.ovn.org/egress-assignable- 2>/dev/null || true
+  done
+}
+
+# Run ovnkube-trace
+ovnkube_trace() {
+    local cmd="$OVNKUBE_TRACE $@ -loglevel ${LOGLEVEL}"
+    echo -e "\e[1mRunning: ${cmd}\e[0m"
+    ${cmd}
+}
+
+parse_args "$@"
+
+if [ ! -f ${OVNKUBE_TRACE} ]; then
+  echo "ovnkube trace binary not found"
+  exit 1
+fi
+
+if [ ${SETUP} == true ]; then
+  cleanup
+  spawn_deployment
+  spawn_hostnetwork_deployment
+  spawn_service
+  spawn_egressip ${EGRESS_IP}
+fi
+
+src_pods=()
+dst_pods=()
+src_pods_hostnetwork=()
+dst_pods_hostnetwork=()
+egressip_src_pods=()
+dst_svc=( "-dst-namespace ovn-kubetrace-service-test -service service-test" )
+
+for namespace in ovn-kubetrace-pod-test; do
+  pods=$(${KUBECTL} get pods -o name -n $namespace | sed 's#pod/##')
+  for pod in ${pods}; do
+    src_pods+=( "-src-namespace ${namespace} -src ${pod}" )
+    dst_pods+=( "-dst-namespace ${namespace} -dst ${pod}" )
+  done
+done
+
+for namespace in egressip-kubetrace-pod-test; do
+  pods=$(${KUBECTL} get pods -o name -n $namespace | sed 's#pod/##')
+  for pod in ${pods}; do
+    egressip_src_pods+=( "-src-namespace ${namespace} -src ${pod}" )
+  done
+done
+
+for namespace in ovn-kubetrace-pod-test-hostnetwork; do
+  pods=$(${KUBECTL} get pods -o name -n $namespace | sed 's#pod/##')
+  for pod in ${pods}; do
+    src_pods_hostnetwork+=( "-src-namespace ${namespace} -src ${pod}" )
+    dst_pods_hostnetwork+=( "-dst-namespace ${namespace} -dst ${pod}" )
+  done
+done
+
+if [ $RUN_DEST_IP_TESTS == true ]; then
+  echo "Run ovnkube-trace from all pod-test pods to 8.8.8.8"
+  for ((i = 0; i < ${#src_pods[@]}; i++)); do
+    for protocol in tcp udp; do
+      ovnkube_trace ${src_pods[$i]} -dst-ip 8.8.8.8 -${protocol}
+    done
+  done
+
+  echo "Run ovnkube-trace from all egressip-pod-test pods to 8.8.8.8"
+  for ((i = 0; i < ${#egressip_src_pods[@]}; i++)); do
+    for protocol in tcp udp; do
+      ovnkube_trace ${egressip_src_pods[$i]} -dst-ip 8.8.8.8 -${protocol}
+    done
+  done
+
+  echo "Run ovnkube-trace from a pod-test-hostnetwork pod to 8.8.8.8 - this should fail"
+  if ovnkube_trace ${src_pods_hostnetwork[0]} -dst-ip 8.8.8.8 -${protocol}; then
+    echo "The result of this test should be a failure condition"
+    exit 1
+  fi
+fi
+
+echo "Run ovnkube-trace from all pod-test pods to all other pod-test pods"
+for ((i = 0; i < ${#src_pods[@]}; i++)); do
+  for ((j = 0; j < ${#dst_pods[@]}; j++)); do
+    for protocol in tcp udp; do
+      ovnkube_trace ${src_pods[$i]} ${dst_pods[$j]} -${protocol}
+    done
+  done
+done
+
+echo "Run ovnkube-trace from all pod-test pods to all pod-test-hostnetwork pods"
+for ((i = 0; i < ${#src_pods[@]}; i++)); do
+  for ((j = 0; j < ${#dst_pods_hostnetwork[@]}; j++)); do
+    for protocol in tcp udp; do
+      ovnkube_trace ${src_pods[$i]} ${dst_pods_hostnetwork[$j]} -${protocol}
+    done
+  done
+done
+
+echo "Run ovnkube-trace from all pod-test pods to the service-test service via tcp"
+for ((i = 0; i < ${#src_pods[@]}; i++)); do
+  for ((j = 0; j < ${#dst_svc[@]}; j++)); do
+    # udp with services is not a valid option
+    for protocol in tcp; do
+      ovnkube_trace ${src_pods[$i]} ${dst_svc[$j]} -${protocol}
+    done
+  done
+done
+
+echo "Run ovnkube-trace from a pod-test pod to a service-test service on udp - this should fail"
+if ovnkube_trace ${src_pods[0]} ${dst_svc[0]} -udp; then
+  echo "The result of this test should be a failure condition"
+  exit 1
+fi
+
+if [ ${POST_CLEANUP} == true ]; then
+  cleanup
+fi


### PR DESCRIPTION
Minimal conflicts in a couple of cherry-picks due to b0efc6b31 landing out of order.

ovnkube-trace is exactly the same now as for 4.12:
~~~
[akaris@linux ovnkube-trace (OCPBUGS-1720b)]$ pwd
/home/akaris/development/ovn-kubernetes/go-controller/cmd/ovnkube-trace
[akaris@linux ovnkube-trace (OCPBUGS-1720b)]$ ll
total 48
-rw-r--r--. 1 akaris akaris 48971 Dec 12 21:33 ovnkube-trace.go
[akaris@linux ovnkube-trace (OCPBUGS-1720b)]$ git diff downstream/release-4.12 -- ovnkube-trace.go
[akaris@linux ovnkube-trace (OCPBUGS-1720b)]$ 
~~~