### PR TITLE
OCPBUGS-3651: [release-4.12] cherry-pick hybrid overlay fixes from master branch 

### DIFF
--- a/go-controller/pkg/ovn/logical_switch_manager/logical_switch_manager.go
+++ b/go-controller/pkg/ovn/logical_switch_manager/logical_switch_manager.go
@@ -295,7 +295,7 @@ func (manager *LogicalSwitchManager) AllocateHybridOverlay(nodeName string, hybr
 		}
 		// attempt to allocate the IP address that is annotated on the node. The only way there would be a collision is if the annotations of podIP or hybridOverlayDRIP
 		// where manually edited and we do not support that
-		err := manager.AllocateIPs(switchName, allocateAddresses)
+		err := manager.AllocateIPs(nodeName, allocateAddresses)
 		if err != nil && err != ipallocator.ErrAllocated {
 			return nil, err
 		}

--- a/go-controller/pkg/ovn/logical_switch_manager/logical_switch_manager.go
+++ b/go-controller/pkg/ovn/logical_switch_manager/logical_switch_manager.go
@@ -9,6 +9,7 @@ import (
 
 	libovsdbclient "github.com/ovn-org/libovsdb/client"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/ipallocator"
 	ipam "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/ipallocator"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/ipallocator/allocator"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
@@ -292,8 +293,10 @@ func (manager *LogicalSwitchManager) AllocateHybridOverlay(nodeName string, hybr
 		for _, ip := range hybridOverlayAnnotation {
 			allocateAddresses = append(allocateAddresses, &net.IPNet{IP: net.ParseIP(ip).To4(), Mask: net.CIDRMask(32, 32)})
 		}
-		err := manager.AllocateIPs(nodeName, allocateAddresses)
-		if err != nil {
+		// attempt to allocate the IP address that is annotated on the node. The only way there would be a collision is if the annotations of podIP or hybridOverlayDRIP
+		// where manually edited and we do not support that
+		err := manager.AllocateIPs(switchName, allocateAddresses)
+		if err != nil && err != ipallocator.ErrAllocated {
 			return nil, err
 		}
 		return allocateAddresses, nil

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -106,6 +106,21 @@ func (oc *Controller) syncPods(pods []interface{}) error {
 			}
 		}
 	}
+
+	if config.HybridOverlay.Enabled {
+		// allocate all previously annoted hybridOverlay Distributed Router IP addresses. Allocation needs to happen here
+		// before a Pod Add event can be processed and be allocated a previously assigned hybridOverlay Distributed Router IP address.
+		// we do not support manually setting the hybrid overlay DRIP address
+		nodes, err := oc.watchFactory.GetNodes()
+		if err != nil {
+			return fmt.Errorf("failed to get nodes: %v", err)
+		}
+		for _, node := range nodes {
+			if err := oc.allocateHybridOverlayDRIP(node); err != nil {
+				return fmt.Errorf("cannot allocate hybridOverlay DRIP on node %s (%v)", node.Name, err)
+			}
+		}
+	}
 	// all pods present before ovn-kube startup have been processed
 	atomic.StoreUint32(&oc.allInitialPodsProcessed, 1)
 

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -106,6 +106,8 @@ func (oc *Controller) syncPods(pods []interface{}) error {
 			}
 		}
 	}
+	// all pods present before ovn-kube startup have been processed
+	atomic.StoreUint32(&oc.allInitialPodsProcessed, 1)
 
 	if config.HybridOverlay.Enabled {
 		// allocate all previously annoted hybridOverlay Distributed Router IP addresses. Allocation needs to happen here
@@ -121,8 +123,6 @@ func (oc *Controller) syncPods(pods []interface{}) error {
 			}
 		}
 	}
-	// all pods present before ovn-kube startup have been processed
-	atomic.StoreUint32(&oc.allInitialPodsProcessed, 1)
 
 	// get all the nodes from the watchFactory
 	nodes, err := oc.watchFactory.GetNodes()


### PR DESCRIPTION
cherry-pick: 82dcb005b966c1f71792a464bab038f54f991c8c, dabaf9fb8e024d8a52fbb1dc470fdce596caf505 the former did not apply cleanly but only needed a minor revision in AllocateHybridOverlay() the ladder did apply cleanly. 

This fixes allocation of the hybrid overlay DRIP by insuring that it will not collide with the IP of a new pod. 
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->