### PR TITLE
OCPBUGS-15127: Dockerfile: bump to ovn 23.03.0-69 (for LB templates) and ovs 3.1.0-32 (upgrade perf)

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -12,8 +12,8 @@ RUN dnf install -y --nodocs \
 	selinux-policy procps-ng && \
 	dnf clean all
 
-ARG ovsver=3.1.0-10.el9fdp
-ARG ovnver=23.03.0-49.el9fdp
+ARG ovsver=3.1.0-32.el9fdp
+ARG ovnver=23.03.0-69.el9fdp
 
 RUN INSTALL_PKGS="iptables" && \
 	ovsver_short=$(echo "$ovsver" | cut -d'.' -f1,2) && \


### PR DESCRIPTION
```
OVN changes 49 -> 69:
    - Implement MTU Path Discovery for multichassis ports
    - northd: Add logical flow to skip GARP with LLA (#2211240)
    - northd: match only on supported protocols to handle_svc_check (#1913162)
    - northd: Fix address set incremental processing (#2196885)
    - controller: Ignore DNS queries with RRs
    - controller: Handle OpenFlow errors. (#2134880)
    - northd: fix ls_in_hairpin l3dgw flow generation
    - ovn-controller.c: Fix assertion failure during address set update.
    
OVS changes 10 -> 32:
    859071224c ovsdb: monitor: Destroy initial change set when new columns added.
    54e45e3fee ovsdb: Monitor: Keep and maintain the initial change set.
    9529e9aa96 ovsdb: Allow conversion records with no data in a clustered storage.
    7006bb112b ovsdb: Check for ephemeral columns before writing a new schema.
    27678b3a19 ovsdb-tool: Fix cluster-to-standalone for DB conversion records.
    
    61b39d8c47 ofproto-dpif-xlate: Always mask ip proto field. (#2134873)
    037e2d9161 db-ctl-base: Partially revert b8bf410a5. (#2182767)
    5fe322e169 fatal-signal: Don't share signal fds/handles with forked process.
    3fcb817840 cpu: Fix cpuid check for some AMD processors. (#2211747)
    01f0668fdf tc: Fix crash on malformed reply from kernel.
    e913394054 ovs-fields: Modify the width of tpa and spa.
    087439e416 ofproto-dpif-xlate: Fix use-after-free when xlate_actions().
    c6cb828870 tc: Fix cleaning chains.
    615548e532 dpif-netlink: Fix memory leak dpif_netlink_open().
    42edc9a1d5 ofp-parse: Check ranges on string to uint32_t conversion.
    d3a479c4b4 learning-switch: Fix coredump of OpenFlow15 learning-switch.
```

Corresponding 4.13 PR is https://github.com/openshift/ovn-kubernetes/pull/1708