### PR TITLE
Dockerfiles: copy RHEL-9 bits over top of unused RHEL8 bits

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -5,23 +5,23 @@
 # The standard name for this image is ovn-kubernetes-base
 
 # build base image shared by both OpenShift and MicroShift
-FROM registry.ci.openshift.org/ocp/4.13:base
+FROM registry.ci.openshift.org/ocp/4.14:base-rhel9
 
 # install selinux-policy first to avoid a race
 RUN dnf install -y --nodocs \
-	selinux-policy && \
+	selinux-policy procps-ng && \
 	dnf clean all
 
-ARG ovsver=2.17.0-62.el8fdp
-ARG ovnver=22.12.0-18.el8fdp
+ARG ovsver=3.1.0-2.el9fdp
+ARG ovnver=23.03.0-7.el9fdp
 
 RUN INSTALL_PKGS="iptables" && \
 	dnf install -y --nodocs $INSTALL_PKGS && \
-	dnf install -y --nodocs "openvswitch2.17 = $ovsver" "python3-openvswitch2.17 = $ovsver" && \
-	dnf install -y --nodocs "ovn22.12 = $ovnver" "ovn22.12-central = $ovnver" "ovn22.12-host = $ovnver" && \
+	dnf install -y --nodocs "openvswitch3.1 = $ovsver" "python3-openvswitch3.1 = $ovsver" && \
+	dnf install -y --nodocs "ovn23.03 = $ovnver" "ovn23.03-central = $ovnver" "ovn23.03-host = $ovnver" && \
 	dnf clean all && rm -rf /var/cache/*
 
-RUN sed 's/%/"/g' <<<"%openvswitch2.17-devel = $ovsver% %openvswitch2.17-ipsec = $ovsver% %ovn22.12-vtep = $ovnver%" > /more-pkgs
+RUN sed 's/%/"/g' <<<"%openvswitch3.1-devel = $ovsver% %openvswitch3.1-ipsec = $ovsver% %ovn23.03-vtep = $ovnver%" > /more-pkgs
 
 RUN mkdir -p /var/run/openvswitch && \
     mkdir -p /var/run/ovn && \

--- a/Dockerfile.microshift
+++ b/Dockerfile.microshift
@@ -12,7 +12,7 @@
 # openvswitch-devel, openvswitch-ipsec, libpcap, iproute etc
 # ovn-kube-util, hybrid-overlay-node.exe, ovndbchecker and ovnkube-trace
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-4.13 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.19-openshift-4.14 AS builder
 
 WORKDIR /go/src/github.com/openshift/ovn-kubernetes
 COPY . .
@@ -20,7 +20,7 @@ COPY . .
 # build the binaries
 RUN cd go-controller; CGO_ENABLED=0 make
 
-FROM registry.ci.openshift.org/ocp/4.13:ovn-kubernetes-base
+FROM registry.ci.openshift.org/ocp/4.14:ovn-kubernetes-base
 
 USER root
 


### PR DESCRIPTION
Step 2 to get back to using regular names (eg without "-rhel-9" suffix). This is posssible without breaking CI because
https://github.com/openshift/release/pull/36772 merged which stops using these Dockerfiles.

Next steps:
- flip the dockerfile_paths in openshift/release back to the non-.rhel9 names since this PR makes the normal names RHEL9 now.
- finally 'git rm' the old .rhel9 Dockefiles in ovnkube.
