### PR TITLE
[release-4.13] OCPBUGS-14314: Fix compilation error in e2e.go tests due to missing int32 parameter

### DIFF
--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"k8s.io/apimachinery/pkg/types"
 	"math/rand"
 	"net"
 	"net/http"
@@ -16,6 +15,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/extensions/table"
@@ -1662,7 +1663,7 @@ var _ = ginkgo.Describe("e2e network policy hairpinning validation", func() {
 		pod2 = f.PodClient().CreateSync(pod2)
 
 		ginkgo.By("creating a service with a single backend")
-		svcIP, err := createServiceForPodsWithLabel(f, namespaceName, serviceHTTPPort, endpointHTTPPort, "ClusterIP", hairpinPodSel)
+		svcIP, err := createServiceForPodsWithLabel(f, namespaceName, serviceHTTPPort, endpointHTTPPort, 0, "ClusterIP", hairpinPodSel)
 		framework.ExpectNoError(err, fmt.Sprintf("unable to create ClusterIP svc: %v", err))
 
 		err = framework.WaitForServiceEndpointsNum(f.ClientSet, namespaceName, "service-for-pods", 1, time.Second, wait.ForeverTestTimeout)


### PR DESCRIPTION
Fixes a compilation issue found when running the e2e tests due to a missing int32 parameter while calling the `createServiceForPodsWithLabel` helper function.

@zeeke PTAL.