### PR TITLE
[WIP] Changes IC chassis update to be a mutate operation

### DIFF
--- a/go-controller/pkg/libovsdb/ops/chassis.go
+++ b/go-controller/pkg/libovsdb/ops/chassis.go
@@ -151,10 +151,10 @@ func CreateOrUpdateChassis(sbClient libovsdbclient.Client, chassis *sbdb.Chassis
 			BulkOp:         false,
 		},
 		{
-			Model:          chassis,
-			OnModelUpdates: onModelUpdatesAllNonDefault(),
-			ErrNotFound:    false,
-			BulkOp:         false,
+			Model:            chassis,
+			OnModelMutations: []interface{}{&chassis.OtherConfig},
+			ErrNotFound:      false,
+			BulkOp:           false,
 		},
 	}
 


### PR DESCRIPTION
By updating the chassis with incomplete information, it was causing ovn-controler to rewrite the values in the DB, and furthermore causing northd to rewrite logical flows during ovnkube-master restart. The notable consequence of this would be that access to a service via loadbalancer type (using LB templates) would be momentarily disrupted. This is the root cause for the outage we see in Azure upgrades.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->