### PR TITLE
Revert "OCPBUGS-5046: [release-4.12] egressip: fix test data race accessing podAssignment cache"

### DIFF
--- a/go-controller/pkg/ovn/egressip.go
+++ b/go-controller/pkg/ovn/egressip.go
@@ -2047,22 +2047,6 @@ type podAssignmentState struct {
 	standbyEgressIPNames sets.String
 }
 
-// Clone deep-copies and returns the copied podAssignmentState
-func (pas *podAssignmentState) Clone() *podAssignmentState {
-	clone := &podAssignmentState{
-		egressIPName: pas.egressIPName,
-	}
-	clone.standbyEgressIPNames = make(sets.String, len(pas.standbyEgressIPNames))
-	for k := range pas.standbyEgressIPNames {
-		clone.standbyEgressIPNames.Insert(k)
-	}
-	clone.egressStatuses = make(map[egressipv1.EgressIPStatusItem]string, len(pas.egressStatuses))
-	for k, v := range pas.egressStatuses {
-		clone.egressStatuses[k] = v
-	}
-	return clone
-}
-
 type allocator struct {
 	*sync.Mutex
 	// A cache used for egress IP assignments containing data for all cluster nodes

--- a/go-controller/pkg/ovn/egressip_test.go
+++ b/go-controller/pkg/ovn/egressip_test.go
@@ -252,15 +252,6 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 		fakeOvn.shutdown()
 	})
 
