### PR TITLE
OCPBUGS-14482: Dockerfiles: sync RHEL9 dockerfiles to regular unused ones

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 #
 # The standard name for this image is ovn-kube
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-4.13 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.19-openshift-4.13 AS builder
 
 WORKDIR /go/src/github.com/openshift/ovn-kubernetes
 COPY . .
@@ -12,8 +12,6 @@ COPY . .
 # build the binaries
 RUN cd go-controller; CGO_ENABLED=0 make
 RUN cd go-controller; CGO_ENABLED=0 make windows
-
-FROM registry.ci.openshift.org/ocp/4.13:cli AS cli
 
 # ovn-kubernetes-base image is built from Dockerfile.base
 # The following changes are included in ovn-kubernetes-base
@@ -23,7 +21,7 @@ FROM registry.ci.openshift.org/ocp/4.13:cli AS cli
 # - creating directories required by ovn-kubernetes
 # - git commit number
 # - ovnkube.sh script
-FROM registry.ci.openshift.org/ocp/4.13:ovn-kubernetes-base
+FROM registry.ci.openshift.org/ocp/4.13:ovn-kubernetes-base-rhel-9
 
 USER root
 
@@ -35,12 +33,13 @@ ENV PYTHONDONTWRITEBYTECODE yes
 # - openvswitch-ipsec
 # - ovn-vtep
 RUN INSTALL_PKGS=" \
-	openssl python3-pyOpenSSL firewalld-filesystem \
+	openssl firewalld-filesystem \
 	libpcap iproute iproute-tc strace \
 	containernetworking-plugins \
 	tcpdump iputils \
 	libreswan \
 	ethtool conntrack-tools \
+	openshift-clients \
 	" && \
 	dnf install -y --nodocs $INSTALL_PKGS && \
 	eval "dnf install -y --nodocs $(cat /more-pkgs)" && \
@@ -53,8 +52,6 @@ COPY --from=builder /go/src/github.com/openshift/ovn-kubernetes/go-controller/_o
 COPY --from=builder /go/src/github.com/openshift/ovn-kubernetes/go-controller/_output/go/bin/ovndbchecker /usr/bin/
 COPY --from=builder /go/src/github.com/openshift/ovn-kubernetes/go-controller/_output/go/bin/ovnkube-trace /usr/bin/
 
-COPY --from=cli /usr/bin/oc /usr/bin/
-RUN ln -s /usr/bin/oc /usr/bin/kubectl
 RUN stat /usr/bin/oc
 
 LABEL io.k8s.display-name="ovn kubernetes" \

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -5,23 +5,23 @@
 # The standard name for this image is ovn-kubernetes-base
 
 # build base image shared by both OpenShift and MicroShift
-FROM registry.ci.openshift.org/ocp/4.13:base
+FROM registry.ci.openshift.org/ocp/4.13:base-rhel9
 
 # install selinux-policy first to avoid a race
 RUN dnf install -y --nodocs \
-	selinux-policy && \
+	selinux-policy procps-ng && \
 	dnf clean all
 
-ARG ovsver=2.17.0-62.el8fdp
-ARG ovnver=22.12.0-18.el8fdp
+ARG ovsver=3.1.0-2.el9fdp
+ARG ovnver=23.03.0-7.el9fdp
 
 RUN INSTALL_PKGS="iptables" && \
 	dnf install -y --nodocs $INSTALL_PKGS && \
-	dnf install -y --nodocs "openvswitch2.17 = $ovsver" "python3-openvswitch2.17 = $ovsver" && \
-	dnf install -y --nodocs "ovn22.12 = $ovnver" "ovn22.12-central = $ovnver" "ovn22.12-host = $ovnver" && \
+	dnf install -y --nodocs "openvswitch3.1 = $ovsver" "python3-openvswitch3.1 = $ovsver" && \
+	dnf install -y --nodocs "ovn23.03 = $ovnver" "ovn23.03-central = $ovnver" "ovn23.03-host = $ovnver" && \
 	dnf clean all && rm -rf /var/cache/*
 
-RUN sed 's/%/"/g' <<<"%openvswitch2.17-devel = $ovsver% %openvswitch2.17-ipsec = $ovsver% %ovn22.12-vtep = $ovnver%" > /more-pkgs
+RUN sed 's/%/"/g' <<<"%openvswitch3.1-devel = $ovsver% %openvswitch3.1-ipsec = $ovsver% %ovn23.03-vtep = $ovnver%" > /more-pkgs
 
 RUN mkdir -p /var/run/openvswitch && \
     mkdir -p /var/run/ovn && \

--- a/Dockerfile.microshift
+++ b/Dockerfile.microshift
@@ -12,7 +12,7 @@
 # openvswitch-devel, openvswitch-ipsec, libpcap, iproute etc
 # ovn-kube-util, hybrid-overlay-node.exe, ovndbchecker and ovnkube-trace
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-4.13 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.19-openshift-4.13 AS builder
 
 WORKDIR /go/src/github.com/openshift/ovn-kubernetes
 COPY . .
@@ -20,7 +20,7 @@ COPY . .
 # build the binaries
 RUN cd go-controller; CGO_ENABLED=0 make
 
-FROM registry.ci.openshift.org/ocp/4.13:ovn-kubernetes-base
+FROM registry.ci.openshift.org/ocp/4.13:ovn-kubernetes-base-rhel-9
 
 USER root
 


### PR DESCRIPTION
Then we can retarget the openshift/release tests to the regular dockerfiles, and eventually remove our .rhel9 variants.