### PR TITLE
[release-4.12] OCPBUGS-7026: Bump OVN to 22.12 and turn off neighbour response in router options.

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -13,14 +13,14 @@ RUN yum install -y  \
 	yum clean all
 
 ARG ovsver=2.17.0-62.el8fdp
-ARG ovnver=22.09.0-54.el8fdp
+ARG ovnver=22.12.0-18.el8fdp
 
 RUN \
     yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False "openvswitch2.17 = $ovsver" "python3-openvswitch2.17 = $ovsver" && \
-    yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False "ovn22.09 = $ovnver" "ovn22.09-central = $ovnver" "ovn22.09-host = $ovnver" && \
+    yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False "ovn22.12 = $ovnver" "ovn22.12-central = $ovnver" "ovn22.12-host = $ovnver" && \
     yum clean all && rm -rf /var/cache/*
 
-RUN sed 's/%/"/g' <<<"%openvswitch2.17-devel = $ovsver% %openvswitch2.17-ipsec = $ovsver% %ovn22.09-vtep = $ovnver%" > /more-pkgs
+RUN sed 's/%/"/g' <<<"%openvswitch2.17-devel = $ovsver% %openvswitch2.17-ipsec = $ovsver% %ovn22.12-vtep = $ovnver%" > /more-pkgs
 
 RUN mkdir -p /var/run/openvswitch && \
     mkdir -p /var/run/ovn && \

--- a/go-controller/pkg/ovn/controller/services/services_controller_test.go
+++ b/go-controller/pkg/ovn/controller/services/services_controller_test.go
@@ -614,9 +614,10 @@ func nodeSwitchRouterLoadBalancerName(nodeName string, serviceNamespace string, 
 
 func servicesOptions() map[string]string {
 	return map[string]string{
-		"event":     "false",
-		"reject":    "true",
-		"skip_snat": "false",
+		"event":              "false",
+		"reject":             "true",
+		"skip_snat":          "false",
+		"neighbor_responder": "none",
 	}
 }
 

--- a/go-controller/pkg/ovn/loadbalancer/loadbalancer.go
+++ b/go-controller/pkg/ovn/loadbalancer/loadbalancer.go
@@ -252,9 +252,10 @@ func buildLB(lb *LB) *nbdb.LoadBalancer {
 	}
 
 	options := map[string]string{
-		"reject":    reject,
-		"event":     event,
-		"skip_snat": skipSNAT,
+		"reject":             reject,
+		"event":              event,
+		"skip_snat":          skipSNAT,
+		"neighbor_responder": "none",
 	}
 
 	// Session affinity


### PR DESCRIPTION
See
https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2343944
for details.

NOTE: This is mainly being done to bring in 4.12 to latest plus
to avoid having to maintain the downstream specific commits
around session affinity timeout on the OVN side.
