### PR TITLE
OCPBUGS-11701: [release-4.12] CARRY: use "prefer local" for annotated services

### DIFF
--- a/go-controller/pkg/ovn/controller/services/load_balancer.go
+++ b/go-controller/pkg/ovn/controller/services/load_balancer.go
@@ -18,6 +18,7 @@ import (
 // magic string used in vips to indicate that the node's physical
 // ips should be substituted in
 const placeholderNodeIPs = "node"
+const localWithFallbackAnnotation = "traffic-policy.network.alpha.openshift.io/local-with-fallback"
 
 // lbConfig is the abstract desired load balancer configuration.
 // vips and endpoints are mixed families.
@@ -306,6 +307,28 @@ func buildPerNodeLBs(service *v1.Service, configs []lbConfig, nodes []nodeInfo) 
 					switchV4targetips = util.FilterIPsSlice(switchV4targetips, node.nodeSubnets(), true)
 					switchV6targetips = util.FilterIPsSlice(switchV6targetips, node.nodeSubnets(), true)
 				}
+				// OCP HACK BEGIN
+				zeroRouterV4LocalEndpoints := false
+				zeroRouterV6LocalEndpoints := false
+				if _, set := service.Annotations[localWithFallbackAnnotation]; set && config.externalTrafficLocal {
+					// if service is annotated and is ETP=local, fallback to ETP=cluster on nodes with no local endpoints:
+					// include endpoints from other nodes
+					if len(routerV4targetips) == 0 {
+						zeroRouterV4LocalEndpoints = true
+						routerV4targetips = config.eps.V4IPs
+					}
+					if len(routerV6targetips) == 0 {
+						zeroRouterV6LocalEndpoints = true
+						routerV6targetips = config.eps.V6IPs
+					}
+					if len(switchV4targetips) == 0 {
+						switchV4targetips = config.eps.V4IPs
+					}
+					if len(switchV6targetips) == 0 {
+						switchV6targetips = config.eps.V6IPs
+					}
+				}
+				// OCP HACK END
 				// at this point, the targets may be empty
 
 				// any targets local to the node need to have a special
@@ -396,10 +419,12 @@ func buildPerNodeLBs(service *v1.Service, configs []lbConfig, nodes []nodeInfo) 
 						Targets: targets,
 					}
 
+					localWithFallback := (isv6 && zeroRouterV6LocalEndpoints) || (!isv6 && zeroRouterV4LocalEndpoints)
+
 					// in other words, is this ExternalTrafficPolicy=local?
 					// if so, this gets a separate load balancer with SNAT disabled
 					// (but there's no need to do this if the list of targets is empty)
