### PR TITLE
[release-4.13] OCPBUGS-12864: Drop packets were not properly SNATed

### DIFF
--- a/go-controller/pkg/node/gateway_localnet.go
+++ b/go-controller/pkg/node/gateway_localnet.go
@@ -102,14 +102,14 @@ func newLocalGateway(nodeName string, hostSubnets []*net.IPNet, gwNextHops []net
 			return fmt.Errorf("failed to set the node masquerade route to OVN: %v", err)
 		}
 
-		gw.openflowManager, err = newGatewayOpenFlowManager(gwBridge, exGwBridge, gw.nodeIPManager.ListAddresses())
+		gw.openflowManager, err = newGatewayOpenFlowManager(gwBridge, exGwBridge, hostSubnets, gw.nodeIPManager.ListAddresses())
 		if err != nil {
 			return err
 		}
 		// resync flows on IP change
 		gw.nodeIPManager.OnChanged = func() {
 			klog.V(5).Info("Node addresses changed, re-syncing bridge flows")
-			if err := gw.openflowManager.updateBridgeFlowCache(gw.nodeIPManager.ListAddresses()); err != nil {
+			if err := gw.openflowManager.updateBridgeFlowCache(hostSubnets, gw.nodeIPManager.ListAddresses()); err != nil {
 				// very unlikely - somehow node has lost its IP address
 				klog.Errorf("Failed to re-generate gateway flows after address change: %v", err)
 			}

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -1080,7 +1080,7 @@ func (npwipt *nodePortWatcherIptables) SyncServices(services []interface{}) erro
 //
 // -- to handle host -> service access, via masquerading from the host to OVN GR
 // -- to handle external -> service(ExternalTrafficPolicy: Local) -> host access without SNAT
-func newGatewayOpenFlowManager(gwBridge, exGWBridge *bridgeConfiguration, extraIPs []net.IP) (*openflowManager, error) {
+func newGatewayOpenFlowManager(gwBridge, exGWBridge *bridgeConfiguration, subnets []*net.IPNet, extraIPs []net.IP) (*openflowManager, error) {
 	// add health check function to check default OpenFlow flows are on the shared gateway bridge
 	ofm := &openflowManager{
 		defaultBridge:         gwBridge,
@@ -1092,7 +1092,7 @@ func newGatewayOpenFlowManager(gwBridge, exGWBridge *bridgeConfiguration, extraI
 		flowChan:              make(chan struct{}, 1),
 	}
 
-	if err := ofm.updateBridgeFlowCache(extraIPs); err != nil {
+	if err := ofm.updateBridgeFlowCache(subnets, extraIPs); err != nil {
 		return nil, err
 	}
 
@@ -1102,7 +1102,7 @@ func newGatewayOpenFlowManager(gwBridge, exGWBridge *bridgeConfiguration, extraI
 
 // updateBridgeFlowCache generates the "static" per-bridge flows
 // note: this is shared between shared and local gateway modes
-func (ofm *openflowManager) updateBridgeFlowCache(extraIPs []net.IP) error {
+func (ofm *openflowManager) updateBridgeFlowCache(subnets []*net.IPNet, extraIPs []net.IP) error {
 	// protect defaultBridge config from being updated by gw.nodeIPManager
 	ofm.defaultBridge.Lock()
 	defer ofm.defaultBridge.Unlock()
@@ -1111,7 +1111,7 @@ func (ofm *openflowManager) updateBridgeFlowCache(extraIPs []net.IP) error {
 	if err != nil {
 		return err
 	}
-	dftCommonFlows, err := commonFlows(ofm.defaultBridge)
+	dftCommonFlows, err := commonFlows(subnets, ofm.defaultBridge)
 	if err != nil {
 		return err
 	}
@@ -1123,7 +1123,7 @@ func (ofm *openflowManager) updateBridgeFlowCache(extraIPs []net.IP) error {
 	// we consume ex gw bridge flows only if that is enabled
 	if ofm.externalGatewayBridge != nil {
 		ofm.updateExBridgeFlowCacheEntry("NORMAL", []string{fmt.Sprintf("table=0,priority=0,actions=%s\n", util.NormalAction)})
-		exGWBridgeDftFlows, err := commonFlows(ofm.externalGatewayBridge)
+		exGWBridgeDftFlows, err := commonFlows(subnets, ofm.externalGatewayBridge)
 		if err != nil {
 			return err
 		}
@@ -1384,7 +1384,7 @@ func flowsForDefaultBridge(bridge *bridgeConfiguration, extraIPs []net.IP) ([]st
 	return dftFlows, nil
 }
 
-func commonFlows(bridge *bridgeConfiguration) ([]string, error) {
+func commonFlows(subnets []*net.IPNet, bridge *bridgeConfiguration) ([]string, error) {
 	ofPortPhys := bridge.ofPortPhys
 	bridgeMacAddress := bridge.macAddress.String()
 	ofPortPatch := bridge.ofPortPatch
@@ -1508,6 +1508,36 @@ func commonFlows(bridge *bridgeConfiguration) ([]string, error) {
 		dftFlows = append(dftFlows,
 			fmt.Sprintf("cookie=%s, priority=50, in_port=%s, ipv6, "+
 				"actions=ct(zone=%d, nat, table=1)", defaultOpenFlowCookie, ofPortPhys, config.Default.ConntrackZone))
+	}
+
+	// Egress IP is often configured on a node different from the one hosting the affected pod.
+	// Due to the fact that ovn-controllers on different nodes apply the changes independently,
+	// there is a chance that the pod traffic will reach the egress node before it configures the SNAT flows.
+	// Drop pod traffic that is not SNATed, excluding local pods(required for ICNIv2)
+	if config.OVNKubernetesFeature.EnableEgressIP {
+		for _, clusterEntry := range config.Default.ClusterSubnets {
+			cidr := clusterEntry.CIDR
+			ipPrefix := "ip"
+			if utilnet.IsIPv6CIDR(cidr) {
+				ipPrefix = "ipv6"
+			}
+			// table 0, drop packets coming from pods headed externally that were not SNATed.
+			dftFlows = append(dftFlows,
+				fmt.Sprintf("cookie=%s, priority=104, in_port=%s, %s, %s_src=%s, actions=drop",
+					defaultOpenFlowCookie, ofPortPatch, ipPrefix, ipPrefix, cidr))
+		}
+		for _, subnet := range subnets {
+			ipPrefix := "ip"
+			if utilnet.IsIPv6CIDR(subnet) {
+				ipPrefix = "ipv6"
+			}
+			// table 0, commit connections from local pods.
+			// ICNIv2 requires that local pod traffic can leave the node without SNAT.
+			dftFlows = append(dftFlows,
+				fmt.Sprintf("cookie=%s, priority=109, in_port=%s, %s, %s_src=%s"+
+					"actions=ct(commit, zone=%d, exec(set_field:%s->ct_mark)), output:%s",
+					defaultOpenFlowCookie, ofPortPatch, ipPrefix, ipPrefix, subnet, config.Default.ConntrackZone, ctMarkOVN, ofPortPhys))
+		}
 	}
 
 	actions := fmt.Sprintf("output:%s", ofPortPatch)
@@ -1725,7 +1755,7 @@ func newSharedGateway(nodeName string, subnets []*net.IPNet, gwNextHops []net.IP
 			}
 		}
 
-		gw.openflowManager, err = newGatewayOpenFlowManager(gwBridge, exGwBridge, nodeIPs)
+		gw.openflowManager, err = newGatewayOpenFlowManager(gwBridge, exGwBridge, subnets, nodeIPs)
 		if err != nil {
 			return err
 		}
@@ -1733,7 +1763,7 @@ func newSharedGateway(nodeName string, subnets []*net.IPNet, gwNextHops []net.IP
 		// resync flows on IP change
 		gw.nodeIPManager.OnChanged = func() {
 			klog.V(5).Info("Node addresses changed, re-syncing bridge flows")
-			if err := gw.openflowManager.updateBridgeFlowCache(gw.nodeIPManager.ListAddresses()); err != nil {
+			if err := gw.openflowManager.updateBridgeFlowCache(subnets, gw.nodeIPManager.ListAddresses()); err != nil {
 				// very unlikely - somehow node has lost its IP address
 				klog.Errorf("Failed to re-generate gateway flows after address change: %v", err)
 			}


### PR DESCRIPTION
Clean backport of https://github.com/openshift/ovn-kubernetes/commit/39b55de034c7291122b3c9be7df0bf4323abe74d

Signed-off-by: Patryk Diak <pdiak@redhat.com>
(cherry picked from commit 39b55de034c7291122b3c9be7df0bf4323abe74d)
