### PR TITLE
rhel9: remove stray `oc` install

### DIFF
--- a/Dockerfile.rhel9
+++ b/Dockerfile.rhel9
@@ -58,7 +58,6 @@ COPY --from=builder /go/src/github.com/openshift/ovn-kubernetes/go-controller/_o
 COPY --from=builder /go/src/github.com/openshift/ovn-kubernetes/go-controller/_output/go/bin/ovndbchecker /usr/bin/
 COPY --from=builder /go/src/github.com/openshift/ovn-kubernetes/go-controller/_output/go/bin/ovnkube-trace /usr/bin/
 
-COPY --from=cli /usr/bin/oc /usr/bin/
 RUN ln -s /usr/bin/oc /usr/bin/kubectl
 RUN stat /usr/bin/oc
 


### PR DESCRIPTION
We're installing from RPMs so we don't need the copy anymore, plus the 'cli' image doesn't exist in RHEL9 streams.