### PR TITLE
node: small downstream CARRY patch cleanup

### DIFF
--- a/go-controller/pkg/node/OCP_HACKS.go
+++ b/go-controller/pkg/node/OCP_HACKS.go
@@ -4,6 +4,10 @@
 package node
 
 import (
+	"fmt"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+
 	"github.com/coreos/go-iptables/iptables"
 )
 
@@ -30,4 +34,20 @@ func generateBlockMCSRules(rules *[]iptRule, protocol iptables.Protocol) {
 	}
 
 	_ = delIptRules(delRules)
+}
+
+// insertMCSBlockIptRules inserts iptables rules to block local Machine Config Service
+// ports. See https://github.com/openshift/ovn-kubernetes/pull/170
+func insertMCSBlockIptRules() error {
+	rules := []iptRule{}
+	if config.IPv4Mode {
+		generateBlockMCSRules(&rules, iptables.ProtocolIPv4)
+	}
+	if config.IPv6Mode {
+		generateBlockMCSRules(&rules, iptables.ProtocolIPv6)
+	}
+	if err := insertIptRules(rules); err != nil {
+		return fmt.Errorf("failed to setup MCS-blocking rules: %w", err)
+	}
+	return nil
 }

--- a/go-controller/pkg/node/gateway_localnet.go
+++ b/go-controller/pkg/node/gateway_localnet.go
@@ -8,7 +8,6 @@ import (
 	"net"
 	"strings"
 
-	"github.com/coreos/go-iptables/iptables"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
@@ -49,15 +48,8 @@ func newLocalGateway(nodeName string, hostSubnets []*net.IPNet, gwNextHops []net
 	}
 
 	// OCP HACK -- block MCS ports https://github.com/openshift/ovn-kubernetes/pull/170
-	rules := []iptRule{}
-	if config.IPv4Mode {
-		generateBlockMCSRules(&rules, iptables.ProtocolIPv4)
-	}
-	if config.IPv6Mode {
-		generateBlockMCSRules(&rules, iptables.ProtocolIPv6)
-	}
-	if err := insertIptRules(rules); err != nil {
-		return nil, fmt.Errorf("failed to setup MCS-blocking rules: %w", err)
+	if err := insertMCSBlockIptRules(); err != nil {
+		return nil, err
 	}
 	// END OCP HACK
 

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/coreos/go-iptables/iptables"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
@@ -1685,16 +1684,9 @@ func newSharedGateway(nodeName string, subnets []*net.IPNet, gwNextHops []net.IP
 		}
 	}
 
-	// OCP HACK -- block MCS ports
-	rules := []iptRule{}
-	if config.IPv4Mode {
-		generateBlockMCSRules(&rules, iptables.ProtocolIPv4)
-	}
-	if config.IPv6Mode {
-		generateBlockMCSRules(&rules, iptables.ProtocolIPv6)
-	}
-	if err := insertIptRules(rules); err != nil {
-		return nil, fmt.Errorf("failed to setup MCS-blocking rules: %w", err)
+	// OCP HACK -- block MCS ports https://github.com/openshift/ovn-kubernetes/pull/170
+	if err := insertMCSBlockIptRules(); err != nil {
+		return nil, err
 	}
 	// END OCP HACK
 


### PR DESCRIPTION
Consolidate some MCS blocking code that's the same between local and shared gateway modes.