### PR TITLE
[release-4.12] OCPBUGS-13744: Improve syncNodes to remove stale data

### DIFF
--- a/go-controller/pkg/libovsdbops/router.go
+++ b/go-controller/pkg/libovsdbops/router.go
@@ -930,16 +930,16 @@ func FindNATsWithPredicate(nbClient libovsdbclient.Client, predicate natPredicat
 // GetRouterNATs looks up NATs associated to the provided logical router from
 // the cache
 func GetRouterNATs(nbClient libovsdbclient.Client, router *nbdb.LogicalRouter) ([]*nbdb.NAT, error) {
-	router, err := GetLogicalRouter(nbClient, router)
+	r, err := GetLogicalRouter(nbClient, router)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get router: %s, error: %w", router.Name, err)
 	}
 
 	nats := []*nbdb.NAT{}
-	for _, uuid := range router.Nat {
+	for _, uuid := range r.Nat {
 		nat, err := GetNAT(nbClient, &nbdb.NAT{UUID: uuid})
-		if err != nil {
-			return nil, err
+		if err != nil && err != libovsdbclient.ErrNotFound {
+			return nil, fmt.Errorf("failed to lookup NAT entry with uuid: %s, error: %w", uuid, err)
 		}
 		nats = append(nats, nat)
 	}

--- a/go-controller/pkg/libovsdbops/router.go
+++ b/go-controller/pkg/libovsdbops/router.go
@@ -310,7 +310,7 @@ func DeleteLogicalRouterPolicyWithPredicateOps(nbClient libovsdbclient.Client, o
 			Model:            router,
 			ModelPredicate:   func(lr *nbdb.LogicalRouter) bool { return lr.Name == router.Name },
 			OnModelMutations: []interface{}{&router.Policies},
-			ErrNotFound:      true,
+			ErrNotFound:      false,
 			BulkOp:           false,
 		},
 	}
@@ -1035,7 +1035,7 @@ func DeleteNATsOps(nbClient libovsdbclient.Client, ops []libovsdb.Operation, rou
 	opModel := operationModel{
 		Model:            router,
 		OnModelMutations: []interface{}{&router.Nat},
-		ErrNotFound:      true,
+		ErrNotFound:      false,
 		BulkOp:           false,
 	}
 	opModels = append(opModels, opModel)
@@ -1073,7 +1073,8 @@ func DeleteNATsWithPredicateOps(nbClient libovsdbclient.Client, ops []libovsdb.O
 				router.Nat = extractUUIDsFromModels(&deleted)
 				natUUIDs.Insert(router.Nat...)
 			},
-			BulkOp: true,
+			BulkOp:      true,
+			ErrNotFound: false,
 		},
 		{
 			Model:            router,

--- a/go-controller/pkg/libovsdbops/router.go
+++ b/go-controller/pkg/libovsdbops/router.go
@@ -192,7 +192,7 @@ func DeleteLogicalRouterPorts(nbClient libovsdbclient.Client, router *nbdb.Logic
 		Model:            router,
 		ModelPredicate:   func(item *nbdb.LogicalRouter) bool { return item.Name == router.Name },
 		OnModelMutations: []interface{}{&router.Ports},
-		ErrNotFound:      true,
+		ErrNotFound:      false,
 		BulkOp:           false,
 	}
 	opModels = append(opModels, opModel)
@@ -656,7 +656,7 @@ func DeleteLogicalRouterStaticRoutesWithPredicate(nbClient libovsdbclient.Client
 			Model:            router,
 			ModelPredicate:   func(item *nbdb.LogicalRouter) bool { return item.Name == router.Name },
 			OnModelMutations: []interface{}{&router.StaticRoutes},
-			ErrNotFound:      true,
+			ErrNotFound:      false,
 			BulkOp:           false,
 		},
 	}

--- a/go-controller/pkg/libovsdbops/router.go
+++ b/go-controller/pkg/libovsdbops/router.go
@@ -938,7 +938,10 @@ func GetRouterNATs(nbClient libovsdbclient.Client, router *nbdb.LogicalRouter) (
 	nats := []*nbdb.NAT{}
 	for _, uuid := range r.Nat {
 		nat, err := GetNAT(nbClient, &nbdb.NAT{UUID: uuid})
-		if err != nil && err != libovsdbclient.ErrNotFound {
+		if err == libovsdbclient.ErrNotFound {
+			continue
+		}
+		if err != nil {
 			return nil, fmt.Errorf("failed to lookup NAT entry with uuid: %s, error: %w", uuid, err)
 		}
 		nats = append(nats, nat)

--- a/go-controller/pkg/libovsdbops/switch.go
+++ b/go-controller/pkg/libovsdbops/switch.go
@@ -319,7 +319,7 @@ func DeleteLogicalSwitchPortsOps(nbClient libovsdbclient.Client, ops []libovsdb.
 		Model:            sw,
 		ModelPredicate:   func(item *nbdb.LogicalSwitch) bool { return item.Name == sw.Name },
 		OnModelMutations: []interface{}{&sw.Ports},
-		ErrNotFound:      true,
+		ErrNotFound:      false,
 		BulkOp:           false,
 	}
 	opModels = append(opModels, opModel)
@@ -387,7 +387,7 @@ func DeleteLogicalSwitchPortsWithPredicateOps(nbClient libovsdbclient.Client, op
 	opModel := operationModel{
 		Model:            sw,
 		OnModelMutations: []interface{}{&sw.Ports},
-		ErrNotFound:      true,
+		ErrNotFound:      false,
 		BulkOp:           false,
 	}
 	opModels = append(opModels, opModel)

--- a/go-controller/pkg/libovsdbops/switch.go
+++ b/go-controller/pkg/libovsdbops/switch.go
@@ -330,7 +330,7 @@ func DeleteLogicalSwitchPortsOps(nbClient libovsdbclient.Client, ops []libovsdb.
 	return ops, err
 }
 
-// DeleteLogicalSwitchPortsOps deletes the provided logical switch ports and
+// DeleteLogicalSwitchPorts deletes the provided logical switch ports and
 // removes them from the provided logical switch
 func DeleteLogicalSwitchPorts(nbClient libovsdbclient.Client, sw *nbdb.LogicalSwitch, lsps ...*nbdb.LogicalSwitchPort) error {
 	ops, err := DeleteLogicalSwitchPortsOps(nbClient, nil, sw, lsps...)

--- a/go-controller/pkg/ovn/gateway_cleanup.go
+++ b/go-controller/pkg/ovn/gateway_cleanup.go
@@ -6,8 +6,10 @@ import (
 	"strconv"
 	"strings"
 
+	libovsdbclient "github.com/ovn-org/libovsdb/client"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdbops"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
+	"github.com/pkg/errors"
 
 	ovnlb "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/loadbalancer"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/sbdb"
@@ -27,7 +29,7 @@ func (oc *Controller) gatewayCleanup(nodeName string) error {
 	var nextHops []net.IP
 
 	gwIPAddrs, err := util.GetLRPAddrs(oc.nbClient, types.GWRouterToJoinSwitchPrefix+gatewayRouter)
-	if err != nil {
+	if err != nil && !errors.Is(err, libovsdbclient.ErrNotFound) {
 		return err
 	}
 

--- a/go-controller/pkg/ovn/gateway_cleanup.go
+++ b/go-controller/pkg/ovn/gateway_cleanup.go
@@ -1,6 +1,7 @@
 package ovn
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"strconv"
@@ -9,7 +10,6 @@ import (
 	libovsdbclient "github.com/ovn-org/libovsdb/client"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdbops"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
-	"github.com/pkg/errors"
 
 	ovnlb "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/loadbalancer"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/sbdb"

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -1351,6 +1351,7 @@ func (oc *Controller) addUpdateNodeEvent(node *kapi.Node, nSyncs *nodeSyncs) err
 	if err != nil {
 		oc.recordNodeErrorEvent(node, err)
 	}
+
 	return err
 }
 

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -30,6 +30,7 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/metrics"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/sbdb"
+	"github.com/pkg/errors"
 
 	hotypes "github.com/ovn-org/ovn-kubernetes/go-controller/hybrid-overlay/pkg/types"
 	houtil "github.com/ovn-org/ovn-kubernetes/go-controller/hybrid-overlay/pkg/util"
@@ -937,9 +938,12 @@ func (oc *Controller) deleteNodeLogicalNetwork(nodeName string) error {
 	// Remove switch to lb associations from the LBCache before removing the switch
 	lbCache, err := ovnlb.GetLBCache(oc.nbClient)
 	if err != nil {
-		return fmt.Errorf("failed to get load_balancer cache for node %s: %v", nodeName, err)
+		if !errors.Is(err, libovsdbclient.ErrNotFound) {
+			return fmt.Errorf("failed to get load_balancer cache for node %s: %w", nodeName, err)
+		}
+	} else {
+		lbCache.RemoveSwitch(nodeName)
 	}
-	lbCache.RemoveSwitch(nodeName)
 
 	// Remove the logical switch associated with the node
 	err = libovsdbops.DeleteLogicalSwitch(oc.nbClient, nodeName)
@@ -953,7 +957,7 @@ func (oc *Controller) deleteNodeLogicalNetwork(nodeName string) error {
 	}
 	err = libovsdbops.DeleteLogicalRouterPorts(oc.nbClient, &logiccalRouter, &logicalRouterPort)
 	if err != nil {
-		return fmt.Errorf("failed to delete router port %s: %v", logicalRouterPort.Name, err)
+		return fmt.Errorf("failed to delete router port %s: %w", logicalRouterPort.Name, err)
 	}
 
 	return nil
@@ -967,7 +971,7 @@ func (oc *Controller) deleteNode(nodeName string) error {
 	}
 
 	if err := oc.gatewayCleanup(nodeName); err != nil {
-		return fmt.Errorf("failed to clean up node %s gateway: (%v)", nodeName, err)
+		return fmt.Errorf("failed to clean up node %s gateway: (%w)", nodeName, err)
 	}
 
 	if err := oc.joinSwIPManager.ReleaseJoinLRPIPs(nodeName); err != nil {
@@ -1121,11 +1125,46 @@ func (oc *Controller) syncNodes(nodes []interface{}) error {
 	if err != nil {
 		return fmt.Errorf("failed to get node logical switches which have other-config set: %v", err)
 	}
+
+	staleNodes := sets.NewString()
 	for _, nodeSwitch := range nodeSwitches {
 		if !foundNodes.Has(nodeSwitch.Name) {
-			if err := oc.deleteNode(nodeSwitch.Name); err != nil {
-				return fmt.Errorf("failed to delete node:%s, err:%v", nodeSwitch.Name, err)
-			}
+			staleNodes.Insert(nodeSwitch.Name)
+		}
+	}
+
+	// Find stale external logical swiches, based on well known prefix and node name
+	lookupExtSwFunction := func(item *nbdb.LogicalSwitch) bool {
+		nodeName := strings.TrimPrefix(item.Name, types.ExternalSwitchPrefix)
+		if nodeName != item.Name && len(nodeName) > 0 && !foundNodes.Has(nodeName) {
+			staleNodes.Insert(nodeName)
+			return true
+		}
+		return false
+	}
+	_, err = libovsdbops.FindLogicalSwitchesWithPredicate(oc.nbClient, lookupExtSwFunction)
+	if err != nil && !errors.Is(err, libovsdbclient.ErrNotFound) {
+		klog.Warning("Failed trying to find stale external logical switches")
+	}
+
+	// Find stale gateway routers, based on well known prefix and node name
+	lookupGwRouterFunction := func(item *nbdb.LogicalRouter) bool {
+		nodeName := strings.TrimPrefix(item.Name, types.GWRouterPrefix)
+		if nodeName != item.Name && len(nodeName) > 0 && !foundNodes.Has(nodeName) {
+			staleNodes.Insert(nodeName)
+			return true
+		}
+		return false
+	}
+	_, err = libovsdbops.FindLogicalRoutersWithPredicate(oc.nbClient, lookupGwRouterFunction)
+	if err != nil && !errors.Is(err, libovsdbclient.ErrNotFound) {
+		klog.Warning("Failed trying to find stale gateway routers")
+	}
+
+	// Cleanup stale nodes (including gateway routers and external logical switches)
+	for _, staleNode := range staleNodes.UnsortedList() {
+		if err := oc.deleteNode(staleNode); err != nil {
+			return fmt.Errorf("failed to delete node:%s, err:%w", staleNode, err)
 		}
 	}
 

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
@@ -30,6 +31,7 @@ import (
 	libovsdbtest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	"github.com/pkg/errors"
 	"github.com/urfave/cli/v2"
 	kapi "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
@@ -1504,20 +1506,18 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 			err = clusterController.syncGatewayLogicalNetwork(updatedNode, l3GatewayConfig, []*net.IPNet{subnet}, hostAddrs)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			// Delete the node's gateway Logical Router Port to force an error. But save
-			// it first so we can add it back to let the delete proceed after we know the
-			// retry was successful
-			gatewayRouter := types.GWRouterPrefix + node1.Name
-			lr := &nbdb.LogicalRouter{Name: gatewayRouter}
-			lrp := &nbdb.LogicalRouterPort{Name: types.GWRouterToJoinSwitchPrefix + gatewayRouter}
-			lrp, err = libovsdbops.GetLogicalRouterPort(libovsdbOvnNBClient, lrp)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			err = libovsdbops.DeleteLogicalRouterPorts(libovsdbOvnNBClient, lr, lrp)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			// inject transient problem, nbdb is down
+			clusterController.nbClient.Close()
+			gomega.Eventually(func() bool {
+				return clusterController.nbClient.Connected()
+			}).Should(gomega.BeFalse())
 
 			// Node delete will fail with Failed to delete node node1,
 			err = fakeClient.KubeClient.CoreV1().Nodes().Delete(context.TODO(), testNode.Name, metav1.DeleteOptions{})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			// sleep long enough for TransactWithRetry to fail, causing LS (and other rows related to node) delete to fail
+			time.Sleep(types.OVSDBTimeout + time.Second)
 
 			// check the retry entry for this node
 			ginkgo.By("retry entry: old obj should not be nil, new obj should be nil")
@@ -1528,10 +1528,12 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 				gomega.BeNil(),             // newObj should be nil
 			)
 
-			// Add the LRP back to allow the delete the continue
-			err = libovsdbops.CreateOrUpdateLogicalRouterPorts(libovsdbOvnNBClient,
-				lr, []*nbdb.LogicalRouterPort{lrp}, &lrp.MAC, &lrp.Networks, &lrp.ExternalIDs)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			// reconnect nbdb
+			connCtx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout)
+			defer cancel()
+			resetNBClient(connCtx, clusterController.nbClient)
+
+			// reset backoff for immediate retry
 			retry.SetRetryObjWithNoBackoff(node1.Name, clusterController.retryNodes)
 			clusterController.retryNodes.RequestRetryObjs() // retry the failed entry
 
@@ -1547,6 +1549,70 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 		})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
+
+	ginkgo.It("delete a partially constructed node", func() {
+		app.Action = func(ctx *cli.Context) error {
+			_, err := config.InitConfig(ctx, nil, nil)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			config.Kubernetes.HostNetworkNamespace = ""
+
+			// Let the real code run and ensure OVN database sync
+			gomega.Expect(clusterController.WatchNodes()).To(gomega.Succeed())
+			gomega.Expect(clusterController.StartServiceController(wg, false)).To(gomega.Succeed())
+
+			subnet := ovntest.MustParseIPNet(node1.NodeSubnet)
+			err = clusterController.syncGatewayLogicalNetwork(&testNode, l3GatewayConfig, []*net.IPNet{subnet}, nodeHostAddrs)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			// Delete the node's gateway Logical Router Port to force node delete to handle a
+			// partially removed OVN DB
+			gatewayRouter := types.GWRouterPrefix + node1.Name
+			lr := &nbdb.LogicalRouter{Name: gatewayRouter}
+			lrp := &nbdb.LogicalRouterPort{Name: types.GWRouterToJoinSwitchPrefix + gatewayRouter}
+			lrp, err = libovsdbops.GetLogicalRouterPort(clusterController.nbClient, lrp)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			err = libovsdbops.DeleteLogicalRouterPorts(clusterController.nbClient, lr, lrp)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			_, err = libovsdbops.GetLogicalSwitch(clusterController.nbClient, &nbdb.LogicalSwitch{Name: node1.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			externalSwitch := types.ExternalSwitchPrefix + node1.Name
+			_, err = libovsdbops.GetLogicalSwitch(clusterController.nbClient, &nbdb.LogicalSwitch{Name: externalSwitch})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			// Node delete should not fail
+			err = fakeClient.KubeClient.CoreV1().Nodes().Delete(context.TODO(), testNode.Name, metav1.DeleteOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			gomega.Eventually(func() bool {
+				_, err := libovsdbops.GetLogicalSwitch(clusterController.nbClient, &nbdb.LogicalSwitch{Name: node1.Name})
+				return errors.Is(err, libovsdbclient.ErrNotFound)
+			}, 10).Should(gomega.BeTrue())
+
+			gomega.Eventually(func() bool {
+				_, err := libovsdbops.GetLogicalSwitch(clusterController.nbClient, &nbdb.LogicalSwitch{Name: externalSwitch})
+				return errors.Is(err, libovsdbclient.ErrNotFound)
+			}, 10).Should(gomega.BeTrue())
+
+			gomega.Eventually(func() bool {
+				_, err = libovsdbops.GetLogicalRouter(clusterController.nbClient, &nbdb.LogicalRouter{Name: gatewayRouter})
+				return errors.Is(err, libovsdbclient.ErrNotFound)
+			}, 10).Should(gomega.BeTrue())
+
+			// check the retry entry for this node
+			retry.CheckRetryObjectEventually(testNode.Name, false, clusterController.retryNodes)
+			return nil
+		}
+
+		err := app.Run([]string{
+			app.Name,
+			"-cluster-subnets=" + clusterCIDR,
+			"--init-gateways",
+			"--nodeport",
+		})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+
 	ginkgo.It("use node retry for a node without a host subnet", func() {
 		app.Action = func(ctx *cli.Context) error {
 			_, err := config.InitConfig(ctx, nil, nil)
@@ -1662,22 +1728,108 @@ func newNodeSNAT(uuid, logicalIP, externalIP string) *nbdb.NAT {
 }
 
 func TestController_syncNodes(t *testing.T) {
+	node1Name := "node1"
+	nodeRmName := "deleteMeNode"
+
 	tests := []struct {
 		name         string
+		initialNBDB  []libovsdbtest.TestData
+		expectedNBDB []libovsdbtest.TestData
 		initialSBDB  []libovsdbtest.TestData
 		expectedSBDB []libovsdbtest.TestData
 	}{
 		{
+			name: "removes node 2, leaves node 1 alone",
+			initialNBDB: []libovsdbtest.TestData{
+				&nbdb.LogicalSwitch{
+					Name:        node1Name,
+					UUID:        node1Name + "-UUID",
+					OtherConfig: map[string]string{"subnet": "1.2.3.4/24"},
+				},
+				&nbdb.LogicalSwitch{
+					Name: types.ExternalSwitchPrefix + node1Name,
+					UUID: types.ExternalSwitchPrefix + node1Name + "-UUID",
+				},
+				&nbdb.LogicalSwitch{
+					Name: types.EgressGWSwitchPrefix + types.ExternalSwitchPrefix + node1Name,
+					UUID: types.EgressGWSwitchPrefix + types.ExternalSwitchPrefix + node1Name + "-UUID",
+				},
+				&nbdb.LogicalRouter{
+					Name: types.GWRouterPrefix + node1Name,
+					UUID: types.GWRouterPrefix + node1Name + "-UUID",
+				},
+				// these should be deleted
+				&nbdb.LogicalSwitch{
+					Name:        nodeRmName,
+					UUID:        nodeRmName + "-UUID",
+					OtherConfig: map[string]string{"subnet": "1.2.3.5/24"},
+				},
+				&nbdb.LogicalSwitch{
+					Name: types.ExternalSwitchPrefix + nodeRmName,
+					UUID: types.ExternalSwitchPrefix + nodeRmName + "-UUID",
+				},
+				&nbdb.LogicalSwitch{
+					Name: types.EgressGWSwitchPrefix + types.ExternalSwitchPrefix + nodeRmName,
+					UUID: types.EgressGWSwitchPrefix + types.ExternalSwitchPrefix + nodeRmName + "-UUID",
+				},
+				&nbdb.LogicalRouter{
+					Name: types.GWRouterPrefix + nodeRmName,
+					UUID: types.GWRouterPrefix + nodeRmName + "-UUID",
+				},
+			},
+			expectedNBDB: []libovsdbtest.TestData{
+				&nbdb.LogicalSwitch{
+					Name:        node1Name,
+					UUID:        node1Name + "-UUID",
+					OtherConfig: map[string]string{"subnet": "1.2.3.4/24"},
+				},
+				&nbdb.LogicalSwitch{
+					Name: types.ExternalSwitchPrefix + node1Name,
+					UUID: types.ExternalSwitchPrefix + node1Name + "-UUID",
+				},
+				&nbdb.LogicalSwitch{
+					Name: types.EgressGWSwitchPrefix + types.ExternalSwitchPrefix + node1Name,
+					UUID: types.EgressGWSwitchPrefix + types.ExternalSwitchPrefix + node1Name + "-UUID",
+				},
+				&nbdb.LogicalRouter{
+					Name: types.GWRouterPrefix + node1Name,
+					UUID: types.GWRouterPrefix + node1Name + "-UUID",
+				},
+			},
+		},
+		{
+			name: "removes node that only had external logical switch left behind",
+			initialNBDB: []libovsdbtest.TestData{
+				// left-over external logical switch
+				&nbdb.LogicalSwitch{
+					Name: types.ExternalSwitchPrefix + nodeRmName,
+					UUID: types.ExternalSwitchPrefix + nodeRmName + "-UUID",
+				},
+			},
+			expectedNBDB: []libovsdbtest.TestData{},
+		},
+		{
+			name: "removes node that only had external gw logical router left behind",
+			initialNBDB: []libovsdbtest.TestData{
+				// left-over gateway router
+				&nbdb.LogicalRouter{
+					Name: types.GWRouterPrefix + nodeRmName,
+					UUID: types.GWRouterPrefix + nodeRmName + "-UUID",
+				},
+			},
+			expectedNBDB: []libovsdbtest.TestData{},
+		},
+		{
 			name: "removes stale chassis and chassis private",
 			initialSBDB: []libovsdbtest.TestData{
-				&sbdb.Chassis{Name: "chassis-node1", Hostname: "node1"},
+				&sbdb.Chassis{Name: "chassis-node1", Hostname: node1Name},
 				&sbdb.ChassisPrivate{Name: "chassis-node1"},
-				&sbdb.Chassis{Name: "chassis-node2", Hostname: "node2"},
+				&sbdb.Chassis{Name: "chassis-node2", Hostname: nodeRmName},
 				&sbdb.ChassisPrivate{Name: "chassis-node2"},
 				&sbdb.ChassisPrivate{Name: "chassis-node3"},
 			},
 			expectedSBDB: []libovsdbtest.TestData{
-				&sbdb.Chassis{Name: "chassis-node1", Hostname: "node1"},
+				&sbdb.Chassis{Name: "chassis-node1", Hostname: node1Name},
 				&sbdb.ChassisPrivate{Name: "chassis-node1"},
 			},
 		},
@@ -1707,6 +1859,7 @@ func TestController_syncNodes(t *testing.T) {
 			}
 
 			dbSetup := libovsdbtest.TestSetup{
+				NBData: tt.initialNBDB,
 				SBData: tt.initialSBDB,
 			}
 			nbClient, sbClient, libovsdbCleanup, err := libovsdbtest.NewNBSBTestHarness(dbSetup)
@@ -1734,13 +1887,26 @@ func TestController_syncNodes(t *testing.T) {
 				t.Fatalf("%s: Error on syncNodes: %v", tt.name, err)
 			}
 
-			matcher := libovsdbtest.HaveDataIgnoringUUIDs(tt.expectedSBDB)
-			match, err := matcher.Match(sbClient)
-			if err != nil {
-				t.Fatalf("%s: matcher error: %v", tt.name, err)
+			if tt.expectedNBDB != nil {
+				matcher := libovsdbtest.HaveDataIgnoringUUIDs(tt.expectedNBDB)
+				match, err := matcher.Match(nbClient)
+				if err != nil {
+					t.Fatalf("%s: NB matcher error: %v", tt.name, err)
+				}
+				if !match {
+					t.Fatalf("%s: NB DB state did not match: %s", tt.name, matcher.FailureMessage(sbClient))
+				}
 			}
-			if !match {
-				t.Fatalf("%s: DB state did not match: %s", tt.name, matcher.FailureMessage(sbClient))
+
+			if tt.expectedSBDB != nil {
+				matcher := libovsdbtest.HaveDataIgnoringUUIDs(tt.expectedSBDB)
+				match, err := matcher.Match(sbClient)
+				if err != nil {
+					t.Fatalf("%s: SB matcher error: %v", tt.name, err)
+				}
+				if !match {
+					t.Fatalf("%s: SB DB state did not match: %s", tt.name, matcher.FailureMessage(sbClient))
+				}
 			}
 		})
 	}

--- a/go-controller/pkg/util/net.go
+++ b/go-controller/pkg/util/net.go
@@ -73,7 +73,7 @@ func GetLRPAddrs(nbClient client.Client, portName string) ([]*net.IPNet, error) 
 	lrp := &nbdb.LogicalRouterPort{Name: portName}
 	lrp, err := libovsdbops.GetLogicalRouterPort(nbClient, lrp)
 	if err != nil {
-		return nil, fmt.Errorf("unable to find router port %s: %w", portName, err)
+		return nil, fmt.Errorf("failed to get router port %s: %w", portName, err)
 	}
 	gwLRPIPs := []*net.IPNet{}
 	for _, network := range lrp.Networks {


### PR DESCRIPTION
Cherry pick from https://github.com/openshift/ovn-kubernetes/pull/1731

Partial removal of nodes can leave OVN database with the gateway logical router and external logical switch of the removed node. This commit improves syncNode functionality, so these cases are also taken into consideration.

When deleting a port from a logical switch or router, it is possible that the logical switch or router themselves have been deleted. This commit changes the behavior of delete so it is not an error when if that happens.

Conflicts:
- go-controller/pkg/ovn/base_network_controller.go 
    - deleteNodeLogicalNetwork located in .../pkg/ovn/master.go
- go-controller/pkg/ovn/master_test.go

Signed-off-by: Flavio Fernandes <flaviof@redhat.com>
(cherry picked from commit 9fc87b22dad9919fd432d8dd20ed87f1605184e2)
