### PR TITLE
OCPBUGS-10395: Bump OVN to disable CT flush

### DIFF
--- a/Dockerfile.base.rhel9
+++ b/Dockerfile.base.rhel9
@@ -13,7 +13,7 @@ RUN dnf install -y --nodocs \
 	dnf clean all
 
 ARG ovsver=3.1.0-2.el9fdp
-ARG ovnver=23.03.0-4.el9fdp
+ARG ovnver=23.03.0-7.el9fdp
 
 RUN INSTALL_PKGS="iptables" && \
 	dnf install -y --nodocs $INSTALL_PKGS && \


### PR DESCRIPTION
**- What this PR does and why is it needed**

See https://bugzilla.redhat.com/show_bug.cgi?id=2178962#c0 for details.
/cc @jcaamano @dcbw 

