### PR TITLE
iptables: use container iptables, not the host's

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,6 @@ FROM registry.ci.openshift.org/ocp/4.13:cli AS cli
 # - creating directories required by ovn-kubernetes
 # - git commit number
 # - ovnkube.sh script
-# - iptables wrappers
 FROM registry.ci.openshift.org/ocp/4.13:ovn-kubernetes-base
 
 USER root
@@ -44,7 +43,7 @@ RUN INSTALL_PKGS=" \
 	openssl python3-pyOpenSSL firewalld-filesystem \
 	libpcap iproute iproute-tc strace \
 	containernetworking-plugins \
-	tcpdump iputils \
+	tcpdump iputils iptables \
 	libreswan \
 	ethtool conntrack-tools \
 	" && \

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -37,14 +37,5 @@ COPY .git/refs/heads/ /root/.git/refs/heads/
 # variables to direct operation and configure ovn
 COPY dist/images/ovnkube.sh /root/
 
-# iptables wrappers
-COPY ./dist/images/iptables-scripts/iptables /usr/sbin/
-COPY ./dist/images/iptables-scripts/iptables-save /usr/sbin/
-COPY ./dist/images/iptables-scripts/iptables-restore /usr/sbin/
-COPY ./dist/images/iptables-scripts/ip6tables /usr/sbin/
-COPY ./dist/images/iptables-scripts/ip6tables-save /usr/sbin/
-COPY ./dist/images/iptables-scripts/ip6tables-restore /usr/sbin/
-COPY ./dist/images/iptables-scripts/iptables /usr/sbin/
-
 WORKDIR /root
 ENTRYPOINT /root/ovnkube.sh


### PR DESCRIPTION
Using the host's iptables was necessary when the container image might have been running on RHEL7 BYOH, but given that's no longer possible, we can clean this up and just use the container's iptables (since both it and the host will be iptables-nft).
