### PR TITLE
[release-4.11] OCPBUGS-4829: Set the node as reachable only when it is being added as an egressip node

### DIFF
--- a/go-controller/pkg/ovn/egressip.go
+++ b/go-controller/pkg/ovn/egressip.go
@@ -1954,7 +1954,6 @@ func (oc *Controller) initClusterEgressPolicies(nodes []interface{}) error {
 	if err := oc.createDefaultNoRerouteServicePolicies(v4ClusterSubnet, v6ClusterSubnet); err != nil {
 		return err
 	}
-	// TODO(FF): Make go routine below use oc.stopChan
 	go oc.checkEgressNodesReachability()
 	return nil
 }
@@ -2319,36 +2318,47 @@ func (e *egressIPController) deleteEgressIPStatusSetup(name string, status egres
 // is important because egress IP is based upon routing traffic to these nodes,
 // and if they aren't reachable we shouldn't be using them for egress IP.
 func (oc *Controller) checkEgressNodesReachability() {
+	timer := time.NewTicker(5 * time.Second)
+	defer timer.Stop()
 	for {
-		reAddOrDelete := map[string]bool{}
-		oc.eIPC.allocator.Lock()
-		for _, eNode := range oc.eIPC.allocator.cache {
-			if eNode.isEgressAssignable && eNode.isReady {
-				wasReachable := eNode.isReachable
-				isReachable := oc.isReachable(eNode)
-				if wasReachable && !isReachable {
-					reAddOrDelete[eNode.name] = true
-				} else if !wasReachable && isReachable {
-					reAddOrDelete[eNode.name] = false
-				}
-				eNode.isReachable = isReachable
+		select {
+		case <-timer.C:
+			checkEgressNodesReachabilityIterate(oc)
+		case <-oc.stopChan:
+			klog.V(5).Infof("Stop channel got triggered: will stop checkEgressNodesReachability")
+			return
+		}
+	}
+}
+
+func checkEgressNodesReachabilityIterate(oc *Controller) {
+	reAddOrDelete := map[string]bool{}
+	oc.eIPC.allocator.Lock()
+	for _, eNode := range oc.eIPC.allocator.cache {
+		if eNode.isEgressAssignable && eNode.isReady {
+			wasReachable := eNode.isReachable
+			isReachable := oc.isReachable(eNode)
+			if wasReachable && !isReachable {
+				reAddOrDelete[eNode.name] = true
+			} else if !wasReachable && isReachable {
+				reAddOrDelete[eNode.name] = false
+			}
+			eNode.isReachable = isReachable
+		}
+	}
+	oc.eIPC.allocator.Unlock()
+	for nodeName, shouldDelete := range reAddOrDelete {
+		if shouldDelete {
+			klog.Warningf("Node: %s is detected as unreachable, deleting it from egress assignment", nodeName)
+			if err := oc.deleteEgressNode(nodeName); err != nil {
+				klog.Errorf("Node: %s is detected as unreachable, but could not re-assign egress IPs, err: %v", nodeName, err)
+			}
+		} else {
+			klog.Infof("Node: %s is detected as reachable and ready again, adding it to egress assignment", nodeName)
+			if err := oc.addEgressNode(nodeName); err != nil {
+				klog.Errorf("Node: %s is detected as reachable and ready again, but could not re-assign egress IPs, err: %v", nodeName, err)
 			}
 		}
-		oc.eIPC.allocator.Unlock()
-		for nodeName, shouldDelete := range reAddOrDelete {
-			if shouldDelete {
-				klog.Warningf("Node: %s is detected as unreachable, deleting it from egress assignment", nodeName)
-				if err := oc.deleteEgressNode(nodeName); err != nil {
-					klog.Errorf("Node: %s is detected as unreachable, but could not re-assign egress IPs, err: %v", nodeName, err)
-				}
-			} else {
-				klog.Infof("Node: %s is detected as reachable and ready again, adding it to egress assignment", nodeName)
-				if err := oc.addEgressNode(nodeName); err != nil {
-					klog.Errorf("Node: %s is detected as reachable and ready again, but could not re-assign egress IPs, err: %v", nodeName, err)
-				}
-			}
-		}
-		time.Sleep(5 * time.Second)
 	}
 }
 

--- a/go-controller/pkg/ovn/egressip.go
+++ b/go-controller/pkg/ovn/egressip.go
@@ -2034,6 +2034,8 @@ type egressIPController struct {
 	watchFactory *factory.WatchFactory
 	// EgressIP Node reachability total timeout configuration
 	egressIPTotalTimeout int
+	// reachability check interval
+	reachabilityCheckInterval time.Duration
 }
 
 // addStandByEgressIPAssignment does the same setup that is done by addPodEgressIPAssignments but for
@@ -2318,7 +2320,7 @@ func (e *egressIPController) deleteEgressIPStatusSetup(name string, status egres
 // is important because egress IP is based upon routing traffic to these nodes,
 // and if they aren't reachable we shouldn't be using them for egress IP.
 func (oc *Controller) checkEgressNodesReachability() {
-	timer := time.NewTicker(5 * time.Second)
+	timer := time.NewTicker(oc.eIPC.reachabilityCheckInterval)
 	defer timer.Stop()
 	for {
 		select {

--- a/go-controller/pkg/ovn/egressip_test.go
+++ b/go-controller/pkg/ovn/egressip_test.go
@@ -26,10 +26,12 @@ import (
 	utilpointer "k8s.io/utils/pointer"
 )
 
-type fakeEgressIPDialer struct{}
+type fakeEgressIPDialer struct {
+	dialResult bool
+}
 
-func (f fakeEgressIPDialer) dial(ip net.IP, timeout time.Duration) bool {
-	return true
+func (f *fakeEgressIPDialer) dial(ip net.IP, timeout time.Duration) bool {
+	return f.dialResult
 }
 
 var (
@@ -134,7 +136,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 		},
 	}
 
-	dialer = fakeEgressIPDialer{}
+	dialer = &fakeEgressIPDialer{true}
 
 	getEgressIPAllocatorSizeSafely := func() int {
 		fakeOvn.controller.eIPC.allocator.Lock()
@@ -7091,6 +7093,114 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		})
 
+		ginkgo.It("egress node update should not mark the node as reachable if there was no label/readiness change", func() {
+			// When an egress node becomes reachable during a node update event and there is no changes to node labels/readiness
+			// unassigned egress IP should be eventually added by the periodic reachability check.
+			// Test steps:
+			//  - disable periodic check from running in background, so it can be called directly from the test
+			//  - assign egress IP to an available node
+			//  - make the node unreachable and verify that the egress IP was unassigned
+			//  - make the node reachable and update a node
+			//  - verify that the egress IP was assigned by calling the periodic reachability check
+			app.Action = func(ctx *cli.Context) error {
+				egressIP := "192.168.126.101"
+				nodeIPv4 := "192.168.126.51/24"
+				node := v1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: node1Name,
+						Annotations: map[string]string{
+							"k8s.ovn.org/node-primary-ifaddr": fmt.Sprintf("{\"ipv4\": \"%s\"}", nodeIPv4),
+							"k8s.ovn.org/node-subnets":        fmt.Sprintf("{\"default\":[\"%s\"]}", v4NodeSubnet),
+						},
+						Labels: map[string]string{
+							"k8s.ovn.org/egress-assignable": "",
+						},
+					},
+					Status: v1.NodeStatus{
+						Conditions: []v1.NodeCondition{
+							{
+								Type:   v1.NodeReady,
+								Status: v1.ConditionTrue,
+							},
+						},
+					},
+				}
+				eIP1 := egressipv1.EgressIP{
+					ObjectMeta: newEgressIPMeta(egressIPName),
+					Spec: egressipv1.EgressIPSpec{
+						EgressIPs: []string{egressIP},
+					},
+				}
+				fakeOvn.startWithDBSetup(
+					libovsdbtest.TestSetup{
+						NBData: []libovsdbtest.TestData{
+							&nbdb.LogicalRouter{
+								Name: ovntypes.OVNClusterRouter,
+								UUID: ovntypes.OVNClusterRouter + "-UUID",
+							},
+							&nbdb.LogicalRouter{
+								Name: ovntypes.GWRouterPrefix + node.Name,
+								UUID: ovntypes.GWRouterPrefix + node.Name + "-UUID",
+							},
+							&nbdb.LogicalRouterPort{
+								UUID:     ovntypes.GWRouterToJoinSwitchPrefix + ovntypes.GWRouterPrefix + node.Name + "-UUID",
+								Name:     ovntypes.GWRouterToJoinSwitchPrefix + ovntypes.GWRouterPrefix + node.Name,
+								Networks: []string{nodeLogicalRouterIfAddrV4},
+							},
+							&nbdb.LogicalSwitchPort{
+								UUID: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node.Name + "UUID",
+								Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node.Name,
+								Type: "router",
+								Options: map[string]string{
+									"router-port": types.GWRouterToExtSwitchPrefix + "GR_" + node.Name,
+								},
+							},
+						},
+					},
+					&egressipv1.EgressIPList{
+						Items: []egressipv1.EgressIP{eIP1},
+					},
+					&v1.NodeList{
+						Items: []v1.Node{node},
+					},
+				)
+
+				// Virtually disable background reachability check by using a huge interval
+				fakeOvn.controller.eIPC.reachabilityCheckInterval = time.Hour
+
+				// Use a fake dialer that we control
+				fakeDialer := fakeEgressIPDialer{true}
+				dialer = &fakeDialer
+
+				err := fakeOvn.controller.WatchEgressNodes()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				gomega.Eventually(getEgressIPStatusLen(eIP1.Name)).Should(gomega.Equal(1))
+				egressIPs, _ := getEgressIPStatus(eIP1.Name)
+				gomega.Expect(egressIPs[0]).To(gomega.Equal(egressIP))
+
+				fakeDialer.dialResult = false
+				// explicitly call check reachability, periodic checker is not active
+				checkEgressNodesReachabilityIterate(fakeOvn.controller)
+				gomega.Eventually(getEgressIPStatusLen(eIP1.Name)).Should(gomega.Equal(0))
+
+				fakeDialer.dialResult = true
+				node.Annotations["test"] = "dummy"
+				_, err = fakeOvn.fakeClient.KubeClient.CoreV1().Nodes().Update(context.TODO(), &node, metav1.UpdateOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				// the node should not be marked as reachable in the update handler as it is not getting added
+				gomega.Consistently(func() bool { return fakeOvn.controller.eIPC.allocator.cache[node.Name].isReachable }).Should(gomega.Equal(false))
+
+				// egress IP should get assigned on the next checkEgressNodesReachabilityIterate call
+				// explicitly call check reachability, periodic checker is not active
+				checkEgressNodesReachabilityIterate(fakeOvn.controller)
+				gomega.Eventually(getEgressIPStatusLen(eIP1.Name)).Should(gomega.Equal(1))
+
+				return nil
+			}
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
 	})
 
 	ginkgo.Context("Dual-stack assignment", func() {

--- a/go-controller/pkg/ovn/obj_retry.go
+++ b/go-controller/pkg/ovn/obj_retry.go
@@ -721,10 +721,8 @@ func (oc *Controller) addResource(objectsToRetry *retryObjs, obj interface{}, fr
 			oc.setNodeEgressReady(node.Name, true)
 		}
 		isReachable := oc.isEgressNodeReachable(node)
-		if isReachable {
-			oc.setNodeEgressReachable(node.Name, true)
-		}
 		if hasEgressLabel && isReachable && isReady {
+			oc.setNodeEgressReachable(node.Name, true)
 			if err := oc.addEgressNode(node.Name); err != nil {
 				return err
 			}
@@ -843,11 +841,11 @@ func (oc *Controller) updateResource(objectsToRetry *retryObjs, oldObj, newObj i
 		isNewReady := oc.isEgressNodeReady(newNode)
 		isNewReachable := oc.isEgressNodeReachable(newNode)
 		oc.setNodeEgressReady(newNode.Name, isNewReady)
-		oc.setNodeEgressReachable(newNode.Name, isNewReachable)
 		if !oldHadEgressLabel && newHasEgressLabel {
 			klog.Infof("Node: %s has been labeled, adding it for egress assignment", newNode.Name)
 			oc.setNodeEgressAssignable(newNode.Name, true)
 			if isNewReady && isNewReachable {
+				oc.setNodeEgressReachable(newNode.Name, isNewReachable)
 				if err := oc.addEgressNode(newNode.Name); err != nil {
 					return err
 				}
@@ -866,6 +864,7 @@ func (oc *Controller) updateResource(objectsToRetry *retryObjs, oldObj, newObj i
 			}
 		} else if isNewReady && isNewReachable {
 			klog.Infof("Node: %s is ready and reachable, adding it for egress assignment", newNode.Name)
+			oc.setNodeEgressReachable(newNode.Name, isNewReachable)
 			if err := oc.addEgressNode(newNode.Name); err != nil {
 				return err
 			}

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -47,7 +47,8 @@ import (
 )
 
 const (
-	egressFirewallDNSDefaultDuration time.Duration = 30 * time.Minute
+	egressFirewallDNSDefaultDuration  = 30 * time.Minute
+	egressIPReachabilityCheckInterval = 5 * time.Second
 )
 
 // ACL logging severity levels
@@ -245,6 +246,7 @@ func NewOvnController(ovnClient *util.OVNClientset, wf *factory.WatchFactory, st
 			nbClient:                          libovsdbOvnNBClient,
 			watchFactory:                      wf,
 			egressIPTotalTimeout:              config.OVNKubernetesFeature.EgressIPReachabiltyTotalTimeout,
+			reachabilityCheckInterval:         egressIPReachabilityCheckInterval,
 		},
 		loadbalancerClusterCache:  make(map[kapi.Protocol]string),
 		multicastSupport:          config.EnableMulticast,


### PR DESCRIPTION
egressip node update: set the node as reachable only when it is being added as an egressip node

there are three places where ovnkube marks an egress node as reachable:
- node add event handler
- node update even handler
- periodic connectivity checker

In a scenario where the egressip node becomes reachable at the same time as the node object is updated
the node is set as reachable but because there was no label/readiness change it is never added as an egressip node.
The periodic check will then ignore the node because it considers it as already reachable.

To address the issue only set the node as reachable if it is actually getting added as an egressip node.

Conflicts:
go-controller/pkg/ovn/egressip.go
go-controller/pkg/ovn/obj_retry_master.go --> go-controller/pkg/ovn/obj_retry.go
go-controller/pkg/ovn/ovn.go
go-controller/pkg/ovn/egressip_test.go --> depends on changes that do not exist in release-4.11

Signed-off-by: Patryk Diak <pdiak@redhat.com>
(cherry picked from commit 65bd3ae8c7d8ccc9a2814a221c989dd8ab8155d0)