### PR TITLE
OCPBUGS-4864: [release-4.10] Fix address set cleanup: only delete address sets owned by given object

### DIFF
--- a/go-controller/pkg/ovn/address_set/address_set.go
+++ b/go-controller/pkg/ovn/address_set/address_set.go
@@ -30,7 +30,7 @@ const (
 	ipv6AddressSetSuffix = "_v6"
 )
 
-type AddressSetIterFunc func(hashedName, namespace, suffix string) error
+type AddressSetIterFunc func(hashedName, name string) error
 type AddressSetDoFunc func(as AddressSet) error
 
 // AddressSetFactory is an interface for managing address set objects
@@ -176,7 +176,7 @@ func (asf *ovnAddressSetFactory) EnsureAddressSet(name string) (AddressSet, erro
 	return &ovnAddressSets{nbClient: asf.nbClient, name: name, ipv4: v4set, ipv6: v6set}, nil
 }
 
-func forEachAddressSet(nbClient libovsdbclient.Client, do func(string) error) error {
+func forEachAddressSet(nbClient libovsdbclient.Client, do func(string, string) error) error {
 	addrSetList := &[]nbdb.AddressSet{}
 	ctx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout)
 	defer cancel()
@@ -191,7 +191,7 @@ func forEachAddressSet(nbClient libovsdbclient.Client, do func(string) error) er
 
 	var errors []error
 	for _, addrSet := range *addrSetList {
-		if err := do(addrSet.ExternalIDs["name"]); err != nil {
+		if err := do(addrSet.Name, addrSet.ExternalIDs["name"]); err != nil {
 			errors = append(errors, err)
 		}
 	}
@@ -203,12 +203,10 @@ func forEachAddressSet(nbClient libovsdbclient.Client, do func(string) error) er
 	return nil
 }
 
-// ProcessEachAddressSet will pass the unhashed address set name, namespace name
-// and the first suffix in the name to the 'iteratorFn' for every address_set in
-// OVN. (Unhashed address set names are of the form namespaceName[.suffix1.suffix2. .suffixN])
+// ProcessEachAddressSet will pass the hashed and unhashed address set name to iteratorFn for every address set.
 func (asf *ovnAddressSetFactory) ProcessEachAddressSet(iteratorFn AddressSetIterFunc) error {
 	processedAddressSets := sets.String{}
-	return forEachAddressSet(asf.nbClient, func(name string) error {
+	return forEachAddressSet(asf.nbClient, func(hashedName, name string) error {
 		// Remove the suffix from the address set name and normalize
 		addrSetName := truncateSuffixFromAddressSet(name)
 		if processedAddressSets.Has(addrSetName) {
@@ -218,13 +216,7 @@ func (asf *ovnAddressSetFactory) ProcessEachAddressSet(iteratorFn AddressSetIter
 			return nil
 		}
 		processedAddressSets.Insert(addrSetName)
-		names := strings.Split(addrSetName, ".")
-		addrSetNamespace := names[0]
-		nameSuffix := ""
-		if len(names) >= 2 {
-			nameSuffix = names[1]
-		}
-		return iteratorFn(addrSetName, addrSetNamespace, nameSuffix)
+		return iteratorFn(hashedName, addrSetName)
 	})
 }
 

--- a/go-controller/pkg/ovn/address_set/address_set.go
+++ b/go-controller/pkg/ovn/address_set/address_set.go
@@ -176,6 +176,8 @@ func (asf *ovnAddressSetFactory) EnsureAddressSet(name string) (AddressSet, erro
 	return &ovnAddressSets{nbClient: asf.nbClient, name: name, ipv4: v4set, ipv6: v6set}, nil
 }
 
+// forEachAddressSet executes a do function on each address set found to have ExternalIDs["name"].
+// do function should take parameters: hashed addr set name, real name
 func forEachAddressSet(nbClient libovsdbclient.Client, do func(string, string) error) error {
 	addrSetList := &[]nbdb.AddressSet{}
 	ctx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout)

--- a/go-controller/pkg/ovn/address_set/address_set_cleanup.go
+++ b/go-controller/pkg/ovn/address_set/address_set_cleanup.go
@@ -16,7 +16,7 @@ func NonDualStackAddressSetCleanup(nbClient libovsdbclient.Client) error {
 	const old = 0
 	const new = 1
 	addressSets := map[string][2]bool{}
-	err := forEachAddressSet(nbClient, func(name string) error {
+	err := forEachAddressSet(nbClient, func(hashedName, name string) error {
 		shortName := truncateSuffixFromAddressSet(name)
 		spec, found := addressSets[shortName]
 		if !found {

--- a/go-controller/pkg/ovn/address_set/address_set_test.go
+++ b/go-controller/pkg/ovn/address_set/address_set_test.go
@@ -70,16 +70,16 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 					NBData: []libovsdbtest.TestData{
 						&nbdb.AddressSet{
 							Name:        "1",
-							ExternalIDs: map[string]string{"name": "ns1.foo.bar"},
+							ExternalIDs: map[string]string{"name": "foo.bar"},
 						},
 						&nbdb.AddressSet{
 							Name:        "2",
-							ExternalIDs: map[string]string{"name": "ns2.test.test2"},
+							ExternalIDs: map[string]string{"name": "test.test2"},
 						},
 
 						&nbdb.AddressSet{
 							Name:        "3",
-							ExternalIDs: map[string]string{"name": "ns3"},
+							ExternalIDs: map[string]string{"name": "test3"},
 						},
 					},
 				}
@@ -91,17 +91,17 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 
 				_, err = config.InitConfig(ctx, nil, nil)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				namespaces := map[string]bool{
-					"ns1.foo.bar":    true,
-					"ns2.test.test2": true,
-					"ns3":            true,
+				expectedAddressSets := map[string]bool{
+					"foo.bar":    true,
+					"test.test2": true,
+					"test3":      true,
 				}
 				err = asFactory.ProcessEachAddressSet(func(hashedName, addrSetName string) error {
-					gomega.Expect(namespaces[addrSetName]).To(gomega.BeTrue())
-					delete(namespaces, addrSetName)
+					gomega.Expect(expectedAddressSets[addrSetName]).To(gomega.BeTrue())
+					delete(expectedAddressSets, addrSetName)
 					return nil
 				})
-				gomega.Expect(len(namespaces)).To(gomega.Equal(0))
+				gomega.Expect(len(expectedAddressSets)).To(gomega.Equal(0))
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				return nil
 			}

--- a/go-controller/pkg/ovn/egressfirewall.go
+++ b/go-controller/pkg/ovn/egressfirewall.go
@@ -287,11 +287,16 @@ func (oc *Controller) deleteEgressFirewall(egressFirewallObj *egressfirewallapi.
 			break
 		}
 	}
+	// delete acls first, then dns address set that is referenced in these acls
+	if err := oc.deleteEgressFirewallRules(egressFirewallObj.Namespace); err != nil {
+		return err
+	}
+
 	if deleteDNS {
 		oc.egressFirewallDNS.Delete(egressFirewallObj.Namespace)
 	}
 
-	return oc.deleteEgressFirewallRules(egressFirewallObj.Namespace)
+	return nil
 }
 
 func (oc *Controller) updateEgressFirewallWithRetry(egressfirewall *egressfirewallapi.EgressFirewall) error {

--- a/go-controller/pkg/ovn/egressfirewall.go
+++ b/go-controller/pkg/ovn/egressfirewall.go
@@ -26,6 +26,8 @@ const (
 	egressFirewallAppliedCorrectly = "EgressFirewall Rules applied"
 	egressFirewallAddError         = "EgressFirewall Rules not correctly added"
 	egressFirewallUpdateError      = "EgressFirewall Rules not correctly updated"
+	// egressFirewallACLExtIdKey external ID key for egress firewall ACLs
+	egressFirewallACLExtIdKey = "egressFirewall"
 )
 
 type egressFirewall struct {
@@ -176,7 +178,7 @@ func (oc *Controller) syncEgressFirewallRetriable(egressFirewalls []interface{})
 	ovnEgressFirewalls := make(map[string]struct{})
 
 	for _, egressFirewallACL := range egressFirewallACLs {
-		if ns, ok := egressFirewallACL.ExternalIDs["egressFirewall"]; ok {
+		if ns, ok := egressFirewallACL.ExternalIDs[egressFirewallACLExtIdKey]; ok {
 			// Most egressFirewalls will have more then one ACL but we only need to know if there is one for the namespace
 			// so a map is fine and we will add an entry every iteration but because it is a map will overwrite the previous
 			// entry if it already existed
@@ -362,7 +364,7 @@ func (oc *Controller) createEgressFirewallRules(priority int, match, action, ext
 		Direction:   types.DirectionToLPort,
 		Match:       match,
 		Action:      action,
-		ExternalIDs: map[string]string{"egressFirewall": externalID},
+		ExternalIDs: map[string]string{egressFirewallACLExtIdKey: externalID},
 	}
 
 	// add it's UUID to the necessary logical switches
@@ -408,7 +410,7 @@ func (oc *Controller) createEgressFirewallRules(priority int, match, action, ext
 // deleteEgressFirewallRules delete the specific logical router policy/join switch Acls
 func (oc *Controller) deleteEgressFirewallRules(externalID string) error {
 	// Find ACLs for a given egressFirewall
-	egressFirewallACLs, err := libovsdbops.FindACLsByExternalID(oc.nbClient, map[string]string{"egressFirewall": externalID})
+	egressFirewallACLs, err := libovsdbops.FindACLsByExternalID(oc.nbClient, map[string]string{egressFirewallACLExtIdKey: externalID})
 	if err != nil {
 		return fmt.Errorf("unable to list egress firewall ACLs, cannot cleanup old stale data, err: %v", err)
 	}

--- a/go-controller/pkg/ovn/egressfirewall_test.go
+++ b/go-controller/pkg/ovn/egressfirewall_test.go
@@ -87,7 +87,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations for local gateway mode", 
 					"",
 					"",
 					false,
-					map[string]string{"egressFirewall": "none"},
+					map[string]string{egressFirewallACLExtIdKey: "none"},
 				)
 				purgeACL.UUID = libovsdbops.BuildNamedUUID()
 
@@ -100,7 +100,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations for local gateway mode", 
 					"",
 					"",
 					false,
-					map[string]string{"egressFirewall": "default"},
+					map[string]string{egressFirewallACLExtIdKey: "default"},
 				)
 				keepACL.UUID = libovsdbops.BuildNamedUUID()
 
@@ -114,7 +114,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations for local gateway mode", 
 					"",
 					"",
 					false,
-					map[string]string{"egressFirewall": "default"},
+					map[string]string{egressFirewallACLExtIdKey: "default"},
 				)
 				otherACL.UUID = libovsdbops.BuildNamedUUID()
 
@@ -247,7 +247,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations for local gateway mode", 
 					"",
 					"",
 					false,
-					map[string]string{"egressFirewall": "namespace1"},
+					map[string]string{egressFirewallACLExtIdKey: "namespace1"},
 				)
 				ipv4ACL.UUID = libovsdbops.BuildNamedUUID()
 
@@ -335,7 +335,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations for local gateway mode", 
 					"",
 					"",
 					false,
-					map[string]string{"egressFirewall": "namespace1"},
+					map[string]string{egressFirewallACLExtIdKey: "namespace1"},
 				)
 				ipv6ACL.UUID = libovsdbops.BuildNamedUUID()
 
@@ -431,7 +431,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations for local gateway mode", 
 					"",
 					"",
 					false,
-					map[string]string{"egressFirewall": "namespace1"},
+					map[string]string{egressFirewallACLExtIdKey: "namespace1"},
 				)
 
 				udpACL.UUID = libovsdbops.BuildNamedUUID()
@@ -528,7 +528,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations for local gateway mode", 
 					"",
 					"",
 					false,
-					map[string]string{"egressFirewall": "namespace1"},
+					map[string]string{egressFirewallACLExtIdKey: "namespace1"},
 				)
 				ipv4ACL.UUID = libovsdbops.BuildNamedUUID()
 
@@ -632,7 +632,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations for local gateway mode", 
 					"",
 					"",
 					false,
-					map[string]string{"egressFirewall": "namespace1"},
+					map[string]string{egressFirewallACLExtIdKey: "namespace1"},
 				)
 				ipv4ACL.UUID = libovsdbops.BuildNamedUUID()
 
@@ -711,7 +711,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations for shared gateway mode",
 					"",
 					"",
 					false,
-					map[string]string{"egressFirewall": "none"},
+					map[string]string{egressFirewallACLExtIdKey: "none"},
 				)
 				purgeACL.UUID = libovsdbops.BuildNamedUUID()
 
@@ -724,7 +724,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations for shared gateway mode",
 					"",
 					"",
 					false,
-					map[string]string{"egressFirewall": "default"},
+					map[string]string{egressFirewallACLExtIdKey: "default"},
 				)
 				keepACL.UUID = libovsdbops.BuildNamedUUID()
 
@@ -738,7 +738,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations for shared gateway mode",
 					"",
 					"",
 					false,
-					map[string]string{"egressFirewall": "default"},
+					map[string]string{egressFirewallACLExtIdKey: "default"},
 				)
 				otherACL.UUID = libovsdbops.BuildNamedUUID()
 
@@ -866,7 +866,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations for shared gateway mode",
 					"",
 					"",
 					false,
-					map[string]string{"egressFirewall": "namespace1"},
+					map[string]string{egressFirewallACLExtIdKey: "namespace1"},
 				)
 				ipv4ACL.UUID = libovsdbops.BuildNamedUUID()
 
@@ -949,7 +949,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations for shared gateway mode",
 					"",
 					"",
 					false,
-					map[string]string{"egressFirewall": "namespace1"},
+					map[string]string{egressFirewallACLExtIdKey: "namespace1"},
 				)
 				ipv6ACL.UUID = libovsdbops.BuildNamedUUID()
 
@@ -1042,7 +1042,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations for shared gateway mode",
 					"",
 					"",
 					false,
-					map[string]string{"egressFirewall": "namespace1"},
+					map[string]string{egressFirewallACLExtIdKey: "namespace1"},
 				)
 
 				udpACL.UUID = libovsdbops.BuildNamedUUID()
