### PR TITLE
OCPBUGS-13953: [release-4.12] Use loadbalancer.Name as client index

### DIFF
--- a/go-controller/pkg/libovsdb/libovsdb.go
+++ b/go-controller/pkg/libovsdb/libovsdb.go
@@ -146,6 +146,11 @@ func NewNBClientWithConfig(cfg config.OvnAuthConfig, promRegistry prometheus.Reg
 	enableMetricsOption := client.WithMetricsRegistryNamespaceSubsystem(promRegistry, "ovnkube",
 		"master_libovsdb")
 
+	// define client indexes for objects that are using dbIDs
+	dbModel.SetIndexes(map[string][]model.ClientIndex{
+		"Load_Balancer": {{Columns: []model.ColumnKey{{Column: "name"}}}},
+	})
+
 	c, err := newClient(cfg, dbModel, stopCh, enableMetricsOption)
 	if err != nil {
 		return nil, err

--- a/go-controller/pkg/libovsdbops/model.go
+++ b/go-controller/pkg/libovsdbops/model.go
@@ -152,6 +152,8 @@ func copyIndexes(model model.Model) model.Model {
 	case *nbdb.LoadBalancer:
 		return &nbdb.LoadBalancer{
 			UUID: t.UUID,
+			// client index
+			Name: t.Name,
 		}
 	case *nbdb.LoadBalancerGroup:
 		return &nbdb.LoadBalancerGroup{
@@ -362,9 +364,6 @@ func buildFailOnDuplicateOps(c client.Client, m model.Model) ([]ovsdb.Operation,
 	var field interface{}
 	var value string
 	switch t := m.(type) {
-	case *nbdb.LoadBalancer:
-		field = &t.Name
-		value = t.Name
 	case *nbdb.LogicalRouter:
 		field = &t.Name
 		value = t.Name


### PR DESCRIPTION
Backport of https://github.com/openshift/ovn-kubernetes/pull/1660
Simple conflicts on `ovn/controller/services/loadbalancer.go`