### PR TITLE
OCPBUGS-14979: Validate port before deleting conntrack flow

### DIFF
--- a/go-controller/pkg/node/default_node_network_controller.go
+++ b/go-controller/pkg/node/default_node_network_controller.go
@@ -774,8 +774,8 @@ func (nc *DefaultNodeNetworkController) reconcileConntrackUponEndpointSliceEvent
 					continue
 				}
 				// upon update and delete events, flush conntrack only for UDP
-				err := util.DeleteConntrack(oldIPStr, *oldPort.Port, *oldPort.Protocol, netlink.ConntrackReplyAnyIP, nil)
-				if err != nil {
+				if err := util.DeleteConntrackServicePort(oldIPStr, *oldPort.Port, *oldPort.Protocol,
+					netlink.ConntrackReplyAnyIP, nil); err != nil {
 					klog.Errorf("Failed to delete conntrack entry for %s: %v", oldIPStr, err)
 				}
 			}

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -631,8 +631,8 @@ func (npw *nodePortWatcher) UpdateService(old, new *kapi.Service) error {
 func deleteConntrackForServiceVIP(svcVIPs []string, svcPorts []kapi.ServicePort, ns, name string) error {
 	for _, svcVIP := range svcVIPs {
 		for _, svcPort := range svcPorts {
-			err := util.DeleteConntrack(svcVIP, svcPort.Port, svcPort.Protocol, netlink.ConntrackOrigDstIP, nil)
-			if err != nil {
+			if err := util.DeleteConntrackServicePort(svcVIP, svcPort.Port, svcPort.Protocol,
+				netlink.ConntrackOrigDstIP, nil); err != nil {
 				return fmt.Errorf("failed to delete conntrack entry for service %s/%s with svcVIP %s, svcPort %d, protocol %s: %v",
 					ns, name, svcVIP, svcPort.Port, svcPort.Protocol, err)
 			}
@@ -653,8 +653,8 @@ func (npw *nodePortWatcher) deleteConntrackForService(service *kapi.Service) err
 		nodeIPs := npw.nodeIPManager.ListAddresses()
 		for _, nodeIP := range nodeIPs {
 			for _, svcPort := range service.Spec.Ports {
-				err := util.DeleteConntrack(nodeIP.String(), svcPort.NodePort, svcPort.Protocol, netlink.ConntrackOrigDstIP, nil)
-				if err != nil {
+				if err := util.DeleteConntrackServicePort(nodeIP.String(), svcPort.NodePort, svcPort.Protocol,
+					netlink.ConntrackOrigDstIP, nil); err != nil {
 					return fmt.Errorf("failed to delete conntrack entry for service %s/%s with nodeIP %s, nodePort %d, protocol %s: %v",
 						service.Namespace, service.Name, nodeIP, svcPort.Port, svcPort.Protocol, err)
 				}

--- a/go-controller/pkg/util/net_linux.go
+++ b/go-controller/pkg/util/net_linux.go
@@ -469,6 +469,19 @@ func DeleteConntrack(ip string, port int32, protocol kapi.Protocol, ipFilterType
 	return nil
 }
 
+// DeleteConntrackServicePort is a wrapper around DeleteConntrack for the purpose of deleting conntrack entries that
+// belong to ServicePorts. Before deleting any conntrack entry, it makes sure that the port is valid. If the port is
+// invalid, it will log a level 5 info message and simply return.
+func DeleteConntrackServicePort(ip string, port int32, protocol kapi.Protocol, ipFilterType netlink.ConntrackFilterType,
+	labels [][]byte) error {
+	if err := ValidatePort(protocol, port); err != nil {
+		klog.V(5).Infof("Skipping conntrack deletion for IP %q, protocol %q, port \"%d\", err: %q",
+			ip, protocol, port, err)
+		return nil
+	}
+	return DeleteConntrack(ip, port, protocol, ipFilterType, labels)
+}
+
 // GetNetworkInterfaceIPs returns the IP addresses for the network interface 'iface'.
 func GetNetworkInterfaceIPs(iface string) ([]*net.IPNet, error) {
 	link, err := netLinkOps.LinkByName(iface)


### PR DESCRIPTION
For services and endpoints, make sure that the protocol and port are valid before deleting conntrack flows.
Under certain circumstances, the port may be the default value (meaning 0), indicating that all conntrack flows for a given IP shall be deleted. However, for endpoints and services, only ever delete exact matches. Otherwise, ovnkube-node might remove conntrack flows inserted by unrelated components (such as iptables rules). If for any reason protocol is invalid, skip conntrack deletion instead.

Reported-at: https://issues.redhat.com/browse/OCPBUGS-14769
Signed-off-by: Andreas Karis <ak.karis@gmail.com>
(cherry picked from commit eacdaa721dc3d4bd7a1b5b248aa94ac22a6d5da6)
