### PR TITLE
OCPBUGS-13745: [release-4.13] ovnkube-master pod failed to reconnect to ovn db due to ssl expire

### DIFF
--- a/go-controller/pkg/libovsdb/libovsdb.go
+++ b/go-controller/pkg/libovsdb/libovsdb.go
@@ -6,6 +6,7 @@ import (
 	"crypto/x509"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"reflect"
 	"strings"
 	"time"
@@ -19,6 +20,7 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/prometheus/client_golang/prometheus"
 	"gopkg.in/fsnotify/fsnotify.v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 	"k8s.io/klog/v2/klogr"
 )
@@ -209,6 +211,22 @@ func newSSLKeyPairWatcherFunc(certFile, privKeyFile string, tlsConfig *tls.Confi
 			select {
 			case event, ok := <-watcher.Events:
 				if ok && event.Op&(fsnotify.Write|fsnotify.Remove) != 0 {
+					if event.Op&fsnotify.Remove != 0 {
+						// cert/key file removed, need wait for the file to be created again.
+						if err := wait.PollImmediate(10*time.Millisecond, 5*time.Second, func() (bool, error) {
+							if _, err := os.Stat(event.Name); os.IsNotExist(err) {
+								return false, nil
+							}
+							return true, nil
+						}); err != nil {
+							klog.Errorf("Fatal error: tiemout waiting for %s to be created", event.Name)
+							os.Exit(1)
+						}
+						if err := watcher.Add(event.Name); err != nil {
+							klog.Errorf("Cannot add %s back to watcher, err: %s", event.Name, err)
+							os.Exit(1)
+						}
+					}
 					cert, err := tls.LoadX509KeyPair(certFile, privKeyFile)
 					if err != nil {
 						klog.Infof("Cannot load new cert with cert %s key %s err %s", certFile, privKeyFile, err)
@@ -220,7 +238,7 @@ func newSSLKeyPairWatcherFunc(certFile, privKeyFile string, tlsConfig *tls.Confi
 					}
 					tlsConfig.Certificates = []tls.Certificate{cert}
 					client.Disconnect()
-					klog.Infof("TLS connection to %s force reconnected with new TLS config")
+					klog.Infof("TLS connection to %s force reconnected with new TLS config", client.Schema().Name)
 					// We do not call client.Connect() as reconnection is handled in the reconnect goroutine
 				}
 			case err, ok := <-watcher.Errors:


### PR DESCRIPTION
When the cert/key files got removed during cert/key update, With current code, libovsdb will only works for once with first remove event. To fix this issue, watcher need remove the old file and add new file back to watcher.

Signed-off-by: Zhen Wang <zhewang@nvidia.com>
(cherry picked from commit 702c7e3e39abc6a1f17af04f27bdf6f40cd11e9a)
