### PR TITLE
OCPBUGS-4655: [release-4.11] Don't delete equivalent ACLs by predicate, since it will fail if

### DIFF
--- a/go-controller/pkg/libovsdbops/acl.go
+++ b/go-controller/pkg/libovsdbops/acl.go
@@ -2,7 +2,6 @@ package libovsdbops
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"reflect"
 
@@ -167,53 +166,5 @@ func UpdateACLsDirection(nbClient libovsdbclient.Client, acls ...*nbdb.ACL) erro
 
 	modelClient := newModelClient(nbClient)
 	_, err := modelClient.CreateOrUpdate(opModels...)
-	return err
-}
-
-// DeleteACLsOps deletes the provided ACLs and returns the corresponding ops
-// portGroupNames and switchPred reminds to delete ACL references for port groups or switches
-// in case port group or switch is not completely deleted
-func DeleteACLsOps(nbClient libovsdbclient.Client, ops []libovsdb.Operation,
-	portGroupNames []string, switchPred switchPredicate, acls ...*nbdb.ACL) ([]libovsdb.Operation, error) {
-	var err error
-	for _, portGroupName := range portGroupNames {
-		ops, err = DeleteACLsFromPortGroupOps(nbClient, ops, portGroupName, acls...)
-		if err != nil && !errors.Is(err, libovsdbclient.ErrNotFound) {
-			return ops, fmt.Errorf("deleting ACLs from port group %s failed: %v", portGroupName, err)
-		}
-	}
-	if switchPred != nil {
-		ops, err = RemoveACLsFromLogicalSwitchesWithPredicateOps(nbClient, ops, switchPred, acls...)
-		if err != nil && !errors.Is(err, libovsdbclient.ErrNotFound) {
-			return ops, fmt.Errorf("deleting ACLs from switch with predicate failed: %v", err)
-		}
-	}
-	opModels := make([]operationModel, 0, len(acls))
-	for i := range acls {
-		// can't use i in the predicate, for loop replaces it in-memory
-		acl := acls[i]
-		opModel := operationModel{
-			Model:          acl,
-			ModelPredicate: func(item *nbdb.ACL) bool { return isEquivalentACL(item, acl) },
-			ErrNotFound:    false,
-			BulkOp:         true,
-		}
-		opModels = append(opModels, opModel)
-	}
-
-	modelClient := newModelClient(nbClient)
-	return modelClient.DeleteOps(ops, opModels...)
-}
-
-// DeleteACLs deletes the provided ACLs
-// portGroupNames and switchPred reminds to delete ACL references for port groups or switches
-// in case port group or switch is not completely deleted
-func DeleteACLs(nbClient libovsdbclient.Client, portGroupNames []string, switchPred switchPredicate, acls ...*nbdb.ACL) error {
-	ops, err := DeleteACLsOps(nbClient, nil, portGroupNames, switchPred, acls...)
-	if err != nil {
-		return err
-	}
-
-	_, err = TransactAndCheck(nbClient, ops)
 	return err
 }

--- a/go-controller/pkg/libovsdbops/portgroup.go
+++ b/go-controller/pkg/libovsdbops/portgroup.go
@@ -196,6 +196,19 @@ func DeleteACLsFromPortGroupOps(nbClient libovsdbclient.Client, ops []libovsdb.O
 	return m.DeleteOps(ops, opModel)
 }
 
