### PR TITLE
OCPBUGS-5841: ovnkube-node: Existing management port check

### DIFF
--- a/go-controller/pkg/node/management-port_dpu_test.go
+++ b/go-controller/pkg/node/management-port_dpu_test.go
@@ -17,9 +17,16 @@ import (
 	"github.com/vishvananda/netlink"
 )
 
-func genOVSAddMgmtPortCmd(nodeName string) string {
-	return fmt.Sprintf("ovs-vsctl --timeout=15 -- --may-exist add-port br-int %s -- set interface %s external-ids:iface-id=%s",
-		types.K8sMgmtIntfName, types.K8sMgmtIntfName, types.K8sPrefix+nodeName)
+func genOVSAddMgmtPortCmd(nodeName, repName string) string {
+	return fmt.Sprintf("ovs-vsctl --timeout=15 -- --may-exist add-port br-int %s -- set interface %s external-ids:iface-id=%s"+
+		" external-ids:ovn-orig-mgmt-port-rep-name=%s",
+		types.K8sMgmtIntfName, types.K8sMgmtIntfName, types.K8sPrefix+nodeName, repName)
+}
+
+func mockOVSListInterfaceMgmtPortNotExistCmd(execMock *ovntest.FakeExec, mgmtPortName string) {
+	execMock.AddFakeCmdsNoOutputNoError([]string{
+		"ovs-vsctl --timeout=15 --no-headings --data bare --format csv --columns type,name find Interface name=" + mgmtPortName,
+	})
 }
 
 var _ = Describe("Mananagement port DPU tests", func() {
@@ -47,6 +54,17 @@ var _ = Describe("Mananagement port DPU tests", func() {
 	})
 
 	Context("Create Management port DPU", func() {
+		It("Fails if representor link lookup failed with error", func() {
+			mgmtPortDpu := managementPortRepresentor{
+				repName: "non-existent-netdev",
+			}
+			netlinkOpsMock.On("LinkByName", "non-existent-netdev").Return(nil, fmt.Errorf("netlink mock error"))
+			netlinkOpsMock.On("IsLinkNotFoundError", mock.Anything).Return(false)
+
+			_, err := mgmtPortDpu.Create(nodeAnnotatorMock, waiter)
+			Expect(err).To(HaveOccurred())
+		})
+
 		It("Fails if representor and ovn-k8s-mp0 netdev is not found", func() {
 			mgmtPortDpu := managementPortRepresentor{
 				repName: "non-existent-netdev",
@@ -55,6 +73,7 @@ var _ = Describe("Mananagement port DPU tests", func() {
 				nil, fmt.Errorf("failed to get interface"))
 			netlinkOpsMock.On("LinkByName", types.K8sMgmtIntfName).Return(
 				nil, fmt.Errorf("failed to get interface"))
+			netlinkOpsMock.On("IsLinkNotFoundError", mock.Anything).Return(true)
 
 			_, err := mgmtPortDpu.Create(nodeAnnotatorMock, waiter)
 			Expect(err).To(HaveOccurred())
@@ -69,8 +88,12 @@ var _ = Describe("Mananagement port DPU tests", func() {
 
 			netlinkOpsMock.On("LinkByName", "enp3s0f0v0").Return(
 				linkMock, nil)
+			netlinkOpsMock.On("LinkByName", types.K8sMgmtIntfName).Return(
+				nil, fmt.Errorf("link not found"))
+			netlinkOpsMock.On("IsLinkNotFoundError", mock.Anything).Return(true)
 			netlinkOpsMock.On("LinkSetDown", linkMock).Return(nil)
 			netlinkOpsMock.On("LinkSetName", linkMock, types.K8sMgmtIntfName).Return(fmt.Errorf("failed to set name"))
+			mockOVSListInterfaceMgmtPortNotExistCmd(execMock, types.K8sMgmtIntfName)
 
 			_, err := mgmtPortDpu.Create(nodeAnnotatorMock, waiter)
 			Expect(err).To(HaveOccurred())
@@ -92,12 +115,16 @@ var _ = Describe("Mananagement port DPU tests", func() {
 
 			netlinkOpsMock.On("LinkByName", "enp3s0f0v0").Return(
 				linkMock, nil)
+			netlinkOpsMock.On("LinkByName", types.K8sMgmtIntfName).Return(
+				nil, fmt.Errorf("link not found"))
+			netlinkOpsMock.On("IsLinkNotFoundError", mock.Anything).Return(true)
 			netlinkOpsMock.On("LinkSetDown", linkMock).Return(nil)
 			netlinkOpsMock.On("LinkSetName", linkMock, types.K8sMgmtIntfName).Return(nil)
 			netlinkOpsMock.On("LinkSetMTU", linkMock, config.Default.MTU).Return(nil)
 			netlinkOpsMock.On("LinkSetUp", linkMock).Return(nil)
+			mockOVSListInterfaceMgmtPortNotExistCmd(execMock, types.K8sMgmtIntfName)
 			execMock.AddFakeCmd(&ovntest.ExpectedCmd{
-				Cmd: genOVSAddMgmtPortCmd(mgmtPortDpu.nodeName),
+				Cmd: genOVSAddMgmtPortCmd(mgmtPortDpu.nodeName, mgmtPortDpu.repName),
 			})
 
 			mpcfg, err := mgmtPortDpu.Create(nodeAnnotatorMock, waiter)
@@ -123,11 +150,12 @@ var _ = Describe("Mananagement port DPU tests", func() {
 
 			netlinkOpsMock.On("LinkByName", "enp3s0f0v0").Return(
 				nil, fmt.Errorf("failed to get link device"))
-			netlinkOpsMock.On("LinkByName", "ovn-k8s-mp0").Return(
+			netlinkOpsMock.On("LinkByName", types.K8sMgmtIntfName).Return(
 				linkMock, nil)
+			netlinkOpsMock.On("IsLinkNotFoundError", mock.Anything).Return(true)
 			netlinkOpsMock.On("LinkSetUp", linkMock).Return(nil)
 			execMock.AddFakeCmd(&ovntest.ExpectedCmd{
-				Cmd: genOVSAddMgmtPortCmd(mgmtPortDpu.nodeName),
+				Cmd: genOVSAddMgmtPortCmd(mgmtPortDpu.nodeName, mgmtPortDpu.repName),
 			})
 
 			mpcfg, err := mgmtPortDpu.Create(nodeAnnotatorMock, waiter)
@@ -139,6 +167,17 @@ var _ = Describe("Mananagement port DPU tests", func() {
 	})
 
 	Context("Create Management port DPU host", func() {
+		It("Fails if netdev link lookup failed", func() {
+			mgmtPortDpuHost := managementPortNetdev{
+				netdevName: "non-existent-netdev",
+			}
+			netlinkOpsMock.On("LinkByName", "non-existent-netdev").Return(nil, fmt.Errorf("netlink mock error"))
+			netlinkOpsMock.On("IsLinkNotFoundError", mock.Anything).Return(false)
+
+			_, err := mgmtPortDpuHost.Create(nil, waiter)
+			Expect(err).To(HaveOccurred())
+		})
+
 		It("Fails if netdev does not exist", func() {
 			mgmtPortDpuHost := managementPortNetdev{
 				netdevName: "non-existent-netdev",
@@ -147,6 +186,7 @@ var _ = Describe("Mananagement port DPU tests", func() {
 				nil, fmt.Errorf("failed to get interface"))
 			netlinkOpsMock.On("LinkByName", types.K8sMgmtIntfName).Return(
 				nil, fmt.Errorf("failed to get interface"))
+			netlinkOpsMock.On("IsLinkNotFoundError", mock.Anything).Return(true)
 
 			_, err := mgmtPortDpuHost.Create(nil, waiter)
 			Expect(err).To(HaveOccurred())
@@ -169,11 +209,16 @@ var _ = Describe("Mananagement port DPU tests", func() {
 
 			netlinkOpsMock.On("LinkByName", "enp3s0f0v0").Return(
 				linkMock, nil)
+			netlinkOpsMock.On("IsLinkNotFoundError", mock.Anything).Return(true)
 			netlinkOpsMock.On("LinkSetDown", linkMock).Return(nil)
 			netlinkOpsMock.On("LinkSetHardwareAddr", linkMock, expectedMgmtPortMac).Return(nil)
 			netlinkOpsMock.On("LinkSetName", linkMock, types.K8sMgmtIntfName).Return(nil)
 			netlinkOpsMock.On("LinkSetMTU", linkMock, config.Default.MTU).Return(nil)
 			netlinkOpsMock.On("LinkSetUp", linkMock).Return(nil, nil)
+			mockOVSListInterfaceMgmtPortNotExistCmd(execMock, types.K8sMgmtIntfName)
+			execMock.AddFakeCmdsNoOutputNoError([]string{
+				"ovs-vsctl --timeout=15 set Open_vSwitch . external-ids:ovn-orig-mgmt-port-netdev-name=" + mgmtPortDpuHost.netdevName,
+			})
 
 			// mock createPlatformManagementPort, we fail it as it covers what we want to test without the
 			// need to mock the entire flow down to routes and iptable rules.
@@ -203,9 +248,13 @@ var _ = Describe("Mananagement port DPU tests", func() {
 
 			netlinkOpsMock.On("LinkByName", "enp3s0f0v0").Return(
 				nil, fmt.Errorf("failed to get link")).Once()
-			netlinkOpsMock.On("LinkByName", "ovn-k8s-mp0").Return(
+			netlinkOpsMock.On("LinkByName", types.K8sMgmtIntfName).Return(
 				linkMock, nil).Once()
 			netlinkOpsMock.On("LinkSetUp", linkMock).Return(nil, nil).Once()
+			netlinkOpsMock.On("IsLinkNotFoundError", mock.Anything).Return(true)
+			execMock.AddFakeCmdsNoOutputNoError([]string{
+				"ovs-vsctl --timeout=15 set Open_vSwitch . external-ids:ovn-orig-mgmt-port-netdev-name=" + mgmtPortDpuHost.netdevName,
+			})
 
 			// mock createPlatformManagementPort, we fail it as it covers what we want to test without the
 			// need to mock the entire flow down to routes and iptable rules.

--- a/go-controller/pkg/node/management-port_linux.go
+++ b/go-controller/pkg/node/management-port_linux.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net"
 	"strings"
+	"time"
 
 	"github.com/coreos/go-iptables/iptables"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
@@ -135,30 +136,42 @@ func newManagementPortConfig(interfaceName string, hostSubnets []*net.IPNet) (*m
 	return mpcfg, nil
 }
 
-func tearDownManagementPortConfig(mpcfg *managementPortConfig) error {
-	// for the initial setup we need to start from the clean slate, so flush
-	// all (non-LL) addresses on this link, routes through this link, and
-	// finally any IPtable rules for this link.
-	if err := util.LinkAddrFlush(mpcfg.link); err != nil {
+func tearDownInterfaceIPConfig(link netlink.Link, ipt4, ipt6 util.IPTablesHelper) error {
+	if err := util.LinkAddrFlush(link); err != nil {
 		return err
 	}
 
-	if err := util.LinkRoutesDel(mpcfg.link, nil); err != nil {
+	if err := util.LinkRoutesDel(link, nil); err != nil {
 		return err
 	}
-	if mpcfg.ipv4 != nil {
-		if err := mpcfg.ipv4.ipt.ClearChain("nat", iptableMgmPortChain); err != nil {
+	if ipt4 != nil {
+		if err := ipt4.ClearChain("nat", iptableMgmPortChain); err != nil {
 			return fmt.Errorf("could not clear the iptables chain for management port: %v", err)
 		}
 	}
 
-	if mpcfg.ipv6 != nil {
-		if err := mpcfg.ipv6.ipt.ClearChain("nat", iptableMgmPortChain); err != nil {
+	if ipt6 != nil {
+		if err := ipt6.ClearChain("nat", iptableMgmPortChain); err != nil {
 			return fmt.Errorf("could not clear the iptables chain for management port: %v", err)
 		}
 	}
 
 	return nil
+}
+
+func tearDownManagementPortConfig(mpcfg *managementPortConfig) error {
+	// for the initial setup we need to start from the clean slate, so flush
+	// all (non-LL) addresses on this link, routes through this link, and
+	// finally any IPtable rules for this link.
+	var ipt4, ipt6 util.IPTablesHelper
+
+	if mpcfg.ipv4 != nil {
+		ipt4 = mpcfg.ipv4.ipt
+	}
+	if mpcfg.ipv6 != nil {
+		ipt6 = mpcfg.ipv6.ipt
+	}
+	return tearDownInterfaceIPConfig(mpcfg.link, ipt4, ipt6)
 }
 
 func setupManagementPortIPFamilyConfig(mpcfg *managementPortConfig, cfg *managementPortIPFamilyConfig) ([]string, error) {
@@ -280,7 +293,146 @@ func createPlatformManagementPort(interfaceName string, localSubnets []*net.IPNe
 	return cfg, nil
 }
 
-//DelMgtPortIptRules delete all the iptable rules for the management port.
+func getIPTablesForHostSubnets(hostSubnets []*net.IPNet) (util.IPTablesHelper, util.IPTablesHelper, error) {
+	var ipt4, ipt6 util.IPTablesHelper
+	var err error
+
+	for _, hostSubnet := range hostSubnets {
+		if utilnet.IsIPv6CIDR(hostSubnet) {
+			if ipt6 != nil {
+				continue
+			}
+			ipt6, err = util.GetIPTablesHelper(iptables.ProtocolIPv6)
+		} else {
+			if ipt4 != nil {
+				continue
+			}
+			ipt4, err = util.GetIPTablesHelper(iptables.ProtocolIPv4)
+		}
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+	return ipt4, ipt6, nil
+}
+
+// syncMgmtPortInterface verifies if no other interface configured as management port. This may happen if another
+// interface had been used as management port or Node was running in different mode.
+// If old management port is found, its IP configuration is flushed and interface renamed.
+func syncMgmtPortInterface(hostSubnets []*net.IPNet, mgmtPortName string, isExpectedToBeInternal bool) error {
+	// Query both type and name, because with type only stdout will be empty for both non-existing port and representor netdevice
+	stdout, _, _ := util.RunOVSVsctl("--no-headings",
+		"--data", "bare",
+		"--format", "csv",
+		"--columns", "type,name",
+		"find", "Interface", "name="+mgmtPortName)
+	if stdout == "" {
+		// Not found on the bridge. But could be that interface with the same name exists
+		return unconfigureMgmtNetdevicePort(hostSubnets, mgmtPortName)
+	}
+
+	// Found existing port. Check its type
+	if stdout == "internal,"+mgmtPortName {
+		if isExpectedToBeInternal {
+			// Do nothing
+			return nil
+		}
+
+		klog.Infof("Found OVS internal port. Removing it")
+		_, stderr, err := util.RunOVSVsctl("del-port", "br-int", mgmtPortName)
+		if err != nil {
+			return fmt.Errorf("failed to remove OVS internal port: %s", stderr)
+		}
+		return nil
+	}
+
+	// It is representor which was used as management port.
+	// Remove it from the bridge and rename.
+	klog.Infof("Found existing representor management port. Removing it")
+	return unconfigureMgmtRepresentorPort(mgmtPortName)
+}
+
+func unconfigureMgmtRepresentorPort(mgmtPortName string) error {
+	// Get saved port name
+	savedName, stderr, err := util.RunOVSVsctl("--if-exists", "get", "Interface", mgmtPortName, "external-ids:ovn-orig-mgmt-port-rep-name")
+	if err != nil {
+		klog.Warningf("Failed to get external-ds:ovn-orig-mgmt-port-rep-name: %s", stderr)
+	}
+
+	if savedName == "" {
+		// rename to "rep" + "ddmmyyHHMMSS"
+		savedName = time.Now().Format("rep010206150405")
+		klog.Warningf("No saved management port representor name for %s, renaming to %s", mgmtPortName, savedName)
+	}
+
+	_, stderr, err = util.RunOVSVsctl("--if-exists", "del-port", "br-int", mgmtPortName)
+	if err != nil {
+		return fmt.Errorf("failed to remove OVS port: %s", stderr)
+	}
+
+	link, err := util.GetNetLinkOps().LinkByName(mgmtPortName)
+	if err != nil {
+		return fmt.Errorf("failed to lookup %s link: %v", mgmtPortName, err)
+	}
+
+	if err := util.GetNetLinkOps().LinkSetDown(link); err != nil {
+		return fmt.Errorf("failed to set link down: %v", err)
+	}
+
+	if err := util.GetNetLinkOps().LinkSetName(link, savedName); err != nil {
+		return fmt.Errorf("failed to rename %s link to %s: %v", mgmtPortName, savedName, err)
+	}
+	return nil
+}
+
+func unconfigureMgmtNetdevicePort(hostSubnets []*net.IPNet, mgmtPortName string) error {
+	link, err := util.GetNetLinkOps().LinkByName(mgmtPortName)
+	if err != nil {
+		if !util.GetNetLinkOps().IsLinkNotFoundError(err) {
+			return fmt.Errorf("failed to lookup %s link: %v", mgmtPortName, err)
+		}
+		// Nothing to unconfigure. Return.
+		return nil
+	}
+
+	klog.Infof("Found existing management interface. Unconfiguring it")
+	ipt4, ipt6, err := getIPTablesForHostSubnets(hostSubnets)
+	if err != nil {
+		return fmt.Errorf("failed to get iptables: %v", err)
+	}
+
+	if err := tearDownInterfaceIPConfig(link, ipt4, ipt6); err != nil {
+		return fmt.Errorf("teardown failed: %v", err)
+	}
+
+	if err := util.GetNetLinkOps().LinkSetDown(link); err != nil {
+		return fmt.Errorf("failed to set %s link down: %v", mgmtPortName, err)
+	}
+
+	savedName := ""
+	if config.OvnKubeNode.Mode != types.NodeModeDPUHost {
+		// Get original interface name saved at OVS database
+		stdout, stderr, err := util.RunOVSVsctl("--if-exists", "get", "Open_vSwitch", ".", "external-ids:ovn-orig-mgmt-port-netdev-name")
+		if err != nil {
+			klog.Warningf("Failed to get external-ds:ovn-orig-mgmt-port-netdev-name: %s", stderr)
+		}
+		savedName = stdout
+	}
+
+	if savedName == "" {
+		// rename to "net" + "ddmmyyHHMMSS"
+		savedName = time.Now().Format("net010206150405")
+		klog.Warningf("No saved management port netdevice name for %s, renaming to %s", mgmtPortName, savedName)
+	}
+
+	// rename to PortName + "-ddmmyyHHMMSS"
+	if err := util.GetNetLinkOps().LinkSetName(link, savedName); err != nil {
+		return fmt.Errorf("failed to rename %s link to %s: %v", mgmtPortName, savedName, err)
+	}
+	return nil
+}
+
+// DelMgtPortIptRules delete all the iptable rules for the management port.
 func DelMgtPortIptRules() {
 	// Clean up all iptables and ip6tables remnants that may be left around
 	ipt, err := util.GetIPTablesHelper(iptables.ProtocolIPv4)

--- a/go-controller/pkg/util/mocks/NetLinkOps.go
+++ b/go-controller/pkg/util/mocks/NetLinkOps.go
@@ -87,6 +87,20 @@ func (_m *NetLinkOps) ConntrackDeleteFilter(table netlink.ConntrackTableType, fa
 	return r0, r1
 }
 
+// IsLinkNotFoundError provides a mock function with given fields: err
+func (_m *NetLinkOps) IsLinkNotFoundError(err error) bool {
+	ret := _m.Called(err)
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func(error) bool); ok {
+		r0 = rf(err)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
+}
+
 // LinkByIndex provides a mock function with given fields: index
 func (_m *NetLinkOps) LinkByIndex(index int) (netlink.Link, error) {
 	ret := _m.Called(index)

--- a/go-controller/pkg/util/net_linux.go
+++ b/go-controller/pkg/util/net_linux.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"fmt"
 	"net"
+	"reflect"
 	"time"
 
 	"github.com/j-keck/arping"
@@ -31,6 +32,7 @@ type NetLinkOps interface {
 	LinkSetHardwareAddr(link netlink.Link, hwaddr net.HardwareAddr) error
 	LinkSetMTU(link netlink.Link, mtu int) error
 	LinkSetTxQLen(link netlink.Link, qlen int) error
+	IsLinkNotFoundError(err error) bool
 	AddrList(link netlink.Link, family int) ([]netlink.Addr, error)
 	AddrDel(link netlink.Link, addr *netlink.Addr) error
 	AddrAdd(link netlink.Link, addr *netlink.Addr) error
@@ -107,6 +109,10 @@ func (defaultNetLinkOps) LinkSetMTU(link netlink.Link, mtu int) error {
 
 func (defaultNetLinkOps) LinkSetTxQLen(link netlink.Link, qlen int) error {
 	return netlink.LinkSetTxQLen(link, qlen)
+}
+
+func (defaultNetLinkOps) IsLinkNotFoundError(err error) bool {
+	return reflect.TypeOf(err) == reflect.TypeOf(netlink.LinkNotFoundError{})
 }
 
 func (defaultNetLinkOps) AddrList(link netlink.Link, family int) ([]netlink.Addr, error) {


### PR DESCRIPTION
When ovnkube-node configures management port interface it may fail if host already have it configured but it is different interface. To handle that do the following:
- verify that port exists on the integrational bridge and it represents provided management port netdevice or OVS internal port, if no netdevice were provided;
- verify that no interface exists with the name of the management port;

If any of the checks had failed then need to remove port from the bridge, unless it is OVS internal port and we expect it; flush IP addresses, routes, tables from management netdevice interface. Both representor and netdevice interfaces renamed to original names, if latter stored in OVS database, or to generic names: {net|rep} + ddmmyyHHMMSS

Because ovnkube doesn't have unload sequence, port check done during new management port creation.

Signed-off-by: Dmytro Linkin <dlinkin@nvidia.com>
(cherry picked from upstream commit 9da055f26906d2dcf40af2584df9196878116503)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->