### PR TITLE
OCPBUGS-4765: [4.8] Dockerfile: bump to OVS 2.15.0-126

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN yum install -y  \
 	selinux-policy && \
 	yum clean all
 
-ARG ovsver=2.15.0-9.el8fdp
+ARG ovsver=2.15.0-126.el8fdp
 ARG ovnver=20.12.0-196.el8fdp
 
 RUN INSTALL_PKGS=" \


### PR DESCRIPTION
Bump to latest support FDP build. If only to shut up the container security grading due to a DPDK issue that isn't used by nor relevant to ovn-kubernetes.