+func DeleteACLsFromPortGroups(nbClient libovsdbclient.Client, names []string, acls ...*nbdb.ACL) error {
+	var err error
+	var ops []libovsdb.Operation
+	for _, pgName := range names {
+		ops, err = DeleteACLsFromPortGroupOps(nbClient, ops, pgName, acls...)
+		if err != nil {
+			return err
+		}
+	}
+	_, err = TransactAndCheck(nbClient, ops)
+	return err
+}
+
 // DeletePortGroupsOps deletes the provided port groups and returns the
 // corresponding ops
 func DeletePortGroupsOps(nbClient libovsdbclient.Client, ops []libovsdb.Operation, names ...string) ([]libovsdb.Operation, error) {

--- a/go-controller/pkg/ovn/egressfirewall.go
+++ b/go-controller/pkg/ovn/egressfirewall.go
@@ -378,7 +378,7 @@ func (oc *Controller) deleteEgressFirewallRules(externalID string) error {
 	// delete egress firewall acls off any logical switch which has it,
 	// then manually remove the egressFirewall ACLs instead of relying on ovsdb garbage collection to do so
 	pSwitch := func(item *nbdb.LogicalSwitch) bool { return true }
-	err = libovsdbops.DeleteACLs(oc.nbClient, nil, pSwitch, egressFirewallACLs...)
+	err = libovsdbops.RemoveACLsFromLogicalSwitchesWithPredicate(oc.nbClient, pSwitch, egressFirewallACLs...)
 	if err != nil {
 		return err
 	}

--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -271,7 +271,7 @@ func (oc *Controller) updateStaleDefaultDenyACLNames(npType knet.PolicyType, gre
 			// this should never be the case but delete everything except 1st ACL
 			ingressPGName := defaultDenyPortGroupName(namespace, ingressDefaultDenySuffix)
 			egressPGName := defaultDenyPortGroupName(namespace, egressDefaultDenySuffix)
-			err := libovsdbops.DeleteACLs(oc.nbClient, []string{ingressPGName, egressPGName}, nil, aclList[1:]...)
+			err := libovsdbops.DeleteACLsFromPortGroups(oc.nbClient, []string{ingressPGName, egressPGName}, aclList[1:]...)
 			if err != nil {
 				return err
 			}
@@ -401,7 +401,7 @@ func (oc *Controller) syncNetworkPolicies(networkPolicies []interface{}) error {
 			pgName = strings.TrimPrefix(gressACL.Match, "outport == @")
 		}
 		pgName = strings.TrimSuffix(pgName, " && "+staleArpAllowPolicyMatch)
-		ops, err = libovsdbops.DeleteACLsOps(oc.nbClient, ops, []string{pgName}, nil, gressACL)
+		ops, err = libovsdbops.DeleteACLsFromPortGroupOps(oc.nbClient, ops, pgName, gressACL)
 		if err != nil {
 			return fmt.Errorf("failed getting delete acl ops: %v", err)
 		}
@@ -576,25 +576,14 @@ func (oc *Controller) createDefaultDenyPGAndACLs(namespace, policy string, aclLo
 // deleteDefaultDenyPGAndACLs deletes the default port groups and acls for a namespace
 // must be called with defaultDenyPortGroups lock
 func (oc *Controller) deleteDefaultDenyPGAndACLs(namespace, policy string) error {
-	var aclsToBeDeleted []*nbdb.ACL
-
 	ingressPGName := defaultDenyPortGroupName(namespace, ingressDefaultDenySuffix)
-	ingressDenyACL, ingressAllowACL := buildDenyACLs(namespace, ingressPGName, nil, lportIngress)
-	aclsToBeDeleted = append(aclsToBeDeleted, ingressDenyACL, ingressAllowACL)
 	egressPGName := defaultDenyPortGroupName(namespace, egressDefaultDenySuffix)
-	egressDenyACL, egressAllowACL := buildDenyACLs(namespace, egressPGName, nil, lportEgressAfterLB)
-	aclsToBeDeleted = append(aclsToBeDeleted, egressDenyACL, egressAllowACL)
 
 	ops, err := libovsdbops.DeletePortGroupsOps(oc.nbClient, nil, ingressPGName, egressPGName)
 	if err != nil {
 		return err
 	}
-	// Manually remove the default ACLs instead of relying on ovsdb garbage collection to do so
-	// don't delete ACL references because port group is completely deleted in the same tnx
-	ops, err = libovsdbops.DeleteACLsOps(oc.nbClient, ops, nil, nil, aclsToBeDeleted...)
-	if err != nil {
-		return err
-	}
+	// No need to delete ACLs, since they will be garbage collected with deleted port groups
 	_, err = libovsdbops.TransactAndCheck(oc.nbClient, ops)
 	if err != nil {
 		return fmt.Errorf("failed to transact deleteDefaultDenyPGAndACLs: %v", err)

--- a/go-controller/pkg/ovn/policy_test.go
+++ b/go-controller/pkg/ovn/policy_test.go
@@ -1331,7 +1331,9 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				acls := []libovsdb.TestData{}
 				acls = append(acls, gressPolicy1ExpectedData[:len(gressPolicy1ExpectedData)-1]...)
 				acls = append(acls, gressPolicy2ExpectedData[:len(gressPolicy2ExpectedData)-1]...)
-				gomega.Eventually(fakeOvn.nbClient).Should(libovsdb.HaveData(append(acls, getExpectedDataPodsAndSwitches([]testPod{nPodTest}, []string{"node1"})...)))
+				acls = append(acls, defaultDenyExpectedData[:len(defaultDenyExpectedData)-2]...)
+				gomega.Eventually(fakeOvn.nbClient).Should(libovsdb.HaveData(append(acls,
+					getExpectedDataPodsAndSwitches([]testPod{nPodTest}, []string{"node1"})...)))
 
 				return nil
 			}
@@ -1893,7 +1895,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 
 				// ACL4: leftover default deny ACL ingress with old name (namespace_policyname)
 				leftOverACL4FromUpgrade := libovsdbops.BuildACL(
-					"leftover1"+"_"+networkPolicy2.Name,
+					"shortName"+"_"+networkPolicy2.Name,
 					nbdb.ACLDirectionToLport,
 					types.DefaultDenyPriority,
 					"outport == @"+pgHash+"_"+ingressDenyPG,
@@ -1960,14 +1962,28 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				}
 				leftOverACL3FromUpgrade.Options = egressOptions
 				newDefaultDenyEgressACLName := "youknownothingjonsnowyouknownothingjonsnowyouknownothingjonsnow" // trims it according to RFC1123
-				newDefaultDenyIngressACLName := "leftover1_" + ingressDefaultDenySuffix
+				newDefaultDenyIngressACLName := "shortName_" + ingressDefaultDenySuffix
 				leftOverACL3FromUpgrade.Name = &newDefaultDenyEgressACLName
 				leftOverACL4FromUpgrade.Name = &newDefaultDenyIngressACLName
 				expectedData = append(expectedData, leftOverACL3FromUpgrade)
 				expectedData = append(expectedData, leftOverACL4FromUpgrade)
-				testOnlyIngressDenyPG.ACLs = nil // Sync Function should remove stale ACL from PGs and delete the ACL
-				testOnlyEgressDenyPG.ACLs = nil  // Sync Function should remove stale ACL from PGs and delete the ACL
+				testOnlyIngressDenyPG.ACLs = nil // Sync Function should remove stale ACL from PGs
+				testOnlyEgressDenyPG.ACLs = nil  // Sync Function should remove stale ACL from PGs
 				expectedData = append(expectedData, testOnlyIngressDenyPG)
+				// since test server doesn't garbage collect dereferenced acls, they will stay in the test db after they
+				// were deleted. Even though they are derefenced from the port group at this point, they will be updated
+				// as all the other ACLs.
+				// Update deleted leftOverACL1FromUpgrade and leftOverACL2FromUpgrade to match on expected data
+				// Once our test server can delete such acls, this part should be deleted
+				// start of db hack
+				newDefaultDenyLeftoverIngressACLName := "leftover1_" + ingressDefaultDenySuffix
+				newDefaultDenyLeftoverEgressACLName := "leftover1_" + egressDefaultDenySuffix
+				leftOverACL2FromUpgrade.Name = &newDefaultDenyLeftoverIngressACLName
+				leftOverACL1FromUpgrade.Name = &newDefaultDenyLeftoverEgressACLName
+				leftOverACL1FromUpgrade.Options = egressOptions
+				expectedData = append(expectedData, leftOverACL2FromUpgrade)
+				expectedData = append(expectedData, leftOverACL1FromUpgrade)
+				// end of db hack
 				expectedData = append(expectedData, testOnlyEgressDenyPG)
 
 				fakeOvn.asf.ExpectAddressSetWithIPs(namespaceName1, []string{nPodTest.podIP})
@@ -2047,7 +2063,8 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 					// older versions of ACLs don't have, should be added by syncNetworkPolicies on startup
 					//	"apply-after-lb": "true",
 				}
-				longLeftOverNameSpaceName := "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz" // namespace is >45 characters long
+				longLeftOverNameSpaceName := "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz"  // namespace is >45 characters long
+				longLeftOverNameSpaceName2 := "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxy1" // namespace is >45 characters long
 				pgHash := hashedPortGroup(longLeftOverNameSpaceName)
 				// ACL1: leftover arp allow ACL egress with old match (arp)
 				leftOverACL1FromUpgrade := libovsdbops.BuildACL(
@@ -2115,7 +2132,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 
 				// ACL4: leftover default deny ACL egress with old name (namespace_policyname)
 				leftOverACL4FromUpgrade := libovsdbops.BuildACL(
-					longLeftOverNameSpaceName+"_"+networkPolicy2.Name, // we are ok here because test server doesn't impose restrictions
+					longLeftOverNameSpaceName2+"_"+networkPolicy2.Name, // we are ok here because test server doesn't impose restrictions
 					nbdb.ACLDirectionFromLport,
 					types.DefaultDenyPriority,
 					"inport == @"+pgHash+"_"+egressDenyPG,
@@ -2132,7 +2149,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 
 				// ACL5: leftover default deny ACL ingress with old name (namespace_policyname)
 				leftOverACL5FromUpgrade := libovsdbops.BuildACL(
-					longLeftOverNameSpaceName+"_"+networkPolicy2.Name, // we are ok here because test server doesn't impose restrictions
+					longLeftOverNameSpaceName2+"_"+networkPolicy2.Name, // we are ok here because test server doesn't impose restrictions
 					nbdb.ACLDirectionToLport,
 					types.DefaultDenyPriority,
 					"outport == @"+pgHash+"_"+ingressDenyPG,
@@ -2227,16 +2244,31 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 					"apply-after-lb": "true",
 				}
 				leftOverACL4FromUpgrade.Options = egressOptions
-				leftOverACL3FromUpgrade.Name = utilpointer.StringPtr(longLeftOverNameSpaceName + "blah_ARPall") // trims it according to RFC1123
-				leftOverACL4FromUpgrade.Name = utilpointer.StringPtr(longLeftOverNameSpaceName + "_egressDefa") // trims it according to RFC1123
-				leftOverACL5FromUpgrade.Name = utilpointer.StringPtr(longLeftOverNameSpaceName + "_ingressDef") // trims it according to RFC1123
-				leftOverACL6FromUpgrade.Name = utilpointer.StringPtr(longLeftOverNameSpaceName62 + "_")         // name stays the same here since its no-op
+				leftOverACL3FromUpgrade.Name = utilpointer.StringPtr(longLeftOverNameSpaceName + "blah_ARPall")  // trims it according to RFC1123
+				leftOverACL4FromUpgrade.Name = utilpointer.StringPtr(longLeftOverNameSpaceName2 + "_egressDefa") // trims it according to RFC1123
+				leftOverACL5FromUpgrade.Name = utilpointer.StringPtr(longLeftOverNameSpaceName2 + "_ingressDef") // trims it according to RFC1123
+				leftOverACL6FromUpgrade.Name = utilpointer.StringPtr(longLeftOverNameSpaceName62 + "_")          // name stays the same here since its no-op
 				expectedData = append(expectedData, leftOverACL3FromUpgrade)
 				expectedData = append(expectedData, leftOverACL4FromUpgrade)
 				expectedData = append(expectedData, leftOverACL5FromUpgrade)
 				expectedData = append(expectedData, leftOverACL6FromUpgrade)
-				testOnlyIngressDenyPG.ACLs = []string{leftOverACL3FromUpgrade.UUID} // Sync Function should remove stale ACL from PGs and delete the ACL
-				testOnlyEgressDenyPG.ACLs = nil                                     // Sync Function should remove stale ACL from PGs and delete the ACL
+				testOnlyIngressDenyPG.ACLs = []string{leftOverACL3FromUpgrade.UUID} // Sync Function should remove stale ACL from PGs
+				testOnlyEgressDenyPG.ACLs = nil                                     // Sync Function should remove stale ACL from PGs
+
+				// since test server doesn't garbage collect dereferenced acls, they will stay in the test db after they
+				// were deleted. Even though they are derefenced from the port group at this point, they will be updated
+				// as all the other ACLs.
+				// Update deleted leftOverACL1FromUpgrade and leftOverACL2FromUpgrade to match on expected data
+				// Once our test server can delete such acls, this part should be deleted
+				// start of db hack
+				longLeftOverIngressName := longLeftOverNameSpaceName + "_ingressDef"
+				longLeftOverEgressName := longLeftOverNameSpaceName + "_egressDefa"
+				leftOverACL2FromUpgrade.Name = &longLeftOverIngressName
+				leftOverACL1FromUpgrade.Name = &longLeftOverEgressName
+				leftOverACL1FromUpgrade.Options = egressOptions
+				expectedData = append(expectedData, leftOverACL2FromUpgrade)
+				expectedData = append(expectedData, leftOverACL1FromUpgrade)
+				// end of db hack
 				expectedData = append(expectedData, testOnlyIngressDenyPG)
 				expectedData = append(expectedData, testOnlyEgressDenyPG)
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdb.HaveData(expectedData...))
@@ -2862,6 +2894,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 
 				acls := []libovsdb.TestData{}
 				acls = append(acls, gressPolicyExpectedData[:len(gressPolicyExpectedData)-1]...)
+				acls = append(acls, defaultDenyExpectedData[:len(defaultDenyExpectedData)-2]...)
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdb.HaveData(append(acls, getExpectedDataPodsAndSwitches([]testPod{nPodTest}, []string{"node1"})...)))
 
 				return nil
@@ -2978,6 +3011,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 
 				acls := []libovsdb.TestData{}
 				acls = append(acls, gressPolicyExpectedData[:len(gressPolicyExpectedData)-1]...)
+				acls = append(acls, defaultDenyExpectedData[:len(defaultDenyExpectedData)-2]...)
 				gomega.Eventually(fakeOvn.controller.nbClient).Should(libovsdb.HaveData(append(acls, getExpectedDataPodsAndSwitches([]testPod{nPodTest}, []string{"node1"})...)))
 
 				// check the cache no longer has the entry


### PR DESCRIPTION
Backport of https://github.com/openshift/ovn-kubernetes/pull/1406 (only the last commit, which is the fix)