### PR TITLE
OCPBUGS-5046: [release-4.12] egressip: fix test data race accessing podAssignment cache

### DIFF
--- a/go-controller/pkg/ovn/egressip.go
+++ b/go-controller/pkg/ovn/egressip.go
@@ -2047,6 +2047,22 @@ type podAssignmentState struct {
 	standbyEgressIPNames sets.String
 }
 
+// Clone deep-copies and returns the copied podAssignmentState
+func (pas *podAssignmentState) Clone() *podAssignmentState {
+	clone := &podAssignmentState{
+		egressIPName: pas.egressIPName,
+	}
+	clone.standbyEgressIPNames = make(sets.String, len(pas.standbyEgressIPNames))
+	for k := range pas.standbyEgressIPNames {
+		clone.standbyEgressIPNames.Insert(k)
+	}
+	clone.egressStatuses = make(map[egressipv1.EgressIPStatusItem]string, len(pas.egressStatuses))
+	for k, v := range pas.egressStatuses {
+		clone.egressStatuses[k] = v
+	}
+	return clone
+}
+
 type allocator struct {
 	*sync.Mutex
 	// A cache used for egress IP assignments containing data for all cluster nodes

--- a/go-controller/pkg/ovn/egressip_test.go
+++ b/go-controller/pkg/ovn/egressip_test.go
@@ -252,6 +252,15 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 		fakeOvn.shutdown()
 	})
 
