### PR TITLE
[release-4.12] OCPBUGS-3399: Drop in-cluster traffic towards svcCIDR at wrong port

### DIFF
--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -1178,6 +1178,13 @@ func flowsForDefaultBridge(bridge *bridgeConfiguration, extraIPs []net.IP) ([]st
 				"actions=ct(zone=%d,nat,table=3)",
 				defaultOpenFlowCookie, ofPortPatch, protoPrefix, protoPrefix, svcCIDR,
 				protoPrefix, masqIP, HostMasqCTZone))
+
+		// table 0, Reply traffic coming from OVN to outside, drop it if the DNAT wasn't done either
+		// at the GR load balancer or switch load balancer. It means the correct port wasn't provided.
+		// nodeCIDR->serviceCIDR traffic flow is internal and it shouldn't be carried to outside the cluster
+		dftFlows = append(dftFlows,
+			fmt.Sprintf("cookie=%s, priority=105, in_port=%s, %s, %s_dst=%s,"+
+				"actions=drop", defaultOpenFlowCookie, ofPortPatch, protoPrefix, protoPrefix, svcCIDR))
 	}
 
 	actions := fmt.Sprintf("output:%s", ofPortPatch)


### PR DESCRIPTION
This PR fixes two traffic flows:

1) podCIDR to svcCIDR:unexposedPort. This flow currently sends the packets towards br-ex in both gateway modes since OVN LB's won't DNAT and OVN doesn't know what to do then other than to send these packets out. However the argument here is svcCIDR is a private range, these packets shouldn't be sent outside. Hence like SDN let's drop them.

2) nodeCIDR to svcCIDR:unexposedPort. Same as above.

Fix: Add a new flow at 105 priority right above the default 100 priority flow (that sends the pkt out to primary interface if coming from OVN) which will drop it instead of sending it out the primary interface.

 cookie=0xdeff105, duration=7804.947s, table=0, n_packets=18, n_bytes=1332, idle_age=6984, priority=105,ip,in_port=2,nw_dst=10.96.0.0/16 actions=drop
 cookie=0xdeff105, duration=7804.947s, table=0, n_packets=0, n_bytes=0, idle_age=7804, priority=100,ip,in_port=2 actions=ct(commit,zone=64000,exec(load:0x1->NXM_NX_CT_MARK[])),output:1

This has been tested for both traffic flows on both SGW and LGW modes.

Signed-off-by: Surya Seetharaman <suryaseetharaman.9@gmail.com>
(cherry picked from commit e5d3e3f3f992bca605a6c194b9209656fe063a40)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->