### PR TITLE
OCPBUGS-10485: Bump OVS to 3.1.0-10

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -12,7 +12,7 @@ RUN dnf install -y --nodocs \
 	selinux-policy procps-ng && \
 	dnf clean all
 
-ARG ovsver=3.1.0-2.el9fdp
+ARG ovsver=3.1.0-10.el9fdp
 ARG ovnver=23.03.0-7.el9fdp
 
 RUN INSTALL_PKGS="iptables" && \

--- a/Dockerfile.base.rhel9
+++ b/Dockerfile.base.rhel9
@@ -12,7 +12,7 @@ RUN dnf install -y --nodocs \
 	selinux-policy procps-ng && \
 	dnf clean all
 
-ARG ovsver=3.1.0-2.el9fdp
+ARG ovsver=3.1.0-10.el9fdp
 ARG ovnver=23.03.0-7.el9fdp
 
 RUN INSTALL_PKGS="iptables" && \


### PR DESCRIPTION
OCPBUGS-10485 requires the following fixes:
```
fff04b838 ovs-thread: Fix cpus not read for the first 10s.
b2b467b3a dpif-netlink: Always create at least 1 handler.
```
The changes are actually needed on the host package, this PR is just to match the versions.

Full change-log in commit message.

/cc @jcaamano @dcbw 