### PR TITLE
OCPBUGS-4861, OCPBUGS-4839: [release-4.10] Avoid duplicate transactions and minimize handlers with empty namespace selectors

### DIFF
--- a/go-controller/pkg/libovsdbops/portgroup.go
+++ b/go-controller/pkg/libovsdbops/portgroup.go
@@ -142,6 +142,25 @@ func CreateOrUpdatePortGroups(nbClient libovsdbclient.Client, pgs ...*nbdb.PortG
 	return err
 }
 
+// GetPortGroup looks up a port group from the cache
+func GetPortGroup(nbClient libovsdbclient.Client, pg *nbdb.PortGroup) (*nbdb.PortGroup, error) {
+	found := []nbdb.PortGroup{}
+	opModel := OperationModel{
+		Model:          pg,
+		ExistingResult: &found,
+		OnModelUpdates: nil, // no update
+		ErrNotFound:    true,
+		BulkOp:         false,
+	}
+
+	m := NewModelClient(nbClient)
+	_, err := m.CreateOrUpdate(opModel)
+	if err != nil {
+		return nil, err
+	}
+	return &found[0], nil
+}
+
 func AddPortsToPortGroupOps(nbClient libovsdbclient.Client, ops []libovsdb.Operation, name string, ports ...string) ([]libovsdb.Operation, error) {
 	if ops == nil {
 		ops = []libovsdb.Operation{}

--- a/go-controller/pkg/ovn/address_set/address_set.go
+++ b/go-controller/pkg/ovn/address_set/address_set.go
@@ -594,6 +594,10 @@ func (as *ovnAddressSet) addIPs(ips []net.IP) ([]ovsdb.Operation, error) {
 	}
 	uniqIPs := ipsToStringUnique(ips)
 
+	if as.hasIPs(uniqIPs...) {
+		return nil, nil
+	}
+
 	klog.V(5).Infof("(%s) adding IPs (%s) to address set", asDetail(as), uniqIPs)
 	addrset := &nbdb.AddressSet{UUID: as.uuid}
 	ops, err = as.nbClient.Where(addrset).Mutate(addrset, model.Mutation{
@@ -607,6 +611,20 @@ func (as *ovnAddressSet) addIPs(ips []net.IP) ([]ovsdb.Operation, error) {
 	}
 
 	return ops, nil
+}
+
+// hasIPs returns true if an address set contains all given IPs
+func (as *ovnAddressSet) hasIPs(ips ...string) bool {
+	existingIPs, err := as.getIPs()
+	if err != nil {
+		return false
+	}
+
+	if len(existingIPs) == 0 {
+		return false
+	}
+
+	return sets.NewString(existingIPs...).HasAll(ips...)
 }
 
 // deleteIPs removes selected IPs from the existing address_set


### PR DESCRIPTION
Backport of https://github.com/openshift/ovn-kubernetes/pull/1447


Conflict: update GetPortGroup to use CreateOrUpdate with empty
update fields, since older version of modelClient doesn't have
Lookup method.