### PR TITLE
OCPBUGS-13885: [release-4.12] Drop packets that were not properly SNATed

### DIFF
--- a/go-controller/pkg/libovsdbops/router.go
+++ b/go-controller/pkg/libovsdbops/router.go
@@ -332,12 +332,12 @@ func DeleteLogicalRouterPoliciesWithPredicate(nbClient libovsdbclient.Client, ro
 	return err
 }
 
-// CreateOrAddNextHopsToLogicalRouterPolicyWithPredicate looks up a logical
+// CreateOrAddNextHopsToLogicalRouterPolicyWithPredicateOps looks up a logical
 // router policy from the cache based on a given predicate. If it doesn't find
 // any, it creates the provided logical router policy. If it does, adds any
 // missing Nexthops to the existing logical router policy. The logical router
-// policy is added to the provided logical router.
-func CreateOrAddNextHopsToLogicalRouterPolicyWithPredicate(nbClient libovsdbclient.Client, routerName string, lrp *nbdb.LogicalRouterPolicy, p logicalRouterPolicyPredicate) error {
+// policy is added to the provided logical router. Returns the corresponding ops
+func CreateOrAddNextHopsToLogicalRouterPolicyWithPredicateOps(nbClient libovsdbclient.Client, ops []libovsdb.Operation, routerName string, lrp *nbdb.LogicalRouterPolicy, p logicalRouterPolicyPredicate) ([]libovsdb.Operation, error) {
 	router := &nbdb.LogicalRouter{
 		Name: routerName,
 	}
@@ -361,8 +361,7 @@ func CreateOrAddNextHopsToLogicalRouterPolicyWithPredicate(nbClient libovsdbclie
 	}
 
 	m := newModelClient(nbClient)
-	_, err := m.CreateOrUpdate(opModels...)
-	return err
+	return m.CreateOrUpdateOps(ops, opModels...)
 }
 
 func deleteNextHopsFromLogicalRouterPolicyOps(nbClient libovsdbclient.Client, ops []libovsdb.Operation, routerName string, lrps []*nbdb.LogicalRouterPolicy, nextHops ...string) ([]libovsdb.Operation, error) {
@@ -448,7 +447,7 @@ func DeleteNextHopFromLogicalRouterPoliciesWithPredicateOps(nbClient libovsdbcli
 		return nil, err
 	}
 
-	return deleteNextHopsFromLogicalRouterPolicyOps(nbClient, nil, routerName, lrps, nextHop)
+	return deleteNextHopsFromLogicalRouterPolicyOps(nbClient, ops, routerName, lrps, nextHop)
 }
 
 // DeleteNextHopFromLogicalRouterPoliciesWithPredicate looks up a logical router

--- a/go-controller/pkg/node/gateway_init.go
+++ b/go-controller/pkg/node/gateway_init.go
@@ -296,8 +296,8 @@ func (n *OvnNode) initGateway(subnets []*net.IPNet, nodeAnnotator kube.Annotator
 		}
 	}
 
