### PR TITLE
OCPBUGS-15424: [release-4.12] Fix network policy to work with long namespace names

### DIFF
--- a/go-controller/pkg/ovn/multicast.go
+++ b/go-controller/pkg/ovn/multicast.go
@@ -94,13 +94,13 @@ func (oc *Controller) createMulticastAllowPolicy(ns string, nsInfo *namespaceInf
 	egressMatch := getACLMatch(portGroupName, getMulticastACLEgrMatch(), aclT)
 	egressACL := BuildACL(getMcastACLName(ns, "MulticastAllowEgress"),
 		types.DefaultMcastAllowPriority, egressMatch, nbdb.ACLActionAllow, nil, aclT,
-		getDefaultDenyPolicyExternalIDs(aclT))
+		getDirectionPolicyACLExternalIDs(aclT))
 
 	aclT = lportIngress
 	ingressMatch := getACLMatch(portGroupName, getMulticastACLIgrMatch(nsInfo), aclT)
 	ingressACL := BuildACL(getMcastACLName(ns, "MulticastAllowIngress"),
 		types.DefaultMcastAllowPriority, ingressMatch, nbdb.ACLActionAllow, nil, aclT,
-		getDefaultDenyPolicyExternalIDs(aclT))
+		getDirectionPolicyACLExternalIDs(aclT))
 
 	acls := []*nbdb.ACL{egressACL, ingressACL}
 	ops, err := libovsdbops.CreateOrUpdateACLsOps(oc.nbClient, nil, acls...)