-	getPodAssignmentState := func(pod *kapi.Pod) *podAssignmentState {
-		fakeOvn.controller.eIPC.podAssignmentMutex.Lock()
-		defer fakeOvn.controller.eIPC.podAssignmentMutex.Unlock()
-		if pas := fakeOvn.controller.eIPC.podAssignment[getPodKey(pod)]; pas != nil {
-			return pas.Clone()
-		}
-		return nil
-	}
-
 	ginkgo.Context("On node UPDATE", func() {
 
 		ginkgo.It("should re-assign EgressIPs and perform proper OVN transactions when pod is created after node egress label switch", func() {
@@ -4344,9 +4335,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 				// even the LSP sticks around for 60 seconds
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(finalDatabaseStatewithPod))
 				// egressIP cache is stale in the sense the podKey has not been deleted since deletion failed
-				pas := getPodAssignmentState(&egressPod1)
-				gomega.Expect(pas).NotTo(gomega.BeNil())
-				gomega.Expect(pas.egressStatuses).To(gomega.Equal(map[egressipv1.EgressIPStatusItem]string{
+				status, exists := fakeOvn.controller.eIPC.podAssignment[getPodKey(&egressPod1)]
+				gomega.Expect(exists).To(gomega.BeTrue())
+				gomega.Expect(status.egressStatuses).To(gomega.Equal(map[egressipv1.EgressIPStatusItem]string{
 					{
 						Node:     "node1",
 						EgressIP: "192.168.126.101",
@@ -4631,23 +4622,31 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 				gomega.Expect(egressIPs2[0]).To(gomega.Equal(egressIP3))
 				recordedEvent = <-fakeOvn.fakeRecorder.Events
 				gomega.Expect(recordedEvent).To(gomega.ContainSubstring("EgressIP object egressip-2 will not be configured for pod egressip-namespace_egress-pod since another egressIP object egressip is serving it, this is undefined"))
+				podCache := make(map[string]*podAssignmentState)
+				fakeOvn.controller.eIPC.podAssignmentMutex.Lock()
+				for k, v := range fakeOvn.controller.eIPC.podAssignment {
+					value := *v
+					podCache[k] = &value // deep copy to avoid map reference issues
+				}
+				fakeOvn.controller.eIPC.podAssignmentMutex.Unlock()
 
-				pas := getPodAssignmentState(&egressPod1)
-				gomega.Expect(pas).NotTo(gomega.BeNil())
+				assginedEIPName := podCache[getPodKey(&egressPod1)].egressIPName
+				standByEIPNames := podCache[getPodKey(&egressPod1)].standbyEgressIPNames
+				assginedStatuses := podCache[getPodKey(&egressPod1)].egressStatuses
 
 				assginedEIP := egressIPs1[0]
-				gomega.Expect(pas.egressIPName).To(gomega.Equal(egressIPName))
+				gomega.Expect(assginedEIPName).To(gomega.Equal(egressIPName))
 				eip1Obj, err := fakeOvn.fakeClient.EgressIPClient.K8sV1().EgressIPs().Get(context.TODO(), eIP1.Name, metav1.GetOptions{})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				gomega.Expect(pas.egressStatuses[eip1Obj.Status.Items[0]]).To(gomega.Equal(""))
-				gomega.Expect(pas.standbyEgressIPNames.Has(egressIPName2)).To(gomega.BeTrue())
+				gomega.Expect(assginedStatuses[eip1Obj.Status.Items[0]]).To(gomega.Equal(""))
+				gomega.Expect(standByEIPNames.Has(egressIPName2)).To(gomega.BeTrue())
 
 				podEIPSNAT := &nbdb.NAT{
 					UUID:       "egressip-nat-UUID1",
 					LogicalIP:  egressPodIP[0].String(),
 					ExternalIP: assginedEIP,
 					ExternalIDs: map[string]string{
-						"name": pas.egressIPName,
+						"name": assginedEIPName,
 					},
 					Type:        nbdb.NATTypeSNAT,
 					LogicalPort: utilpointer.StringPtr("k8s-node1"),
@@ -4661,7 +4660,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 					Action:   nbdb.LogicalRouterPolicyActionReroute,
 					Nexthops: nodeLogicalRouterIPv4,
 					ExternalIDs: map[string]string{
-						"name": pas.egressIPName,
+						"name": assginedEIPName,
 					},
 					UUID: "reroute-UUID1",
 				}
@@ -4747,7 +4746,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 					LogicalIP:  egressPodIP[0].String(),
 					ExternalIP: egressIPs1[1],
 					ExternalIDs: map[string]string{
-						"name": pas.egressIPName,
+						"name": assginedEIPName,
 					},
 					Type:        nbdb.NATTypeSNAT,
 					LogicalPort: utilpointer.StringPtr("k8s-node2"),
@@ -4767,15 +4766,22 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(finalDatabaseStatewithPod))
 
 				// check the state of the cache for podKey
-				pas = getPodAssignmentState(&egressPod1)
-				gomega.Expect(pas).NotTo(gomega.BeNil())
+				fakeOvn.controller.eIPC.podAssignmentMutex.Lock()
+				for k, v := range fakeOvn.controller.eIPC.podAssignment {
+					value := *v
+					podCache[k] = &value // deep copy to avoid map reference issues
+				}
+				fakeOvn.controller.eIPC.podAssignmentMutex.Unlock()
+				assginedEIPName = podCache[getPodKey(&egressPod1)].egressIPName
+				standByEIPNames = podCache[getPodKey(&egressPod1)].standbyEgressIPNames
+				assginedStatuses = podCache[getPodKey(&egressPod1)].egressStatuses
 
-				gomega.Expect(pas.egressIPName).To(gomega.Equal(egressIPName))
+				gomega.Expect(assginedEIPName).To(gomega.Equal(egressIPName))
 				eip1Obj, err = fakeOvn.fakeClient.EgressIPClient.K8sV1().EgressIPs().Get(context.TODO(), eIP1.Name, metav1.GetOptions{})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				gomega.Expect(pas.egressStatuses[eip1Obj.Status.Items[0]]).To(gomega.Equal(""))
-				gomega.Expect(pas.egressStatuses[eip1Obj.Status.Items[1]]).To(gomega.Equal(""))
-				gomega.Expect(pas.standbyEgressIPNames.Has(egressIPName2)).To(gomega.BeTrue())
+				gomega.Expect(assginedStatuses[eip1Obj.Status.Items[0]]).To(gomega.Equal(""))
+				gomega.Expect(assginedStatuses[eip1Obj.Status.Items[1]]).To(gomega.Equal(""))
+				gomega.Expect(standByEIPNames.Has(egressIPName2)).To(gomega.BeTrue())
 
 				// let's test syncPodAssignmentCache works as expected! Nuke the podAssignment cache first
 				fakeOvn.controller.eIPC.podAssignmentMutex.Lock()
@@ -4787,13 +4793,21 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 				err = fakeOvn.controller.syncPodAssignmentCache(egressIPCache)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-				pas = getPodAssignmentState(&egressPod1)
-				gomega.Expect(pas).NotTo(gomega.BeNil())
-				gomega.Expect(pas.egressIPName).To(gomega.Equal(egressIPName))
-				gomega.Expect(pas.egressStatuses).To(gomega.Equal(map[egressipv1.EgressIPStatusItem]string{}))
-				gomega.Expect(pas.standbyEgressIPNames.Has(egressIPName2)).To(gomega.BeTrue())
+				fakeOvn.controller.eIPC.podAssignmentMutex.Lock()
+				for k, v := range fakeOvn.controller.eIPC.podAssignment {
+					value := *v
+					podCache[k] = &value // deep copy to avoid map reference issues
+				}
+				fakeOvn.controller.eIPC.podAssignmentMutex.Unlock()
+				assginedEIPName = podCache[getPodKey(&egressPod1)].egressIPName
+				standByEIPNames = podCache[getPodKey(&egressPod1)].standbyEgressIPNames
+				assginedStatuses = podCache[getPodKey(&egressPod1)].egressStatuses
 
-				// reset egressStatuses for rest of the test to progress correctly
+				gomega.Expect(assginedEIPName).To(gomega.Equal(egressIPName))
+				gomega.Expect(assginedStatuses).To(gomega.Equal(map[egressipv1.EgressIPStatusItem]string{}))
+				gomega.Expect(standByEIPNames.Has(egressIPName2)).To(gomega.BeTrue())
+
+				//reset assginedStatuses for rest of the test to progress correctly
 				fakeOvn.controller.eIPC.podAssignmentMutex.Lock()
 				fakeOvn.controller.eIPC.podAssignment[getPodKey(&egressPod1)].egressStatuses[eip1Obj.Status.Items[0]] = ""
 				fakeOvn.controller.eIPC.podAssignment[getPodKey(&egressPod1)].egressStatuses[eip1Obj.Status.Items[1]] = ""
@@ -4803,23 +4817,29 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 				err = fakeOvn.fakeClient.EgressIPClient.K8sV1().EgressIPs().Delete(context.TODO(), egressIPName2, metav1.DeleteOptions{})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
+				getStandByEgressIPs := func() bool {
+					fakeOvn.controller.eIPC.podAssignmentMutex.Lock()
+					defer fakeOvn.controller.eIPC.podAssignmentMutex.Unlock()
+					for k, v := range fakeOvn.controller.eIPC.podAssignment {
+						value := *v
+						podCache[k] = &value // deep copy to avoid map reference issues
+					}
+					hasStandBy := podCache[getPodKey(&egressPod1)].standbyEgressIPNames.Has(egressIPName2)
+					return hasStandBy
+				}
 				gomega.Eventually(func() bool {
-					pas := getPodAssignmentState(&egressPod1)
-					gomega.Expect(pas).NotTo(gomega.BeNil())
-					return pas.standbyEgressIPNames.Has(egressIPName2)
+					return getStandByEgressIPs()
 				}).Should(gomega.BeFalse())
-				gomega.Expect(getPodAssignmentState(&egressPod1).egressIPName).To(gomega.Equal(egressIPName))
+				gomega.Expect(podCache[getPodKey(&egressPod1)].egressIPName).To(gomega.Equal(egressIPName))
 
 				// add back the standby egressIP object
 				_, err = fakeOvn.fakeClient.EgressIPClient.K8sV1().EgressIPs().Create(context.TODO(), &eIP2, metav1.CreateOptions{})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				gomega.Eventually(func() bool {
-					pas := getPodAssignmentState(&egressPod1)
-					gomega.Expect(pas).NotTo(gomega.BeNil())
-					return pas.standbyEgressIPNames.Has(egressIPName2)
+					return getStandByEgressIPs()
 				}).Should(gomega.BeTrue())
-				gomega.Expect(getPodAssignmentState(&egressPod1).egressIPName).To(gomega.Equal(egressIPName))
+				gomega.Expect(podCache[getPodKey(&egressPod1)].egressIPName).To(gomega.Equal(egressIPName))
 				gomega.Eventually(func() string {
 					return <-fakeOvn.fakeRecorder.Events
 				}).Should(gomega.ContainSubstring("EgressIP object egressip-2 will not be configured for pod egressip-namespace_egress-pod since another egressIP object egressip is serving it, this is undefined"))
@@ -4865,11 +4885,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(finalDatabaseStatewithPod[1:]))
 
 				gomega.Eventually(func() bool {
-					pas := getPodAssignmentState(&egressPod1)
-					gomega.Expect(pas).NotTo(gomega.BeNil())
-					return pas.standbyEgressIPNames.Has(egressIPName2)
+					return getStandByEgressIPs()
 				}).Should(gomega.BeTrue())
-				gomega.Expect(getPodAssignmentState(&egressPod1).egressIPName).To(gomega.Equal(egressIPName))
+				gomega.Expect(podCache[getPodKey(&egressPod1)].egressIPName).To(gomega.Equal(egressIPName))
 
 				// delete the first egressIP object and make sure the cache is updated
 				err = fakeOvn.fakeClient.EgressIPClient.K8sV1().EgressIPs().Delete(context.TODO(), egressIPName, metav1.DeleteOptions{})
@@ -4877,11 +4895,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 
 				// ensure standby takes over and we do the setup for it in OVN DB
 				gomega.Eventually(func() bool {
-					pas := getPodAssignmentState(&egressPod1)
-					gomega.Expect(pas).NotTo(gomega.BeNil())
-					return pas.standbyEgressIPNames.Has(egressIPName2)
+					return getStandByEgressIPs()
 				}).Should(gomega.BeFalse())
-				gomega.Expect(getPodAssignmentState(&egressPod1).egressIPName).To(gomega.Equal(egressIPName2))
+				gomega.Expect(podCache[getPodKey(&egressPod1)].egressIPName).To(gomega.Equal(egressIPName2))
 
 				finalDatabaseStatewithPod = expectedDatabaseStatewithPod
 				finalDatabaseStatewithPod = append(expectedDatabaseStatewithPod, podLSP)
@@ -4910,7 +4926,10 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				gomega.Eventually(func() bool {
-					return getPodAssignmentState(&egressPod1) != nil
+					fakeOvn.controller.eIPC.podAssignmentMutex.Lock()
+					_, ok := fakeOvn.controller.eIPC.podAssignment[getPodKey(&egressPod1)]
+					fakeOvn.controller.eIPC.podAssignmentMutex.Unlock()
+					return ok
 				}).Should(gomega.BeFalse())
 
 				// let's test syncPodAssignmentCache works as expected! Nuke the podAssignment cache first
@@ -4925,7 +4944,10 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 
 				// we don't have any egressIPs, so cache is nil
 				gomega.Eventually(func() bool {
-					return getPodAssignmentState(&egressPod1) != nil
+					fakeOvn.controller.eIPC.podAssignmentMutex.Lock()
+					_, ok := fakeOvn.controller.eIPC.podAssignment[getPodKey(&egressPod1)]
+					fakeOvn.controller.eIPC.podAssignmentMutex.Unlock()
+					return ok
 				}).Should(gomega.BeFalse())
 
 				return nil


### PR DESCRIPTION
Reverts openshift/ovn-kubernetes#1467;; tracked by https://issues.redhat.com/browse/TRT-773 

Per [OpenShift policy](https://github.com/openshift/enhancements/blob/master/enhancements/release/improving-ci-signal.md#quick-revert), we are reverting this breaking change to get CI and/or nightly payloads flowing again.


This change is breaking nightly 4.12 payloads :
 - https://amd64.ocp.releases.ci.openshift.org/releasestream/4.12.0-0.nightly/release/4.12.0-0.nightly-2023-01-11-225659 
 - https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/aggregated-aws-sdn-upgrade-4.12-micro-release-openshift-release-analysis-aggregator/1613309604991602688 


To unrevert this, revert this PR, and layer an additional separate commit on top that addresses the problem. Before merging the unrevert, please run these jobs on the PR and check the result of (job/X or job/X, test/Y tuple) to confirm the fix has corrected the problem:

  `/payload 4.y nightly blocking` (for changes that broke nightly payloads)
  `/payload 4.y nightly informing` (for changes that broke nightly payloads)
  `/test xxxx` (for any PR related test that should also be run)


CC: @dcbw