### PR TITLE
OCPBUGS-14787: Dockerfile: stop installing CNI plugins RPM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,6 @@ ENV PYTHONDONTWRITEBYTECODE yes
 RUN INSTALL_PKGS=" \
 	openssl firewalld-filesystem \
 	libpcap iproute iproute-tc strace \
-	containernetworking-plugins \
 	tcpdump iputils \
 	libreswan \
 	ethtool conntrack-tools \


### PR DESCRIPTION
We used to use it for the loopback plugin, but CRI-O (via ocicni) has configured the loopback interface for years already.