### PR TITLE
Revert "OCPBUGS-7952: Dockerfile: bump to ovn23.03-23.03.0-4.el9fdp for RHEL9"

### DIFF
--- a/Dockerfile.base.rhel9
+++ b/Dockerfile.base.rhel9
@@ -13,7 +13,7 @@ RUN dnf install -y --nodocs \
 	dnf clean all
 
 ARG ovsver=3.1.0-2.el9fdp
-ARG ovnver=23.03.0-4.el9fdp
+ARG ovnver=23.03.0-preview.4.el9fdp
 
 RUN INSTALL_PKGS="iptables" && \
 	dnf install -y --nodocs $INSTALL_PKGS && \


### PR DESCRIPTION
Reverts openshift/ovn-kubernetes#1554

Purely a hypothetical to check if this was what caused a regression in networking.