### PR TITLE
[WIP] [release-4.12] OCPBUGS-16336: Make ServiceTypeHasNodePort account for AllocateLoadBalancerNodePorts

### DIFF
--- a/go-controller/pkg/util/kube.go
+++ b/go-controller/pkg/util/kube.go
@@ -218,9 +218,14 @@ func ServiceTypeHasClusterIP(service *kapi.Service) bool {
 	return service.Spec.Type == kapi.ServiceTypeClusterIP || service.Spec.Type == kapi.ServiceTypeNodePort || service.Spec.Type == kapi.ServiceTypeLoadBalancer
 }
 
+func LoadBalancerServiceHasNodePortAllocation(service *kapi.Service) bool {
+	return service.Spec.AllocateLoadBalancerNodePorts == nil || *service.Spec.AllocateLoadBalancerNodePorts
+}
+
 // ServiceTypeHasNodePort checks if the service has an associated NodePort or not
 func ServiceTypeHasNodePort(service *kapi.Service) bool {
-	return service.Spec.Type == kapi.ServiceTypeNodePort || service.Spec.Type == kapi.ServiceTypeLoadBalancer
+	return service.Spec.Type == kapi.ServiceTypeNodePort ||
+		(service.Spec.Type == kapi.ServiceTypeLoadBalancer && LoadBalancerServiceHasNodePortAllocation(service))
 }
 
 // ServiceTypeHasLoadBalancer checks if the service has an associated LoadBalancer or not


### PR DESCRIPTION
**Alternative suggestion to https://github.com/openshift/ovn-kubernetes/pull/1766**

At various locations in the code, we use ServiceTypeHasNodePort to determine if a service allocated node ports. Make sure to account for services with allocateLoadBalancerNodePorts = false, as these do not allocate node ports and ServiceTypeHasNodePort should hence return false.

Partial cherry pick of 0111e1f.


(cherry picked from commit 0111e1f)

----

**Alternative suggestion to https://github.com/openshift/ovn-kubernetes/pull/1766**

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->