### PR TITLE
OCPBUGS-5928: [release-4.11] Fix egress firewall to allow inbound connections in both gw modes

### DIFF
--- a/go-controller/pkg/ovn/egressfirewall.go
+++ b/go-controller/pkg/ovn/egressfirewall.go
@@ -13,7 +13,6 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdbops"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
 	addressset "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/address_set"
-
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 
 	kapi "k8s.io/api/core/v1"
@@ -81,20 +80,15 @@ func newEgressFirewallRule(rawEgressFirewallRule egressfirewallapi.EgressFirewal
 	return efr, nil
 }
 
-// This function is used to sync egress firewall setup. It does three "cleanups"
-
-// - 	Cleanup the old implementation (using LRP) in local GW mode -> new implementation (using ACLs) local GW mode
+// This function is used to sync egress firewall setup. Egress firewall implementation had many versions,
+// the latest one makes no difference for gateway modes, and creates ACLs on types.ClusterPortGroupName.
+// The following cleanups are needed from the previous versions:
+// - 	Cleanup the old implementation (using LRP) in local GW mode
 //  	For this it just deletes all LRP setup done for egress firewall
 //  	And also convert all old ACLs which specifed from-lport to specifying to-lport
 
-// -	Cleanup the new local GW mode implementation (using ACLs on the node switch) -> shared GW mode implementation (using ACLs on the join switch)
-//  	For this it just deletes all ACL setup done for egress firewall on the node switches
-
-// -	Cleanup the old implementation (using LRP) in local GW mode -> shared GW mode implementation (using ACLs on the join switch)
-//  	For this it just deletes all LRP setup done for egress firewall
-
-// -    Cleanup for migration from shared GW mode -> local GW mode
-//      For this it just deletes all the ACLs on the distributed join switch
+// -	Cleanup the old implementation (using ACLs on the join and node switches)
+//  	For this it deletes all the ACLs on the join and node switches, they will be created from scratch later.
 
 // NOTE: Utilize the fact that we know that all egress firewall related setup must have a priority: types.MinimumReservedEgressFirewallPriority <= priority <= types.EgressFirewallStartPriority
 // Upon failure, it may be invoked multiple times in order to avoid a pod restart.
@@ -108,25 +102,6 @@ func (oc *Controller) syncEgressFirewall(egressFirewalls []interface{}) error {
 		return fmt.Errorf("unable to list egress firewall ACLs, cannot cleanup old stale data, err: %v", err)
 	}
 
