### PR TITLE
Cluster manager lock 

### DIFF
--- a/dist/templates/ovnkube-control-plane.yaml.j2
+++ b/dist/templates/ovnkube-control-plane.yaml.j2
@@ -123,6 +123,13 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        # OCP HACK begin
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        # OCP HACK end
         - name: OVN_HYBRID_OVERLAY_ENABLE
           value: "{{ ovn_hybrid_overlay_enable }}"
         - name: OVN_EGRESSIP_ENABLE

--- a/go-controller/cmd/ovnkube/ovnkube.go
+++ b/go-controller/cmd/ovnkube/ovnkube.go
@@ -247,7 +247,14 @@ func determineOvnkubeRunMode(ctx *cli.Context) (*ovnkubeRunMode, error) {
 	}
 
 	mode.identity, _ = identities.PopAny()
-
+	// OCP HACK begin
+	// when cluster manager runs alone, use pod name as identity to avoid duplicate leaders
+	// while switching from global zone to multizone
+	if mode.clusterManager && !mode.ovnkubeController {
+		mode.identity = os.Getenv("POD_NAME")
+	}
+	// OCP HACK end
+	klog.Infof("identity: %s", mode.identity)
 	return mode, nil
 }
 


### PR DESCRIPTION
Downstream hack to make sure there's only ever one cluster manager leader throughout upgrades from 4.13 to 4.14. 

An [upstream commit](https://github.com/openshift/ovn-kubernetes/commit/9d810a5ed45681bd5ad0b511296629e40f95c76c) has already been merged downstream:
- cluster-manager uses ovnkube-master lock when electing its leader, since that's what's in use in 4.13 where cluster manager is run as a goroutine of ovnkube-master

This PR introduces the following changes an actual downstream-only hack: 
- cluster manager, when running alone, identifies itself to the leader election library with its pod name instead of its node name; 
- this makes sure that during upgrades from 4.13 to 4.14, there are no two leaders during the short window of time where three  cluster manager pods run alongside the (soon-to-be-deleted) single-zone ovnk master pods (end of phase 2).
- without this hack, cluster manager pods would run leader election with their corresponding node names, and so would the existing ovnk master pods; any instance running on the same node where the election has been won will hold the lock at the same time. So if ovnk master on node A won the election, then cluster manager on node A will also believe it is holding the lock.

In 4.15 this downstream hack will be removed, once the 4.13->4.14 upgrade path is made required.

This goes hand in hand with this commit from CNO 1874: https://github.com/openshift/cluster-network-operator/pull/1874/commits/46456cfc2a0511640a5dfe5f610d582be58e709a
 _(YAML for leader election fix
Code for standalone cluster manager will read POD_NAME and use it as its identity for leader election.)_