### PR TITLE
OCPBUGS-15586: [release-4.13]: Allow hostNetwork ingress for network policies with empty namespace selector

### DIFF
--- a/go-controller/pkg/ovn/egressfirewall_test.go
+++ b/go-controller/pkg/ovn/egressfirewall_test.go
@@ -1353,9 +1353,19 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 							},
 						},
 					})
-					startOvn(dbSetup, []v1.Namespace{namespace1}, nil)
 
-					_, err := fakeOVN.fakeClient.EgressFirewallClient.K8sV1().EgressFirewalls(egressFirewall.Namespace).
+					fakeOVN.startWithDBSetup(dbSetup,
+						&v1.NamespaceList{
+							Items: []v1.Namespace{
+								namespace1,
+							},
+						})
+					err := fakeOVN.controller.WatchNamespaces()
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					err = fakeOVN.controller.WatchEgressFirewall()
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+					_, err = fakeOVN.fakeClient.EgressFirewallClient.K8sV1().EgressFirewalls(egressFirewall.Namespace).
 						Create(context.TODO(), egressFirewall, metav1.CreateOptions{})
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -1396,7 +1406,16 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 							},
 						},
 					})
-					startOvn(dbSetup, []v1.Namespace{namespace1}, nil)
+					fakeOVN.startWithDBSetup(dbSetup,
+						&v1.NamespaceList{
+							Items: []v1.Namespace{
+								namespace1,
+							},
+						})
+					err := fakeOVN.controller.WatchNamespaces()
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					err = fakeOVN.controller.WatchEgressFirewall()
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 					// dns-based rule creation will fail, because addressset factory is nil
 					fakeOVN.controller.egressFirewallDNS = &EgressDNS{
@@ -1408,7 +1427,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 						stopChan: make(chan struct{}),
 					}
 
-					_, err := fakeOVN.fakeClient.EgressFirewallClient.K8sV1().EgressFirewalls(egressFirewall.Namespace).
+					_, err = fakeOVN.fakeClient.EgressFirewallClient.K8sV1().EgressFirewalls(egressFirewall.Namespace).
 						Create(context.TODO(), egressFirewall, metav1.CreateOptions{})
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -1419,9 +1438,8 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 
 					// check first acl was successfully created
 					asHash, _ := getNsAddrSetHashNames(namespace1.Name)
-					dbIDs := fakeOVN.controller.getEgressFirewallACLDbIDs(egressFirewall.Namespace, 0)
 					acl := libovsdbops.BuildACL(
-						getACLName(dbIDs),
+						buildEgressFwAclName(namespace1.Name, t.EgressFirewallStartPriority),
 						nbdb.ACLDirectionToLport,
 						t.EgressFirewallStartPriority,
 						"(ip4.dst == 1.2.3.4/23) && ip4.src == $"+asHash,
@@ -1429,9 +1447,13 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 						t.OvnACLLoggingMeter,
 						"",
 						false,
-						dbIDs.GetExternalIDs(),
+						map[string]string{
+							egressFirewallACLExtIdKey:    namespace1.Name,
+							egressFirewallACLPriorityKey: fmt.Sprintf("%d", t.EgressFirewallStartPriority),
+						},
 						nil,
 					)
+
 					acl.UUID = "acl-UUID"
 					clusterPortGroup.ACLs = []string{acl.UUID}
 					expectedDatabaseState := append(initialData, acl)

--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -1270,6 +1270,13 @@ func (oc *DefaultNetworkController) setupGressPolicy(np *networkPolicy, gp *gres
 		}
 		gp.addPeerAddressSets(ipv4as, ipv6as)
 	}
+	if podSel.Empty() && nsSel.Empty() && config.Kubernetes.HostNetworkNamespace != "" {
+		// all namespaces selector, add hostnetwork address set
+		_, err := gp.addNamespaceAddressSet(config.Kubernetes.HostNetworkNamespace, oc.addressSetFactory)
+		if err != nil {
+			return nil, fmt.Errorf("failed to add namespace address set for gress policy: %w", err)
+		}
+	}
 	return nil, nil
 }
 

