### PR TITLE
rhel9: no longer need python3-pyOpenSSL

### DIFF
--- a/Dockerfile.rhel9
+++ b/Dockerfile.rhel9
@@ -39,7 +39,7 @@ RUN yum install -y  \
 # - openvswitch-ipsec
 # - ovn-vtep
 RUN INSTALL_PKGS=" \
-	openssl python3-pyOpenSSL firewalld-filesystem \
+	openssl firewalld-filesystem \
 	libpcap iproute iproute-tc strace \
 	containernetworking-plugins \
 	tcpdump iputils \


### PR DESCRIPTION
The python script bits of OVS that used this switch to Python's built-in SSL implementation in 3.0+.