### PR TITLE
Dockerfiles: bump to OVN 22.12.0-25

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -13,7 +13,7 @@ RUN dnf install -y --nodocs \
 	dnf clean all
 
 ARG ovsver=2.17.0-62.el8fdp
-ARG ovnver=22.12.0-18.el8fdp
+ARG ovnver=22.12.0-25.el8fdp
 
 RUN INSTALL_PKGS="iptables" && \
 	dnf install -y --nodocs $INSTALL_PKGS && \

--- a/Dockerfile.base.rhel9
+++ b/Dockerfile.base.rhel9
@@ -13,7 +13,7 @@ RUN dnf install -y --nodocs \
 	dnf clean all
 
 ARG ovsver=3.0.0-28.el9fdp
-ARG ovnver=22.12.0-18.el9fdp
+ARG ovnver=22.12.0-25.el9fdp
 
 RUN INSTALL_PKGS="iptables" && \
 	dnf install -y --nodocs $INSTALL_PKGS && \


### PR DESCRIPTION
- northd: do not create flows for reserved multicast IPv6 groups (#2154930)
- lb: northd: Properly format IPv6 SB load balancer VIPs.