### PR TITLE
OCPBUGS-11716: [release-4.14] Use loadbalancer.Name as client index

### DIFF
--- a/go-controller/pkg/libovsdb/libovsdb.go
+++ b/go-controller/pkg/libovsdb/libovsdb.go
@@ -148,6 +148,11 @@ func NewNBClientWithConfig(cfg config.OvnAuthConfig, promRegistry prometheus.Reg
 	enableMetricsOption := client.WithMetricsRegistryNamespaceSubsystem(promRegistry, "ovnkube",
 		"master_libovsdb")
 
+	// define client indexes for objects that are using dbIDs
+	dbModel.SetIndexes(map[string][]model.ClientIndex{
+		nbdb.LoadBalancerTable: {{Columns: []model.ColumnKey{{Column: "name"}}}},
+	})
+
 	c, err := newClient(cfg, dbModel, stopCh, enableMetricsOption)
 	if err != nil {
 		return nil, err

--- a/go-controller/pkg/libovsdbops/model.go
+++ b/go-controller/pkg/libovsdbops/model.go
@@ -152,6 +152,8 @@ func copyIndexes(model model.Model) model.Model {
 	case *nbdb.LoadBalancer:
 		return &nbdb.LoadBalancer{
 			UUID: t.UUID,
+			// client index
+			Name: t.Name,
 		}
 	case *nbdb.LoadBalancerGroup:
 		return &nbdb.LoadBalancerGroup{
@@ -362,9 +364,6 @@ func buildFailOnDuplicateOps(c client.Client, m model.Model) ([]ovsdb.Operation,
 	var field interface{}
 	var value string
 	switch t := m.(type) {
-	case *nbdb.LoadBalancer:
-		field = &t.Name
-		value = t.Name
 	case *nbdb.LogicalRouter:
 		field = &t.Name
 		value = t.Name


### PR DESCRIPTION
Revert predicate search optimization
3369d387417ede05033c002b782b0279b201ea76 as predicate search should not bee needed anymore

Signed-off-by: Nadia Pinaeva <npinaeva@redhat.com>
(cherry picked from commit ad052c1c0061f9734d78c93cb2454557238dac25)

Conflicts:
	go-controller/pkg/libovsdb/libovsdb.go: acl client index is not
merged downstream yet
	go-controller/pkg/ovn/controller/services/loadbalancer.go:
loadbalancer cache removal is not merged downstream yet

Cherry-pick of https://github.com/ovn-org/ovn-kubernetes/pull/3533
