### PR TITLE
Don't recreate clusterPGs and clusterRtrPGs unless needed

### DIFF
--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/klog/v2"
 	utilnet "k8s.io/utils/net"
 
+	libovsdbclient "github.com/ovn-org/libovsdb/client"
 	hocontroller "github.com/ovn-org/ovn-kubernetes/go-controller/hybrid-overlay/pkg/controller"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/informer"
@@ -356,22 +357,42 @@ func (oc *Controller) SetupMaster(existingNodeNames []string) error {
 		klog.Info("SCTP support detected in OVN")
 	}
 
-	// Create a cluster-wide port group that all logical switch ports are part of
-	pg := libovsdbops.BuildPortGroup(types.ClusterPortGroupName, types.ClusterPortGroupName, nil, nil)
-	err = libovsdbops.CreateOrUpdatePortGroups(oc.nbClient, pg)
-	if err != nil {
-		klog.Errorf("Failed to create cluster port group: %v", err)
+	pg := &nbdb.PortGroup{
+		Name: types.ClusterPortGroupName,
+	}
+	pg, err = libovsdbops.GetPortGroup(oc.nbClient, pg)
+	if err != nil && err != libovsdbclient.ErrNotFound {
 		return err
 	}
+	if pg == nil {
+		// we didn't find an existing clusterPG, let's create a new empty PG (fresh cluster install)
+		// Create a cluster-wide port group that all logical switch ports are part of
+		pg := libovsdbops.BuildPortGroup(types.ClusterPortGroupName, types.ClusterPortGroupName, nil, nil)
+		err = libovsdbops.CreateOrUpdatePortGroups(oc.nbClient, pg)
+		if err != nil {
+			klog.Errorf("Failed to create cluster port group: %v", err)
+			return err
+		}
+	}
 
-	// Create a cluster-wide port group with all node-to-cluster router
-	// logical switch ports.  Currently the only user is multicast but it might
-	// be used for other features in the future.
-	pg = libovsdbops.BuildPortGroup(types.ClusterRtrPortGroupName, types.ClusterRtrPortGroupName, nil, nil)
-	err = libovsdbops.CreateOrUpdatePortGroups(oc.nbClient, pg)
-	if err != nil {
-		klog.Errorf("Failed to create cluster port group: %v", err)
+	pg = &nbdb.PortGroup{
+		Name: types.ClusterRtrPortGroupName,
+	}
+	pg, err = libovsdbops.GetPortGroup(oc.nbClient, pg)
+	if err != nil && err != libovsdbclient.ErrNotFound {
 		return err
+	}
+	if pg == nil {
+		// we didn't find an existing clusterRtrPG, let's create a new empty PG (fresh cluster install)
+		// Create a cluster-wide port group with all node-to-cluster router
+		// logical switch ports. Currently the only user is multicast but it might
+		// be used for other features in the future.
+		pg = libovsdbops.BuildPortGroup(types.ClusterRtrPortGroupName, types.ClusterRtrPortGroupName, nil, nil)
+		err = libovsdbops.CreateOrUpdatePortGroups(oc.nbClient, pg)
+		if err != nil {
+			klog.Errorf("Failed to create cluster port group: %v", err)
+			return err
+		}
 	}
 
 	// If supported, enable IGMP relay on the router to forward multicast


### PR DESCRIPTION
In SetupMaster, we always call CreateOrUpdatePortGroupsOps with empty ACLs and PGs for the cluster-wide port group and cluster-wide-router-PG. This is disruptive during upgrades since momentarily all efw ACLs and multicast ACLs will be wiped out.

This commit changes this to first check if the PG already exists, if then no need to do anything.
Each of those features are responsible for ensuring ACLs, Ports are good on those PGs they own.

NOTE: This bug was an issue for multicast and started being an issue for egf from https://github.com/ovn-org/ovn-kubernetes/pull/3338/commits/bd29f417b43c257897f27badc64af38df78b99bd Before that we didn't have ACLs on cluster wide PG.

Signed-off-by: Surya Seetharaman <suryaseetharaman.9@gmail.com>
(cherry picked from commit 935bc5570cb6661beb58e98288cae33c13bd6a8e) (cherry picked from commit 7c153b3071bf674fce53de429531d0ffd5c40dd4) (cherry picked from commit eb312deb02407671fff91ab1e9192a6b004a6997)

Conflicts:
	go-controller/pkg/ovn/master.go
tiny conflict in the imports since we have hocontroller import in 4.11 only

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->