### PR TITLE
OCPBUGS-298: Dockerfile: bump OVN to 22.09.0-54

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN yum install -y  \
 	yum clean all
 
 ARG ovsver=2.17.0-62.el8fdp
-ARG ovnver=22.09.0-25.el8fdp
+ARG ovnver=22.09.0-54.el8fdp
 
 RUN INSTALL_PKGS=" \
 	openssl python3-pyOpenSSL firewalld-filesystem \


### PR DESCRIPTION
Follow up to https://github.com/openshift/ovn-kubernetes/pull/1488.
In 4.12 OVN has to be updated both in `Dockerfile.base` and in `Dockerfile`