### PR TITLE
OCPBUGS-4909: Dockerfile: bump OVN to 22.12.0-18

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -13,7 +13,7 @@ RUN yum install -y  \
 	yum clean all
 
 ARG ovsver=2.17.0-62.el8fdp
-ARG ovnver=22.12.0-4.el8fdp
+ARG ovnver=22.12.0-18.el8fdp
 
 RUN \
     yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False "openvswitch2.17 = $ovsver" "python3-openvswitch2.17 = $ovsver" && \


### PR DESCRIPTION
Includes fixes for:

OVN Load Balancers should allow all "related" ICMP error messages to pass through
https://bugzilla.redhat.com/show_bug.cgi?id=2126083

apply-after-lb ACL breaks hairpinning
https://bugzilla.redhat.com/show_bug.cgi?id=2103086

the first ping from pod to external would fail
https://bugzilla.redhat.com/show_bug.cgi?id=2129283

Lack of udp conntrack entries in ovn lb hairpin testing while no port specified
https://bugzilla.redhat.com/show_bug.cgi?id=2157846

ovn-controller: Fix initial requested SNAT zone assignment
https://bugzilla.redhat.com/show_bug.cgi?id=2160403
    
northd: Add logical flows to allow rpl/rel traffic in acl_after_lb stage
https://bugzilla.redhat.com/show_bug.cgi?id=1947807
