### PR TITLE
[release-4.11] OCPBUGS-12819: Handle k8s watcher restart scenario

### DIFF
--- a/go-controller/pkg/factory/factory.go
+++ b/go-controller/pkg/factory/factory.go
@@ -847,3 +847,29 @@ func noAlternateProxySelector() func(options *metav1.ListOptions) {
 		options.LabelSelector = labelSelector.String()
 	}
 }
+
+// WithUpdateHandlingForObjReplace decorates given cache.ResourceEventHandler with checking object
+// replace case in the update event. when old and new object have different UIDs, then consider it
+// as a replace and invoke delete handler for old object followed by add handler for new object.
+func WithUpdateHandlingForObjReplace(funcs cache.ResourceEventHandler) cache.ResourceEventHandlerFuncs {
+	return cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			funcs.OnAdd(obj)
+		},
+		UpdateFunc: func(old, new interface{}) {
+			oldObj := old.(metav1.Object)
+			newObj := new.(metav1.Object)
+			if oldObj.GetUID() == newObj.GetUID() {
+				funcs.OnUpdate(old, new)
+				return
+			}
+			// This occurs not so often, so log this occurance.
+			klog.Infof("Object %s/%s is replaced, invoking delete followed by add handler", newObj.GetNamespace(), newObj.GetName())
+			funcs.OnDelete(old)
+			funcs.OnAdd(new)
+		},
+		DeleteFunc: func(obj interface{}) {
+			funcs.OnDelete(obj)
+		},
+	}
+}

--- a/go-controller/pkg/factory/factory_test.go
+++ b/go-controller/pkg/factory/factory_test.go
@@ -696,6 +696,49 @@ var _ = Describe("Watch Factory Operations", func() {
 		wf.RemovePodHandler(h)
 	})
 
+	It("responds to pod replace with create/update/delete events", func() {
+		wf, err = NewMasterWatchFactory(ovnClientset)
+		Expect(err).NotTo(HaveOccurred())
+		err = wf.Start()
+		Expect(err).NotTo(HaveOccurred())
+
+		added := newPod("pod1", "default")
+		added.UID = "mybar"
+		h, c := addHandler(wf, PodType, cache.ResourceEventHandlerFuncs{
+			AddFunc: func(obj interface{}) {
+				pod := obj.(*v1.Pod)
+				Expect(pod.Spec.NodeName).To(Equal("mynode"))
+			},
+			UpdateFunc: func(old, new interface{}) {
+				newPod := new.(*v1.Pod)
+				Expect(newPod.UID).To(Equal(types.UID("mybar")))
+				Expect(newPod.Spec.NodeName).To(Equal("foobar"))
+			},
+			DeleteFunc: func(obj interface{}) {
+			},
+		})
+
+		pods = append(pods, added)
+		podWatch.Add(added)
+		Eventually(c.getAdded, 2).Should(Equal(1))
+		podCopy := added.DeepCopy()
+		podCopy.Spec.NodeName = "foobar"
+		podWatch.Modify(podCopy)
+		Eventually(c.getUpdated, 2).Should(Equal(1))
+		podCopy = added.DeepCopy()
+		podCopy.UID = "foobar"
+		podCopy.Spec.NodeName = "mynode"
+		podWatch.Modify(podCopy)
+		Eventually(c.getDeleted, 2).Should(Equal(1))
+		Eventually(c.getAdded, 2).Should(Equal(2))
+		Eventually(c.getUpdated, 2).Should(Equal(1))
+		pods = pods[:0]
+		podWatch.Delete(added)
+		Eventually(c.getDeleted, 2).Should(Equal(2))
+
+		wf.RemovePodHandler(h)
+	})
+
 	It("responds to multiple pod add/update/delete events", func() {
 		wf, err = NewMasterWatchFactory(ovnClientset)
 		Expect(err).NotTo(HaveOccurred())

--- a/go-controller/pkg/factory/handler.go
+++ b/go-controller/pkg/factory/handler.go
@@ -16,6 +16,7 @@ import (
 	cloudprivateipconfiglister "github.com/openshift/client-go/cloudnetwork/listers/cloudnetwork/v1"
 	egressiplister "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressip/v1/apis/listers/egressip/v1"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ktypes "k8s.io/apimachinery/pkg/types"
 	listers "k8s.io/client-go/listers/core/v1"
 	netlisters "k8s.io/client-go/listers/networking/v1"
@@ -307,7 +308,16 @@ func (i *informer) newFederatedQueuedHandler(numEventQueues uint32) cache.Resour
 				metrics.MetricResourceUpdateCount.WithLabelValues(name, "update").Inc()
 				start := time.Now()
 				i.forEachQueuedHandler(func(h *Handler) {
-					h.OnUpdate(e.oldObj, e.obj)
+					old := oldObj.(metav1.Object)
+					new := newObj.(metav1.Object)
+					if old.GetUID() != new.GetUID() {
+						// This occurs not so often, so log this occurance.
+						klog.Infof("Object %s/%s is replaced, invoking delete followed by add handler", new.GetNamespace(), new.GetName())
+						h.OnDelete(e.oldObj)
+						h.OnAdd(e.obj)
+					} else {
+						h.OnUpdate(e.oldObj, e.obj)
+					}
 				})
 				metrics.MetricResourceUpdateLatency.Observe(time.Since(start).Seconds())
 				i.unrefQueueEntry(key, entry, false)
@@ -348,7 +358,16 @@ func (i *informer) newFederatedHandler() cache.ResourceEventHandlerFuncs {
 			metrics.MetricResourceUpdateCount.WithLabelValues(name, "update").Inc()
 			start := time.Now()
 			i.forEachHandler(newObj, func(h *Handler) {
-				h.OnUpdate(oldObj, newObj)
+				old := oldObj.(metav1.Object)
+				new := newObj.(metav1.Object)
+				if old.GetUID() != new.GetUID() {
+					// This occurs not so often, so log this occurance.
+					klog.Infof("Object %s/%s is replaced, invoking delete followed by add handler", new.GetNamespace(), new.GetName())
+					h.OnDelete(oldObj)
+					h.OnAdd(newObj)
+				} else {
+					h.OnUpdate(oldObj, newObj)
+				}
 			})
 			metrics.MetricResourceUpdateLatency.Observe(time.Since(start).Seconds())
 		},

--- a/go-controller/pkg/ovn/controller/services/node_tracker.go
+++ b/go-controller/pkg/ovn/controller/services/node_tracker.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	globalconfig "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 
 	v1 "k8s.io/api/core/v1"
@@ -69,7 +70,7 @@ func newNodeTracker(nodeInformer coreinformers.NodeInformer) *nodeTracker {
 		nodes: map[string]nodeInfo{},
 	}
 
-	nodeInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	nodeInformer.Informer().AddEventHandler(factory.WithUpdateHandlingForObjReplace(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			node, ok := obj.(*v1.Node)
 			if !ok {
@@ -114,7 +115,7 @@ func newNodeTracker(nodeInformer coreinformers.NodeInformer) *nodeTracker {
 			}
 			nt.removeNodeWithServiceReSync(node.Name)
 		},
-	})
+	}))
 
 	return nt
 

