### PR TITLE
OCPBUGS-6814: [release-4.10] Ensure loadbalancer cleanup doesn't fail

### DIFF
--- a/go-controller/pkg/libovsdbops/lbgroup.go
+++ b/go-controller/pkg/libovsdbops/lbgroup.go
@@ -2,6 +2,7 @@ package libovsdbops
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	libovsdbclient "github.com/ovn-org/libovsdb/client"
@@ -80,6 +81,10 @@ func RemoveLoadBalancersFromGroupOps(nbClient libovsdbclient.Client, ops []libov
 
 	err := findLBGroup(nbClient, group)
 	if err != nil {
+		if errors.Is(err, libovsdbclient.ErrNotFound) {
+			// if we want to delete loadbalancer from the group that doesn't exist, that is noop
+			return ops, nil
+		}
 		return nil, err
 	}
 

--- a/go-controller/pkg/libovsdbops/router.go
+++ b/go-controller/pkg/libovsdbops/router.go
@@ -2,6 +2,7 @@ package libovsdbops
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 
@@ -86,6 +87,10 @@ func RemoveLoadBalancersFromRouterOps(nbClient libovsdbclient.Client, ops []libo
 
 	_, err := findRouter(nbClient, router)
 	if err != nil {
+		if errors.Is(err, libovsdbclient.ErrNotFound) {
+			// if we want to delete loadbalancer from the router that doesn't exist, that is noop
+			return ops, nil
+		}
 		return nil, err
 	}
 

--- a/go-controller/pkg/libovsdbops/switch.go
+++ b/go-controller/pkg/libovsdbops/switch.go
@@ -2,6 +2,7 @@ package libovsdbops
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -203,6 +204,10 @@ func RemoveLoadBalancersFromSwitchOps(nbClient libovsdbclient.Client, ops []libo
 
 	err := findSwitchUUID(nbClient, lswitch)
 	if err != nil {
+		if errors.Is(err, libovsdbclient.ErrNotFound) {
+			// if we want to delete loadbalancer from the switch that doesn't exist, that is noop
+			return ops, nil
+		}
 		return nil, err
 	}
 

--- a/go-controller/pkg/ovn/loadbalancer/loadbalancer_test.go
+++ b/go-controller/pkg/ovn/loadbalancer/loadbalancer_test.go
@@ -1,0 +1,67 @@
+package loadbalancer
+
+import (
+	"fmt"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdbops"
+	"testing"
+
+	libovsdbtest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
+)
+
+func TestEnsureLBs(t *testing.T) {
+	nbClient, cleanup, err := libovsdbtest.NewNBTestHarness(libovsdbtest.TestSetup{}, nil)
+	if err != nil {
+		t.Fatalf("Error creating NB: %v", err)
+	}
+	t.Cleanup(cleanup.Cleanup)
+	lbCache, err := GetLBCache(nbClient)
+	if err != nil {
+		t.Fatalf("Error creating LB Cache: %v", err)
+	}
+	name := "foo"
+	namespace := "testns"
+	defaultExternalIDs := map[string]string{
+		"k8s.ovn.org/kind":  "Service",
+		"k8s.ovn.org/owner": fmt.Sprintf("%s/%s", namespace, name),
+	}
+	// put stale lb in the cache
+	staleLBs := []LB{
+		{
+			Name:        "Service_testns/foo_TCP_node_router_node-a",
+			ExternalIDs: defaultExternalIDs,
+			Routers:     []string{"gr-node-a", "non-exisitng-router"},
+			Switches:    []string{"non-exisitng-switch"},
+			Groups:      []string{"non-existing-group"},
+			Protocol:    "TCP",
+			Rules: []LBRule{
+				{
+					Source:  Addr{"1.2.3.4", 80},
+					Targets: []Addr{{"169.254.169.2", 8080}},
+				},
+			},
+			UUID: libovsdbops.BuildNamedUUID(),
+		},
+	}
+	lbCache.update(staleLBs, nil)
+	// required lb doesn't have stale router, switch, and lb group reference.
+	// "gr-node-a" is listed as applied in the cache, no update operation will be generated for it.
+	LBs := []LB{
+		{
+			Name:        "Service_testns/foo_TCP_node_router_node-a",
+			ExternalIDs: defaultExternalIDs,
+			Routers:     []string{"gr-node-a"},
+			Protocol:    "TCP",
+			Rules: []LBRule{
+				{
+					Source:  Addr{"1.2.3.4", 80},
+					Targets: []Addr{{"169.254.169.2", 8080}},
+				},
+			},
+		},
+	}
+
+	err = EnsureLBs(nbClient, defaultExternalIDs, LBs)
+	if err != nil {
+		t.Fatalf("Error EnsureLBs: %v", err)
+	}
+}


### PR DESCRIPTION
Backport of https://github.com/openshift/ovn-kubernetes/pull/1498
Conflicts: handle libovsdbclient.ErrNotFound as no error instead of
using ErrNotFound=false