### PR TITLE
[release-4.13] OCPBUGS-17123: Remove stale egressip status entry

### DIFF
--- a/go-controller/pkg/ovn/default_network_controller.go
+++ b/go-controller/pkg/ovn/default_network_controller.go
@@ -1104,6 +1104,9 @@ func (h *defaultNetworkControllerEventHandler) SyncFunc(objs []interface{}) erro
 		case factory.EgressIPNamespaceType:
 			syncFunc = h.oc.syncEgressIPs
 
+		case factory.CloudPrivateIPConfigType:
+			syncFunc = h.oc.syncCloudPrivateIPConfigs
+
 		case factory.EgressNodeType:
 			syncFunc = h.oc.initClusterEgressPolicies
 
@@ -1111,8 +1114,7 @@ func (h *defaultNetworkControllerEventHandler) SyncFunc(objs []interface{}) erro
 			syncFunc = nil
 
 		case factory.EgressIPPodType,
-			factory.EgressIPType,
-			factory.CloudPrivateIPConfigType:
+			factory.EgressIPType:
 			syncFunc = nil
 
 		case factory.NamespaceType:

--- a/go-controller/pkg/ovn/egressip.go
+++ b/go-controller/pkg/ovn/egressip.go
@@ -1693,18 +1693,20 @@ func (oc *DefaultNetworkController) syncCloudPrivateIPConfigs(objs []interface{}
 	}
 	for _, egressIP := range egressIPs {
 		updatedStatus := []egressipv1.EgressIPStatusItem{}
-		cloudPrivateIPNotFoundOrInvalid := false
+		cloudPrivateIPNotFound := false
 		for _, status := range egressIP.Status.Items {
 			cloudPrivateIPConfigName := ipStringToCloudPrivateIPConfigName(status.EgressIP)
-			if nodeName, exists := cloudPrivateIPConfigMap[cloudPrivateIPConfigName]; exists && status.Node == nodeName {
+			if _, exists := cloudPrivateIPConfigMap[cloudPrivateIPConfigName]; exists {
 				updatedStatus = append(updatedStatus, status)
 			} else {
-				// Set cloudPrivateIPNotFoundOrInvalid flag to true because egress ip entry not found or not set with
-				// correct node name in cloud private ip config object.
-				cloudPrivateIPNotFoundOrInvalid = true
+				// Set cloudPrivateIPNotFoundOrInvalid flag to true because egress ip entry not found in
+				// cloud private ip config object. Note that the egress ip status might still reflect an
+				// old node assignment if the informer cache has old data, so do not invalidate if it is
+				// not the same node as the cloud private ip config assignment.
+				cloudPrivateIPNotFound = true
 			}
 		}
-		if cloudPrivateIPNotFoundOrInvalid {
+		if cloudPrivateIPNotFound {
 			// There could be one or more stale entry found in egress ip object, remove it by patching egressip
 			// object with updated status.
 			err = oc.patchReplaceEgressIPStatus(egressIP.Name, updatedStatus)

--- a/go-controller/pkg/ovn/egressip.go
+++ b/go-controller/pkg/ovn/egressip.go
@@ -1673,6 +1673,65 @@ func (oc *DefaultNetworkController) isAnyClusterNodeIP(ip net.IP) *egressNode {
 	return nil
 }
 
+// syncCloudPrivateIPConfigs This method takes care syncing stale data in the
+// egress ip status with cloud private ip config upon master reboot cases.
+// cloud private ip config entry would have been deleted when master was down
+// whereas egress ip status was not updated for the deleted entry in an error
+// scenario. Hence this method ensures egress ip status is upto date with
+// available cloud private ip config entry.
+func (oc *DefaultNetworkController) syncCloudPrivateIPConfigs(objs []interface{}) error {
+	if !util.PlatformTypeIsEgressIPCloudProvider() {
+		return nil
+	}
+	cloudPrivateIPConfigMap, err := oc.getCloudPrivateIPConfigMap(objs)
+	if err != nil {
+		return fmt.Errorf("syncCloudPrivateIPConfigs unable to get cloud private ip config: %w", err)
+	}
+	egressIPs, err := oc.watchFactory.GetEgressIPs()
+	if err != nil {
+		return fmt.Errorf("syncCloudPrivateIPConfigs unable to get Egress IPs: %w", err)
+	}
+	for _, egressIP := range egressIPs {
+		updatedStatus := []egressipv1.EgressIPStatusItem{}
+		cloudPrivateIPNotFoundOrInvalid := false
+		for _, status := range egressIP.Status.Items {
+			cloudPrivateIPConfigName := ipStringToCloudPrivateIPConfigName(status.EgressIP)
+			if nodeName, exists := cloudPrivateIPConfigMap[cloudPrivateIPConfigName]; exists && status.Node == nodeName {
+				updatedStatus = append(updatedStatus, status)
+			} else {
+				// Set cloudPrivateIPNotFoundOrInvalid flag to true because egress ip entry not found or not set with
+				// correct node name in cloud private ip config object.
+				cloudPrivateIPNotFoundOrInvalid = true
+			}
+		}
+		if cloudPrivateIPNotFoundOrInvalid {
+			// There could be one or more stale entry found in egress ip object, remove it by patching egressip
+			// object with updated status.
+			err = oc.patchReplaceEgressIPStatus(egressIP.Name, updatedStatus)
+			if err != nil {
+				return fmt.Errorf("syncCloudPrivateIPConfigs unable to update EgressIP status: %w", err)
+			}
+		}
+	}
+	return nil
+}
+
+// getCloudPrivateIPConfigMap returns cloud private ip config map cotaining ip address the key and
+// assigned node node name as the value. This method is intended to be invoked only in the case of
+// cloud environment.
+func (oc *DefaultNetworkController) getCloudPrivateIPConfigMap(objs []interface{}) (map[string]string, error) {
+	cloudPrivateIPConfigMap := make(map[string]string)
+	for _, obj := range objs {
+		cloudPrivateIPConfig, ok := obj.(*ocpcloudnetworkapi.CloudPrivateIPConfig)
+		if !ok {
+			klog.Errorf("Could not cast %T object to *ocpcloudnetworkapi.CloudPrivateIPConfig", obj)
+			continue
+		}
+		cloudPrivateIPConfigMap[cloudPrivateIPConfig.Name] = cloudPrivateIPConfig.Status.Node
+	}
+	return cloudPrivateIPConfigMap, nil
+}
+
 type EgressIPPatchStatus struct {
 	Op    string                    `json:"op"`
 	Path  string                    `json:"path"`

--- a/go-controller/pkg/ovn/egressip_test.go
+++ b/go-controller/pkg/ovn/egressip_test.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
+	ocpcloudnetworkapi "github.com/openshift/api/cloudnetwork/v1"
+	ocpconfigapi "github.com/openshift/api/config/v1"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	egressipv1 "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressip/v1"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
@@ -101,6 +103,17 @@ const (
 )
 
 func newEgressIPMeta(name string) metav1.ObjectMeta {
+	return metav1.ObjectMeta{
+		UID:  k8stypes.UID(name),
+		Name: name,
+		Labels: map[string]string{
+			"name": name,
+		},
+	}
+}
+
+func newCloudPrivateIPConfigMeta(egressIP string) metav1.ObjectMeta {
+	name := ipStringToCloudPrivateIPConfigName(egressIP)
 	return metav1.ObjectMeta{
 		UID:  k8stypes.UID(name),
 		Name: name,
@@ -6463,6 +6476,122 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 				return nil
 			}
 
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+
+		ginkgo.It("ensure egressIP status is in sync with cloud private ip config", func() {
+			app.Action = func(ctx *cli.Context) error {
+				config.Kubernetes.PlatformType = string(ocpconfigapi.AWSPlatformType)
+
+				egressIP1 := "192.168.126.101"
+				egressIP2 := "192.168.126.100"
+
+				node1 := setupNode(node1Name, []string{"192.168.126.12/24"}, map[string]string{egressIP1: egressIPName})
+				node2 := setupNode(node2Name, []string{"192.168.126.51/24"}, map[string]string{egressIP2: egressIPName})
+
+				eIP := egressipv1.EgressIP{
+					ObjectMeta: newEgressIPMeta(egressIPName),
+					Spec: egressipv1.EgressIPSpec{
+						EgressIPs: []string{egressIP1, egressIP2},
+					},
+					Status: egressipv1.EgressIPStatus{
+						Items: []egressipv1.EgressIPStatusItem{
+							{
+								EgressIP: egressIP1,
+								Node:     node1.name,
+							},
+							{
+								EgressIP: egressIP2,
+								Node:     node2.name,
+							},
+						},
+					},
+				}
+				cloudPrivateIPConfig := ocpcloudnetworkapi.CloudPrivateIPConfig{
+					ObjectMeta: newCloudPrivateIPConfigMeta(egressIP2),
+					Spec:       ocpcloudnetworkapi.CloudPrivateIPConfigSpec{Node: node2Name},
+					Status: ocpcloudnetworkapi.CloudPrivateIPConfigStatus{Node: node2Name,
+						Conditions: []metav1.Condition{{Status: metav1.ConditionTrue, Type: string(ocpcloudnetworkapi.Assigned)}}},
+				}
+				fakeOvn.start(
+					&egressipv1.EgressIPList{
+						Items: []egressipv1.EgressIP{eIP},
+					},
+					&ocpcloudnetworkapi.CloudPrivateIPConfigList{
+						Items: []ocpcloudnetworkapi.CloudPrivateIPConfig{cloudPrivateIPConfig},
+					},
+				)
+
+				fakeOvn.controller.eIPC.allocator.cache[node1.name] = &node1
+				fakeOvn.controller.eIPC.allocator.cache[node2.name] = &node2
+
+				err := fakeOvn.controller.WatchEgressIP()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				err = fakeOvn.controller.WatchCloudPrivateIPConfig()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				// Since there is no assignment of cloud private ip for one of the egress ip.
+				// syncCloudPrivateIPConfigs removes stale entry from egress ip object status
+				// and check if that is done properly or not.
+				gomega.Eventually(getEgressIPStatusLen(egressIPName)).Should(gomega.Equal(1))
+				egressIPs, nodes := getEgressIPStatus(egressIPName)
+				gomega.Expect(nodes[0]).To(gomega.Equal(node2.name))
+				gomega.Expect(egressIPs[0]).To(gomega.Equal(egressIP2))
+
+				return nil
+			}
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+
+		ginkgo.It("ensure egressIP status is in sync with empty cloud private ip config", func() {
+			app.Action = func(ctx *cli.Context) error {
+				config.Kubernetes.PlatformType = string(ocpconfigapi.AWSPlatformType)
+
+				egressIP1 := "192.168.126.101"
+				egressIP2 := "192.168.126.100"
+
+				node1 := setupNode(node1Name, []string{"192.168.126.12/24"}, map[string]string{egressIP1: egressIPName})
+				node2 := setupNode(node2Name, []string{"192.168.126.51/24"}, map[string]string{egressIP2: egressIPName})
+
+				eIP := egressipv1.EgressIP{
+					ObjectMeta: newEgressIPMeta(egressIPName),
+					Spec: egressipv1.EgressIPSpec{
+						EgressIPs: []string{egressIP1, egressIP2},
+					},
+					Status: egressipv1.EgressIPStatus{
+						Items: []egressipv1.EgressIPStatusItem{
+							{
+								EgressIP: egressIP1,
+								Node:     node1.name,
+							},
+							{
+								EgressIP: egressIP2,
+								Node:     node2.name,
+							},
+						},
+					},
+				}
+				fakeOvn.start(
+					&egressipv1.EgressIPList{
+						Items: []egressipv1.EgressIP{eIP},
+					},
+				)
+
+				fakeOvn.controller.eIPC.allocator.cache[node1.name] = &node1
+				fakeOvn.controller.eIPC.allocator.cache[node2.name] = &node2
+
+				err := fakeOvn.controller.WatchEgressIP()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				err = fakeOvn.controller.WatchCloudPrivateIPConfig()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				// Since there is no assignment of cloud private ip. syncCloudPrivateIPConfigs removes
+				// all entries from egress ip object status and check if that is done properly or not.
+				gomega.Eventually(getEgressIPStatusLen(egressIPName)).Should(gomega.Equal(0))
+				return nil
+			}
 			err := app.Run([]string{app.Name})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		})

--- a/go-controller/pkg/ovn/egressip_test.go
+++ b/go-controller/pkg/ovn/egressip_test.go
@@ -6596,6 +6596,66 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		})
 
+		ginkgo.It("ensure failover egressIP status is updated properly while cloud private ip config update in progress", func() {
+			app.Action = func(ctx *cli.Context) error {
+				config.Kubernetes.PlatformType = string(ocpconfigapi.AWSPlatformType)
+
+				egressIP := "192.168.126.101"
+
+				node1 := setupNode(node1Name, []string{"192.168.126.12/24"}, map[string]string{egressIP: egressIPName})
+				node2 := setupNode(node2Name, []string{"192.168.126.51/24"}, map[string]string{})
+
+				eIP := egressipv1.EgressIP{
+					ObjectMeta: newEgressIPMeta(egressIPName),
+					Spec: egressipv1.EgressIPSpec{
+						EgressIPs: []string{egressIP},
+					},
+					Status: egressipv1.EgressIPStatus{
+						Items: []egressipv1.EgressIPStatusItem{
+							{
+								EgressIP: egressIP,
+								Node:     node1.name,
+							},
+						},
+					},
+				}
+				cloudPrivateIPConfig := ocpcloudnetworkapi.CloudPrivateIPConfig{
+					ObjectMeta: newCloudPrivateIPConfigMeta(egressIP),
+					Spec:       ocpcloudnetworkapi.CloudPrivateIPConfigSpec{Node: node2Name},
+					Status: ocpcloudnetworkapi.CloudPrivateIPConfigStatus{Node: node2Name,
+						Conditions: []metav1.Condition{{Status: metav1.ConditionTrue, Type: string(ocpcloudnetworkapi.Assigned)}}},
+				}
+				fakeOvn.start(
+					&egressipv1.EgressIPList{
+						Items: []egressipv1.EgressIP{eIP},
+					},
+					&ocpcloudnetworkapi.CloudPrivateIPConfigList{
+						Items: []ocpcloudnetworkapi.CloudPrivateIPConfig{cloudPrivateIPConfig},
+					},
+				)
+
+				fakeOvn.controller.eIPC.allocator.cache[node1.name] = &node1
+				fakeOvn.controller.eIPC.allocator.cache[node2.name] = &node2
+
+				err := fakeOvn.controller.WatchEgressIP()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				err = fakeOvn.controller.WatchCloudPrivateIPConfig()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				// syncCloudPrivateIPConfigs might find different node assignments in the
+				// egress ip status and the cloud private ip config status because of old
+				// data in the informer cache. Check that the egress ip status is not
+				// considered stale in this case and reconciliation happens without issues.
+				gomega.Eventually(getEgressIPStatusLen(egressIPName)).Should(gomega.Equal(1))
+				egressIPs, nodes := getEgressIPStatus(egressIPName)
+				gomega.Expect(nodes[0]).To(gomega.Equal(node1.name))
+				gomega.Expect(egressIPs[0]).To(gomega.Equal(egressIP))
+
+				return nil
+			}
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+
 		ginkgo.It("should only get assigned EgressIPs which matches their subnet when the node is tagged", func() {
 			app.Action = func(ctx *cli.Context) error {
 

--- a/go-controller/pkg/ovn/ovn_test.go
+++ b/go-controller/pkg/ovn/ovn_test.go
@@ -5,6 +5,8 @@ import (
 	"sync"
 
 	"github.com/onsi/gomega"
+	ocpcloudnetworkapi "github.com/openshift/api/cloudnetwork/v1"
+	cloudservicefake "github.com/openshift/client-go/cloudnetwork/clientset/versioned/fake"
 	libovsdbclient "github.com/ovn-org/libovsdb/client"
 	egressfirewall "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressfirewall/v1"
 	egressfirewallfake "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressfirewall/v1/apis/clientset/versioned/fake"
@@ -72,6 +74,7 @@ func (o *FakeOVN) start(objects ...runtime.Object) {
 	egressFirewallObjects := []runtime.Object{}
 	egressQoSObjects := []runtime.Object{}
 	v1Objects := []runtime.Object{}
+	cloudObjects := []runtime.Object{}
 	for _, object := range objects {
 		if _, isEgressIPObject := object.(*egressip.EgressIPList); isEgressIPObject {
 			egressIPObjects = append(egressIPObjects, object)
@@ -79,6 +82,8 @@ func (o *FakeOVN) start(objects ...runtime.Object) {
 			egressFirewallObjects = append(egressFirewallObjects, object)
 		} else if _, isEgressQoSObject := object.(*egressqos.EgressQoSList); isEgressQoSObject {
 			egressQoSObjects = append(egressQoSObjects, object)
+		} else if _, isCloudPrivateIPConfig := object.(*ocpcloudnetworkapi.CloudPrivateIPConfigList); isCloudPrivateIPConfig {
+			cloudObjects = append(cloudObjects, object)
 		} else {
 			v1Objects = append(v1Objects, object)
 		}
@@ -88,6 +93,7 @@ func (o *FakeOVN) start(objects ...runtime.Object) {
 		EgressIPClient:       egressipfake.NewSimpleClientset(egressIPObjects...),
 		EgressFirewallClient: egressfirewallfake.NewSimpleClientset(egressFirewallObjects...),
 		EgressQoSClient:      egressqosfake.NewSimpleClientset(egressQoSObjects...),
+		CloudNetworkClient:   cloudservicefake.NewSimpleClientset(cloudObjects...),
 	}
 	o.init()
 }


### PR DESCRIPTION
Manual cherry-pick of 152ae1e4b3f80f299899de99c12c7ba55402f994 8dd5d2e3b109bfe328e6d5cecf3050860c70fbba c08382b8167732ca29b47045dc8e3ff99de4edc9 and 712978def57809d7dd73e23fb4e2e16f55bb998f.
Conflicts due to complete redesign of egress ip module. 
Needed to squash first 3 commits manually and did manual commit for the last one.