### PR TITLE
OCPBUGS-6957: [release-4.12] Ensure routes are not duplicated

### DIFF
--- a/go-controller/pkg/config/utils.go
+++ b/go-controller/pkg/config/utils.go
@@ -226,3 +226,21 @@ func (cs *configSubnets) checkIPFamilies() (usingIPv4, usingIPv6 bool, err error
 
 	return false, false, fmt.Errorf("illegal network configuration: %s", netConfig)
 }
+
+func ContainsJoinIP(ip net.IP) bool {
+	var joinSubnetsConfig []string
+	if IPv4Mode {
+		joinSubnetsConfig = append(joinSubnetsConfig, Gateway.V4JoinSubnet)
+	}
+	if IPv6Mode {
+		joinSubnetsConfig = append(joinSubnetsConfig, Gateway.V6JoinSubnet)
+	}
+
+	for _, subnet := range joinSubnetsConfig {
+		_, joinSubnet, _ := net.ParseCIDR(subnet)
+		if joinSubnet.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}

--- a/go-controller/pkg/libovsdbops/router.go
+++ b/go-controller/pkg/libovsdbops/router.go
@@ -528,7 +528,6 @@ func CreateOrUpdateLogicalRouterStaticRoutesWithPredicateOps(nbClient libovsdbcl
 	opModels := []operationModel{
 		{
 			Model:          lrsr,
-			ModelPredicate: p,
 			OnModelUpdates: fields,
 			DoAfter:        func() { router.StaticRoutes = []string{lrsr.UUID} },
 			ErrNotFound:    false,
@@ -543,22 +542,96 @@ func CreateOrUpdateLogicalRouterStaticRoutesWithPredicateOps(nbClient libovsdbcl
 		},
 	}
 
+	if p != nil {
+		opModels[0].ModelPredicate = p
+	}
+
 	m := newModelClient(nbClient)
 	return m.CreateOrUpdateOps(ops, opModels...)
 }
 
-// CreateOrUpdateLogicalRouterStaticRoutesWithPredicateOps looks up a logical
+// PolicyEqualPredicate determines if two static routes have the same routing policy (dst-ip or src-ip)
+// If policy is nil, OVN considers that as dst-ip
+func PolicyEqualPredicate(p1, p2 *nbdb.LogicalRouterStaticRoutePolicy) bool {
+	if p1 == nil {
+		return p2 == nil || (p2 != nil && *p2 == nbdb.LogicalRouterStaticRoutePolicyDstIP)
+	}
+
+	if p2 == nil {
+		return *p1 == nbdb.LogicalRouterStaticRoutePolicyDstIP
+	}
+
+	return *p1 == *p2
+}
+
+// CreateOrReplaceLogicalRouterStaticRouteWithPredicate looks up a logical
 // router static route from the cache based on a given predicate. If it does not
 // exist, it creates the provided logical router static route. If it does, it
 // updates it. The logical router static route is added to the provided logical
-// router
-func CreateOrUpdateLogicalRouterStaticRoutesWithPredicate(nbClient libovsdbclient.Client, routerName string,
+// router.
+// If more than one route matches the predicate on the router, the additional routes are removed.
+func CreateOrReplaceLogicalRouterStaticRouteWithPredicate(nbClient libovsdbclient.Client, routerName string,
 	lrsr *nbdb.LogicalRouterStaticRoute, p logicalRouterStaticRoutePredicate, fields ...interface{}) error {
-	ops, err := CreateOrUpdateLogicalRouterStaticRoutesWithPredicateOps(nbClient, nil, routerName, lrsr, p, fields...)
+
+	lr := &nbdb.LogicalRouter{Name: routerName}
+	router, err := GetLogicalRouter(nbClient, lr)
+	if err != nil {
+		return err
+	}
+	newPredicate := func(item *nbdb.LogicalRouterStaticRoute) bool {
+		for _, routeUUID := range router.StaticRoutes {
+			if routeUUID == item.UUID && p(item) {
+				return true
+			}
+		}
+		return false
+	}
+	routes, err := FindLogicalRouterStaticRoutesWithPredicate(nbClient, newPredicate)
 	if err != nil {
 		return err
 	}
 
+	var ops []libovsdb.Operation
+	m := newModelClient(nbClient)
+
+	if len(routes) > 0 {
+		lrsr.UUID = routes[0].UUID
+	}
+
+	if len(routes) > 1 {
+		// should only be a single route remove all except the first
+		routes = routes[1:]
+		opModels := make([]operationModel, 0, len(routes)+1)
+		router.StaticRoutes = []string{}
+		for _, route := range routes {
+			route := route
+			router.StaticRoutes = append(router.StaticRoutes, route.UUID)
+			opModel := operationModel{
+				Model:       route,
+				ErrNotFound: false,
+				BulkOp:      false,
+			}
+			opModels = append(opModels, opModel)
+		}
+		opModel := operationModel{
+			Model:            router,
+			ModelPredicate:   func(item *nbdb.LogicalRouter) bool { return item.Name == router.Name },
+			OnModelMutations: []interface{}{&router.StaticRoutes},
+			ErrNotFound:      true,
+			BulkOp:           false,
+		}
+		opModels = append(opModels, opModel)
+
+		ops, err = m.DeleteOps(nil, opModels...)
+		if err != nil {
+			return err
+		}
+	}
+
+	ops, err = CreateOrUpdateLogicalRouterStaticRoutesWithPredicateOps(nbClient, ops, routerName, lrsr, nil, fields...)
+	if err != nil {
+		return err
+	}
 	_, err = TransactAndCheck(nbClient, ops)
 	return err
 }
@@ -593,7 +666,7 @@ func DeleteLogicalRouterStaticRoutesWithPredicate(nbClient libovsdbclient.Client
 	return m.Delete(opModels...)
 }
 
-// DeleteLogicalRouterPolicies deletes the logical router static routes and
+// DeleteLogicalRouterStaticRoutes deletes the logical router static routes and
 // removes them from the provided logical router
 func DeleteLogicalRouterStaticRoutes(nbClient libovsdbclient.Client, routerName string, lrsrs ...*nbdb.LogicalRouterStaticRoute) error {
 	router := &nbdb.LogicalRouter{

--- a/go-controller/pkg/libovsdbops/router.go
+++ b/go-controller/pkg/libovsdbops/router.go
@@ -676,6 +676,7 @@ func DeleteLogicalRouterStaticRoutes(nbClient libovsdbclient.Client, routerName 
 
 	opModels := make([]operationModel, 0, len(lrsrs)+1)
 	for _, lrsr := range lrsrs {
+		lrsr := lrsr
 		router.StaticRoutes = append(router.StaticRoutes, lrsr.UUID)
 		opModel := operationModel{
 			Model:       lrsr,

--- a/go-controller/pkg/ovn/gateway_init.go
+++ b/go-controller/pkg/ovn/gateway_init.go
@@ -227,9 +227,10 @@ func (oc *Controller) gatewayInit(nodeName string, clusterIPSubnet []*net.IPNet,
 			Nexthop:  drLRPIfAddr.IP.String(),
 		}
 		p := func(item *nbdb.LogicalRouterStaticRoute) bool {
-			return item.IPPrefix == lrsr.IPPrefix && util.SliceHasStringItem(updatedLogicalRouter.StaticRoutes, item.UUID)
+			return item.IPPrefix == lrsr.IPPrefix && libovsdbops.PolicyEqualPredicate(item.Policy, lrsr.Policy) &&
+				util.SliceHasStringItem(updatedLogicalRouter.StaticRoutes, item.UUID)
 		}
-		err = libovsdbops.CreateOrUpdateLogicalRouterStaticRoutesWithPredicate(oc.nbClient, gatewayRouter, &lrsr, p,
+		err = libovsdbops.CreateOrReplaceLogicalRouterStaticRouteWithPredicate(oc.nbClient, gatewayRouter, &lrsr, p,
 			&lrsr.Nexthop)
 		if err != nil {
 			return fmt.Errorf("failed to add a static route %+v in GR %s with distributed router as the nexthop, err: %v", lrsr, gatewayRouter, err)
@@ -285,10 +286,11 @@ func (oc *Controller) gatewayInit(nodeName string, clusterIPSubnet []*net.IPNet,
 			OutputPort: &externalRouterPort,
 		}
 		p := func(item *nbdb.LogicalRouterStaticRoute) bool {
-			return item.OutputPort != nil && *item.OutputPort == *lrsr.OutputPort && item.IPPrefix == lrsr.IPPrefix
+			return item.OutputPort != nil && *item.OutputPort == *lrsr.OutputPort && item.IPPrefix == lrsr.IPPrefix &&
+				libovsdbops.PolicyEqualPredicate(lrsr.Policy, item.Policy)
 		}
-		err := libovsdbops.CreateOrUpdateLogicalRouterStaticRoutesWithPredicate(oc.nbClient, gatewayRouter, &lrsr, p,
-			&lrsr.Nexthop)
+		err := libovsdbops.CreateOrReplaceLogicalRouterStaticRouteWithPredicate(oc.nbClient, gatewayRouter, &lrsr,
+			p, &lrsr.Nexthop)
 		if err != nil {
 			return fmt.Errorf("error creating static route %+v in GR %s: %v", lrsr, gatewayRouter, err)
 		}
@@ -305,12 +307,13 @@ func (oc *Controller) gatewayInit(nodeName string, clusterIPSubnet []*net.IPNet,
 			Nexthop:  gwLRPIP.String(),
 		}
 		p := func(item *nbdb.LogicalRouterStaticRoute) bool {
-			return item.Nexthop == lrsr.Nexthop && item.IPPrefix == lrsr.IPPrefix
+			return item.IPPrefix == lrsr.IPPrefix &&
+				libovsdbops.PolicyEqualPredicate(lrsr.Policy, item.Policy)
 		}
-		err := libovsdbops.CreateOrUpdateLogicalRouterStaticRoutesWithPredicate(oc.nbClient, types.OVNClusterRouter,
-			&lrsr, p)
+		err := libovsdbops.CreateOrReplaceLogicalRouterStaticRouteWithPredicate(oc.nbClient,
+			types.OVNClusterRouter, &lrsr, p, &lrsr.Nexthop)
 		if err != nil {
-			return fmt.Errorf("error creating static route %+v in GR %s: %v", lrsr, gatewayRouter, err)
+			return fmt.Errorf("error creating static route %+v in %s: %v", lrsr, types.OVNClusterRouter, err)
 		}
 	}
 
@@ -329,25 +332,31 @@ func (oc *Controller) gatewayInit(nodeName string, clusterIPSubnet []*net.IPNet,
 			IPPrefix: hostSubnet.String(),
 			Nexthop:  gwLRPIP[0].String(),
 		}
-		p := func(item *nbdb.LogicalRouterStaticRoute) bool {
-			return item.Nexthop == lrsr.Nexthop && item.IPPrefix == lrsr.IPPrefix && item.Policy != nil && *item.Policy == *lrsr.Policy
-		}
+
 		if config.Gateway.Mode != config.GatewayModeLocal {
+			p := func(item *nbdb.LogicalRouterStaticRoute) bool {
+				return item.IPPrefix == lrsr.IPPrefix && libovsdbops.PolicyEqualPredicate(lrsr.Policy, item.Policy)
+			}
 			// If migrating from local to shared gateway, let's remove the static routes towards
 			// management port interface for the hostSubnet prefix before adding the routes
 			// towards join switch.
 			mgmtIfAddr := util.GetNodeManagementIfAddr(hostSubnet)
 			oc.staticRouteCleanup([]net.IP{mgmtIfAddr.IP})
 
-			err := libovsdbops.CreateOrUpdateLogicalRouterStaticRoutesWithPredicate(oc.nbClient, types.OVNClusterRouter,
-				&lrsr, p)
+			err := libovsdbops.CreateOrReplaceLogicalRouterStaticRouteWithPredicate(oc.nbClient, types.OVNClusterRouter,
+				&lrsr, p, &lrsr.Nexthop)
 			if err != nil {
 				return fmt.Errorf("error creating static route %+v in GR %s: %v", lrsr, types.OVNClusterRouter, err)
 			}
 		} else if config.Gateway.Mode == config.GatewayModeLocal {
 			// If migrating from shared to local gateway, let's remove the static routes towards
-			// join switch for the hostSubnet prefix before adding the routes
-			// towards management port which is done in syncNodeManagementPort.
+			// join switch for the hostSubnet prefix
+			// Note syncManagementPort happens before gateway sync so only remove things pointing to join subnet
+
+			p := func(item *nbdb.LogicalRouterStaticRoute) bool {
+				return item.IPPrefix == lrsr.IPPrefix && item.Policy != nil && *item.Policy == *lrsr.Policy &&
+					config.ContainsJoinIP(net.ParseIP(item.Nexthop))
+			}
 			err := libovsdbops.DeleteLogicalRouterStaticRoutesWithPredicate(oc.nbClient, types.OVNClusterRouter, p)
 			if err != nil {
 				return fmt.Errorf("error deleting static route %+v in GR %s: %v", lrsr, types.OVNClusterRouter, err)

--- a/go-controller/pkg/ovn/gateway_test.go
+++ b/go-controller/pkg/ovn/gateway_test.go
@@ -878,7 +878,7 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 			config.Gateway.DisableSNATMultipleGWs = true
 
 			var err error
-			fakeOvn.controller.defaultCOPPUUID, err = EnsureDefaultCOPP(fakeOvn.nbClient)
+			fakeOvn.controller.defaultGatewayCOPPUUID, err = EnsureDefaultCOPP(fakeOvn.nbClient)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			err = fakeOvn.controller.gatewayInit(
@@ -1038,7 +1038,7 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 			config.Gateway.DisableSNATMultipleGWs = true
 
 			var err error
-			fakeOvn.controller.defaultCOPPUUID, err = EnsureDefaultCOPP(fakeOvn.nbClient)
+			fakeOvn.controller.defaultGatewayCOPPUUID, err = EnsureDefaultCOPP(fakeOvn.nbClient)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			err = fakeOvn.controller.gatewayInit(

--- a/go-controller/pkg/ovn/hybrid.go
+++ b/go-controller/pkg/ovn/hybrid.go
@@ -264,18 +264,23 @@ func (oc *Controller) setupHybridLRPolicySharedGw(nodeSubnets []*net.IPNet, node
 
 			// Static route to steer packets from external to nodePort service backed by pods on hybrid overlay node.
 			// This route is to used for triggering above route policy
-			clutsterRouterStaticRoutes := nbdb.LogicalRouterStaticRoute{
+			clusterRouterStaticRoutes := nbdb.LogicalRouterStaticRoute{
 				IPPrefix: hybridCIDR.String(),
 				Nexthop:  drIP.String(),
 				ExternalIDs: map[string]string{
 					"name": ovntypes.HybridSubnetPrefix + nodeName,
 				},
 			}
-			if err := libovsdbops.CreateOrUpdateLogicalRouterStaticRoutesWithPredicate(oc.nbClient, ovntypes.OVNClusterRouter, &clutsterRouterStaticRoutes, func(item *nbdb.LogicalRouterStaticRoute) bool {
-				return item.IPPrefix == clutsterRouterStaticRoutes.IPPrefix && item.Nexthop == clutsterRouterStaticRoutes.Nexthop &&
-					item.ExternalIDs["name"] == clutsterRouterStaticRoutes.ExternalIDs["name"]
-			}); err != nil {
-				return fmt.Errorf("failed to add policy route static '%s %s' for on %s , error: %v", clutsterRouterStaticRoutes.IPPrefix, clutsterRouterStaticRoutes.Nexthop, ovntypes.GWRouterPrefix+nodeName, err)
+			if err := libovsdbops.CreateOrReplaceLogicalRouterStaticRouteWithPredicate(oc.nbClient,
+				ovntypes.OVNClusterRouter, &clusterRouterStaticRoutes,
+				func(item *nbdb.LogicalRouterStaticRoute) bool {
+					return item.IPPrefix == clusterRouterStaticRoutes.IPPrefix &&
+						item.ExternalIDs["name"] == clusterRouterStaticRoutes.ExternalIDs["name"] &&
+						libovsdbops.PolicyEqualPredicate(clusterRouterStaticRoutes.Policy, item.Policy)
+				}, &clusterRouterStaticRoutes.Nexthop); err != nil {
+				return fmt.Errorf("failed to add policy route static '%s %s' for on %s , error: %v",
+					clusterRouterStaticRoutes.IPPrefix, clusterRouterStaticRoutes.Nexthop,
+					ovntypes.GWRouterPrefix+nodeName, err)
 			}
 			klog.Infof("Created hybrid overlay logical route static route at cluster router for node %s", nodeName)
 
@@ -295,11 +300,16 @@ func (oc *Controller) setupHybridLRPolicySharedGw(nodeSubnets []*net.IPNet, node
 					"name": ovntypes.HybridSubnetPrefix + nodeName + "-gr",
 				},
 			}
-			if err := libovsdbops.CreateOrUpdateLogicalRouterStaticRoutesWithPredicate(oc.nbClient, ovntypes.GWRouterPrefix+nodeName, &nodeGWRouterStaticRoutes, func(item *nbdb.LogicalRouterStaticRoute) bool {
-				return item.IPPrefix == nodeGWRouterStaticRoutes.IPPrefix && item.Nexthop == nodeGWRouterStaticRoutes.Nexthop &&
-					item.ExternalIDs["name"] == nodeGWRouterStaticRoutes.ExternalIDs["name"]
-			}); err != nil {
-				return fmt.Errorf("failed to add policy route static '%s %s' for on %s , error: %v", nodeGWRouterStaticRoutes.IPPrefix, nodeGWRouterStaticRoutes.Nexthop, ovntypes.GWRouterPrefix+nodeName, err)
+			if err := libovsdbops.CreateOrReplaceLogicalRouterStaticRouteWithPredicate(oc.nbClient,
+				ovntypes.GWRouterPrefix+nodeName, &nodeGWRouterStaticRoutes,
+				func(item *nbdb.LogicalRouterStaticRoute) bool {
+					return item.IPPrefix == nodeGWRouterStaticRoutes.IPPrefix &&
+						item.ExternalIDs["name"] == nodeGWRouterStaticRoutes.ExternalIDs["name"] &&
+						libovsdbops.PolicyEqualPredicate(nodeGWRouterStaticRoutes.Policy, item.Policy)
+				}, &nodeGWRouterStaticRoutes.Nexthop); err != nil {
+				return fmt.Errorf("failed to add policy route static '%s %s' for on %s , error: %v",
+					nodeGWRouterStaticRoutes.IPPrefix, nodeGWRouterStaticRoutes.Nexthop,
+					ovntypes.GWRouterPrefix+nodeName, err)
 			}
 			klog.Infof("Created hybrid overlay logical route static route at gateway router for node %s", nodeName)
 		}

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -489,7 +489,6 @@ func (oc *Controller) syncNodeManagementPort(node *kapi.Node, hostSubnets []*net
 		if !utilnet.IsIPv6CIDR(hostSubnet) {
 			v4Subnet = hostSubnet
 		}
-
 		if config.Gateway.Mode == config.GatewayModeLocal {
 			lrsr := nbdb.LogicalRouterStaticRoute{
 				Policy:   &nbdb.LogicalRouterStaticRoutePolicySrcIP,
@@ -497,10 +496,10 @@ func (oc *Controller) syncNodeManagementPort(node *kapi.Node, hostSubnets []*net
 				Nexthop:  mgmtIfAddr.IP.String(),
 			}
 			p := func(item *nbdb.LogicalRouterStaticRoute) bool {
-				return item.IPPrefix == lrsr.IPPrefix && item.Nexthop == lrsr.Nexthop && item.Policy != nil && *item.Policy == *lrsr.Policy
+				return item.IPPrefix == lrsr.IPPrefix && libovsdbops.PolicyEqualPredicate(lrsr.Policy, item.Policy)
 			}
-			err := libovsdbops.CreateOrUpdateLogicalRouterStaticRoutesWithPredicate(oc.nbClient, types.OVNClusterRouter,
-				&lrsr, p)
+			err := libovsdbops.CreateOrReplaceLogicalRouterStaticRouteWithPredicate(oc.nbClient, types.OVNClusterRouter,
+				&lrsr, p, &lrsr.Nexthop)
 			if err != nil {
 				return fmt.Errorf("error creating static route %+v on router %s: %v", lrsr, types.OVNClusterRouter, err)
 			}

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -876,6 +876,9 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 		events            []string
 		eventsLock        sync.Mutex
 		recorder          *record.FakeRecorder
+
+		l3GatewayConfig *util.L3GatewayConfig
+		nodeHostAddrs   sets.String
 	)
 
 	const (
@@ -952,13 +955,14 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		config.Kubernetes.HostNetworkNamespace = ""
 		nodeAnnotator = kube.NewNodeAnnotator(&kube.Kube{kubeFakeClient, fakeClient.EgressIPClient, fakeClient.EgressFirewallClient, nil}, testNode.Name)
-		l3Config := node1.gatewayConfig(config.GatewayModeLocal, uint(vlanID))
-		err = util.SetL3GatewayConfig(nodeAnnotator, l3Config)
+		l3GatewayConfig = node1.gatewayConfig(config.GatewayModeLocal, uint(vlanID))
+		err = util.SetL3GatewayConfig(nodeAnnotator, l3GatewayConfig)
 		err = util.SetNodeManagementPortMACAddress(nodeAnnotator, ovntest.MustParseMAC(node1.NodeMgmtPortMAC))
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		err = util.SetNodeHostSubnetAnnotation(nodeAnnotator, ovntest.MustParseIPNets(node1.NodeSubnet))
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		err = util.SetNodeHostAddresses(nodeAnnotator, sets.NewString(node1.NodeHostAddress...))
+		nodeHostAddrs = sets.NewString(node1.NodeHostAddress...)
+		err = util.SetNodeHostAddresses(nodeAnnotator, nodeHostAddrs)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		err = nodeAnnotator.Run()
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -1083,7 +1087,12 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 		app.Action = func(ctx *cli.Context) error {
 			_, err := config.InitConfig(ctx, nil, nil)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			clusterSubnets := startFakeController(oc, wg)
+			var clusterSubnets []*net.IPNet
+			for _, clusterSubnet := range config.Default.ClusterSubnets {
+				clusterSubnets = append(clusterSubnets, clusterSubnet.CIDR)
+			}
+			// Let the real code run and ensure OVN database sync
+			gomega.Expect(clusterController.WatchNodes()).To(gomega.Succeed())
 
 			subnet := ovntest.MustParseIPNet(node1.NodeSubnet)
 			// add stale route
@@ -1094,24 +1103,33 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 			}
 			ginkgo.By("Creating stale route")
 			p := func(item *nbdb.LogicalRouterStaticRoute) bool { return false }
-			err = libovsdbops.CreateOrReplaceLogicalRouterStaticRouteWithPredicate(nbClient,
+			err = libovsdbops.CreateOrReplaceLogicalRouterStaticRouteWithPredicate(clusterController.nbClient,
 				types.OVNClusterRouter, badRoute, p)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			ginkgo.By("Syncing node with OVNK")
-			node, err := oc.kube.GetNode(testNode.Name)
+			node, err := clusterController.kube.GetNode(testNode.Name)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			err = oc.syncNodeManagementPort(node, []*net.IPNet{subnet})
+			err = clusterController.syncNodeManagementPort(node, []*net.IPNet{subnet})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			err = oc.syncGatewayLogicalNetwork(node, l3GatewayConfig, []*net.IPNet{subnet}, nodeHostAddrs)
+			err = clusterController.syncGatewayLogicalNetwork(node, l3GatewayConfig, []*net.IPNet{subnet}, nodeHostAddrs)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			ginkgo.By("Stale route should have been removed")
 
 			skipSnat := false
+			expectedClusterLBGroup := newLoadBalancerGroup()
+			expectedOVNClusterRouter := newOVNClusterRouter()
+			expectedNodeSwitch := node1.logicalSwitch(expectedClusterLBGroup.UUID)
+			expectedClusterRouterPortGroup := newRouterPortGroup()
+			expectedClusterPortGroup := newClusterPortGroup()
+			expectedDatabaseState := []libovsdbtest.TestData{}
+			expectedDatabaseState = addNodeLogicalFlows(expectedDatabaseState, expectedOVNClusterRouter,
+				expectedNodeSwitch, expectedClusterRouterPortGroup, expectedClusterPortGroup, &node1)
+
 			expectedDatabaseState = generateGatewayInitExpectedNB(expectedDatabaseState, expectedOVNClusterRouter,
 				expectedNodeSwitch, node1.Name, clusterSubnets, []*net.IPNet{subnet}, l3GatewayConfig,
 				[]*net.IPNet{classBIPAddress(node1.LrpIP)}, []*net.IPNet{classBIPAddress(node1.DrLrpIP)},
 				skipSnat, node1.NodeMgmtPortIP, "1400")
-			gomega.Eventually(oc.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+			gomega.Eventually(clusterController.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 
 			return nil
 		}

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -1079,6 +1079,53 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 
+	ginkgo.It("clears stale ovn_cluster_router routes in local gw", func() {
+		app.Action = func(ctx *cli.Context) error {
+			_, err := config.InitConfig(ctx, nil, nil)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			clusterSubnets := startFakeController(oc, wg)
+
+			subnet := ovntest.MustParseIPNet(node1.NodeSubnet)
+			// add stale route
+			badRoute := &nbdb.LogicalRouterStaticRoute{
+				Policy:   &nbdb.LogicalRouterStaticRoutePolicySrcIP,
+				IPPrefix: subnet.String(),
+				Nexthop:  "10.244.0.6",
+			}
+			ginkgo.By("Creating stale route")
+			p := func(item *nbdb.LogicalRouterStaticRoute) bool { return false }
+			err = libovsdbops.CreateOrReplaceLogicalRouterStaticRouteWithPredicate(nbClient,
+				types.OVNClusterRouter, badRoute, p)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			ginkgo.By("Syncing node with OVNK")
+			node, err := oc.kube.GetNode(testNode.Name)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			err = oc.syncNodeManagementPort(node, []*net.IPNet{subnet})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			err = oc.syncGatewayLogicalNetwork(node, l3GatewayConfig, []*net.IPNet{subnet}, nodeHostAddrs)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			ginkgo.By("Stale route should have been removed")
+
+			skipSnat := false
+			expectedDatabaseState = generateGatewayInitExpectedNB(expectedDatabaseState, expectedOVNClusterRouter,
+				expectedNodeSwitch, node1.Name, clusterSubnets, []*net.IPNet{subnet}, l3GatewayConfig,
+				[]*net.IPNet{classBIPAddress(node1.LrpIP)}, []*net.IPNet{classBIPAddress(node1.DrLrpIP)},
+				skipSnat, node1.NodeMgmtPortIP, "1400")
+			gomega.Eventually(oc.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+
+			return nil
+		}
+
+		err := app.Run([]string{
+			app.Name,
+			"-cluster-subnets=" + clusterCIDR,
+			"--init-gateways",
+			"--gateway-local",
+			"--nodeport",
+		})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+
 	ginkgo.It("sets up a shared gateway", func() {
 
 		app.Action = func(ctx *cli.Context) error {


### PR DESCRIPTION
Some minor unit test conflicts in backport. Added them as a 3rd commit to make reviewing easier.

There can be a case where multiple routes exist on ovn_cluster_router
matching on the same IP prefix. For example:

            10.130.0.0/23                100.64.0.4 src-ip ecmp
            10.130.0.0/23                100.64.0.6 src-ip ecmp
            10.130.0.0/23                100.64.0.9 src-ip ecmp

In this case stale routes exist for old join subnet nexthops matching on
the same host subnet. OVN allows for these extra routes to be added and
considers them ecmp.

This commit modifies our behavior to ensure only a single route exists.
If more than one route for a predicate are found, the additional routes
are removed and then the leftover route is updated with the correct
fields.

A route is considered unique when it has the same prefix and policy type
(dst-ip vs src-ip) on the same router. The only case in OVNK where we
will allow more than one identical route is for ECMP routes with
multiple external gateways. In this case it is intended for a single
prefix to have multiple nexthops. Note, egressgw code uses its own
method to generate the ops for creating the routes.

Signed-off-by: Tim Rozet <trozet@redhat.com>