### PR TITLE
[release-4.11] OCPBUGS-10734: Bump OVN to 22.12 and turn off neighbour response in router options.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN yum install -y  \
 	yum clean all
 
 ARG ovsver=2.17.0-62.el8fdp
-ARG ovnver=22.09.0-54.el8fdp
+ARG ovnver=22.12.0-18.el8fdp
 
 RUN INSTALL_PKGS=" \
 	openssl python3-pyOpenSSL firewalld-filesystem \
@@ -45,7 +45,7 @@ RUN INSTALL_PKGS=" \
 	" && \
 	yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False $INSTALL_PKGS && \
 	yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False "openvswitch2.17 = $ovsver" "openvswitch2.17-devel = $ovsver" "python3-openvswitch2.17 = $ovsver" "openvswitch2.17-ipsec = $ovsver" && \
-	yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False "ovn22.09 = $ovnver" "ovn22.09-central = $ovnver" "ovn22.09-host = $ovnver" "ovn22.09-vtep = $ovnver" && \
+	yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False "ovn22.12 = $ovnver" "ovn22.12-central = $ovnver" "ovn22.12-host = $ovnver" "ovn22.12-vtep = $ovnver" && \
 	yum clean all && rm -rf /var/cache/*
 
 RUN mkdir -p /var/run/openvswitch && \

--- a/go-controller/pkg/ovn/controller/services/services_controller_test.go
+++ b/go-controller/pkg/ovn/controller/services/services_controller_test.go
@@ -609,9 +609,10 @@ func nodeSwitchRouterLoadBalancerName(nodeName string, serviceNamespace string, 
 
 func servicesOptions() map[string]string {
 	return map[string]string{
-		"event":     "false",
-		"reject":    "true",
-		"skip_snat": "false",
+		"event":              "false",
+		"reject":             "true",
+		"skip_snat":          "false",
+		"neighbor_responder": "none",
 	}
 }
 

--- a/go-controller/pkg/ovn/loadbalancer/loadbalancer.go
+++ b/go-controller/pkg/ovn/loadbalancer/loadbalancer.go
@@ -252,9 +252,10 @@ func buildLB(lb *LB) *nbdb.LoadBalancer {
 	}
 
 	options := map[string]string{
-		"reject":    reject,
-		"event":     event,
-		"skip_snat": skipSNAT,
+		"reject":             reject,
+		"event":              event,
+		"skip_snat":          skipSNAT,
+		"neighbor_responder": "none",
 	}
 
 	// Session affinity


### PR DESCRIPTION
Cherry-pick/backport of https://github.com/openshift/ovn-kubernetes/pull/1521

We don't want to stay on a bespoke downstream version of 22.09 with the session affinity timeout patches; we want to move to a fully supported/tested/etc 22.12 that 4.12 is also using.