### PR TITLE
Dockerfile: bump to ovn23.03-23.03.0-4.el9fdp for RHEL9

### DIFF
--- a/Dockerfile.base.rhel9
+++ b/Dockerfile.base.rhel9
@@ -13,7 +13,7 @@ RUN dnf install -y --nodocs \
 	dnf clean all
 
 ARG ovsver=3.1.0-2.el9fdp
-ARG ovnver=23.03.0-preview.4.el9fdp
+ARG ovnver=23.03.0-4.el9fdp
 
 RUN INSTALL_PKGS="iptables" && \
 	dnf install -y --nodocs $INSTALL_PKGS && \


### PR DESCRIPTION
Fix for hairpin_snat_ip that OCP 4.13 uses:

- controller: Fix hairpin SNAT flow explosion if hairpin_snat_ip is set.
- https://bugzilla.redhat.com/show_bug.cgi?id=2171423

And a couple northd perf improvements:

- treewide: Remove unnecessary strlen() calls.
- ovn-util: Optimize is_dynamic_lsp_address.
- northd: Don't parse LSP addresses twice.

@tssurya 