+	getPodAssignmentState := func(pod *kapi.Pod) *podAssignmentState {
+		fakeOvn.controller.eIPC.podAssignmentMutex.Lock()
+		defer fakeOvn.controller.eIPC.podAssignmentMutex.Unlock()
+		if pas := fakeOvn.controller.eIPC.podAssignment[getPodKey(pod)]; pas != nil {
+			return pas.Clone()
+		}
+		return nil
+	}
+
 	ginkgo.Context("On node UPDATE", func() {
 
 		ginkgo.It("should re-assign EgressIPs and perform proper OVN transactions when pod is created after node egress label switch", func() {
@@ -4335,9 +4344,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 				// even the LSP sticks around for 60 seconds
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(finalDatabaseStatewithPod))
 				// egressIP cache is stale in the sense the podKey has not been deleted since deletion failed
-				status, exists := fakeOvn.controller.eIPC.podAssignment[getPodKey(&egressPod1)]
-				gomega.Expect(exists).To(gomega.BeTrue())
-				gomega.Expect(status.egressStatuses).To(gomega.Equal(map[egressipv1.EgressIPStatusItem]string{
+				pas := getPodAssignmentState(&egressPod1)
+				gomega.Expect(pas).NotTo(gomega.BeNil())
+				gomega.Expect(pas.egressStatuses).To(gomega.Equal(map[egressipv1.EgressIPStatusItem]string{
 					{
 						Node:     "node1",
 						EgressIP: "192.168.126.101",
@@ -4622,31 +4631,23 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 				gomega.Expect(egressIPs2[0]).To(gomega.Equal(egressIP3))
 				recordedEvent = <-fakeOvn.fakeRecorder.Events
 				gomega.Expect(recordedEvent).To(gomega.ContainSubstring("EgressIP object egressip-2 will not be configured for pod egressip-namespace_egress-pod since another egressIP object egressip is serving it, this is undefined"))
-				podCache := make(map[string]*podAssignmentState)
-				fakeOvn.controller.eIPC.podAssignmentMutex.Lock()
-				for k, v := range fakeOvn.controller.eIPC.podAssignment {
-					value := *v
-					podCache[k] = &value // deep copy to avoid map reference issues
-				}
-				fakeOvn.controller.eIPC.podAssignmentMutex.Unlock()
 
-				assginedEIPName := podCache[getPodKey(&egressPod1)].egressIPName
-				standByEIPNames := podCache[getPodKey(&egressPod1)].standbyEgressIPNames
-				assginedStatuses := podCache[getPodKey(&egressPod1)].egressStatuses
+				pas := getPodAssignmentState(&egressPod1)
+				gomega.Expect(pas).NotTo(gomega.BeNil())
 
 				assginedEIP := egressIPs1[0]
-				gomega.Expect(assginedEIPName).To(gomega.Equal(egressIPName))
+				gomega.Expect(pas.egressIPName).To(gomega.Equal(egressIPName))
 				eip1Obj, err := fakeOvn.fakeClient.EgressIPClient.K8sV1().EgressIPs().Get(context.TODO(), eIP1.Name, metav1.GetOptions{})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				gomega.Expect(assginedStatuses[eip1Obj.Status.Items[0]]).To(gomega.Equal(""))
-				gomega.Expect(standByEIPNames.Has(egressIPName2)).To(gomega.BeTrue())
+				gomega.Expect(pas.egressStatuses[eip1Obj.Status.Items[0]]).To(gomega.Equal(""))
+				gomega.Expect(pas.standbyEgressIPNames.Has(egressIPName2)).To(gomega.BeTrue())
 
 				podEIPSNAT := &nbdb.NAT{
 					UUID:       "egressip-nat-UUID1",
 					LogicalIP:  egressPodIP[0].String(),
 					ExternalIP: assginedEIP,
 					ExternalIDs: map[string]string{
-						"name": assginedEIPName,
+						"name": pas.egressIPName,
 					},
 					Type:        nbdb.NATTypeSNAT,
 					LogicalPort: utilpointer.StringPtr("k8s-node1"),
@@ -4660,7 +4661,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 					Action:   nbdb.LogicalRouterPolicyActionReroute,
 					Nexthops: nodeLogicalRouterIPv4,
 					ExternalIDs: map[string]string{
-						"name": assginedEIPName,
+						"name": pas.egressIPName,
 					},
 					UUID: "reroute-UUID1",
 				}
@@ -4746,7 +4747,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 					LogicalIP:  egressPodIP[0].String(),
 					ExternalIP: egressIPs1[1],
 					ExternalIDs: map[string]string{
-						"name": assginedEIPName,
+						"name": pas.egressIPName,
 					},
 					Type:        nbdb.NATTypeSNAT,
 					LogicalPort: utilpointer.StringPtr("k8s-node2"),
@@ -4766,22 +4767,15 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(finalDatabaseStatewithPod))
 
 				// check the state of the cache for podKey
-				fakeOvn.controller.eIPC.podAssignmentMutex.Lock()
-				for k, v := range fakeOvn.controller.eIPC.podAssignment {
-					value := *v
-					podCache[k] = &value // deep copy to avoid map reference issues
-				}
-				fakeOvn.controller.eIPC.podAssignmentMutex.Unlock()
-				assginedEIPName = podCache[getPodKey(&egressPod1)].egressIPName
-				standByEIPNames = podCache[getPodKey(&egressPod1)].standbyEgressIPNames
-				assginedStatuses = podCache[getPodKey(&egressPod1)].egressStatuses
+				pas = getPodAssignmentState(&egressPod1)
+				gomega.Expect(pas).NotTo(gomega.BeNil())
 
-				gomega.Expect(assginedEIPName).To(gomega.Equal(egressIPName))
+				gomega.Expect(pas.egressIPName).To(gomega.Equal(egressIPName))
 				eip1Obj, err = fakeOvn.fakeClient.EgressIPClient.K8sV1().EgressIPs().Get(context.TODO(), eIP1.Name, metav1.GetOptions{})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				gomega.Expect(assginedStatuses[eip1Obj.Status.Items[0]]).To(gomega.Equal(""))
-				gomega.Expect(assginedStatuses[eip1Obj.Status.Items[1]]).To(gomega.Equal(""))
-				gomega.Expect(standByEIPNames.Has(egressIPName2)).To(gomega.BeTrue())
+				gomega.Expect(pas.egressStatuses[eip1Obj.Status.Items[0]]).To(gomega.Equal(""))
+				gomega.Expect(pas.egressStatuses[eip1Obj.Status.Items[1]]).To(gomega.Equal(""))
+				gomega.Expect(pas.standbyEgressIPNames.Has(egressIPName2)).To(gomega.BeTrue())
 
 				// let's test syncPodAssignmentCache works as expected! Nuke the podAssignment cache first
 				fakeOvn.controller.eIPC.podAssignmentMutex.Lock()
@@ -4793,21 +4787,13 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 				err = fakeOvn.controller.syncPodAssignmentCache(egressIPCache)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-				fakeOvn.controller.eIPC.podAssignmentMutex.Lock()
-				for k, v := range fakeOvn.controller.eIPC.podAssignment {
-					value := *v
-					podCache[k] = &value // deep copy to avoid map reference issues
-				}
-				fakeOvn.controller.eIPC.podAssignmentMutex.Unlock()
-				assginedEIPName = podCache[getPodKey(&egressPod1)].egressIPName
-				standByEIPNames = podCache[getPodKey(&egressPod1)].standbyEgressIPNames
-				assginedStatuses = podCache[getPodKey(&egressPod1)].egressStatuses
+				pas = getPodAssignmentState(&egressPod1)
+				gomega.Expect(pas).NotTo(gomega.BeNil())
+				gomega.Expect(pas.egressIPName).To(gomega.Equal(egressIPName))
+				gomega.Expect(pas.egressStatuses).To(gomega.Equal(map[egressipv1.EgressIPStatusItem]string{}))
+				gomega.Expect(pas.standbyEgressIPNames.Has(egressIPName2)).To(gomega.BeTrue())
 
-				gomega.Expect(assginedEIPName).To(gomega.Equal(egressIPName))
-				gomega.Expect(assginedStatuses).To(gomega.Equal(map[egressipv1.EgressIPStatusItem]string{}))
-				gomega.Expect(standByEIPNames.Has(egressIPName2)).To(gomega.BeTrue())
-
-				//reset assginedStatuses for rest of the test to progress correctly
+				// reset egressStatuses for rest of the test to progress correctly
 				fakeOvn.controller.eIPC.podAssignmentMutex.Lock()
 				fakeOvn.controller.eIPC.podAssignment[getPodKey(&egressPod1)].egressStatuses[eip1Obj.Status.Items[0]] = ""
 				fakeOvn.controller.eIPC.podAssignment[getPodKey(&egressPod1)].egressStatuses[eip1Obj.Status.Items[1]] = ""
@@ -4817,29 +4803,23 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 				err = fakeOvn.fakeClient.EgressIPClient.K8sV1().EgressIPs().Delete(context.TODO(), egressIPName2, metav1.DeleteOptions{})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-				getStandByEgressIPs := func() bool {
-					fakeOvn.controller.eIPC.podAssignmentMutex.Lock()
-					defer fakeOvn.controller.eIPC.podAssignmentMutex.Unlock()
-					for k, v := range fakeOvn.controller.eIPC.podAssignment {
-						value := *v
-						podCache[k] = &value // deep copy to avoid map reference issues
-					}
-					hasStandBy := podCache[getPodKey(&egressPod1)].standbyEgressIPNames.Has(egressIPName2)
-					return hasStandBy
-				}
 				gomega.Eventually(func() bool {
-					return getStandByEgressIPs()
+					pas := getPodAssignmentState(&egressPod1)
+					gomega.Expect(pas).NotTo(gomega.BeNil())
+					return pas.standbyEgressIPNames.Has(egressIPName2)
 				}).Should(gomega.BeFalse())
-				gomega.Expect(podCache[getPodKey(&egressPod1)].egressIPName).To(gomega.Equal(egressIPName))
+				gomega.Expect(getPodAssignmentState(&egressPod1).egressIPName).To(gomega.Equal(egressIPName))
 
 				// add back the standby egressIP object
 				_, err = fakeOvn.fakeClient.EgressIPClient.K8sV1().EgressIPs().Create(context.TODO(), &eIP2, metav1.CreateOptions{})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				gomega.Eventually(func() bool {
-					return getStandByEgressIPs()
+					pas := getPodAssignmentState(&egressPod1)
+					gomega.Expect(pas).NotTo(gomega.BeNil())
+					return pas.standbyEgressIPNames.Has(egressIPName2)
 				}).Should(gomega.BeTrue())
-				gomega.Expect(podCache[getPodKey(&egressPod1)].egressIPName).To(gomega.Equal(egressIPName))
+				gomega.Expect(getPodAssignmentState(&egressPod1).egressIPName).To(gomega.Equal(egressIPName))
 				gomega.Eventually(func() string {
 					return <-fakeOvn.fakeRecorder.Events
 				}).Should(gomega.ContainSubstring("EgressIP object egressip-2 will not be configured for pod egressip-namespace_egress-pod since another egressIP object egressip is serving it, this is undefined"))
@@ -4885,9 +4865,11 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(finalDatabaseStatewithPod[1:]))
 
 				gomega.Eventually(func() bool {
-					return getStandByEgressIPs()
+					pas := getPodAssignmentState(&egressPod1)
+					gomega.Expect(pas).NotTo(gomega.BeNil())
+					return pas.standbyEgressIPNames.Has(egressIPName2)
 				}).Should(gomega.BeTrue())
-				gomega.Expect(podCache[getPodKey(&egressPod1)].egressIPName).To(gomega.Equal(egressIPName))
+				gomega.Expect(getPodAssignmentState(&egressPod1).egressIPName).To(gomega.Equal(egressIPName))
 
 				// delete the first egressIP object and make sure the cache is updated
 				err = fakeOvn.fakeClient.EgressIPClient.K8sV1().EgressIPs().Delete(context.TODO(), egressIPName, metav1.DeleteOptions{})
@@ -4895,9 +4877,11 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 
 				// ensure standby takes over and we do the setup for it in OVN DB
 				gomega.Eventually(func() bool {
-					return getStandByEgressIPs()
+					pas := getPodAssignmentState(&egressPod1)
+					gomega.Expect(pas).NotTo(gomega.BeNil())
+					return pas.standbyEgressIPNames.Has(egressIPName2)
 				}).Should(gomega.BeFalse())
-				gomega.Expect(podCache[getPodKey(&egressPod1)].egressIPName).To(gomega.Equal(egressIPName2))
+				gomega.Expect(getPodAssignmentState(&egressPod1).egressIPName).To(gomega.Equal(egressIPName2))
 
 				finalDatabaseStatewithPod = expectedDatabaseStatewithPod
 				finalDatabaseStatewithPod = append(expectedDatabaseStatewithPod, podLSP)
@@ -4926,10 +4910,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				gomega.Eventually(func() bool {
-					fakeOvn.controller.eIPC.podAssignmentMutex.Lock()
-					_, ok := fakeOvn.controller.eIPC.podAssignment[getPodKey(&egressPod1)]
-					fakeOvn.controller.eIPC.podAssignmentMutex.Unlock()
-					return ok
+					return getPodAssignmentState(&egressPod1) != nil
 				}).Should(gomega.BeFalse())
 
 				// let's test syncPodAssignmentCache works as expected! Nuke the podAssignment cache first
@@ -4944,10 +4925,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 
 				// we don't have any egressIPs, so cache is nil
 				gomega.Eventually(func() bool {
-					fakeOvn.controller.eIPC.podAssignmentMutex.Lock()
-					_, ok := fakeOvn.controller.eIPC.podAssignment[getPodKey(&egressPod1)]
-					fakeOvn.controller.eIPC.podAssignmentMutex.Unlock()
-					return ok
+					return getPodAssignmentState(&egressPod1) != nil
 				}).Should(gomega.BeFalse())
 
 				return nil


### PR DESCRIPTION
The tests were copying the podAssignment cache under the cache's lock, but unfortunately it was just a shallow-copy of element of that cache. Maps within structs are copied by reference, not by value (eg deep-copy), so neither the 'egressStatuses' nor the 'standbyEgressIPNames' members of each podAssignmentState element were deep-copied.

This led to data races in the tests like:

```
2022-10-27T13:00:36.6560710Z WARNING: DATA RACE
2022-10-27T13:00:36.6560988Z Write at 0x00c01c6480c0 by goroutine 1527:
2022-10-27T13:00:36.6561275Z   runtime.mapdelete_faststr()
2022-10-27T13:00:36.6561762Z       /opt/hostedtoolcache/go/1.18.4/x64/src/runtime/map_faststr.go:301 +0x0
2022-10-27T13:00:36.6562144Z   k8s.io/apimachinery/pkg/util/sets.String.Delete()
2022-10-27T13:00:36.6563012Z       /home/runner/work/ovn-kubernetes/ovn-kubernetes/go-controller/vendor/k8s.io/apimachinery/pkg/util/sets/string.go:59 +0x1557
2022-10-27T13:00:36.6563831Z   github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn.(*Controller).addPodEgressIPAssignments()
2022-10-27T13:00:36.6564613Z       /home/runner/work/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/egressip.go:1108 +0x14bc
2022-10-27T13:00:36.6565295Z   github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn.(*Controller).addPodEgressIPAssignmentsWithLock()
2022-10-27T13:00:36.6566049Z       /home/runner/work/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/egressip.go:1053 +0x14c
2022-10-27T13:00:36.6566705Z   github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn.(*Controller).addNamespaceEgressIPAssignments()
2022-10-27T13:00:36.6567461Z       /home/runner/work/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/egressip.go:1043 +0x2ae
2022-10-27T13:00:36.6568085Z   github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn.(*Controller).addEgressIPAssignments()
2022-10-27T13:00:36.6568808Z       /home/runner/work/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/egressip.go:1020 +0x1e5
2022-10-27T13:00:36.6569415Z   github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn.(*Controller).reconcileEgressIP()
2022-10-27T13:00:36.6570142Z       /home/runner/work/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/egressip.go:214 +0x1eb3
```

because sets.String objects are actually maps underneath. We need to clone them (and the 'egressStatuses' map) before tests can use them.