### PR TITLE
[release-4.11] OCPBUGS-7319: Bump OVN to 22.09, enable session affinity timeout

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN yum install -y  \
 	yum clean all
 
 ARG ovsver=2.17.0-62.el8fdp
-ARG ovnver=22.06.0-111.el8fdp
+ARG ovnver=22.09.0-54.el8fdp
 
 RUN INSTALL_PKGS=" \
 	openssl python3-pyOpenSSL firewalld-filesystem \
@@ -45,7 +45,7 @@ RUN INSTALL_PKGS=" \
 	" && \
 	yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False $INSTALL_PKGS && \
 	yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False "openvswitch2.17 = $ovsver" "openvswitch2.17-devel = $ovsver" "python3-openvswitch2.17 = $ovsver" "openvswitch2.17-ipsec = $ovsver" && \
-	yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False "ovn22.06 = $ovnver" "ovn22.06-central = $ovnver" "ovn22.06-host = $ovnver" "ovn22.06-vtep = $ovnver" && \
+	yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False "ovn22.09 = $ovnver" "ovn22.09-central = $ovnver" "ovn22.09-host = $ovnver" "ovn22.09-vtep = $ovnver" && \
 	yum clean all && rm -rf /var/cache/*
 
 RUN mkdir -p /var/run/openvswitch && \

--- a/go-controller/pkg/libovsdbops/loadbalancer.go
+++ b/go-controller/pkg/libovsdbops/loadbalancer.go
@@ -47,14 +47,13 @@ func getNonZeroLoadBalancerMutableFields(lb *nbdb.LoadBalancer) []interface{} {
 }
 
 // BuildLoadBalancer builds a load balancer
-func BuildLoadBalancer(name string, protocol nbdb.LoadBalancerProtocol, selectionFields []nbdb.LoadBalancerSelectionFields, vips, options, externalIds map[string]string) *nbdb.LoadBalancer {
+func BuildLoadBalancer(name string, protocol nbdb.LoadBalancerProtocol, vips, options, externalIds map[string]string) *nbdb.LoadBalancer {
 	return &nbdb.LoadBalancer{
-		Name:            name,
-		Protocol:        &protocol,
-		SelectionFields: selectionFields,
-		Vips:            vips,
-		Options:         options,
-		ExternalIDs:     externalIds,
+		Name:        name,
+		Protocol:    &protocol,
+		Vips:        vips,
+		Options:     options,
+		ExternalIDs: externalIds,
 	}
 }
 

--- a/go-controller/pkg/ovn/controller/services/load_balancer.go
+++ b/go-controller/pkg/ovn/controller/services/load_balancer.go
@@ -475,13 +475,29 @@ func configsByProto(configs []lbConfig) map[v1.Protocol][]lbConfig {
 	return out
 }
 
+func getSessionAffinityTimeOut(service *v1.Service) int32 {
+	// NOTE: This if condition is actually not needed, present only for protection against nil value as good coding practice,
+	// The API always puts the default value of 10800 whenever sessionAffinity == ClientIP if timeout is not explicitly set
+	// There is no ClientIP session affinity without a timeout set.
+	if service.Spec.SessionAffinityConfig == nil ||
+		service.Spec.SessionAffinityConfig.ClientIP == nil ||
+		service.Spec.SessionAffinityConfig.ClientIP.TimeoutSeconds == nil {
+		return 10800 // default value
+	}
+	return *service.Spec.SessionAffinityConfig.ClientIP.TimeoutSeconds
+}
+
 // lbOpts generates the OVN load balancer options from the kubernetes Service.
 func lbOpts(service *v1.Service) ovnlb.LBOpts {
-	return ovnlb.LBOpts{
+	affinity := service.Spec.SessionAffinity == v1.ServiceAffinityClientIP
+	lbOptions := ovnlb.LBOpts{
 		Unidling: svcNeedsIdling(service.GetAnnotations()),
-		Affinity: service.Spec.SessionAffinity == v1.ServiceAffinityClientIP,
 		SkipSNAT: false, // never service-wide, ExternalTrafficPolicy-specific
 	}
+	if affinity {
+		lbOptions.AffinityTimeOut = getSessionAffinityTimeOut(service)
+	}
+	return lbOptions
 }
 
 // mergeLBs joins two LBs together if it is safe to do so.

--- a/go-controller/pkg/ovn/loadbalancer/loadbalancer.go
+++ b/go-controller/pkg/ovn/loadbalancer/loadbalancer.go
@@ -258,20 +258,16 @@ func buildLB(lb *LB) *nbdb.LoadBalancer {
 	}
 
 	// Session affinity
-	// If enabled, then bucket flows by 3-tuple (proto, srcip, dstip)
+	// If enabled, then bucket flows by 3-tuple (proto, srcip, dstip) for the specific timeout value
 	// otherwise, use default ovn value
-	selectionFields := []nbdb.LoadBalancerSelectionFields{}
-	if lb.Opts.Affinity {
-		selectionFields = []string{
-			nbdb.LoadBalancerSelectionFieldsIPSrc,
-			nbdb.LoadBalancerSelectionFieldsIPDst,
-		}
+	if lb.Opts.AffinityTimeOut > 0 {
+		options["affinity_timeout"] = fmt.Sprintf("%d", lb.Opts.AffinityTimeOut)
 	}
 
 	// vipMap
 	vips := buildVipMap(lb.Rules)
 
-	return libovsdbops.BuildLoadBalancer(lb.Name, strings.ToLower(lb.Protocol), selectionFields, vips, options, lb.ExternalIDs)
+	return libovsdbops.BuildLoadBalancer(lb.Name, strings.ToLower(lb.Protocol), vips, options, lb.ExternalIDs)
 }
 
 // buildVipMap returns a viups map from a set of rules

--- a/go-controller/pkg/ovn/loadbalancer/types.go
+++ b/go-controller/pkg/ovn/loadbalancer/types.go
@@ -22,8 +22,8 @@ type LBOpts struct {
 	// if true, then enable unidling. Otherwise, generate reject
 	Unidling bool
 
-	// If true, then enable per-client-IP affinity.
-	Affinity bool
+	// If greater than 0, then enable per-client-IP affinity.
+	AffinityTimeOut int32
 
 	// If true, then disable SNAT entirely
 	SkipSNAT bool

--- a/test/scripts/e2e-kind.sh
+++ b/test/scripts/e2e-kind.sh
@@ -25,9 +25,6 @@ should have ipv4 and ipv6 internal node ip
 kube-proxy
 should set TCP CLOSE_WAIT timeout
 
-# not implemented - OVN doesn't support time
-should have session affinity timeout work
-
 # NOT IMPLEMENTED; SEE DISCUSSION IN https://github.com/ovn-org/ovn-kubernetes/pull/1225
 named port.+\[Feature:NetworkPolicy\]
 


### PR DESCRIPTION
See individual commits for more details.
/cc @dcbw @trozet : for help with risk analysis.