### PR TITLE
[release-4.12] OCPBUGS-6040: addMasqueradeRoute: fallback to gateway interface IPs

### DIFF
--- a/go-controller/pkg/node/gateway_init.go
+++ b/go-controller/pkg/node/gateway_init.go
@@ -402,11 +402,16 @@ func (n *OvnNode) initGatewayDPUHost(kubeNodeIP net.IP) error {
 		return err
 	}
 
+	ifAddrs, err := getNetworkInterfaceIPAddresses(gatewayIntf)
+	if err != nil {
+		return err
+	}
+
 	if err := setNodeMasqueradeIPOnExtBridge(gwIntf); err != nil {
 		return fmt.Errorf("failed to set the node masquerade IP on the ext bridge %s: %v", gwIntf, err)
 	}
 
-	if err := addMasqueradeRoute(gwIntf, n.name, n.watchFactory); err != nil {
+	if err := addMasqueradeRoute(gwIntf, n.name, ifAddrs, n.watchFactory); err != nil {
 		return fmt.Errorf("failed to set the node masquerade route to OVN: %v", err)
 	}
 

--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -41,7 +41,7 @@ import (
 )
 
 func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
-	eth0Name, eth0MAC, eth0GWIP, eth0CIDR string, gatewayVLANID uint, l netlink.Link, hwOffload bool) {
+	eth0Name, eth0MAC, eth0GWIP, eth0CIDR string, gatewayVLANID uint, l netlink.Link, hwOffload, setNodeIP bool) {
 	const mtu string = "1234"
 	const clusterCIDR string = "10.1.0.0/16"
 
@@ -167,13 +167,16 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 		_, err = config.InitConfig(ctx, fexec, nil)
 		Expect(err).NotTo(HaveOccurred())
 
-		expectedAddr, err := netlink.ParseAddr(eth0CIDR)
-		Expect(err).NotTo(HaveOccurred())
-		nodeAddr := v1.NodeAddress{Type: v1.NodeInternalIP, Address: expectedAddr.IP.String()}
-		existingNode := v1.Node{ObjectMeta: metav1.ObjectMeta{
-			Name: nodeName,
-		},
-			Status: v1.NodeStatus{Addresses: []v1.NodeAddress{nodeAddr}},
+		existingNode := v1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: nodeName,
+			},
+		}
+		if setNodeIP {
+			expectedAddr, err := netlink.ParseAddr(eth0CIDR)
+			Expect(err).NotTo(HaveOccurred())
+			nodeAddr := v1.NodeAddress{Type: v1.NodeInternalIP, Address: expectedAddr.IP.String()}
+			existingNode.Status = v1.NodeStatus{Addresses: []v1.NodeAddress{nodeAddr}}
 		}
 
 		_, nodeNet, err := net.ParseCIDR(nodeSubnet)
@@ -235,7 +238,8 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 
 			gatewayNextHops, gatewayIntf, err := getGatewayNextHops()
 			Expect(err).NotTo(HaveOccurred())
-			sharedGw, err := newSharedGateway(nodeName, ovntest.MustParseIPNets(nodeSubnet), gatewayNextHops, gatewayIntf, "", nil, nodeAnnotator, k,
+			ifAddrs := ovntest.MustParseIPNets(eth0CIDR)
+			sharedGw, err := newSharedGateway(nodeName, ovntest.MustParseIPNets(nodeSubnet), gatewayNextHops, gatewayIntf, "", ifAddrs, nodeAnnotator, k,
 				&fakeMgmtPortConfig, wf)
 			Expect(err).NotTo(HaveOccurred())
 			err = sharedGw.Init(wf)
@@ -264,6 +268,20 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 			Expect(found).To(BeTrue())
 
 			Expect(l.Attrs().HardwareAddr.String()).To(Equal(eth0MAC))
+
+			// check that the masquerade route was added
+			expRoute := &netlink.Route{
+				Dst:       ovntest.MustParseIPNet(fmt.Sprintf("%s/32", types.V4OVNMasqueradeIP)),
+				LinkIndex: l.Attrs().Index,
+				Src:       ifAddrs[0].IP,
+			}
+			route, err := util.LinkRouteGetFilteredRoute(
+				expRoute,
+				netlink.RT_FILTER_DST|netlink.RT_FILTER_OIF|netlink.RT_FILTER_SRC,
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(route).ToNot(BeNil())
+
 			return nil
 		})
 		Expect(err).NotTo(HaveOccurred())
