### PR TITLE
OCPBUGS-4761: [4.11] Dockerfile: bump OVS to 2.17.0-62.el8fdp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN yum install -y  \
 	selinux-policy && \
 	yum clean all
 
-ARG ovsver=2.17.0-37.4.el8fdp
+ARG ovsver=2.17.0-62.el8fdp
 ARG ovnver=22.06.0-27.el8fdp
 
 RUN INSTALL_PKGS=" \


### PR DESCRIPTION
Mainly to get:
"ovsdb/transaction.c: Refactor assess_weak_refs."
http://patchwork.ozlabs.org/project/openvswitch/list/?series=325800&state=%2A&archive=both

which fixes a memory leak in ovsdb-server.

Cherry-pick of https://github.com/openshift/ovn-kubernetes/pull/1387