### PR TITLE
[release-4.12] OCPBUGS-298: Bump OVN to 22.09.0-54

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -13,7 +13,7 @@ RUN yum install -y  \
 	yum clean all
 
 ARG ovsver=2.17.0-62.el8fdp
-ARG ovnver=22.09.0-25.el8fdp
+ARG ovnver=22.09.0-54.el8fdp
 RUN echo $ovsver > /ovs-version && echo $ovnver > /ovn-version
 
 RUN mkdir -p /var/run/openvswitch && \


### PR DESCRIPTION
Bumped OVN to latest available for 22.09.

Bring in a fix allowing ovn-trace to connect to SB followers.
All additional changes listed in the commit message.