### PR TITLE
OCPBUGS-11423: [release-4.10] Handle Completed pods deletion

### DIFF
--- a/go-controller/pkg/ovn/policy_test.go
+++ b/go-controller/pkg/ovn/policy_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/urfave/cli/v2"
 
+	kapi "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	knet "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -2542,6 +2543,92 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 					Name: "node1",
 				})
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdb.HaveData(expectedData...))
+
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+
+		ginkgo.It("reconciles a completed and deleted pod whose IP has been assigned to a running pod", func() {
+			app.Action = func(ctx *cli.Context) error {
+				namespace1 := *newNamespace(namespaceName1)
+				nodeName := "node1"
+
+				// Use simple allow-same-namespace network policy
+				networkPolicy := newNetworkPolicy("networkpolicy1", namespace1.Name,
+					metav1.LabelSelector{},
+					[]knet.NetworkPolicyIngressRule{{
+						From: []knet.NetworkPolicyPeer{{
+							PodSelector: &metav1.LabelSelector{},
+						}},
+					}},
+					[]knet.NetworkPolicyEgressRule{})
+
+				fakeOvn.startWithDBSetup(initialDB,
+					&v1.NamespaceList{
+						Items: []v1.Namespace{
+							namespace1,
+						},
+					},
+					&knet.NetworkPolicyList{
+						Items: []knet.NetworkPolicy{
+							*networkPolicy,
+						},
+					},
+				)
+
+				err := fakeOvn.controller.lsManager.AddNode(
+					nodeName,
+					getLogicalSwitchUUID(fakeOvn.controller.nbClient, nodeName),
+					[]*net.IPNet{ovntest.MustParseIPNet("10.128.1.0/29")})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				fakeOvn.controller.WatchNamespaces()
+				fakeOvn.controller.WatchPods()
+				fakeOvn.controller.WatchNetworkPolicy()
+
+				// Start a pod
+				completedPod, err := fakeOvn.fakeClient.KubeClient.CoreV1().Pods(namespace1.Name).
+					Create(
+						context.TODO(),
+						newPod(namespace1.Name, "completed-pod", nodeName, "10.128.1.3"),
+						metav1.CreateOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				eventuallyExpectAddressSetsWithIP(fakeOvn, networkPolicy, "10.128.1.3")
+
+				// Consume the entire node ip pool
+				fakeOvn.controller.lsManager.AllocateUntilFull(nodeName)
+
+				// Mark the pod as Completed, so the "10.128.1.3" moves back to the allocatable pool
+				completedPod.Status.Phase = kapi.PodSucceeded
+				completedPod, err = fakeOvn.fakeClient.KubeClient.CoreV1().Pods(completedPod.Namespace).
+					Update(context.TODO(), completedPod, metav1.UpdateOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				eventuallyExpectEmptyAddressSetsExist(fakeOvn, networkPolicy)
+
+				// Spawn a pod with an IP address that collides with a completed pod
+				_, err = fakeOvn.fakeClient.KubeClient.CoreV1().Pods(namespace1.Name).
+					Create(
+						context.TODO(),
+						newPod(namespace1.Name, "running-pod", nodeName, "10.128.1.3"),
+						metav1.CreateOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				eventuallyExpectAddressSetsWithIP(fakeOvn, networkPolicy, "10.128.1.3")
+
+				// Simulate garbage collector: deletes all completed pods
+				err = fakeOvn.fakeClient.KubeClient.CoreV1().Pods(completedPod.Namespace).Delete(context.TODO(), completedPod.Name, *metav1.NewDeleteOptions(0))
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				// Wait for every controller to be have finished its work
+				time.Sleep(200 * time.Millisecond)
+
+				// Running pod policy should not be affected by pod deletions
+				eventuallyExpectAddressSetsWithIP(fakeOvn, networkPolicy, "10.128.1.3")
 
 				return nil
 			}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->
Backport of:
- https://github.com/openshift/ovn-kubernetes/pull/1616

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

Solved conflicts around `handlePeerPodSelectorDelete(...)` as there is no retry framework for network policies in release-4.10.




**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->