### PR TITLE
OCPBUGS-10982: [release-4.13] Fixes Egress Firewall node selector for ipv6

### DIFF
--- a/go-controller/pkg/ovn/egressfirewall.go
+++ b/go-controller/pkg/ovn/egressfirewall.go
@@ -343,7 +343,7 @@ func (oc *DefaultNetworkController) addEgressFirewallRules(ef *egressFirewall, h
 		}
 		if len(rule.to.nodeAddrs) > 0 {
 			for addr := range rule.to.nodeAddrs {
-				if utilnet.IsIPv6CIDRString(addr) {
+				if utilnet.IsIPv6String(addr) {
 					matchTargets = append(matchTargets, matchTarget{matchKindV6CIDR, addr, false})
 				} else {
 					matchTargets = append(matchTargets, matchTarget{matchKindV4CIDR, addr, false})


### PR DESCRIPTION
Simple fix where I was parsing the node address incorrectly.

Signed-off-by: Tim Rozet <trozet@redhat.com>
(cherry picked from commit 3a72af93f2e5c1a874e9a888e7f28920c2cc63df)

clean backport