@@ -553,15 +571,16 @@ func shareGatewayInterfaceDPUTest(app *cli.App, testNS ns.NetNS,
 		err = nodeAnnotator.Run()
 		Expect(err).NotTo(HaveOccurred())
 
+		ifAddrs := ovntest.MustParseIPNets(hostCIDR)
+		ifAddrs[0].IP = ovntest.MustParseIP(dpuIP)
+
 		err = testNS.Do(func(ns.NetNS) error {
 			defer GinkgoRecover()
 
 			gatewayNextHops, gatewayIntf, err := getGatewayNextHops()
 			Expect(err).NotTo(HaveOccurred())
-			// provide host IP as GR IP
-			gwIPs := []*net.IPNet{ovntest.MustParseIPNet(hostCIDR)}
 			sharedGw, err := newSharedGateway(nodeName, ovntest.MustParseIPNets(nodeSubnet), gatewayNextHops,
-				gatewayIntf, "", gwIPs, nodeAnnotator, k, &fakeMgmtPortConfig, wf)
+				gatewayIntf, "", ifAddrs, nodeAnnotator, k, &fakeMgmtPortConfig, wf)
 
 			Expect(err).NotTo(HaveOccurred())
 			err = sharedGw.Init(wf)
@@ -571,6 +590,21 @@ func shareGatewayInterfaceDPUTest(app *cli.App, testNS ns.NetNS,
 			Expect(err).NotTo(HaveOccurred())
 
 			sharedGw.Start(stop, wg)
+
+			// check that the masquerade route was not added
+			l, err := netlink.LinkByName(brphys)
+			expRoute := &netlink.Route{
+				Dst:       ovntest.MustParseIPNet(fmt.Sprintf("%s/32", types.V4OVNMasqueradeIP)),
+				LinkIndex: l.Attrs().Index,
+				Src:       ifAddrs[0].IP,
+			}
+			route, err := util.LinkRouteGetFilteredRoute(
+				expRoute,
+				netlink.RT_FILTER_DST|netlink.RT_FILTER_OIF|netlink.RT_FILTER_SRC,
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(route).To(BeNil())
+
 			return nil
 		})
 		Expect(err).NotTo(HaveOccurred())
@@ -583,7 +617,7 @@ func shareGatewayInterfaceDPUTest(app *cli.App, testNS ns.NetNS,
 		l3gwConfig, err := util.ParseNodeL3GatewayAnnotation(updatedNode)
 		Expect(err).To(Not(HaveOccurred()))
 		Expect(l3gwConfig.MACAddress.String()).To(Equal(hostMAC))
-		Expect(l3gwConfig.IPAddresses[0]).To(Equal(ovntest.MustParseIPNet(hostCIDR)))
+		Expect(l3gwConfig.IPAddresses[0].String()).To(Equal(ifAddrs[0].String()))
 		return nil
 	}
 
@@ -652,23 +686,35 @@ func shareGatewayInterfaceDPUHostTest(app *cli.App, testNS ns.NetNS, uplinkName,
 			err := n.initGatewayDPUHost(net.ParseIP(hostIP))
 			Expect(err).NotTo(HaveOccurred())
 
-			// Check svc routes added towards eth0GWIP
-			expectedRoutes := []string{svcCIDR}
 			link, err := netlink.LinkByName(uplinkName)
 			Expect(err).NotTo(HaveOccurred())
-			routes, err := netlink.RouteList(link, netlink.FAMILY_ALL)
-			Expect(err).NotTo(HaveOccurred())
-			for _, expRoute := range expectedRoutes {
-				found := false
-				for _, route := range routes {
-					if route.Dst != nil {
-						if route.Dst.String() == expRoute && route.Gw.String() == gwIP {
-							found = true
-						}
-					}
-				}
-				Expect(found).To(BeTrue(), fmt.Sprintf("Expected route %s was not found", expRoute))
+
+			// check that the service route was added
+			expRoute := &netlink.Route{
+				Dst:       ovntest.MustParseIPNet(svcCIDR),
+				LinkIndex: link.Attrs().Index,
+				Gw:        ovntest.MustParseIP(gwIP),
 			}
+			route, err := util.LinkRouteGetFilteredRoute(
+				expRoute,
+				netlink.RT_FILTER_DST|netlink.RT_FILTER_OIF|netlink.RT_FILTER_GW,
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(route).ToNot(BeNil())
+
+			// check that the masquerade route was added
+			expRoute = &netlink.Route{
+				Dst:       ovntest.MustParseIPNet(fmt.Sprintf("%s/32", types.V4OVNMasqueradeIP)),
+				LinkIndex: link.Attrs().Index,
+				Src:       ovntest.MustParseIP(hostIP),
+			}
+			route, err = util.LinkRouteGetFilteredRoute(
+				expRoute,
+				netlink.RT_FILTER_DST|netlink.RT_FILTER_OIF|netlink.RT_FILTER_SRC,
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(route).ToNot(BeNil())
+
 			return nil
 		})
 		Expect(err).NotTo(HaveOccurred())
@@ -922,7 +968,8 @@ OFPT_GET_CONFIG_REPLY (xid=0x4): frags=normal miss_send_len=0`,
 
 			gatewayNextHops, gatewayIntf, err := getGatewayNextHops()
 			Expect(err).NotTo(HaveOccurred())
-			localGw, err := newLocalGateway(nodeName, ovntest.MustParseIPNets(nodeSubnet), gatewayNextHops, gatewayIntf, "", nil,
+			ifAddrs := ovntest.MustParseIPNets(eth0CIDR)
+			localGw, err := newLocalGateway(nodeName, ovntest.MustParseIPNets(nodeSubnet), gatewayNextHops, gatewayIntf, "", ifAddrs,
 				nodeAnnotator, &fakeMgmtPortConfig, k, wf)
 			Expect(err).NotTo(HaveOccurred())
 			err = localGw.Init(wf)
@@ -951,6 +998,20 @@ OFPT_GET_CONFIG_REPLY (xid=0x4): frags=normal miss_send_len=0`,
 			Expect(found).To(BeTrue())
 
 			Expect(l.Attrs().HardwareAddr.String()).To(Equal(eth0MAC))
+
+			// check that the masquerade route was added
+			expRoute := &netlink.Route{
+				Dst:       ovntest.MustParseIPNet(fmt.Sprintf("%s/32", types.V4OVNMasqueradeIP)),
+				LinkIndex: l.Attrs().Index,
+				Src:       ifAddrs[0].IP,
+			}
+			route, err := util.LinkRouteGetFilteredRoute(
+				expRoute,
+				netlink.RT_FILTER_DST|netlink.RT_FILTER_OIF|netlink.RT_FILTER_SRC,
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(route).ToNot(BeNil())
+
 			return nil
 		})
 		Expect(err).NotTo(HaveOccurred())
@@ -1102,28 +1163,34 @@ var _ = Describe("Gateway Init Operations", func() {
 		})
 
 		ovntest.OnSupportedPlatformsIt("sets up a shared interface gateway", func() {
-			shareGatewayInterfaceTest(app, testNS, eth0Name, eth0MAC, eth0GWIP, eth0CIDR, 0, link, false)
+			shareGatewayInterfaceTest(app, testNS, eth0Name, eth0MAC, eth0GWIP, eth0CIDR, 0, link, false, true)
 		})
 
 		ovntest.OnSupportedPlatformsIt("sets up a shared interface gateway with hw-offloading", func() {
-			shareGatewayInterfaceTest(app, testNS, eth0Name, eth0MAC, eth0GWIP, eth0CIDR, 0, link, true)
+			shareGatewayInterfaceTest(app, testNS, eth0Name, eth0MAC, eth0GWIP, eth0CIDR, 0, link, true, true)
 		})
 
 		ovntest.OnSupportedPlatformsIt("sets up a shared interface gateway with tagged VLAN", func() {
-			shareGatewayInterfaceTest(app, testNS, eth0Name, eth0MAC, eth0GWIP, eth0CIDR, 3000, link, false)
+			shareGatewayInterfaceTest(app, testNS, eth0Name, eth0MAC, eth0GWIP, eth0CIDR, 3000, link, false, true)
 		})
 
 		config.Gateway.Interface = eth0Name
 		ovntest.OnSupportedPlatformsIt("sets up a shared interface gateway with predetermined gateway interface", func() {
-			shareGatewayInterfaceTest(app, testNS, eth0Name, eth0MAC, eth0GWIP, eth0CIDR, 0, link, false)
+			shareGatewayInterfaceTest(app, testNS, eth0Name, eth0MAC, eth0GWIP, eth0CIDR, 0, link, false, true)
 		})
 
 		ovntest.OnSupportedPlatformsIt("sets up a shared interface gateway with tagged VLAN + predetermined gateway interface", func() {
-			shareGatewayInterfaceTest(app, testNS, eth0Name, eth0MAC, eth0GWIP, eth0CIDR, 3000, link, false)
+			shareGatewayInterfaceTest(app, testNS, eth0Name, eth0MAC, eth0GWIP, eth0CIDR, 3000, link, false, true)
 		})
 
 		ovntest.OnSupportedPlatformsIt("sets up a shared interface gateway with predetermined gateway interface and no default route", func() {
-			shareGatewayInterfaceTest(app, testNS, eth0Name, eth0MAC, "", eth0CIDR, 0, link, false)
+			shareGatewayInterfaceTest(app, testNS, eth0Name, eth0MAC, "", eth0CIDR, 0, link, false, true)
+		})
+
+		// don't set the node status internal IP, addMasqueradeRoute will
+		// fallback to the provided interface IP
+		ovntest.OnSupportedPlatformsIt("sets up a shared interface gateway with node status internal IPs unset", func() {
+			shareGatewayInterfaceTest(app, testNS, eth0Name, eth0MAC, eth0GWIP, eth0CIDR, 0, link, false, false)
 		})
 	})
 })