--- a/go-controller/pkg/ovn/controller/services/services_controller.go
+++ b/go-controller/pkg/ovn/controller/services/services_controller.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	libovsdbclient "github.com/ovn-org/libovsdb/client"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/metrics"
 	ovnlb "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/loadbalancer"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
@@ -70,21 +71,21 @@ func NewController(client clientset.Interface,
 
 	// services
 	klog.Info("Setting up event handlers for services")
-	serviceInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	serviceInformer.Informer().AddEventHandler(factory.WithUpdateHandlingForObjReplace(cache.ResourceEventHandlerFuncs{
 		AddFunc:    c.onServiceAdd,
 		UpdateFunc: c.onServiceUpdate,
 		DeleteFunc: c.onServiceDelete,
-	})
+	}))
 	c.serviceLister = serviceInformer.Lister()
 	c.servicesSynced = serviceInformer.Informer().HasSynced
 
 	// endpoints slices
 	klog.Info("Setting up event handlers for endpoint slices")
-	endpointSliceInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	endpointSliceInformer.Informer().AddEventHandler(factory.WithUpdateHandlingForObjReplace(cache.ResourceEventHandlerFuncs{
 		AddFunc:    c.onEndpointSliceAdd,
 		UpdateFunc: c.onEndpointSliceUpdate,
 		DeleteFunc: c.onEndpointSliceDelete,
-	})
+	}))
 
 	c.endpointSliceLister = endpointSliceInformer.Lister()
 	c.endpointSlicesSynced = endpointSliceInformer.Informer().HasSynced

--- a/go-controller/pkg/ovn/egressqos.go
+++ b/go-controller/pkg/ovn/egressqos.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	egressqosapi "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressqos/v1"
 	egressqosinformer "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressqos/v1/apis/informers/externalversions/egressqos/v1"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdbops"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
 	addressset "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/address_set"
@@ -170,11 +171,11 @@ func (oc *Controller) initEgressQoSController(
 		workqueue.NewItemFastSlowRateLimiter(1*time.Second, 5*time.Second, 5),
 		"egressqos",
 	)
-	eqInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	eqInformer.Informer().AddEventHandler(factory.WithUpdateHandlingForObjReplace(cache.ResourceEventHandlerFuncs{
 		AddFunc:    oc.onEgressQoSAdd,
 		UpdateFunc: oc.onEgressQoSUpdate,
 		DeleteFunc: oc.onEgressQoSDelete,
-	})
+	}))
 
 	oc.egressQoSPodLister = podInformer.Lister()
 	oc.egressQoSPodSynced = podInformer.Informer().HasSynced
@@ -182,11 +183,11 @@ func (oc *Controller) initEgressQoSController(
 		workqueue.NewItemFastSlowRateLimiter(1*time.Second, 5*time.Second, 5),
 		"egressqospods",
 	)
-	podInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	podInformer.Informer().AddEventHandler(factory.WithUpdateHandlingForObjReplace(cache.ResourceEventHandlerFuncs{
 		AddFunc:    oc.onEgressQoSPodAdd,
 		UpdateFunc: oc.onEgressQoSPodUpdate,
 		DeleteFunc: oc.onEgressQoSPodDelete,
-	})
+	}))
 
 	oc.egressQoSNodeLister = nodeInformer.Lister()
 	oc.egressQoSNodeSynced = nodeInformer.Informer().HasSynced


### PR DESCRIPTION
Backport of 4.12 commit 63330f2220ff88256db076adfd93886591618889.

Resolved conflict:
`go-controller/pkg/ovn/controller/egress_services/egress_services_controller.go`
(removed this file as this is not valid for 4.11)