### PR TITLE
Dockerfiles: switch to dnf

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,9 +42,9 @@ RUN INSTALL_PKGS=" \
 	libreswan \
 	ethtool conntrack-tools \
 	" && \
-	yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False $INSTALL_PKGS && \
-	eval "yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False $(cat /more-pkgs)" && \
-	yum clean all && rm -rf /var/cache/*
+	dnf install -y --nodocs $INSTALL_PKGS && \
+	eval "dnf install -y --nodocs $(cat /more-pkgs)" && \
+	dnf clean all && rm -rf /var/cache/*
 
 COPY --from=builder /go/src/github.com/openshift/ovn-kubernetes/go-controller/_output/go/bin/ovnkube /usr/bin/
 COPY --from=builder /go/src/github.com/openshift/ovn-kubernetes/go-controller/_output/go/bin/ovn-kube-util /usr/bin/

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -8,18 +8,18 @@
 FROM registry.ci.openshift.org/ocp/4.13:base
 
 # install selinux-policy first to avoid a race
-RUN yum install -y  \
+RUN dnf install -y --nodocs \
 	selinux-policy && \
-	yum clean all
+	dnf clean all
 
 ARG ovsver=2.17.0-62.el8fdp
 ARG ovnver=22.12.0-18.el8fdp
 
 RUN INSTALL_PKGS="iptables" && \
-	yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False $INSTALL_PKGS && \
-	yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False "openvswitch2.17 = $ovsver" "python3-openvswitch2.17 = $ovsver" && \
-	yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False "ovn22.12 = $ovnver" "ovn22.12-central = $ovnver" "ovn22.12-host = $ovnver" && \
-	yum clean all && rm -rf /var/cache/*
+	dnf install -y --nodocs $INSTALL_PKGS && \
+	dnf install -y --nodocs "openvswitch2.17 = $ovsver" "python3-openvswitch2.17 = $ovsver" && \
+	dnf install -y --nodocs "ovn22.12 = $ovnver" "ovn22.12-central = $ovnver" "ovn22.12-host = $ovnver" && \
+	dnf clean all && rm -rf /var/cache/*
 
 RUN sed 's/%/"/g' <<<"%openvswitch2.17-devel = $ovsver% %openvswitch2.17-ipsec = $ovsver% %ovn22.12-vtep = $ovnver%" > /more-pkgs
 

--- a/Dockerfile.base.rhel9
+++ b/Dockerfile.base.rhel9
@@ -8,18 +8,18 @@
 FROM registry.ci.openshift.org/ocp/builder:rhel-9-base-openshift-4.13
 
 # install selinux-policy first to avoid a race
-RUN yum install -y  \
+RUN dnf install -y --nodocs \
 	selinux-policy procps-ng && \
-	yum clean all
+	dnf clean all
 
 ARG ovsver=3.0.0-28.el9fdp
 ARG ovnver=22.12.0-18.el9fdp
 
 RUN INSTALL_PKGS="iptables" && \
-	yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False $INSTALL_PKGS && \
-	yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False "openvswitch3.0 = $ovsver" "python3-openvswitch3.0 = $ovsver" && \
-	yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False "ovn22.12 = $ovnver" "ovn22.12-central = $ovnver" "ovn22.12-host = $ovnver" && \
-	yum clean all && rm -rf /var/cache/*
+	dnf install -y --nodocs $INSTALL_PKGS && \
+	dnf install -y --nodocs "openvswitch3.0 = $ovsver" "python3-openvswitch3.0 = $ovsver" && \
+	dnf install -y --nodocs "ovn22.12 = $ovnver" "ovn22.12-central = $ovnver" "ovn22.12-host = $ovnver" && \
+	dnf clean all && rm -rf /var/cache/*
 
 RUN sed 's/%/"/g' <<<"%openvswitch3.0-devel = $ovsver% %openvswitch3.0-ipsec = $ovsver% %ovn22.12-vtep = $ovnver%" > /more-pkgs
 

--- a/Dockerfile.rhel9
+++ b/Dockerfile.rhel9
@@ -41,9 +41,9 @@ RUN INSTALL_PKGS=" \
 	ethtool conntrack-tools \
 	openshift-clients \
 	" && \
-	yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False $INSTALL_PKGS && \
-	eval "yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False $(cat /more-pkgs)" && \
-	yum clean all && rm -rf /var/cache/*
+	dnf install -y --nodocs $INSTALL_PKGS && \
+	eval "dnf install -y --nodocs $(cat /more-pkgs)" && \
+	dnf clean all && rm -rf /var/cache/*
 
 COPY --from=builder /go/src/github.com/openshift/ovn-kubernetes/go-controller/_output/go/bin/ovnkube /usr/bin/
 COPY --from=builder /go/src/github.com/openshift/ovn-kubernetes/go-controller/_output/go/bin/ovn-kube-util /usr/bin/


### PR DESCRIPTION
We're already using DNF instead of yum through DNF's yum compat CLI. Just switch to DNF. Use `--nodocs` to prevent installing documentation dependencies. Remove the
`skip_missing_names_on_install=False` option because that's the default DNF behavior already.