### PR TITLE
OCPBUGS-5840: ovnkube-node: Existing management port check

### DIFF
--- a/go-controller/pkg/node/management-port_dpu_test.go
+++ b/go-controller/pkg/node/management-port_dpu_test.go
@@ -17,9 +17,16 @@ import (
 	"github.com/vishvananda/netlink"
 )
 
-func genOVSAddMgmtPortCmd(nodeName string) string {
-	return fmt.Sprintf("ovs-vsctl --timeout=15 -- --may-exist add-port br-int %s -- set interface %s external-ids:iface-id=%s",
-		types.K8sMgmtIntfName, types.K8sMgmtIntfName, types.K8sPrefix+nodeName)
+func genOVSAddMgmtPortCmd(nodeName, repName string) string {
+	return fmt.Sprintf("ovs-vsctl --timeout=15 -- --may-exist add-port br-int %s -- set interface %s external-ids:iface-id=%s"+
+		" external-ids:ovn-orig-mgmt-port-rep-name=%s",
+		types.K8sMgmtIntfName, types.K8sMgmtIntfName, types.K8sPrefix+nodeName, repName)
+}
+
+func mockOVSListInterfaceMgmtPortNotExistCmd(execMock *ovntest.FakeExec, mgmtPortName string) {
+	execMock.AddFakeCmdsNoOutputNoError([]string{
+		"ovs-vsctl --timeout=15 --no-headings --data bare --format csv --columns type,name find Interface name=" + mgmtPortName,
+	})
 }
 
 var _ = Describe("Mananagement port DPU tests", func() {
@@ -47,6 +54,17 @@ var _ = Describe("Mananagement port DPU tests", func() {
 	})
 
 	Context("Create Management port DPU", func() {
+		It("Fails if representor link lookup failed with error", func() {
+			mgmtPortDpu := managementPortRepresentor{
+				repName: "non-existent-netdev",
+			}
+			netlinkOpsMock.On("LinkByName", "non-existent-netdev").Return(nil, fmt.Errorf("netlink mock error"))
+			netlinkOpsMock.On("IsLinkNotFoundError", mock.Anything).Return(false)
+
+			_, err := mgmtPortDpu.Create(nodeAnnotatorMock, waiter)
+			Expect(err).To(HaveOccurred())
+		})
+
 		It("Fails if representor and ovn-k8s-mp0 netdev is not found", func() {
 			mgmtPortDpu := managementPortRepresentor{
 				repName: "non-existent-netdev",
@@ -55,6 +73,7 @@ var _ = Describe("Mananagement port DPU tests", func() {
 				nil, fmt.Errorf("failed to get interface"))
 			netlinkOpsMock.On("LinkByName", types.K8sMgmtIntfName).Return(
 				nil, fmt.Errorf("failed to get interface"))
+			netlinkOpsMock.On("IsLinkNotFoundError", mock.Anything).Return(true)
 
 			_, err := mgmtPortDpu.Create(nodeAnnotatorMock, waiter)
 			Expect(err).To(HaveOccurred())
@@ -69,8 +88,12 @@ var _ = Describe("Mananagement port DPU tests", func() {
 
 			netlinkOpsMock.On("LinkByName", "enp3s0f0v0").Return(
 				linkMock, nil)
+			netlinkOpsMock.On("LinkByName", types.K8sMgmtIntfName).Return(
+				nil, fmt.Errorf("link not found"))
+			netlinkOpsMock.On("IsLinkNotFoundError", mock.Anything).Return(true)
 			netlinkOpsMock.On("LinkSetDown", linkMock).Return(nil)
 			netlinkOpsMock.On("LinkSetName", linkMock, types.K8sMgmtIntfName).Return(fmt.Errorf("failed to set name"))
+			mockOVSListInterfaceMgmtPortNotExistCmd(execMock, types.K8sMgmtIntfName)
 
 			_, err := mgmtPortDpu.Create(nodeAnnotatorMock, waiter)
 			Expect(err).To(HaveOccurred())
@@ -92,12 +115,16 @@ var _ = Describe("Mananagement port DPU tests", func() {
 
 			netlinkOpsMock.On("LinkByName", "enp3s0f0v0").Return(
 				linkMock, nil)
+			netlinkOpsMock.On("LinkByName", types.K8sMgmtIntfName).Return(
+				nil, fmt.Errorf("link not found"))
+			netlinkOpsMock.On("IsLinkNotFoundError", mock.Anything).Return(true)
 			netlinkOpsMock.On("LinkSetDown", linkMock).Return(nil)
 			netlinkOpsMock.On("LinkSetName", linkMock, types.K8sMgmtIntfName).Return(nil)
 			netlinkOpsMock.On("LinkSetMTU", linkMock, config.Default.MTU).Return(nil)
 			netlinkOpsMock.On("LinkSetUp", linkMock).Return(nil)
+			mockOVSListInterfaceMgmtPortNotExistCmd(execMock, types.K8sMgmtIntfName)
 			execMock.AddFakeCmd(&ovntest.ExpectedCmd{
-				Cmd: genOVSAddMgmtPortCmd(mgmtPortDpu.nodeName),
+				Cmd: genOVSAddMgmtPortCmd(mgmtPortDpu.nodeName, mgmtPortDpu.repName),
 			})
 
 			mpcfg, err := mgmtPortDpu.Create(nodeAnnotatorMock, waiter)
@@ -123,11 +150,12 @@ var _ = Describe("Mananagement port DPU tests", func() {
 
 			netlinkOpsMock.On("LinkByName", "enp3s0f0v0").Return(
 				nil, fmt.Errorf("failed to get link device"))
-			netlinkOpsMock.On("LinkByName", "ovn-k8s-mp0").Return(
+			netlinkOpsMock.On("LinkByName", types.K8sMgmtIntfName).Return(
 				linkMock, nil)
+			netlinkOpsMock.On("IsLinkNotFoundError", mock.Anything).Return(true)
 			netlinkOpsMock.On("LinkSetUp", linkMock).Return(nil)
 			execMock.AddFakeCmd(&ovntest.ExpectedCmd{
-				Cmd: genOVSAddMgmtPortCmd(mgmtPortDpu.nodeName),
+				Cmd: genOVSAddMgmtPortCmd(mgmtPortDpu.nodeName, mgmtPortDpu.repName),
 			})
 
 			mpcfg, err := mgmtPortDpu.Create(nodeAnnotatorMock, waiter)
@@ -139,6 +167,17 @@ var _ = Describe("Mananagement port DPU tests", func() {
 	})
 
 	Context("Create Management port DPU host", func() {
+		It("Fails if netdev link lookup failed", func() {
+			mgmtPortDpuHost := managementPortNetdev{
+				netdevName: "non-existent-netdev",
+			}
+			netlinkOpsMock.On("LinkByName", "non-existent-netdev").Return(nil, fmt.Errorf("netlink mock error"))
+			netlinkOpsMock.On("IsLinkNotFoundError", mock.Anything).Return(false)
+
+			_, err := mgmtPortDpuHost.Create(nil, waiter)
+			Expect(err).To(HaveOccurred())
+		})
+
 		It("Fails if netdev does not exist", func() {
 			mgmtPortDpuHost := managementPortNetdev{
 				netdevName: "non-existent-netdev",
@@ -147,6 +186,7 @@ var _ = Describe("Mananagement port DPU tests", func() {
 				nil, fmt.Errorf("failed to get interface"))
 			netlinkOpsMock.On("LinkByName", types.K8sMgmtIntfName).Return(
 				nil, fmt.Errorf("failed to get interface"))
+			netlinkOpsMock.On("IsLinkNotFoundError", mock.Anything).Return(true)
 
 			_, err := mgmtPortDpuHost.Create(nil, waiter)
 			Expect(err).To(HaveOccurred())
@@ -169,11 +209,16 @@ var _ = Describe("Mananagement port DPU tests", func() {
 
 			netlinkOpsMock.On("LinkByName", "enp3s0f0v0").Return(
 				linkMock, nil)
+			netlinkOpsMock.On("IsLinkNotFoundError", mock.Anything).Return(true)
 			netlinkOpsMock.On("LinkSetDown", linkMock).Return(nil)
 			netlinkOpsMock.On("LinkSetHardwareAddr", linkMock, expectedMgmtPortMac).Return(nil)
 			netlinkOpsMock.On("LinkSetName", linkMock, types.K8sMgmtIntfName).Return(nil)
 			netlinkOpsMock.On("LinkSetMTU", linkMock, config.Default.MTU).Return(nil)
 			netlinkOpsMock.On("LinkSetUp", linkMock).Return(nil, nil)
+			mockOVSListInterfaceMgmtPortNotExistCmd(execMock, types.K8sMgmtIntfName)
+			execMock.AddFakeCmdsNoOutputNoError([]string{
+				"ovs-vsctl --timeout=15 set Open_vSwitch . external-ids:ovn-orig-mgmt-port-netdev-name=" + mgmtPortDpuHost.netdevName,
+			})
 
 			// mock createPlatformManagementPort, we fail it as it covers what we want to test without the
 			// need to mock the entire flow down to routes and iptable rules.
@@ -203,9 +248,13 @@ var _ = Describe("Mananagement port DPU tests", func() {
 
 			netlinkOpsMock.On("LinkByName", "enp3s0f0v0").Return(
 				nil, fmt.Errorf("failed to get link")).Once()
-			netlinkOpsMock.On("LinkByName", "ovn-k8s-mp0").Return(
+			netlinkOpsMock.On("LinkByName", types.K8sMgmtIntfName).Return(
 				linkMock, nil).Once()
 			netlinkOpsMock.On("LinkSetUp", linkMock).Return(nil, nil).Once()
+			netlinkOpsMock.On("IsLinkNotFoundError", mock.Anything).Return(true)
+			execMock.AddFakeCmdsNoOutputNoError([]string{
+				"ovs-vsctl --timeout=15 set Open_vSwitch . external-ids:ovn-orig-mgmt-port-netdev-name=" + mgmtPortDpuHost.netdevName,
+			})
 
 			// mock createPlatformManagementPort, we fail it as it covers what we want to test without the
 			// need to mock the entire flow down to routes and iptable rules.

--- a/go-controller/pkg/util/mocks/NetLinkOps.go
+++ b/go-controller/pkg/util/mocks/NetLinkOps.go
@@ -87,6 +87,20 @@ func (_m *NetLinkOps) ConntrackDeleteFilter(table netlink.ConntrackTableType, fa
 	return r0, r1
 }
 
+// IsLinkNotFoundError provides a mock function with given fields: err
+func (_m *NetLinkOps) IsLinkNotFoundError(err error) bool {
+	ret := _m.Called(err)
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func(error) bool); ok {
+		r0 = rf(err)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
+}
+
 // LinkByIndex provides a mock function with given fields: index
 func (_m *NetLinkOps) LinkByIndex(index int) (netlink.Link, error) {
 	ret := _m.Called(index)

--- a/go-controller/pkg/util/net_linux.go
+++ b/go-controller/pkg/util/net_linux.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"fmt"
 	"net"
+	"reflect"
 	"time"
 
 	"github.com/j-keck/arping"
@@ -31,6 +32,7 @@ type NetLinkOps interface {
 	LinkSetHardwareAddr(link netlink.Link, hwaddr net.HardwareAddr) error
 	LinkSetMTU(link netlink.Link, mtu int) error
 	LinkSetTxQLen(link netlink.Link, qlen int) error
+	IsLinkNotFoundError(err error) bool
 	AddrList(link netlink.Link, family int) ([]netlink.Addr, error)
 	AddrDel(link netlink.Link, addr *netlink.Addr) error
 	AddrAdd(link netlink.Link, addr *netlink.Addr) error
@@ -107,6 +109,10 @@ func (defaultNetLinkOps) LinkSetMTU(link netlink.Link, mtu int) error {
 
 func (defaultNetLinkOps) LinkSetTxQLen(link netlink.Link, qlen int) error {
 	return netlink.LinkSetTxQLen(link, qlen)
+}
+
+func (defaultNetLinkOps) IsLinkNotFoundError(err error) bool {
+	return reflect.TypeOf(err) == reflect.TypeOf(netlink.LinkNotFoundError{})
 }
 
 func (defaultNetLinkOps) AddrList(link netlink.Link, family int) ([]netlink.Addr, error) {


### PR DESCRIPTION
When ovnkube-node configures management port interface it may fail if host already have it configured but it is different interface. To handle that do the following:
- verify that port exists on the integrational bridge and it represents provided management port netdevice or OVS internal port, if no netdevice were provided;
- verify that no interface exists with the name of the management port;

If any of the checks had failed then need to remove port from the bridge, unless it is OVS internal port and we expect it; flush IP addresses, routes, tables from management netdevice interface. Both representor and netdevice interfaces renamed to original names, if latter stored in OVS database, or to generic names: {net|rep} + ddmmyyHHMMSS

Because ovnkube doesn't have unload sequence, port check done during new management port creation.

Signed-off-by: Dmytro Linkin <dlinkin@nvidia.com>
(cherry picked from upstream commit 9da055f26906d2dcf40af2584df9196878116503)