### PR TITLE
[release 4.13] OCPBUGS-15914: pip3 not available in ovn-kube-node container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,7 @@ ENV PYTHONDONTWRITEBYTECODE yes
 # - openvswitch-ipsec
 # - ovn-vtep
 RUN INSTALL_PKGS=" \
+        python3-pip \
 	openssl firewalld-filesystem \
 	libpcap iproute iproute-tc strace \
 	containernetworking-plugins \


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
--> With the use of rhel9 images, pip3 package is not by default available and hence ovnkube-trace fails

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
--> Added the pip3 package in the Dockerfile


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
--> Installed pip3 inside the container and ran the ovnkube-trace which works successfully.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
--> Added pip3 package to the ovn-kubernetes image

Signed-off-by: Himank Chaturvedi himankchaturvedi98@gmail.com