### PR TITLE
rhel9: no longer need to use iptables wrappers

### DIFF
--- a/Dockerfile.base.rhel9
+++ b/Dockerfile.base.rhel9
@@ -9,7 +9,7 @@ FROM registry.ci.openshift.org/ocp/builder:rhel-9-base-openshift-4.13
 
 # install selinux-policy first to avoid a race
 RUN yum install -y  \
-	selinux-policy && \
+	selinux-policy procps-ng && \
 	yum clean all
 
 ARG ovsver=3.0.0-28.el9fdp

--- a/Dockerfile.base.rhel9
+++ b/Dockerfile.base.rhel9
@@ -37,14 +37,5 @@ COPY .git/refs/heads/ /root/.git/refs/heads/
 # variables to direct operation and configure ovn
 COPY dist/images/ovnkube.sh /root/
 
-# iptables wrappers
-COPY ./dist/images/iptables-scripts/iptables /usr/sbin/
-COPY ./dist/images/iptables-scripts/iptables-save /usr/sbin/
-COPY ./dist/images/iptables-scripts/iptables-restore /usr/sbin/
-COPY ./dist/images/iptables-scripts/ip6tables /usr/sbin/
-COPY ./dist/images/iptables-scripts/ip6tables-save /usr/sbin/
-COPY ./dist/images/iptables-scripts/ip6tables-restore /usr/sbin/
-COPY ./dist/images/iptables-scripts/iptables /usr/sbin/
-
 WORKDIR /root
 ENTRYPOINT /root/ovnkube.sh

--- a/Dockerfile.rhel9
+++ b/Dockerfile.rhel9
@@ -21,7 +21,6 @@ RUN cd go-controller; CGO_ENABLED=0 make windows
 # - creating directories required by ovn-kubernetes
 # - git commit number
 # - ovnkube.sh script
-# - iptables wrappers
 FROM registry.ci.openshift.org/ocp/4.13:ovn-kubernetes-base-rhel-9
 
 USER root
@@ -37,7 +36,7 @@ RUN INSTALL_PKGS=" \
 	openssl firewalld-filesystem \
 	libpcap iproute iproute-tc strace \
 	containernetworking-plugins \
-	tcpdump iputils \
+	tcpdump iputils iptables \
 	libreswan \
 	ethtool conntrack-tools \
 	openshift-clients \


### PR DESCRIPTION
Make the same change for rhel9 as https://github.com/openshift/ovn-kubernetes/pull/1481 did for rhel8.

Also install procps-ng to get sysctl, which ovnkube wants.