### PR TITLE
OCPBUGS-15226: EgressIP: do not patch the status if the object no longer exists

### DIFF
--- a/go-controller/pkg/clustermanager/egressip_controller.go
+++ b/go-controller/pkg/clustermanager/egressip_controller.go
@@ -995,8 +995,13 @@ func (eIPC *egressIPClusterController) reconcileEgressIP(old, new *egressipv1.Eg
 			// trigger an event for the ovnkube-master to take action upon.
 			// Note that once we figure out the statusToAdd parts below we will trigger an
 			// update to cloudPrivateIP object which will trigger another patch for the eIP object.
-			if err := eIPC.patchReplaceEgressIPStatus(name, statusToKeep); err != nil {
-				return err
+			//
+			// Update the object only on an ADD/UPDATE. If we are processing a
+			// DELETE, new will be nil and we should not update the object.
+			if new != nil {
+				if err := eIPC.patchReplaceEgressIPStatus(name, statusToKeep); err != nil {
+					return err
+				}
 			}
 		}
 		// When egress IP is not fully assigned to a node, then statusToRemove may not


### PR DESCRIPTION
Signed-off-by: Patryk Diak <pdiak@redhat.com>
(cherry picked from commit 4759e64a6f29b18f99cd58a103d0981f8b391e23)