--- a/go-controller/pkg/node/gateway_localnet.go
+++ b/go-controller/pkg/node/gateway_localnet.go
@@ -98,7 +98,7 @@ func newLocalGateway(nodeName string, hostSubnets []*net.IPNet, gwNextHops []net
 			return fmt.Errorf("failed to set the node masquerade IP on the ext bridge %s: %v", gwBridge.bridgeName, err)
 		}
 
-		if err := addMasqueradeRoute(gwBridge.bridgeName, nodeName, watchFactory); err != nil {
+		if err := addMasqueradeRoute(gwBridge.bridgeName, nodeName, gwIPs, watchFactory); err != nil {
 			return fmt.Errorf("failed to set the node masquerade route to OVN: %v", err)
 		}
 

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -108,8 +108,9 @@ type cidrAndFlags struct {
 // traffic instead will be steered directly into the host and DNAT-ed to the targetPort on the host.
 //
 // case2: All other types of services in SGW mode i.e:
-//        case2a: if externalTrafficPolicy=cluster + SGW mode, traffic will be steered into OVN via GR.
-//        case2b: if externalTrafficPolicy=local + !hasLocalHostNetworkEp + SGW mode, traffic will be steered into OVN via GR.
+//
+//	case2a: if externalTrafficPolicy=cluster + SGW mode, traffic will be steered into OVN via GR.
+//	case2b: if externalTrafficPolicy=local + !hasLocalHostNetworkEp + SGW mode, traffic will be steered into OVN via GR.
 //
 // NOTE: If LGW mode, the default flow will take care of sending traffic to host irrespective of service flow type.
 //
@@ -223,8 +224,9 @@ func (npw *nodePortWatcher) updateServiceFlowCache(service *kapi.Service, add, h
 // traffic instead will be steered directly into the host and DNAT-ed to the targetPort on the host.
 //
 // case2: All other types of services in SGW mode i.e:
-//        case2a: if externalTrafficPolicy=cluster + SGW mode, traffic will be steered into OVN via GR.
-//        case2b: if externalTrafficPolicy=local + !hasLocalHostNetworkEp + SGW mode, traffic will be steered into OVN via GR.
+//
+//	case2a: if externalTrafficPolicy=cluster + SGW mode, traffic will be steered into OVN via GR.
+//	case2b: if externalTrafficPolicy=local + !hasLocalHostNetworkEp + SGW mode, traffic will be steered into OVN via GR.
 //
 // NOTE: If LGW mode, the default flow will take care of sending traffic to host irrespective of service flow type.
 //
@@ -986,7 +988,9 @@ func (npwipt *nodePortWatcherIptables) SyncServices(services []interface{}) erro
 // since we share the host's k8s node IP, add OpenFlow flows
 // -- to steer the NodePort traffic arriving on the host to the OVN logical topology and
 // -- to also connection track the outbound north-south traffic through l3 gateway so that
-//    the return traffic can be steered back to OVN logical topology
+//
+//	the return traffic can be steered back to OVN logical topology
+//
 // -- to handle host -> service access, via masquerading from the host to OVN GR
 // -- to handle external -> service(ExternalTrafficPolicy: Local) -> host access without SNAT
 func newGatewayOpenFlowManager(gwBridge, exGWBridge *bridgeConfiguration, extraIPs []net.IP) (*openflowManager, error) {
@@ -1537,12 +1541,14 @@ func newSharedGateway(nodeName string, subnets []*net.IPNet, gwNextHops []net.IP
 		gw.nodeIPManager = newAddressManager(nodeName, kube, cfg, watchFactory)
 		nodeIPs := gw.nodeIPManager.ListAddresses()
 
-		if err := setNodeMasqueradeIPOnExtBridge(gwBridge.bridgeName); err != nil {
-			return fmt.Errorf("failed to set the node masquerade IP on the ext bridge %s: %v", gwBridge.bridgeName, err)
-		}
+		if config.OvnKubeNode.Mode == types.NodeModeFull {
+			if err := setNodeMasqueradeIPOnExtBridge(gwBridge.bridgeName); err != nil {
+				return fmt.Errorf("failed to set the node masquerade IP on the ext bridge %s: %v", gwBridge.bridgeName, err)
+			}
 
-		if err := addMasqueradeRoute(gwBridge.bridgeName, nodeName, watchFactory); err != nil {
-			return fmt.Errorf("failed to set the node masquerade route to OVN: %v", err)
+			if err := addMasqueradeRoute(gwBridge.bridgeName, nodeName, gwIPs, watchFactory); err != nil {
+				return fmt.Errorf("failed to set the node masquerade route to OVN: %v", err)
+			}
 		}
 
 		gw.openflowManager, err = newGatewayOpenFlowManager(gwBridge, exGwBridge, nodeIPs)
@@ -1705,52 +1711,89 @@ func svcToCookie(namespace string, name string, token string, port int32) (strin
 	return fmt.Sprintf("0x%x", h.Sum64()), nil
 }
 
-func addMasqueradeRoute(netIfaceName, nodeName string, watchFactory factory.NodeWatchFactory) error {
+func addMasqueradeRoute(netIfaceName, nodeName string, ifAddrs []*net.IPNet, watchFactory factory.NodeWatchFactory) error {
+	var ipv4, ipv6 net.IP
+	findIPs := func(ips []net.IP) error {
+		var err error
+		if config.IPv4Mode && ipv4 == nil {
+			ipv4, err = util.MatchFirstIPFamily(false, ips)
+			if err != nil {
+				return fmt.Errorf("missing IP among %+v: %v", ips, err)
+			}
+		}
+		if config.IPv6Mode && ipv6 == nil {
+			ipv6, err = util.MatchFirstIPFamily(true, ips)
+			if err != nil {
+				return fmt.Errorf("missing IP among %+v: %v", ips, err)
+			}
+		}
+		return nil
+	}
+
+	// Try first with the node status IPs and fallback to the interface IPs. The
+	// fallback is a workaround for instances where the node status might not
+	// have the minimum set of IPs we need (for example, when ovnkube is
+	// restarted after enabling an IP family without actually restarting kubelet
+	// with a new configuration including an IP address for that family). Node
+	// status IPs are preferred though because a user might add arbitrary IP
+	// addresses to the interface that we don't really want to use and might
+	// cause problems.
+
+	var nodeIPs []net.IP
 	node, err := watchFactory.GetNode(nodeName)
 	if err != nil {
 		return err
 	}
-	netIfaceLink, err := util.LinkSetUp(netIfaceName)
-	if err != nil {
-		return fmt.Errorf("unable to find shared gw bridge interface: %s", netIfaceName)
-	}
-	var v4Found, v6Found bool
 	for _, nodeAddr := range node.Status.Addresses {
 		if nodeAddr.Type != kapi.NodeInternalIP {
 			continue
 		}
-		var masqIPNet *net.IPNet
-		nodeIP := net.ParseIP(nodeAddr.Address)
-		if utilnet.IsIPv6(nodeIP) && !v6Found {
-			_, masqIPNet, _ = net.ParseCIDR(fmt.Sprintf("%s/128", types.V6OVNMasqueradeIP))
-			v6Found = true
-		} else if !v4Found {
-			_, masqIPNet, _ = net.ParseCIDR(fmt.Sprintf("%s/32", types.V4OVNMasqueradeIP))
-			v4Found = true
+		nodeIP := utilnet.ParseIPSloppy(nodeAddr.Address)
+		nodeIPs = append(nodeIPs, nodeIP)
+	}
+
+	err = findIPs(nodeIPs)
+	if err != nil {
+		klog.Warningf("Unable to add OVN masquerade route to host using source node status IPs: %v", err)
+		// fallback to the interface IPs
+		var ifIPs []net.IP
+		for _, ifAddr := range ifAddrs {
+			ifIPs = append(ifIPs, ifAddr.IP)
 		}
-		mtu := config.Default.MTU
-		if config.Default.RoutableMTU != 0 {
-			mtu = config.Default.RoutableMTU
-		}
-		if masqIPNet != nil {
-			klog.Infof("Setting OVN Masquerade route with source: %s", nodeIP)
-			err = util.LinkRoutesAddOrUpdateSourceOrMTU(netIfaceLink, nil, []*net.IPNet{masqIPNet},
-				mtu, nodeIP)
-			if err != nil {
-				return fmt.Errorf("unable to add OVN masquerade route to host, error: %v", err)
-			}
+		err := findIPs(ifIPs)
+		if err != nil {
+			return fmt.Errorf("unable to add OVN masquerade route to host using interface IPs: %v", err)
 		}
 	}
 
-	if config.IPv4Mode && !v4Found {
-		return fmt.Errorf("could not find node IPv4 address to configure OVN masquerade route, addresses: %+v",
-			node.Status.Addresses)
+	netIfaceLink, err := util.LinkSetUp(netIfaceName)
+	if err != nil {
+		return fmt.Errorf("unable to find shared gw bridge interface: %s", netIfaceName)
 	}
 
-	if config.IPv6Mode && !v6Found {
-		return fmt.Errorf("could not find node IPv6 address to configure OVN masquerade route, addresses: %+v",
-			node.Status.Addresses)
+	mtu := config.Default.MTU
+	if config.Default.RoutableMTU != 0 {
+		mtu = config.Default.RoutableMTU
 	}
+
+	if ipv4 != nil {
+		_, masqIPNet, _ := net.ParseCIDR(fmt.Sprintf("%s/32", types.V4OVNMasqueradeIP))
+		klog.Infof("Setting OVN Masquerade route with source: %s", ipv4)
+		err = util.LinkRoutesAddOrUpdateSourceOrMTU(netIfaceLink, nil, []*net.IPNet{masqIPNet}, mtu, ipv4)
+		if err != nil {
+			return fmt.Errorf("unable to add OVN masquerade route to host, error: %v", err)
+		}
+	}
+
+	if ipv6 != nil {
+		_, masqIPNet, _ := net.ParseCIDR(fmt.Sprintf("%s/128", types.V6OVNMasqueradeIP))
+		klog.Infof("Setting OVN Masquerade route with source: %s", ipv6)
+		err = util.LinkRoutesAddOrUpdateSourceOrMTU(netIfaceLink, nil, []*net.IPNet{masqIPNet}, mtu, ipv6)
+		if err != nil {
+			return fmt.Errorf("unable to add OVN masquerade route to host, error: %v", err)
+		}
+	}
+
 	return nil
 }
 

--- a/go-controller/pkg/util/net.go
+++ b/go-controller/pkg/util/net.go
@@ -240,6 +240,17 @@ func MatchIPFamily(isIPv6 bool, ips []net.IP) ([]net.IP, error) {
 	return nil, fmt.Errorf("no %s IP available", IPFamilyName(isIPv6))
 }
 
+// MatchFirstIPFamily loops through the array of net.IP and returns the first
+// entry in the list in the same IP Family, based on input flag isIPv6.
+func MatchFirstIPFamily(isIPv6 bool, ips []net.IP) (net.IP, error) {
+	for _, ip := range ips {
+		if utilnet.IsIPv6(ip) == isIPv6 {
+			return ip, nil
+		}
+	}
+	return nil, fmt.Errorf("no %s IP available", IPFamilyName(isIPv6))
+}
+
 // MatchIPNetFamily loops through the array of *net.IPNet and returns the
 // first entry in the list in the same IP Family, based on input flag isIPv6.
 func MatchIPNetFamily(isIPv6 bool, ipnets []*net.IPNet) (*net.IPNet, error) {


### PR DESCRIPTION
There might be circumstances where the node status internal IPs are not current (in our case, a dual-stack conversion procedure in which kubelet is not configured with the newly acquired IPv6 address and restarted, which in itself is a problem that would need to be fixed).

While node status IPs are preferred to avoid issues with IPs that the user or other components might arbitrarily add to the gateway interface, fallback to an interface IP if we are missing it from the node status.

Also fix DPU. Masquerading should not be needed in the DPU (when newSharedGateway is called with mode NodeModeDPU), only in the host (where initGatewayDPUHost is use instead for NodeModeDPUHost). Ref: https://github.com/openshift/ovn-kubernetes/blob/master/docs/design/dpu_support.md

Signed-off-by: Jaime Caamaño Ruiz <jcaamano@redhat.com>
(cherry picked from commit f105108f2cbc6f026b214d99ba198eaf2c5d3b3f)

Conflicts:
* [go-controller/pkg/node/gateway_shared_intf.go](https://github.com/openshift/ovn-kubernetes/compare/release-4.12...jcaamano:ovn-kubernetes-downstream:release-4.12?expand=1#diff-d3aa58d9b58a0a09264f072df46ab01d0501eb508c4656411ae2dc1ac68fb3c4)
  Replace 4.13 LinkRoutesApply with 4.12 LinkRoutesAddOrUpdateSourceOrMTU
* [go-controller/pkg/node/gateway_init_linux_test.go](https://github.com/openshift/ovn-kubernetes/compare/release-4.12...jcaamano:ovn-kubernetes-downstream:release-4.12?expand=1#diff-baef649410d0c75a89ece69e5a452be4a68d9fb8f8febed16657ff4fc2e6b2a4)
  For DPU host test, sharedGw.Start() call was added in 4.13, but the version of that in 4.12 is sharedGw.Start(stop, wg)