### PR TITLE
OCPBUGS-15372: [release-4.13] Fix network policy to work with long namespace names

### DIFF
--- a/go-controller/pkg/ovn/multicast.go
+++ b/go-controller/pkg/ovn/multicast.go
@@ -94,13 +94,13 @@ func (oc *DefaultNetworkController) createMulticastAllowPolicy(ns string, nsInfo
 	egressMatch := getACLMatch(portGroupName, getMulticastACLEgrMatch(), aclT)
 	egressACL := BuildACL(getMcastACLName(ns, "MulticastAllowEgress"),
 		types.DefaultMcastAllowPriority, egressMatch, nbdb.ACLActionAllow, nil, aclT,
-		getDefaultDenyPolicyExternalIDs(aclT))
+		getDirectionPolicyACLExternalIDs(aclT))
 
 	aclT = lportIngress
 	ingressMatch := getACLMatch(portGroupName, getMulticastACLIgrMatch(nsInfo), aclT)
 	ingressACL := BuildACL(getMcastACLName(ns, "MulticastAllowIngress"),
 		types.DefaultMcastAllowPriority, ingressMatch, nbdb.ACLActionAllow, nil, aclT,
-		getDefaultDenyPolicyExternalIDs(aclT))
+		getDirectionPolicyACLExternalIDs(aclT))
 
 	acls := []*nbdb.ACL{egressACL, ingressACL}
 	ops, err := libovsdbops.CreateOrUpdateACLsOps(oc.nbClient, nil, acls...)
