### PR TITLE
OCPBUGS-10318: [release-4.12] node: add node healthz server for cloud load balancers

### DIFF
--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -306,6 +306,7 @@ type KubernetesConfig struct {
 	NoHostSubnetNodes    *metav1.LabelSelector
 	HostNetworkNamespace string `gcfg:"host-network-namespace"`
 	PlatformType         string `gcfg:"platform-type"`
+	HealthzBindAddress   string `gcfg:"healthz-bind-address"`
 
 	// CompatMetricsBindAddress is overridden by the corresponding option in MetricsConfig
 	CompatMetricsBindAddress string `gcfg:"metrics-bind-address"`
@@ -967,6 +968,11 @@ var K8sFlags = []cli.Flag{
 			"Valid values can be found in: https://github.com/ovn-org/ovn-kubernetes/blob/master/go-controller/vendor/github.com/openshift/api/config/v1/types_infrastructure.go#L130-L172",
 		Destination: &cliConfig.Kubernetes.PlatformType,
 		Value:       Kubernetes.PlatformType,
+	},
+	&cli.StringFlag{
+		Name:        "healthz-bind-address",
+		Usage:       "The IP address and port for the node proxy healthz server to serve on (set to '0.0.0.0:10256' or '[::]:10256' for listening in all interfaces and IP families). Disabled by default.",
+		Destination: &cliConfig.Kubernetes.HealthzBindAddress,
 	},
 }
 

--- a/go-controller/pkg/config/config_test.go
+++ b/go-controller/pkg/config/config_test.go
@@ -148,6 +148,7 @@ tokenFile=/path/to/token
 cacert=/path/to/kubeca.crt
 service-cidrs=172.18.0.0/24
 no-hostsubnet-nodes=label=another-test-label
+healthz-bind-address=0.0.0.0:1234
 
 [metrics]
 bind-address=1.1.1.1:8080