@@ -166,13 +166,13 @@ func (oc *Controller) createDefaultDenyMulticastPolicy() error {
 	aclT := lportEgressAfterLB
 	egressACL := BuildACL(getMcastACLName(types.ClusterPortGroupName, "DefaultDenyMulticastEgress"),
 		types.DefaultMcastDenyPriority, match, nbdb.ACLActionDrop, nil,
-		aclT, getDefaultDenyPolicyExternalIDs(aclT))
+		aclT, getDirectionPolicyACLExternalIDs(aclT))
 
 	// By default deny any ingress multicast traffic to any pod.
 	aclT = lportIngress
 	ingressACL := BuildACL(getMcastACLName(types.ClusterPortGroupName, "DefaultDenyMulticastIngress"),
 		types.DefaultMcastDenyPriority, match, nbdb.ACLActionDrop, nil,
-		aclT, getDefaultDenyPolicyExternalIDs(aclT))
+		aclT, getDirectionPolicyACLExternalIDs(aclT))
 
 	ops, err := libovsdbops.CreateOrUpdateACLsOps(oc.nbClient, nil, egressACL, ingressACL)
 	if err != nil {
@@ -210,13 +210,13 @@ func (oc *Controller) createDefaultAllowMulticastPolicy() error {
 	egressMatch := getACLMatch(types.ClusterRtrPortGroupName, mcastMatch, aclT)
 	egressACL := BuildACL(getMcastACLName(types.ClusterRtrPortGroupName, "DefaultAllowMulticastEgress"),
 		types.DefaultMcastAllowPriority, egressMatch, nbdb.ACLActionAllow, nil,
-		aclT, getDefaultDenyPolicyExternalIDs(aclT))
+		aclT, getDirectionPolicyACLExternalIDs(aclT))
 
 	aclT = lportIngress
 	ingressMatch := getACLMatch(types.ClusterRtrPortGroupName, mcastMatch, aclT)
 	ingressACL := BuildACL(getMcastACLName(types.ClusterRtrPortGroupName, "DefaultAllowMulticastIngress"),
 		types.DefaultMcastAllowPriority, ingressMatch, nbdb.ACLActionAllow, nil,
-		aclT, getDefaultDenyPolicyExternalIDs(aclT))
+		aclT, getDirectionPolicyACLExternalIDs(aclT))
 
 	ops, err := libovsdbops.CreateOrUpdateACLsOps(oc.nbClient, nil, egressACL, ingressACL)
 	if err != nil {

--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -28,9 +28,12 @@ import (
 	utilnet "k8s.io/utils/net"
 )
 
+type netpolDefaultDenyACLAction string
+
 const (
 	// defaultDenyPolicyTypeACLExtIdKey external ID key for default deny policy type
-	defaultDenyPolicyTypeACLExtIdKey = "default-deny-policy-type"
+	defaultDenyPolicyTypeACLExtIdKey   = "default-deny-policy-type"
+	defaultDenyPolicyActionACLExtIdKey = "default-deny-policy-action"
 	// l4MatchACLExtIdKey external ID key for L4 Match on 'gress policy ACLs
 	l4MatchACLExtIdKey = "l4Match"
 	// ipBlockCIDRACLExtIdKey external ID key for IP block CIDR on 'gress policy ACLs
@@ -54,7 +57,9 @@ const (
 	// staleArpAllowPolicyMatch "was" the old match used when creating default allow ARP ACLs for a namespace
 	// NOTE: This is succeed by arpAllowPolicyMatch to allow support for IPV6. This is currently only
 	// used when removing stale ACLs from the syncNetworkPolicy function and should NOT be used in any main logic.
-	staleArpAllowPolicyMatch = "arp"
+	staleArpAllowPolicyMatch                            = "arp"
+	denyAction               netpolDefaultDenyACLAction = "deny"
+	allowAction              netpolDefaultDenyACLAction = "allow"
 )
 
 // defaultDenyPortGroups is a shared object and should be used by only 1 thread at a time
@@ -288,6 +293,28 @@ func (oc *Controller) updateStaleDefaultDenyACLNames(npType knet.PolicyType, gre
 	return nil
 }
 
+func (oc *Controller) updateStaleDefaultDenyACLExternalIDs() error {
+	p := func(item *nbdb.ACL) bool {
+		return item.ExternalIDs[defaultDenyPolicyTypeACLExtIdKey] != "" && // default deny + multicast acls
+			(item.Priority == types.DefaultDenyPriority || item.Priority == types.DefaultAllowPriority) && // default deny acls only
+			item.ExternalIDs[defaultDenyPolicyActionACLExtIdKey] == "" // non-updated default deny acls only
+	}
+	staleACLs, err := libovsdbops.FindACLsWithPredicate(oc.nbClient, p)
+	if err != nil {
+		return fmt.Errorf("cannot find NetworkPolicy default deny ACLs: %v", err)
+	}
+	for _, acl := range staleACLs {
+		var aclAction netpolDefaultDenyACLAction
+		if acl.Priority == types.DefaultDenyPriority {
+			aclAction = denyAction
+		} else {
+			aclAction = allowAction
+		}
+		acl.ExternalIDs[defaultDenyPolicyActionACLExtIdKey] = string(aclAction)
+	}
+	return libovsdbops.CreateOrUpdateACLs(oc.nbClient, staleACLs...)
+}
+
 func (oc *Controller) syncNetworkPolicies(networkPolicies []interface{}) error {
 	expectedPolicies := make(map[string]map[string]bool)
 	for _, npInterface := range networkPolicies {
@@ -420,6 +447,10 @@ func (oc *Controller) syncNetworkPolicies(networkPolicies []interface{}) error {
 		return fmt.Errorf("cannot clean up ingress default deny ACL name: %v", err)
 	}
 
+	if err := oc.updateStaleDefaultDenyACLExternalIDs(); err != nil {
+		return fmt.Errorf("failed to update default deny ACL ExternalIDs: %w", err)
+	}
+
 	return nil
 }
 
@@ -468,8 +499,17 @@ func getDefaultDenyPolicyACLName(ns string, aclT aclType) string {
 	return joinACLName(ns, defaultDenySuffix)
 }
 
-func getDefaultDenyPolicyExternalIDs(aclT aclType) map[string]string {
-	return map[string]string{defaultDenyPolicyTypeACLExtIdKey: string(aclTypeToPolicyType(aclT))}
+func getDenyACLExternalIDs(aclT aclType, aclAction netpolDefaultDenyACLAction) map[string]string {
+	return map[string]string{
+		defaultDenyPolicyTypeACLExtIdKey:   string(aclTypeToPolicyType(aclT)),
+		defaultDenyPolicyActionACLExtIdKey: string(aclAction),
+	}
+}
+
+func getDirectionPolicyACLExternalIDs(aclT aclType) map[string]string {
+	return map[string]string{
+		defaultDenyPolicyTypeACLExtIdKey: string(aclTypeToPolicyType(aclT)),
+	}
 }
 
 func getARPAllowACLName(ns string) string {
@@ -484,9 +524,9 @@ func buildDenyACLs(namespace, pg string, aclLogging *ACLLoggingLevels, aclT aclT
 	denyMatch := getACLMatch(pg, "", aclT)
 	allowMatch := getACLMatch(pg, arpAllowPolicyMatch, aclT)
 	denyACL = BuildACL(getDefaultDenyPolicyACLName(namespace, aclT), types.DefaultDenyPriority, denyMatch,
-		nbdb.ACLActionDrop, aclLogging, aclT, getDefaultDenyPolicyExternalIDs(aclT))
+		nbdb.ACLActionDrop, aclLogging, aclT, getDenyACLExternalIDs(aclT, denyAction))
 	allowACL = BuildACL(getARPAllowACLName(namespace), types.DefaultAllowPriority, allowMatch,
-		nbdb.ACLActionAllow, nil, aclT, getDefaultDenyPolicyExternalIDs(aclT))
+		nbdb.ACLActionAllow, nil, aclT, getDenyACLExternalIDs(aclT, allowAction))
 	return
 }
 


### PR DESCRIPTION
Add default deny acl externalID to avoid duplicate acls for namespaces with long names.
every namespace has 4 default deny acls: ingress/egress and deny/allow. Direction was in the ExternalIDs before, but action was a suffix in acl name, that gets truncated for long namespace names, therefore deny and allow acls for the same direction would have the same name and ExternalIDs. New ExternalID should fix this case.

Multicast acls don't need extra ID, therefore I renamed the old function to getDirectionPolicyACLExternalIDs and multicast still uses that.
To check the difference on restart, you can run the new test on the old implementation and see duplicate acls error in the logs. Also create namespace with long name + networkpolicy and restart ovn-k master can be used as reproducer

Backport of https://github.com/openshift/ovn-kubernetes/pull/1722
Had some simple conflicts, the changed parts are exactly the same