-	if len(egressFirewallACLs) != 0 {
-		var p func(item *nbdb.LogicalSwitch) bool
-		if config.Gateway.Mode == config.GatewayModeShared {
-			p = func(item *nbdb.LogicalSwitch) bool {
-				// Ignore external and Join switches(both legacy and current)
-				return !(strings.HasPrefix(item.Name, types.JoinSwitchPrefix) || item.Name == "join" || strings.HasPrefix(item.Name, types.ExternalSwitchPrefix))
-			}
-		} else if config.Gateway.Mode == config.GatewayModeLocal {
-			p = func(item *nbdb.LogicalSwitch) bool {
-				// Return only join switch (the per node ones if its old topology & distributed one if its new topology)
-				return (strings.HasPrefix(item.Name, types.JoinSwitchPrefix) || item.Name == "join")
-			}
-		}
-		err = libovsdbops.RemoveACLsFromLogicalSwitchesWithPredicate(oc.nbClient, p, egressFirewallACLs...)
-		if err != nil {
-			return fmt.Errorf("failed to remove reject acl from node logical switches: %v", err)
-		}
-	}
-
 	// update the direction of each egressFirewallACL if needed
 	for i := range egressFirewallACLs {
 		egressFirewallACLs[i].Direction = types.DirectionToLPort
@@ -137,13 +112,21 @@ func (oc *Controller) syncEgressFirewall(egressFirewalls []interface{}) error {
 	}
 
 	// In any gateway mode, make sure to delete all LRPs on ovn_cluster_router.
-	// This covers migration from LGW mode that used LRPs for EFW to using ACLs in SGW/LGW modes
 	p := func(item *nbdb.LogicalRouterPolicy) bool {
 		return item.Priority <= types.EgressFirewallStartPriority && item.Priority >= types.MinimumReservedEgressFirewallPriority
 	}
 	err = libovsdbops.DeleteLogicalRouterPoliciesWithPredicate(oc.nbClient, types.OVNClusterRouter, p)
 	if err != nil {
 		return fmt.Errorf("error deleting egress firewall policies on router %s: %v", types.OVNClusterRouter, err)
+	}
+
+	// delete acls from all switches, they reside on the port group now
+	if len(egressFirewallACLs) != 0 {
+		err = libovsdbops.RemoveACLsFromLogicalSwitchesWithPredicate(oc.nbClient, func(item *nbdb.LogicalSwitch) bool { return true },
+			egressFirewallACLs...)
+		if err != nil {
+			return fmt.Errorf("failed to remove reject acl from node logical switches: %v", err)
+		}
 	}
 
 	// sync the ovn and k8s egressFirewall states
@@ -313,26 +296,8 @@ func (oc *Controller) addEgressFirewallRules(ef *egressFirewall, hashedAddressSe
 }
 
 // createEgressFirewallRules uses the previously generated elements and creates the
-// logical_router_policy/join_switch_acl for a specific egressFirewallRouter
+// acls for all node switches
 func (oc *Controller) createEgressFirewallRules(priority int, match, action, externalID string) error {
-	logicalSwitches := []string{}
-	if config.Gateway.Mode == config.GatewayModeLocal {
-		// Find all node switches
-		p := func(item *nbdb.LogicalSwitch) bool {
-			// Ignore external and Join switches(both legacy and current)
-			return !(strings.HasPrefix(item.Name, types.JoinSwitchPrefix) || item.Name == "join" || strings.HasPrefix(item.Name, types.ExternalSwitchPrefix))
-		}
-		nodeLocalSwitches, err := libovsdbops.FindLogicalSwitchesWithPredicate(oc.nbClient, p)
-		if err != nil {
-			return fmt.Errorf("unable to setup egress firewall ACLs on cluster nodes, err: %v", err)
-		}
-		for _, nodeLocalSwitch := range nodeLocalSwitches {
-			logicalSwitches = append(logicalSwitches, nodeLocalSwitch.Name)
-		}
-	} else {
-		logicalSwitches = append(logicalSwitches, types.OVNJoinSwitch)
-	}
-
 	egressFirewallACL := &nbdb.ACL{
 		Priority:    priority,
 		Direction:   types.DirectionToLPort,
@@ -346,13 +311,13 @@ func (oc *Controller) createEgressFirewallRules(priority int, match, action, ext
 		return fmt.Errorf("failed to create egressFirewall ACL %v: %v", egressFirewallACL, err)
 	}
 
-	for _, logicalSwitchName := range logicalSwitches {
-		ops, err = libovsdbops.AddACLsToLogicalSwitchOps(oc.nbClient, ops, logicalSwitchName, egressFirewallACL)
-		if err != nil {
-			return fmt.Errorf("failed to add egressFirewall ACL %v to switch %s: %v", egressFirewallACL, logicalSwitchName, err)
-		}
+	// Applying ACLs on types.ClusterPortGroupName is equivalent to applying on every node switch, since
+	// types.ClusterPortGroupName contains management port from every switch.
+	ops, err = libovsdbops.AddACLsToPortGroupOps(oc.nbClient, ops, types.ClusterPortGroupName, egressFirewallACL)
+	if err != nil {
+		return fmt.Errorf("failed to add egressFirewall ACL %v to port group %s: %v",
+			egressFirewallACL, types.ClusterPortGroupName, err)
 	}
-
 	_, err = libovsdbops.TransactAndCheck(oc.nbClient, ops)
 	if err != nil {
 		return fmt.Errorf("failed to transact egressFirewall ACL: %v", err)
@@ -361,7 +326,7 @@ func (oc *Controller) createEgressFirewallRules(priority int, match, action, ext
 	return nil
 }
 
-// deleteEgressFirewallRules delete the specific logical router policy/join switch Acls
+// deleteEgressFirewallRules delete egress firewall Acls
 func (oc *Controller) deleteEgressFirewallRules(externalID string) error {
 	// Find ACLs for a given egressFirewall
 	pACL := func(item *nbdb.ACL) bool {
@@ -377,10 +342,7 @@ func (oc *Controller) deleteEgressFirewallRules(externalID string) error {
 		return nil
 	}
 
-	// delete egress firewall acls off any logical switch which has it,
-	// then manually remove the egressFirewall ACLs instead of relying on ovsdb garbage collection to do so
-	pSwitch := func(item *nbdb.LogicalSwitch) bool { return true }
-	err = libovsdbops.RemoveACLsFromLogicalSwitchesWithPredicate(oc.nbClient, pSwitch, egressFirewallACLs...)
+	err = libovsdbops.DeleteACLsFromPortGroups(oc.nbClient, []string{types.ClusterPortGroupName}, egressFirewallACLs...)
 	if err != nil {
 		return err
 	}
@@ -460,11 +422,8 @@ func generateMatch(ipv4Source, ipv6Source string, destinations []matchTarget, ds
 		match = fmt.Sprintf("%s && %s", match, egressGetL4Match(dstPorts))
 	}
 
-	if config.Gateway.Mode == config.GatewayModeLocal {
-		extraMatch = getClusterSubnetsExclusion()
-	} else {
-		extraMatch = fmt.Sprintf("inport == \"%s%s\"", types.JoinSwitchToGWRouterPrefix, types.OVNClusterRouter)
-	}
+	// TODO only add exclusion when egress firewall rule subnet intersects with cluster subnet
+	extraMatch = getClusterSubnetsExclusion()
 	return fmt.Sprintf("%s && %s", match, extraMatch)
 }
 

--- a/go-controller/pkg/ovn/egressfirewall.go
+++ b/go-controller/pkg/ovn/egressfirewall.go
@@ -45,6 +45,10 @@ type egressFirewallRule struct {
 type destination struct {
 	cidrSelector string
 	dnsName      string
+	// clusterSubnetIntersection is true, if egress firewall rule CIDRSelector intersects with clusterSubnet.
+	// Based on this flag we can omit clusterSubnet exclusion from the related ACL.
+	// For dns-based rules, EgressDNS won't add ips from clusterSubnet to the address set.
+	clusterSubnetIntersection bool
 }
 
 // cloneEgressFirewall shallow copies the egressfirewallapi.EgressFirewall object provided.
@@ -69,11 +73,19 @@ func newEgressFirewallRule(rawEgressFirewallRule egressfirewallapi.EgressFirewal
 		efr.to.dnsName = rawEgressFirewallRule.To.DNSName
 	} else {
 
-		_, _, err := net.ParseCIDR(rawEgressFirewallRule.To.CIDRSelector)
+		_, ipNet, err := net.ParseCIDR(rawEgressFirewallRule.To.CIDRSelector)
 		if err != nil {
 			return nil, err
 		}
 		efr.to.cidrSelector = rawEgressFirewallRule.To.CIDRSelector
+		intersect := false
+		for _, clusterSubnet := range config.Default.ClusterSubnets {
+			if clusterSubnet.CIDR.Contains(ipNet.IP) || ipNet.Contains(clusterSubnet.CIDR.IP) {
+				intersect = true
+				break
+			}
+		}
+		efr.to.clusterSubnetIntersection = intersect
 	}
 	efr.ports = rawEgressFirewallRule.Ports
 
@@ -268,9 +280,9 @@ func (oc *Controller) addEgressFirewallRules(ef *egressFirewall, hashedAddressSe
 		}
 		if rule.to.cidrSelector != "" {
 			if utilnet.IsIPv6CIDRString(rule.to.cidrSelector) {
-				matchTargets = []matchTarget{{matchKindV6CIDR, rule.to.cidrSelector}}
+				matchTargets = []matchTarget{{matchKindV6CIDR, rule.to.cidrSelector, rule.to.clusterSubnetIntersection}}
 			} else {
-				matchTargets = []matchTarget{{matchKindV4CIDR, rule.to.cidrSelector}}
+				matchTargets = []matchTarget{{matchKindV4CIDR, rule.to.cidrSelector, rule.to.clusterSubnetIntersection}}
 			}
 		} else {
 			// rule based on DNS NAME
@@ -280,10 +292,10 @@ func (oc *Controller) addEgressFirewallRules(ef *egressFirewall, hashedAddressSe
 			}
 			dnsNameIPv4ASHashName, dnsNameIPv6ASHashName := dnsNameAddressSets.GetASHashNames()
 			if dnsNameIPv4ASHashName != "" {
-				matchTargets = append(matchTargets, matchTarget{matchKindV4AddressSet, dnsNameIPv4ASHashName})
+				matchTargets = append(matchTargets, matchTarget{matchKindV4AddressSet, dnsNameIPv4ASHashName, rule.to.clusterSubnetIntersection})
 			}
 			if dnsNameIPv6ASHashName != "" {
-				matchTargets = append(matchTargets, matchTarget{matchKindV6AddressSet, dnsNameIPv6ASHashName})
+				matchTargets = append(matchTargets, matchTarget{matchKindV6AddressSet, dnsNameIPv6ASHashName, rule.to.clusterSubnetIntersection})
 			}
 		}
 		match := generateMatch(hashedAddressSetNameIPv4, hashedAddressSetNameIPv6, matchTargets, rule.ports)
@@ -353,6 +365,11 @@ func (oc *Controller) deleteEgressFirewallRules(externalID string) error {
 type matchTarget struct {
 	kind  matchKind
 	value string
+	// clusterSubnetIntersection is inherited from the egressFirewallRule destination.
+	// clusterSubnetIntersection is true, if egress firewall rule CIDRSelector intersects with clusterSubnet.
+	// Based on this flag we can omit clusterSubnet exclusion from the related ACL.
+	// For dns-based rules, EgressDNS won't add ips from clusterSubnet to the address set.
+	clusterSubnetIntersection bool
 }
 
 type matchKind int
@@ -401,6 +418,7 @@ func generateMatch(ipv4Source, ipv6Source string, destinations []matchTarget, ds
 		src = fmt.Sprintf("ip6.src == $%s", ipv6Source)
 	}
 
+	subnetExclusionRequired := false
 	for _, entry := range destinations {
 		if entry.value == "" {
 			continue
@@ -415,16 +433,20 @@ func generateMatch(ipv4Source, ipv6Source string, destinations []matchTarget, ds
 		} else {
 			dst = strings.Join([]string{dst, ipDst}, " || ")
 		}
+		if entry.clusterSubnetIntersection {
+			subnetExclusionRequired = true
+		}
 	}
-
 	match := fmt.Sprintf("(%s) && %s", dst, src)
 	if len(dstPorts) > 0 {
 		match = fmt.Sprintf("%s && %s", match, egressGetL4Match(dstPorts))
 	}
-
-	// TODO only add exclusion when egress firewall rule subnet intersects with cluster subnet
-	extraMatch = getClusterSubnetsExclusion()
-	return fmt.Sprintf("%s && %s", match, extraMatch)
+	// only add clusterSubnet exclusion if dst CIDR intersects with one of the clusterSubnets
+	if subnetExclusionRequired {
+		extraMatch = getClusterSubnetsExclusion()
+		match = fmt.Sprintf("%s && %s", match, extraMatch)
+	}
+	return match
 }
 
 // egressGetL4Match generates the rules for when ports are specified in an egressFirewall Rule

--- a/go-controller/pkg/ovn/egressfirewall_dns_test.go
+++ b/go-controller/pkg/ovn/egressfirewall_dns_test.go
@@ -94,6 +94,9 @@ func TestAdd(t *testing.T) {
 	test1IPv4 := "2.2.2.2"
 	test1IPv4Update := "3.3.3.3"
 	test1IPv6 := "2001:0db8:85a3:0000:0000:8a2e:0370:7334"
+	clusterSubnetStr := "10.128.0.0/14"
+	_, clusterSubnet, _ := net.ParseCIDR(clusterSubnetStr)
+	clusterSubnetIP := "10.128.0.1"
 	tests := []struct {
 		desc                       string
 		errExp                     bool
@@ -144,7 +147,56 @@ func TestAdd(t *testing.T) {
 				{"SetIPs", []string{"[]net.IP"}, []interface{}{nil}, 0, 1},
 			},
 		},
+		{
+			desc:       "EgressFirewall Add(dnsName) ignores ips from clusterSubnet",
+			errExp:     false,
+			syncTime:   5 * time.Minute,
+			dnsName:    test1DNSName,
+			configIPv4: true,
+			configIPv6: false,
 
+			dnsOpsMockHelper: []ovntest.TestifyMockHelper{
+				{"ClientConfigFromFile", []string{"string"}, []interface{}{&dns.ClientConfig{
+					Servers: []string{"1.1.1.1"},
+					Port:    "1234"}, nil}, 0, 1},
+				{"Fqdn", []string{"string"}, []interface{}{test1DNSName}, 0, 1},
+
+				{"SetQuestion", []string{"*dns.Msg", "string", "uint16"}, []interface{}{&dns.Msg{}}, 0, 1},
+				{"Exchange", []string{"*dns.Client", "*dns.Msg", "string"},
+					[]interface{}{&dns.Msg{Answer: []dns.RR{generateRR(test1DNSName, clusterSubnetIP, "300")}}, 500 * time.Second, nil}, 0, 1},
+			},
+			addressSetFactoryOpsHelper: []ovntest.TestifyMockHelper{
+				{"NewAddressSet", []string{"string", "[]net.IP"}, []interface{}{mockAddressSetOps, nil}, 0, 1},
+			},
+			addressSetOpsHelper: []ovntest.TestifyMockHelper{
+				{"SetIPs", []string{"[]net.IP"}, []interface{}{nil}, 0, 1},
+			},
+		},
+		{
+			desc:       "EgressFirewall Add(dnsName) ignores ips from clusterSubnet leaving other ips",
+			errExp:     false,
+			syncTime:   5 * time.Minute,
+			dnsName:    test1DNSName,
+			configIPv4: true,
+			configIPv6: false,
+
+			dnsOpsMockHelper: []ovntest.TestifyMockHelper{
+				{"ClientConfigFromFile", []string{"string"}, []interface{}{&dns.ClientConfig{
+					Servers: []string{"1.1.1.1"},
+					Port:    "1234"}, nil}, 0, 1},
+				{"Fqdn", []string{"string"}, []interface{}{test1DNSName}, 0, 1},
+
+				{"SetQuestion", []string{"*dns.Msg", "string", "uint16"}, []interface{}{&dns.Msg{}}, 0, 1},
+				{"Exchange", []string{"*dns.Client", "*dns.Msg", "string"},
+					[]interface{}{&dns.Msg{Answer: []dns.RR{generateRR(test1DNSName, test1IPv4, "300"), generateRR(test1DNSName, clusterSubnetIP, "300")}}, 500 * time.Second, nil}, 0, 1},
+			},
+			addressSetFactoryOpsHelper: []ovntest.TestifyMockHelper{
+				{"NewAddressSet", []string{"string", "[]net.IP"}, []interface{}{mockAddressSetOps, nil}, 0, 1},
+			},
+			addressSetOpsHelper: []ovntest.TestifyMockHelper{
+				{"SetIPs", []string{"[]net.IP"}, []interface{}{nil}, 0, 1},
+			},
+		},
 		{
 			desc:                     "EgressFirewall Add(dnsName) succeeds dual stack",
 			errExp:                   false,
@@ -209,6 +261,7 @@ func TestAdd(t *testing.T) {
 			testCh := make(chan struct{})
 			config.IPv4Mode = tc.configIPv4
 			config.IPv6Mode = tc.configIPv6
+			config.Default.ClusterSubnets = []config.CIDRNetworkEntry{{CIDR: clusterSubnet}}
 
 			for _, item := range tc.dnsOpsMockHelper {
 				call := mockDnsOps.On(item.OnCallMethodName)

--- a/go-controller/pkg/ovn/egressfirewall_test.go
+++ b/go-controller/pkg/ovn/egressfirewall_test.go
@@ -197,6 +197,25 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 
 					// Direction of both ACLs will be converted to
 					keepACL.Direction = t.DirectionToLPort
+					// subnet exclusion will be deleted
+					keepACL.Match = "(ip4.dst == 1.2.3.4/23) && ip4.src == $a10481622940199974102"
+
+					// egress firewall is updated by deleting and creating from scratch.
+					// since old acl won't be garbage-collected by the test server, it will stay,
+					// but won't be referenced from the switch
+					keepACLStale := libovsdbops.BuildACL(
+						"",
+						t.DirectionToLPort,
+						t.EgressFirewallStartPriority,
+						"(ip4.dst == 1.2.3.4/23) && ip4.src == $a10481622940199974102 && ip4.dst != 10.128.0.0/14",
+						nbdb.ACLActionAllow,
+						"",
+						"",
+						false,
+						map[string]string{"egressFirewall": "namespace1"},
+						nil,
+					)
+					keepACLStale.UUID = "keepACLStale-UUID"
 
 					// purgeACL ACL will be deleted when test server starts deleting dereferenced ACLs
 					// for now we need to update its fields, since it is present in the db
@@ -206,6 +225,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 						otherACL,
 						purgeACL,
 						keepACL,
+						keepACLStale,
 						nodeSwitch,
 						joinSwitch,
 						clusterRouter,
@@ -213,7 +233,6 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 					}
 
 					gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
-
 					return nil
 				}
 
@@ -259,7 +278,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 						"",
 						t.DirectionToLPort,
 						t.EgressFirewallStartPriority,
-						"(ip4.dst == 1.2.3.4/23) && ip4.src == $a10481622940199974102 && ip4.dst != 10.128.0.0/14",
+						"(ip4.dst == 1.2.3.4/23) && ip4.src == $a10481622940199974102",
 						nbdb.ACLActionAllow,
 						"",
 						"",
@@ -325,7 +344,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 						"",
 						t.DirectionToLPort,
 						t.EgressFirewallStartPriority,
-						"(ip6.dst == 2002::1234:abcd:ffff:c0a8:101/64) && (ip4.src == $a10481622940199974102 || ip6.src == $a10481620741176717680) && ip4.dst != 10.128.0.0/14",
+						"(ip6.dst == 2002::1234:abcd:ffff:c0a8:101/64) && (ip4.src == $a10481622940199974102 || ip6.src == $a10481620741176717680)",
 						nbdb.ACLActionAllow,
 						"",
 						"",
@@ -402,7 +421,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 						"",
 						t.DirectionToLPort,
 						t.EgressFirewallStartPriority,
-						"(ip4.dst == 1.2.3.4/23) && ip4.src == $a10481622940199974102 && ((udp && ( udp.dst == 100 ))) && ip4.dst != 10.128.0.0/14",
+						"(ip4.dst == 1.2.3.4/23) && ip4.src == $a10481622940199974102 && ((udp && ( udp.dst == 100 )))",
 						nbdb.ACLActionDrop,
 						"",
 						"",
@@ -469,7 +488,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 						"",
 						t.DirectionToLPort,
 						t.EgressFirewallStartPriority,
-						"(ip4.dst == 1.2.3.5/23) && ip4.src == $a10481622940199974102 && ((tcp && ( tcp.dst == 100 ))) && ip4.dst != 10.128.0.0/14",
+						"(ip4.dst == 1.2.3.5/23) && ip4.src == $a10481622940199974102 && ((tcp && ( tcp.dst == 100 )))",
 						nbdb.ACLActionAllow,
 						"",
 						"",
@@ -550,7 +569,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 						"",
 						t.DirectionToLPort,
 						t.EgressFirewallStartPriority,
-						"(ip4.dst == 1.2.3.4/23) && ip4.src == $a10481622940199974102 && ip4.dst != 10.128.0.0/14",
+						"(ip4.dst == 1.2.3.4/23) && ip4.src == $a10481622940199974102",
 						nbdb.ACLActionAllow,
 						"",
 						"",
@@ -577,7 +596,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 						"",
 						t.DirectionToLPort,
 						t.EgressFirewallStartPriority,
-						"(ip4.dst == 1.2.3.4/23) && ip4.src == $a10481622940199974102 && ip4.dst != 10.128.0.0/14",
+						"(ip4.dst == 1.2.3.4/23) && ip4.src == $a10481622940199974102",
 						nbdb.ACLActionAllow,
 						"",
 						"",
@@ -644,7 +663,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 						"",
 						t.DirectionToLPort,
 						t.EgressFirewallStartPriority,
-						"(ip4.dst == 1.2.3.5/23) && ip4.src == $a10481622940199974102 && ((tcp && ( tcp.dst == 100 ))) && ip4.dst != 10.128.0.0/14",
+						"(ip4.dst == 1.2.3.5/23) && ip4.src == $a10481622940199974102 && ((tcp && ( tcp.dst == 100 )))",
 						nbdb.ACLActionAllow,
 						"",
 						"",
@@ -751,7 +770,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 						"",
 						t.DirectionToLPort,
 						t.EgressFirewallStartPriority,
-						"(ip4.dst == 1.2.3.4/23) && ip4.src == $a10481622940199974102 && ip4.dst != 10.128.0.0/14",
+						"(ip4.dst == 1.2.3.4/23) && ip4.src == $a10481622940199974102",
 						nbdb.ACLActionAllow,
 						"",
 						"",
@@ -807,7 +826,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 						"",
 						t.DirectionToLPort,
 						t.EgressFirewallStartPriority,
-						"(ip4.dst == 1.2.3.4/23) && ip4.src == $a10481622940199974102 && ip4.dst != 10.128.0.0/14",
+						"(ip4.dst == 1.2.3.4/23) && ip4.src == $a10481622940199974102",
 						nbdb.ACLActionAllow,
 						"",
 						"",
@@ -826,14 +845,80 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 
 				err := app.Run([]string{app.Name})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			})
+			ginkgo.It(fmt.Sprintf("correctly creates an egressfirewall with subnet exclusion, gateway mode %s", gwMode), func() {
+				app.Action = func(ctx *cli.Context) error {
+					clusterSubnetStr := "10.128.0.0/14"
+					_, clusterSubnet, _ := net.ParseCIDR(clusterSubnetStr)
+					config.Default.ClusterSubnets = []config.CIDRNetworkEntry{{CIDR: clusterSubnet}}
 
+					namespace1 := *newNamespace("namespace1")
+					egressFirewall := newEgressFirewallObject("default", namespace1.Name, []egressfirewallapi.EgressFirewallRule{
+						{
+							Type: "Deny",
+							To: egressfirewallapi.EgressFirewallDestination{
+								CIDRSelector: "0.0.0.0/0",
+							},
+						},
+					})
+					fakeOVN.startWithDBSetup(dbSetup,
+						&egressfirewallapi.EgressFirewallList{
+							Items: []egressfirewallapi.EgressFirewall{
+								*egressFirewall,
+							},
+						},
+						&v1.NamespaceList{
+							Items: []v1.Namespace{
+								namespace1,
+							},
+						},
+						&v1.NodeList{
+							Items: []v1.Node{
+								{
+									Status: v1.NodeStatus{
+										Phase: v1.NodeRunning,
+									},
+									ObjectMeta: newObjectMeta(node1Name, ""),
+								},
+							},
+						})
+
+					err := fakeOVN.controller.WatchNamespaces()
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					_, err = fakeOVN.fakeClient.EgressFirewallClient.K8sV1().EgressFirewalls(egressFirewall.Namespace).Get(context.TODO(), egressFirewall.Name, metav1.GetOptions{})
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+					fakeOVN.controller.WatchEgressFirewall()
+
+					acl := libovsdbops.BuildACL(
+						"",
+						nbdb.ACLDirectionToLport,
+						t.EgressFirewallStartPriority,
+						"(ip4.dst == 0.0.0.0/0) && ip4.src == $a10481622940199974102 && ip4.dst != "+clusterSubnetStr,
+						nbdb.ACLActionDrop,
+						"",
+						"",
+						false,
+						map[string]string{egressFirewallACLExtIdKey: "namespace1"},
+						nil,
+					)
+					acl.UUID = "acl-UUID"
+
+					// new ACL will be added to the port group
+					clusterPortGroup.ACLs = []string{acl.UUID}
+					expectedDatabaseState := append(initialData, acl)
+					gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+
+					return nil
+				}
+				err := app.Run([]string{app.Name})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			})
 		}
 	})
 })
 
 var _ = ginkgo.Describe("OVN test basic functions", func() {
-
 	ginkgo.It("computes correct L4Match", func() {
 		type testcase struct {
 			ports         []egressfirewallapi.EgressFirewallPort
@@ -890,75 +975,106 @@ var _ = ginkgo.Describe("OVN test basic functions", func() {
 	})
 	ginkgo.It("computes correct match function", func() {
 		type testcase struct {
-			internalCIDRs []string
-			ipv4source    string
-			ipv6source    string
-			ipv4Mode      bool
-			ipv6Mode      bool
-			destinations  []matchTarget
-			ports         []egressfirewallapi.EgressFirewallPort
-			output        string
+			clusterSubnets []string
+			ipv4source     string
+			ipv6source     string
+			ipv4Mode       bool
+			ipv6Mode       bool
+			destinations   []matchTarget
+			ports          []egressfirewallapi.EgressFirewallPort
+			output         string
 		}
 		testcases := []testcase{
 			{
-				internalCIDRs: []string{"10.128.0.0/14"},
-				ipv4source:    "testv4",
-				ipv6source:    "",
-				ipv4Mode:      true,
-				ipv6Mode:      false,
-				destinations:  []matchTarget{{matchKindV4CIDR, "1.2.3.4/32"}},
-				ports:         nil,
-				output:        "(ip4.dst == 1.2.3.4/32) && ip4.src == $testv4 && ip4.dst != 10.128.0.0/14",
+				clusterSubnets: []string{"10.128.0.0/14"},
+				ipv4source:     "testv4",
+				ipv6source:     "",
+				ipv4Mode:       true,
+				ipv6Mode:       false,
+				destinations:   []matchTarget{{matchKindV4CIDR, "1.2.3.4/32", false}},
+				ports:          nil,
+				output:         "(ip4.dst == 1.2.3.4/32) && ip4.src == $testv4",
 			},
 			{
-				internalCIDRs: []string{"10.128.0.0/14", "2002:0:0:1234::/64"},
-				ipv4source:    "testv4",
-				ipv6source:    "testv6",
-				ipv4Mode:      true,
-				ipv6Mode:      true,
-				destinations:  []matchTarget{{matchKindV4CIDR, "1.2.3.4/32"}},
-				ports:         nil,
-				output:        "(ip4.dst == 1.2.3.4/32) && (ip4.src == $testv4 || ip6.src == $testv6) && ip4.dst != 10.128.0.0/14 && ip6.dst != 2002:0:0:1234::/64",
+				clusterSubnets: []string{"10.128.0.0/14", "2002:0:0:1234::/64"},
+				ipv4source:     "testv4",
+				ipv6source:     "testv6",
+				ipv4Mode:       true,
+				ipv6Mode:       true,
+				destinations:   []matchTarget{{matchKindV4CIDR, "1.2.3.4/32", false}},
+				ports:          nil,
+				output:         "(ip4.dst == 1.2.3.4/32) && (ip4.src == $testv4 || ip6.src == $testv6)",
 			},
 			{
-				internalCIDRs: []string{"10.128.0.0/14", "2002:0:0:1234::/64"},
-				ipv4source:    "testv4",
-				ipv6source:    "testv6",
-				ipv4Mode:      true,
-				ipv6Mode:      true,
-				destinations:  []matchTarget{{matchKindV4AddressSet, "destv4"}, {matchKindV6AddressSet, "destv6"}},
-				ports:         nil,
-				output:        "(ip4.dst == $destv4 || ip6.dst == $destv6) && (ip4.src == $testv4 || ip6.src == $testv6) && ip4.dst != 10.128.0.0/14 && ip6.dst != 2002:0:0:1234::/64",
+				clusterSubnets: []string{"10.128.0.0/14", "2002:0:0:1234::/64"},
+				ipv4source:     "testv4",
+				ipv6source:     "testv6",
+				ipv4Mode:       true,
+				ipv6Mode:       true,
+				destinations:   []matchTarget{{matchKindV4AddressSet, "destv4", false}, {matchKindV6AddressSet, "destv6", false}},
+				ports:          nil,
+				output:         "(ip4.dst == $destv4 || ip6.dst == $destv6) && (ip4.src == $testv4 || ip6.src == $testv6)",
 			},
 			{
-				internalCIDRs: []string{"10.128.0.0/14"},
-				ipv4source:    "testv4",
-				ipv6source:    "",
-				ipv4Mode:      true,
-				ipv6Mode:      false,
-				destinations:  []matchTarget{{matchKindV4AddressSet, "destv4"}, {matchKindV6AddressSet, ""}},
-				ports:         nil,
-				output:        "(ip4.dst == $destv4) && ip4.src == $testv4 && ip4.dst != 10.128.0.0/14",
+				clusterSubnets: []string{"10.128.0.0/14"},
+				ipv4source:     "testv4",
+				ipv6source:     "",
+				ipv4Mode:       true,
+				ipv6Mode:       false,
+				destinations:   []matchTarget{{matchKindV4AddressSet, "destv4", false}, {matchKindV6AddressSet, "", false}},
+				ports:          nil,
+				output:         "(ip4.dst == $destv4) && ip4.src == $testv4",
 			},
 			{
-				internalCIDRs: []string{"10.128.0.0/14", "2002:0:0:1234::/64"},
-				ipv4source:    "testv4",
-				ipv6source:    "testv6",
-				ipv4Mode:      true,
-				ipv6Mode:      true,
-				destinations:  []matchTarget{{matchKindV6CIDR, "2001::/64"}},
-				ports:         nil,
-				output:        "(ip6.dst == 2001::/64) && (ip4.src == $testv4 || ip6.src == $testv6) && ip4.dst != 10.128.0.0/14 && ip6.dst != 2002:0:0:1234::/64",
+				clusterSubnets: []string{"10.128.0.0/14", "2002:0:0:1234::/64"},
+				ipv4source:     "testv4",
+				ipv6source:     "testv6",
+				ipv4Mode:       true,
+				ipv6Mode:       true,
+				destinations:   []matchTarget{{matchKindV6CIDR, "2001::/64", false}},
+				ports:          nil,
+				output:         "(ip6.dst == 2001::/64) && (ip4.src == $testv4 || ip6.src == $testv6)",
 			},
 			{
-				internalCIDRs: []string{"2002:0:0:1234::/64"},
-				ipv4source:    "",
-				ipv6source:    "testv6",
-				ipv4Mode:      false,
-				ipv6Mode:      true,
-				destinations:  []matchTarget{{matchKindV6AddressSet, "destv6"}},
-				ports:         nil,
-				output:        "(ip6.dst == $destv6) && ip6.src == $testv6 && ip6.dst != 2002:0:0:1234::/64",
+				clusterSubnets: []string{"2002:0:0:1234::/64"},
+				ipv4source:     "",
+				ipv6source:     "testv6",
+				ipv4Mode:       false,
+				ipv6Mode:       true,
+				destinations:   []matchTarget{{matchKindV6AddressSet, "destv6", false}},
+				ports:          nil,
+				output:         "(ip6.dst == $destv6) && ip6.src == $testv6",
+			},
+			// with cluster subnet exclusion
+			{
+				clusterSubnets: []string{"10.128.0.0/14"},
+				ipv4source:     "testv4",
+				ipv6source:     "",
+				ipv4Mode:       true,
+				ipv6Mode:       false,
+				destinations:   []matchTarget{{matchKindV4CIDR, "1.2.3.4/32", true}},
+				ports:          nil,
+				output:         "(ip4.dst == 1.2.3.4/32) && ip4.src == $testv4 && ip4.dst != 10.128.0.0/14",
+			},
+			{
+				clusterSubnets: []string{"2002:0:0:1234::/64"},
+				ipv4source:     "",
+				ipv6source:     "testv6",
+				ipv4Mode:       false,
+				ipv6Mode:       true,
+				destinations:   []matchTarget{{matchKindV6AddressSet, "destv6", true}},
+				ports:          nil,
+				output:         "(ip6.dst == $destv6) && ip6.src == $testv6 && ip6.dst != 2002:0:0:1234::/64",
+			},
+			{
+				clusterSubnets: []string{"10.128.0.0/14", "2002:0:0:1234::/64"},
+				ipv4source:     "testv4",
+				ipv6source:     "testv6",
+				ipv4Mode:       true,
+				ipv6Mode:       true,
+				destinations:   []matchTarget{{matchKindV4CIDR, "1.2.3.4/32", true}},
+				ports:          nil,
+				output:         "(ip4.dst == 1.2.3.4/32) && (ip4.src == $testv4 || ip6.src == $testv6) && ip4.dst != 10.128.0.0/14 && ip6.dst != 2002:0:0:1234::/64",
 			},
 		}
 
@@ -966,7 +1082,7 @@ var _ = ginkgo.Describe("OVN test basic functions", func() {
 			config.IPv4Mode = tc.ipv4Mode
 			config.IPv6Mode = tc.ipv6Mode
 			subnets := []config.CIDRNetworkEntry{}
-			for _, clusterCIDR := range tc.internalCIDRs {
+			for _, clusterCIDR := range tc.clusterSubnets {
 				_, cidr, _ := net.ParseCIDR(clusterCIDR)
 				subnets = append(subnets, config.CIDRNetworkEntry{CIDR: cidr})
 			}
@@ -974,7 +1090,7 @@ var _ = ginkgo.Describe("OVN test basic functions", func() {
 
 			config.Gateway.Mode = config.GatewayModeShared
 			matchExpression := generateMatch(tc.ipv4source, tc.ipv6source, tc.destinations, tc.ports)
-			gomega.Expect(tc.output).To(gomega.Equal(matchExpression))
+			gomega.Expect(matchExpression).To(gomega.Equal(tc.output))
 		}
 	})
 	ginkgo.It("correctly parses egressFirewallRules", func() {
@@ -984,6 +1100,7 @@ var _ = ginkgo.Describe("OVN test basic functions", func() {
 			err                bool
 			errOutput          string
 			output             egressFirewallRule
+			clusterSubnets     []string
 		}
 		testcases := []testcase{
 			{
@@ -1000,6 +1117,7 @@ var _ = ginkgo.Describe("OVN test basic functions", func() {
 				},
 			},
 			{
+				clusterSubnets: []string{"10.128.0.0/16"},
 				egressFirewallRule: egressfirewallapi.EgressFirewallRule{
 					Type: egressfirewallapi.EgressFirewallRuleAllow,
 					To:   egressfirewallapi.EgressFirewallDestination{CIDRSelector: "1.2.3./32"},
@@ -1010,27 +1128,134 @@ var _ = ginkgo.Describe("OVN test basic functions", func() {
 				output:    egressFirewallRule{},
 			},
 			{
+				clusterSubnets: []string{"2002:0:0:1234::/64"},
 				egressFirewallRule: egressfirewallapi.EgressFirewallRule{
 					Type: egressfirewallapi.EgressFirewallRuleAllow,
-					To:   egressfirewallapi.EgressFirewallDestination{CIDRSelector: "2002::1234:abcd:ffff:c0a8:101/64"},
+					To:   egressfirewallapi.EgressFirewallDestination{CIDRSelector: "2002::1235:abcd:ffff:c0a8:101/64"},
 				},
 				id:  2,
 				err: false,
 				output: egressFirewallRule{
 					id:     2,
 					access: egressfirewallapi.EgressFirewallRuleAllow,
-					to:     destination{cidrSelector: "2002::1234:abcd:ffff:c0a8:101/64"},
+					to:     destination{cidrSelector: "2002::1235:abcd:ffff:c0a8:101/64"},
+				},
+			},
+			// check clusterSubnet intersection
+			{
+				clusterSubnets: []string{"10.128.0.0/16"},
+				egressFirewallRule: egressfirewallapi.EgressFirewallRule{
+					Type: egressfirewallapi.EgressFirewallRuleAllow,
+					To:   egressfirewallapi.EgressFirewallDestination{CIDRSelector: "1.2.3.4/32"},
+				},
+				id:  1,
+				err: false,
+				output: egressFirewallRule{
+					id:     1,
+					access: egressfirewallapi.EgressFirewallRuleAllow,
+					to:     destination{cidrSelector: "1.2.3.4/32", clusterSubnetIntersection: false},
+				},
+			},
+			{
+				clusterSubnets: []string{"10.128.0.0/16"},
+				egressFirewallRule: egressfirewallapi.EgressFirewallRule{
+					Type: egressfirewallapi.EgressFirewallRuleAllow,
+					To:   egressfirewallapi.EgressFirewallDestination{CIDRSelector: "10.128.3.4/32"},
+				},
+				id:  1,
+				err: false,
+				output: egressFirewallRule{
+					id:     1,
+					access: egressfirewallapi.EgressFirewallRuleAllow,
+					to:     destination{cidrSelector: "10.128.3.4/32", clusterSubnetIntersection: true},
+				},
+			},
+			{
+				clusterSubnets: []string{"10.128.0.0/16"},
+				egressFirewallRule: egressfirewallapi.EgressFirewallRule{
+					Type: egressfirewallapi.EgressFirewallRuleAllow,
+					To:   egressfirewallapi.EgressFirewallDestination{CIDRSelector: "10.128.3.0/24"},
+				},
+				id:  1,
+				err: false,
+				output: egressFirewallRule{
+					id:     1,
+					access: egressfirewallapi.EgressFirewallRuleAllow,
+					to:     destination{cidrSelector: "10.128.3.0/24", clusterSubnetIntersection: true},
+				},
+			},
+			{
+				clusterSubnets: []string{"2002:0:0:1234::/64"},
+				egressFirewallRule: egressfirewallapi.EgressFirewallRule{
+					Type: egressfirewallapi.EgressFirewallRuleAllow,
+					To:   egressfirewallapi.EgressFirewallDestination{CIDRSelector: "2002:0:0:1234:0001::/80"},
+				},
+				id:  1,
+				err: false,
+				output: egressFirewallRule{
+					id:     1,
+					access: egressfirewallapi.EgressFirewallRuleAllow,
+					to:     destination{cidrSelector: "2002:0:0:1234:0001::/80", clusterSubnetIntersection: true},
+				},
+			},
+			{
+				clusterSubnets: []string{"2002:0:0:1234::/64"},
+				egressFirewallRule: egressfirewallapi.EgressFirewallRule{
+					Type: egressfirewallapi.EgressFirewallRuleAllow,
+					To:   egressfirewallapi.EgressFirewallDestination{CIDRSelector: "2002:0:0:1235::/80"},
+				},
+				id:  1,
+				err: false,
+				output: egressFirewallRule{
+					id:     1,
+					access: egressfirewallapi.EgressFirewallRuleAllow,
+					to:     destination{cidrSelector: "2002:0:0:1235::/80", clusterSubnetIntersection: false},
+				},
+			},
+			// dual stack
+			{
+				clusterSubnets: []string{"10.128.0.0/16", "2002:0:0:1234::/64"},
+				egressFirewallRule: egressfirewallapi.EgressFirewallRule{
+					Type: egressfirewallapi.EgressFirewallRuleAllow,
+					To:   egressfirewallapi.EgressFirewallDestination{CIDRSelector: "10.128.3.4/32"},
+				},
+				id:  1,
+				err: false,
+				output: egressFirewallRule{
+					id:     1,
+					access: egressfirewallapi.EgressFirewallRuleAllow,
+					to:     destination{cidrSelector: "10.128.3.4/32", clusterSubnetIntersection: true},
+				},
+			},
+			{
+				clusterSubnets: []string{"10.128.0.0/16", "2002:0:0:1234::/64"},
+				egressFirewallRule: egressfirewallapi.EgressFirewallRule{
+					Type: egressfirewallapi.EgressFirewallRuleAllow,
+					To:   egressfirewallapi.EgressFirewallDestination{CIDRSelector: "2002:0:0:1234:0001::/80"},
+				},
+				id:  1,
+				err: false,
+				output: egressFirewallRule{
+					id:     1,
+					access: egressfirewallapi.EgressFirewallRuleAllow,
+					to:     destination{cidrSelector: "2002:0:0:1234:0001::/80", clusterSubnetIntersection: true},
 				},
 			},
 		}
 		for _, tc := range testcases {
+			subnets := []config.CIDRNetworkEntry{}
+			for _, clusterCIDR := range tc.clusterSubnets {
+				_, cidr, _ := net.ParseCIDR(clusterCIDR)
+				subnets = append(subnets, config.CIDRNetworkEntry{CIDR: cidr})
+			}
+			config.Default.ClusterSubnets = subnets
 			output, err := newEgressFirewallRule(tc.egressFirewallRule, tc.id)
 			if tc.err == true {
 				gomega.Expect(err).To(gomega.HaveOccurred())
 				gomega.Expect(tc.errOutput).To(gomega.Equal(err.Error()))
 			} else {
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				gomega.Expect(tc.output).To(gomega.Equal(*output))
+				gomega.Expect(*output).To(gomega.Equal(tc.output))
 			}
 		}
 	})

--- a/go-controller/pkg/ovn/egressfirewall_test.go
+++ b/go-controller/pkg/ovn/egressfirewall_test.go
@@ -8,17 +8,16 @@ import (
 
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
+	"github.com/urfave/cli/v2"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	egressfirewallapi "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressfirewall/v1"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdbops"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
 	addressset "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/address_set"
-
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
 	libovsdbtest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
 	t "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
-	"github.com/urfave/cli/v2"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -44,10 +43,14 @@ func newEgressFirewallObject(name, namespace string, egressRules []egressfirewal
 	}
 }
 
-var _ = ginkgo.Describe("OVN EgressFirewall Operations for local gateway mode", func() {
+var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 	var (
-		app     *cli.App
-		fakeOVN *FakeOVN
+		app                    *cli.App
+		fakeOVN                *FakeOVN
+		clusterPortGroup       *nbdb.PortGroup
+		nodeSwitch, joinSwitch *nbdb.LogicalSwitch
+		initialData            []libovsdbtest.TestData
+		dbSetup                libovsdbtest.TestSetup
 	)
 	const (
 		node1Name string = "node1"
@@ -62,7 +65,6 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations for local gateway mode", 
 	ginkgo.BeforeEach(func() {
 		// Restore global default values before each testcase
 		config.PrepareTestConfig()
-		config.Gateway.Mode = config.GatewayModeLocal
 		config.OVNKubernetesFeature.EnableEgressFirewall = true
 
 		app = cli.NewApp()
@@ -70,6 +72,24 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations for local gateway mode", 
 		app.Flags = config.Flags
 
 		fakeOVN = NewFakeOVN()
+		clusterPortGroup = newClusterPortGroup()
+		nodeSwitch = &nbdb.LogicalSwitch{
+			UUID: node1Name + "-UUID",
+			Name: node1Name,
+		}
+		joinSwitch = &nbdb.LogicalSwitch{
+			UUID: "join-UUID",
+			Name: "join",
+		}
+		initialData = []libovsdbtest.TestData{
+			nodeSwitch,
+			joinSwitch,
+			clusterPortGroup,
+			clusterRouter,
+		}
+		dbSetup = libovsdbtest.TestSetup{
+			NBData: initialData,
+		}
 	})
 
 	ginkgo.AfterEach(func() {
@@ -77,1569 +97,739 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations for local gateway mode", 
 	})
 
 	ginkgo.Context("on startup", func() {
-		ginkgo.It("reconciles existing and non-existing egressfirewalls", func() {
-			app.Action = func(ctx *cli.Context) error {
-				const (
-					node1Name string = "node1"
-				)
+		for _, gwMode := range []config.GatewayMode{config.GatewayModeLocal, config.GatewayModeShared} {
+			config.Gateway.Mode = gwMode
+			ginkgo.It(fmt.Sprintf("reconciles stale ACLs, gateway mode %s", gwMode), func() {
+				app.Action = func(ctx *cli.Context) error {
+					purgeACL := libovsdbops.BuildACL(
+						"",
+						t.DirectionFromLPort,
+						t.EgressFirewallStartPriority,
+						"",
+						nbdb.ACLActionDrop,
+						"",
+						"",
+						false,
+						map[string]string{egressFirewallACLExtIdKey: "none"},
+						nil,
+					)
+					purgeACL.UUID = "purgeACL-UUID"
 
-				purgeACL := libovsdbops.BuildACL(
-					"",
-					t.DirectionFromLPort,
-					t.EgressFirewallStartPriority,
-					"",
-					nbdb.ACLActionDrop,
-					"",
-					"",
-					false,
-					map[string]string{egressFirewallACLExtIdKey: "none"},
-					nil,
-				)
-				purgeACL.UUID = "purgeACL-UUID"
+					namespace1 := *newNamespace("namespace1")
+					egressFirewall := newEgressFirewallObject("default", namespace1.Name, []egressfirewallapi.EgressFirewallRule{
+						{
+							Type: "Allow",
+							To: egressfirewallapi.EgressFirewallDestination{
+								CIDRSelector: "1.2.3.4/23",
+							},
+						},
+					})
+					keepACL := libovsdbops.BuildACL(
+						"",
+						t.DirectionFromLPort,
+						t.EgressFirewallStartPriority,
+						"(ip4.dst == 1.2.3.4/23) && ip4.src == $a10481622940199974102 && ip4.dst != 10.128.0.0/14",
+						nbdb.ACLActionAllow,
+						"",
+						"",
+						false,
+						map[string]string{egressFirewallACLExtIdKey: namespace1.Name},
+						nil,
+					)
+					keepACL.UUID = "keepACL-UUID"
 
-				keepACL := libovsdbops.BuildACL(
-					"",
-					t.DirectionFromLPort,
-					t.EgressFirewallStartPriority-1,
-					"",
-					nbdb.ACLActionDrop,
-					"",
-					"",
-					false,
-					map[string]string{egressFirewallACLExtIdKey: "default"},
-					nil,
-				)
-				keepACL.UUID = "keepACL-UUID"
+					// this ACL is not in the egress firewall priority range and should be untouched
+					otherACL := libovsdbops.BuildACL(
+						"",
+						t.DirectionFromLPort,
+						t.MinimumReservedEgressFirewallPriority-1,
+						"",
+						nbdb.ACLActionDrop,
+						"",
+						"",
+						false,
+						map[string]string{egressFirewallACLExtIdKey: "default"},
+						nil,
+					)
+					otherACL.UUID = "otherACL-UUID"
 
-				// this ACL is not in the egress firewall priority range and should be untouched
-				otherACL := libovsdbops.BuildACL(
-					"",
-					t.DirectionFromLPort,
-					t.MinimumReservedEgressFirewallPriority-1,
-					"",
-					nbdb.ACLActionDrop,
-					"",
-					"",
-					false,
-					map[string]string{egressFirewallACLExtIdKey: "default"},
-					nil,
-				)
-				otherACL.UUID = "otherACL-UUID"
+					nodeSwitch.ACLs = []string{purgeACL.UUID, keepACL.UUID}
+					joinSwitch.ACLs = []string{purgeACL.UUID, keepACL.UUID}
 
-				InitialNodeSwitch := &nbdb.LogicalSwitch{
-					UUID: node1Name + "-UUID",
-					Name: node1Name,
-					ACLs: []string{purgeACL.UUID, keepACL.UUID},
-				}
-				InitialJoinSwitch := &nbdb.LogicalSwitch{
-					UUID: "join-UUID",
-					Name: "join",
-					ACLs: []string{purgeACL.UUID, keepACL.UUID},
-				}
+					dbSetup := libovsdbtest.TestSetup{
+						NBData: []libovsdbtest.TestData{
+							otherACL,
+							purgeACL,
+							keepACL,
+							nodeSwitch,
+							joinSwitch,
+							clusterRouter,
+							clusterPortGroup,
+						},
+					}
 
-				dbSetup := libovsdbtest.TestSetup{
-					NBData: []libovsdbtest.TestData{
+					fakeOVN.startWithDBSetup(dbSetup,
+						&v1.NodeList{
+							Items: []v1.Node{
+								{
+									Status: v1.NodeStatus{
+										Phase: v1.NodeRunning,
+									},
+									ObjectMeta: newObjectMeta(node1Name, ""),
+								},
+							},
+						})
+
+					// only create one egressFirewall
+					_, err := fakeOVN.fakeClient.EgressFirewallClient.K8sV1().EgressFirewalls(namespace1.Name).
+						Create(context.TODO(), egressFirewall, metav1.CreateOptions{})
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+					fakeOVN.controller.WatchEgressFirewall()
+
+					// Both ACLs will be removed from the join switch
+					joinSwitch.ACLs = nil
+					// Both ACLs will be removed from the node switch
+					nodeSwitch.ACLs = nil
+
+					// keepACL will be added to the clusterPortGroup
+					clusterPortGroup.ACLs = []string{keepACL.UUID}
+
+					// Direction of both ACLs will be converted to
+					keepACL.Direction = t.DirectionToLPort
+
+					// purgeACL ACL will be deleted when test server starts deleting dereferenced ACLs
+					// for now we need to update its fields, since it is present in the db
+					purgeACL.Direction = t.DirectionToLPort
+
+					expectedDatabaseState := []libovsdb.TestData{
 						otherACL,
 						purgeACL,
 						keepACL,
-						InitialNodeSwitch,
-						InitialJoinSwitch,
+						nodeSwitch,
+						joinSwitch,
 						clusterRouter,
-					},
+						clusterPortGroup,
+					}
+
+					gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+
+					return nil
 				}
 
-				fakeOVN.startWithDBSetup(dbSetup,
-					&v1.NodeList{
-						Items: []v1.Node{
-							{
-								Status: v1.NodeStatus{
-									Phase: v1.NodeRunning,
-								},
-								ObjectMeta: newObjectMeta(node1Name, ""),
+				err := app.Run([]string{app.Name})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			})
+			ginkgo.It(fmt.Sprintf("reconciles an existing egressFirewall with IPv4 CIDR, gateway mode %s", gwMode), func() {
+				app.Action = func(ctx *cli.Context) error {
+					namespace1 := *newNamespace("namespace1")
+					egressFirewall := newEgressFirewallObject("default", namespace1.Name, []egressfirewallapi.EgressFirewallRule{
+						{
+							Type: "Allow",
+							To: egressfirewallapi.EgressFirewallDestination{
+								CIDRSelector: "1.2.3.4/23",
 							},
 						},
 					})
 
-				// only create one egressFirewall
-				_, err := fakeOVN.fakeClient.EgressFirewallClient.K8sV1().EgressFirewalls("default").Create(context.TODO(), &egressfirewallapi.EgressFirewall{}, metav1.CreateOptions{})
+					fakeOVN.startWithDBSetup(dbSetup,
+						&egressfirewallapi.EgressFirewallList{
+							Items: []egressfirewallapi.EgressFirewall{
+								*egressFirewall,
+							},
+						},
+						&v1.NodeList{
+							Items: []v1.Node{
+								{
+									Status: v1.NodeStatus{
+										Phase: v1.NodeRunning,
+									},
+									ObjectMeta: newObjectMeta(node1Name, ""),
+								},
+							},
+						})
+
+					fakeOVN.controller.WatchEgressFirewall()
+
+					_, err := fakeOVN.fakeClient.EgressFirewallClient.K8sV1().EgressFirewalls(egressFirewall.Namespace).Get(context.TODO(), egressFirewall.Name, metav1.GetOptions{})
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+					ipv4ACL := libovsdbops.BuildACL(
+						"",
+						t.DirectionToLPort,
+						t.EgressFirewallStartPriority,
+						"(ip4.dst == 1.2.3.4/23) && ip4.src == $a10481622940199974102 && ip4.dst != 10.128.0.0/14",
+						nbdb.ACLActionAllow,
+						"",
+						"",
+						false,
+						map[string]string{egressFirewallACLExtIdKey: "namespace1"},
+						nil,
+					)
+					ipv4ACL.UUID = "ipv4ACL-UUID"
+
+					// new ACL will be added to the port group
+					clusterPortGroup.ACLs = []string{ipv4ACL.UUID}
+					expectedDatabaseState := append(initialData, ipv4ACL)
+					gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+
+					return nil
+				}
+
+				err := app.Run([]string{app.Name})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-				fakeOVN.controller.WatchEgressFirewall()
-
-				// Both ACLS will be removed from the join switch
-				finalJoinSwitch := &nbdb.LogicalSwitch{
-					UUID: InitialJoinSwitch.UUID,
-					Name: InitialJoinSwitch.Name,
-				}
-
-				// stale ACL will be removed from the node switch
-				finalNodeSwitch := &nbdb.LogicalSwitch{
-					UUID: InitialNodeSwitch.UUID,
-					Name: InitialNodeSwitch.Name,
-					ACLs: []string{keepACL.UUID},
-				}
-
-				// Direction of both ACLs will be converted to
-				keepACL.Direction = t.DirectionToLPort
-
-				// purgeACL ACL will be deleted when test server starts deleting dereferenced ACLs
-				// for now we need to update its fields, since it is present in the db
-				purgeACL.Direction = t.DirectionToLPort
-
-				expectedDatabaseState := []libovsdb.TestData{
-					otherACL,
-					purgeACL,
-					keepACL,
-					finalNodeSwitch,
-					finalJoinSwitch,
-					clusterRouter,
-				}
-
-				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
-
-				return nil
-			}
-
-			err := app.Run([]string{app.Name})
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-		})
-		ginkgo.It("reconciles an existing egressFirewall with IPv4 CIDR", func() {
-			app.Action = func(ctx *cli.Context) error {
-				const (
-					node1Name string = "node1"
-				)
-
-				InitialNodeSwitch := &nbdb.LogicalSwitch{
-					UUID: node1Name + "-UUID",
-					Name: node1Name,
-				}
-
-				dbSetup := libovsdbtest.TestSetup{
-					NBData: []libovsdbtest.TestData{
-						InitialNodeSwitch,
-						clusterRouter,
-					},
-				}
-
-				namespace1 := *newNamespace("namespace1")
-				egressFirewall := newEgressFirewallObject("default", namespace1.Name, []egressfirewallapi.EgressFirewallRule{
-					{
-						Type: "Allow",
-						To: egressfirewallapi.EgressFirewallDestination{
-							CIDRSelector: "1.2.3.4/23",
-						},
-					},
-				})
-
-				fakeOVN.startWithDBSetup(dbSetup,
-					&egressfirewallapi.EgressFirewallList{
-						Items: []egressfirewallapi.EgressFirewall{
-							*egressFirewall,
-						},
-					},
-					&v1.NodeList{
-						Items: []v1.Node{
-							{
-								Status: v1.NodeStatus{
-									Phase: v1.NodeRunning,
-								},
-								ObjectMeta: newObjectMeta(node1Name, ""),
+			})
+			ginkgo.It(fmt.Sprintf("reconciles an existing egressFirewall with IPv6 CIDR, gateway mode %s", gwMode), func() {
+				app.Action = func(ctx *cli.Context) error {
+					namespace1 := *newNamespace("namespace1")
+					egressFirewall := newEgressFirewallObject("default", namespace1.Name, []egressfirewallapi.EgressFirewallRule{
+						{
+							Type: "Allow",
+							To: egressfirewallapi.EgressFirewallDestination{
+								CIDRSelector: "2002::1234:abcd:ffff:c0a8:101/64",
 							},
 						},
 					})
 
-				fakeOVN.controller.WatchEgressFirewall()
-
-				_, err := fakeOVN.fakeClient.EgressFirewallClient.K8sV1().EgressFirewalls(egressFirewall.Namespace).Get(context.TODO(), egressFirewall.Name, metav1.GetOptions{})
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-				ipv4ACL := libovsdbops.BuildACL(
-					"",
-					t.DirectionToLPort,
-					t.EgressFirewallStartPriority,
-					"(ip4.dst == 1.2.3.4/23) && ip4.src == $a10481622940199974102 && ip4.dst != 10.128.0.0/14",
-					nbdb.ACLActionAllow,
-					"",
-					"",
-					false,
-					map[string]string{egressFirewallACLExtIdKey: "namespace1"},
-					nil,
-				)
-				ipv4ACL.UUID = "ipv4ACL-UUID"
-
-				// new ACL will be added to the switch
-				finalNodeSwitch := &nbdb.LogicalSwitch{
-					UUID: InitialNodeSwitch.UUID,
-					Name: InitialNodeSwitch.Name,
-					ACLs: []string{ipv4ACL.UUID},
-				}
-
-				expectedDatabaseState := []libovsdb.TestData{
-					ipv4ACL,
-					finalNodeSwitch,
-					clusterRouter,
-				}
-
-				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
-
-				return nil
-			}
-
-			err := app.Run([]string{app.Name})
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-		})
-		ginkgo.It("reconciles an existing egressFirewall with IPv6 CIDR", func() {
-			app.Action = func(ctx *cli.Context) error {
-				const (
-					node1Name string = "node1"
-				)
-
-				InitialNodeSwitch := &nbdb.LogicalSwitch{
-					UUID: node1Name + "-UUID",
-					Name: node1Name,
-				}
-
-				dbSetup := libovsdbtest.TestSetup{
-					NBData: []libovsdbtest.TestData{
-						InitialNodeSwitch,
-						clusterRouter,
-					},
-				}
-
-				namespace1 := *newNamespace("namespace1")
-				egressFirewall := newEgressFirewallObject("default", namespace1.Name, []egressfirewallapi.EgressFirewallRule{
-					{
-						Type: "Allow",
-						To: egressfirewallapi.EgressFirewallDestination{
-							CIDRSelector: "2002::1234:abcd:ffff:c0a8:101/64",
-						},
-					},
-				})
-
-				fakeOVN.startWithDBSetup(dbSetup,
-					&egressfirewallapi.EgressFirewallList{
-						Items: []egressfirewallapi.EgressFirewall{
-							*egressFirewall,
-						},
-					},
-					&v1.NamespaceList{
-						Items: []v1.Namespace{
-							namespace1,
-						},
-					}, &v1.NodeList{
-						Items: []v1.Node{
-							{
-								Status: v1.NodeStatus{
-									Phase: v1.NodeRunning,
-								},
-								ObjectMeta: newObjectMeta(node1Name, ""),
+					fakeOVN.startWithDBSetup(dbSetup,
+						&egressfirewallapi.EgressFirewallList{
+							Items: []egressfirewallapi.EgressFirewall{
+								*egressFirewall,
 							},
 						},
-					})
-				config.IPv6Mode = true
-				err := fakeOVN.controller.WatchNamespaces()
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				fakeOVN.controller.WatchEgressFirewall()
+						&v1.NamespaceList{
+							Items: []v1.Namespace{
+								namespace1,
+							},
+						}, &v1.NodeList{
+							Items: []v1.Node{
+								{
+									Status: v1.NodeStatus{
+										Phase: v1.NodeRunning,
+									},
+									ObjectMeta: newObjectMeta(node1Name, ""),
+								},
+							},
+						})
+					config.IPv6Mode = true
+					err := fakeOVN.controller.WatchNamespaces()
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					fakeOVN.controller.WatchEgressFirewall()
 
-				_, err = fakeOVN.fakeClient.EgressFirewallClient.K8sV1().EgressFirewalls(egressFirewall.Namespace).Get(context.TODO(), egressFirewall.Name, metav1.GetOptions{})
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					_, err = fakeOVN.fakeClient.EgressFirewallClient.K8sV1().EgressFirewalls(egressFirewall.Namespace).Get(context.TODO(), egressFirewall.Name, metav1.GetOptions{})
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-				ipv6ACL := libovsdbops.BuildACL(
-					"",
-					t.DirectionToLPort,
-					t.EgressFirewallStartPriority,
-					"(ip6.dst == 2002::1234:abcd:ffff:c0a8:101/64) && (ip4.src == $a10481622940199974102 || ip6.src == $a10481620741176717680) && ip4.dst != 10.128.0.0/14",
-					nbdb.ACLActionAllow,
-					"",
-					"",
-					false,
-					map[string]string{egressFirewallACLExtIdKey: "namespace1"},
-					nil,
-				)
-				ipv6ACL.UUID = "ipv6ACL-UUID"
+					ipv6ACL := libovsdbops.BuildACL(
+						"",
+						t.DirectionToLPort,
+						t.EgressFirewallStartPriority,
+						"(ip6.dst == 2002::1234:abcd:ffff:c0a8:101/64) && (ip4.src == $a10481622940199974102 || ip6.src == $a10481620741176717680) && ip4.dst != 10.128.0.0/14",
+						nbdb.ACLActionAllow,
+						"",
+						"",
+						false,
+						map[string]string{egressFirewallACLExtIdKey: "namespace1"},
+						nil,
+					)
+					ipv6ACL.UUID = "ipv6ACL-UUID"
 
-				// new ACL will be added to the switch
-				finalNodeSwitch := &nbdb.LogicalSwitch{
-					UUID: InitialNodeSwitch.UUID,
-					Name: InitialNodeSwitch.Name,
-					ACLs: []string{ipv6ACL.UUID},
+					// new ACL will be added to the port group
+					clusterPortGroup.ACLs = []string{ipv6ACL.UUID}
+					expectedDatabaseState := append(initialData, ipv6ACL)
+					gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+
+					return nil
 				}
 
-				expectedDatabaseState := []libovsdb.TestData{
-					ipv6ACL,
-					finalNodeSwitch,
-					clusterRouter,
-				}
+				err := app.Run([]string{app.Name})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
-
-				return nil
-			}
-
-			err := app.Run([]string{app.Name})
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-		})
+			})
+		}
 	})
 	ginkgo.Context("during execution", func() {
-		ginkgo.It("correctly creates an egressfirewall denying traffic udp traffic on port 100", func() {
-			app.Action = func(ctx *cli.Context) error {
-				const (
-					node1Name string = "node1"
-				)
-
-				InitialNodeSwitch := &nbdb.LogicalSwitch{
-					UUID: node1Name + "-UUID",
-					Name: node1Name,
-				}
-
-				dbSetup := libovsdbtest.TestSetup{
-					NBData: []libovsdbtest.TestData{
-						InitialNodeSwitch,
-						clusterRouter,
-					},
-				}
-
-				namespace1 := *newNamespace("namespace1")
-				egressFirewall := newEgressFirewallObject("default", namespace1.Name, []egressfirewallapi.EgressFirewallRule{
-					{
-						Type: "Deny",
-						Ports: []egressfirewallapi.EgressFirewallPort{
-							{
-								Protocol: "UDP",
-								Port:     100,
+		for _, gwMode := range []config.GatewayMode{config.GatewayModeLocal, config.GatewayModeShared} {
+			config.Gateway.Mode = gwMode
+			ginkgo.It(fmt.Sprintf("correctly creates an egressfirewall denying traffic udp traffic on port 100, gateway mode %s", gwMode), func() {
+				app.Action = func(ctx *cli.Context) error {
+					namespace1 := *newNamespace("namespace1")
+					egressFirewall := newEgressFirewallObject("default", namespace1.Name, []egressfirewallapi.EgressFirewallRule{
+						{
+							Type: "Deny",
+							Ports: []egressfirewallapi.EgressFirewallPort{
+								{
+									Protocol: "UDP",
+									Port:     100,
+								},
+							},
+							To: egressfirewallapi.EgressFirewallDestination{
+								CIDRSelector: "1.2.3.4/23",
 							},
 						},
-						To: egressfirewallapi.EgressFirewallDestination{
-							CIDRSelector: "1.2.3.4/23",
+					})
+					fakeOVN.startWithDBSetup(dbSetup,
+						&egressfirewallapi.EgressFirewallList{
+							Items: []egressfirewallapi.EgressFirewall{
+								*egressFirewall,
+							},
 						},
-					},
-				})
-				fakeOVN.startWithDBSetup(dbSetup,
-					&egressfirewallapi.EgressFirewallList{
-						Items: []egressfirewallapi.EgressFirewall{
-							*egressFirewall,
+						&v1.NamespaceList{
+							Items: []v1.Namespace{
+								namespace1,
+							},
 						},
-					},
-					&v1.NamespaceList{
-						Items: []v1.Namespace{
-							namespace1,
-						},
-					},
-					&v1.NodeList{
-						Items: []v1.Node{
-							{
-								Status: v1.NodeStatus{
-									Phase: v1.NodeRunning,
+						&v1.NodeList{
+							Items: []v1.Node{
+								{
+									Status: v1.NodeStatus{
+										Phase: v1.NodeRunning,
+									},
+									ObjectMeta: newObjectMeta(node1Name, ""),
 								},
-								ObjectMeta: newObjectMeta(node1Name, ""),
+							},
+						})
+
+					err := fakeOVN.controller.WatchNamespaces()
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					_, err = fakeOVN.fakeClient.EgressFirewallClient.K8sV1().EgressFirewalls(egressFirewall.Namespace).Get(context.TODO(), egressFirewall.Name, metav1.GetOptions{})
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+					fakeOVN.controller.WatchEgressFirewall()
+
+					udpACL := libovsdbops.BuildACL(
+						"",
+						t.DirectionToLPort,
+						t.EgressFirewallStartPriority,
+						"(ip4.dst == 1.2.3.4/23) && ip4.src == $a10481622940199974102 && ((udp && ( udp.dst == 100 ))) && ip4.dst != 10.128.0.0/14",
+						nbdb.ACLActionDrop,
+						"",
+						"",
+						false,
+						map[string]string{egressFirewallACLExtIdKey: "namespace1"},
+						nil,
+					)
+					udpACL.UUID = "udpACL-UUID"
+
+					// new ACL will be added to the port group
+					clusterPortGroup.ACLs = []string{udpACL.UUID}
+					expectedDatabaseState := append(initialData, udpACL)
+					gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+
+					return nil
+				}
+				err := app.Run([]string{app.Name})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			})
+			ginkgo.It(fmt.Sprintf("correctly deletes an egressfirewall, gateway mode %s", gwMode), func() {
+				app.Action = func(ctx *cli.Context) error {
+					namespace1 := *newNamespace("namespace1")
+					egressFirewall := newEgressFirewallObject("default", namespace1.Name, []egressfirewallapi.EgressFirewallRule{
+						{
+							Type: "Allow",
+							Ports: []egressfirewallapi.EgressFirewallPort{
+								{
+									Protocol: "TCP",
+									Port:     100,
+								},
+							},
+							To: egressfirewallapi.EgressFirewallDestination{
+								CIDRSelector: "1.2.3.5/23",
 							},
 						},
 					})
 
-				err := fakeOVN.controller.WatchNamespaces()
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				_, err = fakeOVN.fakeClient.EgressFirewallClient.K8sV1().EgressFirewalls(egressFirewall.Namespace).Get(context.TODO(), egressFirewall.Name, metav1.GetOptions{})
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-				fakeOVN.controller.WatchEgressFirewall()
-
-				udpACL := libovsdbops.BuildACL(
-					"",
-					t.DirectionToLPort,
-					t.EgressFirewallStartPriority,
-					"(ip4.dst == 1.2.3.4/23) && ip4.src == $a10481622940199974102 && ((udp && ( udp.dst == 100 ))) && ip4.dst != 10.128.0.0/14",
-					nbdb.ACLActionDrop,
-					"",
-					"",
-					false,
-					map[string]string{egressFirewallACLExtIdKey: "namespace1"},
-					nil,
-				)
-				udpACL.UUID = "udpACL-UUID"
-
-				// new ACL will be added to the switch
-				finalNodeSwitch := &nbdb.LogicalSwitch{
-					UUID: InitialNodeSwitch.UUID,
-					Name: InitialNodeSwitch.Name,
-					ACLs: []string{udpACL.UUID},
-				}
-
-				expectedDatabaseState := []libovsdb.TestData{
-					udpACL,
-					finalNodeSwitch,
-					clusterRouter,
-				}
-
-				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
-
-				return nil
-			}
-			err := app.Run([]string{app.Name})
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		})
-		ginkgo.It("correctly deletes an egressfirewall", func() {
-			app.Action = func(ctx *cli.Context) error {
-				const (
-					node1Name string = "node1"
-					node2Name string = "node2"
-				)
-
-				nodeSwitch1 := &nbdb.LogicalSwitch{
-					UUID: node1Name + "-UUID",
-					Name: node1Name,
-				}
-				nodeSwitch2 := &nbdb.LogicalSwitch{
-					UUID: node2Name + "-UUID",
-					Name: node2Name,
-				}
-
-				dbSetup := libovsdbtest.TestSetup{
-					NBData: []libovsdbtest.TestData{
-						nodeSwitch1,
-						nodeSwitch2,
-						clusterRouter,
-					},
-				}
-
-				namespace1 := *newNamespace("namespace1")
-				egressFirewall := newEgressFirewallObject("default", namespace1.Name, []egressfirewallapi.EgressFirewallRule{
-					{
-						Type: "Allow",
-						Ports: []egressfirewallapi.EgressFirewallPort{
-							{
-								Protocol: "TCP",
-								Port:     100,
+					fakeOVN.startWithDBSetup(dbSetup,
+						&egressfirewallapi.EgressFirewallList{
+							Items: []egressfirewallapi.EgressFirewall{
+								*egressFirewall,
 							},
 						},
-						To: egressfirewallapi.EgressFirewallDestination{
-							CIDRSelector: "1.2.3.5/23",
-						},
-					},
-				})
-
-				fakeOVN.startWithDBSetup(dbSetup,
-					&egressfirewallapi.EgressFirewallList{
-						Items: []egressfirewallapi.EgressFirewall{
-							*egressFirewall,
-						},
-					},
-					&v1.NodeList{
-						Items: []v1.Node{
-							{
-								Status: v1.NodeStatus{
-									Phase: v1.NodeRunning,
+						&v1.NodeList{
+							Items: []v1.Node{
+								{
+									Status: v1.NodeStatus{
+										Phase: v1.NodeRunning,
+									},
+									ObjectMeta: newObjectMeta(node1Name, ""),
 								},
-								ObjectMeta: newObjectMeta(node1Name, ""),
-							},
-							{
-								Status: v1.NodeStatus{
-									Phase: v1.NodeRunning,
+								{
+									Status: v1.NodeStatus{
+										Phase: v1.NodeRunning,
+									},
+									ObjectMeta: newObjectMeta(node2Name, ""),
 								},
-								ObjectMeta: newObjectMeta(node2Name, ""),
 							},
-						},
-					})
+						})
 
-				fakeOVN.controller.WatchEgressFirewall()
+					fakeOVN.controller.WatchEgressFirewall()
 
-				ipv4ACL := libovsdbops.BuildACL(
-					"",
-					t.DirectionToLPort,
-					t.EgressFirewallStartPriority,
-					"(ip4.dst == 1.2.3.5/23) && ip4.src == $a10481622940199974102 && ((tcp && ( tcp.dst == 100 ))) && ip4.dst != 10.128.0.0/14",
-					nbdb.ACLActionAllow,
-					"",
-					"",
-					false,
-					map[string]string{egressFirewallACLExtIdKey: "namespace1"},
-					nil,
-				)
-				ipv4ACL.UUID = "ipv4ACL-UUID"
+					ipv4ACL := libovsdbops.BuildACL(
+						"",
+						t.DirectionToLPort,
+						t.EgressFirewallStartPriority,
+						"(ip4.dst == 1.2.3.5/23) && ip4.src == $a10481622940199974102 && ((tcp && ( tcp.dst == 100 ))) && ip4.dst != 10.128.0.0/14",
+						nbdb.ACLActionAllow,
+						"",
+						"",
+						false,
+						map[string]string{egressFirewallACLExtIdKey: "namespace1"},
+						nil,
+					)
+					ipv4ACL.UUID = "ipv4ACL-UUID"
 
-				// new ACL will be added to the switches
-				nodeSwitch1.ACLs = []string{ipv4ACL.UUID}
-				nodeSwitch2.ACLs = []string{ipv4ACL.UUID}
+					// new ACL will be added to the port group
+					clusterPortGroup.ACLs = []string{ipv4ACL.UUID}
+					expectedDatabaseState := append(initialData, ipv4ACL)
 
-				expectedDatabaseState := []libovsdb.TestData{
-					ipv4ACL,
-					nodeSwitch1,
-					nodeSwitch2,
-					clusterRouter,
-				}
+					gomega.Expect(fakeOVN.nbClient).To(libovsdbtest.HaveData(expectedDatabaseState))
 
-				gomega.Expect(fakeOVN.nbClient).To(libovsdbtest.HaveData(expectedDatabaseState))
+					err := fakeOVN.fakeClient.EgressFirewallClient.K8sV1().EgressFirewalls(egressFirewall.Namespace).Delete(context.TODO(), egressFirewall.Name, *metav1.NewDeleteOptions(0))
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-				err := fakeOVN.fakeClient.EgressFirewallClient.K8sV1().EgressFirewalls(egressFirewall.Namespace).Delete(context.TODO(), egressFirewall.Name, *metav1.NewDeleteOptions(0))
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-				// ACL should be removed from switches after egfw is deleted
-				nodeSwitch1.ACLs = []string{}
-				nodeSwitch2.ACLs = []string{}
-				expectedDatabaseState = []libovsdb.TestData{
+					// ACL should be removed from the port group egfw is deleted
+					clusterPortGroup.ACLs = []string{}
 					// this ACL will be deleted when test server starts deleting dereferenced ACLs
-					ipv4ACL,
-					nodeSwitch1,
-					nodeSwitch2,
-					clusterRouter,
+					expectedDatabaseState = append(initialData, ipv4ACL)
+					gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+
+					return nil
 				}
 
-				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
-
-				return nil
-			}
-
-			err := app.Run([]string{app.Name})
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		})
-		ginkgo.It("correctly updates an egressfirewall", func() {
-			app.Action = func(ctx *cli.Context) error {
-				const (
-					node1Name string = "node1"
-				)
-
-				InitialNodeSwitch := &nbdb.LogicalSwitch{
-					UUID: node1Name + "-UUID",
-					Name: node1Name,
-				}
-
-				dbSetup := libovsdbtest.TestSetup{
-					NBData: []libovsdbtest.TestData{
-						InitialNodeSwitch,
-						clusterRouter,
-					},
-				}
-
-				namespace1 := *newNamespace("namespace1")
-				egressFirewall := newEgressFirewallObject("default", namespace1.Name, []egressfirewallapi.EgressFirewallRule{
-					{
-						Type: "Allow",
-						To: egressfirewallapi.EgressFirewallDestination{
-							CIDRSelector: "1.2.3.4/23",
+				err := app.Run([]string{app.Name})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			})
+			ginkgo.It(fmt.Sprintf("correctly updates an egressfirewall, gateway mode %s", gwMode), func() {
+				app.Action = func(ctx *cli.Context) error {
+					namespace1 := *newNamespace("namespace1")
+					egressFirewall := newEgressFirewallObject("default", namespace1.Name, []egressfirewallapi.EgressFirewallRule{
+						{
+							Type: "Allow",
+							To: egressfirewallapi.EgressFirewallDestination{
+								CIDRSelector: "1.2.3.4/23",
+							},
 						},
-					},
-				})
-				egressFirewall1 := newEgressFirewallObject("default", namespace1.Name, []egressfirewallapi.EgressFirewallRule{
-					{
-						Type: "Deny",
-						To: egressfirewallapi.EgressFirewallDestination{
-							CIDRSelector: "1.2.3.4/23",
-						},
-					},
-				})
-
-				fakeOVN.startWithDBSetup(dbSetup,
-					&egressfirewallapi.EgressFirewallList{
-						Items: []egressfirewallapi.EgressFirewall{
-							*egressFirewall,
-						},
-					},
-					&v1.NamespaceList{
-						Items: []v1.Namespace{
-							namespace1,
-						},
-					},
-					&v1.NodeList{
-						Items: []v1.Node{
-							{
-								Status: v1.NodeStatus{
-									Phase: v1.NodeRunning,
-								},
-								ObjectMeta: newObjectMeta(node1Name, ""),
+					})
+					egressFirewall1 := newEgressFirewallObject("default", namespace1.Name, []egressfirewallapi.EgressFirewallRule{
+						{
+							Type: "Deny",
+							To: egressfirewallapi.EgressFirewallDestination{
+								CIDRSelector: "1.2.3.4/23",
 							},
 						},
 					})
 
-				err := fakeOVN.controller.WatchNamespaces()
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				fakeOVN.controller.WatchEgressFirewall()
-
-				ipv4ACL := libovsdbops.BuildACL(
-					"",
-					t.DirectionToLPort,
-					t.EgressFirewallStartPriority,
-					"(ip4.dst == 1.2.3.4/23) && ip4.src == $a10481622940199974102 && ip4.dst != 10.128.0.0/14",
-					nbdb.ACLActionAllow,
-					"",
-					"",
-					false,
-					map[string]string{egressFirewallACLExtIdKey: "namespace1"},
-					nil,
-				)
-				ipv4ACL.UUID = "ipv4ACL-UUID"
-
-				// new ACL will be added to the switch
-				finalNodeSwitch := &nbdb.LogicalSwitch{
-					UUID: InitialNodeSwitch.UUID,
-					Name: InitialNodeSwitch.Name,
-					ACLs: []string{ipv4ACL.UUID},
-				}
-
-				// new ACL will be added to the switch
-				expectedDatabaseState := []libovsdb.TestData{
-					ipv4ACL,
-					finalNodeSwitch,
-					clusterRouter,
-				}
-
-				gomega.Expect(fakeOVN.nbClient).To(libovsdbtest.HaveData(expectedDatabaseState))
-
-				_, err = fakeOVN.fakeClient.EgressFirewallClient.K8sV1().EgressFirewalls(egressFirewall.Namespace).Get(context.TODO(), egressFirewall.Name, metav1.GetOptions{})
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				_, err = fakeOVN.fakeClient.EgressFirewallClient.K8sV1().EgressFirewalls(egressFirewall1.Namespace).Update(context.TODO(), egressFirewall1, metav1.UpdateOptions{})
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-				// egress firewall is updated by deleting and creating from scratch.
-				// since old acl won't be garbage-collected by the test server, it will stay,
-				// but won't be referenced from the switch
-				ipv4ACLStale := libovsdbops.BuildACL(
-					"",
-					t.DirectionToLPort,
-					t.EgressFirewallStartPriority,
-					"(ip4.dst == 1.2.3.4/23) && ip4.src == $a10481622940199974102 && ip4.dst != 10.128.0.0/14",
-					nbdb.ACLActionAllow,
-					"",
-					"",
-					false,
-					map[string]string{"egressFirewall": "namespace1"},
-					nil,
-				)
-				ipv4ACLStale.UUID = "ipv4ACLStale-UUID"
-
-				ipv4ACL.Action = nbdb.ACLActionDrop
-				expectedDatabaseState = append(expectedDatabaseState, ipv4ACLStale)
-				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
-
-				return nil
-			}
-
-			err := app.Run([]string{app.Name})
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-		})
-		ginkgo.It("correctly retries deleting an egressfirewall", func() {
-			app.Action = func(ctx *cli.Context) error {
-				const (
-					node1Name string = "node1"
-					node2Name string = "node2"
-				)
-
-				nodeSwitch1 := &nbdb.LogicalSwitch{
-					UUID: node1Name + "-UUID",
-					Name: node1Name,
-				}
-				nodeSwitch2 := &nbdb.LogicalSwitch{
-					UUID: node2Name + "-UUID",
-					Name: node2Name,
-				}
-
-				dbSetup := libovsdbtest.TestSetup{
-					NBData: []libovsdbtest.TestData{
-						nodeSwitch1,
-						nodeSwitch2,
-						clusterRouter,
-					},
-				}
-
-				namespace1 := *newNamespace("namespace1")
-				egressFirewall := newEgressFirewallObject("default", namespace1.Name, []egressfirewallapi.EgressFirewallRule{
-					{
-						Type: "Allow",
-						Ports: []egressfirewallapi.EgressFirewallPort{
-							{
-								Protocol: "TCP",
-								Port:     100,
+					fakeOVN.startWithDBSetup(dbSetup,
+						&egressfirewallapi.EgressFirewallList{
+							Items: []egressfirewallapi.EgressFirewall{
+								*egressFirewall,
 							},
 						},
-						To: egressfirewallapi.EgressFirewallDestination{
-							CIDRSelector: "1.2.3.5/23",
-						},
-					},
-				})
-
-				fakeOVN.startWithDBSetup(dbSetup,
-					&egressfirewallapi.EgressFirewallList{
-						Items: []egressfirewallapi.EgressFirewall{
-							*egressFirewall,
-						},
-					},
-					&v1.NodeList{
-						Items: []v1.Node{
-							{
-								Status: v1.NodeStatus{
-									Phase: v1.NodeRunning,
-								},
-								ObjectMeta: newObjectMeta(node1Name, ""),
+						&v1.NamespaceList{
+							Items: []v1.Namespace{
+								namespace1,
 							},
-							{
-								Status: v1.NodeStatus{
-									Phase: v1.NodeRunning,
+						},
+						&v1.NodeList{
+							Items: []v1.Node{
+								{
+									Status: v1.NodeStatus{
+										Phase: v1.NodeRunning,
+									},
+									ObjectMeta: newObjectMeta(node1Name, ""),
 								},
-								ObjectMeta: newObjectMeta(node2Name, ""),
+							},
+						})
+
+					err := fakeOVN.controller.WatchNamespaces()
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					fakeOVN.controller.WatchEgressFirewall()
+
+					ipv4ACL := libovsdbops.BuildACL(
+						"",
+						t.DirectionToLPort,
+						t.EgressFirewallStartPriority,
+						"(ip4.dst == 1.2.3.4/23) && ip4.src == $a10481622940199974102 && ip4.dst != 10.128.0.0/14",
+						nbdb.ACLActionAllow,
+						"",
+						"",
+						false,
+						map[string]string{egressFirewallACLExtIdKey: "namespace1"},
+						nil,
+					)
+					ipv4ACL.UUID = "ipv4ACL-UUID"
+
+					// new ACL will be added to the port group
+					clusterPortGroup.ACLs = []string{ipv4ACL.UUID}
+					expectedDatabaseState := append(initialData, ipv4ACL)
+					gomega.Expect(fakeOVN.nbClient).To(libovsdbtest.HaveData(expectedDatabaseState))
+
+					_, err = fakeOVN.fakeClient.EgressFirewallClient.K8sV1().EgressFirewalls(egressFirewall.Namespace).Get(context.TODO(), egressFirewall.Name, metav1.GetOptions{})
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					_, err = fakeOVN.fakeClient.EgressFirewallClient.K8sV1().EgressFirewalls(egressFirewall1.Namespace).Update(context.TODO(), egressFirewall1, metav1.UpdateOptions{})
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+					// egress firewall is updated by deleting and creating from scratch.
+					// since old acl won't be garbage-collected by the test server, it will stay,
+					// but won't be referenced from the switch
+					ipv4ACLStale := libovsdbops.BuildACL(
+						"",
+						t.DirectionToLPort,
+						t.EgressFirewallStartPriority,
+						"(ip4.dst == 1.2.3.4/23) && ip4.src == $a10481622940199974102 && ip4.dst != 10.128.0.0/14",
+						nbdb.ACLActionAllow,
+						"",
+						"",
+						false,
+						map[string]string{"egressFirewall": "namespace1"},
+						nil,
+					)
+					ipv4ACLStale.UUID = "ipv4ACLStale-UUID"
+					ipv4ACL.Action = nbdb.ACLActionDrop
+					expectedDatabaseState = append(expectedDatabaseState, ipv4ACLStale)
+					gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+
+					return nil
+				}
+
+				err := app.Run([]string{app.Name})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			})
+			ginkgo.It(fmt.Sprintf("correctly retries deleting an egressfirewall, gateway mode %s", gwMode), func() {
+				app.Action = func(ctx *cli.Context) error {
+					namespace1 := *newNamespace("namespace1")
+					egressFirewall := newEgressFirewallObject("default", namespace1.Name, []egressfirewallapi.EgressFirewallRule{
+						{
+							Type: "Allow",
+							Ports: []egressfirewallapi.EgressFirewallPort{
+								{
+									Protocol: "TCP",
+									Port:     100,
+								},
+							},
+							To: egressfirewallapi.EgressFirewallDestination{
+								CIDRSelector: "1.2.3.5/23",
 							},
 						},
 					})
 
-				fakeOVN.controller.WatchEgressFirewall()
+					fakeOVN.startWithDBSetup(dbSetup,
+						&egressfirewallapi.EgressFirewallList{
+							Items: []egressfirewallapi.EgressFirewall{
+								*egressFirewall,
+							},
+						},
+						&v1.NodeList{
+							Items: []v1.Node{
+								{
+									Status: v1.NodeStatus{
+										Phase: v1.NodeRunning,
+									},
+									ObjectMeta: newObjectMeta(node1Name, ""),
+								},
+								{
+									Status: v1.NodeStatus{
+										Phase: v1.NodeRunning,
+									},
+									ObjectMeta: newObjectMeta(node2Name, ""),
+								},
+							},
+						})
 
-				ipv4ACL := libovsdbops.BuildACL(
-					"",
-					t.DirectionToLPort,
-					t.EgressFirewallStartPriority,
-					"(ip4.dst == 1.2.3.5/23) && ip4.src == $a10481622940199974102 && ((tcp && ( tcp.dst == 100 ))) && ip4.dst != 10.128.0.0/14",
-					nbdb.ACLActionAllow,
-					"",
-					"",
-					false,
-					map[string]string{egressFirewallACLExtIdKey: "namespace1"},
-					nil,
-				)
-				ipv4ACL.UUID = "ipv4ACL-UUID"
+					fakeOVN.controller.WatchEgressFirewall()
 
-				// new ACL will be added to the switches
-				nodeSwitch1.ACLs = []string{ipv4ACL.UUID}
-				nodeSwitch2.ACLs = []string{ipv4ACL.UUID}
+					ipv4ACL := libovsdbops.BuildACL(
+						"",
+						t.DirectionToLPort,
+						t.EgressFirewallStartPriority,
+						"(ip4.dst == 1.2.3.5/23) && ip4.src == $a10481622940199974102 && ((tcp && ( tcp.dst == 100 ))) && ip4.dst != 10.128.0.0/14",
+						nbdb.ACLActionAllow,
+						"",
+						"",
+						false,
+						map[string]string{egressFirewallACLExtIdKey: "namespace1"},
+						nil,
+					)
+					ipv4ACL.UUID = "ipv4ACL-UUID"
 
-				expectedDatabaseState := []libovsdb.TestData{
-					ipv4ACL,
-					nodeSwitch1,
-					nodeSwitch2,
-					clusterRouter,
-				}
+					// new ACL will be added to the port group
+					clusterPortGroup.ACLs = []string{ipv4ACL.UUID}
+					expectedDatabaseState := append(initialData, ipv4ACL)
+					gomega.Expect(fakeOVN.nbClient).To(libovsdbtest.HaveData(expectedDatabaseState))
 
-				gomega.Expect(fakeOVN.nbClient).To(libovsdbtest.HaveData(expectedDatabaseState))
+					ginkgo.By("Bringing down NBDB")
+					// inject transient problem, nbdb is down
+					fakeOVN.controller.nbClient.Close()
+					gomega.Eventually(func() bool {
+						return fakeOVN.controller.nbClient.Connected()
+					}).Should(gomega.BeFalse())
 
-				ginkgo.By("Bringing down NBDB")
-				// inject transient problem, nbdb is down
-				fakeOVN.controller.nbClient.Close()
-				gomega.Eventually(func() bool {
-					return fakeOVN.controller.nbClient.Connected()
-				}).Should(gomega.BeFalse())
+					err := fakeOVN.fakeClient.EgressFirewallClient.K8sV1().EgressFirewalls(egressFirewall.Namespace).Delete(context.TODO(), egressFirewall.Name, *metav1.NewDeleteOptions(0))
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					// sleep long enough for TransactWithRetry to fail, causing egress firewall Add to fail
+					time.Sleep(t.OVSDBTimeout + time.Second)
+					// check to see if the retry cache has an entry for this egress firewall
+					key := getEgressFirewallNamespacedName(egressFirewall)
+					gomega.Eventually(func() *retryObjEntry {
+						return fakeOVN.controller.retryEgressFirewalls.getObjRetryEntry(key)
+					}).ShouldNot(gomega.BeNil())
+					retryEntry := fakeOVN.controller.retryEgressFirewalls.getObjRetryEntry(key)
+					ginkgo.By("retry entry new obj should be nil")
+					gomega.Expect(retryEntry.newObj).To(gomega.BeNil())
+					ginkgo.By("retry entry old obj should not be nil")
+					gomega.Expect(retryEntry.oldObj).NotTo(gomega.BeNil())
 
-				err := fakeOVN.fakeClient.EgressFirewallClient.K8sV1().EgressFirewalls(egressFirewall.Namespace).Delete(context.TODO(), egressFirewall.Name, *metav1.NewDeleteOptions(0))
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				// sleep long enough for TransactWithRetry to fail, causing egress firewall Add to fail
-				time.Sleep(t.OVSDBTimeout + time.Second)
-				// check to see if the retry cache has an entry for this egress firewall
-				key := getEgressFirewallNamespacedName(egressFirewall)
-				gomega.Eventually(func() *retryObjEntry {
-					return fakeOVN.controller.retryEgressFirewalls.getObjRetryEntry(key)
-				}).ShouldNot(gomega.BeNil())
-				retryEntry := fakeOVN.controller.retryEgressFirewalls.getObjRetryEntry(key)
-				ginkgo.By("retry entry new obj should be nil")
-				gomega.Expect(retryEntry.newObj).To(gomega.BeNil())
-				ginkgo.By("retry entry old obj should not be nil")
-				gomega.Expect(retryEntry.oldObj).NotTo(gomega.BeNil())
+					connCtx, cancel := context.WithTimeout(context.Background(), t.OVSDBTimeout)
+					defer cancel()
+					resetNBClient(connCtx, fakeOVN.controller.nbClient)
+					fakeOVN.controller.retryEgressFirewalls.requestRetryObjs()
 
-				connCtx, cancel := context.WithTimeout(context.Background(), t.OVSDBTimeout)
-				defer cancel()
-				resetNBClient(connCtx, fakeOVN.controller.nbClient)
-				fakeOVN.controller.retryEgressFirewalls.requestRetryObjs()
-
-				// ACL should be removed from switches after egfw is deleted
-				nodeSwitch1.ACLs = []string{}
-				nodeSwitch2.ACLs = []string{}
-				expectedDatabaseState = []libovsdb.TestData{
+					// ACL should be removed from the port group after egfw is deleted
+					clusterPortGroup.ACLs = []string{}
 					// this ACL will be deleted when test server starts deleting dereferenced ACLs
-					ipv4ACL,
-					nodeSwitch1,
-					nodeSwitch2,
-					clusterRouter,
+					expectedDatabaseState = append(initialData, ipv4ACL)
+
+					gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+					// check the cache no longer has the entry
+					gomega.Eventually(func() *retryObjEntry {
+						return fakeOVN.controller.retryEgressFirewalls.getObjRetryEntry(key)
+					}).Should(gomega.BeNil())
+					return nil
 				}
 
-				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
-				// check the cache no longer has the entry
-				gomega.Eventually(func() *retryObjEntry {
-					return fakeOVN.controller.retryEgressFirewalls.getObjRetryEntry(key)
-				}).Should(gomega.BeNil())
-				return nil
-			}
-
-			err := app.Run([]string{app.Name})
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		})
-
-		ginkgo.It("correctly retries adding and updating an egressfirewall", func() {
-			app.Action = func(ctx *cli.Context) error {
-				const (
-					node1Name string = "node1"
-				)
-
-				InitialNodeSwitch := &nbdb.LogicalSwitch{
-					UUID: node1Name + "-UUID",
-					Name: node1Name,
-				}
-
-				dbSetup := libovsdbtest.TestSetup{
-					NBData: []libovsdbtest.TestData{
-						InitialNodeSwitch,
-						clusterRouter,
-					},
-				}
-
-				namespace1 := *newNamespace("namespace1")
-				egressFirewall := newEgressFirewallObject("default", namespace1.Name, []egressfirewallapi.EgressFirewallRule{
-					{
-						Type: "Allow",
-						To: egressfirewallapi.EgressFirewallDestination{
-							CIDRSelector: "1.2.3.4/23",
+				err := app.Run([]string{app.Name})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			})
+			ginkgo.It(fmt.Sprintf("correctly retries adding and updating an egressfirewall, gateway mode %s", gwMode), func() {
+				app.Action = func(ctx *cli.Context) error {
+					namespace1 := *newNamespace("namespace1")
+					egressFirewall := newEgressFirewallObject("default", namespace1.Name, []egressfirewallapi.EgressFirewallRule{
+						{
+							Type: "Allow",
+							To: egressfirewallapi.EgressFirewallDestination{
+								CIDRSelector: "1.2.3.4/23",
+							},
 						},
-					},
-				})
-				egressFirewall1 := newEgressFirewallObject("default", namespace1.Name, []egressfirewallapi.EgressFirewallRule{
-					{
-						Type: "Deny",
-						To: egressfirewallapi.EgressFirewallDestination{
-							CIDRSelector: "1.2.3.4/23",
-						},
-					},
-				})
-
-				fakeOVN.startWithDBSetup(dbSetup,
-					&egressfirewallapi.EgressFirewallList{
-						Items: []egressfirewallapi.EgressFirewall{
-							*egressFirewall,
-						},
-					},
-					&v1.NamespaceList{
-						Items: []v1.Namespace{
-							namespace1,
-						},
-					},
-					&v1.NodeList{
-						Items: []v1.Node{
-							{
-								Status: v1.NodeStatus{
-									Phase: v1.NodeRunning,
-								},
-								ObjectMeta: newObjectMeta(node1Name, ""),
+					})
+					egressFirewall1 := newEgressFirewallObject("default", namespace1.Name, []egressfirewallapi.EgressFirewallRule{
+						{
+							Type: "Deny",
+							To: egressfirewallapi.EgressFirewallDestination{
+								CIDRSelector: "1.2.3.4/23",
 							},
 						},
 					})
 
-				fakeOVN.controller.WatchNamespaces()
-				fakeOVN.controller.WatchEgressFirewall()
+					fakeOVN.startWithDBSetup(dbSetup,
+						&egressfirewallapi.EgressFirewallList{
+							Items: []egressfirewallapi.EgressFirewall{
+								*egressFirewall,
+							},
+						},
+						&v1.NamespaceList{
+							Items: []v1.Namespace{
+								namespace1,
+							},
+						},
+						&v1.NodeList{
+							Items: []v1.Node{
+								{
+									Status: v1.NodeStatus{
+										Phase: v1.NodeRunning,
+									},
+									ObjectMeta: newObjectMeta(node1Name, ""),
+								},
+							},
+						})
 
-				ipv4ACL := libovsdbops.BuildACL(
-					"",
-					t.DirectionToLPort,
-					t.EgressFirewallStartPriority,
-					"(ip4.dst == 1.2.3.4/23) && ip4.src == $a10481622940199974102 && ip4.dst != 10.128.0.0/14",
-					nbdb.ACLActionAllow,
-					"",
-					"",
-					false,
-					map[string]string{egressFirewallACLExtIdKey: "namespace1"},
-					nil,
-				)
-				ipv4ACL.UUID = "ipv4ACL-UUID"
+					fakeOVN.controller.WatchNamespaces()
+					fakeOVN.controller.WatchEgressFirewall()
 
-				// new ACL will be added to the switch
-				finalNodeSwitch := &nbdb.LogicalSwitch{
-					UUID: InitialNodeSwitch.UUID,
-					Name: InitialNodeSwitch.Name,
-					ACLs: []string{ipv4ACL.UUID},
+					ipv4ACL := libovsdbops.BuildACL(
+						"",
+						t.DirectionToLPort,
+						t.EgressFirewallStartPriority,
+						"(ip4.dst == 1.2.3.4/23) && ip4.src == $a10481622940199974102 && ip4.dst != 10.128.0.0/14",
+						nbdb.ACLActionAllow,
+						"",
+						"",
+						false,
+						map[string]string{egressFirewallACLExtIdKey: "namespace1"},
+						nil,
+					)
+					ipv4ACL.UUID = "ipv4ACL-UUID"
+
+					// new ACL will be added to the port group
+					clusterPortGroup.ACLs = []string{ipv4ACL.UUID}
+					expectedDatabaseState := append(initialData, ipv4ACL)
+
+					gomega.Expect(fakeOVN.nbClient).To(libovsdbtest.HaveData(expectedDatabaseState))
+					ginkgo.By("Bringing down NBDB")
+					// inject transient problem, nbdb is down
+					fakeOVN.controller.nbClient.Close()
+					gomega.Eventually(func() bool {
+						return fakeOVN.controller.nbClient.Connected()
+					}).Should(gomega.BeFalse())
+
+					_, err := fakeOVN.fakeClient.EgressFirewallClient.K8sV1().EgressFirewalls(egressFirewall.Namespace).Get(context.TODO(), egressFirewall.Name, metav1.GetOptions{})
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					_, err = fakeOVN.fakeClient.EgressFirewallClient.K8sV1().EgressFirewalls(egressFirewall1.Namespace).Update(context.TODO(), egressFirewall1, metav1.UpdateOptions{})
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					// sleep long enough for TransactWithRetry to fail, causing egress firewall Add to fail
+					time.Sleep(t.OVSDBTimeout + time.Second)
+					// check to see if the retry cache has an entry for this egress firewall
+					key := getEgressFirewallNamespacedName(egressFirewall)
+					gomega.Eventually(func() *retryObjEntry {
+						return fakeOVN.controller.retryEgressFirewalls.getObjRetryEntry(key)
+					}).ShouldNot(gomega.BeNil())
+					retryEntry := fakeOVN.controller.retryEgressFirewalls.getObjRetryEntry(key)
+					ginkgo.By("retry entry new obj should not be nil")
+					gomega.Expect(retryEntry.newObj).NotTo(gomega.BeNil())
+					ginkgo.By("retry entry old obj should not be nil")
+					gomega.Expect(retryEntry.oldObj).NotTo(gomega.BeNil())
+
+					connCtx, cancel := context.WithTimeout(context.Background(), t.OVSDBTimeout)
+					defer cancel()
+					ginkgo.By("bringing up NBDB and requesting retry of entry")
+					resetNBClient(connCtx, fakeOVN.controller.nbClient)
+					fakeOVN.controller.retryEgressFirewalls.requestRetryObjs()
+					// check the cache no longer has the entry
+					gomega.Eventually(func() *retryObjEntry {
+						return fakeOVN.controller.retryEgressFirewalls.getObjRetryEntry(key)
+					}).Should(gomega.BeNil())
+
+					// egress firewall is updated by deleting and creating from scratch.
+					// since old acl won't be garbage-collected by the test server, it will stay,
+					// but won't be referenced from the switch
+					ipv4ACLStale := libovsdbops.BuildACL(
+						"",
+						t.DirectionToLPort,
+						t.EgressFirewallStartPriority,
+						"(ip4.dst == 1.2.3.4/23) && ip4.src == $a10481622940199974102 && ip4.dst != 10.128.0.0/14",
+						nbdb.ACLActionAllow,
+						"",
+						"",
+						false,
+						map[string]string{"egressFirewall": "namespace1"},
+						nil,
+					)
+					ipv4ACLStale.UUID = "ipv4ACLStale-UUID"
+
+					ipv4ACL.Action = nbdb.ACLActionDrop
+					expectedDatabaseState = append(expectedDatabaseState, ipv4ACLStale)
+
+					gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+					return nil
 				}
 
-				// new ACL will be added to the switch
-				expectedDatabaseState := []libovsdb.TestData{
-					ipv4ACL,
-					finalNodeSwitch,
-					clusterRouter,
-				}
-
-				gomega.Expect(fakeOVN.nbClient).To(libovsdbtest.HaveData(expectedDatabaseState))
-				ginkgo.By("Bringing down NBDB")
-				// inject transient problem, nbdb is down
-				fakeOVN.controller.nbClient.Close()
-				gomega.Eventually(func() bool {
-					return fakeOVN.controller.nbClient.Connected()
-				}).Should(gomega.BeFalse())
-
-				_, err := fakeOVN.fakeClient.EgressFirewallClient.K8sV1().EgressFirewalls(egressFirewall.Namespace).Get(context.TODO(), egressFirewall.Name, metav1.GetOptions{})
+				err := app.Run([]string{app.Name})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				_, err = fakeOVN.fakeClient.EgressFirewallClient.K8sV1().EgressFirewalls(egressFirewall1.Namespace).Update(context.TODO(), egressFirewall1, metav1.UpdateOptions{})
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				// sleep long enough for TransactWithRetry to fail, causing egress firewall Add to fail
-				time.Sleep(t.OVSDBTimeout + time.Second)
-				// check to see if the retry cache has an entry for this egress firewall
-				key := getEgressFirewallNamespacedName(egressFirewall)
-				gomega.Eventually(func() *retryObjEntry {
-					return fakeOVN.controller.retryEgressFirewalls.getObjRetryEntry(key)
-				}).ShouldNot(gomega.BeNil())
-				retryEntry := fakeOVN.controller.retryEgressFirewalls.getObjRetryEntry(key)
-				ginkgo.By("retry entry new obj should not be nil")
-				gomega.Expect(retryEntry.newObj).NotTo(gomega.BeNil())
-				ginkgo.By("retry entry old obj should not be nil")
-				gomega.Expect(retryEntry.oldObj).NotTo(gomega.BeNil())
-				connCtx, cancel := context.WithTimeout(context.Background(), t.OVSDBTimeout)
-				defer cancel()
-				resetNBClient(connCtx, fakeOVN.controller.nbClient)
-				fakeOVN.controller.retryEgressFirewalls.requestRetryObjs()
-				// check the cache no longer has the entry
-				gomega.Eventually(func() *retryObjEntry {
-					return fakeOVN.controller.retryEgressFirewalls.getObjRetryEntry(key)
-				}).Should(gomega.BeNil())
 
-				// egress firewall is updated by deleting and creating from scratch.
-				// since old acl won't be garbage-collected by the test server, it will stay,
-				// but won't be referenced from the switch
-				ipv4ACLStale := libovsdbops.BuildACL(
-					"",
-					t.DirectionToLPort,
-					t.EgressFirewallStartPriority,
-					"(ip4.dst == 1.2.3.4/23) && ip4.src == $a10481622940199974102 && ip4.dst != 10.128.0.0/14",
-					nbdb.ACLActionAllow,
-					"",
-					"",
-					false,
-					map[string]string{"egressFirewall": "namespace1"},
-					nil,
-				)
-				ipv4ACLStale.UUID = "ipv4ACLStale-UUID"
-
-				ipv4ACL.Action = nbdb.ACLActionDrop
-				expectedDatabaseState = append(expectedDatabaseState, ipv4ACLStale)
-
-				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
-				return nil
-			}
-
-			err := app.Run([]string{app.Name})
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-		})
+			})
+		}
 	})
-})
-
-var _ = ginkgo.Describe("OVN EgressFirewall Operations for shared gateway mode", func() {
-	var (
-		app     *cli.App
-		fakeOVN *FakeOVN
-	)
-	const (
-		node1Name string = "node1"
-		node2Name string = "node2"
-	)
-
-	clusterRouter := &nbdb.LogicalRouter{
-		UUID: t.OVNClusterRouter + "-UUID",
-		Name: t.OVNClusterRouter,
-	}
-
-	ginkgo.BeforeEach(func() {
-		// Restore global default values before each test
-		config.PrepareTestConfig()
-		config.Gateway.Mode = config.GatewayModeShared
-		config.OVNKubernetesFeature.EnableEgressFirewall = true
-
-		app = cli.NewApp()
-		app.Name = "test"
-		app.Flags = config.Flags
-
-		fakeOVN = NewFakeOVN()
-	})
-
-	ginkgo.AfterEach(func() {
-		fakeOVN.shutdown()
-	})
-
-	ginkgo.Context("on startup", func() {
-		ginkgo.It("reconciles existing and non-existing egressfirewalls", func() {
-			app.Action = func(ctx *cli.Context) error {
-				purgeACL := libovsdbops.BuildACL(
-					"",
-					t.DirectionFromLPort,
-					t.EgressFirewallStartPriority,
-					"",
-					nbdb.ACLActionDrop,
-					"",
-					"",
-					false,
-					map[string]string{egressFirewallACLExtIdKey: "none"},
-					nil,
-				)
-				purgeACL.UUID = "purgeACL-UUID"
-
-				keepACL := libovsdbops.BuildACL(
-					"",
-					t.DirectionFromLPort,
-					t.EgressFirewallStartPriority-1,
-					"",
-					nbdb.ACLActionDrop,
-					"",
-					"",
-					false,
-					map[string]string{egressFirewallACLExtIdKey: "default"},
-					nil,
-				)
-				keepACL.UUID = "keepACL-UUID"
-
-				// this ACL is not in the egress firewall priority range and should be untouched
-				otherACL := libovsdbops.BuildACL(
-					"",
-					t.DirectionFromLPort,
-					t.MinimumReservedEgressFirewallPriority-1,
-					"",
-					nbdb.ACLActionDrop,
-					"",
-					"",
-					false,
-					map[string]string{egressFirewallACLExtIdKey: "default"},
-					nil,
-				)
-				otherACL.UUID = "otherACL-UUID"
-
-				InitialNodeSwitch := &nbdb.LogicalSwitch{
-					UUID: node1Name + "-UUID",
-					Name: node1Name,
-					ACLs: []string{purgeACL.UUID, keepACL.UUID},
-				}
-
-				InitialJoinSwitch := &nbdb.LogicalSwitch{
-					UUID: "join-UUID",
-					Name: "join",
-					ACLs: []string{purgeACL.UUID, keepACL.UUID},
-				}
-
-				dbSetup := libovsdbtest.TestSetup{
-					NBData: []libovsdbtest.TestData{
-						purgeACL,
-						keepACL,
-						otherACL,
-						InitialNodeSwitch,
-						InitialJoinSwitch,
-						clusterRouter,
-					},
-				}
-				fakeOVN.startWithDBSetup(dbSetup,
-					&v1.NodeList{
-						Items: []v1.Node{
-							{
-								Status: v1.NodeStatus{
-									Phase: v1.NodeRunning,
-								},
-								ObjectMeta: newObjectMeta(node1Name, ""),
-							},
-						},
-					})
-
-				// only create one egressFirewall
-				_, err := fakeOVN.fakeClient.EgressFirewallClient.K8sV1().EgressFirewalls("default").Create(context.TODO(), &egressfirewallapi.EgressFirewall{}, metav1.CreateOptions{})
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-				fakeOVN.controller.WatchEgressFirewall()
-
-				// Both ACLS will be removed from the node switch
-				finalNodeSwitch := &nbdb.LogicalSwitch{
-					UUID: InitialNodeSwitch.UUID,
-					Name: node1Name,
-				}
-
-				// purgeACL will be removed form the join switch
-				finalJoinSwitch := &nbdb.LogicalSwitch{
-					UUID: InitialJoinSwitch.UUID,
-					Name: InitialJoinSwitch.Name,
-					ACLs: []string{keepACL.UUID},
-				}
-
-				// Direction of both ACLs will be converted to
-				keepACL.Direction = t.DirectionToLPort
-
-				// purgeACL ACL will be deleted when test server starts deleting dereferenced ACLs
-				// for now we need to update its fields, since it is present in the db
-				purgeACL.Direction = t.DirectionToLPort
-
-				expectedDatabaseState := []libovsdb.TestData{
-					otherACL,
-					purgeACL,
-					keepACL,
-					finalNodeSwitch,
-					finalJoinSwitch,
-					clusterRouter,
-				}
-
-				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
-
-				return nil
-			}
-
-			err := app.Run([]string{app.Name})
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-		})
-		ginkgo.It("reconciles an existing egressFirewall with IPv4 CIDR", func() {
-			app.Action = func(ctx *cli.Context) error {
-				InitialJoinSwitch := &nbdb.LogicalSwitch{
-					UUID: "join-UUID",
-					Name: "join",
-				}
-
-				namespace1 := *newNamespace("namespace1")
-				egressFirewall := newEgressFirewallObject("default", namespace1.Name, []egressfirewallapi.EgressFirewallRule{
-					{
-						Type: "Allow",
-						To: egressfirewallapi.EgressFirewallDestination{
-							CIDRSelector: "1.2.3.4/23",
-						},
-					},
-				})
-
-				dbSetup := libovsdbtest.TestSetup{
-					NBData: []libovsdbtest.TestData{
-						InitialJoinSwitch,
-						clusterRouter,
-					},
-				}
-				fakeOVN.startWithDBSetup(dbSetup,
-					&egressfirewallapi.EgressFirewallList{
-						Items: []egressfirewallapi.EgressFirewall{
-							*egressFirewall,
-						},
-					},
-					&v1.NodeList{
-						Items: []v1.Node{
-							{
-								Status: v1.NodeStatus{
-									Phase: v1.NodeRunning,
-								},
-								ObjectMeta: newObjectMeta(node1Name, ""),
-							},
-						},
-					})
-
-				fakeOVN.controller.WatchEgressFirewall()
-
-				_, err := fakeOVN.fakeClient.EgressFirewallClient.K8sV1().EgressFirewalls(egressFirewall.Namespace).Get(context.TODO(), egressFirewall.Name, metav1.GetOptions{})
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-				ipv4ACL := libovsdbops.BuildACL(
-					"",
-					t.DirectionToLPort,
-					t.EgressFirewallStartPriority,
-					"(ip4.dst == 1.2.3.4/23) && ip4.src == $a10481622940199974102 && inport == \""+t.JoinSwitchToGWRouterPrefix+t.OVNClusterRouter+"\"",
-					nbdb.ACLActionAllow,
-					"",
-					"",
-					false,
-					map[string]string{egressFirewallACLExtIdKey: "namespace1"},
-					nil,
-				)
-				ipv4ACL.UUID = "ipv4ACL-UUID"
-
-				// new ACL will be added to the switch
-				finalJoinSwitch := &nbdb.LogicalSwitch{
-					UUID: InitialJoinSwitch.UUID,
-					Name: InitialJoinSwitch.Name,
-					ACLs: []string{ipv4ACL.UUID},
-				}
-
-				expectedDatabaseState := []libovsdb.TestData{
-					ipv4ACL,
-					finalJoinSwitch,
-					clusterRouter,
-				}
-
-				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
-
-				return nil
-			}
-
-			err := app.Run([]string{app.Name})
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-		})
-		ginkgo.It("reconciles an existing egressFirewall with IPv6 CIDR", func() {
-			app.Action = func(ctx *cli.Context) error {
-				InitialJoinSwitch := &nbdb.LogicalSwitch{
-					UUID: "join-UUID",
-					Name: "join",
-				}
-
-				namespace1 := *newNamespace("namespace1")
-				egressFirewall := newEgressFirewallObject("default", namespace1.Name, []egressfirewallapi.EgressFirewallRule{
-					{
-						Type: "Allow",
-						To: egressfirewallapi.EgressFirewallDestination{
-							CIDRSelector: "2002::1234:abcd:ffff:c0a8:101/64",
-						},
-					},
-				})
-
-				dbSetup := libovsdbtest.TestSetup{
-					NBData: []libovsdbtest.TestData{
-						InitialJoinSwitch,
-						clusterRouter,
-					},
-				}
-				fakeOVN.startWithDBSetup(dbSetup,
-					&egressfirewallapi.EgressFirewallList{
-						Items: []egressfirewallapi.EgressFirewall{
-							*egressFirewall,
-						},
-					},
-					&v1.NamespaceList{
-						Items: []v1.Namespace{
-							namespace1,
-						},
-					}, &v1.NodeList{
-						Items: []v1.Node{
-							{
-								Status: v1.NodeStatus{
-									Phase: v1.NodeRunning,
-								},
-								ObjectMeta: newObjectMeta(node1Name, ""),
-							},
-						},
-					})
-				config.IPv6Mode = true
-				err := fakeOVN.controller.WatchNamespaces()
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				fakeOVN.controller.WatchEgressFirewall()
-
-				_, err = fakeOVN.fakeClient.EgressFirewallClient.K8sV1().EgressFirewalls(egressFirewall.Namespace).Get(context.TODO(), egressFirewall.Name, metav1.GetOptions{})
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-				ipv6ACL := libovsdbops.BuildACL(
-					"",
-					t.DirectionToLPort,
-					t.EgressFirewallStartPriority,
-					"(ip6.dst == 2002::1234:abcd:ffff:c0a8:101/64) && (ip4.src == $a10481622940199974102 || ip6.src == $a10481620741176717680) && inport == \""+t.JoinSwitchToGWRouterPrefix+t.OVNClusterRouter+"\"",
-					nbdb.ACLActionAllow,
-					"",
-					"",
-					false,
-					map[string]string{egressFirewallACLExtIdKey: "namespace1"},
-					nil,
-				)
-				ipv6ACL.UUID = "ipv6ACL-UUID"
-
-				// new ACL will be added to the switch
-				finalJoinSwitch := &nbdb.LogicalSwitch{
-					UUID: InitialJoinSwitch.UUID,
-					Name: InitialJoinSwitch.Name,
-					ACLs: []string{ipv6ACL.UUID},
-				}
-
-				expectedDatabaseState := []libovsdb.TestData{
-					ipv6ACL,
-					finalJoinSwitch,
-					clusterRouter,
-				}
-
-				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
-
-				return nil
-			}
-
-			err := app.Run([]string{app.Name})
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-		})
-	})
-	ginkgo.Context("during execution", func() {
-		ginkgo.It("correctly creates an egressfirewall denying traffic udp traffic on port 100", func() {
-			app.Action = func(ctx *cli.Context) error {
-				initialJoinSwitch := &nbdb.LogicalSwitch{
-					UUID: "join-UUID",
-					Name: "join",
-				}
-
-				namespace1 := *newNamespace("namespace1")
-				egressFirewall := newEgressFirewallObject("default", namespace1.Name, []egressfirewallapi.EgressFirewallRule{
-					{
-						Type: "Deny",
-						Ports: []egressfirewallapi.EgressFirewallPort{
-							{
-								Protocol: "UDP",
-								Port:     100,
-							},
-						},
-						To: egressfirewallapi.EgressFirewallDestination{
-							CIDRSelector: "1.2.3.4/23",
-						},
-					},
-				})
-
-				dbSetup := libovsdbtest.TestSetup{
-					NBData: []libovsdbtest.TestData{
-						initialJoinSwitch,
-						clusterRouter,
-					},
-				}
-				fakeOVN.startWithDBSetup(dbSetup,
-					&egressfirewallapi.EgressFirewallList{
-						Items: []egressfirewallapi.EgressFirewall{
-							*egressFirewall,
-						},
-					},
-					&v1.NamespaceList{
-						Items: []v1.Namespace{
-							namespace1,
-						},
-					},
-					&v1.NodeList{
-						Items: []v1.Node{
-							{
-								Status: v1.NodeStatus{
-									Phase: v1.NodeRunning,
-								},
-								ObjectMeta: newObjectMeta(node1Name, ""),
-							},
-						},
-					})
-
-				err := fakeOVN.controller.WatchNamespaces()
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				_, err = fakeOVN.fakeClient.EgressFirewallClient.K8sV1().EgressFirewalls(egressFirewall.Namespace).Get(context.TODO(), egressFirewall.Name, metav1.GetOptions{})
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-				fakeOVN.controller.WatchEgressFirewall()
-
-				udpACL := libovsdbops.BuildACL(
-					"",
-					t.DirectionToLPort,
-					t.EgressFirewallStartPriority,
-					"(ip4.dst == 1.2.3.4/23) && ip4.src == $a10481622940199974102 && ((udp && ( udp.dst == 100 ))) && inport == \""+
-						t.JoinSwitchToGWRouterPrefix+t.OVNClusterRouter+"\"",
-					nbdb.ACLActionDrop,
-					"",
-					"",
-					false,
-					map[string]string{egressFirewallACLExtIdKey: "namespace1"},
-					nil,
-				)
-
-				udpACL.UUID = "udpACL-UUID"
-
-				// new ACL will be added to the switch
-				finalJoinSwitch := &nbdb.LogicalSwitch{
-					UUID: initialJoinSwitch.UUID,
-					Name: initialJoinSwitch.Name,
-					ACLs: []string{udpACL.UUID},
-				}
-
-				expectedDatabaseState := []libovsdb.TestData{
-					udpACL,
-					finalJoinSwitch,
-					clusterRouter,
-				}
-
-				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
-
-				return nil
-			}
-			err := app.Run([]string{app.Name})
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		})
-		ginkgo.It("correctly deletes an egressfirewall", func() {
-			app.Action = func(ctx *cli.Context) error {
-				initialJoinSwitch := &nbdb.LogicalSwitch{
-					UUID: "join-UUID",
-					Name: "join",
-				}
-
-				namespace1 := *newNamespace("namespace1")
-				egressFirewall := newEgressFirewallObject("default", namespace1.Name, []egressfirewallapi.EgressFirewallRule{
-					{
-						Type: "Allow",
-						Ports: []egressfirewallapi.EgressFirewallPort{
-							{
-								Protocol: "TCP",
-								Port:     100,
-							},
-						},
-						To: egressfirewallapi.EgressFirewallDestination{
-							CIDRSelector: "1.2.3.5/23",
-						},
-					},
-				})
-
-				dbSetup := libovsdbtest.TestSetup{
-					NBData: []libovsdbtest.TestData{
-						initialJoinSwitch,
-						clusterRouter,
-					},
-				}
-				fakeOVN.startWithDBSetup(dbSetup,
-					&egressfirewallapi.EgressFirewallList{
-						Items: []egressfirewallapi.EgressFirewall{
-							*egressFirewall,
-						},
-					},
-					&v1.NodeList{
-						Items: []v1.Node{
-							{
-								Status: v1.NodeStatus{
-									Phase: v1.NodeRunning,
-								},
-								ObjectMeta: newObjectMeta(node1Name, ""),
-							},
-						},
-					})
-
-				fakeOVN.controller.WatchEgressFirewall()
-
-				ipv4ACL := libovsdbops.BuildACL(
-					"",
-					t.DirectionToLPort,
-					t.EgressFirewallStartPriority,
-					"(ip4.dst == 1.2.3.5/23) && "+
-						"ip4.src == $a10481622940199974102 && ((tcp && ( tcp.dst == 100 ))) && inport == \""+t.JoinSwitchToGWRouterPrefix+t.OVNClusterRouter+"\"",
-					nbdb.ACLActionAllow,
-					"",
-					"",
-					false,
-					map[string]string{egressFirewallACLExtIdKey: "namespace1"},
-					nil,
-				)
-				ipv4ACL.UUID = "ipv4ACL-UUID"
-
-				// new ACL will be added to the switch
-				finalJoinSwitch := &nbdb.LogicalSwitch{
-					UUID: initialJoinSwitch.UUID,
-					Name: initialJoinSwitch.Name,
-					ACLs: []string{ipv4ACL.UUID},
-				}
-
-				expectedDatabaseState := []libovsdb.TestData{
-					ipv4ACL,
-					finalJoinSwitch,
-					clusterRouter,
-				}
-
-				gomega.Expect(fakeOVN.nbClient).To(libovsdbtest.HaveData(expectedDatabaseState))
-
-				err := fakeOVN.fakeClient.EgressFirewallClient.K8sV1().EgressFirewalls(egressFirewall.Namespace).Delete(context.TODO(), egressFirewall.Name, *metav1.NewDeleteOptions(0))
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-				// join switch should return to orignal state, egfw was deleted
-				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(append(fakeOVN.dbSetup.NBData,
-					// this ACL will be deleted when test server starts deleting dereferenced ACLs
-					ipv4ACL)))
-
-				return nil
-			}
-
-			err := app.Run([]string{app.Name})
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		})
-		ginkgo.It("correctly updates an egressfirewall", func() {
-			app.Action = func(ctx *cli.Context) error {
-				initialJoinSwitch := &nbdb.LogicalSwitch{
-					UUID: "join-UUID",
-					Name: "join",
-				}
-
-				namespace1 := *newNamespace("namespace1")
-				egressFirewall := newEgressFirewallObject("default", namespace1.Name, []egressfirewallapi.EgressFirewallRule{
-					{
-						Type: "Allow",
-						To: egressfirewallapi.EgressFirewallDestination{
-							CIDRSelector: "1.2.3.4/23",
-						},
-					},
-				})
-				egressFirewall1 := newEgressFirewallObject("default", namespace1.Name, []egressfirewallapi.EgressFirewallRule{
-					{
-						Type: "Deny",
-						To: egressfirewallapi.EgressFirewallDestination{
-							CIDRSelector: "1.2.3.4/23",
-						},
-					},
-				})
-
-				dbSetup := libovsdbtest.TestSetup{
-					NBData: []libovsdbtest.TestData{
-						initialJoinSwitch,
-						clusterRouter,
-					},
-				}
-				fakeOVN.startWithDBSetup(dbSetup,
-					&egressfirewallapi.EgressFirewallList{
-						Items: []egressfirewallapi.EgressFirewall{
-							*egressFirewall,
-						},
-					},
-					&v1.NodeList{
-						Items: []v1.Node{
-							{
-								Status: v1.NodeStatus{
-									Phase: v1.NodeRunning,
-								},
-								ObjectMeta: newObjectMeta(node1Name, ""),
-							},
-						},
-					})
-
-				fakeOVN.controller.WatchEgressFirewall()
-
-				ipv4ACL := libovsdbops.BuildACL(
-					"",
-					t.DirectionToLPort,
-					t.EgressFirewallStartPriority,
-					"(ip4.dst == 1.2.3.4/23) && ip4.src == $a10481622940199974102 && inport == \""+t.JoinSwitchToGWRouterPrefix+t.OVNClusterRouter+"\"",
-					nbdb.ACLActionAllow,
-					"",
-					"",
-					false,
-					map[string]string{egressFirewallACLExtIdKey: "namespace1"},
-					nil,
-				)
-				ipv4ACL.UUID = "ipv4ACL-UUID"
-
-				// new ACL will be added to the switch
-				finalJoinSwitch := &nbdb.LogicalSwitch{
-					UUID: initialJoinSwitch.UUID,
-					Name: initialJoinSwitch.Name,
-					ACLs: []string{ipv4ACL.UUID},
-				}
-
-				expectedDatabaseState := []libovsdb.TestData{
-					ipv4ACL,
-					finalJoinSwitch,
-					clusterRouter,
-				}
-
-				gomega.Expect(fakeOVN.nbClient).To(libovsdbtest.HaveData(expectedDatabaseState))
-
-				_, err := fakeOVN.fakeClient.EgressFirewallClient.K8sV1().EgressFirewalls(egressFirewall.Namespace).Get(context.TODO(), egressFirewall.Name, metav1.GetOptions{})
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				_, err = fakeOVN.fakeClient.EgressFirewallClient.K8sV1().EgressFirewalls(egressFirewall1.Namespace).Update(context.TODO(), egressFirewall1, metav1.UpdateOptions{})
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				// egress firewall is updated by deleting and creating from scratch
-				// since old acl won't be garbage-collected by the test server, it will stay,
-				// but won't be referenced from the switch
-				ipv4ACLStale := libovsdbops.BuildACL(
-					"",
-					t.DirectionToLPort,
-					t.EgressFirewallStartPriority,
-					"(ip4.dst == 1.2.3.4/23) && ip4.src == $a10481622940199974102 && inport == \""+t.JoinSwitchToGWRouterPrefix+t.OVNClusterRouter+"\"",
-					nbdb.ACLActionAllow,
-					"",
-					"",
-					false,
-					map[string]string{"egressFirewall": "namespace1"},
-					nil,
-				)
-				ipv4ACLStale.UUID = "ipv4ACLStale-UUID"
-
-				ipv4ACL.Action = nbdb.ACLActionDrop
-				expectedDatabaseState = append(expectedDatabaseState, ipv4ACLStale)
-
-				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
-
-				return nil
-			}
-
-			err := app.Run([]string{app.Name})
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-		})
-	})
-
 })
 
 var _ = ginkgo.Describe("OVN test basic functions", func() {
@@ -1700,83 +890,88 @@ var _ = ginkgo.Describe("OVN test basic functions", func() {
 	})
 	ginkgo.It("computes correct match function", func() {
 		type testcase struct {
-			internalCIDR string
-			ipv4source   string
-			ipv6source   string
-			ipv4Mode     bool
-			ipv6Mode     bool
-			destinations []matchTarget
-			ports        []egressfirewallapi.EgressFirewallPort
-			output       string
+			internalCIDRs []string
+			ipv4source    string
+			ipv6source    string
+			ipv4Mode      bool
+			ipv6Mode      bool
+			destinations  []matchTarget
+			ports         []egressfirewallapi.EgressFirewallPort
+			output        string
 		}
 		testcases := []testcase{
 			{
-				internalCIDR: "10.128.0.0/14",
-				ipv4source:   "testv4",
-				ipv6source:   "",
-				ipv4Mode:     true,
-				ipv6Mode:     false,
-				destinations: []matchTarget{{matchKindV4CIDR, "1.2.3.4/32"}},
-				ports:        nil,
-				output:       "(ip4.dst == 1.2.3.4/32) && ip4.src == $testv4 && inport == \"" + t.JoinSwitchToGWRouterPrefix + t.OVNClusterRouter + "\"",
+				internalCIDRs: []string{"10.128.0.0/14"},
+				ipv4source:    "testv4",
+				ipv6source:    "",
+				ipv4Mode:      true,
+				ipv6Mode:      false,
+				destinations:  []matchTarget{{matchKindV4CIDR, "1.2.3.4/32"}},
+				ports:         nil,
+				output:        "(ip4.dst == 1.2.3.4/32) && ip4.src == $testv4 && ip4.dst != 10.128.0.0/14",
 			},
 			{
-				internalCIDR: "10.128.0.0/14",
-				ipv4source:   "testv4",
-				ipv6source:   "testv6",
-				ipv4Mode:     true,
-				ipv6Mode:     true,
-				destinations: []matchTarget{{matchKindV4CIDR, "1.2.3.4/32"}},
-				ports:        nil,
-				output:       "(ip4.dst == 1.2.3.4/32) && (ip4.src == $testv4 || ip6.src == $testv6) && inport == \"" + t.JoinSwitchToGWRouterPrefix + t.OVNClusterRouter + "\"",
+				internalCIDRs: []string{"10.128.0.0/14", "2002:0:0:1234::/64"},
+				ipv4source:    "testv4",
+				ipv6source:    "testv6",
+				ipv4Mode:      true,
+				ipv6Mode:      true,
+				destinations:  []matchTarget{{matchKindV4CIDR, "1.2.3.4/32"}},
+				ports:         nil,
+				output:        "(ip4.dst == 1.2.3.4/32) && (ip4.src == $testv4 || ip6.src == $testv6) && ip4.dst != 10.128.0.0/14 && ip6.dst != 2002:0:0:1234::/64",
 			},
 			{
-				internalCIDR: "10.128.0.0/14",
-				ipv4source:   "testv4",
-				ipv6source:   "testv6",
-				ipv4Mode:     true,
-				ipv6Mode:     true,
-				destinations: []matchTarget{{matchKindV4AddressSet, "destv4"}, {matchKindV6AddressSet, "destv6"}},
-				ports:        nil,
-				output:       "(ip4.dst == $destv4 || ip6.dst == $destv6) && (ip4.src == $testv4 || ip6.src == $testv6) && inport == \"" + t.JoinSwitchToGWRouterPrefix + t.OVNClusterRouter + "\"",
+				internalCIDRs: []string{"10.128.0.0/14", "2002:0:0:1234::/64"},
+				ipv4source:    "testv4",
+				ipv6source:    "testv6",
+				ipv4Mode:      true,
+				ipv6Mode:      true,
+				destinations:  []matchTarget{{matchKindV4AddressSet, "destv4"}, {matchKindV6AddressSet, "destv6"}},
+				ports:         nil,
+				output:        "(ip4.dst == $destv4 || ip6.dst == $destv6) && (ip4.src == $testv4 || ip6.src == $testv6) && ip4.dst != 10.128.0.0/14 && ip6.dst != 2002:0:0:1234::/64",
 			},
 			{
-				internalCIDR: "10.128.0.0/14",
-				ipv4source:   "testv4",
-				ipv6source:   "",
-				ipv4Mode:     true,
-				ipv6Mode:     false,
-				destinations: []matchTarget{{matchKindV4AddressSet, "destv4"}, {matchKindV6AddressSet, ""}},
-				ports:        nil,
-				output:       "(ip4.dst == $destv4) && ip4.src == $testv4 && inport == \"" + t.JoinSwitchToGWRouterPrefix + t.OVNClusterRouter + "\"",
+				internalCIDRs: []string{"10.128.0.0/14"},
+				ipv4source:    "testv4",
+				ipv6source:    "",
+				ipv4Mode:      true,
+				ipv6Mode:      false,
+				destinations:  []matchTarget{{matchKindV4AddressSet, "destv4"}, {matchKindV6AddressSet, ""}},
+				ports:         nil,
+				output:        "(ip4.dst == $destv4) && ip4.src == $testv4 && ip4.dst != 10.128.0.0/14",
 			},
 			{
-				internalCIDR: "10.128.0.0/14",
-				ipv4source:   "testv4",
-				ipv6source:   "testv6",
-				ipv4Mode:     true,
-				ipv6Mode:     true,
-				destinations: []matchTarget{{matchKindV6CIDR, "2001::/64"}},
-				ports:        nil,
-				output:       "(ip6.dst == 2001::/64) && (ip4.src == $testv4 || ip6.src == $testv6) && inport == \"" + t.JoinSwitchToGWRouterPrefix + t.OVNClusterRouter + "\"",
+				internalCIDRs: []string{"10.128.0.0/14", "2002:0:0:1234::/64"},
+				ipv4source:    "testv4",
+				ipv6source:    "testv6",
+				ipv4Mode:      true,
+				ipv6Mode:      true,
+				destinations:  []matchTarget{{matchKindV6CIDR, "2001::/64"}},
+				ports:         nil,
+				output:        "(ip6.dst == 2001::/64) && (ip4.src == $testv4 || ip6.src == $testv6) && ip4.dst != 10.128.0.0/14 && ip6.dst != 2002:0:0:1234::/64",
 			},
 			{
-				internalCIDR: "2002:0:0:1234::/64",
-				ipv4source:   "",
-				ipv6source:   "testv6",
-				ipv4Mode:     false,
-				ipv6Mode:     true,
-				destinations: []matchTarget{{matchKindV6AddressSet, "destv6"}},
-				ports:        nil,
-				output:       "(ip6.dst == $destv6) && ip6.src == $testv6 && inport == \"" + t.JoinSwitchToGWRouterPrefix + t.OVNClusterRouter + "\"",
+				internalCIDRs: []string{"2002:0:0:1234::/64"},
+				ipv4source:    "",
+				ipv6source:    "testv6",
+				ipv4Mode:      false,
+				ipv6Mode:      true,
+				destinations:  []matchTarget{{matchKindV6AddressSet, "destv6"}},
+				ports:         nil,
+				output:        "(ip6.dst == $destv6) && ip6.src == $testv6 && ip6.dst != 2002:0:0:1234::/64",
 			},
 		}
 
 		for _, tc := range testcases {
 			config.IPv4Mode = tc.ipv4Mode
 			config.IPv6Mode = tc.ipv6Mode
-			_, cidr, _ := net.ParseCIDR(tc.internalCIDR)
-			config.Default.ClusterSubnets = []config.CIDRNetworkEntry{{CIDR: cidr}}
+			subnets := []config.CIDRNetworkEntry{}
+			for _, clusterCIDR := range tc.internalCIDRs {
+				_, cidr, _ := net.ParseCIDR(clusterCIDR)
+				subnets = append(subnets, config.CIDRNetworkEntry{CIDR: cidr})
+			}
+			config.Default.ClusterSubnets = subnets
+
 			config.Gateway.Mode = config.GatewayModeShared
 			matchExpression := generateMatch(tc.ipv4source, tc.ipv6source, tc.destinations, tc.ports)
 			gomega.Expect(tc.output).To(gomega.Equal(matchExpression))

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -998,7 +998,7 @@ func createSrcPod(podName, nodeName string, ipCheckInterval, ipCheckTimeout time
 	if err != nil {
 		framework.Failf("Failed to create src pod %s: %v", podName, err)
 	}
-	// Wait for pod exgw setup to be almost ready
+	// Wait for pod setup to be almost ready
 	err = wait.PollImmediate(ipCheckInterval, ipCheckTimeout, func() (bool, error) {
 		kubectlOut := getPodAddress(podName, f.Namespace.Name)
 		validIP := net.ParseIP(kubectlOut)

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -992,6 +992,27 @@ var _ = ginkgo.Describe("e2e non-vxlan external gateway and update validation", 
 	})
 })
 
+func createSrcPod(podName, nodeName string, ipCheckInterval, ipCheckTimeout time.Duration, f *framework.Framework) {
+	_, err := createGenericPod(f, podName, nodeName, f.Namespace.Name,
+		[]string{"bash", "-c", "sleep 20000"})
+	if err != nil {
+		framework.Failf("Failed to create src pod %s: %v", podName, err)
+	}
+	// Wait for pod exgw setup to be almost ready
+	err = wait.PollImmediate(ipCheckInterval, ipCheckTimeout, func() (bool, error) {
+		kubectlOut := getPodAddress(podName, f.Namespace.Name)
+		validIP := net.ParseIP(kubectlOut)
+		if validIP == nil {
+			return false, nil
+		}
+		return true, nil
+	})
+	// Fail the test if no address is ever retrieved
+	if err != nil {
+		framework.Failf("Error trying to get the pod IP address %v", err)
+	}
+}
+
 // Validate the egress firewall policies by applying a policy and verify
 // that both explicitly allowed traffic and implicitly denied traffic
 // is properly handled as defined in the crd configuration in the test.
@@ -1004,6 +1025,7 @@ var _ = ginkgo.Describe("e2e egress firewall policy validation", func() {
 		testTimeout            string = "5"
 		retryInterval                 = 1 * time.Second
 		retryTimeout                  = 30 * time.Second
+		ciNetworkName                 = "kind"
 	)
 
 	type nodeInfo struct {
@@ -1060,7 +1082,6 @@ var _ = ginkgo.Describe("e2e egress firewall policy validation", func() {
 
 	ginkgo.It("Should validate the egress firewall policy functionality against remote hosts", func() {
 		srcPodName := "e2e-egress-fw-src-pod"
-		command := []string{"bash", "-c", "sleep 20000"}
 		frameworkNsFlag := fmt.Sprintf("--namespace=%s", f.Namespace.Name)
 		testContainer := fmt.Sprintf("%s-container", srcPodName)
 		testContainerFlag := fmt.Sprintf("--container=%s", testContainer)
@@ -1105,24 +1126,11 @@ spec:
 		// apply the egress firewall configuration
 		framework.RunKubectlOrDie(f.Namespace.Name, applyArgs...)
 		// create the pod that will be used as the source for the connectivity test
-		createGenericPod(f, srcPodName, serverNodeInfo.name, f.Namespace.Name, command)
+		createSrcPod(srcPodName, serverNodeInfo.name, retryInterval, retryTimeout, f)
 
-		// Wait for pod exgw setup to be almost ready
-		err := wait.PollImmediate(retryInterval, retryTimeout, func() (bool, error) {
-			kubectlOut := getPodAddress(srcPodName, f.Namespace.Name)
-			validIP := net.ParseIP(kubectlOut)
-			if validIP == nil {
-				return false, nil
-			}
-			return true, nil
-		})
-		// Fail the test if no address is ever retrieved
-		if err != nil {
-			framework.Failf("Error trying to get the pod IP address %v", err)
-		}
 		// Verify the remote host/port as explicitly allowed by the firewall policy is reachable
 		ginkgo.By(fmt.Sprintf("Verifying connectivity to an explicitly allowed host %s is permitted as defined by the external firewall policy", exFWPermitTcpDnsDest))
-		_, err = framework.RunKubectl(f.Namespace.Name, "exec", srcPodName, testContainerFlag, "--", "nc", "-vz", "-w", testTimeout, exFWPermitTcpDnsDest, "53")
+		_, err := framework.RunKubectl(f.Namespace.Name, "exec", srcPodName, testContainerFlag, "--", "nc", "-vz", "-w", testTimeout, exFWPermitTcpDnsDest, "53")
 		if err != nil {
 			framework.Failf("Failed to connect to the remote host %s from container %s on node %s: %v", exFWPermitTcpDnsDest, ovnContainer, serverNodeInfo.name, err)
 		}
@@ -1132,7 +1140,7 @@ spec:
 		if err == nil {
 			framework.Failf("Succeeded in connecting the implicitly denied remote host %s from container %s on node %s", exFWDenyTcpDnsDest, ovnContainer, serverNodeInfo.name)
 		}
-		// Verify the the explicitly allowed host/port tcp port 80 rule is functional
+		// Verify the explicitly allowed host/port tcp port 80 rule is functional
 		ginkgo.By(fmt.Sprintf("Verifying connectivity to an explicitly allowed host %s is permitted as defined by the external firewall policy", exFWPermitTcpWwwDest))
 		_, err = framework.RunKubectl(f.Namespace.Name, "exec", srcPodName, testContainerFlag, "--", "nc", "-vz", "-w", testTimeout, exFWPermitTcpWwwDest, "80")
 		if err != nil {
@@ -1229,6 +1237,137 @@ spec:
 			}
 			return strings.Contains(output, "EgressFirewall Rules applied")
 		}, 30*time.Second).Should(gomega.BeTrue())
+	})
+
+	ginkgo.It("Should validate the egress firewall allows inbound connections", func() {
+		// 1. Create nodePort service and external container
+		// 2. Check connectivity works both ways
+		// 3. Apply deny-all egress firewall
+		// 4. Check only inbound traffic is allowed
+
+		efPodName := "e2e-egress-fw-pod"
+		efPodPort := 1234
+		serviceName := "nodeportsvc"
+		servicePort := 31234
+		externalContainerName := "e2e-egress-fw-external-container"
+		externalContainerPort := 1234
+
+		frameworkNsFlag := fmt.Sprintf("--namespace=%s", f.Namespace.Name)
+		testContainer := fmt.Sprintf("%s-container", efPodName)
+		testContainerFlag := fmt.Sprintf("--container=%s", testContainer)
+		// egress firewall crd yaml configuration
+		var egressFirewallConfig = fmt.Sprintf(`kind: EgressFirewall
+apiVersion: k8s.ovn.org/v1
+metadata:
+  name: default
+  namespace: %s
+spec:
+  egress:
+  - type: Deny
+    to:
+      cidrSelector: 0.0.0.0/0
+`, f.Namespace.Name)
+		// write the config to a file for application and defer the removal
+		if err := ioutil.WriteFile(egressFirewallYamlFile, []byte(egressFirewallConfig), 0644); err != nil {
+			framework.Failf("Unable to write CRD config to disk: %v", err)
+		}
+		defer func() {
+			if err := os.Remove(egressFirewallYamlFile); err != nil {
+				framework.Logf("Unable to remove the CRD config from disk: %v", err)
+			}
+		}()
+		// create the CRD config parameters
+		applyArgs := []string{
+			"apply",
+			frameworkNsFlag,
+			"-f",
+			egressFirewallYamlFile,
+		}
+
+		ginkgo.By("Creating the egress firewall pod")
+		// 1. create nodePort service and external container
+		endpointsSelector := map[string]string{"servicebackend": "true"}
+		_, err := createPod(f, efPodName, serverNodeInfo.name, f.Namespace.Name,
+			[]string{"/agnhost", "netexec", fmt.Sprintf("--http-port=%d", efPodPort)}, endpointsSelector)
+		if err != nil {
+			framework.Failf("Failed to create pod %s: %v", efPodName, err)
+		}
+
+		ginkgo.By("Creating the nodePort service")
+		npSpec := &v1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: serviceName,
+			},
+			Spec: v1.ServiceSpec{
+				Type: v1.ServiceTypeNodePort,
+				Ports: []v1.ServicePort{
+					{
+						Port:       int32(servicePort),
+						NodePort:   int32(servicePort),
+						Name:       "http",
+						Protocol:   v1.ProtocolTCP,
+						TargetPort: intstr.FromInt(efPodPort),
+					},
+				},
+				Selector: endpointsSelector,
+			},
+		}
+		_, err = f.ClientSet.CoreV1().Services(f.Namespace.Name).Create(context.Background(), npSpec, metav1.CreateOptions{})
+		framework.ExpectNoError(err)
+
+		ginkgo.By("Waiting for the endpoints to pop up")
+		err = framework.WaitForServiceEndpointsNum(f.ClientSet, f.Namespace.Name, serviceName, 1, time.Second, wait.ForeverTestTimeout)
+		framework.ExpectNoError(err, "failed to validate endpoints for service %s in namespace: %s", serviceName, f.Namespace.Name)
+
+		nodeIP := serverNodeInfo.nodeIP
+		externalContainerIP, _ := createClusterExternalContainer(externalContainerName, agnhostImage,
+			[]string{"--network", ciNetworkName, "-p", fmt.Sprintf("%d:%d", externalContainerPort, externalContainerPort)},
+			[]string{"netexec", fmt.Sprintf("--http-port=%d", externalContainerPort)})
+		defer deleteClusterExternalContainer(externalContainerName)
+
+		// 2. Check connectivity works both ways
+		// pod -> external container should work
+		ginkgo.By(fmt.Sprintf("Verifying connectivity from pod %s to external container [%s]:%d",
+			efPodName, externalContainerIP, externalContainerPort))
+		_, err = framework.RunKubectl(f.Namespace.Name, "exec", efPodName, testContainerFlag,
+			"--", "nc", "-vz", "-w", testTimeout, externalContainerIP, strconv.Itoa(externalContainerPort))
+		if err != nil {
+			framework.Failf("Failed to connect from pod to external container, before egress firewall is applied")
+		}
+		// external container -> nodePort svc should work
+		ginkgo.By(fmt.Sprintf("Verifying connectivity from external container %s to nodePort svc [%s]:%d",
+			externalContainerIP, nodeIP, servicePort))
+		cmd := []string{"docker", "exec", externalContainerName, "nc", "-vz", "-w", testTimeout, nodeIP, strconv.Itoa(servicePort)}
+		framework.Logf("Running command %v", cmd)
+		_, err = runCommand(cmd...)
+		if err != nil {
+			framework.Failf("Failed to connect to nodePort service from external container %s, before egress firewall is applied: %v",
+				externalContainerName, err)
+		}
+
+		// 3. Apply deny-all egress firewall
+		framework.Logf("Applying EgressFirewall configuration: %s ", applyArgs)
+		framework.RunKubectlOrDie(f.Namespace.Name, applyArgs...)
+
+		// 4. Check that only inbound traffic is allowed
+		// pod -> external container should be blocked
+		ginkgo.By(fmt.Sprintf("Verifying connection from pod %s to external container %s is blocked:%d",
+			efPodName, externalContainerIP, externalContainerPort))
+		_, err = framework.RunKubectl(f.Namespace.Name, "exec", efPodName, testContainerFlag,
+			"--", "nc", "-vz", "-w", testTimeout, externalContainerIP, strconv.Itoa(externalContainerPort))
+		if err == nil {
+			framework.Failf("Egress firewall doesn't block connection from pod to external container")
+		}
+		// external container -> nodePort svc should work
+		ginkgo.By(fmt.Sprintf("Verifying connectivity from external container %s to nodePort svc [%s]:%d",
+			externalContainerIP, nodeIP, servicePort))
+		cmd = []string{"docker", "exec", externalContainerName, "nc", "-vz", "-w", testTimeout, nodeIP, strconv.Itoa(servicePort)}
+		framework.Logf("Running command %v", cmd)
+		_, err = runCommand(cmd...)
+		if err != nil {
+			framework.Failf("Failed to connect to nodePort service from external container %s: %v",
+				externalContainerName, err)
+		}
 	})
 })
 


### PR DESCRIPTION
Backport of https://github.com/openshift/ovn-kubernetes/pull/1477
Minor conflicts in the test files
Conflicts:
	go-controller/pkg/ovn/egressfirewall_dns_test.go -
TestifyMockHelper doesn't allow to set exact call args in that version,
update to only check types.
	go-controller/pkg/ovn/egressfirewall_test.go -
add acls that are not garbage-collected.