-					if config.externalTrafficLocal && len(targets) > 0 {
+					if config.externalTrafficLocal && len(targets) > 0 && !localWithFallback {
 						noSNATRouterRules = append(noSNATRouterRules, rule)
 					} else {
 						routerRules = append(routerRules, rule)

--- a/go-controller/pkg/ovn/controller/services/load_balancer_test.go
+++ b/go-controller/pkg/ovn/controller/services/load_balancer_test.go
@@ -1973,3 +1973,290 @@ func Test_buildPerNodeLBs_OCPHackForDNS(t *testing.T) {
 }
 
 // OCP hack end
+
+// OCP hack begin
+func Test_buildPerNodeLBs_OCPHackForLocalWithFallback(t *testing.T) {
+	oldClusterSubnet := globalconfig.Default.ClusterSubnets
+	oldGwMode := globalconfig.Gateway.Mode
+	defer func() {
+		globalconfig.Gateway.Mode = oldGwMode
+		globalconfig.Default.ClusterSubnets = oldClusterSubnet
+	}()
+	_, cidr4, _ := net.ParseCIDR("10.128.0.0/16")
+	globalconfig.Default.ClusterSubnets = []globalconfig.CIDRNetworkEntry{{cidr4, 26}}
+
+	name := "router-default"
+	namespace := "openshift-ingress"
+	inport := int32(80)
+	outport := int32(8080)
+
+	defaultService := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   namespace,
+			Annotations: map[string]string{localWithFallbackAnnotation: ""}, // code checks for this annotation
+		},
+		Spec: v1.ServiceSpec{
+			Type:                  v1.ServiceTypeLoadBalancer,
+			ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeLocal,
+			// add ingress IP
+			ClusterIP:  "192.168.1.1",
+			ClusterIPs: []string{"192.168.1.1"},
+			Ports: []v1.ServicePort{ // don't consider https for simplicity
+				{
+					Name:       "http",
+					Port:       80,
+					Protocol:   v1.ProtocolTCP,
+					TargetPort: intstr.FromInt(80),
+					NodePort:   5,
+				},
+			},
+		},
+		Status: v1.ServiceStatus{
+			LoadBalancer: v1.LoadBalancerStatus{
+				Ingress: []v1.LoadBalancerIngress{{
+					IP: "5.5.5.5",
+				}},
+			},
+		},
+	}
+
+	defaultNodes := []nodeInfo{
+		{
+			name:              "node-a",
+			nodeIPs:           []string{"10.0.0.1"},
+			gatewayRouterName: "gr-node-a",
+			switchName:        "switch-node-a",
+			podSubnets:        []net.IPNet{{IP: net.ParseIP("10.128.0.0"), Mask: net.CIDRMask(24, 32)}},
+		},
+		{
+			name:              "node-b",
+			nodeIPs:           []string{"10.0.0.2"},
+			gatewayRouterName: "gr-node-b",
+			switchName:        "switch-node-b",
+			podSubnets:        []net.IPNet{{IP: net.ParseIP("10.128.1.0"), Mask: net.CIDRMask(24, 32)}},
+		},
+	}
+
+	defaultExternalIDs := map[string]string{
+		"k8s.ovn.org/kind":  "Service",
+		"k8s.ovn.org/owner": fmt.Sprintf("%s/%s", namespace, name),
+	}
+
+	defaultOpts := ovnlb.LBOpts{}
+	noSNATOpts := ovnlb.LBOpts{SkipSNAT: true}
+
+	tc := []struct {
+		name     string
+		service  *v1.Service
+		configs  []lbConfig
+		expected []ovnlb.LB
+	}{
+		{
+			name:    "Load Balancer service with ETP local and local-with-fallback annotation, ovn-networked endpoints, all endpoints are up: no fallback",
+			service: defaultService,
+			configs: []lbConfig{
+				{
+					vips:                 []string{"node"}, //  placeholder for node IP
+					protocol:             v1.ProtocolTCP,
+					inport:               5, // node port
+					externalTrafficLocal: true,
+					hasNodePort:          true,
+					eps: util.LbEndpoints{
+						V4IPs: []string{"10.128.0.2", "10.128.1.2"},
+						V6IPs: []string{},
+						Port:  outport,
+					},
+				},
+				{
+					vips:                 []string{"5.5.5.5"}, // external VIP
+					protocol:             v1.ProtocolTCP,
+					inport:               inport,
+					externalTrafficLocal: true,
+					eps: util.LbEndpoints{
+						V4IPs: []string{"10.128.0.2", "10.128.1.2"},
+						V6IPs: []string{},
+						Port:  outport,
+					},
+				},
+			},
+			expected: []ovnlb.LB{
+				{
+					Name:        "Service_openshift-ingress/router-default_TCP_node_local_router_node-a",
+					Protocol:    "TCP",
+					ExternalIDs: defaultExternalIDs,
+					Opts:        noSNATOpts,
+					Routers:     []string{"gr-node-a"},
+					Rules: []ovnlb.LBRule{
+						{
+							Source:  ovnlb.Addr{IP: "10.0.0.1", Port: 5},
+							Targets: []ovnlb.Addr{{IP: "10.128.0.2", Port: 8080}}},
+						{
+							Source:  ovnlb.Addr{IP: "5.5.5.5", Port: 80},
+							Targets: []ovnlb.Addr{{IP: "10.128.0.2", Port: 8080}}}},
+				},
+				{
+					Name:        "Service_openshift-ingress/router-default_TCP_node_switch_node-a",
+					Protocol:    "TCP",
+					ExternalIDs: defaultExternalIDs,
+					Opts:        defaultOpts,
+					Switches:    []string{"switch-node-a"},
+					Rules: []ovnlb.LBRule{
+						{
+							Source:  ovnlb.Addr{IP: "169.254.169.3", Port: 5},
+							Targets: []ovnlb.Addr{{IP: "10.128.0.2", Port: 8080}}},
+						{
+							Source:  ovnlb.Addr{IP: "10.0.0.1", Port: 5},
+							Targets: []ovnlb.Addr{{IP: "10.128.0.2", Port: 8080}, {IP: "10.128.1.2", Port: 8080}}},
+						{
+							Source:  ovnlb.Addr{IP: "5.5.5.5", Port: 80},
+							Targets: []ovnlb.Addr{{IP: "10.128.0.2", Port: 8080}, {IP: "10.128.1.2", Port: 8080}}}},
+				},
+				{
+					Name:        "Service_openshift-ingress/router-default_TCP_node_local_router_node-b",
+					Protocol:    "TCP",
+					ExternalIDs: defaultExternalIDs,
+					Opts:        noSNATOpts,
+					Routers:     []string{"gr-node-b"},
+					Rules: []ovnlb.LBRule{
+						{
+							Source:  ovnlb.Addr{IP: "10.0.0.2", Port: 5},
+							Targets: []ovnlb.Addr{{IP: "10.128.1.2", Port: 8080}}},
+						{
+							Source:  ovnlb.Addr{IP: "5.5.5.5", Port: 80},
+							Targets: []ovnlb.Addr{{IP: "10.128.1.2", Port: 8080}}}},
+				},
+				{
+					Name:        "Service_openshift-ingress/router-default_TCP_node_switch_node-b",
+					Protocol:    "TCP",
+					ExternalIDs: defaultExternalIDs,
+					Opts:        defaultOpts,
+					Rules: []ovnlb.LBRule{
+						{
+							Source:  ovnlb.Addr{IP: "169.254.169.3", Port: 5},
+							Targets: []ovnlb.Addr{{IP: "10.128.1.2", Port: 8080}}},
+						{
+							Source:  ovnlb.Addr{IP: "10.0.0.2", Port: 5},
+							Targets: []ovnlb.Addr{{IP: "10.128.0.2", Port: 8080}, {IP: "10.128.1.2", Port: 8080}}},
+						{
+							Source:  ovnlb.Addr{IP: "5.5.5.5", Port: 80},
+							Targets: []ovnlb.Addr{{IP: "10.128.0.2", Port: 8080}, {IP: "10.128.1.2", Port: 8080}}}},
+					Switches: []string{"switch-node-b"},
+				},
+			},
+		},
+		{
+			name:    "Load Balancer service with ETP local and local-with-fallback annotation, ovn-networked endpoints, endpoint on node-a is down: fallback to ETP Cluster",
+			service: defaultService,
+			configs: []lbConfig{
+				{
+					vips:                 []string{"node"}, //  placeholder for node IP
+					protocol:             v1.ProtocolTCP,
+					inport:               5, // node port
+					externalTrafficLocal: true,
+					hasNodePort:          true,
+					eps: util.LbEndpoints{
+						V4IPs: []string{"10.128.1.2"}, // only endpoint on node-b is running
+						V6IPs: []string{},
+						Port:  outport,
+					},
+				},
+				{
+					vips:                 []string{"5.5.5.5"}, // external VIP
+					protocol:             v1.ProtocolTCP,
+					inport:               inport,
+					externalTrafficLocal: true,
+					eps: util.LbEndpoints{
+						V4IPs: []string{"10.128.1.2"},
+						V6IPs: []string{},
+						Port:  outport,
+					},
+				},
+			},
+			expected: []ovnlb.LB{
+				{
+					Name:        "Service_openshift-ingress/router-default_TCP_node_router_node-a", // fallback, because no local endpoints left
+					Protocol:    "TCP",
+					ExternalIDs: defaultExternalIDs,
+					Opts:        defaultOpts,
+					Routers:     []string{"gr-node-a"},
+					Rules: []ovnlb.LBRule{
+						{
+							Source:  ovnlb.Addr{IP: "10.0.0.1", Port: 5},
+							Targets: []ovnlb.Addr{{IP: "10.128.1.2", Port: 8080}}, // forwarding to endpoint on node-b, as if ETP=Cluster
+						},
+						{
+							Source:  ovnlb.Addr{IP: "5.5.5.5", Port: 80},
+							Targets: []ovnlb.Addr{{IP: "10.128.1.2", Port: 8080}}, // forwarding to endpoint on node-b, as if ETP=Cluster
+						},
+					},
+				},
+				{
+					Name:        "Service_openshift-ingress/router-default_TCP_node_switch_node-a",
+					Protocol:    "TCP",
+					ExternalIDs: defaultExternalIDs,
+					Opts:        defaultOpts,
+					Switches:    []string{"switch-node-a"},
+					Rules: []ovnlb.LBRule{
+						{
+							Source:  ovnlb.Addr{IP: "169.254.169.3", Port: 5},
+							Targets: []ovnlb.Addr{{IP: "10.128.1.2", Port: 8080}}},
+						{
+							Source:  ovnlb.Addr{IP: "10.0.0.1", Port: 5},
+							Targets: []ovnlb.Addr{{IP: "10.128.1.2", Port: 8080}}},
+						{
+							Source:  ovnlb.Addr{IP: "5.5.5.5", Port: 80},
+							Targets: []ovnlb.Addr{{IP: "10.128.1.2", Port: 8080}}}},
+				},
+
+				{
+					Name:        "Service_openshift-ingress/router-default_TCP_node_local_router_node-b",
+					Protocol:    "TCP",
+					ExternalIDs: defaultExternalIDs,
+					Opts:        noSNATOpts,
+					Rules: []ovnlb.LBRule{
+						{
+							Source:  ovnlb.Addr{IP: "10.0.0.2", Port: 5},
+							Targets: []ovnlb.Addr{{IP: "10.128.1.2", Port: 8080}}}, // endpoint is on node-b, so eTP=local is respected
+						{
+							Source:  ovnlb.Addr{IP: "5.5.5.5", Port: 80},
+							Targets: []ovnlb.Addr{{IP: "10.128.1.2", Port: 8080}}}}, // endpoint is on node-b, so eTP=local is respected
+					Switches: []string(nil), Routers: []string{"gr-node-b"},
+				},
+				{
+					Name:        "Service_openshift-ingress/router-default_TCP_node_switch_node-b",
+					UUID:        "",
+					Protocol:    "TCP",
+					ExternalIDs: defaultExternalIDs,
+					Opts:        defaultOpts,
+					Rules: []ovnlb.LBRule{
+						{
+							Source:  ovnlb.Addr{IP: "169.254.169.3", Port: 5},
+							Targets: []ovnlb.Addr{{IP: "10.128.1.2", Port: 8080}}},
+						{
+							Source:  ovnlb.Addr{IP: "10.0.0.2", Port: 5},
+							Targets: []ovnlb.Addr{{IP: "10.128.1.2", Port: 8080}}},
+						{
+							Source:  ovnlb.Addr{IP: "5.5.5.5", Port: 80},
+							Targets: []ovnlb.Addr{{IP: "10.128.1.2", Port: 8080}}}},
+					Switches: []string{"switch-node-b"},
+				},
+			},
+		},
+	}
+
+	for i, tt := range tc {
+		t.Run(fmt.Sprintf("%d_%s", i, tt.name), func(t *testing.T) {
+
+			globalconfig.Gateway.Mode = globalconfig.GatewayModeShared
+			actual := buildPerNodeLBs(tt.service, tt.configs, defaultNodes)
+			assert.Equal(t, tt.expected, actual, "shared gateway mode not as expected")
+
+			globalconfig.Gateway.Mode = globalconfig.GatewayModeLocal
+			actual = buildPerNodeLBs(tt.service, tt.configs, defaultNodes)
+			assert.Equal(t, tt.expected, actual, "local gateway mode not as expected")
+		})
+	}
+}
+
+// OCP hack end