@@ -166,13 +166,13 @@ func (oc *DefaultNetworkController) createDefaultDenyMulticastPolicy() error {
 	aclT := lportEgressAfterLB
 	egressACL := BuildACL(getMcastACLName(types.ClusterPortGroupName, "DefaultDenyMulticastEgress"),
 		types.DefaultMcastDenyPriority, match, nbdb.ACLActionDrop, nil,
-		aclT, getDefaultDenyPolicyExternalIDs(aclT))
+		aclT, getDirectionPolicyACLExternalIDs(aclT))
 
 	// By default deny any ingress multicast traffic to any pod.
 	aclT = lportIngress
 	ingressACL := BuildACL(getMcastACLName(types.ClusterPortGroupName, "DefaultDenyMulticastIngress"),
 		types.DefaultMcastDenyPriority, match, nbdb.ACLActionDrop, nil,
-		aclT, getDefaultDenyPolicyExternalIDs(aclT))
+		aclT, getDirectionPolicyACLExternalIDs(aclT))
 
 	ops, err := libovsdbops.CreateOrUpdateACLsOps(oc.nbClient, nil, egressACL, ingressACL)
 	if err != nil {
@@ -210,13 +210,13 @@ func (oc *DefaultNetworkController) createDefaultAllowMulticastPolicy() error {
 	egressMatch := getACLMatch(types.ClusterRtrPortGroupName, mcastMatch, aclT)
 	egressACL := BuildACL(getMcastACLName(types.ClusterRtrPortGroupName, "DefaultAllowMulticastEgress"),
 		types.DefaultMcastAllowPriority, egressMatch, nbdb.ACLActionAllow, nil,
-		aclT, getDefaultDenyPolicyExternalIDs(aclT))
+		aclT, getDirectionPolicyACLExternalIDs(aclT))
 
 	aclT = lportIngress
 	ingressMatch := getACLMatch(types.ClusterRtrPortGroupName, mcastMatch, aclT)
 	ingressACL := BuildACL(getMcastACLName(types.ClusterRtrPortGroupName, "DefaultAllowMulticastIngress"),
 		types.DefaultMcastAllowPriority, ingressMatch, nbdb.ACLActionAllow, nil,
-		aclT, getDefaultDenyPolicyExternalIDs(aclT))
+		aclT, getDirectionPolicyACLExternalIDs(aclT))
 
 	ops, err := libovsdbops.CreateOrUpdateACLsOps(oc.nbClient, nil, egressACL, ingressACL)
 	if err != nil {

--- a/go-controller/pkg/ovn/policy_test.go
+++ b/go-controller/pkg/ovn/policy_test.go
@@ -85,9 +85,7 @@ func getDefaultDenyData(networkPolicy *knet.NetworkPolicy, ports []string,
 		types.OvnACLLoggingMeter,
 		denyLogSeverity,
 		shouldBeLogged,
-		map[string]string{
-			defaultDenyPolicyTypeACLExtIdKey: string(knet.PolicyTypeEgress),
-		},
+		getDenyACLExternalIDs(lportEgressAfterLB, denyAction),
 		map[string]string{
 			"apply-after-lb": "true",
 		},
@@ -104,9 +102,7 @@ func getDefaultDenyData(networkPolicy *knet.NetworkPolicy, ports []string,
 		types.OvnACLLoggingMeter,
 		"",
 		false,
-		map[string]string{
-			defaultDenyPolicyTypeACLExtIdKey: string(knet.PolicyTypeEgress),
-		},
+		getDenyACLExternalIDs(lportEgressAfterLB, allowAction),
 		map[string]string{
 			"apply-after-lb": "true",
 		},
@@ -124,9 +120,7 @@ func getDefaultDenyData(networkPolicy *knet.NetworkPolicy, ports []string,
 		types.OvnACLLoggingMeter,
 		denyLogSeverity,
 		shouldBeLogged,
-		map[string]string{
-			defaultDenyPolicyTypeACLExtIdKey: string(knet.PolicyTypeIngress),
-		},
+		getDenyACLExternalIDs(lportIngress, denyAction),
 		nil,
 	)
 	ingressDenyACL.UUID = aclName + "-ingressDenyACL-UUID"
@@ -141,9 +135,7 @@ func getDefaultDenyData(networkPolicy *knet.NetworkPolicy, ports []string,
 		types.OvnACLLoggingMeter,
 		"",
 		false,
-		map[string]string{
-			defaultDenyPolicyTypeACLExtIdKey: string(knet.PolicyTypeIngress),
-		},
+		getDenyACLExternalIDs(lportIngress, allowAction),
 		nil,
 	)
 	ingressAllowACL.UUID = aclName + "-ingressAllowACL-UUID"
@@ -196,6 +188,7 @@ func getStaleDefaultACL(acls []*nbdb.ACL) []*nbdb.ACL {
 	for _, acl := range acls {
 		acl.Options = nil
 		acl.Direction = nbdb.ACLDirectionToLport
+		delete(acl.ExternalIDs, defaultDenyPolicyActionACLExtIdKey)
 	}
 	return acls
 }
@@ -895,6 +888,44 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 			err := app.Run([]string{app.Name})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		})
+
+		ginkgo.It("reconciles an existing networkPolicy with long name updating stale ACLs", func() {
+			app.Action = func(ctx *cli.Context) error {
+				namespace1 := *newNamespace("abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk")
+				namespace2 := *newNamespace(namespaceName2)
+				networkPolicy := getMatchLabelsNetworkPolicy(netPolicyName1, namespace1.Name,
+					namespace2.Name, "", true, true)
+				// start with stale ACLs
+				// this function will cut off the namespace name to have no suffix
+				gressPolicyInitialData := getPolicyData(networkPolicy, nil, []string{namespace2.Name},
+					nil, "", true)
+				defaultDenyInitialData := getDefaultDenyData(networkPolicy, nil, "", true)
+				initialData := initialDB.NBData
+				initialData = append(initialData, gressPolicyInitialData...)
+				initialData = append(initialData, defaultDenyInitialData...)
+				startOvn(libovsdb.TestSetup{NBData: initialData}, []v1.Namespace{namespace1, namespace2},
+					[]knet.NetworkPolicy{*networkPolicy}, nil, nil)
+
+				fakeOvn.asf.ExpectEmptyAddressSet(namespace1.Name)
+				fakeOvn.asf.ExpectEmptyAddressSet(namespaceName2)
+
+				_, err := fakeOvn.fakeClient.KubeClient.NetworkingV1().NetworkPolicies(networkPolicy.Namespace).
+					Get(context.TODO(), networkPolicy.Name, metav1.GetOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				// make sure stale ACLs were updated
+				expectedData := getPolicyData(networkPolicy, nil, []string{namespace2.Name}, nil,
+					"", false)
+				defaultDenyExpectedData := getDefaultDenyData(networkPolicy, nil, "", false)
+				expectedData = append(expectedData, defaultDenyExpectedData...)
+				expectedData = append(expectedData, initialDB.NBData...)
+				gomega.Eventually(fakeOvn.nbClient).Should(libovsdb.HaveData(expectedData...))
+
+				return nil
+			}
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		})
 	})
 
 	ginkgo.Context("during execution", func() {
@@ -1223,7 +1254,9 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 
 				// ensure the default PGs and ACLs were removed via rollback from add failure
 				expectedData := getUpdatedInitialDB([]testPod{nPodTest})
-				// note stale leftovers from previous upgrades won't be cleanedup
+				// note stale leftovers from previous upgrades won't be cleanedup, but will be updated
+				leftOverACLFromUpgrade1.ExternalIDs = getDenyACLExternalIDs(lportEgressAfterLB, allowAction)
+				leftOverACLFromUpgrade2.ExternalIDs = getDenyACLExternalIDs(lportEgressAfterLB, allowAction)
 				expectedData = append(expectedData, leftOverACLFromUpgrade1, leftOverACLFromUpgrade2)
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdb.HaveData(expectedData...))
 
@@ -1369,6 +1402,9 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				newDefaultDenyIngressACLName := getDefaultDenyPolicyACLName("shortName", lportIngress)
 				leftOverACL3FromUpgrade.Name = &newDefaultDenyEgressACLName
 				leftOverACL4FromUpgrade.Name = &newDefaultDenyIngressACLName
+				leftOverACL3FromUpgrade.ExternalIDs = getDenyACLExternalIDs(lportEgressAfterLB, denyAction)
+				leftOverACL4FromUpgrade.ExternalIDs = getDenyACLExternalIDs(lportIngress, denyAction)
+
 				expectedData = append(expectedData, leftOverACL3FromUpgrade)
 				expectedData = append(expectedData, leftOverACL4FromUpgrade)
 				testOnlyIngressDenyPG.ACLs = nil // Sync Function should remove stale ACL from PGs
@@ -1385,6 +1421,9 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				leftOverACL2FromUpgrade.Name = &newDefaultDenyLeftoverIngressACLName
 				leftOverACL1FromUpgrade.Name = &newDefaultDenyLeftoverEgressACLName
 				leftOverACL1FromUpgrade.Options = egressOptions
+				leftOverACL1FromUpgrade.ExternalIDs = getDenyACLExternalIDs(lportEgressAfterLB, allowAction)
+				leftOverACL2FromUpgrade.ExternalIDs = getDenyACLExternalIDs(lportIngress, allowAction)
+
 				expectedData = append(expectedData, leftOverACL2FromUpgrade)
 				expectedData = append(expectedData, leftOverACL1FromUpgrade)
 				// end of db hack
@@ -1577,6 +1616,11 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				leftOverACL4FromUpgrade.Name = utilpointer.StringPtr(longLeftOverNameSpaceName2 + "_egressDefa") // trims it according to RFC1123
 				leftOverACL5FromUpgrade.Name = utilpointer.StringPtr(longLeftOverNameSpaceName2 + "_ingressDef") // trims it according to RFC1123
 				leftOverACL6FromUpgrade.Name = utilpointer.StringPtr(longLeftOverNameSpaceName62 + "_")          // name stays the same here since its no-op
+				leftOverACL3FromUpgrade.ExternalIDs = getDenyACLExternalIDs(lportIngress, allowAction)
+				leftOverACL4FromUpgrade.ExternalIDs = getDenyACLExternalIDs(lportEgressAfterLB, denyAction)
+				leftOverACL5FromUpgrade.ExternalIDs = getDenyACLExternalIDs(lportIngress, denyAction)
+				leftOverACL6FromUpgrade.ExternalIDs = getDenyACLExternalIDs(lportIngress, denyAction)
+
 				expectedData = append(expectedData, leftOverACL3FromUpgrade)
 				expectedData = append(expectedData, leftOverACL4FromUpgrade)
 				expectedData = append(expectedData, leftOverACL5FromUpgrade)
@@ -1595,6 +1639,9 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				leftOverACL2FromUpgrade.Name = &longLeftOverIngressName
 				leftOverACL1FromUpgrade.Name = &longLeftOverEgressName
 				leftOverACL1FromUpgrade.Options = egressOptions
+				leftOverACL1FromUpgrade.ExternalIDs = getDenyACLExternalIDs(lportEgressAfterLB, allowAction)
+				leftOverACL2FromUpgrade.ExternalIDs = getDenyACLExternalIDs(lportIngress, allowAction)
+
 				expectedData = append(expectedData, leftOverACL2FromUpgrade)
 				expectedData = append(expectedData, leftOverACL1FromUpgrade)
 				// end of db hack
@@ -1611,11 +1658,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				fakeOvn.controller.networkPolicies.Delete(getPolicyKey(networkPolicy1))
 				fakeOvn.controller.sharedNetpolPortGroups.Delete(networkPolicy1.Namespace) // reset cache so that we simulate the add that happens during upgrades
 				err = fakeOvn.controller.addNetworkPolicy(networkPolicy1)
-				// TODO: FIX ME
-				gomega.Expect(err).To(gomega.HaveOccurred())
-				gomega.Expect(err.Error()).To(gomega.ContainSubstring("failed to create Network Policy " +
-					"abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk/networkpolicy1: " +
-					"failed to create default deny port groups: unexpectedly found multiple results for provided predicate"))
+				gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 				return nil
 			}


### PR DESCRIPTION
Add default deny acl externalID to avoid duplicate acls for namespaces with long names.
every namespace has 4 default deny acls: ingress/egress and deny/allow. Direction was in the ExternalIDs before, but action was a suffix in acl name, that gets truncated for long namespace names, therefore deny and allow acls for the same direction would have the same name and ExternalIDs. New ExternalID should fix this case.

Multicast acls don't need extra ID, therefore I renamed the old function to `getDirectionPolicyACLExternalIDs` and multicast still uses that.
To check the difference on restart, you can run the new test on the old implementation and see duplicate acls error in the logs. Also create namespace with long name + networkpolicy and restart ovn-k master can be used as reproducer