### PR TITLE
[release-4.12] OCPBUGS-7732: Fix leak in service controller cache

### DIFF
--- a/go-controller/pkg/ovn/controller/services/services_controller.go
+++ b/go-controller/pkg/ovn/controller/services/services_controller.go
@@ -271,6 +271,10 @@ func (c *Controller) syncService(key string) error {
 				namespace, name, err)
 		}
 
+		c.alreadyAppliedLock.Lock()
+		delete(c.alreadyApplied, key)
+		c.alreadyAppliedLock.Unlock()
+
 		c.repair.serviceSynced(key)
 		return nil
 	}


### PR DESCRIPTION
This is a partial backport of https://issues.redhat.com/browse/OCPBUGS-6739 commit https://github.com/openshift/ovn-kubernetes/pull/1533/commits/2000f2e057267414d5c639326e31f5472cb39f06

When services are deleted, the controller cache should also remove the service from its top level cache to avoid growing forever.