-	v4IfAddr, _ := util.MatchIPNetFamily(false, ifAddrs)
-	v6IfAddr, _ := util.MatchIPNetFamily(true, ifAddrs)
+	v4IfAddr, _ := util.MatchFirstIPNetFamily(false, ifAddrs)
+	v6IfAddr, _ := util.MatchFirstIPNetFamily(true, ifAddrs)
 
 	if err := util.SetNodePrimaryIfAddr(nodeAnnotator, v4IfAddr, v6IfAddr); err != nil {
 		klog.Errorf("Unable to set primary IP net label on node, err: %v", err)

--- a/go-controller/pkg/node/gateway_localnet.go
+++ b/go-controller/pkg/node/gateway_localnet.go
@@ -102,14 +102,14 @@ func newLocalGateway(nodeName string, hostSubnets []*net.IPNet, gwNextHops []net
 			return fmt.Errorf("failed to set the node masquerade route to OVN: %v", err)
 		}
 
-		gw.openflowManager, err = newGatewayOpenFlowManager(gwBridge, exGwBridge, gw.nodeIPManager.ListAddresses())
+		gw.openflowManager, err = newGatewayOpenFlowManager(gwBridge, exGwBridge, hostSubnets, gw.nodeIPManager.ListAddresses())
 		if err != nil {
 			return err
 		}
 		// resync flows on IP change
 		gw.nodeIPManager.OnChanged = func() {
 			klog.V(5).Info("Node addresses changed, re-syncing bridge flows")
-			if err := gw.openflowManager.updateBridgeFlowCache(gw.nodeIPManager.ListAddresses()); err != nil {
+			if err := gw.openflowManager.updateBridgeFlowCache(hostSubnets, gw.nodeIPManager.ListAddresses()); err != nil {
 				// very unlikely - somehow node has lost its IP address
 				klog.Errorf("Failed to re-generate gateway flows after address change: %v", err)
 			}

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -1069,7 +1069,7 @@ func flowsForDefaultBridge(bridge *bridgeConfiguration, extraIPs []net.IP) ([]st
 			fmt.Sprintf("cookie=%s, priority=200, in_port=%s, udp, udp_dst=%d, "+
 				"actions=output:%s", defaultOpenFlowCookie, ovsLocalPort, config.Default.EncapPort, ofPortPhys))
 
-		physicalIP, err := util.MatchIPNetFamily(false, bridgeIPs)
+		physicalIP, err := util.MatchFirstIPNetFamily(false, bridgeIPs)
 		if err != nil {
 			return nil, fmt.Errorf("unable to determine IPv4 physical IP of host: %v", err)
 		}
@@ -1125,7 +1125,7 @@ func flowsForDefaultBridge(bridge *bridgeConfiguration, extraIPs []net.IP) ([]st
 			fmt.Sprintf("cookie=%s, priority=200, in_port=%s, udp6, udp_dst=%d, "+
 				"actions=output:%s", defaultOpenFlowCookie, ovsLocalPort, config.Default.EncapPort, ofPortPhys))
 
-		physicalIP, err := util.MatchIPNetFamily(true, bridgeIPs)
+		physicalIP, err := util.MatchFirstIPNetFamily(true, bridgeIPs)
 		if err != nil {
 			return nil, fmt.Errorf("unable to determine IPv6 physical IP of host: %v", err)
 		}

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -1001,7 +1001,7 @@ func (npwipt *nodePortWatcherIptables) SyncServices(services []interface{}) erro
 //
 // -- to handle host -> service access, via masquerading from the host to OVN GR
 // -- to handle external -> service(ExternalTrafficPolicy: Local) -> host access without SNAT
-func newGatewayOpenFlowManager(gwBridge, exGWBridge *bridgeConfiguration, extraIPs []net.IP) (*openflowManager, error) {
+func newGatewayOpenFlowManager(gwBridge, exGWBridge *bridgeConfiguration, subnets []*net.IPNet, extraIPs []net.IP) (*openflowManager, error) {
 	// add health check function to check default OpenFlow flows are on the shared gateway bridge
 	ofm := &openflowManager{
 		defaultBridge:         gwBridge,
@@ -1013,7 +1013,7 @@ func newGatewayOpenFlowManager(gwBridge, exGWBridge *bridgeConfiguration, extraI
 		flowChan:              make(chan struct{}, 1),
 	}
 
-	if err := ofm.updateBridgeFlowCache(extraIPs); err != nil {
+	if err := ofm.updateBridgeFlowCache(subnets, extraIPs); err != nil {
 		return nil, err
 	}
 
@@ -1023,12 +1023,12 @@ func newGatewayOpenFlowManager(gwBridge, exGWBridge *bridgeConfiguration, extraI
 
 // updateBridgeFlowCache generates the "static" per-bridge flows
 // note: this is shared between shared and local gateway modes
-func (ofm *openflowManager) updateBridgeFlowCache(extraIPs []net.IP) error {
+func (ofm *openflowManager) updateBridgeFlowCache(subnets []*net.IPNet, extraIPs []net.IP) error {
 	dftFlows, err := flowsForDefaultBridge(ofm.defaultBridge, extraIPs)
 	if err != nil {
 		return err
 	}
-	dftCommonFlows := commonFlows(ofm.defaultBridge)
+	dftCommonFlows := commonFlows(subnets, ofm.defaultBridge)
 	dftFlows = append(dftFlows, dftCommonFlows...)
 
 	ofm.updateFlowCacheEntry("NORMAL", []string{fmt.Sprintf("table=0,priority=0,actions=%s\n", util.NormalAction)})
@@ -1037,7 +1037,7 @@ func (ofm *openflowManager) updateBridgeFlowCache(extraIPs []net.IP) error {
 	// we consume ex gw bridge flows only if that is enabled
 	if ofm.externalGatewayBridge != nil {
 		ofm.updateExBridgeFlowCacheEntry("NORMAL", []string{fmt.Sprintf("table=0,priority=0,actions=%s\n", util.NormalAction)})
-		exGWBridgeDftFlows := commonFlows(ofm.externalGatewayBridge)
+		exGWBridgeDftFlows := commonFlows(subnets, ofm.externalGatewayBridge)
 		ofm.updateExBridgeFlowCacheEntry("DEFAULT", exGWBridgeDftFlows)
 	}
 	return nil
@@ -1295,7 +1295,7 @@ func flowsForDefaultBridge(bridge *bridgeConfiguration, extraIPs []net.IP) ([]st
 	return dftFlows, nil
 }
 
-func commonFlows(bridge *bridgeConfiguration) []string {
+func commonFlows(subnets []*net.IPNet, bridge *bridgeConfiguration) []string {
 	ofPortPhys := bridge.ofPortPhys
 	bridgeMacAddress := bridge.macAddress.String()
 	ofPortPatch := bridge.ofPortPatch
@@ -1349,6 +1349,36 @@ func commonFlows(bridge *bridgeConfiguration) []string {
 		dftFlows = append(dftFlows,
 			fmt.Sprintf("cookie=%s, priority=50, in_port=%s, ipv6, "+
 				"actions=ct(zone=%d, table=1)", defaultOpenFlowCookie, ofPortPhys, config.Default.ConntrackZone))
+	}
+
+	// Egress IP is often configured on a node different from the one hosting the affected pod.
+	// Due to the fact that ovn-controllers on different nodes apply the changes independently,
+	// there is a chance that the pod traffic will reach the egress node before it configures the SNAT flows.
+	// Drop pod traffic that is not SNATed, excluding local pods(required for ICNIv2)
+	if config.OVNKubernetesFeature.EnableEgressIP {
+		for _, clusterEntry := range config.Default.ClusterSubnets {
+			cidr := clusterEntry.CIDR
+			ipPrefix := "ip"
+			if utilnet.IsIPv6CIDR(cidr) {
+				ipPrefix = "ipv6"
+			}
+			// table 0, drop packets coming from pods headed externally that were not SNATed.
+			dftFlows = append(dftFlows,
+				fmt.Sprintf("cookie=%s, priority=104, in_port=%s, %s, %s_src=%s, actions=drop",
+					defaultOpenFlowCookie, ofPortPatch, ipPrefix, ipPrefix, cidr))
+		}
+		for _, subnet := range subnets {
+			ipPrefix := "ip"
+			if utilnet.IsIPv6CIDR(subnet) {
+				ipPrefix = "ipv6"
+			}
+			// table 0, commit connections from local pods.
+			// ICNIv2 requires that local pod traffic can leave the node without SNAT.
+			dftFlows = append(dftFlows,
+				fmt.Sprintf("cookie=%s, priority=109, in_port=%s, %s, %s_src=%s"+
+					"actions=ct(commit, zone=%d, exec(set_field:%s->ct_mark)), output:%s",
+					defaultOpenFlowCookie, ofPortPatch, ipPrefix, ipPrefix, subnet, config.Default.ConntrackZone, ctMarkOVN, ofPortPhys))
+		}
 	}
 
 	actions := fmt.Sprintf("output:%s", ofPortPatch)
@@ -1566,7 +1596,7 @@ func newSharedGateway(nodeName string, subnets []*net.IPNet, gwNextHops []net.IP
 			}
 		}
 
-		gw.openflowManager, err = newGatewayOpenFlowManager(gwBridge, exGwBridge, nodeIPs)
+		gw.openflowManager, err = newGatewayOpenFlowManager(gwBridge, exGwBridge, subnets, nodeIPs)
 		if err != nil {
 			return err
 		}
@@ -1574,7 +1604,7 @@ func newSharedGateway(nodeName string, subnets []*net.IPNet, gwNextHops []net.IP
 		// resync flows on IP change
 		gw.nodeIPManager.OnChanged = func() {
 			klog.V(5).Info("Node addresses changed, re-syncing bridge flows")
-			if err := gw.openflowManager.updateBridgeFlowCache(gw.nodeIPManager.ListAddresses()); err != nil {
+			if err := gw.openflowManager.updateBridgeFlowCache(subnets, gw.nodeIPManager.ListAddresses()); err != nil {
 				// very unlikely - somehow node has lost its IP address
 				klog.Errorf("Failed to re-generate gateway flows after address change: %v", err)
 			}

--- a/go-controller/pkg/ovn/egressgw.go
+++ b/go-controller/pkg/ovn/egressgw.go
@@ -649,7 +649,7 @@ func (oc *Controller) addHybridRoutePolicyForPod(podIP net.IP, node string) erro
 		if err != nil {
 			return fmt.Errorf("unable to find IP address for node: %s, %s port, err: %v", node, types.GWRouterToJoinSwitchPrefix, err)
 		}
-		grJoinIfAddr, err := util.MatchIPNetFamily(utilnet.IsIPv6(podIP), grJoinIfAddrs)
+		grJoinIfAddr, err := util.MatchFirstIPNetFamily(utilnet.IsIPv6(podIP), grJoinIfAddrs)
 		if err != nil {
 			return fmt.Errorf("failed to match gateway router join interface IPs: %v, err: %v", grJoinIfAddr, err)
 		}

--- a/go-controller/pkg/ovn/egressgw.go
+++ b/go-controller/pkg/ovn/egressgw.go
@@ -525,7 +525,6 @@ func (oc *Controller) addGWRoutesForPod(gateways []*gatewayInfo, podIfAddrs []*n
 }
 
 // buildPodSNAT builds per pod SNAT rules towards the nodeIP that are applied to the GR where the pod resides
-// if allSNATs flag is set, then all the SNATs (including against egressIPs if any) for that pod will be returned
 func buildPodSNAT(extIPs, podIPNets []*net.IPNet) ([]*nbdb.NAT, error) {
 	nats := make([]*nbdb.NAT, 0, len(extIPs)*len(podIPNets))
 	var nat *nbdb.NAT
@@ -568,21 +567,35 @@ func getExternalIPsGR(watchFactory *factory.WatchFactory, nodeName string) ([]*n
 }
 
 // deletePodSNAT removes per pod SNAT rules towards the nodeIP that are applied to the GR where the pod resides
-// if allSNATs flag is set, then all the SNATs (including against egressIPs if any) for that pod will be deleted
 // used when disableSNATMultipleGWs=true
 func deletePodSNAT(nbClient libovsdbclient.Client, nodeName string, extIPs, podIPNets []*net.IPNet) error {
-	nats, err := buildPodSNAT(extIPs, podIPNets)
+	ops, err := deletePodSNATOps(nbClient, nil, nodeName, extIPs, podIPNets)
 	if err != nil {
 		return err
+	}
+
+	_, err = libovsdbops.TransactAndCheck(nbClient, ops)
+	if err != nil {
+		return fmt.Errorf("failed to delete SNAT rule for pod on gateway router %s: %w", types.GWRouterPrefix+nodeName, err)
+	}
+	return nil
+}
+
+// deletePodSNATOps creates ovsdb operation that removes per pod SNAT rules towards the nodeIP that are applied to the GR where the pod resides
+// used when disableSNATMultipleGWs=true
+func deletePodSNATOps(nbClient libovsdbclient.Client, ops []ovsdb.Operation, nodeName string, extIPs, podIPNets []*net.IPNet) ([]ovsdb.Operation, error) {
+	nats, err := buildPodSNAT(extIPs, podIPNets)
+	if err != nil {
+		return nil, err
 	}
 	logicalRouter := nbdb.LogicalRouter{
 		Name: types.GWRouterPrefix + nodeName,
 	}
-	err = libovsdbops.DeleteNATs(nbClient, &logicalRouter, nats...)
+	ops, err = libovsdbops.DeleteNATsOps(nbClient, ops, &logicalRouter, nats...)
 	if err != nil {
-		return fmt.Errorf("failed to delete SNAT rule for pod on gateway router %s: %v", logicalRouter.Name, err)
+		return nil, fmt.Errorf("failed create operation for deleting SNAT rule for pod on gateway router %s: %v", logicalRouter.Name, err)
 	}
-	return nil
+	return ops, nil
 }
 
 // addOrUpdatePodSNAT adds or updates per pod SNAT rules towards the nodeIP that are applied to the GR where the pod resides
@@ -601,17 +614,17 @@ func addOrUpdatePodSNAT(nbClient libovsdbclient.Client, nodeName string, extIPs,
 	return nil
 }
 
-// addOrUpdatePodSNATReturnOps returns the operation that adds or updates per pod SNAT rules towards the nodeIP that are
+// addOrUpdatePodSNATOps returns the operation that adds or updates per pod SNAT rules towards the nodeIP that are
 // applied to the GR where the pod resides
 // used when disableSNATMultipleGWs=true
-func (oc *Controller) addOrUpdatePodSNATReturnOps(nodeName string, extIPs, podIfAddrs []*net.IPNet, ops []ovsdb.Operation) ([]ovsdb.Operation, error) {
+func addOrUpdatePodSNATOps(nbClient libovsdbclient.Client, nodeName string, extIPs, podIfAddrs []*net.IPNet, ops []ovsdb.Operation) ([]ovsdb.Operation, error) {
 	gr := types.GWRouterPrefix + nodeName
 	router := &nbdb.LogicalRouter{Name: gr}
 	nats, err := buildPodSNAT(extIPs, podIfAddrs)
 	if err != nil {
 		return nil, err
 	}
-	if ops, err = libovsdbops.CreateOrUpdateNATsOps(oc.nbClient, ops, router, nats...); err != nil {
+	if ops, err = libovsdbops.CreateOrUpdateNATsOps(nbClient, ops, router, nats...); err != nil {
 		return nil, fmt.Errorf("failed to update SNAT for pods of router: %s, error: %v", gr, err)
 	}
 	return ops, nil

--- a/go-controller/pkg/ovn/egressip.go
+++ b/go-controller/pkg/ovn/egressip.go
@@ -1252,10 +1252,7 @@ func (oc *Controller) deletePodEgressIPAssignments(name string, statusesToRemove
 	}
 	for _, statusToRemove := range statusesToRemove {
 		klog.V(2).Infof("Deleting pod egress IP status: %v for EgressIP: %s and pod: %s/%s", statusToRemove, name, pod.Name, pod.Namespace)
-		if err := oc.eIPC.deletePodEgressIPAssignment(name, statusToRemove, podIPs); err != nil {
-			return err
-		}
-		if err := oc.eIPC.addExternalGWPodSNAT(pod.Namespace, pod.Name, statusToRemove); err != nil {
+		if err := oc.eIPC.deletePodEgressIPAssignment(name, statusToRemove, pod, podIPs); err != nil {
 			return err
 		}
 		delete(podStatus.egressStatuses, statusToRemove)
@@ -2181,24 +2178,29 @@ func (e *egressIPController) addPodEgressIPAssignment(egressIPName string, statu
 			metrics.RecordEgressIPAssign(duration)
 		}()
 	}
-	if err = e.deleteExternalGWPodSNAT(pod, podIPs, status); err != nil {
+
+	ops, err := createNATRuleOps(e.nbClient, nil, podIPs, status, egressIPName)
+	if err != nil {
+		return fmt.Errorf("unable to create NAT rule ops for status: %v, err: %v", status, err)
+	}
+
+	ops, err = e.createReroutePolicyOps(ops, podIPs, status, egressIPName)
+	if err != nil {
+		return fmt.Errorf("unable to create logical router policy ops, err: %v", err)
+	}
+
+	ops, err = e.deleteExternalGWPodSNATOps(ops, pod, podIPs, status)
+	if err != nil {
 		return err
 	}
-	if err = e.createReroutePolicy(podIPs, status, egressIPName); err != nil {
-		return fmt.Errorf("unable to create logical router policy, err: %v", err)
-	}
-	var ops []ovsdb.Operation
-	ops, err = createNATRuleOps(e.nbClient, podIPs, status, egressIPName)
-	if err != nil {
-		return fmt.Errorf("unable to create NAT rule for status: %v, err: %v", status, err)
-	}
+
 	_, err = libovsdbops.TransactAndCheck(e.nbClient, ops)
 	return err
 }
 
 // deletePodEgressIPAssignment deletes the OVN programmed egress IP
 // configuration mentioned for addPodEgressIPAssignment.
-func (e *egressIPController) deletePodEgressIPAssignment(egressIPName string, status egressipv1.EgressIPStatusItem, podIPs []*net.IPNet) (err error) {
+func (e *egressIPController) deletePodEgressIPAssignment(egressIPName string, status egressipv1.EgressIPStatusItem, pod *kapi.Pod, podIPs []*net.IPNet) (err error) {
 	if config.Metrics.EnableScaleMetrics {
 		start := time.Now()
 		defer func() {
@@ -2209,14 +2211,21 @@ func (e *egressIPController) deletePodEgressIPAssignment(egressIPName string, st
 			metrics.RecordEgressIPUnassign(duration)
 		}()
 	}
-	if err = e.deleteReroutePolicy(podIPs, status, egressIPName); errors.Is(err, libovsdbclient.ErrNotFound) {
+
+	ops, err := e.addExternalGWPodSNATOps(nil, pod.Namespace, pod.Name, status)
+	if err != nil {
+		return err
+	}
+
+	ops, err = e.deleteReroutePolicyOps(ops, podIPs, status, egressIPName)
+	if errors.Is(err, libovsdbclient.ErrNotFound) {
 		// if the gateway router join IP setup is already gone, then don't count it as error.
 		klog.Warningf("Unable to delete logical router policy, err: %v", err)
 	} else if err != nil {
 		return fmt.Errorf("unable to delete logical router policy, err: %v", err)
 	}
-	var ops []ovsdb.Operation
-	ops, err = deleteNATRuleOps(e.nbClient, []ovsdb.Operation{}, podIPs, status, egressIPName)
+
+	ops, err = deleteNATRuleOps(e.nbClient, ops, podIPs, status, egressIPName)
 	if err != nil {
 		return fmt.Errorf("unable to delete NAT rule for status: %v, err: %v", status, err)
 	}
@@ -2236,46 +2245,69 @@ func (e *egressIPController) deletePodEgressIPAssignment(egressIPName string, st
 // triggered after the update to the informer cache. We should not re-add the
 // external GW setup in those cases.
 func (e *egressIPController) addExternalGWPodSNAT(podNamespace, podName string, status egressipv1.EgressIPStatusItem) error {
+	ops, err := e.addExternalGWPodSNATOps(nil, podNamespace, podName, status)
+	if err != nil {
+		return fmt.Errorf("error creating ops for adding external gw pod snat: %+v", err)
+	}
+	_, err = libovsdbops.TransactAndCheck(e.nbClient, ops)
+	if err != nil {
+		return fmt.Errorf("error trasnsacting ops %+v: %v", ops, err)
+	}
+	return nil
+}
+
+// addExternalGWPodSNATOps returns ovsdb ops that perform the required external GW setup in two particular
+// cases:
+// - An egress IP matching pod stops matching by means of EgressIP object
+// deletion
+// - An egress IP matching pod stops matching by means of changed EgressIP
+// selector change.
+// In both cases we should re-add the external GW setup. We however need to
+// guard against a third case, which is: pod deletion, for that it's enough to
+// check the informer cache since on pod deletion the event handlers are
+// triggered after the update to the informer cache. We should not re-add the
+// external GW setup in those cases.
+func (e *egressIPController) addExternalGWPodSNATOps(ops []ovsdb.Operation, podNamespace, podName string, status egressipv1.EgressIPStatusItem) ([]ovsdb.Operation, error) {
 	if config.Gateway.DisableSNATMultipleGWs {
 		if pod, err := e.watchFactory.GetPod(podNamespace, podName); err == nil && pod.Spec.NodeName == status.Node {
 			// if the pod still exists, add snats to->nodeIP (on the node where the pod exists) for these podIPs after deleting the snat to->egressIP
 			// NOTE: This needs to be done only if the pod was on the same node as egressNode
 			extIPs, err := getExternalIPsGR(e.watchFactory, pod.Spec.NodeName)
 			if err != nil {
-				return err
+				return nil, err
 			}
 			podIPs, err := util.GetPodCIDRsWithFullMask(pod)
 			if err != nil {
-				return err
+				return nil, err
 			}
-			err = addOrUpdatePodSNAT(e.nbClient, pod.Spec.NodeName, extIPs, podIPs)
+			ops, err = addOrUpdatePodSNATOps(e.nbClient, pod.Spec.NodeName, extIPs, podIPs, ops)
 			if err != nil {
-				return err
+				return nil, err
 			}
 			klog.V(5).Infof("Adding SNAT on %s since egress node managing %s/%s was the same: %s", pod.Spec.NodeName, pod.Namespace, pod.Name, status.Node)
 		}
 	}
-	return nil
+	return ops, nil
 }
 
-// deleteExternalGWPodSNAT performs the required external GW teardown for the given pod
-func (e *egressIPController) deleteExternalGWPodSNAT(pod *kapi.Pod, podIPs []*net.IPNet, status egressipv1.EgressIPStatusItem) error {
+// deleteExternalGWPodSNATOps creates ops for the required external GW teardown for the given pod
+func (e *egressIPController) deleteExternalGWPodSNATOps(ops []ovsdb.Operation, pod *kapi.Pod, podIPs []*net.IPNet, status egressipv1.EgressIPStatusItem) ([]ovsdb.Operation, error) {
 	if config.Gateway.DisableSNATMultipleGWs && status.Node == pod.Spec.NodeName {
 		// remove snats to->nodeIP (from the node where pod exists if that node is also serving
 		// as an egress node for this pod) for these podIPs before adding the snat to->egressIP
 		extIPs, err := getExternalIPsGR(e.watchFactory, pod.Spec.NodeName)
 		if err != nil {
-			return err
+			return nil, err
 		}
-		err = deletePodSNAT(e.nbClient, pod.Spec.NodeName, extIPs, podIPs)
+		ops, err = deletePodSNATOps(e.nbClient, ops, pod.Spec.NodeName, extIPs, podIPs)
 		if err != nil {
-			return err
+			return nil, err
 		}
 	} else if config.Gateway.DisableSNATMultipleGWs {
 		// it means the pod host is different from the egressNode that is managing the pod
 		klog.V(5).Infof("Not deleting SNAT on %s since egress node managing %s/%s is %s", pod.Spec.NodeName, pod.Namespace, pod.Name, status.Node)
 	}
-	return nil
+	return ops, nil
 }
 
 func (e *egressIPController) getGatewayRouterJoinIP(node string, wantsIPv6 bool) (net.IP, error) {
@@ -2298,7 +2330,7 @@ func ipFamilyName(isIPv6 bool) string {
 	return "ip4"
 }
 
-// createReroutePolicy performs idempotent updates of the
+// createReroutePolicyOps creates an operation that does idempotent updates of the
 // LogicalRouterPolicy corresponding to the egressIP status item, according to the
 // following update procedure:
 // - if the LogicalRouterPolicy does not exist: it adds it by creating the
@@ -2306,11 +2338,11 @@ func ipFamilyName(isIPv6 bool) string {
 // to equal [gatewayRouterIP]
 // - if the LogicalRouterPolicy does exist: it adds the gatewayRouterIP to the
 // array of nexthops
-func (e *egressIPController) createReroutePolicy(podIPNets []*net.IPNet, status egressipv1.EgressIPStatusItem, egressIPName string) error {
+func (e *egressIPController) createReroutePolicyOps(ops []ovsdb.Operation, podIPNets []*net.IPNet, status egressipv1.EgressIPStatusItem, egressIPName string) ([]ovsdb.Operation, error) {
 	isEgressIPv6 := utilnet.IsIPv6String(status.EgressIP)
 	gatewayRouterIP, err := e.getGatewayRouterJoinIP(status.Node, isEgressIPv6)
 	if err != nil {
-		return fmt.Errorf("unable to retrieve gateway IP for node: %s, protocol is IPv6: %v, err: %w", status.Node, isEgressIPv6, err)
+		return nil, fmt.Errorf("unable to retrieve gateway IP for node: %s, protocol is IPv6: %v, err: %w", status.Node, isEgressIPv6, err)
 	}
 
 	// Handle all pod IPs that match the egress IP address family
@@ -2328,26 +2360,26 @@ func (e *egressIPController) createReroutePolicy(podIPNets []*net.IPNet, status 
 			return item.Match == lrp.Match && item.Priority == lrp.Priority && item.ExternalIDs["name"] == lrp.ExternalIDs["name"]
 		}
 
-		err := libovsdbops.CreateOrAddNextHopsToLogicalRouterPolicyWithPredicate(e.nbClient, types.OVNClusterRouter, &lrp, p)
+		ops, err = libovsdbops.CreateOrAddNextHopsToLogicalRouterPolicyWithPredicateOps(e.nbClient, ops, types.OVNClusterRouter, &lrp, p)
 		if err != nil {
-			return fmt.Errorf("error creating logical router policy %+v on router %s: %v", lrp, types.OVNClusterRouter, err)
+			return nil, fmt.Errorf("error creating logical router policy %+v on router %s: %v", lrp, types.OVNClusterRouter, err)
 		}
 	}
-	return nil
+	return ops, nil
 }
 
-// deleteReroutePolicy performs idempotent updates of the
+// deleteReroutePolicyOps creates an operation that does idempotent updates of the
 // LogicalRouterPolicy corresponding to the egressIP object, according to the
 // following update procedure:
 // - if the LogicalRouterPolicy exist and has the len(nexthops) > 1: it removes
 // the specified gatewayRouterIP from nexthops
 // - if the LogicalRouterPolicy exist and has the len(nexthops) == 1: it removes
 // the LogicalRouterPolicy completely
-func (e *egressIPController) deleteReroutePolicy(podIPNets []*net.IPNet, status egressipv1.EgressIPStatusItem, egressIPName string) error {
+func (e *egressIPController) deleteReroutePolicyOps(ops []ovsdb.Operation, podIPNets []*net.IPNet, status egressipv1.EgressIPStatusItem, egressIPName string) ([]ovsdb.Operation, error) {
 	isEgressIPv6 := utilnet.IsIPv6String(status.EgressIP)
 	gatewayRouterIP, err := e.getGatewayRouterJoinIP(status.Node, isEgressIPv6)
 	if err != nil {
-		return fmt.Errorf("unable to retrieve gateway IP for node: %s, protocol is IPv6: %v, err: %w", status.Node, isEgressIPv6, err)
+		return nil, fmt.Errorf("unable to retrieve gateway IP for node: %s, protocol is IPv6: %v, err: %w", status.Node, isEgressIPv6, err)
 	}
 
 	// Handle all pod IPs that match the egress IP address family
@@ -2356,13 +2388,13 @@ func (e *egressIPController) deleteReroutePolicy(podIPNets []*net.IPNet, status 
 		p := func(item *nbdb.LogicalRouterPolicy) bool {
 			return item.Match == filterOption && item.Priority == types.EgressIPReroutePriority && item.ExternalIDs["name"] == egressIPName
 		}
-		err := libovsdbops.DeleteNextHopFromLogicalRouterPoliciesWithPredicate(e.nbClient, types.OVNClusterRouter, p, gatewayRouterIP.String())
+		ops, err = libovsdbops.DeleteNextHopFromLogicalRouterPoliciesWithPredicateOps(e.nbClient, ops, types.OVNClusterRouter, p, gatewayRouterIP.String())
 		if err != nil {
-			return fmt.Errorf("error removing nexthop IP %s from egress ip %s policies on router %s: %v",
+			return nil, fmt.Errorf("error removing nexthop IP %s from egress ip %s policies on router %s: %v",
 				gatewayRouterIP, egressIPName, types.OVNClusterRouter, err)
 		}
 	}
-	return nil
+	return ops, nil
 }
 
 // deleteEgressIPStatusSetup deletes the entire set up in the NB DB for an
@@ -2712,7 +2744,7 @@ func buildSNATFromEgressIPStatus(podIP net.IP, status egressipv1.EgressIPStatusI
 	return nat, nil
 }
 
-func createNATRuleOps(nbClient libovsdbclient.Client, podIPs []*net.IPNet, status egressipv1.EgressIPStatusItem, egressIPName string) ([]ovsdb.Operation, error) {
+func createNATRuleOps(nbClient libovsdbclient.Client, ops []ovsdb.Operation, podIPs []*net.IPNet, status egressipv1.EgressIPStatusItem, egressIPName string) ([]ovsdb.Operation, error) {
 	nats := make([]*nbdb.NAT, 0, len(podIPs))
 	var nat *nbdb.NAT
 	var err error
@@ -2728,7 +2760,7 @@ func createNATRuleOps(nbClient libovsdbclient.Client, podIPs []*net.IPNet, statu
 	router := &nbdb.LogicalRouter{
 		Name: util.GetGatewayRouterFromNode(status.Node),
 	}
-	ops, err := libovsdbops.CreateOrUpdateNATsOps(nbClient, []ovsdb.Operation{}, router, nats...)
+	ops, err = libovsdbops.CreateOrUpdateNATsOps(nbClient, ops, router, nats...)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create snat rules, for router: %s, error: %v", router.Name, err)
 	}

--- a/go-controller/pkg/ovn/egressip.go
+++ b/go-controller/pkg/ovn/egressip.go
@@ -2184,7 +2184,7 @@ func (e *egressIPController) addPodEgressIPAssignment(egressIPName string, statu
 	if err = e.deleteExternalGWPodSNAT(pod, podIPs, status); err != nil {
 		return err
 	}
-	if err = e.handleEgressReroutePolicy(podIPs, status, egressIPName, e.createEgressReroutePolicy); err != nil {
+	if err = e.createReroutePolicy(podIPs, status, egressIPName); err != nil {
 		return fmt.Errorf("unable to create logical router policy, err: %v", err)
 	}
 	var ops []ovsdb.Operation
@@ -2209,7 +2209,7 @@ func (e *egressIPController) deletePodEgressIPAssignment(egressIPName string, st
 			metrics.RecordEgressIPUnassign(duration)
 		}()
 	}
-	if err = e.handleEgressReroutePolicy(podIPs, status, egressIPName, e.deleteEgressReroutePolicy); errors.Is(err, libovsdbclient.ErrNotFound) {
+	if err = e.deleteReroutePolicy(podIPs, status, egressIPName); errors.Is(err, libovsdbclient.ErrNotFound) {
 		// if the gateway router join IP setup is already gone, then don't count it as error.
 		klog.Warningf("Unable to delete logical router policy, err: %v", err)
 	} else if err != nil {
@@ -2272,7 +2272,7 @@ func (e *egressIPController) deleteExternalGWPodSNAT(pod *kapi.Pod, podIPs []*ne
 			return err
 		}
 	} else if config.Gateway.DisableSNATMultipleGWs {
-		// it means the node on which the pod is is different from the egressNode that is managing the pod
+		// it means the pod host is different from the egressNode that is managing the pod
 		klog.V(5).Infof("Not deleting SNAT on %s since egress node managing %s/%s is %s", pod.Spec.NodeName, pod.Namespace, pod.Name, status.Node)
 	}
 	return nil
@@ -2290,83 +2290,78 @@ func (e *egressIPController) getGatewayRouterJoinIP(node string, wantsIPv6 bool)
 	}
 }
 
-// createEgressReroutePolicy uses logical router policies to force egress traffic to the egress node, for that we need
-// to retrive the internal gateway router IP attached to the egress node. This method handles both the shared and
-// local gateway mode case
-func (e *egressIPController) handleEgressReroutePolicy(podIPNets []*net.IPNet, status egressipv1.EgressIPStatusItem, egressIPName string, cb func(filterOption, egressIPName string, gatewayRouterIP string) error) error {
-	gatewayRouterIPv4, gatewayRouterIPv6 := "", ""
+// ipFamilyName returns IP family name based on the provided flag
+func ipFamilyName(isIPv6 bool) string {
+	if isIPv6 {
+		return "ip6"
+	}
+	return "ip4"
+}
+
+// createReroutePolicy performs idempotent updates of the
+// LogicalRouterPolicy corresponding to the egressIP status item, according to the
+// following update procedure:
+// - if the LogicalRouterPolicy does not exist: it adds it by creating the
+// reference to it from ovn_cluster_router and specifying the array of nexthops
+// to equal [gatewayRouterIP]
+// - if the LogicalRouterPolicy does exist: it adds the gatewayRouterIP to the
+// array of nexthops
+func (e *egressIPController) createReroutePolicy(podIPNets []*net.IPNet, status egressipv1.EgressIPStatusItem, egressIPName string) error {
 	isEgressIPv6 := utilnet.IsIPv6String(status.EgressIP)
 	gatewayRouterIP, err := e.getGatewayRouterJoinIP(status.Node, isEgressIPv6)
 	if err != nil {
 		return fmt.Errorf("unable to retrieve gateway IP for node: %s, protocol is IPv6: %v, err: %w", status.Node, isEgressIPv6, err)
 	}
-	if isEgressIPv6 {
-		gatewayRouterIPv6 = gatewayRouterIP.String()
-	} else {
-		gatewayRouterIPv4 = gatewayRouterIP.String()
-	}
-	for _, podIPNet := range podIPNets {
-		podIP := podIPNet.IP
-		if utilnet.IsIPv6(podIP) && gatewayRouterIPv6 != "" {
-			filterOption := fmt.Sprintf("ip6.src == %s", podIP.String())
-			if err := cb(filterOption, egressIPName, gatewayRouterIPv6); err != nil {
-				return err
-			}
-		} else if !utilnet.IsIPv6(podIP) && gatewayRouterIPv4 != "" {
-			filterOption := fmt.Sprintf("ip4.src == %s", podIP.String())
-			if err := cb(filterOption, egressIPName, gatewayRouterIPv4); err != nil {
-				return err
-			}
+
+	// Handle all pod IPs that match the egress IP address family
+	for _, podIPNet := range util.MatchAllIPNetFamily(isEgressIPv6, podIPNets) {
+		lrp := nbdb.LogicalRouterPolicy{
+			Match:    fmt.Sprintf("%s.src == %s", ipFamilyName(isEgressIPv6), podIPNet.IP.String()),
+			Priority: types.EgressIPReroutePriority,
+			Nexthops: []string{gatewayRouterIP.String()},
+			Action:   nbdb.LogicalRouterPolicyActionReroute,
+			ExternalIDs: map[string]string{
+				"name": egressIPName,
+			},
+		}
+		p := func(item *nbdb.LogicalRouterPolicy) bool {
+			return item.Match == lrp.Match && item.Priority == lrp.Priority && item.ExternalIDs["name"] == lrp.ExternalIDs["name"]
+		}
+
+		err := libovsdbops.CreateOrAddNextHopsToLogicalRouterPolicyWithPredicate(e.nbClient, types.OVNClusterRouter, &lrp, p)
+		if err != nil {
+			return fmt.Errorf("error creating logical router policy %+v on router %s: %v", lrp, types.OVNClusterRouter, err)
 		}
 	}
 	return nil
 }
 
-// createEgressReroutePolicy performs idempotent updates of the
-// LogicalRouterPolicy corresponding to the egressIP object, according to the
-// following update procedure:
-// - if the LogicalRouterPolicy does not exist: it adds it by creating the
-// reference to it from ovn_cluster_router and specifying the array of nexthops
-// to equal [gatewayRouterIP]
-// - if the LogicalRouterPolicy does exist: it add the gatewayRouterIP to the
-// array of nexthops
-func (e *egressIPController) createEgressReroutePolicy(filterOption, egressIPName string, gatewayRouterIP string) error {
-	lrp := nbdb.LogicalRouterPolicy{
-		Match:    filterOption,
-		Priority: types.EgressIPReroutePriority,
-		Nexthops: []string{gatewayRouterIP},
-		Action:   nbdb.LogicalRouterPolicyActionReroute,
-		ExternalIDs: map[string]string{
-			"name": egressIPName,
-		},
-	}
-	p := func(item *nbdb.LogicalRouterPolicy) bool {
-		return item.Match == lrp.Match && item.Priority == lrp.Priority && item.ExternalIDs["name"] == lrp.ExternalIDs["name"]
-	}
-	err := libovsdbops.CreateOrAddNextHopsToLogicalRouterPolicyWithPredicate(e.nbClient, types.OVNClusterRouter, &lrp, p)
-	if err != nil {
-		return fmt.Errorf("error creating logical router policy %+v on router %s: %v", lrp, types.OVNClusterRouter, err)
-	}
-	return nil
-}
-
-// deleteEgressReroutePolicy performs idempotent updates of the
+// deleteReroutePolicy performs idempotent updates of the
 // LogicalRouterPolicy corresponding to the egressIP object, according to the
 // following update procedure:
 // - if the LogicalRouterPolicy exist and has the len(nexthops) > 1: it removes
 // the specified gatewayRouterIP from nexthops
 // - if the LogicalRouterPolicy exist and has the len(nexthops) == 1: it removes
 // the LogicalRouterPolicy completely
-func (e *egressIPController) deleteEgressReroutePolicy(filterOption, egressIPName string, gatewayRouterIP string) error {
-	p := func(item *nbdb.LogicalRouterPolicy) bool {
-		return item.Match == filterOption && item.Priority == types.EgressIPReroutePriority && item.ExternalIDs["name"] == egressIPName
-	}
-	err := libovsdbops.DeleteNextHopFromLogicalRouterPoliciesWithPredicate(e.nbClient, types.OVNClusterRouter, p, gatewayRouterIP)
+func (e *egressIPController) deleteReroutePolicy(podIPNets []*net.IPNet, status egressipv1.EgressIPStatusItem, egressIPName string) error {
+	isEgressIPv6 := utilnet.IsIPv6String(status.EgressIP)
+	gatewayRouterIP, err := e.getGatewayRouterJoinIP(status.Node, isEgressIPv6)
 	if err != nil {
-		return fmt.Errorf("error removing nexthop IP %s from egress ip %s policies on router %s: %v",
-			gatewayRouterIP, egressIPName, types.OVNClusterRouter, err)
+		return fmt.Errorf("unable to retrieve gateway IP for node: %s, protocol is IPv6: %v, err: %w", status.Node, isEgressIPv6, err)
 	}
 
+	// Handle all pod IPs that match the egress IP address family
+	for _, podIPNet := range util.MatchAllIPNetFamily(isEgressIPv6, podIPNets) {
+		filterOption := fmt.Sprintf("%s.src == %s", ipFamilyName(isEgressIPv6), podIPNet.IP.String())
+		p := func(item *nbdb.LogicalRouterPolicy) bool {
+			return item.Match == filterOption && item.Priority == types.EgressIPReroutePriority && item.ExternalIDs["name"] == egressIPName
+		}
+		err := libovsdbops.DeleteNextHopFromLogicalRouterPoliciesWithPredicate(e.nbClient, types.OVNClusterRouter, p, gatewayRouterIP.String())
+		if err != nil {
+			return fmt.Errorf("error removing nexthop IP %s from egress ip %s policies on router %s: %v",
+				gatewayRouterIP, egressIPName, types.OVNClusterRouter, err)
+		}
+	}
 	return nil
 }
 

--- a/go-controller/pkg/ovn/egressip.go
+++ b/go-controller/pkg/ovn/egressip.go
@@ -2283,7 +2283,7 @@ func (e *egressIPController) getGatewayRouterJoinIP(node string, wantsIPv6 bool)
 	if err != nil {
 		return nil, fmt.Errorf("attempt at finding node gateway router network information failed, err: %w", err)
 	}
-	if gatewayIP, err := util.MatchIPNetFamily(wantsIPv6, gatewayIPs); err != nil {
+	if gatewayIP, err := util.MatchFirstIPNetFamily(wantsIPv6, gatewayIPs); err != nil {
 		return nil, fmt.Errorf("could not find node %s gateway router: %v", node, err)
 	} else {
 		return gatewayIP.IP, nil

--- a/go-controller/pkg/ovn/egressip_test.go
+++ b/go-controller/pkg/ovn/egressip_test.go
@@ -5873,6 +5873,14 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 							&nbdb.LogicalRouter{
 								Name: types.OVNClusterRouter,
 							},
+							&nbdb.LogicalRouter{
+								Name: ovntypes.GWRouterPrefix + node1.Name,
+								UUID: ovntypes.GWRouterPrefix + node1.Name + "-UUID",
+							},
+							&nbdb.LogicalRouter{
+								Name: ovntypes.GWRouterPrefix + node2.Name,
+								UUID: ovntypes.GWRouterPrefix + node2.Name + "-UUID",
+							},
 							&nbdb.LogicalRouterPort{
 								UUID:     ovntypes.GWRouterToJoinSwitchPrefix + ovntypes.GWRouterPrefix + node1.Name + "-UUID",
 								Name:     ovntypes.GWRouterToJoinSwitchPrefix + ovntypes.GWRouterPrefix + node1.Name,
@@ -5930,6 +5938,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 
 				gomega.Eventually(getEgressIPStatusLen(egressIPName)).Should(gomega.Equal(1))
 				gomega.Eventually(getEgressIPReassignmentCount).Should(gomega.Equal(0))
+				expectedNatLogicalPort := "k8s-node2"
 				expectedDatabaseState := []libovsdbtest.TestData{
 					&nbdb.LogicalRouterPolicy{
 						Priority: types.DefaultNoRereoutePriority,
@@ -5953,10 +5962,32 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						},
 						UUID: "reroute-UUID",
 					},
+					&nbdb.NAT{
+						UUID:       "egressip-nat-UUID",
+						LogicalIP:  podV4IP,
+						ExternalIP: egressIP1,
+						ExternalIDs: map[string]string{
+							"name": egressIPName,
+						},
+						Type:        nbdb.NATTypeSNAT,
+						LogicalPort: &expectedNatLogicalPort,
+						Options: map[string]string{
+							"stateless": "false",
+						},
+					},
 					&nbdb.LogicalRouter{
 						Name:     ovntypes.OVNClusterRouter,
 						UUID:     ovntypes.OVNClusterRouter + "-UUID",
 						Policies: []string{"reroute-UUID", "default-no-reroute-UUID", "no-reroute-service-UUID"},
+					},
+					&nbdb.LogicalRouter{
+						Name: ovntypes.GWRouterPrefix + node1.Name,
+						UUID: ovntypes.GWRouterPrefix + node1.Name + "-UUID",
+					},
+					&nbdb.LogicalRouter{
+						Name: ovntypes.GWRouterPrefix + node2.Name,
+						UUID: ovntypes.GWRouterPrefix + node2.Name + "-UUID",
+						Nat:  []string{"egressip-nat-UUID"},
 					},
 					&nbdb.LogicalRouterPort{
 						UUID:     ovntypes.GWRouterToJoinSwitchPrefix + ovntypes.GWRouterPrefix + node2.Name + "-UUID",

--- a/go-controller/pkg/ovn/gateway_init.go
+++ b/go-controller/pkg/ovn/gateway_init.go
@@ -202,7 +202,7 @@ func (oc *Controller) gatewayInit(nodeName string, clusterIPSubnet []*net.IPNet,
 	}
 
 	for _, entry := range clusterIPSubnet {
-		drLRPIfAddr, err := util.MatchIPNetFamily(utilnet.IsIPv6CIDR(entry), drLRPIfAddrs)
+		drLRPIfAddr, err := util.MatchFirstIPNetFamily(utilnet.IsIPv6CIDR(entry), drLRPIfAddrs)
 		if err != nil {
 			return fmt.Errorf("failed to add a static route in GR %s with distributed "+
 				"router as the nexthop: %v",

--- a/go-controller/pkg/ovn/gateway_test.go
+++ b/go-controller/pkg/ovn/gateway_test.go
@@ -102,7 +102,7 @@ func generateGatewayInitExpectedNB(testData []libovsdb.TestData, expectedOVNClus
 		} else {
 			hasIPv4 = true
 		}
-		nexthop, _ := util.MatchIPNetFamily(utilnet.IsIPv6CIDR(subnet), defLRPIPs)
+		nexthop, _ := util.MatchFirstIPNetFamily(utilnet.IsIPv6CIDR(subnet), defLRPIPs)
 		grStaticRouteNamedUUID := fmt.Sprintf("static-subnet-route-%v-UUID", i)
 		grStaticRoutes = append(grStaticRoutes, grStaticRouteNamedUUID)
 		testData = append(testData, &nbdb.LogicalRouterStaticRoute{
@@ -114,7 +114,7 @@ func generateGatewayInitExpectedNB(testData []libovsdb.TestData, expectedOVNClus
 	}
 	if config.Gateway.Mode == config.GatewayModeShared {
 		for i, hostSubnet := range hostSubnets {
-			joinLRPIP, _ := util.MatchIPNetFamily(utilnet.IsIPv6CIDR(hostSubnet), joinLRPIPs)
+			joinLRPIP, _ := util.MatchFirstIPNetFamily(utilnet.IsIPv6CIDR(hostSubnet), joinLRPIPs)
 			ocrStaticRouteNamedUUID := fmt.Sprintf("subnet-static-route-ovn-cluster-router-%v-UUID", i)
 			expectedOVNClusterRouter.StaticRoutes = append(expectedOVNClusterRouter.StaticRoutes, ocrStaticRouteNamedUUID)
 			testData = append(testData, &nbdb.LogicalRouterStaticRoute{
@@ -200,7 +200,7 @@ func generateGatewayInitExpectedNB(testData []libovsdb.TestData, expectedOVNClus
 		for i, subnet := range clusterIPSubnets {
 			natUUID := fmt.Sprintf("nat-%d-UUID", i)
 			natUUIDs = append(natUUIDs, natUUID)
-			physicalIP, _ := util.MatchIPNetFamily(utilnet.IsIPv6CIDR(subnet), l3GatewayConfig.IPAddresses)
+			physicalIP, _ := util.MatchFirstIPNetFamily(utilnet.IsIPv6CIDR(subnet), l3GatewayConfig.IPAddresses)
 			testData = append(testData, &nbdb.NAT{
 				UUID:       natUUID,
 				ExternalIP: physicalIP.IP.String(),

--- a/go-controller/pkg/ovn/hybrid.go
+++ b/go-controller/pkg/ovn/hybrid.go
@@ -238,7 +238,7 @@ func (oc *Controller) setupHybridLRPolicySharedGw(nodeSubnets []*net.IPNet, node
 			if err != nil {
 				return err
 			}
-			gwLRPIfAddr, err := util.MatchIPNetFamily(utilnet.IsIPv6CIDR(hybridCIDR), gwLRPIfAddrs)
+			gwLRPIfAddr, err := util.MatchFirstIPNetFamily(utilnet.IsIPv6CIDR(hybridCIDR), gwLRPIfAddrs)
 			if err != nil {
 				return err
 			}
@@ -289,7 +289,7 @@ func (oc *Controller) setupHybridLRPolicySharedGw(nodeSubnets []*net.IPNet, node
 			if err != nil {
 				return err
 			}
-			drLRPIfAddr, err := util.MatchIPNetFamily(utilnet.IsIPv6CIDR(hybridCIDR), drLRPIfAddrs)
+			drLRPIfAddr, err := util.MatchFirstIPNetFamily(utilnet.IsIPv6CIDR(hybridCIDR), drLRPIfAddrs)
 			if err != nil {
 				return fmt.Errorf("failed to match cluster router join interface IPs: %v, err: %v", drLRPIfAddr, err)
 			}

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -578,7 +578,7 @@ func (oc *Controller) syncGatewayLogicalNetwork(node *kapi.Node, l3GatewayConfig
 
 	for _, subnet := range hostSubnets {
 		hostIfAddr := util.GetNodeManagementIfAddr(subnet)
-		l3GatewayConfigIP, err := util.MatchIPNetFamily(utilnet.IsIPv6(hostIfAddr.IP), l3GatewayConfig.IPAddresses)
+		l3GatewayConfigIP, err := util.MatchFirstIPNetFamily(utilnet.IsIPv6(hostIfAddr.IP), l3GatewayConfig.IPAddresses)
 		if err != nil {
 			return err
 		}

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -419,7 +419,7 @@ func (oc *Controller) addRoutesGatewayIP(pod *kapi.Pod, podAnnotation *util.PodA
 
 	for _, podIfAddr := range podAnnotation.IPs {
 		isIPv6 := utilnet.IsIPv6CIDR(podIfAddr)
-		nodeSubnet, err := util.MatchIPNetFamily(isIPv6, nodeSubnets)
+		nodeSubnet, err := util.MatchFirstIPNetFamily(isIPv6, nodeSubnets)
 		if err != nil {
 			return err
 		}

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -741,7 +741,7 @@ func (oc *Controller) addLogicalPort(pod *kapi.Pod) (err error) {
 		// namespace annotations to go through external egress router
 		if extIPs, err := getExternalIPsGR(oc.watchFactory, pod.Spec.NodeName); err != nil {
 			return err
-		} else if ops, err = oc.addOrUpdatePodSNATReturnOps(pod.Spec.NodeName, extIPs, podIfAddrs, ops); err != nil {
+		} else if ops, err = addOrUpdatePodSNATOps(oc.nbClient, pod.Spec.NodeName, extIPs, podIfAddrs, ops); err != nil {
 			return err
 		}
 	}

--- a/go-controller/pkg/util/net.go
+++ b/go-controller/pkg/util/net.go
@@ -251,9 +251,9 @@ func MatchFirstIPFamily(isIPv6 bool, ips []net.IP) (net.IP, error) {
 	return nil, fmt.Errorf("no %s IP available", IPFamilyName(isIPv6))
 }
 
-// MatchIPNetFamily loops through the array of *net.IPNet and returns the
+// MatchFirstIPNetFamily loops through the array of ipnets and returns the
 // first entry in the list in the same IP Family, based on input flag isIPv6.
-func MatchIPNetFamily(isIPv6 bool, ipnets []*net.IPNet) (*net.IPNet, error) {
+func MatchFirstIPNetFamily(isIPv6 bool, ipnets []*net.IPNet) (*net.IPNet, error) {
 	for _, ipnet := range ipnets {
 		if utilnet.IsIPv6CIDR(ipnet) == isIPv6 {
 			return ipnet, nil

--- a/go-controller/pkg/util/net.go
+++ b/go-controller/pkg/util/net.go
@@ -262,6 +262,18 @@ func MatchFirstIPNetFamily(isIPv6 bool, ipnets []*net.IPNet) (*net.IPNet, error)
 	return nil, fmt.Errorf("no %s value available", IPFamilyName(isIPv6))
 }
 
+// MatchAllIPNetFamily loops through the array of *net.IPNet and returns a
+// slice of ipnets with the same IP Family, based on input flag isIPv6.
+func MatchAllIPNetFamily(isIPv6 bool, ipnets []*net.IPNet) []*net.IPNet {
+	var ret []*net.IPNet
+	for _, ipnet := range ipnets {
+		if utilnet.IsIPv6CIDR(ipnet) == isIPv6 {
+			ret = append(ret, ipnet)
+		}
+	}
+	return ret
+}
+
 // MatchIPStringFamily loops through the array of string and returns the
 // first entry in the list in the same IP Family, based on input flag isIPv6.
 func MatchIPStringFamily(isIPv6 bool, ipStrings []string) (string, error) {

--- a/go-controller/pkg/util/net_unit_test.go
+++ b/go-controller/pkg/util/net_unit_test.go
@@ -281,7 +281,7 @@ func TestMatchIPFamily(t *testing.T) {
 	}
 }
 
-func TestMatchIPNetFamily(t *testing.T) {
+func TestMatchFirstIPNetFamily(t *testing.T) {
 	tests := []struct {
 		desc       string
 		inpIsIPv6  bool // true matches with IPv6 and false with IPv4
@@ -321,7 +321,7 @@ func TestMatchIPNetFamily(t *testing.T) {
 	}
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
-			res, err := MatchIPNetFamily(tc.inpIsIPv6, ovntest.MustParseIPNets(tc.inpSubnets...))
+			res, err := MatchFirstIPNetFamily(tc.inpIsIPv6, ovntest.MustParseIPNets(tc.inpSubnets...))
 			t.Log(res, err)
 			if tc.expected == "" {
 				assert.Error(t, err)


### PR DESCRIPTION
Manual backport of https://github.com/openshift/ovn-kubernetes/pull/1662 and https://github.com/ovn-org/ovn-kubernetes/pull/3349.
There were conflicts in all but the [second commit](20ba6175664b11fb8130cab982b75e522b7fb438) due to the general differences between 4.12 and 4.13 releases.