### PR TITLE
OCPBUGS-4884: [release-4.12] Fixes scenario where deleted + completed pods may leak

### DIFF
--- a/go-controller/pkg/retry/obj_retry.go
+++ b/go-controller/pkg/retry/obj_retry.go
@@ -401,8 +401,8 @@ func (r *RetryFramework) processObjectInTerminalState(obj interface{}, lockedKey
 	_, loaded := r.terminatedObjects.LoadOrStore(lockedKey, true)
 	if loaded {
 		// object was already terminated
-		klog.Infof("Detected object %s of type %s in terminal state (e.g. completed) will be " +
-			"ignored as it has already been processed")
+		klog.Infof("Detected object %s of type %s in terminal state (e.g. completed) will be "+
+			"ignored as it has already been processed", lockedKey, r.ResourceHandler.ObjType)
 		return
 	}
 

--- a/go-controller/pkg/retry/obj_retry.go
+++ b/go-controller/pkg/retry/obj_retry.go
@@ -522,13 +522,22 @@ func (r *RetryFramework) WatchResourceFiltered(namespaceForFilteredHandler strin
 					// When processing an object in terminal state there is a chance that it was already removed from
 					// the API server. Since delete events for objects in terminal state are skipped delete it here.
 					// This only applies to pod watchers (pods + dynamic network policy handlers watching pods).
-					if kerrors.IsNotFound(err) && r.ResourceHandler.IsObjectInTerminalState(newer) {
-						klog.Warningf("%s %s is in terminal state but no longer exists in informer cache, removing",
-							r.ResourceHandler.ObjType, newKey)
-						r.processObjectInTerminalState(newer, newKey, resourceEventUpdate)
+					if kerrors.IsNotFound(err) {
+						if r.ResourceHandler.IsObjectInTerminalState(newer) {
+							klog.Warningf("%s %s is in terminal state but no longer exists in informer cache, removing",
+								r.ResourceHandler.ObjType, newKey)
+							r.DoWithLock(newKey, func(key string) {
+								r.processObjectInTerminalState(newer, newKey, resourceEventUpdate)
+							})
+						} else {
+							klog.V(5).Infof("Ignoring update event for %s %s as it was not found in"+
+								" informer cache and is not in a terminal state", r.ResourceHandler.ObjType, newKey)
+						}
 					} else {
-						klog.Warningf("Unable to get %s %s from informer cache (perhaps it was already"+
-							" deleted?), skipping update: %v", r.ResourceHandler.ObjType, newKey, err)
+						// This should never happen. The cache storage backend type cannot return any error
+						// other than not found
+						klog.Errorf("Unhandled error while trying to retrieve %s %s from informer cache: %v",
+							r.ResourceHandler.ObjType, newKey, err)
 					}
 					return
 				}


### PR DESCRIPTION
Previously delete events were being ignored for completed pods. This would end up leaking the pod and IP if for some reason we never got an update event signalling the pod was completed.