### PR TITLE
rhel9: oc RPM does the kubectl symlink

### DIFF
--- a/Dockerfile.rhel9
+++ b/Dockerfile.rhel9
@@ -58,7 +58,6 @@ COPY --from=builder /go/src/github.com/openshift/ovn-kubernetes/go-controller/_o
 COPY --from=builder /go/src/github.com/openshift/ovn-kubernetes/go-controller/_output/go/bin/ovndbchecker /usr/bin/
 COPY --from=builder /go/src/github.com/openshift/ovn-kubernetes/go-controller/_output/go/bin/ovnkube-trace /usr/bin/
 
-RUN ln -s /usr/bin/oc /usr/bin/kubectl
 RUN stat /usr/bin/oc
 
 LABEL io.k8s.display-name="ovn kubernetes" \


### PR DESCRIPTION
So we don't have to.