### PR TITLE
OCPBUGS-16120: Dockerfile: bump to ovn 23.06

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -13,7 +13,7 @@ RUN dnf install -y --nodocs \
 	dnf clean all
 
 ARG ovsver=3.1.0-32.el9fdp
-ARG ovnver=23.03.0-69.el9fdp
+ARG ovnver=23.06.0-13.el9fdp
 
 RUN INSTALL_PKGS="iptables" && \
 	ovsver_short=$(echo "$ovsver" | cut -d'.' -f1,2) && \


### PR DESCRIPTION
    New features and improvements:
    - ARP proxy support (needed for CNV)
    - Per-Load Balancer ct_flush
    - Tiered ACLs
    - northd: Update obsolete datapath groups instead of re-creating (perf/scale)
    
    Relevant bug fixes:
    - controller: Handle OpenFlow errors (rhbz#2134880)
    - ovn-controller: fixed port not always set down when unbinding interface (rhbz#2150905)
    - ovn-controller.c: Fix assertion failure during address set update
