### PR TITLE
[release-4.13] rhel9: rollback to ovn22.12-22.12.0-25.el9fdp

### DIFF
--- a/Dockerfile.base.rhel9
+++ b/Dockerfile.base.rhel9
@@ -13,15 +13,15 @@ RUN dnf install -y --nodocs \
 	dnf clean all
 
 ARG ovsver=3.1.0-2.el9fdp
-ARG ovnver=23.03.0-4.el9fdp
+ARG ovnver=22.12.0-25.el9fdp
 
 RUN INSTALL_PKGS="iptables" && \
 	dnf install -y --nodocs $INSTALL_PKGS && \
 	dnf install -y --nodocs "openvswitch3.1 = $ovsver" "python3-openvswitch3.1 = $ovsver" && \
-	dnf install -y --nodocs "ovn23.03 = $ovnver" "ovn23.03-central = $ovnver" "ovn23.03-host = $ovnver" && \
+	dnf install -y --nodocs "ovn22.12 = $ovnver" "ovn22.12-central = $ovnver" "ovn22.12-host = $ovnver" && \
 	dnf clean all && rm -rf /var/cache/*
 
-RUN sed 's/%/"/g' <<<"%openvswitch3.1-devel = $ovsver% %openvswitch3.1-ipsec = $ovsver% %ovn23.03-vtep = $ovnver%" > /more-pkgs
+RUN sed 's/%/"/g' <<<"%openvswitch3.1-devel = $ovsver% %openvswitch3.1-ipsec = $ovsver% %ovn22.12-vtep = $ovnver%" > /more-pkgs
 
 RUN mkdir -p /var/run/openvswitch && \
     mkdir -p /var/run/ovn && \


### PR DESCRIPTION
CT flush behavior introduced with ovn23.03 bump is not working well for us.

https://bugzilla.redhat.com/show_bug.cgi?id=2178962