@@ -1123,7 +1123,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations for shared gateway mode",
 					"",
 					"",
 					false,
-					map[string]string{"egressFirewall": "namespace1"},
+					map[string]string{egressFirewallACLExtIdKey: "namespace1"},
 				)
 				ipv4ACL.UUID = libovsdbops.BuildNamedUUID()
 
@@ -1211,7 +1211,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations for shared gateway mode",
 					"",
 					"",
 					false,
-					map[string]string{"egressFirewall": "namespace1"},
+					map[string]string{egressFirewallACLExtIdKey: "namespace1"},
 				)
 				ipv4ACL.UUID = libovsdbops.BuildNamedUUID()
 

--- a/go-controller/pkg/ovn/namespace.go
+++ b/go-controller/pkg/ovn/namespace.go
@@ -39,39 +39,41 @@ func (oc *Controller) syncNamespacesRetriable(namespaces []interface{}) error {
 	}
 
 	err := oc.addressSetFactory.ProcessEachAddressSet(func(hashedName, addrSetName string) error {
-		// filter out address sets owned by HybridRoutePolicy by prefix, and
-		// owned by network policy by dot in the name (namespace can't have dots in its name).
+		// filter out address sets owned by HybridRoutePolicy and EgressQoS by prefix.
+		// network policy-owned address set would have a dot in the address set name due to the format
+		// (namespace can't have dots in its name, and their address sets too).
 		// the only left address sets may be owned by egress firewall dns or namespace
-		if !strings.HasPrefix(addrSetName, types.HybridRoutePolicyPrefix) &&
-			!strings.Contains(addrSetName, ".") {
-			// make sure address set is not owned by egress firewall dns
-			// find ACLs referencing given address set (by hashName)
+		if strings.HasPrefix(addrSetName, types.HybridRoutePolicyPrefix) ||
+			strings.Contains(addrSetName, ".") {
+			return nil
+		}
 
-			aclPred := func(acl *nbdb.ACL) bool {
-				return strings.Contains(acl.Match, "$"+hashedName)
-			}
-			acls, err := libovsdbops.FindACLsByPredicate(oc.nbClient, aclPred)
-			if err != nil {
-				return fmt.Errorf("failed to find referencing acls for address set %s: %v", addrSetName, err)
-			}
-			if len(acls) > 0 {
-				// if given address set is owned by egress firewall, all ACLs will be owned by the same object
-				acl := acls[0]
-				// check if egress firewall dns is the owner
-				// the only address set that may be referenced in egress firewall destination is dns address set
-				if acl.ExternalIDs[egressFirewallACLExtIdKey] != "" && strings.Contains(acl.Match, ".dst == $"+hashedName) {
-					// address set is owned by egress firewall, skip
-					return nil
-				}
-			}
-			// address set is owned by namespace, namespace name = address set name
-			if !expectedNs[addrSetName] {
-				if err := oc.addressSetFactory.DestroyAddressSetInBackingStore(addrSetName); err != nil {
-					klog.Errorf(err.Error())
-					return err
-				}
+		// make sure address set is not owned by egress firewall dns
+		// find ACLs referencing given address set (by hashName)
+		aclPred := func(acl *nbdb.ACL) bool {
+			return strings.Contains(acl.Match, "$"+hashedName)
+		}
+		acls, err := libovsdbops.FindACLsByPredicate(oc.nbClient, aclPred)
+		if err != nil {
+			return fmt.Errorf("failed to find referencing acls for address set %s: %v", addrSetName, err)
+		}
+		if len(acls) > 0 {
+			// if given address set is owned by egress firewall, all ACLs will be owned by the same object
+			acl := acls[0]
+			// check if egress firewall dns is the owner
+			// the only address set that may be referenced in egress firewall destination is dns address set
+			if acl.ExternalIDs[egressFirewallACLExtIdKey] != "" && strings.Contains(acl.Match, ".dst == $"+hashedName) {
+				// address set is owned by egress firewall, skip
+				return nil
 			}
 		}
+		// address set is owned by namespace, namespace name = address set name
+		if !expectedNs[addrSetName] {
+			if err = oc.addressSetFactory.DestroyAddressSetInBackingStore(addrSetName); err != nil {
+				return err
+			}
+		}
+
 		return nil
 	})
 	if err != nil {

--- a/go-controller/pkg/ovn/namespace_test.go
+++ b/go-controller/pkg/ovn/namespace_test.go
@@ -90,6 +90,38 @@ var _ = ginkgo.Describe("OVN Namespace Operations", func() {
 	})
 
 	ginkgo.Context("on startup", func() {
+		ginkgo.It("only cleans up address sets owned by namespace", func() {
+			namespace1 := newNamespace(namespaceName)
+			// namespace-owned address set for existing namespace, should stay
+			fakeOvn.asf.NewAddressSet(namespaceName, []net.IP{net.ParseIP("1.1.1.1")})
+			// namespace-owned address set for stale namespace, should be deleted
+			fakeOvn.asf.NewAddressSet("namespace2", []net.IP{net.ParseIP("1.1.1.2")})
+			// netpol-owned address set for existing netpol, should stay
+			fakeOvn.asf.NewAddressSet("namespace1.netpol1.egress.0", []net.IP{net.ParseIP("1.1.1.3")})
+			// hybridNode-owned address set, should stay
+			fakeOvn.asf.NewAddressSet(ovntypes.HybridRoutePolicyPrefix+"node", []net.IP{net.ParseIP("1.1.1.5")})
+			// egress firewall-owned address set, should stay
+			// needs exiting ACL to distinguish from namespace-owned
+			dnsAS, err := fakeOvn.asf.NewAddressSet("dnsname", []net.IP{net.ParseIP("1.1.1.6")})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			dnsHashName, _ := dnsAS.GetASHashNames()
+			egressFirewallACL := &nbdb.ACL{
+				Priority:    1,
+				Direction:   ovntypes.DirectionToLPort,
+				Match:       "ip4.dst == $" + dnsHashName,
+				Action:      nbdb.ACLActionAllow,
+				ExternalIDs: map[string]string{egressFirewallACLExtIdKey: "egressfirewall1"},
+			}
+
+			fakeOvn.startWithDBSetup(libovsdbtest.TestSetup{NBData: []libovsdbtest.TestData{egressFirewallACL}})
+			fakeOvn.controller.syncNamespaces([]interface{}{namespace1})
+
+			fakeOvn.asf.ExpectAddressSetWithIPs(namespaceName, []string{"1.1.1.1"})
+			fakeOvn.asf.EventuallyExpectNoAddressSet("namespace2")
+			fakeOvn.asf.ExpectAddressSetWithIPs("namespace1.netpol1.egress.0", []string{"1.1.1.3"})
+			fakeOvn.asf.ExpectAddressSetWithIPs(ovntypes.HybridRoutePolicyPrefix+"node", []string{"1.1.1.5"})
+			fakeOvn.asf.ExpectAddressSetWithIPs("dnsname", []string{"1.1.1.6"})
+		})
 
 		ginkgo.It("reconciles an existing namespace with pods", func() {
 			namespaceT := *newNamespace(namespaceName)

--- a/go-controller/pkg/ovn/namespace_test.go
+++ b/go-controller/pkg/ovn/namespace_test.go
@@ -101,7 +101,7 @@ var _ = ginkgo.Describe("OVN Namespace Operations", func() {
 			// hybridNode-owned address set, should stay
 			fakeOvn.asf.NewAddressSet(ovntypes.HybridRoutePolicyPrefix+"node", []net.IP{net.ParseIP("1.1.1.5")})
 			// egress firewall-owned address set, should stay
-			// needs exiting ACL to distinguish from namespace-owned
+			// needs existing ACL to distinguish from namespace-owned
 			dnsAS, err := fakeOvn.asf.NewAddressSet("dnsname", []net.IP{net.ParseIP("1.1.1.6")})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			dnsHashName, _ := dnsAS.GetASHashNames()

--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"reflect"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -233,16 +234,28 @@ func (oc *Controller) syncNetworkPoliciesRetriable(networkPolicies []interface{}
 	}
 
 	stalePGs := []string{}
-	err := oc.addressSetFactory.ProcessEachAddressSet(func(addrSetName, namespaceName, policyName string) error {
-		if policyName != "" && !expectedPolicies[namespaceName][policyName] {
-			// policy doesn't exist on k8s. Delete the port group
-			portGroupName := fmt.Sprintf("%s_%s", namespaceName, policyName)
-			hashedLocalPortGroup := hashedPortGroup(portGroupName)
-			stalePGs = append(stalePGs, hashedLocalPortGroup)
-			// delete the address sets for this old policy from OVN
-			if err := oc.addressSetFactory.DestroyAddressSetInBackingStore(addrSetName); err != nil {
-				klog.Errorf(err.Error())
-				return err
+	err := oc.addressSetFactory.ProcessEachAddressSet(func(hashedName, addrSetName string) error {
+		// netpol name has format fmt.Sprintf("%s.%s.%s.%d", gp.policyNamespace, gp.policyName, direction, gp.idx)
+		s := strings.Split(addrSetName, ".")
+		sLen := len(s)
+		// priority should be a number
+		_, numErr := strconv.Atoi(s[sLen-1])
+		if sLen >= 4 && (s[sLen-2] == "ingress" || s[sLen-2] == "egress") && numErr == nil {
+			// address set is owned by network policy
+			// namespace doesn't have dots
+			namespaceName := s[0]
+			// policyName may have dots, join in that case
+			policyName := strings.Join(s[1:sLen-2], ".")
+			if !expectedPolicies[namespaceName][policyName] {
+				// policy doesn't exist on k8s. Delete the port group
+				portGroupName := fmt.Sprintf("%s_%s", namespaceName, policyName)
+				hashedLocalPortGroup := hashedPortGroup(portGroupName)
+				stalePGs = append(stalePGs, hashedLocalPortGroup)
+				// delete the address sets for this old policy from OVN
+				if err := oc.addressSetFactory.DestroyAddressSetInBackingStore(addrSetName); err != nil {
+					klog.Errorf(err.Error())
+					return err
+				}
 			}
 		}
 		return nil

--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -234,28 +234,30 @@ func (oc *Controller) syncNetworkPoliciesRetriable(networkPolicies []interface{}
 	}
 
 	stalePGs := []string{}
-	err := oc.addressSetFactory.ProcessEachAddressSet(func(hashedName, addrSetName string) error {
+	err := oc.addressSetFactory.ProcessEachAddressSet(func(_, addrSetName string) error {
 		// netpol name has format fmt.Sprintf("%s.%s.%s.%d", gp.policyNamespace, gp.policyName, direction, gp.idx)
 		s := strings.Split(addrSetName, ".")
 		sLen := len(s)
 		// priority should be a number
 		_, numErr := strconv.Atoi(s[sLen-1])
-		if sLen >= 4 && (s[sLen-2] == "ingress" || s[sLen-2] == "egress") && numErr == nil {
-			// address set is owned by network policy
-			// namespace doesn't have dots
-			namespaceName := s[0]
-			// policyName may have dots, join in that case
-			policyName := strings.Join(s[1:sLen-2], ".")
-			if !expectedPolicies[namespaceName][policyName] {
-				// policy doesn't exist on k8s. Delete the port group
-				portGroupName := fmt.Sprintf("%s_%s", namespaceName, policyName)
-				hashedLocalPortGroup := hashedPortGroup(portGroupName)
-				stalePGs = append(stalePGs, hashedLocalPortGroup)
-				// delete the address sets for this old policy from OVN
-				if err := oc.addressSetFactory.DestroyAddressSetInBackingStore(addrSetName); err != nil {
-					klog.Errorf(err.Error())
-					return err
-				}
+		if sLen < 4 || (s[sLen-2] != "ingress" && s[sLen-2] != "egress") || numErr != nil {
+			// address set name is not formatted by network policy
+			return nil
+		}
+
+		// address set is owned by network policy
+		// namespace doesn't have dots
+		namespaceName := s[0]
+		// policyName may have dots, join in that case
+		policyName := strings.Join(s[1:sLen-2], ".")
+		if !expectedPolicies[namespaceName][policyName] {
+			// policy doesn't exist on k8s. Delete the port group
+			portGroupName := fmt.Sprintf("%s_%s", namespaceName, policyName)
+			hashedLocalPortGroup := hashedPortGroup(portGroupName)
+			stalePGs = append(stalePGs, hashedLocalPortGroup)
+			// delete the address sets for this old policy from OVN
+			if err := oc.addressSetFactory.DestroyAddressSetInBackingStore(addrSetName); err != nil {
+				return err
 			}
 		}
 		return nil

--- a/go-controller/pkg/ovn/policy_test.go
+++ b/go-controller/pkg/ovn/policy_test.go
@@ -3,6 +3,7 @@ package ovn
 import (
 	"context"
 	"fmt"
+	"net"
 	"sort"
 	"strconv"
 	"strings"
@@ -732,8 +733,66 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 	})
 
 	ginkgo.Context("on startup", func() {
+		ginkgo.It("only cleans up address sets owned by network policy", func() {
+			app.Action = func(ctx *cli.Context) error {
+				namespace1 := *newNamespace(namespaceName1)
+				namespace2 := *newNamespace(namespaceName2)
+				policyName := "networkpolicy1"
+				networkPolicy := newNetworkPolicy(policyName, namespace1.Name,
+					metav1.LabelSelector{},
+					[]knet.NetworkPolicyIngressRule{
+						{
+							From: []knet.NetworkPolicyPeer{
+								{
+									NamespaceSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"name": namespace2.Name,
+										},
+									},
+								},
+							},
+						},
+					},
+					[]knet.NetworkPolicyEgressRule{
+						{
+							To: []knet.NetworkPolicyPeer{
+								{
+									NamespaceSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"name": namespace2.Name,
+										},
+									},
+								},
+							},
+						},
+					})
+				// namespace-owned address set, should stay
+				fakeOvn.asf.NewAddressSet("namespace", []net.IP{net.ParseIP("1.1.1.1")})
+				// netpol-owned address set for existing netpol, should stay
+				fakeOvn.asf.NewAddressSet(fmt.Sprintf("namespace1.%s.egress.0", policyName), []net.IP{net.ParseIP("1.1.1.2")})
+				// netpol-owned address set for non-exisitng netpol, should be deleted
+				fakeOvn.asf.NewAddressSet("namespace1.not-existing.egress.0", []net.IP{net.ParseIP("1.1.1.3")})
+				// hybridNode-owned address set, should stay
+				fakeOvn.asf.NewAddressSet(types.HybridRoutePolicyPrefix+"node", []net.IP{net.ParseIP("1.1.1.5")})
+				// egress firewall-owned address set, should stay
+				fakeOvn.asf.NewAddressSet("test.dns.name", []net.IP{net.ParseIP("1.1.1.6")})
 
-		ginkgo.It("reconciles an existing ingress networkPolicy with a namespace selector", func() {
+				fakeOvn.start()
+				fakeOvn.controller.syncNetworkPolicies([]interface{}{networkPolicy})
+
+				fakeOvn.asf.ExpectAddressSetWithIPs("namespace", []string{"1.1.1.1"})
+				fakeOvn.asf.ExpectAddressSetWithIPs(fmt.Sprintf("namespace1.%s.egress.0", policyName), []string{"1.1.1.2"})
+				fakeOvn.asf.EventuallyExpectNoAddressSet("namespace1.not-existing.egress.0")
+				fakeOvn.asf.ExpectAddressSetWithIPs(types.HybridRoutePolicyPrefix+"node", []string{"1.1.1.5"})
+				fakeOvn.asf.ExpectAddressSetWithIPs("test.dns.name", []string{"1.1.1.6"})
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+
+		ginkgo.It("reconciles an existing networkPolicy with empty db", func() {
 			app.Action = func(ctx *cli.Context) error {
 
 				namespace1 := *newNamespace(namespaceName1)


### PR DESCRIPTION
Backport of https://github.com/openshift/ovn-kubernetes/pull/1448

Conflicts:
Use old methods to get acls from the db.
Remove EgressQos address set check, since it is not present on 4.10