### PR TITLE
cleanup: drop redundant selinux-policy install in onvkube dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,11 +30,6 @@ USER root
 
 ENV PYTHONDONTWRITEBYTECODE yes
 
-# install selinux-policy first to avoid a race
-RUN yum install -y  \
-	selinux-policy && \
-	yum clean all
-
 # more-pkgs file is updated in Dockerfile.base
 # more-pkgs file contains the following ovs/ovn packages to be installed in this Dockerfile
 # - openvswitch-devel

--- a/Dockerfile.rhel9
+++ b/Dockerfile.rhel9
@@ -28,11 +28,6 @@ USER root
 
 ENV PYTHONDONTWRITEBYTECODE yes
 
-# install selinux-policy first to avoid a race
-RUN yum install -y  \
-	selinux-policy && \
-	yum clean all
-
 # more-pkgs file is updated in Dockerfile.base
 # more-pkgs file contains the following ovs/ovn packages to be installed in this Dockerfile
 # - openvswitch-devel


### PR DESCRIPTION
They're already installed by the base Dockerfiles.