### PR TITLE
[release-4.10] OCPBUGS-5299: Set the node as reachable only when it is being added as an egressip node

### DIFF
--- a/go-controller/pkg/ovn/egressip.go
+++ b/go-controller/pkg/ovn/egressip.go
@@ -1853,6 +1853,8 @@ type egressIPController struct {
 	modelClient libovsdbops.ModelClient
 	// watchFactory watching k8s objects
 	watchFactory *factory.WatchFactory
+	// reachability check interval
+	reachabilityCheckInterval time.Duration
 }
 
 // addStandByEgressIPAssignment does the same setup that is done by addPodEgressIPAssignments but for
@@ -2213,7 +2215,7 @@ func (e *egressIPController) deleteEgressIPStatusSetup(name string, status egres
 // is important because egress IP is based upon routing traffic to these nodes,
 // and if they aren't reachable we shouldn't be using them for egress IP.
 func (oc *Controller) checkEgressNodesReachability() {
-	timer := time.NewTicker(5 * time.Second)
+	timer := time.NewTicker(oc.eIPC.reachabilityCheckInterval)
 	defer timer.Stop()
 	for {
 		select {

--- a/go-controller/pkg/ovn/egressip.go
+++ b/go-controller/pkg/ovn/egressip.go
@@ -2213,36 +2213,47 @@ func (e *egressIPController) deleteEgressIPStatusSetup(name string, status egres
 // is important because egress IP is based upon routing traffic to these nodes,
 // and if they aren't reachable we shouldn't be using them for egress IP.
 func (oc *Controller) checkEgressNodesReachability() {
+	timer := time.NewTicker(5 * time.Second)
+	defer timer.Stop()
 	for {
-		reAddOrDelete := map[string]bool{}
-		oc.eIPC.allocator.Lock()
-		for _, eNode := range oc.eIPC.allocator.cache {
-			if eNode.isEgressAssignable && eNode.isReady {
-				wasReachable := eNode.isReachable
-				isReachable := oc.isReachable(eNode)
-				if wasReachable && !isReachable {
-					reAddOrDelete[eNode.name] = true
-				} else if !wasReachable && isReachable {
-					reAddOrDelete[eNode.name] = false
-				}
-				eNode.isReachable = isReachable
+		select {
+		case <-timer.C:
+			checkEgressNodesReachabilityIterate(oc)
+		case <-oc.stopChan:
+			klog.V(5).Infof("Stop channel got triggered: will stop checkEgressNodesReachability")
+			return
+		}
+	}
+}
+
+func checkEgressNodesReachabilityIterate(oc *Controller) {
+	reAddOrDelete := map[string]bool{}
+	oc.eIPC.allocator.Lock()
+	for _, eNode := range oc.eIPC.allocator.cache {
+		if eNode.isEgressAssignable && eNode.isReady {
+			wasReachable := eNode.isReachable
+			isReachable := oc.isReachable(eNode)
+			if wasReachable && !isReachable {
+				reAddOrDelete[eNode.name] = true
+			} else if !wasReachable && isReachable {
+				reAddOrDelete[eNode.name] = false
+			}
+			eNode.isReachable = isReachable
+		}
+	}
+	oc.eIPC.allocator.Unlock()
+	for nodeName, shouldDelete := range reAddOrDelete {
+		if shouldDelete {
+			klog.Warningf("Node: %s is detected as unreachable, deleting it from egress assignment", nodeName)
+			if err := oc.deleteEgressNode(nodeName); err != nil {
+				klog.Errorf("Node: %s is detected as unreachable, but could not re-assign egress IPs, err: %v", nodeName, err)
+			}
+		} else {
+			klog.Infof("Node: %s is detected as reachable and ready again, adding it to egress assignment", nodeName)
+			if err := oc.addEgressNode(nodeName); err != nil {
+				klog.Errorf("Node: %s is detected as reachable and ready again, but could not re-assign egress IPs, err: %v", nodeName, err)
 			}
 		}
-		oc.eIPC.allocator.Unlock()
-		for nodeName, shouldDelete := range reAddOrDelete {
-			if shouldDelete {
-				klog.Warningf("Node: %s is detected as unreachable, deleting it from egress assignment", nodeName)
-				if err := oc.deleteEgressNode(nodeName); err != nil {
-					klog.Errorf("Node: %s is detected as unreachable, but could not re-assign egress IPs, err: %v", nodeName, err)
-				}
-			} else {
-				klog.Infof("Node: %s is detected as reachable and ready again, adding it to egress assignment", nodeName)
-				if err := oc.addEgressNode(nodeName); err != nil {
-					klog.Errorf("Node: %s is detected as reachable and ready again, but could not re-assign egress IPs, err: %v", nodeName, err)
-				}
-			}
-		}
-		time.Sleep(5 * time.Second)
 	}
 }
 

--- a/go-controller/pkg/ovn/egressip_test.go
+++ b/go-controller/pkg/ovn/egressip_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"time"
 
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
@@ -24,10 +25,12 @@ import (
 	utilpointer "k8s.io/utils/pointer"
 )
 
-type fakeEgressIPDialer struct{}
+type fakeEgressIPDialer struct {
+	dialResult bool
+}
 
-func (f fakeEgressIPDialer) dial(ip net.IP) bool {
-	return true
+func (f *fakeEgressIPDialer) dial(ip net.IP) bool {
+	return f.dialResult
 }
 
 var (
@@ -123,7 +126,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 		node2Name = "node2"
 	)
 
-	dialer = fakeEgressIPDialer{}
+	dialer = &fakeEgressIPDialer{true}
 
 	getEgressIPAllocatorSizeSafely := func() int {
 		fakeOvn.controller.eIPC.allocator.Lock()
@@ -6489,6 +6492,113 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		})
 
+		ginkgo.It("egress node update should not mark the node as reachable if there was no label/readiness change", func() {
+			// When an egress node becomes reachable during a node update event and there is no changes to node labels/readiness
+			// unassigned egress IP should be eventually added by the periodic reachability check.
+			// Test steps:
+			//  - disable periodic check from running in background, so it can be called directly from the test
+			//  - assign egress IP to an available node
+			//  - make the node unreachable and verify that the egress IP was unassigned
+			//  - make the node reachable and update a node
+			//  - verify that the egress IP was assigned by calling the periodic reachability check
+			app.Action = func(ctx *cli.Context) error {
+				egressIP := "192.168.126.101"
+				nodeIPv4 := "192.168.126.51/24"
+				node := v1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: node1Name,
+						Annotations: map[string]string{
+							"k8s.ovn.org/node-primary-ifaddr": fmt.Sprintf("{\"ipv4\": \"%s\"}", nodeIPv4),
+							"k8s.ovn.org/node-subnets":        fmt.Sprintf("{\"default\":[\"%s\"]}", v4NodeSubnet),
+						},
+						Labels: map[string]string{
+							"k8s.ovn.org/egress-assignable": "",
+						},
+					},
+					Status: v1.NodeStatus{
+						Conditions: []v1.NodeCondition{
+							{
+								Type:   v1.NodeReady,
+								Status: v1.ConditionTrue,
+							},
+						},
+					},
+				}
+				eIP1 := egressipv1.EgressIP{
+					ObjectMeta: newEgressIPMeta(egressIPName),
+					Spec: egressipv1.EgressIPSpec{
+						EgressIPs: []string{egressIP},
+					},
+				}
+				fakeOvn.startWithDBSetup(
+					libovsdbtest.TestSetup{
+						NBData: []libovsdbtest.TestData{
+							&nbdb.LogicalRouter{
+								Name: ovntypes.OVNClusterRouter,
+								UUID: ovntypes.OVNClusterRouter + "-UUID",
+							},
+							&nbdb.LogicalRouter{
+								Name: ovntypes.GWRouterPrefix + node.Name,
+								UUID: ovntypes.GWRouterPrefix + node.Name + "-UUID",
+							},
+							&nbdb.LogicalRouterPort{
+								UUID:     ovntypes.GWRouterToJoinSwitchPrefix + ovntypes.GWRouterPrefix + node.Name + "-UUID",
+								Name:     ovntypes.GWRouterToJoinSwitchPrefix + ovntypes.GWRouterPrefix + node.Name,
+								Networks: []string{nodeLogicalRouterIfAddrV4},
+							},
+							&nbdb.LogicalSwitchPort{
+								UUID: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node.Name + "UUID",
+								Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node.Name,
+								Type: "router",
+								Options: map[string]string{
+									"router-port": types.GWRouterToExtSwitchPrefix + "GR_" + node.Name,
+								},
+							},
+						},
+					},
+					&egressipv1.EgressIPList{
+						Items: []egressipv1.EgressIP{eIP1},
+					},
+					&v1.NodeList{
+						Items: []v1.Node{node},
+					},
+				)
+
+				// Virtually disable background reachability check by using a huge interval
+				fakeOvn.controller.eIPC.reachabilityCheckInterval = time.Hour
+
+				// Use a fake dialer that we control
+				fakeDialer := fakeEgressIPDialer{true}
+				dialer = &fakeDialer
+
+				fakeOvn.controller.WatchEgressNodes()
+
+				gomega.Eventually(getEgressIPStatusLen(eIP1.Name)).Should(gomega.Equal(1))
+				egressIPs, _ := getEgressIPStatus(eIP1.Name)
+				gomega.Expect(egressIPs[0]).To(gomega.Equal(egressIP))
+
+				fakeDialer.dialResult = false
+				// explicitly call check reachability, periodic checker is not active
+				checkEgressNodesReachabilityIterate(fakeOvn.controller)
+				gomega.Eventually(getEgressIPStatusLen(eIP1.Name)).Should(gomega.Equal(0))
+
+				fakeDialer.dialResult = true
+				node.Annotations["test"] = "dummy"
+				_, err := fakeOvn.fakeClient.KubeClient.CoreV1().Nodes().Update(context.TODO(), &node, metav1.UpdateOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				// the node should not be marked as reachable in the update handler as it is not getting added
+				gomega.Consistently(func() bool { return fakeOvn.controller.eIPC.allocator.cache[node.Name].isReachable }).Should(gomega.Equal(false))
+
+				// egress IP should get assigned on the next checkEgressNodesReachabilityIterate call
+				// explicitly call check reachability, periodic checker is not active
+				checkEgressNodesReachabilityIterate(fakeOvn.controller)
+				gomega.Eventually(getEgressIPStatusLen(eIP1.Name)).Should(gomega.Equal(1))
+
+				return nil
+			}
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
 	})
 
 	ginkgo.Context("Dual-stack assignment", func() {


### PR DESCRIPTION
egressip node update: set the node as reachable only when it is being added as an egressip node

there are three places where ovnkube marks an egress node as reachable:

- node add event handler
- node update even handler
- periodic connectivity checker

In a scenario where the egressip node becomes reachable at the same time as the node object is updated
the node is set as reachable but because there was no label/readiness change it is never added as an egressip node.
The periodic check will then ignore the node because it considers it as already reachable.

To address the issue only set the node as reachable if it is actually getting added as an egressip node.
