### PR TITLE
[release-4.12] OCPBUGS-6034: Update egress node assignability on every egress node update

### DIFF
--- a/go-controller/pkg/ovn/obj_retry_master.go
+++ b/go-controller/pkg/ovn/obj_retry_master.go
@@ -620,9 +620,9 @@ func (h *masterEventHandler) UpdateResource(oldObj, newObj interface{}, inRetryC
 		if !oldHadEgressLabel && !newHasEgressLabel {
 			return nil
 		}
+		h.oc.setNodeEgressAssignable(oldNode.Name, newHasEgressLabel)
 		if oldHadEgressLabel && !newHasEgressLabel {
 			klog.Infof("Node: %s has been un-labeled, deleting it from egress assignment", newNode.Name)
-			h.oc.setNodeEgressAssignable(oldNode.Name, false)
 			return h.oc.deleteEgressNode(oldNode.Name)
 		}
 		isOldReady := h.oc.isEgressNodeReady(oldNode)
@@ -631,7 +631,6 @@ func (h *masterEventHandler) UpdateResource(oldObj, newObj interface{}, inRetryC
 		h.oc.setNodeEgressReady(newNode.Name, isNewReady)
 		if !oldHadEgressLabel && newHasEgressLabel {
 			klog.Infof("Node: %s has been labeled, adding it for egress assignment", newNode.Name)
-			h.oc.setNodeEgressAssignable(newNode.Name, true)
 			if isNewReady && isNewReachable {
 				h.oc.setNodeEgressReachable(newNode.Name, isNewReachable)
 				if err := h.oc.addEgressNode(newNode.Name); err != nil {


### PR DESCRIPTION
Backport of https://github.com/ovn-org/ovn-kubernetes/pull/3331 that merged downstream here: https://github.com/openshift/ovn-kubernetes/pull/1474/commits/0bb7c19be33ce4ed5966e8444404f6739b3e6fa8

Conflicts:
  go-controller/pkg/ovn/default_network_controller.go - doesn't exist in 4.12

(cherry picked from commit 0bb7c19be33ce4ed5966e8444404f6739b3e6fa8)
Signed-off-by: Patryk Diak <pdiak@redhat.com>