### PR TITLE
DNM/test: Bump OVN minor ver to 111

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN yum install -y  \
 	yum clean all
 
 ARG ovsver=2.17.0-62.el8fdp
-ARG ovnver=22.06.0-27.el8fdp
+ARG ovnver=22.06.0-111.el8fdp
 
 RUN INSTALL_PKGS=" \
 	openssl python3-pyOpenSSL firewalld-filesystem \


### PR DESCRIPTION
* Tue Jan 31 2023 Surya Seetharaman <suryaseetharaman.9@gmail.com> - 22.06.0-111
- Add the metalLB install flag for CI actions [Upstream: 045fea4aa51f98507147cb3719cf3a95c81e03bf]

* Mon Jan 23 2023 Ales Musil <amusil@redhat.com> - 22.06.0-110
- ovn-trace: Use the original ovnact for execute_load [Upstream: 1b61cc8b98d04ecee9409609ff65b3e4a864395a]

* Mon Jan 23 2023 Dumitru Ceara <dceara@redhat.com> - 22.06.0-109
- northd: Add logical flows to allow rpl/rel traffic in acl_after_lb stage. (#1947807) [Upstream: be1e73c8523008a6ea3b461ebbe904089f7cd07b]

* Mon Jan 23 2023 Ales Musil <amusil@redhat.com> - 22.06.0-108
- northd: Add flag for CT related (#2126083) [Upstream: b57fe49c058dfb0eaf5efeb845f5d220d12ffab3]

* Mon Jan 23 2023 Ales Musil <amusil@redhat.com> - 22.06.0-107
- northd: Store skip_snat and force_snat in ct_label/mark (#2126083) [Upstream: d2bf5a8f83a2aa59c8eb9d96851135b011ff898c]

* Mon Jan 23 2023 Ales Musil <amusil@redhat.com> - 22.06.0-106
- northd: Add logical flow to defrag ICMP traffic (#2126083) [Upstream: 67533aa647f635b7e6e0195ff3cb5d6a387e49cd]

* Mon Jan 23 2023 Ales Musil <amusil@redhat.com> - 22.06.0-105
- northd: Allow related traffic through LB (#2126083) [Upstream: 94b9a4396c0a96d528f6e6824364b00a15135e51]

* Mon Jan 23 2023 Ales Musil <amusil@redhat.com> - 22.06.0-104
- actions: Add new action called ct_commit_nat (#2126083) [Upstream: 58c9efdccdb4bd7c5e56a14d123c2949d68d6d89]

* Fri Jan 20 2023 Mark Michelson <mmichels@redhat.com> - 22.06.0-103
- ovn-controller: Fix initial requested SNAT zone assignment. (#2160403) [Upstream: 0c94740caf57f42f2b5966f566b1ffb62ea604e0]

* Wed Jan 18 2023 Xavier Simonart <xsimonar@redhat.com> - 22.06.0-102
- tests: Fixed flaky ACL fair Meters [Upstream: 9bb8e5333c9c639c0905cfc2ece2bd4ddeaf69a4]

* Wed Jan 18 2023 Lorenzo Bianconi <lorenzo.bianconi@redhat.com> - 22.06.0-101
- northd: move hairpin stages before acl_after_lb (#2103086) [Upstream: 9b99d30d4e4c5b7989ea7307f35c6ed75694fc24]

* Tue Jan 17 2023 Xavier Simonart <xsimonar@redhat.com> - 22.06.0-100
- controller: Fix missing first ping from pod to external (#2129283) [Upstream: 334bc936841a76a9687254778a16318d26e2b2fa]

* Mon Jan 16 2023 Lorenzo Bianconi <lorenzo.bianconi@redhat.com> - 22.06.0-99
- controller: use packet proto for hairpin traffic learned action if not specified (#2157846) [Upstream: ac90cdc527b9e539b0c80ff16468566709e06488]

* Fri Jan 13 2023 Dumitru Ceara <dceara@redhat.com> - 22.06.0-98
- .ci: ovn-kubernetes: Skip session affinity related tests. [Upstream: 83e37e8e3bcb9a3c12f079ab60de39d4fb586c8f]

* Fri Jan 13 2023 Dumitru Ceara <dceara@redhat.com> - 22.06.0-97
- .ci: ovn-kubernetes: Add a "prepare" stage to allow for custom actions. [Upstream: 5532b938f7abd1068911f86fb52fdb4391d99bb2]

* Wed Jan 11 2023 Han Zhou <hzhou@ovn.org> - 22.06.0-96
- build-aux/sodepends.py: Fix flake8 error. [Upstream: e42317e538b2c5789392cd8a839972468ba59ecc]

* Wed Jan 11 2023 Han Zhou <hzhou@ovn.org> - 22.06.0-95
- build-aux/sodepends.py: Fix broken build when manpage changes. [Upstream: 73fc193089bd8eebc9b362b4a183a07620f145c5]

* Wed Jan 11 2023 Dumitru Ceara <dceara@redhat.com> - 22.06.0-94
- ovn-ic: Only monitor useful tables and columns. [Upstream: 9ba750c19f0ed3b4d85932f5d7f016e973b3edb4]

* Tue Dec 20 2022 Mark Michelson <mmichels@redhat.com> - 22.06.0-93
- Prepare for 22.06.2. [Upstream: d5be88e44390baed04f3147ef24082270549d255]

* Tue Dec 20 2022 Mark Michelson <mmichels@redhat.com> - 22.06.0-92
- Set release date for 22.06.1. [Upstream: 8a48c63aba22e6bba1a8f8bc4b33fc315de71d71]

* Fri Dec 16 2022 Vladislav Odintsov <odivlad@gmail.com> - 22.06.0-91
- ic: minor code improvements [Upstream: 9532920107043db93994a713552731c85957e270]

* Fri Dec 16 2022 Vladislav Odintsov <odivlad@gmail.com> - 22.06.0-90
- ic: prevent advertising/learning multiple same routes [Upstream: 6cd865743a1860fa15eec6776861f0fd822b4efd]

* Fri Dec 16 2022 Vladislav Odintsov <odivlad@gmail.com> - 22.06.0-89
- ic: lookup southbound port_binding only if needed [Upstream: 727e61513903d8e4d18c9fc5b278017e3a741674]

* Fri Dec 16 2022 Vladislav Odintsov <odivlad@gmail.com> - 22.06.0-88
- ic: remove orphan ovn interconnection routes [Upstream: 95d14053a36b913cd4beb0886973bb5e737a37e6]

* Wed Dec 14 2022 Dumitru Ceara <dceara@redhat.com> - 22.06.0-87
- ovn-controller: Only set monitor conditions on available tables. (#2151063) [Upstream: b0a84c9b283d2017984e9f7f600ea03a22fe20e7]

* Mon Dec 12 2022 Dumitru Ceara <dceara@redhat.com> - 22.06.0-86
- ovn-trace: Support connecting to SB raft followers. (#2152151) [Upstream: 7f8318b480eb9578f28f36627edb36191c8df74e]

* Mon Dec 12 2022 Ales Musil <amusil@redhat.com> - 22.06.0-85
- CI: Remove .cirrus.yml [Upstream: 853171ef00f90295ef37f706ddad577ea8f17eb0]

* Tue Dec 06 2022 Frode Nordahl <frode.nordahl@canonical.com> - 22.06.0-84
- northd: Add missing RBAC rules for BFD table. [Upstream: 65e86e2bb6b2f67544c023665f2bcb70da033699]

* Tue Dec 06 2022 Frode Nordahl <frode.nordahl@canonical.com> - 22.06.0-83
- ovn-nbctl: Fix removal of BFD entry on route deletion [Upstream: c0befbe814dc098296a3d3e748b524d01bf40d9d]

* Fri Nov 25 2022 Xavier Simonart <xsimonar@redhat.com> - 22.06.0-82
- controller: Fixed ovs/ovn(features) connection lost when running more than 120 seconds (#2144084) [Upstream: c6061d58bd0b31aeebef26ca12835d3c4079193f]

* Thu Nov 24 2022 Dumitru Ceara <dceara@redhat.com> - 22.06.0-81
- ovs: Bump submodule to include latest fixes. [Upstream: aaad311664481aee0f6e42383c6ab6d603c7dcd4]

* Tue Nov 22 2022 Xavier Simonart <xsimonar@redhat.com> - 22.06.0-80
- ovn-controller: Fixed missing flows after interface deletion (#2129866) [Upstream: 43a8b1e49306abb0e1bdfc21af2ad77bd1fde343]

* Tue Nov 22 2022 Xavier Simonart <xsimonar@redhat.com> - 22.06.0-79
- ovn-controller: Fix releasing wrong vif [Upstream: d5aada0accbfbab1fd5753f9ca978841758b79bc]

* Tue Nov 22 2022 Xavier Simonart <xsimonar@redhat.com> - 22.06.0-78
- tests: Fix flaky test "multi-vtep SB Chassis encap updates" [Upstream: a13cd4d2f75c6b1d58e017f4864ec332906e32f1]

* Fri Nov 18 2022 Ilya Maximets <i.maximets@ovn.org> - 22.06.0-77
- controller: Fix QoS for ports with undetected or too low link speed. (#2136716) [Upstream: 38127600f9bc8c5393d179588bed6b16216a4f1e]

* Tue Nov 15 2022 Mark Michelson <mmichels@redhat.com> - 22.06.0-76
- ovn-controller: Fix some issues with CT zone assignment. (#2126406) [Upstream: fda37ecdc23ea5c76ef7a64149ae16006843cece]

* Tue Nov 01 2022 Mohammad Heib <mheib@redhat.com> - 22.06.0-75
- OVN-CI: Add test cases with monitor-all enabled. [Upstream: 728afe31a0ca2e3093d547abbf69291283dc846f]

* Tue Nov 01 2022 Mohammad Heib <mheib@redhat.com> - 22.06.0-74
- OVN-CI: remove ddlog test cases. [Upstream: 03f1e2f0e8ec2c04af0156e5074cdc5cc6fcacc0]

* Thu Oct 27 2022 Dumitru Ceara <dceara@redhat.com> - 22.06.0-73
- tests: Avoid matching on the OVS flow key contents. [Upstream: af7c01db7dabd0cefedf82e85211f497f11ebdcd]

* Fri Oct 21 2022 Xavier Simonart <xsimonar@redhat.com> - 22.06.0-72
- ovs: Bump submodule to tip of branch-3.0 and add related test (#2126450) [Upstream: d6b59b35fb4c0bc174e9f1cace4a1b9b244f3c58]

* Fri Oct 21 2022 Ales Musil <amusil@redhat.com> - 22.06.0-71
- ci: Add missing tests after switch to parallel jobs [Upstream: b04065057cb9e86583368ac6dd04617c9439298d]

* Fri Oct 21 2022 Mohammad Heib <mheib@redhat.com> - 22.06.0-70
- OVN-CI: ovn unit tests run in parallel jobs. (#2114862) [Upstream: 74a4bcf18b7623f939216f1244d57e1882c93daf]

* Fri Oct 21 2022 Mohammad Heib <mheib@redhat.com> - 22.06.0-69
- CI-Actions: define matrix as a list [Upstream: 6579dc836f7788bccdf6cea72e6d00e0b7aad866]

* Fri Oct 21 2022 Ales Musil <amusil@redhat.com> - 22.06.0-68
- ci: Use CFLAGS instead of OVS_CFLAGS [Upstream: ddaa65a20f1c53e0c3667cf23ee6c6453b37c9a5]

* Fri Oct 21 2022 Igor Zhukov <ivzhukov@sbercloud.ru> - 22.06.0-67
- Build tests with asan and ubsan together to reduce CI time. [Upstream: 89dab07821a2cf3d881bf156ee3071af9ab3e80b]

* Fri Oct 21 2022 Dumitru Ceara <dceara@redhat.com> - 22.06.0-66
- ci: Add UB Sanitizer. [Upstream: dc7df1213ed25adbb00e43a2d5626a86b0fbc32c]

* Thu Oct 20 2022 Ales Musil <amusil@redhat.com> - 22.06.0-65
- controller: Add delay after multicast ARP packet [Upstream: 736734a5c123568019369e40eabc64a0ced10af7]

* Wed Oct 05 2022 Lorenzo Bianconi <lorenzo.bianconi@redhat.com> - 22.06.0-64
- controller: fix ipv6 prefix delegation in gw router mode (#2129244 2129247) [Upstream: b490c4b9f0f0a215713f440b73ebaca4634b3592]

* Wed Oct 05 2022 Vladislav Odintsov <odivlad@gmail.com> - 22.06.0-63
- spec: require python3-openvswitch for ovn-detrace [Upstream: 51f0f88bd81d8ccefc2b77b9d17138aa27ca3b90]

* Mon Oct 03 2022 Mark Michelson <mmichels@redhat.com> - 22.06.0-62
- northd: Use separate SNAT for already-DNATted traffic. [Upstream: 6020ed22eafe3741e92dfd150aa98ca3a767ae43]

* Fri Sep 30 2022 Ales Musil <amusil@redhat.com> - 22.06.0-61
- controller: Restore MAC and vlan for DVR scenario (#2123837) [Upstream: c0a6339f37e09a46bb034070aebd0b8fdd4456fc]

* Fri Sep 30 2022 Xavier Simonart <xsimonar@redhat.com> - 22.06.0-60
- northd: Fix multicast table full (#2094710) [Upstream: b336ef8dcb860693d5017bf73f489e6a78eb8f97]

* Wed Sep 28 2022 Dumitru Ceara <dceara@redhat.com> - 22.06.0-59
- ci: ovn-kubernetes: Align CI jobs with recent ovn-kubernetes upstream. [Upstream: 31b2f6c76ebaa429c79511272277a5796257c43c]

* Wed Sep 28 2022 Xavier Simonart <xsimonar@redhat.com> - 22.06.0-58
- controller: Fix first ping from lsp to external through snat failing (#2130045) [Upstream: 7ec418f29b37fe76c968d0a581a4defca4815e7e]

* Mon Sep 19 2022 Mark Michelson <mmichels@redhat.com> - 22.06.0-57
- Revert "ovn-controller: fix a crash when deleting a port claimed when sb was ro" [Upstream: 981b87f0450cda3532e42329994178a5cca9d09b]

* Fri Sep 16 2022 Xavier Simonart <xsimonar@redhat.com> - 22.06.0-56
- ovn-controller: fix a crash when deleting a port claimed when sb was ro [Upstream: 25152000923af1b1c35fd2d758dcc8564c158c42]

* Fri Sep 16 2022 Vladislav Odintsov <odivlad@gmail.com> - 22.06.0-55
- northd: drop traffic to disabled LSPs in ingress pipeline [Upstream: 167a7bf1a0838ecbf0617fe0856ba9087df2337b]

* Fri Sep 16 2022 Vladislav Odintsov <odivlad@gmail.com> - 22.06.0-54
- controller: flush associated conntrack zone on PB release [Upstream: adb79f2838ce37fdd237d54a73bf9955b2df52c5]

* Fri Sep 16 2022 Ilya Maximets <i.maximets@ovn.org> - 22.06.0-53
- northd: Re-use IP sets created for load balancer groups. [Upstream: 23676602ce71e0fc160c4691bcc748c197a073e9]

* Fri Sep 16 2022 Ilya Maximets <i.maximets@ovn.org> - 22.06.0-52
- northd: Retrieve load balancer options only once. [Upstream: 7de8774e5aa8cf07e49c483ce3f1e729ad135d06]

* Fri Sep 16 2022 Ilya Maximets <i.maximets@ovn.org> - 22.06.0-51
- northd: Add datapaths to load balancers in bulk. [Upstream: 12d9780ab01d97c6d6f80af8533400f4209f7457]

* Fri Sep 16 2022 Ilya Maximets <i.maximets@ovn.org> - 22.06.0-50
- northd: Optimize load balancer lookups for groups. [Upstream: c0fa05571b30db0760ba9f38b884c8d97d77f865]

* Fri Sep 16 2022 Dumitru Ceara <dceara@redhat.com> - 22.06.0-49
- Bump required python version to 3.6. [Upstream: 65c9911ed6c8a2575b205b11afd1679f487ca204]

* Fri Sep 16 2022 Dumitru Ceara <dceara@redhat.com> - 22.06.0-48
- tests: Fix tests/check_acl_log.py outputs. [Upstream: a553f2716cf068478bd50192a3bff6e4eeef9aff]

* Thu Sep 15 2022 Vladislav Odintsov <odivlad@gmail.com> - 22.06.0-47
- northd: don't include disabled LSP's IP to Load Balancing [Upstream: 75f2fe197569362f6cd86d05c72e4f75f11447d0]

* Fri Sep 09 2022 Dumitru Ceara <dceara@redhat.com> - 22.06.0-46
- tests: Factor out reset_pcap_file() helper. [Upstream: f4c7a4223abe7129234bd4568e9f2a75b4800d2b]

* Thu Sep 08 2022 Han Zhou <hzhou@ovn.org> - 22.06.0-45
- Don't blindly save original dst IP and Port to avoid megaflow unwildcarding. [Upstream: fe9fc89961ea893755cfcd613703d03785b9bf48]

* Mon Aug 29 2022 Xavier Simonart <xsimonar@redhat.com> - 22.06.0-44
- controller: fix potential segmentation violation when removing ports [Upstream: b89b96e1a16134c0aa8cd6513d920d49ff8c6cda]

* Fri Aug 19 2022 Mohammad Heib <mheib@redhat.com> - 22.06.0-43
- binding.c: update ld->peers when lsp type updated (#2077078) [Upstream: 978c1db7e1678d69be0f69e2c7ced3e96a0f7488]

* Fri Aug 19 2022 Lorenzo Bianconi <lorenzo.bianconi@redhat.com> - 22.06.0-42
- northd: rely on new actions for ecmp-symmetric routing (#2096233) [Upstream: 8434cdd06cac1d16f7140b39862cdf826ea9174b]

* Fri Aug 19 2022 Lorenzo Bianconi <lorenzo.bianconi@redhat.com> - 22.06.0-41
- actions: introduce chk_ecmp_nh and chk_ecmp_nh_mac actions [Upstream: c1b2251563b47075d29dfbc5a37278e11c5f8090]

* Fri Aug 19 2022 Lorenzo Bianconi <lorenzo.bianconi@redhat.com> - 22.06.0-40
- actions: introduce commit_ecmp_nh action [Upstream: fbe3da470f7631169eb6987ee7c1050bbcadffdf]

* Thu Aug 18 2022 Dumitru Ceara <dceara@redhat.com> - 22.06.0-39
- github: ovn-kubernetes: Update go, kube and libovsdb versions. [Upstream: 959e035ca12f98818595d0e2442610f4f0ba907c]

* Thu Aug 18 2022 Lorenzo Bianconi <lorenzo.bianconi@redhat.com> - 22.06.0-38
- controller: physical: fix regression for container ports (#2105901) [Upstream: 5e2baaa4402b7cf600c4822c7b6c1bae89badaf1]

* Wed Aug 17 2022 Olaf Seibert <o.seibert@syseleven.de> - 22.06.0-37
- northd: Fix memory leak. [Upstream: d9a050e0c9f2e09f8066879809aa96acf6544347]

* Wed Aug 17 2022 Ihar Hrachyshka <ihrachys@redhat.com> - 22.06.0-36
- controller: throttle port claim attempts [Upstream: 8f1d63bbf6f67ab2bc4eb3d59ba1de43a4f6548f]

* Wed Aug 17 2022 Ihar Hrachyshka <ihrachys@redhat.com> - 22.06.0-35
- Split out code to handle port binding db updates [Upstream: 3171d0ce474eb90c89cbd2b2e4ed7c885195bba4]

* Tue Aug 09 2022 Dumitru Ceara <dceara@redhat.com> - 22.06.0-34
- northd: Do not relay local IP multicast (224.0.0.X). (#2077306) [Upstream: 5ad79df0229ff190687225a06df73a50d2100f50]

* Mon Aug 08 2022 Ihar Hrachyshka <ihrachys@redhat.com> - 22.06.0-33
- tests: Enable vif-plug tests and fix the vif-provider. [Upstream: 1293b7f0fb6854cdc0a6a7d760a444db28df1212]

* Mon Aug 08 2022 Ales Musil <amusil@redhat.com> - 22.06.0-32
- ovn-ctl: Ensure that log/run directory have correct permission (#2113855) [Upstream: e9da1112d171063c9a8cee417105b65cb85e233d]

* Fri Aug 05 2022 Han Zhou <hzhou@ovn.org> - 22.06.0-31
- ofctrl.c: mff_ovn_geneve should be available at state WAIT_BEFORE_CLEAR. [Upstream: d6a8d9eb1579aa1542540e51ae7c53e84e9616d7]

* Tue Aug 02 2022 Ales Musil <amusil@redhat.com> - 22.06.0-30
- controller: Fix IPv6 prefix delegation (#2108726) [Upstream: 910523a0b9fc1e5da04ca8d954b03c4f0e641e53]

* Tue Aug 02 2022 Ales Musil <amusil@redhat.com> - 22.06.0-29
- system-tests: Reduce flakiness of IPv6 prefix delegation (#2108726) [Upstream: fe639323b3911f2a99e495c3fcf6ea3c18654066]

* Tue Aug 02 2022 Mohammad Heib <mheib@redhat.com> - 22.06.0-28
- northd: handle virtual lport type update (#2099288) [Upstream: 367dda01b9fcaab15079fd3dc1418353890745a6]

* Thu Jul 28 2022 Han Zhou <hzhou@ovn.org> - 22.06.0-27
- extend-table: Fix table ID double allocation after OVS restart. (#2112111) [Upstream: 3affdfe8952fa359ed52aa0cbb28ffb879ba6fb6]

* Sat Jul 23 2022 Andreas Karis <ak.karis@gmail.com> - 22.06.0-26
- IPsec: Add option to force NAT-T encapsulation (#2041681) [Upstream: 0e3ee19efea923ca6293af12e6610460c0cfb8b8]

* Thu Jul 21 2022 Numan Siddique <numans@ovn.org> - 22.06.0-25
- Fix compilation issue in fedora 37/rawhide. [Upstream: 5f948fc8f99fc12fc666ffe1ee4b54e005ff7038]

* Tue Jul 19 2022 wangchuanlei <wangchuanlei@inspur.com> - 22.06.0-24
- pinctrl: fix ovn-controller abort when service start. [Upstream: 593b3c25e1ab88db3e13fe93c8a265e7efea3863]

* Tue Jul 19 2022 Lorenzo Bianconi <lorenzo.bianconi@redhat.com> - 22.06.0-23
- lflow: fix possible use-after-free in add_lb_vip_hairpin_reply_action [Upstream: 6bcb3b7931c3e705c9d2ff0235accc0575cfbc7b]

* Tue Jul 19 2022 Lorenzo Bianconi <lorenzo.bianconi@redhat.com> - 22.06.0-22
- ovn-ic: do not learn routes with link-local next-hops (#2100355) [Upstream: 55d2f0c805ef912aab5483fed384e2b749fbe413]

* Tue Jul 12 2022 Xavier Simonart <xsimonar@redhat.com> - 22.06.0-21
- tests: fixed flaky test localnet connectivity with multiple requested-chassis [Upstream: 592ba5643c5e250e0f2fd0232d475cee1a3e2014]

* Mon Jul 11 2022 Dumitru Ceara <dceara@redhat.com> - 22.06.0-20
- ovn-nb: Properly document multicast flood config defaults. [Upstream: 503e7333efc193fd8457f981e32d48ec27c417df]

* Mon Jul 11 2022 Ales Musil <amusil@redhat.com> - 22.06.0-19
- ovn-nbctl: Fix priority arg of lrp-set-gateway-chassis (#2102930) [Upstream: bc46ab4dbdd866307ce4851fc68170764625f397]

* Mon Jul 11 2022 Ihar Hrachyshka <ihrachys@redhat.com> - 22.06.0-18
- Always funnel multichassis port traffic through tunnels [Upstream: 894bcac4922928eb5701bdeb0fd8319973fd3ba6]

* Thu Jul 07 2022 Vladislav Odintsov <odivlad@gmail.com> - 22.06.0-17
- northd: set svc_mon status to offline if port_binding released (#2103740) [Upstream: 8cc90ac02fff34d640c551230c712f9184d35e2a]

* Fri Jul 01 2022 Mark Michelson <mmichels@redhat.com> - 22.06.0-16
- ovs: Bump submodule to newer version (#2102618) [Upstream: 5593044a8be0d2ce730e4890cf213ee760916889]

* Wed Jun 29 2022 Ihar Hrachyshka <ihrachys@redhat.com> - 22.06.0-15
- tests: add multi-chassis keyword to relevant test cases [Upstream: 4bdade3593ae3c6604822716d22ab04b0af962da]

* Wed Jun 29 2022 Lorenzo Bianconi <lorenzo.bianconi@redhat.com> - 22.06.0-14
- northd: add condition for stateless nat drop flow in S_ROUTER_IN_GW_REDIRECT pipeline (#2094980) [Upstream: 9885154fc41005dbb8fbbdca9e3a38d892870f53]

* Wed Jun 29 2022 Ales Musil <amusil@redhat.com> - 22.06.0-13
- northd.c: Add flow to skip put_nd action if ip6.src or nd.sll is 0 [Upstream: c5596102cb84e22086d7807b31cbe5c9e893ac38]

* Wed Jun 29 2022 Terry Wilson <twilson@redhat.com> - 22.06.0-12
- Allow arbitrary args to be passed to called binary [Upstream: 849106f6ee75d7b1ff990763325d41d45c843a64]

* Mon Jun 27 2022 Ihar Hrachyshka <ihrachys@redhat.com> - 22.06.0-11
- tests: ovn-nbctl dump-flows -> ovn-sbctl dump-flows [Upstream: 656a91b6b5cd9d9e48b8e938fcffb81ead2d9fda]

* Mon Jun 27 2022 Ihar Hrachyshka <ihrachys@redhat.com> - 22.06.0-10
- Fix memleak in ovn-nbctl when args can't be parsed [Upstream: 70b360325c13f399835b1f5c7ac0c0acd4832773]

* Mon Jun 20 2022 Ihar Hrachyshka <ihrachys@redhat.com> - 22.06.0-9
- Implement RARP activation strategy for ports [Upstream: c75ddaf804cc8ea8499706430b438ae53f2f1224]

* Tue Jun 14 2022 Ihar Hrachyshka <ihrachys@redhat.com> - 22.06.0-8
- Fix pidfile_is_running when $cmd is not passed [Upstream: 44e047d6f1be5ae4f564e82a928cf1f08f1908ef]

* Thu Jun 09 2022 Ihar Hrachyshka <ihrachys@redhat.com> - 22.06.0-7
- Lock pinctrl_mutex for pinctrl_wait [Upstream: 6e36ad7a52ec4e6443ccb3185bda6421cdf6747e]

* Thu Jun 09 2022 Terry Wilson <twilson@redhat.com> - 22.06.0-6
- Ensure pid belongs to ovsdb-server in ovn-ctl [Upstream: d0847f56913245c19a33e087f730c084ca674c83]

* Thu Jun 09 2022 Terry Wilson <twilson@redhat.com> - 22.06.0-5
- Handle re-used pids in pidfile_is_running [Upstream: 98e7d4b3675b237c770763377382075ac08c64ba]

* Fri Jun 03 2022 Mark Michelson <mmichels@redhat.com> - 22.06.0-4
- Prepare for 22.06.1. [Upstream: 437dc3a01266d7f128bba532c674c5827af1bd6f]

Signed-off-by: Martin Kennelly <mkennell@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->