--- a/go-controller/pkg/ovn/policy_test.go
+++ b/go-controller/pkg/ovn/policy_test.go
@@ -3,6 +3,7 @@ package ovn
 import (
 	"context"
 	"fmt"
+	"net"
 	"sort"
 	"strconv"
 	"time"
@@ -222,8 +223,16 @@ func getGressACLs(i int, namespace, policyName string, peerNamespaces []string, 
 	}
 	ipBlock := ""
 	for _, peer := range peers {
-		if peer.PodSelector != nil && len(peerNamespaces) == 0 {
-			peerIndex := getPodSelectorAddrSetDbIDs(getPodSelectorKey(peer.PodSelector, peer.NamespaceSelector, namespace), DefaultNetworkControllerName)
+		// follow the algorithm from setupGressPolicy
+		podSelector := peer.PodSelector
+		if podSelector == nil {
+			// nil pod selector is equivalent to empty pod selector, which selects all
+			podSelector = &metav1.LabelSelector{}
+		}
+		podSel, _ := metav1.LabelSelectorAsSelector(peer.PodSelector)
+		nsSel, _ := metav1.LabelSelectorAsSelector(peer.NamespaceSelector)
+		if !((peer.PodSelector == nil || podSel.Empty()) && (peer.NamespaceSelector == nil || !nsSel.Empty())) {
+			peerIndex := getPodSelectorAddrSetDbIDs(getPodSelectorKey(podSelector, peer.NamespaceSelector, namespace), DefaultNetworkControllerName)
 			asv4, _ := addressset.GetHashNamesForAS(peerIndex)
 			hashedASNames = append(hashedASNames, asv4)
 		}
@@ -2105,6 +2114,57 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 
 			err := app.Run([]string{app.Name})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+
+		ginkgo.It("references all namespace address sets for empty namespace selector, even if they don't have pods (HostNetworkNamespace)", func() {
+			app.Action = func(ctx *cli.Context) error {
+				hostNamespaceName := "host-network"
+				config.Kubernetes.HostNetworkNamespace = hostNamespaceName
+				hostNamespace := *newNamespace(hostNamespaceName)
+
+				namespace1 := *newNamespace(namespaceName1)
+				nPodTest := getTestPod(namespace1.Name, nodeName)
+				networkPolicy := newNetworkPolicy(netPolicyName1, namespaceName1, metav1.LabelSelector{}, []knet.NetworkPolicyIngressRule{
+					{
+						From: []knet.NetworkPolicyPeer{{
+							NamespaceSelector: &metav1.LabelSelector{},
+						}},
+					},
+				}, nil)
+				startOvn(initialDB, []v1.Namespace{namespace1, hostNamespace}, []knet.NetworkPolicy{*networkPolicy},
+					[]testPod{nPodTest}, nil)
+
+				// emulate namespace handler adding management IPs for this address set
+				// we could let controller do that, but that would require adding nodes with their annotations
+				dbIDs := libovsdbops.NewDbObjectIDs(libovsdbops.AddressSetNamespace, fakeOvn.controller.controllerName,
+					map[libovsdbops.ExternalIDKey]string{
+						libovsdbops.ObjectNameKey: hostNamespaceName,
+					})
+				// random set of IPs
+				hostNamespaceAddrSet, err := fakeOvn.asf.GetAddressSet(dbIDs)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				// emulate management IP being added to the hostNetwork address set, but no pods in that namespace
+				err = hostNamespaceAddrSet.SetIPs([]net.IP{net.ParseIP("10.244.0.2")})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				// create networkPolicy, check db
+				_, err = fakeOvn.fakeClient.KubeClient.NetworkingV1().NetworkPolicies(networkPolicy.Namespace).
+					Get(context.TODO(), networkPolicy.Name, metav1.GetOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				fakeOvn.asf.ExpectAddressSetWithIPs(namespaceName1, []string{nPodTest.podIP})
+				fakeOvn.asf.ExpectAddressSetWithIPs(hostNamespaceName, []string{"10.244.0.2"})
+
+				gressPolicyExpectedData := getPolicyData(networkPolicy, []string{nPodTest.portUUID},
+					[]string{hostNamespace.Name}, nil, "", false)
+				defaultDenyExpectedData := getDefaultDenyData(networkPolicy, []string{nPodTest.portUUID}, "", false)
+				expectedData := getUpdatedInitialDB([]testPod{nPodTest})
+				expectedData = append(expectedData, gressPolicyExpectedData...)
+				expectedData = append(expectedData, defaultDenyExpectedData...)
+				gomega.Eventually(fakeOvn.nbClient).Should(libovsdb.HaveData(expectedData...))
+
+				return nil
+			}
+			gomega.Expect(app.Run([]string{app.Name})).To(gomega.Succeed())
 		})
 	})
 


### PR DESCRIPTION
backport of https://github.com/ovn-org/ovn-kubernetes/pull/3669/commits/5e3dc65eb432b5fea7fc91aaea48758a64ccbd76
downstream merge https://github.com/openshift/ovn-kubernetes/pull/1729
includes unit test fix for egressfirewall introduced here https://github.com/openshift/ovn-kubernetes/pull/1733