### PR TITLE
[release-4.12] OCPBUGS-6961: update base image of Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,6 @@
 #
 # The standard name for this image is ovn-kube
 
-# Notes:
-# This is for a build where the ovn-kubernetes utilities
-# are built in this Dockerfile and included in the image (instead of the rpm)
-#
-
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.18-openshift-4.12 AS builder
 
 WORKDIR /go/src/github.com/openshift/ovn-kubernetes
@@ -20,21 +15,31 @@ RUN cd go-controller; CGO_ENABLED=0 make windows
 
 FROM registry.ci.openshift.org/ocp/4.12:cli AS cli
 
-FROM registry.ci.openshift.org/ocp/4.12:base
+# ovn-kubernetes-base image is built from Dockerfile.base
+# The following changes are included in ovn-kubernetes-base
+# image and removed from this Dockerfile:
+# - ovs base rpm package installation (including openvswitch and python3-openvswitch)
+# - ovn base rpm package installation (including ovn, ovn-central and ovn-host)
+# - creating directories required by ovn-kubernetes
+# - git commit number
+# - ovnkube.sh script
+# - iptables wrappers
+FROM registry.ci.openshift.org/ocp/4.12:ovn-kubernetes-base
 
 USER root
 
 ENV PYTHONDONTWRITEBYTECODE yes
 
-# install needed rpms - openvswitch must be 2.10.4 or higher
 # install selinux-policy first to avoid a race
 RUN yum install -y  \
 	selinux-policy && \
 	yum clean all
 
-ARG ovsver=2.17.0-62.el8fdp
-ARG ovnver=22.09.0-25.el8fdp
-
+# more-pkgs file is updated in Dockerfile.base
+# more-pkgs file contains the following ovs/ovn packages to be installed in this Dockerfile
+# - openvswitch-devel
+# - openvswitch-ipsec
+# - ovn-vtep
 RUN INSTALL_PKGS=" \
 	openssl python3-pyOpenSSL firewalld-filesystem \
 	libpcap iproute iproute-tc strace \
@@ -44,16 +49,8 @@ RUN INSTALL_PKGS=" \
 	ethtool conntrack-tools \
 	" && \
 	yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False $INSTALL_PKGS && \
-	yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False "openvswitch2.17 = $ovsver" "openvswitch2.17-devel = $ovsver" "python3-openvswitch2.17 = $ovsver" "openvswitch2.17-ipsec = $ovsver" && \
-	yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False "ovn22.09 = $ovnver" "ovn22.09-central = $ovnver" "ovn22.09-host = $ovnver" "ovn22.09-vtep = $ovnver" && \
+	eval "yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False $(cat /more-pkgs)" && \
 	yum clean all && rm -rf /var/cache/*
-
-RUN mkdir -p /var/run/openvswitch && \
-    mkdir -p /var/run/ovn && \
-    mkdir -p /etc/cni/net.d && \
-    mkdir -p /opt/cni/bin && \
-    mkdir -p /usr/libexec/cni/ && \
-    mkdir -p /root/windows/
 
 COPY --from=builder /go/src/github.com/openshift/ovn-kubernetes/go-controller/_output/go/bin/ovnkube /usr/bin/
 COPY --from=builder /go/src/github.com/openshift/ovn-kubernetes/go-controller/_output/go/bin/ovn-kube-util /usr/bin/
@@ -65,23 +62,6 @@ COPY --from=builder /go/src/github.com/openshift/ovn-kubernetes/go-controller/_o
 COPY --from=cli /usr/bin/oc /usr/bin/
 RUN ln -s /usr/bin/oc /usr/bin/kubectl
 RUN stat /usr/bin/oc
-
-# copy git commit number into image
-COPY .git/HEAD /root/.git/HEAD
-COPY .git/refs/heads/ /root/.git/refs/heads/
-
-# ovnkube.sh is the entry point. This script examines environment
-# variables to direct operation and configure ovn
-COPY dist/images/ovnkube.sh /root/
-
-# iptables wrappers
-COPY ./dist/images/iptables-scripts/iptables /usr/sbin/
-COPY ./dist/images/iptables-scripts/iptables-save /usr/sbin/
-COPY ./dist/images/iptables-scripts/iptables-restore /usr/sbin/
-COPY ./dist/images/iptables-scripts/ip6tables /usr/sbin/
-COPY ./dist/images/iptables-scripts/ip6tables-save /usr/sbin/
-COPY ./dist/images/iptables-scripts/ip6tables-restore /usr/sbin/
-COPY ./dist/images/iptables-scripts/iptables /usr/sbin/
 
 LABEL io.k8s.display-name="ovn kubernetes" \
       io.k8s.description="This is a component of OpenShift Container Platform that provides an overlay network using ovn." \

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -20,9 +20,7 @@ RUN \
     yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False "ovn22.09 = $ovnver" "ovn22.09-central = $ovnver" "ovn22.09-host = $ovnver" && \
     yum clean all && rm -rf /var/cache/*
 
-RUN \
-    morepkgs=("openvswitch2.17-devel = $ovsver" "openvswitch2.17-ipsec = $ovsver" "ovn22.09-vtep = $ovnver") && \
-    echo $(printf '"%s" ' "${morepkgs[@]}") > /more-pkgs
+RUN sed 's/%/"/g' <<<"%openvswitch2.17-devel = $ovsver% %openvswitch2.17-ipsec = $ovsver% %ovn22.09-vtep = $ovnver%" > /more-pkgs
 
 RUN mkdir -p /var/run/openvswitch && \
     mkdir -p /var/run/ovn && \

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -14,7 +14,15 @@ RUN yum install -y  \
 
 ARG ovsver=2.17.0-62.el8fdp
 ARG ovnver=22.09.0-54.el8fdp
-RUN echo $ovsver > /ovs-version && echo $ovnver > /ovn-version
+
+RUN \
+    yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False "openvswitch2.17 = $ovsver" "python3-openvswitch2.17 = $ovsver" && \
+    yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False "ovn22.09 = $ovnver" "ovn22.09-central = $ovnver" "ovn22.09-host = $ovnver" && \
+    yum clean all && rm -rf /var/cache/*
+
+RUN \
+    morepkgs=("openvswitch2.17-devel = $ovsver" "openvswitch2.17-ipsec = $ovsver" "ovn22.09-vtep = $ovnver") && \
+    echo $(printf '"%s" ' "${morepkgs[@]}") > /more-pkgs
 
 RUN mkdir -p /var/run/openvswitch && \
     mkdir -p /var/run/ovn && \

--- a/Dockerfile.microshift
+++ b/Dockerfile.microshift
@@ -26,11 +26,5 @@ USER root
 
 ENV PYTHONDONTWRITEBYTECODE yes
 
-RUN export ovsver=$(cat /ovs-version) && \
-	export ovnver=$(cat /ovn-version) && \
-	yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False "openvswitch2.17 = $ovsver" "python3-openvswitch2.17 = $ovsver" && \
-        yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False "ovn22.09 = $ovnver" "ovn22.09-central = $ovnver" "ovn22.09-host = $ovnver" && \
-        yum clean all && rm -rf /var/cache/*
-
 COPY --from=builder /go/src/github.com/openshift/ovn-kubernetes/go-controller/_output/go/bin/ovnkube /usr/bin/
 COPY --from=builder /go/src/github.com/openshift/ovn-kubernetes/go-controller/_output/go/bin/ovn-k8s-cni-overlay /usr/libexec/cni/


### PR DESCRIPTION
this change moves ovn/ovs versions to dockerfile.base that's shared between microshift and openshift.
future version update only needs to be done once in the dockerfile.base