@@ -287,6 +288,7 @@ var _ = Describe("Config Operations", func() {
 			gomega.Expect(Kubernetes.APIServer).To(gomega.Equal(DefaultAPIServer))
 			gomega.Expect(Kubernetes.RawServiceCIDRs).To(gomega.Equal("172.16.1.0/24"))
 			gomega.Expect(Kubernetes.RawNoHostSubnetNodes).To(gomega.Equal(""))
+			gomega.Expect(Kubernetes.HealthzBindAddress).To(gomega.Equal(""))
 			gomega.Expect(Metrics.NodeServerPrivKey).To(gomega.Equal(""))
 			gomega.Expect(Metrics.NodeServerCert).To(gomega.Equal(""))
 			gomega.Expect(Default.ClusterSubnets).To(gomega.Equal([]CIDRNetworkEntry{
@@ -567,6 +569,7 @@ var _ = Describe("Config Operations", func() {
 			gomega.Expect(Kubernetes.TokenFile).To(gomega.Equal("/path/to/token"))
 			gomega.Expect(Kubernetes.APIServer).To(gomega.Equal("https://1.2.3.4:6443"))
 			gomega.Expect(Kubernetes.RawServiceCIDRs).To(gomega.Equal("172.18.0.0/24"))
+			gomega.Expect(Kubernetes.HealthzBindAddress).To(gomega.Equal("0.0.0.0:1234"))
 			gomega.Expect(Default.ClusterSubnets).To(gomega.Equal([]CIDRNetworkEntry{
 				{ovntest.MustParseIPNet("10.132.0.0/14"), 23},
 			}))
@@ -652,6 +655,7 @@ var _ = Describe("Config Operations", func() {
 			gomega.Expect(Kubernetes.APIServer).To(gomega.Equal("https://4.4.3.2:8080"))
 			gomega.Expect(Kubernetes.RawServiceCIDRs).To(gomega.Equal("172.15.0.0/24"))
 			gomega.Expect(Kubernetes.RawNoHostSubnetNodes).To(gomega.Equal("test=pass"))
+			gomega.Expect(Kubernetes.HealthzBindAddress).To(gomega.Equal("0.0.0.0:4321"))
 			gomega.Expect(Default.ClusterSubnets).To(gomega.Equal([]CIDRNetworkEntry{
 				{ovntest.MustParseIPNet("10.130.0.0/15"), 24},
 			}))
@@ -744,6 +748,7 @@ var _ = Describe("Config Operations", func() {
 			"-metrics-enable-config-duration=true",
 			"-egressip-reachability-total-timeout=5",
 			"-egressip-node-healthcheck-port=4321",
+			"-healthz-bind-address=0.0.0.0:4321",
 		}
 		err = app.Run(cliArgs)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())

--- a/go-controller/pkg/node/healthcheck_node.go
+++ b/go-controller/pkg/node/healthcheck_node.go
@@ -1,0 +1,99 @@
+package node
+
+import (
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/pkg/errors"
+
+	kapi "k8s.io/api/core/v1"
+	ktypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/klog/v2"
+	"k8s.io/utils/clock"
+)
+
+type proxierHealthUpdater struct {
+	address  string
+	nodeRef  *kapi.ObjectReference
+	recorder record.EventRecorder
+	c        clock.Clock
+	healthy  bool
+}
+
+// newNodeProxyHealthzServer creates and returns a new proxier health server
+// if the HealthzBindAddress configuration is set. Cloud load balancers use this
+// health check to determine if the node is available for services with ClusterIP
+// traffic policy.
+func newNodeProxyHealthzServer(nodeName, address string, eventRecorder record.EventRecorder) *proxierHealthUpdater {
+	return &proxierHealthUpdater{
+		address:  address,
+		recorder: eventRecorder,
+		c:        clock.RealClock{},
+		healthy:  true,
+		nodeRef: &kapi.ObjectReference{
+			Kind:      "Node",
+			Name:      nodeName,
+			UID:       ktypes.UID(nodeName),
+			Namespace: "",
+		},
+	}
+}
+
+func (phu *proxierHealthUpdater) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
+	resp.Header().Set("Content-Type", "application/json")
+	resp.Header().Set("X-Content-Type-Options", "nosniff")
+	if phu.healthy {
+		resp.WriteHeader(http.StatusOK)
+	} else {
+		resp.WriteHeader(http.StatusServiceUnavailable)
+	}
+	now := phu.c.Now()
+	fmt.Fprintf(resp, `{"lastUpdated": %q,"currentTime": %q}`, now, now)
+}
+
+// serveNodeProxyHealthz initializes and runs the healthz server. It will always
+// report healthy while the node process is running.
+// TODO: connect node health to something useful
+func (phu *proxierHealthUpdater) Start(stopChan chan struct{}, wg *sync.WaitGroup) {
+	serveMux := http.NewServeMux()
+	serveMux.Handle("/healthz", phu)
+	server := &http.Server{
+		Addr:    phu.address,
+		Handler: serveMux,
+	}
+
+	startedWg := &sync.WaitGroup{}
+
+	wg.Add(1)
+	startedWg.Add(1)
+	go func() {
+		defer wg.Done()
+		startedWg.Done()
+		<-stopChan
+		server.Close()
+	}()
+
+	wg.Add(1)
+	startedWg.Add(1)
+	go func() {
+		defer wg.Done()
+		startedWg.Done()
+
+		klog.V(3).InfoS("Starting node proxy healthz server", "address", phu.address)
+		for {
+			err := server.ListenAndServe()
+			if errors.Is(err, http.ErrServerClosed) {
+				return
+			}
+			msg := fmt.Sprintf("serving healthz on %s failed: %v", phu.address, err)
+			phu.recorder.Eventf(phu.nodeRef, kapi.EventTypeWarning, "FailedToStartProxierHealthcheck", "StartOVNKubernetesNode", msg)
+			klog.Errorf(msg)
+			time.Sleep(5 * time.Second)
+		}
+	}()
+
+	startedWg.Wait()
+}

--- a/go-controller/pkg/node/healthcheck_node_test.go
+++ b/go-controller/pkg/node/healthcheck_node_test.go
@@ -1,0 +1,53 @@
+package node
+
+import (
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/client-go/tools/record"
+)
+
+var _ = Describe("Node healthcheck tests", func() {
+	var (
+		wg     *sync.WaitGroup
+		stopCh chan struct{}
+	)
+
+	BeforeEach(func() {
+		stopCh = make(chan struct{})
+		wg = &sync.WaitGroup{}
+	})
+
+	AfterEach(func() {
+		close(stopCh)
+		wg.Wait()
+	})
+
+	Context("node proxy healthz server is started", func() {
+		It("it reports healthy", func() {
+			recorder := record.NewFakeRecorder(10)
+			const addr string = "127.0.0.1:10256"
+			hzs := newNodeProxyHealthzServer("some-node", addr, recorder)
+			hzs.Start(stopCh, wg)
+
+			// Try a few times to make sure the server is listening,
+			// there's a small race between when Start() returns and
+			// the ListenAndServe() is actually active
+			var err error
+			for i := 0; i < 5; i++ {
+				resp, err := http.Get(fmt.Sprintf("http://%s/healthz", addr))
+				if err == nil {
+					defer resp.Body.Close()
+					Expect(resp.StatusCode).To(Equal(http.StatusOK))
+				}
+				time.Sleep(50 * time.Millisecond)
+			}
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+})

--- a/go-controller/pkg/node/healthcheck_service.go
+++ b/go-controller/pkg/node/healthcheck_service.go
@@ -1,0 +1,223 @@
+package node
+
+import (
+	"fmt"
+	"net"
+	"sync"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube/healthcheck"
+
+	kapi "k8s.io/api/core/v1"
+	discovery "k8s.io/api/discovery/v1"
+	ktypes "k8s.io/apimachinery/pkg/types"
+	apierrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
+	utilnet "k8s.io/utils/net"
+)
+
+// initLoadBalancerHealthChecker initializes the health check server for
+// ServiceTypeLoadBalancer services
+
+type loadBalancerHealthChecker struct {
+	sync.Mutex
+	nodeName     string
+	server       healthcheck.Server
+	services     map[ktypes.NamespacedName]uint16
+	endpoints    map[ktypes.NamespacedName]int
+	watchFactory factory.NodeWatchFactory
+}
+
+func newLoadBalancerHealthChecker(nodeName string, watchFactory factory.NodeWatchFactory) *loadBalancerHealthChecker {
+	return &loadBalancerHealthChecker{
+		nodeName:     nodeName,
+		server:       healthcheck.NewServer(nodeName, nil, nil, nil),
+		services:     make(map[ktypes.NamespacedName]uint16),
+		endpoints:    make(map[ktypes.NamespacedName]int),
+		watchFactory: watchFactory,
+	}
+}
+
+func (l *loadBalancerHealthChecker) AddService(svc *kapi.Service) error {
+	if svc.Spec.HealthCheckNodePort != 0 {
+		l.Lock()
+		defer l.Unlock()
+		name := ktypes.NamespacedName{Namespace: svc.Namespace, Name: svc.Name}
+		l.services[name] = uint16(svc.Spec.HealthCheckNodePort)
+		return l.server.SyncServices(l.services)
+	}
+	return nil
+}
+
+func (l *loadBalancerHealthChecker) UpdateService(old, new *kapi.Service) error {
+	// if the ETP values have changed between local and cluster,
+	// we need to update health checks accordingly
+	// HealthCheckNodePort is used only in ETP=local mode
+	var err error
+	var errors []error
+	if old.Spec.ExternalTrafficPolicy == kapi.ServiceExternalTrafficPolicyTypeCluster &&
+		new.Spec.ExternalTrafficPolicy == kapi.ServiceExternalTrafficPolicyTypeLocal {
+		if err = l.AddService(new); err != nil {
+			errors = append(errors, err)
+		}
+		epSlices, err := l.watchFactory.GetEndpointSlices(new.Namespace, new.Name)
+		if err != nil {
+			errors = append(errors, fmt.Errorf("could not fetch endpointslices "+
+				"for service %s/%s during health check update service: %v",
+				new.Namespace, new.Name, err))
+			return apierrors.NewAggregate(errors)
+		}
+		namespacedName := ktypes.NamespacedName{Namespace: new.Namespace, Name: new.Name}
+		l.Lock()
+		l.endpoints[namespacedName] = l.CountLocalEndpointAddresses(epSlices)
+		if err = l.server.SyncEndpoints(l.endpoints); err != nil {
+			errors = append(errors, err)
+		}
+		l.Unlock()
+	}
+	if old.Spec.ExternalTrafficPolicy == kapi.ServiceExternalTrafficPolicyTypeLocal &&
+		new.Spec.ExternalTrafficPolicy == kapi.ServiceExternalTrafficPolicyTypeCluster {
+		if err = l.DeleteService(old); err != nil {
+			errors = append(errors, err)
+		}
+	}
+	return apierrors.NewAggregate(errors)
+}
+
+func (l *loadBalancerHealthChecker) DeleteService(svc *kapi.Service) error {
+	if svc.Spec.HealthCheckNodePort != 0 {
+		l.Lock()
+		defer l.Unlock()
+		name := ktypes.NamespacedName{Namespace: svc.Namespace, Name: svc.Name}
+		delete(l.services, name)
+		delete(l.endpoints, name)
+		return l.server.SyncServices(l.services)
+	}
+	return nil
+}
+
+func (l *loadBalancerHealthChecker) SyncServices(svcs []interface{}) error {
+	return nil
+}
+
+func (l *loadBalancerHealthChecker) SyncEndPointSlices(epSlice *discovery.EndpointSlice) error {
+	namespacedName, err := namespacedNameFromEPSlice(epSlice)
+	if err != nil {
+		return fmt.Errorf("skipping %s/%s: %v", epSlice.Namespace, epSlice.Name, err)
+	}
+	epSlices, err := l.watchFactory.GetEndpointSlices(epSlice.Namespace, epSlice.Labels[discovery.LabelServiceName])
+	if err != nil {
+		// should be a rare occurence
+		return fmt.Errorf("could not fetch all endpointslices for service %s during health check", namespacedName.String())
+	}
+
+	localEndpointAddressCount := l.CountLocalEndpointAddresses(epSlices)
+	if len(epSlices) == 0 {
+		// let's delete it from cache and wait for the next update;
+		// this will show as 0 endpoints for health checks
+		delete(l.endpoints, namespacedName)
+	} else {
+		l.endpoints[namespacedName] = localEndpointAddressCount
+	}
+	return l.server.SyncEndpoints(l.endpoints)
+}
+
+func (l *loadBalancerHealthChecker) AddEndpointSlice(epSlice *discovery.EndpointSlice) error {
+	namespacedName, err := namespacedNameFromEPSlice(epSlice)
+	if err != nil {
+		return fmt.Errorf("cannot add %s/%s to loadBalancerHealthChecker: %v", epSlice.Namespace, epSlice.Name, err)
+	}
+	l.Lock()
+	defer l.Unlock()
+	if _, exists := l.services[namespacedName]; exists {
+		return l.SyncEndPointSlices(epSlice)
+	}
+	return nil
+}
+
+func (l *loadBalancerHealthChecker) UpdateEndpointSlice(oldEpSlice, newEpSlice *discovery.EndpointSlice) error {
+	namespacedName, err := namespacedNameFromEPSlice(newEpSlice)
+	if err != nil {
+		return fmt.Errorf("cannot update %s/%s in loadBalancerHealthChecker: %v",
+			newEpSlice.Namespace, newEpSlice.Name, err)
+	}
+	l.Lock()
+	defer l.Unlock()
+	if _, exists := l.services[namespacedName]; exists {
+		return l.SyncEndPointSlices(newEpSlice)
+	}
+	return nil
+}
+
+func (l *loadBalancerHealthChecker) DeleteEndpointSlice(epSlice *discovery.EndpointSlice) error {
+	l.Lock()
+	defer l.Unlock()
+	return l.SyncEndPointSlices(epSlice)
+}
+
+// CountLocalEndpointAddresses returns the number of IP addresses from ready endpoints that are local
+// to the node for a service
+func (l *loadBalancerHealthChecker) CountLocalEndpointAddresses(endpointSlices []*discovery.EndpointSlice) int {
+	localEndpointAddresses := sets.NewString()
+	for _, endpointSlice := range endpointSlices {
+		for _, endpoint := range endpointSlice.Endpoints {
+			isLocal := endpoint.NodeName != nil && *endpoint.NodeName == l.nodeName
+			if isEndpointReady(endpoint) && isLocal {
+				localEndpointAddresses.Insert(endpoint.Addresses...)
+			}
+		}
+	}
+	return len(localEndpointAddresses)
+}
+
+// hasLocalHostNetworkEndpoints returns true if there is at least one host-networked endpoint
+// in the provided list that is local to this node.
+// It returns false if none of the endpoints are local host-networked endpoints or if ep.Subsets is nil.
+func hasLocalHostNetworkEndpoints(epSlices []*discovery.EndpointSlice, nodeAddresses []net.IP) bool {
+	for _, epSlice := range epSlices {
+		for _, endpoint := range epSlice.Endpoints {
+			if !isEndpointReady(endpoint) {
+				continue
+			}
+			for _, ip := range endpoint.Addresses {
+				for _, nodeIP := range nodeAddresses {
+					if nodeIP.String() == utilnet.ParseIPSloppy(ip).String() {
+						return true
+					}
+				}
+			}
+		}
+	}
+	return false
+}
+
+// isHostEndpoint determines if the given endpoint ip belongs to a host networked pod
+func isHostEndpoint(endpointIP string) bool {
+	for _, clusterNet := range config.Default.ClusterSubnets {
+		if clusterNet.CIDR.Contains(net.ParseIP(endpointIP)) {
+			return false
+		}
+	}
+	return true
+}
+
+// discovery.EndpointSlice reports in the same slice all endpoints along with their status.
+// isEndpointReady takes an endpoint from an endpoint slice and returns true if the endpoint is
+// to be considered ready.
+func isEndpointReady(endpoint discovery.Endpoint) bool {
+	return endpoint.Conditions.Ready == nil || *endpoint.Conditions.Ready
+}
+
+func namespacedNameFromEPSlice(epSlice *discovery.EndpointSlice) (ktypes.NamespacedName, error) {
+	// Return the namespaced name of the corresponding service
+	var serviceNamespacedName ktypes.NamespacedName
+	svcName := epSlice.Labels[discovery.LabelServiceName]
+	if svcName == "" {
+		// should not happen, since the informer already filters out endpoint slices with an empty service label
+		return serviceNamespacedName,
+			fmt.Errorf("endpointslice %s/%s: empty value for label %s",
+				epSlice.Namespace, epSlice.Name, discovery.LabelServiceName)
+	}
+	return ktypes.NamespacedName{Namespace: epSlice.Namespace, Name: svcName}, nil
+}

--- a/go-controller/pkg/node/node.go
+++ b/go-controller/pkg/node/node.go
@@ -45,6 +45,9 @@ type OvnNode struct {
 	recorder     record.EventRecorder
 	gateway      Gateway
 
+	// Node healthcheck server for cloud load balancers
+	healthzServer *proxierHealthUpdater
+
 	// retry framework for namespaces, used for the removal of stale conntrack entries for external gateways
 	retryNamespaces *retry.RetryFramework
 	// retry framework for endpoint slices, used for the removal of stale conntrack entries for services
@@ -61,6 +64,11 @@ func NewNode(kubeClient clientset.Interface, wf factory.NodeWatchFactory, name s
 		stopChan:     stopChan,
 		recorder:     eventRecorder,
 	}
+
+	if len(config.Kubernetes.HealthzBindAddress) != 0 {
+		n.healthzServer = newNodeProxyHealthzServer(n.name, config.Kubernetes.HealthzBindAddress, n.recorder)
+	}
+
 	n.initRetryFrameworkForNode()
 
 	return n
@@ -635,6 +643,10 @@ func (n *OvnNode) Start(ctx context.Context, wg *sync.WaitGroup) error {
 		if err != nil {
 			return fmt.Errorf("failed to watch endpointSlices: %w", err)
 		}
+	}
+
+	if n.healthzServer != nil {
+		n.healthzServer.Start(n.stopChan, wg)
 	}
 
 	if config.OvnKubeNode.Mode == types.NodeModeDPU {

--- a/go-controller/pkg/node/openflow_manager.go
+++ b/go-controller/pkg/node/openflow_manager.go
@@ -1,220 +1,18 @@
 package node
 
 import (
-	"fmt"
-	"net"
 	"os"
 	"strings"
 	"sync"
 	"time"
 
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube/healthcheck"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 	"github.com/pkg/errors"
 
-	kapi "k8s.io/api/core/v1"
-	discovery "k8s.io/api/discovery/v1"
-	ktypes "k8s.io/apimachinery/pkg/types"
-	apierrors "k8s.io/apimachinery/pkg/util/errors"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
-	utilnet "k8s.io/utils/net"
 )
-
-// initLoadBalancerHealthChecker initializes the health check server for
-// ServiceTypeLoadBalancer services
-
-type loadBalancerHealthChecker struct {
-	sync.Mutex
-	nodeName     string
-	server       healthcheck.Server
-	services     map[ktypes.NamespacedName]uint16
-	endpoints    map[ktypes.NamespacedName]int
-	watchFactory factory.NodeWatchFactory
-}
-
-func newLoadBalancerHealthChecker(nodeName string, watchFactory factory.NodeWatchFactory) *loadBalancerHealthChecker {
-	return &loadBalancerHealthChecker{
-		nodeName:     nodeName,
-		server:       healthcheck.NewServer(nodeName, nil, nil, nil),
-		services:     make(map[ktypes.NamespacedName]uint16),
-		endpoints:    make(map[ktypes.NamespacedName]int),
-		watchFactory: watchFactory,
-	}
-}
-
-func (l *loadBalancerHealthChecker) AddService(svc *kapi.Service) error {
-	if svc.Spec.HealthCheckNodePort != 0 {
-		l.Lock()
-		defer l.Unlock()
-		name := ktypes.NamespacedName{Namespace: svc.Namespace, Name: svc.Name}
-		l.services[name] = uint16(svc.Spec.HealthCheckNodePort)
-		return l.server.SyncServices(l.services)
-	}
-	return nil
-}
-
-func (l *loadBalancerHealthChecker) UpdateService(old, new *kapi.Service) error {
-	// if the ETP values have changed between local and cluster,
-	// we need to update health checks accordingly
-	// HealthCheckNodePort is used only in ETP=local mode
-	var err error
-	var errors []error
-	if old.Spec.ExternalTrafficPolicy == kapi.ServiceExternalTrafficPolicyTypeCluster &&
-		new.Spec.ExternalTrafficPolicy == kapi.ServiceExternalTrafficPolicyTypeLocal {
-		if err = l.AddService(new); err != nil {
-			errors = append(errors, err)
-		}
-		epSlices, err := l.watchFactory.GetEndpointSlices(new.Namespace, new.Name)
-		if err != nil {
-			errors = append(errors, fmt.Errorf("could not fetch endpointslices "+
-				"for service %s/%s during health check update service: %v",
-				new.Namespace, new.Name, err))
-			return apierrors.NewAggregate(errors)
-		}
-		namespacedName := ktypes.NamespacedName{Namespace: new.Namespace, Name: new.Name}
-		l.Lock()
-		l.endpoints[namespacedName] = l.CountLocalEndpointAddresses(epSlices)
-		if err = l.server.SyncEndpoints(l.endpoints); err != nil {
-			errors = append(errors, err)
-		}
-		l.Unlock()
-	}
-	if old.Spec.ExternalTrafficPolicy == kapi.ServiceExternalTrafficPolicyTypeLocal &&
-		new.Spec.ExternalTrafficPolicy == kapi.ServiceExternalTrafficPolicyTypeCluster {
-		if err = l.DeleteService(old); err != nil {
-			errors = append(errors, err)
-		}
-	}
-	return apierrors.NewAggregate(errors)
-}
-
-func (l *loadBalancerHealthChecker) DeleteService(svc *kapi.Service) error {
-	if svc.Spec.HealthCheckNodePort != 0 {
-		l.Lock()
-		defer l.Unlock()
-		name := ktypes.NamespacedName{Namespace: svc.Namespace, Name: svc.Name}
-		delete(l.services, name)
-		delete(l.endpoints, name)
-		return l.server.SyncServices(l.services)
-	}
-	return nil
-}
-
-func (l *loadBalancerHealthChecker) SyncServices(svcs []interface{}) error {
-	return nil
-}
-
-func (l *loadBalancerHealthChecker) SyncEndPointSlices(epSlice *discovery.EndpointSlice) error {
-	namespacedName, err := namespacedNameFromEPSlice(epSlice)
-	if err != nil {
-		return fmt.Errorf("skipping %s/%s: %v", epSlice.Namespace, epSlice.Name, err)
-	}
-	epSlices, err := l.watchFactory.GetEndpointSlices(epSlice.Namespace, epSlice.Labels[discovery.LabelServiceName])
-	if err != nil {
-		// should be a rare occurence
-		return fmt.Errorf("could not fetch all endpointslices for service %s during health check", namespacedName.String())
-	}
-
-	localEndpointAddressCount := l.CountLocalEndpointAddresses(epSlices)
-	if len(epSlices) == 0 {
-		// let's delete it from cache and wait for the next update;
-		// this will show as 0 endpoints for health checks
-		delete(l.endpoints, namespacedName)
-	} else {
-		l.endpoints[namespacedName] = localEndpointAddressCount
-	}
-	return l.server.SyncEndpoints(l.endpoints)
-}
-
-func (l *loadBalancerHealthChecker) AddEndpointSlice(epSlice *discovery.EndpointSlice) error {
-	namespacedName, err := namespacedNameFromEPSlice(epSlice)
-	if err != nil {
-		return fmt.Errorf("cannot add %s/%s to loadBalancerHealthChecker: %v", epSlice.Namespace, epSlice.Name, err)
-	}
-	l.Lock()
-	defer l.Unlock()
-	if _, exists := l.services[namespacedName]; exists {
-		return l.SyncEndPointSlices(epSlice)
-	}
-	return nil
-}
-
-func (l *loadBalancerHealthChecker) UpdateEndpointSlice(oldEpSlice, newEpSlice *discovery.EndpointSlice) error {
-	namespacedName, err := namespacedNameFromEPSlice(newEpSlice)
-	if err != nil {
-		return fmt.Errorf("cannot update %s/%s in loadBalancerHealthChecker: %v",
-			newEpSlice.Namespace, newEpSlice.Name, err)
-	}
-	l.Lock()
-	defer l.Unlock()
-	if _, exists := l.services[namespacedName]; exists {
-		return l.SyncEndPointSlices(newEpSlice)
-	}
-	return nil
-}
-
-func (l *loadBalancerHealthChecker) DeleteEndpointSlice(epSlice *discovery.EndpointSlice) error {
-	l.Lock()
-	defer l.Unlock()
-	return l.SyncEndPointSlices(epSlice)
-}
-
-// CountLocalEndpointAddresses returns the number of IP addresses from ready endpoints that are local
-// to the node for a service
-func (l *loadBalancerHealthChecker) CountLocalEndpointAddresses(endpointSlices []*discovery.EndpointSlice) int {
-	localEndpointAddresses := sets.NewString()
-	for _, endpointSlice := range endpointSlices {
-		for _, endpoint := range endpointSlice.Endpoints {
-			isLocal := endpoint.NodeName != nil && *endpoint.NodeName == l.nodeName
-			if isEndpointReady(endpoint) && isLocal {
-				localEndpointAddresses.Insert(endpoint.Addresses...)
-			}
-		}
-	}
-	return len(localEndpointAddresses)
-}
-
-// hasLocalHostNetworkEndpoints returns true if there is at least one host-networked endpoint
-// in the provided list that is local to this node.
-// It returns false if none of the endpoints are local host-networked endpoints or if ep.Subsets is nil.
-func hasLocalHostNetworkEndpoints(epSlices []*discovery.EndpointSlice, nodeAddresses []net.IP) bool {
-	for _, epSlice := range epSlices {
-		for _, endpoint := range epSlice.Endpoints {
-			if !isEndpointReady(endpoint) {
-				continue
-			}
-			for _, ip := range endpoint.Addresses {
-				for _, nodeIP := range nodeAddresses {
-					if nodeIP.String() == utilnet.ParseIPSloppy(ip).String() {
-						return true
-					}
-				}
-			}
-		}
-	}
-	return false
-}
-
-// isHostEndpoint determines if the given endpoint ip belongs to a host networked pod
-func isHostEndpoint(endpointIP string) bool {
-	for _, clusterNet := range config.Default.ClusterSubnets {
-		if clusterNet.CIDR.Contains(net.ParseIP(endpointIP)) {
-			return false
-		}
-	}
-	return true
-}
-
-// discovery.EndpointSlice reports in the same slice all endpoints along with their status.
-// isEndpointReady takes an endpoint from an endpoint slice and returns true if the endpoint is
-// to be considered ready.
-func isEndpointReady(endpoint discovery.Endpoint) bool {
-	return endpoint.Conditions.Ready == nil || *endpoint.Conditions.Ready
-}
 
 // checkForStaleOVSInternalPorts checks for OVS internal ports without any ofport assigned,
 // they are stale ports that must be deleted
@@ -485,17 +283,4 @@ func checkPorts(patchIntf, ofPortPatch, physIntf, ofPortPhys string) error {
 		os.Exit(1)
 	}
 	return nil
-}
-
-func namespacedNameFromEPSlice(epSlice *discovery.EndpointSlice) (ktypes.NamespacedName, error) {
-	// Return the namespaced name of the corresponding service
-	var serviceNamespacedName ktypes.NamespacedName
-	svcName := epSlice.Labels[discovery.LabelServiceName]
-	if svcName == "" {
-		// should not happen, since the informer already filters out endpoint slices with an empty service label
-		return serviceNamespacedName,
-			fmt.Errorf("endpointslice %s/%s: empty value for label %s",
-				epSlice.Namespace, epSlice.Name, discovery.LabelServiceName)
-	}
-	return ktypes.NamespacedName{Namespace: epSlice.Namespace, Name: svcName}, nil
 }


### PR DESCRIPTION
4.12 backport of https://github.com/openshift/ovn-kubernetes/commit/c8489e3ff9c321e77f265dc9d484ed2549df4a6b and https://github.com/openshift/ovn-kubernetes/commit/9a836e3a547f3464d433ce8b9eef336624d51858

Not a clean backport, because 4.13 changes were against secondary network controller code in ovnk node, which we don't have in 4.12.

Also, in the backport of https://github.com/openshift/ovn-kubernetes/commit/c8489e3ff9c321e77f265dc9d484ed2549df4a6b, I moved to the new source file `pkg/node/openflow_manager.go` the relevant bits of https://github.com/openshift/ovn-kubernetes/blob/release-4.12/go-controller/pkg/node/healthcheck.go instead of what we had in 4.13, where a few functions  (`checkForStaleOVSInternalPorts`, `checkForStaleOVSRepresentorInterfaces`, `checkForStaleOVSInterfaces`) had been removed in previous commits.

The node healthz server is then enabled by CNO with this PR: 
https://github.com/openshift/cluster-network-operator/pull/1731

closes #OCPBUGS-10318
