### PR TITLE
Dockerfile: build both RHEL8 and RHEL9 shims

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,14 +4,18 @@
 #
 # The standard name for this image is ovn-kube
 
+# Build RHEL-9 binaries
 FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.19-openshift-4.13 AS builder
-
 WORKDIR /go/src/github.com/openshift/ovn-kubernetes
 COPY . .
+RUN cd go-controller; CGO_ENABLED=1 make
+RUN cd go-controller; CGO_ENABLED=1 make windows
 
-# build the binaries
-RUN cd go-controller; CGO_ENABLED=0 make
-RUN cd go-controller; CGO_ENABLED=0 make windows
+# Build RHEL-8 binaries (for upgrades from 4.12 and earlier)
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-4.13 AS rhel8
+WORKDIR /go/src/github.com/openshift/ovn-kubernetes
+COPY . .
+RUN cd go-controller; CGO_ENABLED=1 make
 
 # ovn-kubernetes-base image is built from Dockerfile.base
 # The following changes are included in ovn-kubernetes-base
@@ -51,6 +55,12 @@ COPY --from=builder /go/src/github.com/openshift/ovn-kubernetes/go-controller/_o
 COPY --from=builder /go/src/github.com/openshift/ovn-kubernetes/go-controller/_output/go/bin/windows/hybrid-overlay-node.exe /root/windows/
 COPY --from=builder /go/src/github.com/openshift/ovn-kubernetes/go-controller/_output/go/bin/ovndbchecker /usr/bin/
 COPY --from=builder /go/src/github.com/openshift/ovn-kubernetes/go-controller/_output/go/bin/ovnkube-trace /usr/bin/
+
+# Copy RHEL-8 and RHEL-9 shim binaries where the CNO's ovnkube-node container startup script can find them
+RUN mkdir -p /usr/libexec/cni/rhel9
+COPY --from=builder /go/src/github.com/openshift/ovn-kubernetes/go-controller/_output/go/bin/ovn-k8s-cni-overlay /usr/libexec/cni/rhel9/
+RUN mkdir -p /usr/libexec/cni/rhel8
+COPY --from=rhel8 /go/src/github.com/openshift/ovn-kubernetes/go-controller/_output/go/bin/ovn-k8s-cni-overlay /usr/libexec/cni/rhel8/
 
 RUN stat /usr/bin/oc
 


### PR DESCRIPTION
Since the shim (ovn-k8s-cni-overlay) gets copied to the host OS and executed in the host mount namespace by CRIO/Multus it needs to be runtime compatible with the host OS. Running a RHEL9-built shim on a RHEL8 system doesn't work due to different shared library dependencies between the two OS versions.

This wasn't a problem before because CGO_ENABLED=0 which essentially statically linked everything into the binary. But since we actually need CGO_ENABLED=1 (which ART forces on "official" builds anyway) to ensure we use OpenSSL's crypto for FIPS compliance, we run into the OS version problem with our binaries since they are really always built with CGO_ENABLED=1 anyway.

So... build two separate versions of ovn-kubernetes in different layers, and copy the RHEL8 shim into a special location where our container startup scripts can find it.