### PR DESCRIPTION
Backport of https://github.com/openshift/ovn-kubernetes/pull/1630  for 4.12.

Clean backport for the hack itself in `go-controller/pkg/ovn/controller/services/load_balancer.go`, not a clean backport of the unit tests just because:
-  the renaming in the service controller code (https://github.com/openshift/ovn-kubernetes/commit/c7fd02c133233cf940fc7537e481a95700e060a3#diff-78b8ad08a198fcc889bf29d85c44763617fd5320ca9ff10f88fe107a0d968c29) was not backported to 4.12. The result is simply that `LBRule`, `LB`, `LBOpts`, `Addr` had to be prefixed with `ovnlb`.
-  we don't have
`go-controller/pkg/ovn/controller/services/load_balancer_ocphack_test.go` in 4.12, so I moved the unit tests to the existing `go-controller/pkg/ovn/controller/services/load_balancer_test.go` right after the other ocp hack.

---

Openshift hack: the router service is annotated with "traffic-policy.network.alpha.openshift.io/local-with-fallback" because, while it is defined with externalTrafficPolicy=Local, it expects the CNI to switch to externalTrafficPolicy=Cluster as soon as there are no local endpoints on any given node. SDN does this already, let's do it in OVNK as well to further reduce disruption time to openshift ingress during upgrades.

Co-authored-by: Riccardo Ravaioli <rravaiol@redhat.com>
Co-authored-by: Surya Seetharaman <suryaseetharaman.9@gmail.com>
(cherry picked from commit c52131126d9fb909dbe48c1c695a961d7308b11c)
