### PR TITLE
Bug 2075548: [DownstreamMerge] 09 Jan 2023

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -383,6 +383,7 @@ jobs:
       OVN_EMPTY_LB_EVENTS: "${{ matrix.target == 'control-plane' }}"
       OVN_HA: "${{ matrix.ha == 'HA' }}"
       OVN_DISABLE_SNAT_MULTIPLE_GWS: "${{ matrix.disable-snat-multiple-gws == 'noSnatGW' }}"
+      KIND_INSTALL_METALLB: "${{ matrix.target == 'control-plane' }}"
       OVN_GATEWAY_MODE: "${{ matrix.gateway-mode }}"
       OVN_SECOND_BRIDGE: "${{ matrix.second-bridge == '2br' }}"
       KIND_IPV4_SUPPORT: "${{ matrix.ipfamily == 'IPv4' || matrix.ipfamily == 'dualstack' }}"

--- a/dist/images/Dockerfile.fedora
+++ b/dist/images/Dockerfile.fedora
@@ -15,7 +15,7 @@ USER root
 
 ENV PYTHONDONTWRITEBYTECODE yes
 
-ARG ovnver=ovn-22.09.0-25.fc36
+ARG ovnver=ovn-22.12.0-0.fc36
 # Automatically populated when using docker buildx
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM

--- a/go-controller/cmd/ovnkube-trace/ovnkube-trace.go
+++ b/go-controller/cmd/ovnkube-trace/ovnkube-trace.go
@@ -462,7 +462,7 @@ func getPodInfo(coreclient *corev1client.CoreV1Client, restconfig *rest.Config, 
 	}
 
 	// Find rtos MAC (this is the pod's first hop router).
