### PR TITLE
[release-4.10] OCPBUGS-5990: egressip: fix test data race accessing podAssignment cache

### DIFF
--- a/go-controller/pkg/ovn/egressip.go
+++ b/go-controller/pkg/ovn/egressip.go
@@ -1824,6 +1824,22 @@ type podAssignmentState struct {
 	standbyEgressIPNames sets.String
 }
 
+// Clone deep-copies and returns the copied podAssignmentState
+func (pas *podAssignmentState) Clone() *podAssignmentState {
+	clone := &podAssignmentState{
+		egressIPName: pas.egressIPName,
+	}
+	clone.standbyEgressIPNames = make(sets.String, len(pas.standbyEgressIPNames))
+	for k := range pas.standbyEgressIPNames {
+		clone.standbyEgressIPNames.Insert(k)
+	}
+	clone.egressStatuses = make(map[egressipv1.EgressIPStatusItem]string, len(pas.egressStatuses))
+	for k, v := range pas.egressStatuses {
+		clone.egressStatuses[k] = v
+	}
+	return clone
+}
+
 type allocator struct {
 	*sync.Mutex
 	// A cache used for egress IP assignments containing data for all cluster nodes

--- a/go-controller/pkg/ovn/egressip_test.go
+++ b/go-controller/pkg/ovn/egressip_test.go
@@ -17,6 +17,7 @@ import (
 	ovntypes "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 	"github.com/urfave/cli/v2"
+	kapi "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
@@ -199,6 +200,15 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 	ginkgo.AfterEach(func() {
 		fakeOvn.shutdown()
 	})
+
+	getPodAssignmentState := func(pod *kapi.Pod) *podAssignmentState {
+		fakeOvn.controller.eIPC.podAssignmentMutex.Lock()
+		defer fakeOvn.controller.eIPC.podAssignmentMutex.Unlock()
+		if pas := fakeOvn.controller.eIPC.podAssignment[getPodKey(pod)]; pas != nil {
+			return pas.Clone()
+		}
+		return nil
+	}
 
 	ginkgo.Context("On node UPDATE", func() {
 
@@ -3314,9 +3324,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 				// even the LSP sticks around for 60 seconds
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(finalDatabaseStatewithPod))
 				// egressIP cache is stale in the sense the podKey has not been deleted since deletion failed
-				status, exists := fakeOvn.controller.eIPC.podAssignment[getPodKey(&egressPod1)]
-				gomega.Expect(exists).To(gomega.BeTrue())
-				gomega.Expect(status.egressStatuses).To(gomega.Equal(map[egressipv1.EgressIPStatusItem]string{
+				pas := getPodAssignmentState(&egressPod1)
+				gomega.Expect(pas).NotTo(gomega.BeNil())
+				gomega.Expect(pas.egressStatuses).To(gomega.Equal(map[egressipv1.EgressIPStatusItem]string{
 					{
 						Node:     "node1",
 						EgressIP: "192.168.126.101",
@@ -3597,31 +3607,23 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 				gomega.Expect(egressIPs2[0]).To(gomega.Equal(egressIP3))
 				recordedEvent = <-fakeOvn.fakeRecorder.Events
 				gomega.Expect(recordedEvent).To(gomega.ContainSubstring("EgressIP object egressip-2 will not be configured for pod egressip-namespace_egress-pod since another egressIP object egressip is serving it, this is undefined"))
-				podCache := make(map[string]*podAssignmentState)
-				fakeOvn.controller.eIPC.podAssignmentMutex.Lock()
-				for k, v := range fakeOvn.controller.eIPC.podAssignment {
-					value := *v
-					podCache[k] = &value // deep copy to avoid map reference issues
-				}
-				fakeOvn.controller.eIPC.podAssignmentMutex.Unlock()
 
-				assginedEIPName := podCache[getPodKey(&egressPod1)].egressIPName
-				standByEIPNames := podCache[getPodKey(&egressPod1)].standbyEgressIPNames
-				assginedStatuses := podCache[getPodKey(&egressPod1)].egressStatuses
+				pas := getPodAssignmentState(&egressPod1)
+				gomega.Expect(pas).NotTo(gomega.BeNil())
 
 				assginedEIP := egressIPs1[0]
-				gomega.Expect(assginedEIPName).To(gomega.Equal(egressIPName))
+				gomega.Expect(pas.egressIPName).To(gomega.Equal(egressIPName))
 				eip1Obj, err := fakeOvn.fakeClient.EgressIPClient.K8sV1().EgressIPs().Get(context.TODO(), eIP1.Name, metav1.GetOptions{})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				gomega.Expect(assginedStatuses[eip1Obj.Status.Items[0]]).To(gomega.Equal(""))
-				gomega.Expect(standByEIPNames.Has(egressIPName2)).To(gomega.BeTrue())
+				gomega.Expect(pas.egressStatuses[eip1Obj.Status.Items[0]]).To(gomega.Equal(""))
+				gomega.Expect(pas.standbyEgressIPNames.Has(egressIPName2)).To(gomega.BeTrue())
 
 				podEIPSNAT := &nbdb.NAT{
 					UUID:       "egressip-nat-UUID1",
 					LogicalIP:  egressPodIP[0].String(),
 					ExternalIP: assginedEIP,
 					ExternalIDs: map[string]string{
-						"name": assginedEIPName,
+						"name": pas.egressIPName,
 					},
 					Type:        nbdb.NATTypeSNAT,
 					LogicalPort: utilpointer.StringPtr("k8s-node1"),
@@ -3635,7 +3637,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 					Action:   nbdb.LogicalRouterPolicyActionReroute,
 					Nexthops: nodeLogicalRouterIPv4,
 					ExternalIDs: map[string]string{
-						"name": assginedEIPName,
+						"name": pas.egressIPName,
 					},
 					UUID: "reroute-UUID1",
 				}
@@ -3721,7 +3723,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 					LogicalIP:  egressPodIP[0].String(),
 					ExternalIP: egressIPs1[1],
 					ExternalIDs: map[string]string{
-						"name": assginedEIPName,
+						"name": pas.egressIPName,
 					},
 					Type:        nbdb.NATTypeSNAT,
 					LogicalPort: utilpointer.StringPtr("k8s-node2"),
@@ -3741,22 +3743,15 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(finalDatabaseStatewithPod))
 
 				// check the state of the cache for podKey
-				fakeOvn.controller.eIPC.podAssignmentMutex.Lock()
-				for k, v := range fakeOvn.controller.eIPC.podAssignment {
-					value := *v
-					podCache[k] = &value // deep copy to avoid map reference issues
-				}
-				fakeOvn.controller.eIPC.podAssignmentMutex.Unlock()
-				assginedEIPName = podCache[getPodKey(&egressPod1)].egressIPName
-				standByEIPNames = podCache[getPodKey(&egressPod1)].standbyEgressIPNames
-				assginedStatuses = podCache[getPodKey(&egressPod1)].egressStatuses
+				pas = getPodAssignmentState(&egressPod1)
+				gomega.Expect(pas).NotTo(gomega.BeNil())
 
-				gomega.Expect(assginedEIPName).To(gomega.Equal(egressIPName))
+				gomega.Expect(pas.egressIPName).To(gomega.Equal(egressIPName))
 				eip1Obj, err = fakeOvn.fakeClient.EgressIPClient.K8sV1().EgressIPs().Get(context.TODO(), eIP1.Name, metav1.GetOptions{})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				gomega.Expect(assginedStatuses[eip1Obj.Status.Items[0]]).To(gomega.Equal(""))
-				gomega.Expect(assginedStatuses[eip1Obj.Status.Items[1]]).To(gomega.Equal(""))
-				gomega.Expect(standByEIPNames.Has(egressIPName2)).To(gomega.BeTrue())
+				gomega.Expect(pas.egressStatuses[eip1Obj.Status.Items[0]]).To(gomega.Equal(""))
+				gomega.Expect(pas.egressStatuses[eip1Obj.Status.Items[1]]).To(gomega.Equal(""))
+				gomega.Expect(pas.standbyEgressIPNames.Has(egressIPName2)).To(gomega.BeTrue())
 
 				// let's test syncPodAssignmentCache works as expected! Nuke the podAssignment cache first
 				fakeOvn.controller.eIPC.podAssignmentMutex.Lock()
@@ -3768,21 +3763,13 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 				err = fakeOvn.controller.syncPodAssignmentCache(egressIPCache)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-				fakeOvn.controller.eIPC.podAssignmentMutex.Lock()
-				for k, v := range fakeOvn.controller.eIPC.podAssignment {
-					value := *v
-					podCache[k] = &value // deep copy to avoid map reference issues
-				}
-				fakeOvn.controller.eIPC.podAssignmentMutex.Unlock()
-				assginedEIPName = podCache[getPodKey(&egressPod1)].egressIPName
-				standByEIPNames = podCache[getPodKey(&egressPod1)].standbyEgressIPNames
-				assginedStatuses = podCache[getPodKey(&egressPod1)].egressStatuses
+				pas = getPodAssignmentState(&egressPod1)
+				gomega.Expect(pas).NotTo(gomega.BeNil())
+				gomega.Expect(pas.egressIPName).To(gomega.Equal(egressIPName))
+				gomega.Expect(pas.egressStatuses).To(gomega.Equal(map[egressipv1.EgressIPStatusItem]string{}))
+				gomega.Expect(pas.standbyEgressIPNames.Has(egressIPName2)).To(gomega.BeTrue())
 
-				gomega.Expect(assginedEIPName).To(gomega.Equal(egressIPName))
-				gomega.Expect(assginedStatuses).To(gomega.Equal(map[egressipv1.EgressIPStatusItem]string{}))
-				gomega.Expect(standByEIPNames.Has(egressIPName2)).To(gomega.BeTrue())
-
-				//reset assginedStatuses for rest of the test to progress correctly
+				// reset egressStatuses for rest of the test to progress correctly
 				fakeOvn.controller.eIPC.podAssignmentMutex.Lock()
 				fakeOvn.controller.eIPC.podAssignment[getPodKey(&egressPod1)].egressStatuses[eip1Obj.Status.Items[0]] = ""
 				fakeOvn.controller.eIPC.podAssignment[getPodKey(&egressPod1)].egressStatuses[eip1Obj.Status.Items[1]] = ""
@@ -3792,29 +3779,23 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 				err = fakeOvn.fakeClient.EgressIPClient.K8sV1().EgressIPs().Delete(context.TODO(), egressIPName2, metav1.DeleteOptions{})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-				getStandByEgressIPs := func() bool {
-					fakeOvn.controller.eIPC.podAssignmentMutex.Lock()
-					defer fakeOvn.controller.eIPC.podAssignmentMutex.Unlock()
-					for k, v := range fakeOvn.controller.eIPC.podAssignment {
-						value := *v
-						podCache[k] = &value // deep copy to avoid map reference issues
-					}
-					hasStandBy := podCache[getPodKey(&egressPod1)].standbyEgressIPNames.Has(egressIPName2)
-					return hasStandBy
-				}
 				gomega.Eventually(func() bool {
-					return getStandByEgressIPs()
+					pas := getPodAssignmentState(&egressPod1)
+					gomega.Expect(pas).NotTo(gomega.BeNil())
+					return pas.standbyEgressIPNames.Has(egressIPName2)
 				}).Should(gomega.BeFalse())
-				gomega.Expect(podCache[getPodKey(&egressPod1)].egressIPName).To(gomega.Equal(egressIPName))
+				gomega.Expect(getPodAssignmentState(&egressPod1).egressIPName).To(gomega.Equal(egressIPName))
 
 				// add back the standby egressIP object
 				_, err = fakeOvn.fakeClient.EgressIPClient.K8sV1().EgressIPs().Create(context.TODO(), &eIP2, metav1.CreateOptions{})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				gomega.Eventually(func() bool {
-					return getStandByEgressIPs()
+					pas := getPodAssignmentState(&egressPod1)
+					gomega.Expect(pas).NotTo(gomega.BeNil())
+					return pas.standbyEgressIPNames.Has(egressIPName2)
 				}).Should(gomega.BeTrue())
-				gomega.Expect(podCache[getPodKey(&egressPod1)].egressIPName).To(gomega.Equal(egressIPName))
+				gomega.Expect(getPodAssignmentState(&egressPod1).egressIPName).To(gomega.Equal(egressIPName))
 				gomega.Eventually(func() string {
 					return <-fakeOvn.fakeRecorder.Events
 				}).Should(gomega.ContainSubstring("EgressIP object egressip-2 will not be configured for pod egressip-namespace_egress-pod since another egressIP object egressip is serving it, this is undefined"))
@@ -3860,9 +3841,11 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(finalDatabaseStatewithPod[1:]))
 
 				gomega.Eventually(func() bool {
-					return getStandByEgressIPs()
+					pas := getPodAssignmentState(&egressPod1)
+					gomega.Expect(pas).NotTo(gomega.BeNil())
+					return pas.standbyEgressIPNames.Has(egressIPName2)
 				}).Should(gomega.BeTrue())
-				gomega.Expect(podCache[getPodKey(&egressPod1)].egressIPName).To(gomega.Equal(egressIPName))
+				gomega.Expect(getPodAssignmentState(&egressPod1).egressIPName).To(gomega.Equal(egressIPName))
 
 				// delete the first egressIP object and make sure the cache is updated
 				err = fakeOvn.fakeClient.EgressIPClient.K8sV1().EgressIPs().Delete(context.TODO(), egressIPName, metav1.DeleteOptions{})
@@ -3870,9 +3853,11 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 
 				// ensure standby takes over and we do the setup for it in OVN DB
 				gomega.Eventually(func() bool {
-					return getStandByEgressIPs()
+					pas := getPodAssignmentState(&egressPod1)
+					gomega.Expect(pas).NotTo(gomega.BeNil())
+					return pas.standbyEgressIPNames.Has(egressIPName2)
 				}).Should(gomega.BeFalse())
-				gomega.Expect(podCache[getPodKey(&egressPod1)].egressIPName).To(gomega.Equal(egressIPName2))
+				gomega.Expect(getPodAssignmentState(&egressPod1).egressIPName).To(gomega.Equal(egressIPName2))
 
 				finalDatabaseStatewithPod = expectedDatabaseStatewithPod
 				finalDatabaseStatewithPod = append(expectedDatabaseStatewithPod, podLSP)
@@ -3901,10 +3886,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				gomega.Eventually(func() bool {
-					fakeOvn.controller.eIPC.podAssignmentMutex.Lock()
-					_, ok := fakeOvn.controller.eIPC.podAssignment[getPodKey(&egressPod1)]
-					fakeOvn.controller.eIPC.podAssignmentMutex.Unlock()
-					return ok
+					return getPodAssignmentState(&egressPod1) != nil
 				}).Should(gomega.BeFalse())
 
 				// let's test syncPodAssignmentCache works as expected! Nuke the podAssignment cache first
@@ -3919,10 +3901,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 
 				// we don't have any egressIPs, so cache is nil
 				gomega.Eventually(func() bool {
-					fakeOvn.controller.eIPC.podAssignmentMutex.Lock()
-					_, ok := fakeOvn.controller.eIPC.podAssignment[getPodKey(&egressPod1)]
-					fakeOvn.controller.eIPC.podAssignmentMutex.Unlock()
-					return ok
+					return getPodAssignmentState(&egressPod1) != nil
 				}).Should(gomega.BeFalse())
 
 				return nil

--- a/go-controller/pkg/ovn/pods_test.go
+++ b/go-controller/pkg/ovn/pods_test.go
@@ -557,7 +557,7 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 				// there should also be no entry for this pod in the retry cache
 				gomega.Eventually(func() bool {
 					return fakeOvn.controller.getPodRetryEntry(myPod2) == nil
-				}, 2).Should(gomega.BeTrue())
+				}, 31*time.Second).Should(gomega.BeTrue())
 				gomega.Eventually(func() string {
 					return getPodAnnotations(fakeOvn.fakeClient.KubeClient, t2.namespace, t2.podName)
 				}, 2).Should(gomega.MatchJSON(t2.getAnnotationsJson()))


### PR DESCRIPTION
Backport of https://github.com/openshift/ovn-kubernetes/pull/1471