### PR TITLE
[wip] [release-4.11] Update routes GW if it was changed

### DIFF
--- a/go-controller/pkg/node/gateway_init.go
+++ b/go-controller/pkg/node/gateway_init.go
@@ -248,7 +248,7 @@ func configureSvcRouteViaInterface(iface string, gwIPs []net.IP) error {
 			mtu = config.Default.RoutableMTU
 		}
 
-		err = util.LinkRoutesAddOrUpdateMTU(link, gwIP[0], []*net.IPNet{subnet}, mtu)
+		err = util.LinkRoutesApply(link, gwIP[0], []*net.IPNet{subnet}, mtu)
 		if err != nil {
 			return fmt.Errorf("unable to add/update route for service via %s, error: %v", iface, err)
 		}

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -91,8 +91,9 @@ type serviceConfig struct {
 // traffic instead will be steered directly into the host and DNAT-ed to the targetPort on the host.
 //
 // case2: All other types of services in SGW mode i.e:
-//        case2a: if externalTrafficPolicy=cluster + SGW mode, traffic will be steered into OVN via GR.
-//        case2b: if externalTrafficPolicy=local + !hasLocalHostNetworkEp + SGW mode, traffic will be steered into OVN via GR.
+//
+//	case2a: if externalTrafficPolicy=cluster + SGW mode, traffic will be steered into OVN via GR.
+//	case2b: if externalTrafficPolicy=local + !hasLocalHostNetworkEp + SGW mode, traffic will be steered into OVN via GR.
 //
 // NOTE: If LGW mode, the default flow will take care of sending traffic to host irrespective of service flow type.
 //
@@ -214,8 +215,9 @@ func (npw *nodePortWatcher) updateServiceFlowCache(service *kapi.Service, add, h
 // traffic instead will be steered directly into the host and DNAT-ed to the targetPort on the host.
 //
 // case2: All other types of services in SGW mode i.e:
-//        case2a: if externalTrafficPolicy=cluster + SGW mode, traffic will be steered into OVN via GR.
-//        case2b: if externalTrafficPolicy=local + !hasLocalHostNetworkEp + SGW mode, traffic will be steered into OVN via GR.
+//
+//	case2a: if externalTrafficPolicy=cluster + SGW mode, traffic will be steered into OVN via GR.
+//	case2b: if externalTrafficPolicy=local + !hasLocalHostNetworkEp + SGW mode, traffic will be steered into OVN via GR.
 //
 // NOTE: If LGW mode, the default flow will take care of sending traffic to host irrespective of service flow type.
 //
@@ -783,7 +785,9 @@ func (npwipt *nodePortWatcherIptables) SyncServices(services []interface{}) erro
 // since we share the host's k8s node IP, add OpenFlow flows
 // -- to steer the NodePort traffic arriving on the host to the OVN logical topology and
 // -- to also connection track the outbound north-south traffic through l3 gateway so that
-//    the return traffic can be steered back to OVN logical topology
+//
+//	the return traffic can be steered back to OVN logical topology
+//
 // -- to handle host -> service access, via masquerading from the host to OVN GR
 // -- to handle external -> service(ExternalTrafficPolicy: Local) -> host access without SNAT
 func newGatewayOpenFlowManager(gwBridge, exGWBridge *bridgeConfiguration, extraIPs []net.IP) (*openflowManager, error) {
@@ -1529,7 +1533,7 @@ func addMasqueradeRoute(netIfaceName string, nextHops []net.IP) error {
 		return fmt.Errorf("no valid ipv4 next hop exists: %v", err)
 	}
 	_, masqIPNet, _ := net.ParseCIDR(types.V4MasqueradeSubnet)
-	err = util.LinkRoutesAddOrUpdateMTU(netIfaceLink, v4nextHops[0], []*net.IPNet{masqIPNet}, config.Default.RoutableMTU)
+	err = util.LinkRoutesApply(netIfaceLink, v4nextHops[0], []*net.IPNet{masqIPNet}, config.Default.RoutableMTU)
 	if err != nil {
 		return fmt.Errorf("unable to add OVN masquerade route to host, error: %v", err)
 	}

--- a/go-controller/pkg/node/management-port_linux.go
+++ b/go-controller/pkg/node/management-port_linux.go
@@ -187,7 +187,7 @@ func setupManagementPortIPFamilyConfig(mpcfg *managementPortConfig, cfg *managem
 			return warnings, err
 		}
 
-		err = util.LinkRoutesAddOrUpdateMTU(mpcfg.link, cfg.gwIP, []*net.IPNet{subnet}, config.Default.RoutableMTU)
+		err = util.LinkRoutesApply(mpcfg.link, cfg.gwIP, []*net.IPNet{subnet}, config.Default.RoutableMTU)
 		if err != nil {
 			return warnings, err
 		}
@@ -280,7 +280,7 @@ func createPlatformManagementPort(interfaceName string, localSubnets []*net.IPNe
 	return cfg, nil
 }
 
-//DelMgtPortIptRules delete all the iptable rules for the management port.
+// DelMgtPortIptRules delete all the iptable rules for the management port.
 func DelMgtPortIptRules() {
 	// Clean up all iptables and ip6tables remnants that may be left around
 	ipt, err := util.GetIPTablesHelper(iptables.ProtocolIPv4)

--- a/go-controller/pkg/node/node.go
+++ b/go-controller/pkg/node/node.go
@@ -481,7 +481,7 @@ func (n *OvnNode) Start(ctx context.Context, wg *sync.WaitGroup) error {
 					} else {
 						gwIP = mgmtPortConfig.ipv6.gwIP
 					}
-					err := util.LinkRoutesAddOrUpdateMTU(link, gwIP, []*net.IPNet{subnet}, config.Default.RoutableMTU)
+					err := util.LinkRoutesApply(link, gwIP, []*net.IPNet{subnet}, config.Default.RoutableMTU)
 					if err != nil {
 						return fmt.Errorf("unable to add legacy route for services via mp0, error: %v", err)
 					}
@@ -755,7 +755,7 @@ type epAddressItem struct {
 	protocol kapi.Protocol
 }
 
-//buildEndpointAddressMap builds a map of all UDP and SCTP ports in the endpoint subset along with that port's IP address
+// buildEndpointAddressMap builds a map of all UDP and SCTP ports in the endpoint subset along with that port's IP address
 func buildEndpointAddressMap(epSubsets []kapi.EndpointSubset) map[epAddressItem]struct{} {
 	epMap := make(map[epAddressItem]struct{})
 	for _, subset := range epSubsets {

--- a/go-controller/pkg/util/net_linux.go
+++ b/go-controller/pkg/util/net_linux.go
@@ -299,7 +299,7 @@ func LinkRoutesAdd(link netlink.Link, gwIP net.IP, subnets []*net.IPNet, mtu int
 
 func LinkRoutesAddOrUpdateMTU(link netlink.Link, gwIP net.IP, subnets []*net.IPNet, mtu int) error {
 	for _, subnet := range subnets {
-		route, err := LinkRouteGet(link, gwIP, subnet)
+		route, err := LinkRouteGetFilteredRoute(filterRouteByDst(link, subnet))
 		if err != nil {
 			return err
 		}
@@ -319,26 +319,23 @@ func LinkRoutesAddOrUpdateMTU(link netlink.Link, gwIP net.IP, subnets []*net.IPN
 	return nil
 }
 
-// LinkRouteGet gets a route for the given subnet with the specified gwIPStr
+// LinkRouteGetFilteredRoute gets a route for the given route filter.
 // returns nil if route is not found
-func LinkRouteGet(link netlink.Link, gwIP net.IP, subnet *net.IPNet) (*netlink.Route, error) {
-	routeFilter := &netlink.Route{Dst: subnet, LinkIndex: link.Attrs().Index}
-	filterMask := netlink.RT_FILTER_DST | netlink.RT_FILTER_OIF
-	routes, err := netLinkOps.RouteListFiltered(getFamily(gwIP), routeFilter, filterMask)
+func LinkRouteGetFilteredRoute(routeFilter *netlink.Route, filterMask uint64) (*netlink.Route, error) {
+	routes, err := netLinkOps.RouteListFiltered(getFamily(routeFilter.Dst.IP), routeFilter, filterMask)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get routes for subnet %s", subnet.String())
+		return nil, fmt.Errorf(
+			"failed to get routes for filter %v with mask %d: %v", *routeFilter, filterMask, err)
 	}
-	for _, route := range routes {
-		if route.Gw.Equal(gwIP) {
-			return &route, nil
-		}
+	if len(routes) == 0 {
+		return nil, nil
 	}
-	return nil, nil
+	return &routes[0], nil
 }
 
 // LinkRouteExists checks for existence of routes for the given subnet through gwIPStr
 func LinkRouteExists(link netlink.Link, gwIP net.IP, subnet *net.IPNet) (bool, error) {
-	route, err := LinkRouteGet(link, gwIP, subnet)
+	route, err := LinkRouteGetFilteredRoute(filterRouteByDstAndGw(link, subnet, gwIP))
 	return route != nil, err
 }
 
@@ -524,4 +521,21 @@ func GetIFNameAndMTUForAddress(ifAddress net.IP) (string, int, error) {
 	}
 
 	return "", 0, fmt.Errorf("couldn't not find a link associated with the given OVN Encap IP (%s)", ifAddress)
+}
+
+func filterRouteByDst(link netlink.Link, subnet *net.IPNet) (*netlink.Route, uint64) {
+	return &netlink.Route{
+			Dst:       subnet,
+			LinkIndex: link.Attrs().Index,
+		},
+		netlink.RT_FILTER_DST | netlink.RT_FILTER_OIF
+}
+
+func filterRouteByDstAndGw(link netlink.Link, subnet *net.IPNet, gw net.IP) (*netlink.Route, uint64) {
+	return &netlink.Route{
+			Dst:       subnet,
+			LinkIndex: link.Attrs().Index,
+			Gw:        gw,
+		},
+		netlink.RT_FILTER_DST | netlink.RT_FILTER_OIF | netlink.RT_FILTER_GW
 }

--- a/go-controller/pkg/util/net_linux_unit_test.go
+++ b/go-controller/pkg/util/net_linux_unit_test.go
@@ -590,6 +590,7 @@ func TestLinkRoutesAddOrUpdateMTU(t *testing.T) {
 				{OnCallMethodName: "RouteListFiltered", OnCallMethodArgType: []string{"int", "*netlink.Route", "uint64"}, RetArgList: []interface{}{[]netlink.Route{
 					{
 						Gw:  ovntest.MustParseIP("192.168.0.1"),
+						Dst: ovntest.MustParseIPNet("10.18.20.0/24"),
 						MTU: 1400,
 					},
 				}, nil}},
@@ -607,9 +608,33 @@ func TestLinkRoutesAddOrUpdateMTU(t *testing.T) {
 			errExp:       false,
 			onRetArgsNetLinkLibOpers: []ovntest.TestifyMockHelper{
 				{OnCallMethodName: "RouteListFiltered", OnCallMethodArgType: []string{"int", "*netlink.Route", "uint64"}, RetArgList: []interface{}{[]netlink.Route{
-					{Gw: ovntest.MustParseIP("192.168.0.1")},
+					{
+						Gw:  ovntest.MustParseIP("192.168.0.1"),
+						Dst: ovntest.MustParseIPNet("10.18.20.0/24"),
+					},
 				}, nil}},
 				{OnCallMethodName: "RouteReplace", OnCallMethodArgType: []string{"*netlink.Route"}, RetArgList: []interface{}{nil}},
+			},
+			onRetArgsLinkIfaceOpers: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "Attrs", OnCallMethodArgType: []string{}, RetArgList: []interface{}{&netlink.LinkAttrs{Name: "testIfaceName", Index: 1}}},
+			},
+		},
+		{
+			desc:         "Route exists, has the same mtu and is not updated",
+			inputLink:    mockLink,
+			inputGwIP:    nil,
+			inputSubnets: ovntest.MustParseIPNets("10.18.20.0/24"),
+			inputMTU:     1400,
+			errExp:       false,
+			onRetArgsNetLinkLibOpers: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "RouteListFiltered", OnCallMethodArgType: []string{"int", "*netlink.Route", "uint64"}, RetArgList: []interface{}{[]netlink.Route{
+					{
+						Gw:  ovntest.MustParseIP("192.168.0.1"),
+						Dst: ovntest.MustParseIPNet("10.18.20.0/24"),
+						MTU: 1400,
+						Src: ovntest.MustParseIP("192.168.0.10"),
+					},
+				}, nil}},
 			},
 			onRetArgsLinkIfaceOpers: []ovntest.TestifyMockHelper{
 				{OnCallMethodName: "Attrs", OnCallMethodArgType: []string{}, RetArgList: []interface{}{&netlink.LinkAttrs{Name: "testIfaceName", Index: 1}}},

--- a/go-controller/pkg/util/net_linux_unit_test.go
+++ b/go-controller/pkg/util/net_linux_unit_test.go
@@ -535,7 +535,7 @@ func TestLinkRoutesAdd(t *testing.T) {
 	}
 }
 
-func TestLinkRoutesAddOrUpdateMTU(t *testing.T) {
+func TestLinkRoutesApply(t *testing.T) {
 	mockNetLinkOps := new(mocks.NetLinkOps)
 	mockLink := new(netlink_mocks.Link)
 	// below is defined in net_linux.go
@@ -629,7 +629,7 @@ func TestLinkRoutesAddOrUpdateMTU(t *testing.T) {
 			onRetArgsNetLinkLibOpers: []ovntest.TestifyMockHelper{
 				{OnCallMethodName: "RouteListFiltered", OnCallMethodArgType: []string{"int", "*netlink.Route", "uint64"}, RetArgList: []interface{}{[]netlink.Route{
 					{
-						Gw:  ovntest.MustParseIP("192.168.0.1"),
+						Gw:  nil,
 						Dst: ovntest.MustParseIPNet("10.18.20.0/24"),
 						MTU: 1400,
 						Src: ovntest.MustParseIP("192.168.0.10"),
@@ -641,7 +641,49 @@ func TestLinkRoutesAddOrUpdateMTU(t *testing.T) {
 			},
 		},
 		{
-			desc: "LinkRoutesAddOrUpdateMTU() returns NO error when subnets input list is empty",
+			desc:         "Route exists, has different gw and is updated",
+			inputLink:    mockLink,
+			inputGwIP:    ovntest.MustParseIP("192.168.0.1"),
+			inputSubnets: ovntest.MustParseIPNets("10.18.20.0/24"),
+			inputMTU:     1400,
+			errExp:       false,
+			onRetArgsNetLinkLibOpers: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "RouteListFiltered", OnCallMethodArgType: []string{"int", "*netlink.Route", "uint64"}, RetArgList: []interface{}{[]netlink.Route{
+					{
+						Gw:  ovntest.MustParseIP("192.168.0.2"),
+						Dst: ovntest.MustParseIPNet("10.18.20.0/24"),
+						MTU: 1400,
+						Src: ovntest.MustParseIP("192.168.0.8"),
+					},
+				}, nil}},
+				{OnCallMethodName: "RouteReplace", OnCallMethodArgType: []string{"*netlink.Route"}, RetArgList: []interface{}{nil}},
+			},
+			onRetArgsLinkIfaceOpers: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "Attrs", OnCallMethodArgType: []string{}, RetArgList: []interface{}{&netlink.LinkAttrs{Name: "testIfaceName", Index: 1}}},
+			},
+		},
+		{
+			desc:         "Route exists, has the same mtu and gw and is not updated",
+			inputLink:    mockLink,
+			inputGwIP:    ovntest.MustParseIP("192.168.0.1"),
+			inputSubnets: ovntest.MustParseIPNets("10.18.20.0/24"),
+			inputMTU:     1400,
+			errExp:       false,
+			onRetArgsNetLinkLibOpers: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "RouteListFiltered", OnCallMethodArgType: []string{"int", "*netlink.Route", "uint64"}, RetArgList: []interface{}{[]netlink.Route{
+					{
+						Gw:  ovntest.MustParseIP("192.168.0.1"),
+						Dst: ovntest.MustParseIPNet("10.18.20.0/24"),
+						MTU: 1400,
+					},
+				}, nil}},
+			},
+			onRetArgsLinkIfaceOpers: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "Attrs", OnCallMethodArgType: []string{}, RetArgList: []interface{}{&netlink.LinkAttrs{Name: "testIfaceName", Index: 1}}},
+			},
+		},
+		{
+			desc: "LinkRoutesApply() returns NO error when subnets input list is empty",
 		},
 	}
 	for i, tc := range tests {
@@ -650,7 +692,7 @@ func TestLinkRoutesAddOrUpdateMTU(t *testing.T) {
 			ovntest.ProcessMockFnList(&mockNetLinkOps.Mock, tc.onRetArgsNetLinkLibOpers)
 			ovntest.ProcessMockFnList(&mockLink.Mock, tc.onRetArgsLinkIfaceOpers)
 
-			err := LinkRoutesAddOrUpdateMTU(tc.inputLink, tc.inputGwIP, tc.inputSubnets, tc.inputMTU)
+			err := LinkRoutesApply(tc.inputLink, tc.inputGwIP, tc.inputSubnets, tc.inputMTU)
 			t.Log(err)
 			if tc.errExp {
 				assert.Error(t, err)


### PR DESCRIPTION
This is a backport of https://github.com/openshift/ovn-kubernetes/commit/b0c423da7ce95d5377f8773a794e784205de684c and https://github.com/openshift/ovn-kubernetes/commit/32945d0a68e773012df812e674d21bb328f9d977. It is required for downgrades from 4.12 to 4.11.

Renamed `LinkRoutesAddOrUpdateMTU` to `LinkRoutesApply` to be consistent with later releases.
Conflicts:
  go-controller/pkg/util/net_linux_unit_test.go
  go-controller/pkg/util/net_linux.go