-	lspCmd := "ovn-sbctl " + cmd + " --bare --no-heading --column=mac list Port_Binding " + types.RouterToSwitchPrefix + podInfo.NodeName
+	lspCmd := "ovn-sbctl --no-leader-only " + cmd + " --bare --no-heading --column=mac list Port_Binding " + types.RouterToSwitchPrefix + podInfo.NodeName
 	ipOutput, ipError, err := execInPod(coreclient, restconfig, ovnNamespace, podInfo.OvnKubePodName, "ovnkube-node", lspCmd, "")
 	if err != nil {
 		return nil, fmt.Errorf("execInPod() failed. err: %s, stderr: %s, stdout: %s, podInfo: %v", err, ipError, ipOutput, podInfo)
@@ -510,7 +510,7 @@ func getPodInfo(coreclient *corev1client.CoreV1Client, restconfig *rest.Config, 
 
 // getNodeExternalBridgeName gets the name of the external bridge of this node, e.g. breth0 or br-ex.
 func getNodeExternalBridgeName(coreclient *corev1client.CoreV1Client, restconfig *rest.Config, ovnNamespace, podName, sbcmd, nodeName string) (string, error) {
-	cmd := "ovn-sbctl " + sbcmd + " --bare --no-heading --column=logical_port find Port_Binding options:network_name=" + types.PhysicalNetworkName
+	cmd := "ovn-sbctl --no-leader-only " + sbcmd + " --bare --no-heading --column=logical_port find Port_Binding options:network_name=" + types.PhysicalNetworkName
 	stdout, stderr, err := execInPod(coreclient, restconfig, ovnNamespace, podName, "ovnkube-node", cmd, "")
 	if err != nil {
 		return "", fmt.Errorf("execInPod() failed with %s stderr %s stdout %s", err, stderr, stdout)
@@ -643,7 +643,7 @@ func runOvnTraceToService(coreclient *corev1client.CoreV1Client, restconfig *res
 	if srcPodInfo.HostNetwork {
 		inport = srcPodInfo.K8sNodeNamePort
 	}
-	cmd := fmt.Sprintf(`ovn-trace %[1]s %[2]s --ct=new `+
+	cmd := fmt.Sprintf(`ovn-trace --no-leader-only %[1]s %[2]s --ct=new `+
 		`'inport=="%[3]s" && eth.src==%[4]s && eth.dst==%[5]s && %[6]s.src==%[7]s && %[8]s.dst==%[9]s && ip.ttl==64 && %[10]s.dst==%[11]s && %[10]s.src==52888' --lb-dst %[12]s:%[13]s`,
 		sbcmd,                 // 1
 		srcPodInfo.NodeName,   // 2
@@ -682,7 +682,7 @@ func runOvnTraceToIP(coreclient *corev1client.CoreV1Client, restconfig *rest.Con
 			srcPodInfo.IP, parsedDstIP)
 	}
 
-	cmd := fmt.Sprintf(`ovn-trace %[1]s %[2]s `+
+	cmd := fmt.Sprintf(`ovn-trace --no-leader-only %[1]s %[2]s `+
 		`'inport=="%[3]s" && eth.src==%[4]s && eth.dst==%[5]s && %[6]s.src==%[7]s && %[8]s.dst==%[9]s && ip.ttl==64 && %[10]s.dst==%[11]s && %[10]s.src==52888'`,
 		sbcmd,                              // 1
 		srcPodInfo.NodeName,                // 2
@@ -746,7 +746,7 @@ func runOvnTraceToPod(coreclient *corev1client.CoreV1Client, restconfig *rest.Co
 	if srcPodInfo.HostNetwork {
 		inport = srcPodInfo.K8sNodeNamePort
 	}
-	cmd := fmt.Sprintf(`ovn-trace %[1]s %[2]s `+
+	cmd := fmt.Sprintf(`ovn-trace --no-leader-only %[1]s %[2]s `+
 		`'inport=="%[3]s" && eth.src==%[4]s && eth.dst==%[5]s && %[6]s.src==%[7]s && %[8]s.dst==%[9]s && ip.ttl==64 && %[10]s.dst==%[11]s && %[10]s.src==52888'`,
 		sbcmd,                 // 1
 		srcPodInfo.NodeName,   // 2

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -380,6 +380,8 @@ type GatewayConfig struct {
 	// RouterSubnet is the subnet to be used for the GR external port. auto-detected if not given.
 	// Must match the the kube node IP address. Currently valid for DPU only.
 	RouterSubnet string `gcfg:"router-subnet"`
+	// SingeNode indicates the cluster has only one node
+	SingleNode bool `gcfg:"single-node"`
 }
 
 // OvnAuthConfig holds client authentication and location details for
@@ -1169,6 +1171,12 @@ var OVNGatewayFlags = []cli.Flag{
 			"Currently valid for DPUs only",
 		Destination: &cliConfig.Gateway.RouterSubnet,
 		Value:       Gateway.RouterSubnet,
+	},
+	&cli.BoolFlag{
+		Name: "single-node",
+		Usage: "Enable single node optimizations. " +
+			"Single node indicates a one node cluster and allows to simplify ovn-kubernetes gateway logic",
+		Destination: &cliConfig.Gateway.SingleNode,
 	},
 	// Deprecated CLI options
 	&cli.BoolFlag{

--- a/go-controller/pkg/config/config_test.go
+++ b/go-controller/pkg/config/config_test.go
@@ -200,6 +200,7 @@ nodeport=false
 v4-join-subnet=100.65.0.0/16
 v6-join-subnet=fd90::/64
 router-subnet=10.50.0.0/16
+single-node=false
 
 [hybridoverlay]
 enabled=true
@@ -299,6 +300,7 @@ var _ = Describe("Config Operations", func() {
 			gomega.Expect(OvnKubeNode.MgmtPortNetdev).To(gomega.Equal(""))
 			gomega.Expect(OvnKubeNode.MgmtPortRepresentor).To(gomega.Equal(""))
 			gomega.Expect(Gateway.RouterSubnet).To(gomega.Equal(""))
+			gomega.Expect(Gateway.SingleNode).To(gomega.BeFalse())
 			gomega.Expect(OVNKubernetesFeature.EgressIPReachabiltyTotalTimeout).To(gomega.Equal(1))
 			gomega.Expect(OVNKubernetesFeature.EgressIPNodeHealthCheckPort).To(gomega.Equal(0))
 
@@ -602,6 +604,7 @@ var _ = Describe("Config Operations", func() {
 			gomega.Expect(Gateway.V4JoinSubnet).To(gomega.Equal("100.65.0.0/16"))
 			gomega.Expect(Gateway.V6JoinSubnet).To(gomega.Equal("fd90::/64"))
 			gomega.Expect(Gateway.RouterSubnet).To(gomega.Equal("10.50.0.0/16"))
+			gomega.Expect(Gateway.SingleNode).To(gomega.BeFalse())
 
 			gomega.Expect(HybridOverlay.Enabled).To(gomega.BeTrue())
 			gomega.Expect(OVNKubernetesFeature.EgressIPReachabiltyTotalTimeout).To(gomega.Equal(3))
@@ -684,6 +687,7 @@ var _ = Describe("Config Operations", func() {
 			gomega.Expect(Gateway.V4JoinSubnet).To(gomega.Equal("100.63.0.0/16"))
 			gomega.Expect(Gateway.V6JoinSubnet).To(gomega.Equal("fd99::/48"))
 			gomega.Expect(Gateway.RouterSubnet).To(gomega.Equal("10.55.0.0/16"))
+			gomega.Expect(Gateway.SingleNode).To(gomega.BeTrue())
 
 			gomega.Expect(HybridOverlay.Enabled).To(gomega.BeTrue())
 			gomega.Expect(OVNKubernetesFeature.EgressIPReachabiltyTotalTimeout).To(gomega.Equal(5))
@@ -733,6 +737,7 @@ var _ = Describe("Config Operations", func() {
 			"-gateway-v4-join-subnet=100.63.0.0/16",
 			"-gateway-v6-join-subnet=fd99::/48",
 			"-gateway-router-subnet=10.55.0.0/16",
+			"-single-node",
 			"-enable-hybrid-overlay",
 			"-hybrid-overlay-cluster-subnets=11.132.0.0/14/23",
 			"-monitor-all=false",

--- a/go-controller/pkg/factory/factory.go
+++ b/go-controller/pkg/factory/factory.go
@@ -80,9 +80,9 @@ const (
 	defaultNumEventQueues uint32 = 15
 
 	// default priorities for various handlers (also the highest priority)
-	defaultHandlerPriority uint32 = 0
+	defaultHandlerPriority int = 0
 	// lowest priority among various handlers (See GetHandlerPriority for more information)
-	minHandlerPriority uint32 = 4
+	minHandlerPriority int = 4
 )
 
 // types for dynamic handlers created when adding a network policy
@@ -423,7 +423,7 @@ type AddHandlerFuncType func(namespace string, sel labels.Selector, funcs cache.
 // By default handlers get the defaultHandlerPriority which is 0 (highest priority). Higher the number, lower the priority to get an event.
 // Example: EgressIPPodType will always get the pod event after PodType and PeerPodSelectorType will always get the event after PodType and EgressIPPodType
 // NOTE: If you are touching this function to add a new object type that uses shared objects, please make sure to update `minHandlerPriority` if needed
-func (wf *WatchFactory) GetHandlerPriority(objType reflect.Type) (priority uint32) {
+func (wf *WatchFactory) GetHandlerPriority(objType reflect.Type) (priority int) {
 	switch objType {
 	case EgressIPPodType:
 		return 1
@@ -513,7 +513,7 @@ func (wf *WatchFactory) GetResourceHandlerFunc(objType reflect.Type) (AddHandler
 	return nil, fmt.Errorf("cannot get ObjectMeta from type %v", objType)
 }
 
-func (wf *WatchFactory) addHandler(objType reflect.Type, namespace string, sel labels.Selector, funcs cache.ResourceEventHandler, processExisting func([]interface{}) error, priority uint32) (*Handler, error) {
+func (wf *WatchFactory) addHandler(objType reflect.Type, namespace string, sel labels.Selector, funcs cache.ResourceEventHandler, processExisting func([]interface{}) error, priority int) (*Handler, error) {
 	inf, ok := wf.informers[objType]
 	if !ok {
 		klog.Fatalf("Tried to add handler of unknown object type %v", objType)
@@ -579,7 +579,7 @@ func (wf *WatchFactory) AddPodHandler(handlerFuncs cache.ResourceEventHandler, p
 }
 
 // AddFilteredPodHandler adds a handler function that will be executed when Pod objects that match the given filters change
-func (wf *WatchFactory) AddFilteredPodHandler(namespace string, sel labels.Selector, handlerFuncs cache.ResourceEventHandler, processExisting func([]interface{}) error, priority uint32) (*Handler, error) {
+func (wf *WatchFactory) AddFilteredPodHandler(namespace string, sel labels.Selector, handlerFuncs cache.ResourceEventHandler, processExisting func([]interface{}) error, priority int) (*Handler, error) {
 	return wf.addHandler(PodType, namespace, sel, handlerFuncs, processExisting, priority)
 }
 
@@ -664,7 +664,7 @@ func (wf *WatchFactory) AddNamespaceHandler(handlerFuncs cache.ResourceEventHand
 }
 
 // AddFilteredNamespaceHandler adds a handler function that will be executed when Namespace objects that match the given filters change
-func (wf *WatchFactory) AddFilteredNamespaceHandler(namespace string, sel labels.Selector, handlerFuncs cache.ResourceEventHandler, processExisting func([]interface{}) error, priority uint32) (*Handler, error) {
+func (wf *WatchFactory) AddFilteredNamespaceHandler(namespace string, sel labels.Selector, handlerFuncs cache.ResourceEventHandler, processExisting func([]interface{}) error, priority int) (*Handler, error) {
 	return wf.addHandler(NamespaceType, namespace, sel, handlerFuncs, processExisting, priority)
 }
 
@@ -674,7 +674,7 @@ func (wf *WatchFactory) RemoveNamespaceHandler(handler *Handler) {
 }
 
 // AddNodeHandler adds a handler function that will be executed on Node object changes
-func (wf *WatchFactory) AddNodeHandler(handlerFuncs cache.ResourceEventHandler, processExisting func([]interface{}) error, priority uint32) (*Handler, error) {
+func (wf *WatchFactory) AddNodeHandler(handlerFuncs cache.ResourceEventHandler, processExisting func([]interface{}) error, priority int) (*Handler, error) {
 	return wf.addHandler(NodeType, "", nil, handlerFuncs, processExisting, priority)
 }
 

--- a/go-controller/pkg/factory/factory_test.go
+++ b/go-controller/pkg/factory/factory_test.go
@@ -379,7 +379,7 @@ var _ = Describe("Watch Factory Operations", func() {
 	})
 
 	Context("when a processExisting is given", func() {
-		testExisting := func(objType reflect.Type, namespace string, sel labels.Selector, priority uint32) {
+		testExisting := func(objType reflect.Type, namespace string, sel labels.Selector, priority int) {
 			if objType == EndpointSliceType {
 				wf, err = NewNodeWatchFactory(ovnClientset, nodeName)
 			} else {
@@ -401,7 +401,7 @@ var _ = Describe("Watch Factory Operations", func() {
 			wf.removeHandler(objType, h)
 		}
 
-		testExistingFilteredHandler := func(objType reflect.Type, realObj reflect.Type, namespace string, sel labels.Selector, priority uint32) {
+		testExistingFilteredHandler := func(objType reflect.Type, realObj reflect.Type, namespace string, sel labels.Selector, priority int) {
 			if objType == EndpointSliceType {
 				wf, err = NewNodeWatchFactory(ovnClientset, nodeName)
 			} else {
@@ -1171,12 +1171,14 @@ var _ = Describe("Watch Factory Operations", func() {
 			namespace *v1.Namespace
 			added     int
 			updated   int
+			deleted   int
 		}
 		testNamespaces := make(map[string]*opTest)
 
 		for i := 0; i < 998; i++ {
 			name := fmt.Sprintf("mynamespace-%d", i)
 			namespace := newNamespace(name)
+			namespace.Status.Phase = ""
 			testNamespaces[name] = &opTest{namespace: namespace}
 			// Add all namespaces to the initial list
 			namespaces = append(namespaces, namespace)
@@ -1197,6 +1199,7 @@ var _ = Describe("Watch Factory Operations", func() {
 				defer ot.mu.Unlock()
 				Expect(ot.added).To(Equal(0))
 				ot.added++
+				Expect(namespace.Status.Phase).To(BeEmpty())
 			},
 			UpdateFunc: func(old, new interface{}) {
 				defer GinkgoRecover()
@@ -1209,9 +1212,22 @@ var _ = Describe("Watch Factory Operations", func() {
 				Expect(ot.added).To(Equal(4), "update for EIP namespace %s processed before add was processed in all handlers!", newNamespace.Name)
 				Expect(ot.updated).To(Equal(0))
 				ot.updated++
+				Expect(newNamespace.Status.Phase).To(Equal(v1.NamespaceActive))
+			},
+			DeleteFunc: func(obj interface{}) {
+				defer GinkgoRecover()
+				newNamespace := obj.(*v1.Namespace)
+				ot, ok := testNamespaces[newNamespace.Name]
+				Expect(ok).To(BeTrue())
+				// Verify that deletes were processed after the updates and adds
+				ot.mu.Lock()
+				defer ot.mu.Unlock()
+				Expect(ot.added).To(Equal(4), "delete for EIP namespace %s processed before add was processed in all handlers!", newNamespace.Name)
+				Expect(ot.updated).To(Equal(4), "delete for EIP namespace %s processed before update was processed in all handlers!", newNamespace.Name)
+				Expect(ot.deleted).To(Equal(8))
+				ot.deleted = ot.deleted / 2
 				Expect(newNamespace.Status.Phase).To(Equal(v1.NamespaceTerminating))
 			},
-			DeleteFunc: func(obj interface{}) {},
 		})
 
 		eipnsh, c2 := addPriorityHandler(wf, NamespaceType, EgressIPNamespaceType, cache.ResourceEventHandlerFuncs{
@@ -1224,6 +1240,7 @@ var _ = Describe("Watch Factory Operations", func() {
 				defer ot.mu.Unlock()
 				Expect(ot.added).To(Equal(1), "add for EIP namespace %s processed before initial namespace add!", namespace.Name)
 				ot.added = ot.added * 10
+				Expect(namespace.Status.Phase).To(BeEmpty())
 			},
 			UpdateFunc: func(old, new interface{}) {
 				defer GinkgoRecover()
@@ -1236,9 +1253,22 @@ var _ = Describe("Watch Factory Operations", func() {
 				Expect(ot.added).To(Equal(4), "update for EIP namespace %s processed before add was processed in all handlers!", newNamespace.Name)
 				Expect(ot.updated).To(Equal(1), "update for EIP namespace %s processed before initial namespace update!", newNamespace.Name)
 				ot.updated = ot.updated * 10
+				Expect(newNamespace.Status.Phase).To(Equal(v1.NamespaceActive))
+			},
+			DeleteFunc: func(obj interface{}) {
+				defer GinkgoRecover()
+				newNamespace := obj.(*v1.Namespace)
+				ot, ok := testNamespaces[newNamespace.Name]
+				Expect(ok).To(BeTrue())
+				// Verify that deletes were processed after the updates and adds
+				ot.mu.Lock()
+				defer ot.mu.Unlock()
+				Expect(ot.added).To(Equal(4), "delete for EIP namespace %s processed before add was processed in all handlers!", newNamespace.Name)
+				Expect(ot.updated).To(Equal(4), "delete for EIP namespace %s processed before update was processed in all handlers!", newNamespace.Name)
+				Expect(ot.deleted).To(Equal(10))
+				ot.deleted = ot.deleted - 2
 				Expect(newNamespace.Status.Phase).To(Equal(v1.NamespaceTerminating))
 			},
-			DeleteFunc: func(obj interface{}) {},
 		})
 		peernsh, c3 := addPriorityHandler(wf, NamespaceType, PeerNamespaceSelectorType, cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
@@ -1250,6 +1280,7 @@ var _ = Describe("Watch Factory Operations", func() {
 				defer ot.mu.Unlock()
 				Expect(ot.added).To(Equal(10), "add for peer namespace %s processed before EIP namespace add!", namespace.Name)
 				ot.added = ot.added - 2
+				Expect(namespace.Status.Phase).To(BeEmpty())
 			},
 			UpdateFunc: func(old, new interface{}) {
 				defer GinkgoRecover()
@@ -1262,9 +1293,22 @@ var _ = Describe("Watch Factory Operations", func() {
 				Expect(ot.added).To(Equal(4), "update for EIP namespace %s processed before add was processed in all handlers!", newNamespace.Name)
 				Expect(ot.updated).To(Equal(10), "update for peer namespace %s processed before EIP namespace update!", newNamespace.Name)
 				ot.updated = ot.updated - 2
+				Expect(newNamespace.Status.Phase).To(Equal(v1.NamespaceActive))
+			},
+			DeleteFunc: func(obj interface{}) {
+				defer GinkgoRecover()
+				newNamespace := obj.(*v1.Namespace)
+				ot, ok := testNamespaces[newNamespace.Name]
+				Expect(ok).To(BeTrue())
+				// Verify that deletes were processed after the updates and adds
+				ot.mu.Lock()
+				defer ot.mu.Unlock()
+				Expect(ot.added).To(Equal(4), "delete for EIP namespace %s processed before add was processed in all handlers!", newNamespace.Name)
+				Expect(ot.updated).To(Equal(4), "delete for EIP namespace %s processed before update was processed in all handlers!", newNamespace.Name)
+				Expect(ot.deleted).To(Equal(1))
+				ot.deleted = ot.deleted * 10
 				Expect(newNamespace.Status.Phase).To(Equal(v1.NamespaceTerminating))
 			},
-			DeleteFunc: func(obj interface{}) {},
 		})
 		peerpodnsh, c4 := addPriorityHandler(wf, NamespaceType, PeerNamespaceAndPodSelectorType, cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
@@ -1276,6 +1320,7 @@ var _ = Describe("Watch Factory Operations", func() {
 				defer ot.mu.Unlock()
 				Expect(ot.added).To(Equal(8), "add for peerPod namespace %s processed before peer namespace add!", namespace.Name)
 				ot.added = ot.added / 2
+				Expect(namespace.Status.Phase).To(BeEmpty())
 			},
 			UpdateFunc: func(old, new interface{}) {
 				defer GinkgoRecover()
@@ -1288,15 +1333,28 @@ var _ = Describe("Watch Factory Operations", func() {
 				Expect(ot.added).To(Equal(4), "update for peerPod namespace %s processed before peerPod namespace add!", newNamespace.Name)
 				Expect(ot.updated).To(Equal(8), "update for peerPod namespace %s processed before peer namespace update!", newNamespace.Name)
 				ot.updated = ot.updated / 2
+				Expect(newNamespace.Status.Phase).To(Equal(v1.NamespaceActive))
+			},
+			DeleteFunc: func(obj interface{}) {
+				defer GinkgoRecover()
+				newNamespace := obj.(*v1.Namespace)
+				ot, ok := testNamespaces[newNamespace.Name]
+				Expect(ok).To(BeTrue())
+				// Verify that deletes were processed after the updates and adds
+				ot.mu.Lock()
+				defer ot.mu.Unlock()
+				Expect(ot.added).To(Equal(4), "delete for EIP namespace %s processed before add was processed in all handlers!", newNamespace.Name)
+				Expect(ot.updated).To(Equal(4), "delete for EIP namespace %s processed before update was processed in all handlers!", newNamespace.Name)
+				Expect(ot.deleted).To(Equal(0))
+				ot.deleted++
 				Expect(newNamespace.Status.Phase).To(Equal(v1.NamespaceTerminating))
 			},
-			DeleteFunc: func(obj interface{}) {},
 		})
 		done := make(chan bool)
 		go func() {
 			// Send an update event for each namespace
 			for _, n := range namespaces {
-				n.Status.Phase = v1.NamespaceTerminating
+				n.Status.Phase = v1.NamespaceActive
 				namespaceWatch.Modify(n)
 			}
 			done <- true
@@ -1324,6 +1382,28 @@ var _ = Describe("Watch Factory Operations", func() {
 			ot.mu.Lock()
 			// ((((0 + 1) * 10) - 2) / 2) = 4
 			Expect(ot.updated).To(Equal(4), "missing update for namespace %s", ot.namespace.Name)
+			ot.mu.Unlock()
+		}
+
+		go func() {
+			// Send a delete event for each namespace
+			for _, n := range namespaces {
+				n.Status.Phase = v1.NamespaceTerminating
+				namespaceWatch.Delete(n)
+			}
+			done <- true
+		}()
+		<-done
+		// Deletes are async and may take a bit longer to finish
+		Eventually(c1.getDeleted, 10).Should(Equal(len(testNamespaces)))
+		Eventually(c2.getDeleted, 10).Should(Equal(len(testNamespaces)))
+		Eventually(c3.getDeleted, 10).Should(Equal(len(testNamespaces)))
+		Eventually(c4.getDeleted, 10).Should(Equal(len(testNamespaces)))
+
+		for _, ot := range testNamespaces {
+			ot.mu.Lock()
+			// ((((0 + 1) * 10) - 2) / 2) = 4
+			Expect(ot.deleted).To(Equal(4), "missing delete for namespace %s", ot.namespace.Name)
 			ot.mu.Unlock()
 		}
 

--- a/go-controller/pkg/factory/handler.go
+++ b/go-controller/pkg/factory/handler.go
@@ -39,7 +39,7 @@ type Handler struct {
 	// priority is used to track the handler's priority of being invoked.
 	// example: a handler with priority 0 will process the received event first
 	// before a handler with priority 1.
-	priority uint32
+	priority int
 }
 
 func (h *Handler) OnAdd(obj interface{}) {
@@ -88,7 +88,7 @@ type informer struct {
 	// before a handler with priority 1, 0 being the higest priority.
 	// NOTE: we can have multiple handlers with the same priority hence the value
 	// is a map of handlers keyed by its unique id.
-	handlers map[uint32]map[uint64]*Handler
+	handlers map[int]map[uint64]*Handler
 	events   []chan *event
 	lister   listerInterface
 	// initialAddFunc will be called to deliver the initial list of objects
@@ -103,8 +103,19 @@ func (i *informer) forEachQueuedHandler(f func(h *Handler)) {
 	i.RLock()
 	defer i.RUnlock()
 
-	for priority := 0; uint32(priority) <= minHandlerPriority; priority++ { // loop over priority higest to lowest
-		for _, handler := range i.handlers[uint32(priority)] {
+	for priority := 0; priority <= minHandlerPriority; priority++ { // loop over priority higest to lowest
+		for _, handler := range i.handlers[priority] {
+			f(handler)
+		}
+	}
+}
+
+func (i *informer) forEachQueuedHandlerReversed(f func(h *Handler)) {
+	i.RLock()
+	defer i.RUnlock()
+
+	for priority := minHandlerPriority; priority >= 0; priority-- { // loop over priority lowest to highest
+		for _, handler := range i.handlers[priority] {
 			f(handler)
 		}
 	}
@@ -120,14 +131,31 @@ func (i *informer) forEachHandler(obj interface{}, f func(h *Handler)) {
 		return
 	}
 
-	for priority := 0; uint32(priority) <= minHandlerPriority; priority++ { // loop over priority higest to lowest
-		for _, handler := range i.handlers[uint32(priority)] {
+	for priority := 0; priority <= minHandlerPriority; priority++ { // loop over priority higest to lowest
+		for _, handler := range i.handlers[priority] {
 			f(handler)
 		}
 	}
 }
 
-func (i *informer) addHandler(id uint64, priority uint32, filterFunc func(obj interface{}) bool, funcs cache.ResourceEventHandler, existingItems []interface{}) *Handler {
+func (i *informer) forEachHandlerReversed(obj interface{}, f func(h *Handler)) {
+	i.RLock()
+	defer i.RUnlock()
+
+	objType := reflect.TypeOf(obj)
+	if objType != i.oType {
+		klog.Errorf("Object type %v did not match expected %v", objType, i.oType)
+		return
+	}
+
+	for priority := minHandlerPriority; priority >= 0; priority-- { // loop over priority lowest to highest
+		for _, handler := range i.handlers[priority] {
+			f(handler)
+		}
+	}
+}
+
+func (i *informer) addHandler(id uint64, priority int, filterFunc func(obj interface{}) bool, funcs cache.ResourceEventHandler, existingItems []interface{}) *Handler {
 	handler := &Handler{
 		cache.FilteringResourceEventHandler{
 			FilterFunc: filterFunc,
@@ -334,7 +362,7 @@ func (i *informer) newFederatedQueuedHandler(numEventQueues uint32) cache.Resour
 			i.enqueueEvent(nil, realObj, entry.queue, func(e *event) {
 				metrics.MetricResourceUpdateCount.WithLabelValues(name, "delete").Inc()
 				start := time.Now()
-				i.forEachQueuedHandler(func(h *Handler) {
+				i.forEachQueuedHandlerReversed(func(h *Handler) {
 					h.OnDelete(e.obj)
 				})
 				metrics.MetricResourceDeleteLatency.Observe(time.Since(start).Seconds())
@@ -380,7 +408,7 @@ func (i *informer) newFederatedHandler() cache.ResourceEventHandlerFuncs {
 			}
 			metrics.MetricResourceUpdateCount.WithLabelValues(name, "delete").Inc()
 			start := time.Now()
-			i.forEachHandler(realObj, func(h *Handler) {
+			i.forEachHandlerReversed(realObj, func(h *Handler) {
 				h.OnDelete(realObj)
 			})
 			metrics.MetricResourceDeleteLatency.Observe(time.Since(start).Seconds())
@@ -443,7 +471,7 @@ func newBaseInformer(oType reflect.Type, sharedInformer cache.SharedIndexInforme
 		oType:    oType,
 		inf:      sharedInformer,
 		lister:   lister,
-		handlers: make(map[uint32]map[uint64]*Handler),
+		handlers: make(map[int]map[uint64]*Handler),
 		queueMap: make(map[ktypes.NamespacedName]*queueMapEntry),
 	}, nil
 }

--- a/go-controller/pkg/kube/kube.go
+++ b/go-controller/pkg/kube/kube.go
@@ -33,7 +33,6 @@ type Interface interface {
 	UpdateEgressIP(eIP *egressipv1.EgressIP) error
 	PatchEgressIP(name string, patchData []byte) error
 	UpdateNodeStatus(node *kapi.Node) error
-	UpdateNode(node *kapi.Node) error
 	UpdatePod(pod *kapi.Pod) error
 	GetAnnotationsOnPod(namespace, name string) (map[string]string, error)
 	GetNodes() (*kapi.NodeList, error)
@@ -253,13 +252,6 @@ func (k *Kube) UpdateNodeStatus(node *kapi.Node) error {
 	if err != nil {
 		klog.Errorf("Error in updating status on node %s: %v", node.Name, err)
 	}
-	return err
-}
-
-// UpdateNode takes the node object and sets the provided update status
-func (k *Kube) UpdateNode(node *kapi.Node) error {
-	klog.Infof("Updating node %s", node.Name)
-	_, err := k.KClient.CoreV1().Nodes().Update(context.TODO(), node, metav1.UpdateOptions{})
 	return err
 }
 

--- a/go-controller/pkg/kube/mocks/Interface.go
+++ b/go-controller/pkg/kube/mocks/Interface.go
@@ -430,20 +430,6 @@ func (_m *Interface) UpdateEgressIP(eIP *egressipv1.EgressIP) error {
 	return r0
 }
 
-// UpdateNode provides a mock function with given fields: node
-func (_m *Interface) UpdateNode(node *apicorev1.Node) error {
-	ret := _m.Called(node)
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(*apicorev1.Node) error); ok {
-		r0 = rf(node)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
 // UpdateNodeStatus provides a mock function with given fields: node
 func (_m *Interface) UpdateNodeStatus(node *apicorev1.Node) error {
 	ret := _m.Called(node)

--- a/go-controller/pkg/node/gateway_iptables.go
+++ b/go-controller/pkg/node/gateway_iptables.go
@@ -274,6 +274,51 @@ func getNodePortETPLocalIPTRules(svcPort kapi.ServicePort, targetIP string) []ip
 	}
 }
 
+func computeProbability(n, i int) string {
+	return fmt.Sprintf("%0.10f", 1.0/float64(n-i+1))
+}
+
+func generateIPTRulesForLoadBalancersWithoutNodePorts(svcPort kapi.ServicePort, externalIP string, service *kapi.Service, localEndpoints []string) []iptRule {
+	var iptRules []iptRule
+	if len(localEndpoints) == 0 {
+		// either its smart nic mode; etp&itp not implemented, OR
+		// fetching endpointSlices error-ed out prior to reaching here so nothing to do
+		return iptRules
+	}
+	numLocalEndpoints := len(localEndpoints)
+	for i, ip := range localEndpoints {
+		iptRules = append([]iptRule{
+			{
+				table: "nat",
+				chain: iptableETPChain,
+				args: []string{
+					"-p", string(svcPort.Protocol),
+					"-d", externalIP,
+					"--dport", fmt.Sprintf("%v", svcPort.Port),
+					"-j", "DNAT",
+					"--to-destination", util.JoinHostPortInt32(ip, int32(svcPort.TargetPort.IntValue())),
+					"-m", "statistic",
+					"--mode", "random",
+					"--probability", computeProbability(numLocalEndpoints, i+1),
+				},
+				protocol: getIPTablesProtocol(externalIP),
+			},
+			{
+				table: "nat",
+				chain: iptableMgmPortChain,
+				args: []string{
+					"-p", string(svcPort.Protocol),
+					"-d", ip,
+					"--dport", fmt.Sprintf("%v", int32(svcPort.TargetPort.IntValue())),
+					"-j", "RETURN",
+				},
+				protocol: getIPTablesProtocol(externalIP),
+			},
+		}, iptRules...)
+	}
+	return iptRules
+}
+
 // getExternalIPTRules returns the IPTable DNAT rules for a service of type LB or ExternalIP
 // `svcPort` corresponds to port details for this service as specified in the service object
 // `externalIP` can either be the externalIP or LB.status.ingressIP
@@ -449,7 +494,7 @@ func recreateIPTRules(table, chain string, keepIPTRules []iptRule) error {
 // case3: if svcHasLocalHostNetEndPnt and svcTypeIsITPLocal, rule that redirects clusterIP traffic to host targetPort is added.
 //
 //	if !svcHasLocalHostNetEndPnt and svcTypeIsITPLocal, rule that marks clusterIP traffic to steer it to ovn-k8s-mp0 is added.
-func getGatewayIPTRules(service *kapi.Service, svcHasLocalHostNetEndPnt bool) []iptRule {
+func getGatewayIPTRules(service *kapi.Service, localEndpoints []string, svcHasLocalHostNetEndPnt bool) []iptRule {
 	rules := make([]iptRule, 0)
 	clusterIPs := util.GetClusterIPs(service)
 	svcTypeIsETPLocal := util.ServiceExternalTrafficPolicyLocal(service)
@@ -492,7 +537,11 @@ func getGatewayIPTRules(service *kapi.Service, svcHasLocalHostNetEndPnt bool) []
 					// case1 (see function description for details)
 					// DNAT traffic to masqueradeIP:nodePort instead of clusterIP:Port. We are leveraging the existing rules for NODEPORT
 					// service so no need to add skip SNAT rule to OVN-KUBE-SNAT-MGMTPORT since the corresponding nodePort svc would have one.
-					rules = append(rules, getExternalIPTRules(svcPort, externalIP, "", svcHasLocalHostNetEndPnt, svcTypeIsETPLocal)...)
+					if !util.ServiceTypeHasNodePort(service) {
+						rules = append(rules, generateIPTRulesForLoadBalancersWithoutNodePorts(svcPort, externalIP, service, localEndpoints)...)
+					} else {
+						rules = append(rules, getExternalIPTRules(svcPort, externalIP, "", svcHasLocalHostNetEndPnt, svcTypeIsETPLocal)...)
+					}
 				}
 				// case2 (see function description for details)
 				rules = append(rules, getExternalIPTRules(svcPort, externalIP, clusterIP, svcHasLocalHostNetEndPnt, false)...)

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -377,8 +377,12 @@ func (npw *nodePortWatcher) getAndSetServiceInfo(index ktypes.NamespacedName, se
 	defer npw.serviceInfoLock.Unlock()
 
 	old, exists = npw.serviceInfo[index]
+	var ptrCopy serviceConfig
+	if exists {
+		ptrCopy = *old
+	}
 	npw.serviceInfo[index] = &serviceConfig{service: service, hasLocalHostNetworkEp: hasLocalHostNetworkEp}
-	return old, exists
+	return &ptrCopy, exists
 }
 
 // addOrSetServiceInfo creates and sets the serviceConfig if it doesn't exist
@@ -406,7 +410,7 @@ func (npw *nodePortWatcher) updateServiceInfo(index ktypes.NamespacedName, servi
 		klog.V(5).Infof("No serviceConfig found for service %s in namespace %s", index.Name, index.Namespace)
 		return nil, exists
 	}
-
+	ptrCopy := *old
 	if service != nil {
 		npw.serviceInfo[index].service = service
 	}
@@ -415,7 +419,7 @@ func (npw *nodePortWatcher) updateServiceInfo(index ktypes.NamespacedName, servi
 		npw.serviceInfo[index].hasLocalHostNetworkEp = *hasLocalHostNetworkEp
 	}
 
-	return old, exists
+	return &ptrCopy, exists
 }
 
 // addServiceRules ensures the correct iptables rules and OpenFlow physical

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -89,6 +89,8 @@ type serviceConfig struct {
 	service *kapi.Service
 	// hasLocalHostNetworkEp will be true for a service if it has at least one endpoint which is "hostnetworked&local-to-this-node".
 	hasLocalHostNetworkEp bool
+	// localEndpoints stores all the local non-host-networked endpoints for this service
+	localEndpoints sets.String
 }
 
 type serviceEps struct {
@@ -372,7 +374,7 @@ func (npw *nodePortWatcher) getServiceInfo(index ktypes.NamespacedName) (out *se
 }
 
 // getAndSetServiceInfo creates and sets the serviceConfig, returns if it existed and whatever was there
-func (npw *nodePortWatcher) getAndSetServiceInfo(index ktypes.NamespacedName, service *kapi.Service, hasLocalHostNetworkEp bool) (old *serviceConfig, exists bool) {
+func (npw *nodePortWatcher) getAndSetServiceInfo(index ktypes.NamespacedName, service *kapi.Service, hasLocalHostNetworkEp bool, localEndpoints sets.String) (old *serviceConfig, exists bool) {
 	npw.serviceInfoLock.Lock()
 	defer npw.serviceInfoLock.Unlock()
 
@@ -381,18 +383,18 @@ func (npw *nodePortWatcher) getAndSetServiceInfo(index ktypes.NamespacedName, se
 	if exists {
 		ptrCopy = *old
 	}
-	npw.serviceInfo[index] = &serviceConfig{service: service, hasLocalHostNetworkEp: hasLocalHostNetworkEp}
+	npw.serviceInfo[index] = &serviceConfig{service: service, hasLocalHostNetworkEp: hasLocalHostNetworkEp, localEndpoints: localEndpoints}
 	return &ptrCopy, exists
 }
 
 // addOrSetServiceInfo creates and sets the serviceConfig if it doesn't exist
-func (npw *nodePortWatcher) addOrSetServiceInfo(index ktypes.NamespacedName, service *kapi.Service, hasLocalHostNetworkEp bool) (exists bool) {
+func (npw *nodePortWatcher) addOrSetServiceInfo(index ktypes.NamespacedName, service *kapi.Service, hasLocalHostNetworkEp bool, localEndpoints sets.String) (exists bool) {
 	npw.serviceInfoLock.Lock()
 	defer npw.serviceInfoLock.Unlock()
 
 	if _, exists := npw.serviceInfo[index]; !exists {
 		// Only set this if it doesn't exist
-		npw.serviceInfo[index] = &serviceConfig{service: service, hasLocalHostNetworkEp: hasLocalHostNetworkEp}
+		npw.serviceInfo[index] = &serviceConfig{service: service, hasLocalHostNetworkEp: hasLocalHostNetworkEp, localEndpoints: localEndpoints}
 		return false
 	}
 	return true
@@ -401,7 +403,7 @@ func (npw *nodePortWatcher) addOrSetServiceInfo(index ktypes.NamespacedName, ser
 
 // updateServiceInfo sets the serviceConfig for a service and returns the existing serviceConfig, if inputs are nil
 // do not update those fields, if it does not exist return nil.
-func (npw *nodePortWatcher) updateServiceInfo(index ktypes.NamespacedName, service *kapi.Service, hasLocalHostNetworkEp *bool) (old *serviceConfig, exists bool) {
+func (npw *nodePortWatcher) updateServiceInfo(index ktypes.NamespacedName, service *kapi.Service, hasLocalHostNetworkEp *bool, localEndpoints sets.String) (old *serviceConfig, exists bool) {
 
 	npw.serviceInfoLock.Lock()
 	defer npw.serviceInfoLock.Unlock()
@@ -419,12 +421,16 @@ func (npw *nodePortWatcher) updateServiceInfo(index ktypes.NamespacedName, servi
 		npw.serviceInfo[index].hasLocalHostNetworkEp = *hasLocalHostNetworkEp
 	}
 
+	if localEndpoints != nil {
+		npw.serviceInfo[index].localEndpoints = localEndpoints
+	}
+
 	return &ptrCopy, exists
 }
 
 // addServiceRules ensures the correct iptables rules and OpenFlow physical
 // flows are programmed for a given service and endpoint configuration
-func addServiceRules(service *kapi.Service, svcHasLocalHostNetEndPnt bool, npw *nodePortWatcher) error {
+func addServiceRules(service *kapi.Service, localEndpoints []string, svcHasLocalHostNetEndPnt bool, npw *nodePortWatcher) error {
 	// For dpu or Full mode
 	var err error
 	var errors []error
@@ -435,7 +441,7 @@ func addServiceRules(service *kapi.Service, svcHasLocalHostNetEndPnt bool, npw *
 		npw.ofm.requestFlowSync()
 		if !npw.dpuMode {
 			// add iptable rules only in full mode
-			if err = addGatewayIptRules(service, svcHasLocalHostNetEndPnt); err != nil {
+			if err = addGatewayIptRules(service, localEndpoints, svcHasLocalHostNetEndPnt); err != nil {
 				errors = append(errors, err)
 			}
 			if err = updateEgressSVCIptRules(service, npw); err != nil {
@@ -444,7 +450,7 @@ func addServiceRules(service *kapi.Service, svcHasLocalHostNetEndPnt bool, npw *
 		}
 	} else {
 		// For Host Only Mode
-		if err = addGatewayIptRules(service, svcHasLocalHostNetEndPnt); err != nil {
+		if err = addGatewayIptRules(service, localEndpoints, svcHasLocalHostNetEndPnt); err != nil {
 			errors = append(errors, err)
 		}
 
@@ -455,7 +461,7 @@ func addServiceRules(service *kapi.Service, svcHasLocalHostNetEndPnt bool, npw *
 
 // delServiceRules deletes all possible iptables rules and OpenFlow physical
 // flows for a service
-func delServiceRules(service *kapi.Service, npw *nodePortWatcher) error {
+func delServiceRules(service *kapi.Service, localEndpoints []string, npw *nodePortWatcher) error {
 	var err error
 	var errors []error
 	// full mode || dpu mode
@@ -491,10 +497,10 @@ func delServiceRules(service *kapi.Service, npw *nodePortWatcher) error {
 			// |                          |                       |                       |   + default dnat towards CIP   |
 			// +--------------------------+-----------------------+-----------------------+--------------------------------+
 
-			if err = delGatewayIptRules(service, true); err != nil {
+			if err = delGatewayIptRules(service, localEndpoints, true); err != nil {
 				errors = append(errors, fmt.Errorf("error updating service flow cache: %v", err))
 			}
-			if err = delGatewayIptRules(service, false); err != nil {
+			if err = delGatewayIptRules(service, localEndpoints, false); err != nil {
 				errors = append(errors, fmt.Errorf("error updating service flow cache: %v", err))
 			}
 			if err = delAllEgressSVCIptRules(service, npw); err != nil {
@@ -503,10 +509,10 @@ func delServiceRules(service *kapi.Service, npw *nodePortWatcher) error {
 		}
 	} else {
 
-		if err = delGatewayIptRules(service, true); err != nil {
+		if err = delGatewayIptRules(service, localEndpoints, true); err != nil {
 			errors = append(errors, fmt.Errorf("error updating service flow cache: %v", err))
 		}
-		if err = delGatewayIptRules(service, false); err != nil {
+		if err = delGatewayIptRules(service, localEndpoints, false); err != nil {
 			errors = append(errors, fmt.Errorf("error updating service flow cache: %v", err))
 		}
 	}
@@ -523,7 +529,9 @@ func serviceUpdateNotNeeded(old, new *kapi.Service) bool {
 		reflect.DeepEqual(new.Spec.ExternalTrafficPolicy, old.Spec.ExternalTrafficPolicy) &&
 		(new.Spec.InternalTrafficPolicy != nil && old.Spec.InternalTrafficPolicy != nil &&
 			reflect.DeepEqual(*new.Spec.InternalTrafficPolicy, *old.Spec.InternalTrafficPolicy)) &&
-		!util.EgressSVCHostChanged(old, new)
+		!util.EgressSVCHostChanged(old, new) &&
+		(new.Spec.AllocateLoadBalancerNodePorts != nil && old.Spec.AllocateLoadBalancerNodePorts != nil &&
+			reflect.DeepEqual(*new.Spec.AllocateLoadBalancerNodePorts, *old.Spec.AllocateLoadBalancerNodePorts))
 }
 
 // AddService handles configuring shared gateway bridge flows to steer External IP, Node Port, Ingress LB traffic into OVN
@@ -545,12 +553,12 @@ func (npw *nodePortWatcher) AddService(service *kapi.Service) error {
 		nodeIPs := npw.nodeIPManager.ListAddresses()
 		hasLocalHostNetworkEp = hasLocalHostNetworkEndpoints(epSlices, nodeIPs)
 	}
-
+	localEndpoints := npw.GetLocalEndpointAddresses(epSlices)
 	// If something didn't already do it add correct Service rules
-	if exists := npw.addOrSetServiceInfo(name, service, hasLocalHostNetworkEp); !exists {
+	if exists := npw.addOrSetServiceInfo(name, service, hasLocalHostNetworkEp, localEndpoints); !exists {
 		klog.V(5).Infof("Service Add %s event in namespace %s came before endpoint event setting svcConfig",
 			service.Name, service.Namespace)
-		if err := addServiceRules(service, hasLocalHostNetworkEp, npw); err != nil {
+		if err := addServiceRules(service, localEndpoints.List(), hasLocalHostNetworkEp, npw); err != nil {
 			return fmt.Errorf("AddService failed for nodePortWatcher: %v", err)
 		}
 	} else {
@@ -570,9 +578,9 @@ func (npw *nodePortWatcher) UpdateService(old, new *kapi.Service) error {
 			".Spec.ExternalTrafficPolicy, .Spec.InternalTrafficPolicy, Egress service host", new.Name)
 		return nil
 	}
-	// Update the service in svcConfig if we need to, so that other handler
-	// threads do the correct thing, leave hasLocalHostNetworkEp alone in the cache
-	svcConfig, exists := npw.updateServiceInfo(name, new, nil)
+	// Update the service in svcConfig if we need to so that other handler
+	// threads do the correct thing, leave hasLocalHostNetworkEp and localEndpoints alone in the cache
+	svcConfig, exists := npw.updateServiceInfo(name, new, nil, nil)
 	if !exists {
 		klog.V(5).Infof("Service %s in namespace %s was deleted during service Update", old.Name, old.Namespace)
 		return nil
@@ -582,14 +590,14 @@ func (npw *nodePortWatcher) UpdateService(old, new *kapi.Service) error {
 		// Delete old rules if needed, but don't delete svcConfig
 		// so that we don't miss any endpoint update events here
 		klog.V(5).Infof("Deleting old service rules for: %v", old)
-		if err = delServiceRules(old, npw); err != nil {
+		if err = delServiceRules(old, svcConfig.localEndpoints.List(), npw); err != nil {
 			errors = append(errors, err)
 		}
 	}
 
 	if util.ServiceTypeHasClusterIP(new) && util.IsClusterIPSet(new) {
 		klog.V(5).Infof("Adding new service rules for: %v", new)
-		if err = addServiceRules(new, svcConfig.hasLocalHostNetworkEp, npw); err != nil {
+		if err = addServiceRules(new, svcConfig.localEndpoints.List(), svcConfig.hasLocalHostNetworkEp, npw); err != nil {
 			errors = append(errors, err)
 		}
 	}
@@ -652,7 +660,7 @@ func (npw *nodePortWatcher) DeleteService(service *kapi.Service) error {
 	klog.V(5).Infof("Deleting service %s in namespace %s", service.Name, service.Namespace)
 	name := ktypes.NamespacedName{Namespace: service.Namespace, Name: service.Name}
 	if svcConfig, exists := npw.getAndDeleteServiceInfo(name); exists {
-		if err = delServiceRules(svcConfig.service, npw); err != nil {
+		if err = delServiceRules(svcConfig.service, svcConfig.localEndpoints.List(), npw); err != nil {
 			errors = append(errors, err)
 		}
 	} else {
@@ -693,7 +701,8 @@ func (npw *nodePortWatcher) SyncServices(services []interface{}) error {
 		}
 		nodeIPs := npw.nodeIPManager.ListAddresses()
 		hasLocalHostNetworkEp := hasLocalHostNetworkEndpoints(epSlices, nodeIPs)
-		npw.getAndSetServiceInfo(name, service, hasLocalHostNetworkEp)
+		localEndPoints := npw.GetLocalEndpointAddresses(epSlices)
+		npw.getAndSetServiceInfo(name, service, hasLocalHostNetworkEp, localEndPoints)
 		// Delete OF rules for service if they exist
 		if err = npw.updateServiceFlowCache(service, false, hasLocalHostNetworkEp); err != nil {
 			errors = append(errors, err)
@@ -703,7 +712,7 @@ func (npw *nodePortWatcher) SyncServices(services []interface{}) error {
 		}
 		// Add correct iptables rules only for Full mode
 		if !npw.dpuMode {
-			keepIPTRules = append(keepIPTRules, getGatewayIPTRules(service, hasLocalHostNetworkEp)...)
+			keepIPTRules = append(keepIPTRules, getGatewayIPTRules(service, localEndPoints.List(), hasLocalHostNetworkEp)...)
 		}
 
 		if !npw.dpuMode && shouldConfigureEgressSVC(service, npw) {
@@ -775,25 +784,31 @@ func (npw *nodePortWatcher) AddEndpointSlice(epSlice *discovery.EndpointSlice) e
 	nodeIPs := npw.nodeIPManager.ListAddresses()
 	hasLocalHostNetworkEp := hasLocalHostNetworkEndpoints([]*discovery.EndpointSlice{epSlice}, nodeIPs)
 
-	// Here we make sure the correct rules are programmed whenever an AddEndpointSlice
-	// event is received, only alter flows if we need to, i.e if cache wasn't
-	// set or if it was and hasLocalHostNetworkEp state changed, to prevent flow churn
+	epSlices, err := npw.watchFactory.GetEndpointSlices(svc.Namespace, svc.Name)
+	if err != nil {
+		klog.V(5).Infof("Could not fetch endpointslices for service %s/%s during endpointSliceAdd", svc.Name, svc.Namespace)
+	}
+	localEndpoints := npw.GetLocalEndpointAddresses(epSlices)
+	// Here we make sure the correct rules are programmed whenever an AddEndpointSlice event is
+	// received, only alter flows if we need to, i.e if cache wasn't set or if it was and
+	// hasLocalHostNetworkEp or localEndpoints state (for LB svc where NPs=0) changed, to prevent flow churn
 	namespacedName, err := namespacedNameFromEPSlice(epSlice)
 	if err != nil {
 		return fmt.Errorf("cannot add %s/%s to nodePortWatcher: %v", epSlice.Namespace, epSlice.Name, err)
 	}
-	out, exists := npw.getAndSetServiceInfo(namespacedName, svc, hasLocalHostNetworkEp)
+	out, exists := npw.getAndSetServiceInfo(namespacedName, svc, hasLocalHostNetworkEp, localEndpoints)
 	if !exists {
 		klog.V(5).Infof("Endpointslice %s ADD event in namespace %s is creating rules", epSlice.Name, epSlice.Namespace)
-		return addServiceRules(svc, hasLocalHostNetworkEp, npw)
+		return addServiceRules(svc, localEndpoints.List(), hasLocalHostNetworkEp, npw)
 	}
 
-	if out.hasLocalHostNetworkEp != hasLocalHostNetworkEp {
+	if out.hasLocalHostNetworkEp != hasLocalHostNetworkEp ||
+		(!util.LoadBalancerServiceHasNodePortAllocation(svc) && !reflect.DeepEqual(out.localEndpoints, localEndpoints)) {
 		klog.V(5).Infof("Endpointslice %s ADD event in namespace %s is updating rules", epSlice.Name, epSlice.Namespace)
-		if err = delServiceRules(svc, npw); err != nil {
+		if err = delServiceRules(svc, out.localEndpoints.List(), npw); err != nil {
 			errors = append(errors, err)
 		}
-		if err = addServiceRules(svc, hasLocalHostNetworkEp, npw); err != nil {
+		if err = addServiceRules(svc, localEndpoints.List(), hasLocalHostNetworkEp, npw); err != nil {
 			errors = append(errors, err)
 		}
 		return apierrors.NewAggregate(errors)
@@ -822,21 +837,39 @@ func (npw *nodePortWatcher) DeleteEndpointSlice(epSlice *discovery.EndpointSlice
 	if err != nil {
 		return fmt.Errorf("cannot delete %s/%s from nodePortWatcher: %v", epSlice.Namespace, epSlice.Name, err)
 	}
-	if svcConfig, exists := npw.updateServiceInfo(namespacedName, nil, &hasLocalHostNetworkEp); exists {
+	epSlices, err := npw.watchFactory.GetEndpointSlices(epSlice.Namespace, epSlice.Labels[discovery.LabelServiceName])
+	if err != nil {
+		return fmt.Errorf("could not fetch endpointslices for service %s during endpointSliceDelete", namespacedName)
+	}
+	localEndpoints := npw.GetLocalEndpointAddresses(epSlices)
+	if svcConfig, exists := npw.updateServiceInfo(namespacedName, nil, &hasLocalHostNetworkEp, localEndpoints); exists {
 		// Lock the cache mutex here so we don't miss a service delete during an endpoint delete
 		// we have to do this because deleting and adding iptables rules is slow.
 		npw.serviceInfoLock.Lock()
 		defer npw.serviceInfoLock.Unlock()
 
-		if err = delServiceRules(svcConfig.service, npw); err != nil {
+		if err = delServiceRules(svcConfig.service, svcConfig.localEndpoints.List(), npw); err != nil {
 			errors = append(errors, err)
 		}
-		if err = addServiceRules(svcConfig.service, hasLocalHostNetworkEp, npw); err != nil {
+		if err = addServiceRules(svcConfig.service, localEndpoints.List(), hasLocalHostNetworkEp, npw); err != nil {
 			errors = append(errors, err)
 		}
 		return apierrors.NewAggregate(errors)
 	}
 	return nil
+}
+
+// GetLocalEndpointAddresses returns a list of endpoints that are local to the node
+func (npw *nodePortWatcher) GetLocalEndpointAddresses(endpointSlices []*discovery.EndpointSlice) sets.String {
+	localEndpoints := sets.NewString()
+	for _, endpointSlice := range endpointSlices {
+		for _, endpoint := range endpointSlice.Endpoints {
+			if isEndpointReady(endpoint) && endpoint.NodeName != nil && *endpoint.NodeName == npw.nodeIPManager.nodeName {
+				localEndpoints.Insert(endpoint.Addresses...)
+			}
+		}
+	}
+	return localEndpoints
 }
 
 func getEndpointAddresses(endpointSlice *discovery.EndpointSlice) []string {
@@ -852,6 +885,9 @@ func getEndpointAddresses(endpointSlice *discovery.EndpointSlice) []string {
 }
 
 func (npw *nodePortWatcher) UpdateEndpointSlice(oldEpSlice, newEpSlice *discovery.EndpointSlice) error {
+	// TODO (tssurya): refactor bits in this function to ensure add and delete endpoint slices are not called repeatedly
+	// Context: Both add and delete endpointslice are calling delServiceRules followed by addServiceRules which makes double
+	// the number of calls than needed for an update endpoint slice
 	var err error
 	var errors []error
 
@@ -867,7 +903,9 @@ func (npw *nodePortWatcher) UpdateEndpointSlice(oldEpSlice, newEpSlice *discover
 	if err != nil {
 		return fmt.Errorf("cannot update %s/%s in nodePortWatcher: %v", newEpSlice.Namespace, newEpSlice.Name, err)
 	}
-	if _, exists := npw.getServiceInfo(namespacedName); !exists {
+	var serviceInfo *serviceConfig
+	var exists bool
+	if serviceInfo, exists = npw.getServiceInfo(namespacedName); !exists {
 		// When a service is updated from externalName to nodeport type, it won't be
 		// in nodePortWatcher cache (npw): in this case, have the new nodeport IPtable rules
 		// installed.
@@ -882,11 +920,17 @@ func (npw *nodePortWatcher) UpdateEndpointSlice(oldEpSlice, newEpSlice *discover
 		}
 	}
 
-	// Update rules if hasHostNetworkEndpoints status changed
+	// Update rules and service cache if hasHostNetworkEndpoints status changed or localEndpoints changed
 	nodeIPs := npw.nodeIPManager.ListAddresses()
 	hasLocalHostNetworkEpOld := hasLocalHostNetworkEndpoints([]*discovery.EndpointSlice{oldEpSlice}, nodeIPs)
 	hasLocalHostNetworkEpNew := hasLocalHostNetworkEndpoints([]*discovery.EndpointSlice{newEpSlice}, nodeIPs)
-	if hasLocalHostNetworkEpOld != hasLocalHostNetworkEpNew {
+	epSlices, err := npw.watchFactory.GetEndpointSlices(newEpSlice.Namespace, newEpSlice.Labels[discovery.LabelServiceName])
+	if err != nil {
+		klog.V(5).Infof("Could not fetch endpointslices for service %s during endpointSliceDelete", namespacedName)
+	}
+	newLocalEndpoints := npw.GetLocalEndpointAddresses(epSlices)
+	if hasLocalHostNetworkEpOld != hasLocalHostNetworkEpNew ||
+		(serviceInfo != nil && !reflect.DeepEqual(serviceInfo.localEndpoints, newLocalEndpoints)) {
 		if err = npw.DeleteEndpointSlice(oldEpSlice); err != nil {
 			errors = append(errors, err)
 		}
@@ -919,7 +963,7 @@ func (npwipt *nodePortWatcherIptables) AddService(service *kapi.Service) error {
 	if !util.ServiceTypeHasClusterIP(service) || !util.IsClusterIPSet(service) {
 		return nil
 	}
-	if err := addServiceRules(service, false, nil); err != nil {
+	if err := addServiceRules(service, nil, false, nil); err != nil {
 		return fmt.Errorf("AddService failed for nodePortWatcherIptables: %v", err)
 	}
 	return nil
@@ -936,13 +980,13 @@ func (npwipt *nodePortWatcherIptables) UpdateService(old, new *kapi.Service) err
 	}
 
 	if util.ServiceTypeHasClusterIP(old) && util.IsClusterIPSet(old) {
-		if err = delServiceRules(old, nil); err != nil {
+		if err = delServiceRules(old, nil, nil); err != nil {
 			errors = append(errors, err)
 		}
 	}
 
 	if util.ServiceTypeHasClusterIP(new) && util.IsClusterIPSet(new) {
-		if err = addServiceRules(new, false, nil); err != nil {
+		if err = addServiceRules(new, nil, false, nil); err != nil {
 			errors = append(errors, err)
 		}
 	}
@@ -958,7 +1002,7 @@ func (npwipt *nodePortWatcherIptables) DeleteService(service *kapi.Service) erro
 	if !util.ServiceTypeHasClusterIP(service) || !util.IsClusterIPSet(service) {
 		return nil
 	}
-	if err := delServiceRules(service, nil); err != nil {
+	if err := delServiceRules(service, nil, nil); err != nil {
 		return fmt.Errorf("DeleteService failed for nodePortWatcherIptables: %v", err)
 	}
 	return nil
@@ -977,7 +1021,7 @@ func (npwipt *nodePortWatcherIptables) SyncServices(services []interface{}) erro
 		}
 		// Add correct iptables rules.
 		// TODO: ETP and ITP is not implemented for smart NIC mode.
-		keepIPTRules = append(keepIPTRules, getGatewayIPTRules(service, false)...)
+		keepIPTRules = append(keepIPTRules, getGatewayIPTRules(service, nil, false)...)
 	}
 
 	// sync IPtables rules once

--- a/go-controller/pkg/node/gateway_shared_intf_linux.go
+++ b/go-controller/pkg/node/gateway_shared_intf_linux.go
@@ -59,8 +59,8 @@ func deleteLocalNodeAccessBridge() error {
 }
 
 // addGatewayIptRules adds the necessary iptable rules for a service on the node
-func addGatewayIptRules(service *kapi.Service, svcHasLocalHostNetEndPnt bool) error {
-	rules := getGatewayIPTRules(service, svcHasLocalHostNetEndPnt)
+func addGatewayIptRules(service *kapi.Service, localEndpoints []string, svcHasLocalHostNetEndPnt bool) error {
+	rules := getGatewayIPTRules(service, localEndpoints, svcHasLocalHostNetEndPnt)
 
 	if err := addIptRules(rules); err != nil {
 		return fmt.Errorf("failed to add iptables rules for service %s/%s: %v",
@@ -70,8 +70,8 @@ func addGatewayIptRules(service *kapi.Service, svcHasLocalHostNetEndPnt bool) er
 }
 
 // delGatewayIptRules removes the iptable rules for a service from the node
-func delGatewayIptRules(service *kapi.Service, svcHasLocalHostNetEndPnt bool) error {
-	rules := getGatewayIPTRules(service, svcHasLocalHostNetEndPnt)
+func delGatewayIptRules(service *kapi.Service, localEndpoints []string, svcHasLocalHostNetEndPnt bool) error {
+	rules := getGatewayIPTRules(service, localEndpoints, svcHasLocalHostNetEndPnt)
 
 	if err := delIptRules(rules); err != nil {
 		return fmt.Errorf("failed to delete iptables rules for service %s/%s: %v", service.Namespace, service.Name, err)

--- a/go-controller/pkg/node/node.go
+++ b/go-controller/pkg/node/node.go
@@ -852,12 +852,16 @@ func (n *OvnNode) validateVTEPInterfaceMTU() error {
 
 	// calc required MTU
 	var requiredMTU int
-	if config.IPv4Mode && !config.IPv6Mode {
-		// we run in single-stack IPv4 only
-		requiredMTU = config.Default.MTU + types.GeneveHeaderLengthIPv4
+	if config.Gateway.SingleNode {
+		requiredMTU = config.Default.MTU
 	} else {
-		// we run in single-stack IPv6 or dual-stack mode
-		requiredMTU = config.Default.MTU + types.GeneveHeaderLengthIPv6
+		if config.IPv4Mode && !config.IPv6Mode {
+			// we run in single-stack IPv4 only
+			requiredMTU = config.Default.MTU + types.GeneveHeaderLengthIPv4
+		} else {
+			// we run in single-stack IPv6 or dual-stack mode
+			requiredMTU = config.Default.MTU + types.GeneveHeaderLengthIPv6
+		}
 	}
 
 	if mtu < requiredMTU {

--- a/go-controller/pkg/node/node_test.go
+++ b/go-controller/pkg/node/node_test.go
@@ -43,6 +43,8 @@ var _ = Describe("Node", func() {
 			mtuTooSmallForIPv4AndIPv6      = configDefaultMTU + types.GeneveHeaderLengthIPv4 - 1
 			mtuOkForIPv4ButTooSmallForIPv6 = configDefaultMTU + types.GeneveHeaderLengthIPv4
 			mtuOkForIPv4AndIPv6            = configDefaultMTU + types.GeneveHeaderLengthIPv6
+			mtuTooSmallForSingleNode       = configDefaultMTU - 1
+			mtuOkForSingleNode             = configDefaultMTU
 		)
 
 		BeforeEach(func() {
@@ -160,6 +162,38 @@ var _ = Describe("Node", func() {
 				It("should untaint the node", func() {
 					netlinkLinkMock.On("Attrs").Return(&netlink.LinkAttrs{
 						MTU:  mtuOkForIPv4AndIPv6,
+						Name: linkName,
+					})
+
+					err := ovnNode.validateVTEPInterfaceMTU()
+					Expect(err).NotTo(HaveOccurred())
+				})
+			})
+		})
+
+		Context("with a single-node cluster", func() {
+			BeforeEach(func() {
+				config.Gateway.SingleNode = true
+			})
+
+			Context("with the node having a too small MTU", func() {
+
+				It("should taint the node", func() {
+					netlinkLinkMock.On("Attrs").Return(&netlink.LinkAttrs{
+						MTU:  mtuTooSmallForSingleNode,
+						Name: linkName,
+					})
+
+					err := ovnNode.validateVTEPInterfaceMTU()
+					Expect(err).To(HaveOccurred())
+				})
+			})
+
+			Context("with the node having a big enough MTU", func() {
+
+				It("should untaint the node", func() {
+					netlinkLinkMock.On("Attrs").Return(&netlink.LinkAttrs{
+						MTU:  mtuOkForSingleNode,
 						Name: linkName,
 					})
 

--- a/go-controller/pkg/ovn/base_network_controller.go
+++ b/go-controller/pkg/ovn/base_network_controller.go
@@ -352,7 +352,7 @@ func (bnc *BaseNetworkController) UpdateNodeAnnotationWithRetry(nodeName string,
 		for k, v := range otherUpdatedNodeAnnotation {
 			cnode.Annotations[k] = v
 		}
-		return bnc.kube.UpdateNode(cnode)
+		return oc.kube.PatchNode(node, cnode)
 	})
 	if resultErr != nil {
 		return fmt.Errorf("failed to update node %s annotation", nodeName)

--- a/go-controller/pkg/ovn/base_network_controller.go
+++ b/go-controller/pkg/ovn/base_network_controller.go
@@ -352,7 +352,7 @@ func (bnc *BaseNetworkController) UpdateNodeAnnotationWithRetry(nodeName string,
 		for k, v := range otherUpdatedNodeAnnotation {
 			cnode.Annotations[k] = v
 		}
-		return oc.kube.PatchNode(node, cnode)
+		return bnc.kube.PatchNode(node, cnode)
 	})
 	if resultErr != nil {
 		return fmt.Errorf("failed to update node %s annotation", nodeName)

--- a/go-controller/pkg/ovn/default_network_controller.go
+++ b/go-controller/pkg/ovn/default_network_controller.go
@@ -853,9 +853,9 @@ func (h *defaultNetworkControllerEventHandler) UpdateResource(oldObj, newObj int
 		if !oldHadEgressLabel && !newHasEgressLabel {
 			return nil
 		}
+		h.oc.setNodeEgressAssignable(newNode.Name, newHasEgressLabel)
 		if oldHadEgressLabel && !newHasEgressLabel {
 			klog.Infof("Node: %s has been un-labeled, deleting it from egress assignment", newNode.Name)
-			h.oc.setNodeEgressAssignable(oldNode.Name, false)
 			return h.oc.deleteEgressNode(oldNode.Name)
 		}
 		isOldReady := h.oc.isEgressNodeReady(oldNode)
@@ -864,7 +864,6 @@ func (h *defaultNetworkControllerEventHandler) UpdateResource(oldObj, newObj int
 		h.oc.setNodeEgressReady(newNode.Name, isNewReady)
 		if !oldHadEgressLabel && newHasEgressLabel {
 			klog.Infof("Node: %s has been labeled, adding it for egress assignment", newNode.Name)
-			h.oc.setNodeEgressAssignable(newNode.Name, true)
 			if isNewReady && isNewReachable {
 				h.oc.setNodeEgressReachable(newNode.Name, isNewReachable)
 				if err := h.oc.addEgressNode(newNode.Name); err != nil {

--- a/go-controller/pkg/ovn/hybrid_test.go
+++ b/go-controller/pkg/ovn/hybrid_test.go
@@ -3,12 +3,13 @@ package ovn
 import (
 	"context"
 	"fmt"
-	"k8s.io/apimachinery/pkg/runtime"
-	k8stypes "k8s.io/apimachinery/pkg/types"
 	"net"
 	"reflect"
 	"sync"
 	"sync/atomic"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 
 	"github.com/urfave/cli/v2"
 
@@ -284,7 +285,6 @@ var _ = ginkgo.Describe("Hybrid SDN Master Operations", func() {
 				Name:                 "node1",
 				NodeIP:               "1.2.3.4",
 				NodeLRPMAC:           "0a:58:0a:01:01:01",
-				LrpMAC:               "0a:58:64:40:00:03",
 				LrpIP:                "100.64.0.2",
 				DrLrpIP:              "100.64.0.1",
 				PhysicalBridgeMAC:    "11:22:33:44:55:66",
@@ -554,7 +554,6 @@ var _ = ginkgo.Describe("Hybrid SDN Master Operations", func() {
 				Name:                 "node1",
 				NodeIP:               "1.2.3.4",
 				NodeLRPMAC:           "0a:58:0a:01:01:01",
-				LrpMAC:               "0a:58:64:40:00:02",
 				LrpIP:                "100.64.0.2",
 				DrLrpIP:              "100.64.0.1",
 				PhysicalBridgeMAC:    "11:22:33:44:55:66",
@@ -742,7 +741,6 @@ var _ = ginkgo.Describe("Hybrid SDN Master Operations", func() {
 				Name:                 "node1",
 				NodeIP:               "1.2.3.4",
 				NodeLRPMAC:           "0a:58:0a:01:01:01",
-				LrpMAC:               "0a:58:64:40:00:02",
 				LrpIP:                "100.64.0.2",
 				DrLrpIP:              "100.64.0.1",
 				PhysicalBridgeMAC:    "11:22:33:44:55:66",
@@ -1016,7 +1014,6 @@ var _ = ginkgo.Describe("Hybrid SDN Master Operations", func() {
 				Name:                 "node1",
 				NodeIP:               "1.2.3.4",
 				NodeLRPMAC:           "0a:58:0a:01:01:01",
-				LrpMAC:               "0a:58:64:40:00:03",
 				LrpIP:                "100.64.0.2",
 				DrLrpIP:              "100.64.0.1",
 				PhysicalBridgeMAC:    "11:22:33:44:55:66",
@@ -1251,7 +1248,6 @@ var _ = ginkgo.Describe("Hybrid SDN Master Operations", func() {
 				Name:                 "node1",
 				NodeIP:               "1.2.3.4",
 				NodeLRPMAC:           "0a:58:0a:01:01:01",
-				LrpMAC:               "0a:58:64:40:00:03",
 				LrpIP:                "100.64.0.2",
 				DrLrpIP:              "100.64.0.1",
 				PhysicalBridgeMAC:    "11:22:33:44:55:66",
@@ -1400,7 +1396,6 @@ var _ = ginkgo.Describe("Hybrid SDN Master Operations", func() {
 				Name:                 "node1",
 				NodeIP:               "1.2.3.4",
 				NodeLRPMAC:           "0a:58:0a:01:01:01",
-				LrpMAC:               "0a:58:64:40:00:03",
 				LrpIP:                "100.64.0.2",
 				DrLrpIP:              "100.64.0.1",
 				PhysicalBridgeMAC:    "11:22:33:44:55:66",

--- a/go-controller/pkg/ovn/hybrid_test.go
+++ b/go-controller/pkg/ovn/hybrid_test.go
@@ -1313,7 +1313,7 @@ var _ = ginkgo.Describe("Hybrid SDN Master Operations", func() {
 			err = f.Start()
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			clusterController := NewOvnController(fakeClient, f, stopChan, addressset.NewFakeAddressSetFactory(),
-				libovsdbOvnNBClient, libovsdbOvnSBClient, record.NewFakeRecorder(10), &sync.WaitGroup{})
+				libovsdbOvnNBClient, libovsdbOvnSBClient, record.NewFakeRecorder(10), wg)
 			gomega.Expect(clusterController).NotTo(gomega.BeNil())
 			setupClusterController(clusterController, expectedClusterLBGroup.UUID, expectedNodeSwitch.UUID, node1.Name)
 			_, _ = clusterController.joinSwIPManager.EnsureJoinLRPIPs(types.OVNClusterRouter)
@@ -1459,7 +1459,7 @@ var _ = ginkgo.Describe("Hybrid SDN Master Operations", func() {
 			err = f.Start()
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			clusterController := NewOvnController(fakeClient, f, stopChan, addressset.NewFakeAddressSetFactory(),
-				libovsdbOvnNBClient, libovsdbOvnSBClient, record.NewFakeRecorder(10), &sync.WaitGroup{})
+				libovsdbOvnNBClient, libovsdbOvnSBClient, record.NewFakeRecorder(10), wg)
 			gomega.Expect(clusterController).NotTo(gomega.BeNil())
 			setupClusterController(clusterController, expectedClusterLBGroup.UUID, expectedNodeSwitch.UUID, node1.Name)
 			_, _ = clusterController.joinSwIPManager.EnsureJoinLRPIPs(types.OVNClusterRouter)

--- a/go-controller/pkg/ovn/hybrid_test.go
+++ b/go-controller/pkg/ovn/hybrid_test.go
@@ -295,7 +295,6 @@ var _ = ginkgo.Describe("Hybrid SDN Master Operations", func() {
 				GatewayRouterIP:      "172.16.16.2",
 				GatewayRouterNextHop: "172.16.16.1",
 				PhysicalBridgeName:   "br-eth0",
-				NodeHostAddress:      []string{"9.9.9.9"},
 				NodeGWIP:             "10.1.1.1/24",
 				NodeMgmtPortIP:       "10.1.1.2",
 				//NodeMgmtPortMAC:      "0a:58:0a:01:01:02",
@@ -328,7 +327,7 @@ var _ = ginkgo.Describe("Hybrid SDN Master Operations", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			err = util.SetNodeHostSubnetAnnotation(nodeAnnotator, ovntest.MustParseIPNets(node1.NodeSubnet))
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			err = util.SetNodeHostAddresses(nodeAnnotator, sets.NewString("9.9.9.9"))
+			err = util.SetNodeHostAddresses(nodeAnnotator, sets.NewString(node1.NodeIP))
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			err = nodeAnnotator.Run()
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -564,7 +563,6 @@ var _ = ginkgo.Describe("Hybrid SDN Master Operations", func() {
 				GatewayRouterIP:      "172.16.16.2",
 				GatewayRouterNextHop: "172.16.16.1",
 				PhysicalBridgeName:   "br-eth0",
-				NodeHostAddress:      []string{"9.9.9.9"},
 				NodeGWIP:             "10.1.1.1/24",
 				NodeMgmtPortIP:       "10.1.1.2",
 				NodeMgmtPortMAC:      "0a:58:0a:01:01:02",
@@ -598,7 +596,7 @@ var _ = ginkgo.Describe("Hybrid SDN Master Operations", func() {
 
 			err = util.SetNodeHostSubnetAnnotation(nodeAnnotator, ovntest.MustParseIPNets(node1.NodeSubnet))
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			err = util.SetNodeHostAddresses(nodeAnnotator, sets.NewString("9.9.9.9"))
+			err = util.SetNodeHostAddresses(nodeAnnotator, sets.NewString(node1.NodeIP))
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			err = nodeAnnotator.Run()
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -751,7 +749,6 @@ var _ = ginkgo.Describe("Hybrid SDN Master Operations", func() {
 				GatewayRouterIP:      "172.16.16.2",
 				GatewayRouterNextHop: "172.16.16.1",
 				PhysicalBridgeName:   "br-eth0",
-				NodeHostAddress:      []string{"9.9.9.9"},
 				NodeGWIP:             "10.1.1.1/24",
 				NodeMgmtPortIP:       "10.1.1.2",
 				NodeMgmtPortMAC:      "0a:58:0a:01:01:02",
@@ -795,7 +792,7 @@ var _ = ginkgo.Describe("Hybrid SDN Master Operations", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			err = util.SetNodeHostSubnetAnnotation(nodeAnnotator, ovntest.MustParseIPNets(node1.NodeSubnet))
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			err = util.SetNodeHostAddresses(nodeAnnotator, sets.NewString("9.9.9.9"))
+			err = util.SetNodeHostAddresses(nodeAnnotator, sets.NewString(node1.NodeIP))
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			err = nodeAnnotator.Run()
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -1024,7 +1021,6 @@ var _ = ginkgo.Describe("Hybrid SDN Master Operations", func() {
 				GatewayRouterIP:      "172.16.16.2",
 				GatewayRouterNextHop: "172.16.16.1",
 				PhysicalBridgeName:   "br-eth0",
-				NodeHostAddress:      []string{"9.9.9.9"},
 				NodeGWIP:             "10.1.1.1/24",
 				NodeMgmtPortIP:       "10.1.1.2",
 				//NodeMgmtPortMAC:      "0a:58:0a:01:01:02",
@@ -1057,7 +1053,7 @@ var _ = ginkgo.Describe("Hybrid SDN Master Operations", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			err = util.SetNodeHostSubnetAnnotation(nodeAnnotator, ovntest.MustParseIPNets(node1.NodeSubnet))
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			err = util.SetNodeHostAddresses(nodeAnnotator, sets.NewString("9.9.9.9"))
+			err = util.SetNodeHostAddresses(nodeAnnotator, sets.NewString(node1.NodeIP))
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			err = nodeAnnotator.Run()
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -801,7 +801,12 @@ func (oc *DefaultNetworkController) deleteNodeEvent(node *kapi.Node) error {
 		"various caches", node.Name)
 
 	if config.HybridOverlay.Enabled {
-		oc.releaseHybridOverlayNodeSubnet(node.Name)
+		if noHostSubnet := noHostSubnet(node); noHostSubnet {
+			// noHostSubnet nodes are different, only remove the switch and delete the hybrid overlay subnet
+			oc.lsManager.DeleteSwitch(node.Name)
+			oc.releaseHybridOverlayNodeSubnet(node.Name)
+			return nil
+		}
 		if _, ok := node.Annotations[hotypes.HybridOverlayDRMAC]; ok && !houtil.IsHybridOverlayNode(node) {
 			oc.deleteHybridOverlayPort(node)
 		}

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -452,25 +452,25 @@ var _ = ginkgo.Describe("Master Operations", func() {
 			err = f.Start()
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			clusterController := NewOvnController(fakeClient, f, stopChan,
+			oc := NewOvnController(fakeClient, f, stopChan,
 				newFakeAddressSetFactory(),
 				mockOVNNBClient,
 				mockOVNSBClient, record.NewFakeRecorder(0))
 
-			gomega.Expect(clusterController).NotTo(gomega.BeNil())
-			clusterController.TCPLoadBalancerUUID = tcpLBUUID
-			clusterController.UDPLoadBalancerUUID = udpLBUUID
-			clusterController.SCTPLoadBalancerUUID = sctpLBUUID
+			gomega.Expect(oc).NotTo(gomega.BeNil())
+			oc.TCPLoadBalancerUUID = tcpLBUUID
+			oc.UDPLoadBalancerUUID = udpLBUUID
+			oc.SCTPLoadBalancerUUID = sctpLBUUID
 
-			err = clusterController.StartClusterMaster("master")
+			err = oc.StartClusterMaster("master")
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			clusterController.WatchNodes()
+			oc.WatchNodes()
 
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				clusterController.hoMaster.Run(stopChan)
+				oc.hoMaster.Run(stopChan)
 			}()
 
 			gomega.Eventually(fexec.CalledMatchesExpected, 2).Should(gomega.BeTrue(), fexec.ErrorDesc)
@@ -558,24 +558,24 @@ var _ = ginkgo.Describe("Master Operations", func() {
 			err = f.Start()
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			clusterController := NewOvnController(fakeClient, f, stopChan,
+			oc := NewOvnController(fakeClient, f, stopChan,
 				newFakeAddressSetFactory(), mockOVNNBClient,
 				mockOVNSBClient, record.NewFakeRecorder(0))
 
-			gomega.Expect(clusterController).NotTo(gomega.BeNil())
-			clusterController.TCPLoadBalancerUUID = tcpLBUUID
-			clusterController.UDPLoadBalancerUUID = udpLBUUID
-			clusterController.SCTPLoadBalancerUUID = ""
+			gomega.Expect(oc).NotTo(gomega.BeNil())
+			oc.TCPLoadBalancerUUID = tcpLBUUID
+			oc.UDPLoadBalancerUUID = udpLBUUID
+			oc.SCTPLoadBalancerUUID = ""
 
-			err = clusterController.StartClusterMaster("master")
+			err = oc.StartClusterMaster("master")
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			clusterController.WatchNodes()
+			oc.WatchNodes()
 
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				clusterController.hoMaster.Run(stopChan)
+				oc.hoMaster.Run(stopChan)
 			}()
 
 			gomega.Eventually(fexec.CalledMatchesExpected, 2).Should(gomega.BeTrue(), fexec.ErrorDesc)
@@ -663,22 +663,22 @@ var _ = ginkgo.Describe("Master Operations", func() {
 			err = f.Start()
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			clusterController := NewOvnController(fakeClient, f, stopChan,
+			oc := NewOvnController(fakeClient, f, stopChan,
 				newFakeAddressSetFactory(), mockOVNNBClient, mockOVNSBClient, record.NewFakeRecorder(0))
-			gomega.Expect(clusterController).NotTo(gomega.BeNil())
-			clusterController.TCPLoadBalancerUUID = tcpLBUUID
-			clusterController.UDPLoadBalancerUUID = udpLBUUID
-			clusterController.SCTPLoadBalancerUUID = sctpLBUUID
+			gomega.Expect(oc).NotTo(gomega.BeNil())
+			oc.TCPLoadBalancerUUID = tcpLBUUID
+			oc.UDPLoadBalancerUUID = udpLBUUID
+			oc.SCTPLoadBalancerUUID = sctpLBUUID
 
-			err = clusterController.StartClusterMaster("master")
+			err = oc.StartClusterMaster("master")
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			clusterController.WatchNodes()
+			oc.WatchNodes()
 
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				clusterController.hoMaster.Run(stopChan)
+				oc.hoMaster.Run(stopChan)
 			}()
 
 			gomega.Eventually(fexec.CalledMatchesExpected, 2).Should(gomega.BeTrue(), fexec.ErrorDesc)
@@ -824,19 +824,19 @@ subnet=%s
 			err = f.Start()
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			clusterController := NewOvnController(fakeClient, f, stopChan,
+			oc := NewOvnController(fakeClient, f, stopChan,
 				newFakeAddressSetFactory(), ovntest.NewMockOVNClient(goovn.DBNB),
 				ovntest.NewMockOVNClient(goovn.DBSB), record.NewFakeRecorder(0))
-			gomega.Expect(clusterController).NotTo(gomega.BeNil())
-			clusterController.TCPLoadBalancerUUID = tcpLBUUID
-			clusterController.UDPLoadBalancerUUID = udpLBUUID
-			clusterController.SCTPLoadBalancerUUID = sctpLBUUID
-			clusterController.SCTPSupport = true
-			clusterController.joinSwIPManager, _ = newJoinLogicalSwitchIPManager()
-			_, _ = clusterController.joinSwIPManager.ensureJoinLRPIPs(types.OVNClusterRouter)
+			gomega.Expect(oc).NotTo(gomega.BeNil())
+			oc.TCPLoadBalancerUUID = tcpLBUUID
+			oc.UDPLoadBalancerUUID = udpLBUUID
+			oc.SCTPLoadBalancerUUID = sctpLBUUID
+			oc.SCTPSupport = true
+			oc.joinSwIPManager, _ = newJoinLogicalSwitchIPManager()
+			_, _ = oc.joinSwIPManager.ensureJoinLRPIPs(types.OVNClusterRouter)
 
 			// Let the real code run and ensure OVN database sync
-			clusterController.WatchNodes()
+			oc.WatchNodes()
 
 			gomega.Expect(fexec.CalledMatchesExpected()).To(gomega.BeTrue(), fexec.ErrorDesc)
 
@@ -861,16 +861,16 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 		stopChan chan struct{}
 		wg       *sync.WaitGroup
 
-		libovsdbOvnNBClient libovsdbclient.Client
-		libovsdbOvnSBClient libovsdbclient.Client
-		libovsdbCleanup     *libovsdbtest.Cleanup
+		nbClient        libovsdbclient.Client
+		sbClient        libovsdbclient.Client
+		libovsdbCleanup *libovsdbtest.Cleanup
 
 		dbSetup           libovsdbtest.TestSetup
 		node1             tNode
 		testNode          v1.Node
 		fakeClient        *util.OVNClientset
 		kubeFakeClient    *fake.Clientset
-		clusterController *DefaultNetworkController
+		oc                *DefaultNetworkController
 		nodeAnnotator     kube.Annotator
 		events            []string
 		eventsLock        sync.Mutex
@@ -962,7 +962,7 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 		err = nodeAnnotator.Run()
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-		libovsdbOvnNBClient, libovsdbOvnSBClient, libovsdbCleanup, err = libovsdbtest.NewNBSBTestHarness(dbSetup)
+		nbClient, sbClient, libovsdbCleanup, err = libovsdbtest.NewNBSBTestHarness(dbSetup)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		f, err = factory.NewMasterWatchFactory(fakeClient)
@@ -971,16 +971,15 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		recorder = record.NewFakeRecorder(10)
-		clusterController = NewOvnController(fakeClient, f, stopChan, addressset.NewFakeAddressSetFactory(),
-			libovsdbOvnNBClient, libovsdbOvnSBClient,
-			recorder, wg)
-		clusterController.loadBalancerGroupUUID = expectedClusterLBGroup.UUID
-		gomega.Expect(clusterController).NotTo(gomega.BeNil())
-		clusterController.defaultCOPPUUID, err = EnsureDefaultCOPP(libovsdbOvnNBClient)
+		oc = NewOvnController(fakeClient, f, stopChan, addressset.NewFakeAddressSetFactory(),
+			nbClient, sbClient, recorder, wg)
+		oc.loadBalancerGroupUUID = expectedClusterLBGroup.UUID
+		gomega.Expect(oc).NotTo(gomega.BeNil())
+		oc.defaultCOPPUUID, err = EnsureDefaultCOPP(nbClient)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		subnets, err := config.ParseClusterSubnetEntries(clusterCIDR)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		err = clusterController.masterSubnetAllocator.InitRanges(subnets)
+		err = oc.masterSubnetAllocator.InitRanges(subnets)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		// record events for testcases to check
@@ -998,9 +997,9 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 			}
 		}()
 
-		clusterController.SCTPSupport = true
-		clusterController.joinSwIPManager, _ = lsm.NewJoinLogicalSwitchIPManager(clusterController.nbClient, expectedNodeSwitch.UUID, []string{node1.Name})
-		_, _ = clusterController.joinSwIPManager.EnsureJoinLRPIPs(types.OVNClusterRouter)
+		oc.SCTPSupport = true
+		oc.joinSwIPManager, _ = lsm.NewJoinLogicalSwitchIPManager(oc.nbClient, expectedNodeSwitch.UUID, []string{node1.Name})
+		_, _ = oc.joinSwIPManager.EnsureJoinLRPIPs(types.OVNClusterRouter)
 	})
 
 	ginkgo.AfterEach(func() {
@@ -1035,25 +1034,25 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 			expectedDatabaseState = addNodeLogicalFlows(expectedDatabaseState, expectedOVNClusterRouter, expectedNodeSwitch, expectedClusterRouterPortGroup, expectedClusterPortGroup, &node1)
 
 			// Let the real code run and ensure OVN database sync
-			gomega.Expect(clusterController.WatchNodes()).To(gomega.Succeed())
+			gomega.Expect(oc.WatchNodes()).To(gomega.Succeed())
 
-			gomega.Expect(clusterController.StartServiceController(wg, false)).To(gomega.Succeed())
+			gomega.Expect(oc.StartServiceController(wg, false)).To(gomega.Succeed())
 
 			subnet := ovntest.MustParseIPNet(node1.NodeSubnet)
-			err = clusterController.syncGatewayLogicalNetwork(updatedNode, l3GatewayConfig, []*net.IPNet{subnet}, hostAddrs)
+			err = oc.syncGatewayLogicalNetwork(updatedNode, l3GatewayConfig, []*net.IPNet{subnet}, hostAddrs)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			retry.InitRetryObjWithAdd(testNode, testNode.Name, clusterController.retryNodes)
-			gomega.Expect(retry.RetryObjsLen(clusterController.retryNodes)).To(gomega.Equal(1))
+			retry.InitRetryObjWithAdd(testNode, testNode.Name, oc.retryNodes)
+			gomega.Expect(retry.RetryObjsLen(oc.retryNodes)).To(gomega.Equal(1))
 
 			retry.CheckRetryObjectMultipleFieldsEventually(
 				testNode.Name,
-				clusterController.retryNodes,
+				oc.retryNodes,
 				gomega.BeNil(),             // oldObj should be nil
 				gomega.Not(gomega.BeNil()), // newObj should not be nil
 			)
 
-			retry.DeleteRetryObj(testNode.Name, clusterController.retryNodes)
-			gomega.Expect(retry.CheckRetryObj(testNode.Name, clusterController.retryNodes)).To(gomega.BeFalse())
+			retry.DeleteRetryObj(testNode.Name, oc.retryNodes)
+			gomega.Expect(retry.CheckRetryObj(testNode.Name, oc.retryNodes)).To(gomega.BeFalse())
 			var clusterSubnets []*net.IPNet
 			for _, clusterSubnet := range config.Default.ClusterSubnets {
 				clusterSubnets = append(clusterSubnets, clusterSubnet.CIDR)
@@ -1064,7 +1063,7 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 				expectedNodeSwitch, node1.Name, clusterSubnets, []*net.IPNet{subnet}, l3GatewayConfig,
 				[]*net.IPNet{classBIPAddress(node1.LrpIP)}, []*net.IPNet{classBIPAddress(node1.DrLrpIP)},
 				skipSnat, node1.NodeMgmtPortIP, "1400")
-			gomega.Eventually(clusterController.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+			gomega.Eventually(oc.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 
 			return nil
 		}
@@ -1104,12 +1103,12 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 			expectedDatabaseState = addNodeLogicalFlows(expectedDatabaseState, expectedOVNClusterRouter, expectedNodeSwitch, expectedClusterRouterPortGroup, expectedClusterPortGroup, &node1)
 
 			// Let the real code run and ensure OVN database sync
-			gomega.Expect(clusterController.WatchNodes()).To(gomega.Succeed())
+			gomega.Expect(oc.WatchNodes()).To(gomega.Succeed())
 
-			gomega.Expect(clusterController.StartServiceController(wg, false)).To(gomega.Succeed())
+			gomega.Expect(oc.StartServiceController(wg, false)).To(gomega.Succeed())
 
 			subnet := ovntest.MustParseIPNet(node1.NodeSubnet)
-			err = clusterController.syncGatewayLogicalNetwork(updatedNode, l3GatewayConfig, []*net.IPNet{subnet}, hostAddrs)
+			err = oc.syncGatewayLogicalNetwork(updatedNode, l3GatewayConfig, []*net.IPNet{subnet}, hostAddrs)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			var clusterSubnets []*net.IPNet
@@ -1122,7 +1121,7 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 				expectedNodeSwitch, node1.Name, clusterSubnets, []*net.IPNet{subnet}, l3GatewayConfig,
 				[]*net.IPNet{classBIPAddress(node1.LrpIP)}, []*net.IPNet{classBIPAddress(node1.DrLrpIP)},
 				skipSnat, node1.NodeMgmtPortIP, "1400")
-			gomega.Eventually(clusterController.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+			gomega.Eventually(oc.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 
 			return nil
 		}
@@ -1167,7 +1166,7 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			// Let the real code run and ensure OVN database sync
-			gomega.Expect(clusterController.WatchNodes()).To(gomega.Succeed())
+			gomega.Expect(oc.WatchNodes()).To(gomega.Succeed())
 
 			var clusterSubnets []*net.IPNet
 			for _, clusterSubnet := range config.Default.ClusterSubnets {
@@ -1193,12 +1192,12 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 			GR := &nbdb.LogicalRouter{
 				Name: types.GWRouterPrefix + node1.Name,
 			}
-			err = libovsdbops.CreateOrUpdateNATs(libovsdbOvnNBClient, GR, staleNats...)
+			err = libovsdbops.CreateOrUpdateNATs(nbClient, GR, staleNats...)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			// ensure the stale SNAT's are cleaned up
-			gomega.Expect(clusterController.StartServiceController(wg, false)).To(gomega.Succeed())
-			err = clusterController.syncGatewayLogicalNetwork(updatedNode, l3GatewayConfig, []*net.IPNet{subnet}, hostAddrs)
+			gomega.Expect(oc.StartServiceController(wg, false)).To(gomega.Succeed())
+			err = oc.syncGatewayLogicalNetwork(updatedNode, l3GatewayConfig, []*net.IPNet{subnet}, hostAddrs)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			expectedDatabaseState = append(expectedDatabaseState,
@@ -1213,7 +1212,7 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 					break
 				}
 			}
-			gomega.Eventually(clusterController.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+			gomega.Eventually(oc.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 
 			return nil
 		}
@@ -1242,7 +1241,7 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 			expectedDatabaseState = addNodeLogicalFlows(expectedDatabaseState, expectedOVNClusterRouter, expectedNodeSwitch, expectedClusterRouterPortGroup, expectedClusterPortGroup, &node1)
 
 			// Let the real code run and ensure OVN database sync
-			gomega.Expect(clusterController.WatchNodes()).To(gomega.Succeed())
+			gomega.Expect(oc.WatchNodes()).To(gomega.Succeed())
 			// ensure db is consistent
 			subnet := ovntest.MustParseIPNet(node1.NodeSubnet)
 
@@ -1257,7 +1256,7 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 				expectedNodeSwitch, node1.Name, clusterSubnets, []*net.IPNet{subnet}, l3Config,
 				[]*net.IPNet{classBIPAddress(node1.LrpIP)}, []*net.IPNet{classBIPAddress(node1.DrLrpIP)},
 				skipSnat, node1.NodeMgmtPortIP, "1400")
-			gomega.Eventually(clusterController.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+			gomega.Eventually(oc.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 
 			ginkgo.By("modifying the node and triggering an update")
 
@@ -1307,7 +1306,7 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 			expectedDatabaseState = addNodeLogicalFlows(expectedDatabaseState, expectedOVNClusterRouter, expectedNodeSwitch, expectedClusterRouterPortGroup, expectedClusterPortGroup, &node1)
 
 			// Let the real code run and ensure OVN database sync
-			gomega.Expect(clusterController.WatchNodes()).To(gomega.Succeed())
+			gomega.Expect(oc.WatchNodes()).To(gomega.Succeed())
 			// ensure db is consistent
 			subnet := ovntest.MustParseIPNet(node1.NodeSubnet)
 
@@ -1322,12 +1321,12 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 				expectedNodeSwitch, node1.Name, clusterSubnets, []*net.IPNet{subnet}, l3Config,
 				[]*net.IPNet{classBIPAddress(node1.LrpIP)}, []*net.IPNet{classBIPAddress(node1.DrLrpIP)},
 				skipSnat, node1.NodeMgmtPortIP, "1400")
-			gomega.Eventually(clusterController.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+			gomega.Eventually(oc.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 			ginkgo.By("Bringing down NBDB")
 			// inject transient problem, nbdb is down
-			clusterController.nbClient.Close()
+			oc.nbClient.Close()
 			gomega.Eventually(func() bool {
-				return clusterController.nbClient.Connected()
+				return oc.nbClient.Connected()
 			}).Should(gomega.BeFalse())
 
 			ginkgo.By("modifying the node and triggering an update")
@@ -1343,7 +1342,7 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 			// In the retry entry, old obj should be nil, new obj should not be nil
 			retry.CheckRetryObjectMultipleFieldsEventually(
 				testNode.Name,
-				clusterController.retryNodes,
+				oc.retryNodes,
 				gomega.BeNil(),             // oldObj should be nil
 				gomega.Not(gomega.BeNil()), // newObj should not be nil
 			)
@@ -1362,11 +1361,11 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 			connCtx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout)
 			defer cancel()
 			ginkgo.By("bring up NBDB")
-			resetNBClient(connCtx, clusterController.nbClient)
-			retry.SetRetryObjWithNoBackoff(node1.Name, clusterController.retryNodes)
-			clusterController.retryNodes.RequestRetryObjs() // retry the failed entry
+			resetNBClient(connCtx, oc.nbClient)
+			retry.SetRetryObjWithNoBackoff(node1.Name, oc.retryNodes)
+			oc.retryNodes.RequestRetryObjs() // retry the failed entry
 			ginkgo.By("should be no retry entry after update completes")
-			retry.CheckRetryObjectEventually(testNode.Name, false, clusterController.retryNodes)
+			retry.CheckRetryObjectEventually(testNode.Name, false, oc.retryNodes)
 			for _, data := range expectedDatabaseState {
 				if route, ok := data.(*nbdb.LogicalRouterStaticRoute); ok {
 					if route.Nexthop == "172.16.16.1" {
@@ -1374,7 +1373,7 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 					}
 				}
 			}
-			gomega.Eventually(clusterController.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+			gomega.Eventually(oc.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 			return nil
 		}
 
@@ -1409,11 +1408,11 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 			expectedDatabaseState = addNodeLogicalFlows(expectedDatabaseState, expectedOVNClusterRouter, expectedNodeSwitch, expectedClusterRouterPortGroup, expectedClusterPortGroup, &node1)
 
 			// Let the real code run and ensure OVN database sync
-			gomega.Expect(clusterController.WatchNodes()).To(gomega.Succeed())
-			gomega.Expect(clusterController.StartServiceController(wg, false)).To(gomega.Succeed())
+			gomega.Expect(oc.WatchNodes()).To(gomega.Succeed())
+			gomega.Expect(oc.StartServiceController(wg, false)).To(gomega.Succeed())
 
 			subnet := ovntest.MustParseIPNet(node1.NodeSubnet)
-			err = clusterController.syncGatewayLogicalNetwork(updatedNode, l3GatewayConfig, []*net.IPNet{subnet}, hostAddrs)
+			err = oc.syncGatewayLogicalNetwork(updatedNode, l3GatewayConfig, []*net.IPNet{subnet}, hostAddrs)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			// Delete the node's gateway Logical Router Port to force an error. But save
@@ -1422,9 +1421,9 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 			gatewayRouter := types.GWRouterPrefix + node1.Name
 			lr := &nbdb.LogicalRouter{Name: gatewayRouter}
 			lrp := &nbdb.LogicalRouterPort{Name: types.GWRouterToJoinSwitchPrefix + gatewayRouter}
-			lrp, err = libovsdbops.GetLogicalRouterPort(libovsdbOvnNBClient, lrp)
+			lrp, err = libovsdbops.GetLogicalRouterPort(nbClient, lrp)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			err = libovsdbops.DeleteLogicalRouterPorts(libovsdbOvnNBClient, lr, lrp)
+			err = libovsdbops.DeleteLogicalRouterPorts(nbClient, lr, lrp)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			// Node delete will fail with Failed to delete node node1,
@@ -1435,19 +1434,19 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 			ginkgo.By("retry entry: old obj should not be nil, new obj should be nil")
 			retry.CheckRetryObjectMultipleFieldsEventually(
 				testNode.Name,
-				clusterController.retryNodes,
+				oc.retryNodes,
 				gomega.Not(gomega.BeNil()), // oldObj should not be nil
 				gomega.BeNil(),             // newObj should be nil
 			)
 
 			// Add the LRP back to allow the delete the continue
-			err = libovsdbops.CreateOrUpdateLogicalRouterPort(libovsdbOvnNBClient,
+			err = libovsdbops.CreateOrUpdateLogicalRouterPort(nbClient,
 				lr, lrp, nil, &lrp.MAC, &lrp.Networks, &lrp.ExternalIDs)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			retry.SetRetryObjWithNoBackoff(node1.Name, clusterController.retryNodes)
-			clusterController.retryNodes.RequestRetryObjs() // retry the failed entry
+			retry.SetRetryObjWithNoBackoff(node1.Name, oc.retryNodes)
+			oc.retryNodes.RequestRetryObjs() // retry the failed entry
 
-			retry.CheckRetryObjectEventually(testNode.Name, false, clusterController.retryNodes)
+			retry.CheckRetryObjectEventually(testNode.Name, false, oc.retryNodes)
 			return nil
 		}
 
@@ -1465,7 +1464,7 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			// Override the default subnet allocator with a new one
 			// that has no ranges, to force a node add failure and retry
-			clusterController.masterSubnetAllocator = subnetallocator.NewHostSubnetAllocator()
+			oc.masterSubnetAllocator = subnetallocator.NewHostSubnetAllocator()
 
 			config.Kubernetes.HostNetworkNamespace = ""
 			config.Kubernetes.NoHostSubnetNodes = &metav1.LabelSelector{
@@ -1482,7 +1481,7 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 			expectedDatabaseState = addNodeLogicalFlows(expectedDatabaseState, expectedOVNClusterRouter, expectedNodeSwitch, expectedClusterRouterPortGroup, expectedClusterPortGroup, &node1)
 
 			gomega.Expect(
-				clusterController.retryNodes.ResourceHandler.AddResource(
+				oc.retryNodes.ResourceHandler.AddResource(
 					&testNode, false)).To(
 				gomega.MatchError(
 					"nodeAdd: error adding node \"node1\": error allocating networks for node node1: 1 subnets expected only new 0 subnets allocated"))
@@ -1493,7 +1492,7 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By("adding the node becomes possible")
-			gomega.Expect(clusterController.retryNodes.ResourceHandler.AddResource(&testNode, false)).To(gomega.Succeed())
+			gomega.Expect(oc.retryNodes.ResourceHandler.AddResource(&testNode, false)).To(gomega.Succeed())
 
 			return nil
 		}

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -880,6 +880,7 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 		expectedOVNClusterRouter       *nbdb.LogicalRouter
 		expectedClusterRouterPortGroup *nbdb.PortGroup
 		expectedClusterPortGroup       *nbdb.PortGroup
+		expectedDatabaseState          []libovsdbtest.TestData
 		l3GatewayConfig                *util.L3GatewayConfig
 		nodeHostAddrs                  sets.String
 	)
@@ -1010,6 +1011,8 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 		oc.SCTPSupport = true
 		oc.joinSwIPManager, _ = lsm.NewJoinLogicalSwitchIPManager(oc.nbClient, expectedNodeSwitch.UUID, []string{node1.Name})
 		_, _ = oc.joinSwIPManager.EnsureJoinLRPIPs(types.OVNClusterRouter)
+
+		expectedDatabaseState = addNodeLogicalFlows(nil, expectedOVNClusterRouter, expectedNodeSwitch, expectedClusterRouterPortGroup, expectedClusterPortGroup, &node1)
 	})
 
 	ginkgo.AfterEach(func() {
@@ -1026,9 +1029,6 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 
 			_, err := config.InitConfig(ctx, nil, nil)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-			expectedDatabaseState := []libovsdbtest.TestData{}
-			expectedDatabaseState = addNodeLogicalFlows(expectedDatabaseState, expectedOVNClusterRouter, expectedNodeSwitch, expectedClusterRouterPortGroup, expectedClusterPortGroup, &node1)
 
 			// Let the real code run and ensure OVN database sync
 			gomega.Expect(oc.WatchNodes()).To(gomega.Succeed())
@@ -1082,9 +1082,6 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 			_, err := config.InitConfig(ctx, nil, nil)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			expectedDatabaseState := []libovsdbtest.TestData{}
-			expectedDatabaseState = addNodeLogicalFlows(expectedDatabaseState, expectedOVNClusterRouter, expectedNodeSwitch, expectedClusterRouterPortGroup, expectedClusterPortGroup, &node1)
-
 			// Let the real code run and ensure OVN database sync
 			gomega.Expect(oc.WatchNodes()).To(gomega.Succeed())
 
@@ -1124,9 +1121,6 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 			_, err := config.InitConfig(ctx, nil, nil)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			config.Gateway.DisableSNATMultipleGWs = true
-
-			expectedDatabaseState := []libovsdbtest.TestData{}
-			expectedDatabaseState = addNodeLogicalFlows(expectedDatabaseState, expectedOVNClusterRouter, expectedNodeSwitch, expectedClusterRouterPortGroup, expectedClusterPortGroup, &node1)
 
 			// create a pod on this node
 			ns := newNamespace("namespace-1")
@@ -1199,9 +1193,6 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 			_, err := config.InitConfig(ctx, nil, nil)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			expectedDatabaseState := []libovsdbtest.TestData{}
-			expectedDatabaseState = addNodeLogicalFlows(expectedDatabaseState, expectedOVNClusterRouter, expectedNodeSwitch, expectedClusterRouterPortGroup, expectedClusterPortGroup, &node1)
-
 			// Let the real code run and ensure OVN database sync
 			gomega.Expect(oc.WatchNodes()).To(gomega.Succeed())
 			// ensure db is consistent
@@ -1255,9 +1246,6 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 
 			_, err := config.InitConfig(ctx, nil, nil)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-			expectedDatabaseState := []libovsdbtest.TestData{}
-			expectedDatabaseState = addNodeLogicalFlows(expectedDatabaseState, expectedOVNClusterRouter, expectedNodeSwitch, expectedClusterRouterPortGroup, expectedClusterPortGroup, &node1)
 
 			// Let the real code run and ensure OVN database sync
 			gomega.Expect(oc.WatchNodes()).To(gomega.Succeed())
@@ -1344,9 +1332,6 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 			_, err := config.InitConfig(ctx, nil, nil)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			expectedDatabaseState := []libovsdbtest.TestData{}
-			expectedDatabaseState = addNodeLogicalFlows(expectedDatabaseState, expectedOVNClusterRouter, expectedNodeSwitch, expectedClusterRouterPortGroup, expectedClusterPortGroup, &node1)
-
 			// Let the real code run and ensure OVN database sync
 			gomega.Expect(oc.WatchNodes()).To(gomega.Succeed())
 			gomega.Expect(oc.StartServiceController(wg, false)).To(gomega.Succeed())
@@ -1409,9 +1394,6 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 			config.Kubernetes.NoHostSubnetNodes = &metav1.LabelSelector{
 				MatchLabels: nodeNoHostSubnetAnnotation(),
 			}
-
-			expectedDatabaseState := []libovsdbtest.TestData{}
-			expectedDatabaseState = addNodeLogicalFlows(expectedDatabaseState, expectedOVNClusterRouter, expectedNodeSwitch, expectedClusterRouterPortGroup, expectedClusterPortGroup, &node1)
 
 			gomega.Expect(
 				oc.retryNodes.ResourceHandler.AddResource(

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -51,7 +51,6 @@ type tNode struct {
 	Name                 string
 	NodeIP               string
 	NodeLRPMAC           string
-	LrpMAC               string
 	LrpIP                string
 	LrpIPv6              string
 	DrLrpIP              string
@@ -900,7 +899,6 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 			Name:                 "node1",
 			NodeIP:               "1.2.3.4",
 			NodeLRPMAC:           "0a:58:0a:01:01:01",
-			LrpMAC:               "0a:58:64:40:00:02",
 			LrpIP:                "100.64.0.2",
 			LrpIPv6:              "fd98::2",
 			DrLrpIP:              "100.64.0.1",

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -947,7 +947,6 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 		var err error
 
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		config.Kubernetes.HostNetworkNamespace = ""
 		nodeAnnotator = kube.NewNodeAnnotator(&kube.Kube{kubeFakeClient, fakeClient.EgressIPClient, fakeClient.EgressFirewallClient, nil}, testNode.Name)
 		l3Config := node1.gatewayConfig(config.GatewayModeLocal, uint(vlanID))
 		err = util.SetL3GatewayConfig(nodeAnnotator, l3Config)
@@ -1082,7 +1081,6 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 
 			_, err := config.InitConfig(ctx, nil, nil)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			config.Kubernetes.HostNetworkNamespace = ""
 
 			updatedNode, err := fakeClient.KubeClient.CoreV1().Nodes().Get(context.TODO(), testNode.Name, metav1.GetOptions{})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -1138,7 +1136,6 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 
 			_, err := config.InitConfig(ctx, nil, nil)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			config.Kubernetes.HostNetworkNamespace = ""
 			config.Gateway.DisableSNATMultipleGWs = true
 
 			updatedNode, err := fakeClient.KubeClient.CoreV1().Nodes().Get(context.TODO(), testNode.Name, metav1.GetOptions{})
@@ -1227,7 +1224,6 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 		app.Action = func(ctx *cli.Context) error {
 			_, err := config.InitConfig(ctx, nil, nil)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			config.Kubernetes.HostNetworkNamespace = ""
 
 			expectedClusterLBGroup := newLoadBalancerGroup()
 			expectedOVNClusterRouter := newOVNClusterRouter()
@@ -1292,7 +1288,6 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 
 			_, err := config.InitConfig(ctx, nil, nil)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			config.Kubernetes.HostNetworkNamespace = ""
 
 			expectedClusterLBGroup := newLoadBalancerGroup()
 			expectedOVNClusterRouter := newOVNClusterRouter()
@@ -1387,7 +1382,6 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 		app.Action = func(ctx *cli.Context) error {
 			_, err := config.InitConfig(ctx, nil, nil)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			config.Kubernetes.HostNetworkNamespace = ""
 
 			updatedNode, err := fakeClient.KubeClient.CoreV1().Nodes().Get(context.TODO(), testNode.Name, metav1.GetOptions{})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -1464,7 +1458,6 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 			// that has no ranges, to force a node add failure and retry
 			oc.masterSubnetAllocator = subnetallocator.NewHostSubnetAllocator()
 
-			config.Kubernetes.HostNetworkNamespace = ""
 			config.Kubernetes.NoHostSubnetNodes = &metav1.LabelSelector{
 				MatchLabels: nodeNoHostSubnetAnnotation(),
 			}

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -64,7 +64,6 @@ type tNode struct {
 	GatewayRouterIP      string
 	GatewayRouterNextHop string
 	PhysicalBridgeName   string
-	NodeHostAddress      []string
 	NodeGWIP             string
 	NodeMgmtPortIP       string
 	NodeMgmtPortMAC      string
@@ -328,8 +327,7 @@ func addNodeLogicalFlows(testData []libovsdbtest.TestData, expectedOVNClusterRou
 	expectedClusterPortGroup.Ports = []string{types.K8sPrefix + node.Name + "-UUID"}
 
 	matchStr1 := fmt.Sprintf(`inport == "rtos-%s" && ip4.dst == %s /* %s */`, node.Name, node.GatewayRouterIP, node.Name)
-	gomega.Expect(node.NodeHostAddress).To(gomega.HaveLen(1))
-	matchStr2 := fmt.Sprintf(`inport == "rtos-%s" && ip4.dst == %s /* %s */`, node.Name, node.NodeHostAddress[0], node.Name)
+	matchStr2 := fmt.Sprintf(`inport == "rtos-%s" && ip4.dst == %s /* %s */`, node.Name, node.NodeIP, node.Name)
 	intPriority, _ := strconv.Atoi(types.NodeSubnetPolicyPriority)
 	testData = append(testData, &nbdb.LogicalRouterPolicy{
 		UUID:     "policy-based-route-1-UUID",
@@ -932,7 +930,6 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 			GatewayRouterIP:      "172.16.16.2",
 			GatewayRouterNextHop: "172.16.16.1",
 			PhysicalBridgeName:   "br-eth0",
-			NodeHostAddress:      []string{"9.9.9.9"},
 			NodeGWIP:             "10.1.1.1/24",
 			NodeMgmtPortIP:       "10.1.1.2",
 			NodeMgmtPortMAC:      "0a:58:0a:01:01:02",
@@ -980,7 +977,7 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		err = util.SetNodeHostSubnetAnnotation(nodeAnnotator, ovntest.MustParseIPNets(node1.NodeSubnet))
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		nodeHostAddrs = sets.NewString(node1.NodeHostAddress...)
+		nodeHostAddrs = sets.NewString(node1.NodeIP)
 		err = util.SetNodeHostAddresses(nodeAnnotator, nodeHostAddrs)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		err = nodeAnnotator.Run()

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -1039,7 +1039,6 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 	})
 
 	ginkgo.It("sets up a local gateway", func() {
-
 		app.Action = func(ctx *cli.Context) error {
 			_, err := config.InitConfig(ctx, nil, nil)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -1082,7 +1081,6 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 	})
 
 	ginkgo.It("sets up a shared gateway", func() {
-
 		app.Action = func(ctx *cli.Context) error {
 			_, err := config.InitConfig(ctx, nil, nil)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -1110,6 +1108,7 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 		})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
+
 	ginkgo.It("clear stale pod SNATs from syncGateway", func() {
 
 		app.Action = func(ctx *cli.Context) error {
@@ -1184,6 +1183,7 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 		})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
+
 	ginkgo.It("does not list node's pods when updating node after successfully adding the node", func() {
 		app.Action = func(ctx *cli.Context) error {
 			_, err := config.InitConfig(ctx, nil, nil)
@@ -1228,10 +1228,9 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 		})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
+
 	ginkgo.It("use node retry with updating a node", func() {
-
 		app.Action = func(ctx *cli.Context) error {
-
 			_, err := config.InitConfig(ctx, nil, nil)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			clusterSubnets := startFakeController(oc, wg)
@@ -1361,6 +1360,7 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 		})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
+
 	ginkgo.It("use node retry for a node without a host subnet", func() {
 		app.Action = func(ctx *cli.Context) error {
 			_, err := config.InitConfig(ctx, nil, nil)

--- a/go-controller/pkg/ovn/namespace_test.go
+++ b/go-controller/pkg/ovn/namespace_test.go
@@ -191,7 +191,6 @@ var _ = ginkgo.Describe("OVN Namespace Operations", func() {
 				Name:                 "node1",
 				NodeIP:               "1.2.3.4",
 				NodeLRPMAC:           "0a:58:0a:01:01:01",
-				LrpMAC:               "0a:58:64:40:00:02",
 				LrpIP:                "100.64.0.2",
 				LrpIPv6:              "fd98::2",
 				DrLrpIP:              "100.64.0.1",

--- a/go-controller/pkg/ovn/namespace_test.go
+++ b/go-controller/pkg/ovn/namespace_test.go
@@ -203,7 +203,6 @@ var _ = ginkgo.Describe("OVN Namespace Operations", func() {
 				GatewayRouterNextHop: "172.16.16.1",
 				PhysicalBridgeName:   "br-eth0",
 				NodeGWIP:             "10.1.1.1/24",
-				NodeHostAddress:      []string{"9.9.9.9"},
 				NodeMgmtPortIP:       "10.1.1.2",
 				NodeMgmtPortMAC:      "0a:58:0a:01:01:02",
 				DnatSnatIP:           "169.254.0.1",
@@ -261,7 +260,7 @@ var _ = ginkgo.Describe("OVN Namespace Operations", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			err = util.SetNodeHostSubnetAnnotation(nodeAnnotator, ovntest.MustParseIPNets(node1.NodeSubnet))
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			err = util.SetNodeHostAddresses(nodeAnnotator, sets.NewString(node1.NodeHostAddress...))
+			err = util.SetNodeHostAddresses(nodeAnnotator, sets.NewString(node1.NodeIP))
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			err = nodeAnnotator.Run()
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -152,7 +152,7 @@ func (oc *DefaultNetworkController) addLogicalPort(pod *kapi.Pod) (err error) {
 	// Keep track of how long syncs take.
 	start := time.Now()
 	defer func() {
-		klog.Infof("[%s/%s] addLogicalPort took %v, libovsdb time %v: %v",
+		klog.Infof("[%s/%s] addLogicalPort took %v, libovsdb time %v",
 			pod.Namespace, pod.Name, time.Since(start), libovsdbExecuteTime)
 	}()
 

--- a/go-controller/pkg/util/kube.go
+++ b/go-controller/pkg/util/kube.go
@@ -218,9 +218,14 @@ func ServiceTypeHasClusterIP(service *kapi.Service) bool {
 	return service.Spec.Type == kapi.ServiceTypeClusterIP || service.Spec.Type == kapi.ServiceTypeNodePort || service.Spec.Type == kapi.ServiceTypeLoadBalancer
 }
 
+func LoadBalancerServiceHasNodePortAllocation(service *kapi.Service) bool {
+	return service.Spec.AllocateLoadBalancerNodePorts == nil || *service.Spec.AllocateLoadBalancerNodePorts
+}
+
 // ServiceTypeHasNodePort checks if the service has an associated NodePort or not
 func ServiceTypeHasNodePort(service *kapi.Service) bool {
-	return service.Spec.Type == kapi.ServiceTypeNodePort || service.Spec.Type == kapi.ServiceTypeLoadBalancer
+	return service.Spec.Type == kapi.ServiceTypeNodePort ||
+		(service.Spec.Type == kapi.ServiceTypeLoadBalancer && LoadBalancerServiceHasNodePortAllocation(service))
 }
 
 // ServiceTypeHasLoadBalancer checks if the service has an associated LoadBalancer or not

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -1541,7 +1541,7 @@ var _ = ginkgo.Describe("e2e ingress traffic validation", func() {
 			// Then, downgrade back to SingleStack and test endpoints.
 			for _, ipFamilyPolicy := range []string{"PreferDualStack", "SingleStack"} {
 				ginkgo.By(fmt.Sprintf("Changing the nodeport service to %s", ipFamilyPolicy))
-				err = patchService(f.ClientSet, np.Name, np.Namespace, "/spec/ipFamilyPolicy", ipFamilyPolicy)
+				err = patchServiceStringValue(f.ClientSet, np.Name, np.Namespace, "/spec/ipFamilyPolicy", ipFamilyPolicy)
 				framework.ExpectNoError(err)
 
 				// It is expected that endpoints take a bit of time to come up after conversion. We remove all iptables rules and all breth0 flows.

--- a/test/e2e/service.go
+++ b/test/e2e/service.go
@@ -3,8 +3,10 @@ package e2e
 import (
 	"context"
 	"fmt"
+	"io/ioutil"
 	"math/rand"
 	"net"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -544,7 +546,7 @@ var _ = ginkgo.Describe("Service Hairpin SNAT", func() {
 		framework.ExpectNoError(err, fmt.Sprintf("unable to create service: service-for-pods, err: %v", err))
 
 		err = framework.WaitForServiceEndpointsNum(f.ClientSet, namespaceName, "service-for-pods", 1, time.Second, wait.ForeverTestTimeout)
-		framework.ExpectNoError(err, fmt.Sprintf("service: service-for-pods never had an enpoint, err: %v", err))
+		framework.ExpectNoError(err, fmt.Sprintf("service: service-for-pods never had an endpoint, err: %v", err))
 
 		ginkgo.By("by sending a TCP packet to service service-for-pods with type=ClusterIP in namespace " + namespaceName + " from backend pod " + backendName)
 
@@ -589,6 +591,228 @@ var _ = ginkgo.Describe("Service Hairpin SNAT", func() {
 		framework.ExpectNoError(err, "failed to parse client ip:port")
 
 		framework.ExpectEqual(clientIP, nodeIP, fmt.Sprintf("returned client: %v was not correct", clientIP))
+	})
+
+})
+
+var _ = ginkgo.Describe("Load Balancer Service Tests with MetalLB", func() {
+
+	const (
+		svcName          = "lbservice-test"
+		backendName      = "lb-backend-pod"
+		endpointHTTPPort = 80
+		nodeHTTPPort     = 32766
+		loadBalancerYaml = "loadbalancer.yaml"
+		namespaceName    = "default"
+		svcIP            = "192.168.10.0"
+		clientContainer  = "lbclient"
+		routerContainer  = "frr"
+	)
+
+	var (
+		backendNodeName string
+	)
+
+	f := newPrivelegedTestFramework(svcName)
+	ginkgo.BeforeEach(func() {
+		nodes, err := e2enode.GetBoundedReadySchedulableNodes(f.ClientSet, 2)
+		framework.ExpectNoError(err)
+		if len(nodes.Items) < 2 {
+			framework.Failf("Test requires >= 2 Ready nodes, but there are only %v nodes", len(nodes.Items))
+		}
+		backendNodeName = nodes.Items[0].Name
+		var loadBalancerServiceConfig = fmt.Sprintf(`
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: dynamic-claim
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: standard
+  resources:
+    requests:
+      storage: 1000Mi
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ` + backendName + `
+spec:
+  replicas: 4
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+           claimName: dynamic-claim
+      initContainers:
+      - name: get-big-file
+        image: quay.io/itssurya/dev-images:metallb-lbservice
+        command: ['sh', '-c', "dd if=/dev/zero of=/usr/share/nginx/html/big.iso  bs=1024 count=0 seek=102400"]
+        volumeMounts:
+        - name: data
+          mountPath: "/usr/share/nginx/html"
+      containers:
+      - name: nginx
+        image: nginx:1
+        volumeMounts:
+        - name: data
+          mountPath: "/usr/share/nginx/html"
+        ports:
+        - name: http
+          containerPort: 80
+      nodeSelector:
+        kubernetes.io/hostname: ` + backendNodeName + `
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ` + svcName + `
+spec:
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    app: nginx
+  type: LoadBalancer
+`)
+		if err := ioutil.WriteFile(loadBalancerYaml, []byte(loadBalancerServiceConfig), 0644); err != nil {
+			framework.Failf("Unable to write CRD config to disk: %v", err)
+		}
+		framework.Logf("Create the Load Balancer configuration")
+		framework.RunKubectlOrDie("default", "create", "-f", loadBalancerYaml)
+
+	})
+
+	ginkgo.AfterEach(func() {
+		framework.Logf("Delete the Load Balancer configuration")
+		framework.RunKubectlOrDie("default", "delete", "-f", loadBalancerYaml)
+		defer func() {
+			if err := os.Remove(loadBalancerYaml); err != nil {
+				framework.Logf("Unable to remove the CRD config from disk: %v", err)
+			}
+		}()
+	})
+
+	ginkgo.It("Should ensure load balancer service works with pmtu", func() {
+
+		err := framework.WaitForServiceEndpointsNum(f.ClientSet, namespaceName, svcName, 4, time.Second, time.Second*120)
+		framework.ExpectNoError(err, fmt.Sprintf("service: %s never had an endpoint, err: %v", svcName, err))
+
+		time.Sleep(time.Second * 5) // buffer to ensure all rules are created correctly
+
+		numberOfETPRules := pokeIPTableRules(backendNodeName, "OVN-KUBE-EXTERNALIP")
+		framework.ExpectEqual(numberOfETPRules, 4)
+
+		ginkgo.By("by sending a TCP packet to service " + svcName + " with type=LoadBalancer in namespace " + namespaceName + " from backend pod " + backendName)
+
+		_, err = curlInContainer(clientContainer, svcIP, endpointHTTPPort, "big.iso -o big.iso", 120)
+		framework.ExpectNoError(err, "failed to curl load balancer service")
+
+		ginkgo.By("change MTU on intermediary router to force icmp related packets")
+		cmd := []string{containerRuntime, "exec", routerContainer}
+		mtuCommand := strings.Split("ip link set mtu 1200 dev eth1", " ")
+
+		cmd = append(cmd, mtuCommand...)
+		_, err = runCommand(cmd...)
+		framework.ExpectNoError(err, "failed to change MTU on intermediary router")
+
+		time.Sleep(time.Second * 5) // buffer to ensure MTU change took effect
+
+		ginkgo.By("by sending a TCP packet to service " + svcName + " with type=LoadBalancer in namespace " + namespaceName + " from backend pod " + backendName)
+
+		_, err = curlInContainer(clientContainer, svcIP, endpointHTTPPort, "big.iso -o big.iso", 120)
+		framework.ExpectNoError(err, "failed to curl load balancer service")
+	})
+
+	ginkgo.It("Should ensure load balancer service works with 0 node ports when ETP=local", func() {
+
+		err := framework.WaitForServiceEndpointsNum(f.ClientSet, namespaceName, svcName, 4, time.Second, time.Second*120)
+		framework.ExpectNoError(err, fmt.Sprintf("service: %s never had an enpoint, err: %v", svcName, err))
+
+		time.Sleep(time.Second * 5) // buffer to ensure all rules are created correctly
+
+		checkNumberOfETPRules := func(value int, pattern string) wait.ConditionFunc {
+			return func() (bool, error) {
+				numberOfETPRules := pokeIPTableRules(backendNodeName, pattern)
+				return (numberOfETPRules == value), nil
+			}
+		}
+		err = wait.PollImmediate(retryInterval, retryTimeout, checkNumberOfETPRules(2, "OVN-KUBE-ETP"))
+		framework.ExpectNoError(err, "Couldn't fetch the correct number of iptable rules, err: %v", err)
+		err = wait.PollImmediate(retryInterval, retryTimeout, checkNumberOfETPRules(4, "OVN-KUBE-EXTERNALIP"))
+		framework.ExpectNoError(err, "Couldn't fetch the correct number of iptable rules, err: %v", err)
+		err = wait.PollImmediate(retryInterval, retryTimeout, checkNumberOfETPRules(3, "OVN-KUBE-SNAT-MGMTPORT"))
+		framework.ExpectNoError(err, "Couldn't fetch the correct number of iptable rules, err: %v", err)
+
+		ginkgo.By("by sending a TCP packet to service " + svcName + " with type=LoadBalancer in namespace " + namespaceName + " from backend pod " + backendName)
+
+		_, err = curlInContainer(clientContainer, svcIP, endpointHTTPPort, "big.iso -o big.iso", 120)
+		framework.ExpectNoError(err, "failed to curl load balancer service")
+
+		ginkgo.By("patching service " + svcName + " to allocateLoadBalancerNodePorts=false and externalTrafficPolicy=local")
+
+		err = patchServiceBoolValue(f.ClientSet, svcName, "default", "/spec/allocateLoadBalancerNodePorts", false)
+		framework.ExpectNoError(err)
+
+		output := framework.RunKubectlOrDie("default", "get", "svc", svcName, "-o=jsonpath='{.spec.allocateLoadBalancerNodePorts}'")
+		framework.ExpectEqual(output, "'false'")
+
+		err = patchServiceStringValue(f.ClientSet, svcName, "default", "/spec/externalTrafficPolicy", "Local")
+		framework.ExpectNoError(err)
+
+		output = framework.RunKubectlOrDie("default", "get", "svc", svcName, "-o=jsonpath='{.spec.externalTrafficPolicy}'")
+		framework.ExpectEqual(output, "'Local'")
+
+		time.Sleep(time.Second * 5) // buffer to ensure all rules are created correctly
+
+		err = wait.PollImmediate(retryInterval, retryTimeout, checkNumberOfETPRules(6, "OVN-KUBE-ETP"))
+		framework.ExpectNoError(err, "Couldn't fetch the correct number of iptable rules, err: %v", err)
+		err = wait.PollImmediate(retryInterval, retryTimeout, checkNumberOfETPRules(7, "OVN-KUBE-SNAT-MGMTPORT"))
+		framework.ExpectNoError(err, "Couldn't fetch the correct number of iptable rules, err: %v", err)
+
+		ginkgo.By("by sending a TCP packet to service " + svcName + " with type=LoadBalancer in namespace " + namespaceName + " from backend pod " + backendName)
+
+		_, err = curlInContainer(clientContainer, svcIP, endpointHTTPPort, "big.iso -o big.iso", 120)
+		framework.ExpectNoError(err, "failed to curl load balancer service")
+
+		err = wait.PollImmediate(retryInterval, retryTimeout, checkNumberOfETPRules(1, "[1:60] -A OVN-KUBE-ETP"))
+		framework.ExpectNoError(err, "Couldn't fetch the correct number of iptable rules, err: %v", err)
+		err = wait.PollImmediate(retryInterval, retryTimeout, checkNumberOfETPRules(1, "[1:60] -A OVN-KUBE-SNAT-MGMTPORT"))
+		framework.ExpectNoError(err, "Couldn't fetch the correct number of iptable rules, err: %v", err)
+
+		ginkgo.By("Scale down endpoints of service: " + svcName + " to ensure iptable rules are also getting recreated correctly")
+		framework.RunKubectlOrDie("default", "scale", "deployment", backendName, "--replicas=3")
+
+		time.Sleep(time.Second * 5) // buffer to ensure all rules are created correctly
+		// number of iptable rules should have decreased by 1
+		err = wait.PollImmediate(retryInterval, retryTimeout, checkNumberOfETPRules(5, "OVN-KUBE-ETP"))
+		framework.ExpectNoError(err, "Couldn't fetch the correct number of iptable rules, err: %v", err)
+		err = wait.PollImmediate(retryInterval, retryTimeout, checkNumberOfETPRules(6, "OVN-KUBE-SNAT-MGMTPORT"))
+		framework.ExpectNoError(err, "Couldn't fetch the correct number of iptable rules, err: %v", err)
+
+		ginkgo.By("by sending a TCP packet to service " + svcName + " with type=LoadBalancer in namespace " + namespaceName + " from backend pod " + backendName)
+
+		_, err = curlInContainer(clientContainer, svcIP, endpointHTTPPort, "big.iso -o big.iso", 120)
+		framework.ExpectNoError(err, "failed to curl load balancer service")
+
+		err = wait.PollImmediate(retryInterval, retryTimeout, checkNumberOfETPRules(1, "[1:60] -A OVN-KUBE-ETP"))
+		framework.ExpectNoError(err, "Couldn't fetch the correct number of iptable rules, err: %v", err)
+		err = wait.PollImmediate(retryInterval, retryTimeout, checkNumberOfETPRules(1, "[1:60] -A OVN-KUBE-SNAT-MGMTPORT"))
+		framework.ExpectNoError(err, "Couldn't fetch the correct number of iptable rules, err: %v", err)
+
 	})
 
 })

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -399,14 +399,14 @@ func isNeighborEntryStable(clientContainer, targetHost string, iterations int) b
 // curlInContainer leverages a container running the netexec command to send a request to a target running
 // netexec on the given target host / protocol / port.
 // Returns a pair of either result, nil or "", error in case of an error.
-func curlInContainer(clientContainer, protocol, targetHost string, targetPort int32, endPoint string, maxTime int) (string, error) {
+func curlInContainer(clientContainer, targetHost string, targetPort int32, endPoint string, maxTime int) (string, error) {
 	cmd := []string{containerRuntime, "exec", clientContainer}
 	if utilnet.IsIPv6String(targetHost) {
 		targetHost = fmt.Sprintf("[%s]", targetHost)
 	}
 
 	// we leverage the dial command from netexec, that is already supporting multiple protocols
-	curlCommand := strings.Split(fmt.Sprintf("curl -g -q -s --max-time %d http://%s:%d/%s",
+	curlCommand := strings.Split(fmt.Sprintf("curl --max-time %d http://%s:%d/%s",
 		maxTime,
 		targetHost,
 		targetPort,
@@ -765,8 +765,8 @@ func assertACLLogs(targetNodeName string, policyNameRegex string, expectedACLVer
 	return false, nil
 }
 
-// patchService patches service serviceName in namespace serviceNamespace.
-func patchService(c kubernetes.Interface, serviceName, serviceNamespace, jsonPath, value string) error {
+// patchServiceStringValue patches service serviceName in namespace serviceNamespace with provided string value.
+func patchServiceStringValue(c kubernetes.Interface, serviceName, serviceNamespace, jsonPath, value string) error {
 	patch := []struct {
 		Op    string `json:"op"`
 		Path  string `json:"path"`
@@ -778,6 +778,27 @@ func patchService(c kubernetes.Interface, serviceName, serviceNamespace, jsonPat
 	}}
 	patchBytes, _ := json.Marshal(patch)
 
+	return patchService(c, serviceName, serviceNamespace, jsonPath, patchBytes)
+}
+
+// patchServiceBoolValue patches service serviceName in namespace serviceNamespace with provided bool value.
+func patchServiceBoolValue(c kubernetes.Interface, serviceName, serviceNamespace, jsonPath string, value bool) error {
+	patch := []struct {
+		Op    string `json:"op"`
+		Path  string `json:"path"`
+		Value bool   `json:"value"`
+	}{{
+		Op:    "replace",
+		Path:  jsonPath,
+		Value: value,
+	}}
+	patchBytes, _ := json.Marshal(patch)
+
+	return patchService(c, serviceName, serviceNamespace, jsonPath, patchBytes)
+}
+
+// patchService patches service serviceName in namespace serviceNamespace.
+func patchService(c kubernetes.Interface, serviceName, serviceNamespace, jsonPath string, patchBytes []byte) error {
 	_, err := c.CoreV1().Services(serviceNamespace).Patch(
 		context.TODO(),
 		serviceName,
@@ -789,6 +810,24 @@ func patchService(c kubernetes.Interface, serviceName, serviceNamespace, jsonPat
 	}
 
 	return nil
+}
+
+// pokeIPTableRules returns the number of iptable rules that match the provided pattern
+func pokeIPTableRules(clientContainer, pattern string) int {
+	cmd := []string{containerRuntime, "exec", clientContainer}
+	ipTCommand := strings.Split("iptables-save -c", " ")
+
+	cmd = append(cmd, ipTCommand...)
+	iptRules, err := runCommand(cmd...)
+	framework.ExpectNoError(err, "failed to get iptable rules from node %s", clientContainer)
+	numOfMatchRules := 0
+	for _, iptRule := range strings.Split(iptRules, "\n") {
+		match := strings.Contains(iptRule, pattern)
+		if match {
+			numOfMatchRules++
+		}
+	}
+	return numOfMatchRules
 }
 
 // isDualStackCluster returns 'true' if at least one of the nodes has more than one node subnet.

--- a/test/scripts/e2e-cp.sh
+++ b/test/scripts/e2e-cp.sh
@@ -59,6 +59,13 @@ if [ "$OVN_DISABLE_SNAT_MULTIPLE_GWS" == false ]; then
   SKIPPED_TESTS+="e2e multiple external gateway stale conntrack entry deletion validation"
 fi
 
+if [ "$OVN_GATEWAY_MODE" == "shared" ]; then
+  if [ "$SKIPPED_TESTS" != "" ]; then
+    SKIPPED_TESTS+="|"
+  fi
+  SKIPPED_TESTS+="Should ensure load balancer service"
+fi
+
 # skipping the egress ip legacy health check test because it requires two
 # sequenced rollouts of both ovnkube-node and ovnkube-master that take a lot of
 # time.


### PR DESCRIPTION
Modified https://github.com/openshift/ovn-kubernetes/pull/1466/commits/4af1bf20f783be9c48847bf5789288493239077d to remove LrpMAC from downstream tests.
Added https://github.com/openshift/ovn-kubernetes/pull/1466/commits/e74520379c7176ce99a24ed6cd93d8dd52983b7f to avoid data race in downstream hybrid tests:
```
WARNING: DATA RACE
Read at 0x00000442cb09 by goroutine 1638:
  github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn.(*DefaultNetworkController).addLogicalPort()
      /go/src/github.com/openshift/ovn-kubernetes/go-controller/pkg/ovn/pods.go:192 +0xbfa
  github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn.(*DefaultNetworkController).ensurePod()
      /go/src/github.com/openshift/ovn-kubernetes/go-controller/pkg/ovn/ovn.go:141 +0x9b5
  github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn.(*defaultNetworkControllerEventHandler).AddResource()
      /go/src/github.com/openshift/ovn-kubernetes/go-controller/pkg/ovn/default_network_controller.go:622 +0x1a4
  github.com/ovn-org/ovn-kubernetes/go-controller/pkg/retry.(*RetryFramework).resourceRetry.func1()
      /go/src/github.com/openshift/ovn-kubernetes/go-controller/pkg/retry/obj_retry.go:323 +0x1cdd
  github.com/ovn-org/ovn-kubernetes/go-controller/pkg/retry.(*RetryFramework).DoWithLock()
      /go/src/github.com/openshift/ovn-kubernetes/go-controller/pkg/retry/obj_retry.go:109 +0x12a
  github.com/ovn-org/ovn-kubernetes/go-controller/pkg/retry.(*RetryFramework).resourceRetry()
      /go/src/github.com/openshift/ovn-kubernetes/go-controller/pkg/retry/obj_retry.go:223 +0xc4
  github.com/ovn-org/ovn-kubernetes/go-controller/pkg/retry.(*RetryFramework).iterateRetryResources.func1()
      /go/src/github.com/openshift/ovn-kubernetes/go-controller/pkg/retry/obj_retry.go:363 +0xea
  github.com/ovn-org/ovn-kubernetes/go-controller/pkg/retry.(*RetryFramework).iterateRetryResources.func2()
      /go/src/github.com/openshift/ovn-kubernetes/go-controller/pkg/retry/obj_retry.go:364 +0x58

Previous write at 0x00000442cb08 by goroutine 157:
  github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config.PrepareTestConfig()
```