### PR TITLE
OCPBUGS-17503: libovsdb: give monitor setup time to process than normal transactions 

### DIFF
--- a/go-controller/pkg/libovsdb/libovsdb.go
+++ b/go-controller/pkg/libovsdb/libovsdb.go
@@ -98,7 +98,7 @@ func NewSBClientWithConfig(cfg config.OvnAuthConfig, promRegistry prometheus.Reg
 		return nil, err
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout*2)
 	go func() {
 		<-stopCh
 		cancel()
@@ -160,7 +160,7 @@ func NewNBClientWithConfig(cfg config.OvnAuthConfig, promRegistry prometheus.Reg
 		return nil, err
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout*2)
 	go func() {
 		<-stopCh
 		cancel()


### PR DESCRIPTION
Backport of https://github.com/ovn-org/ovn-kubernetes/pull/3819
downstream merge https://github.com/openshift/ovn-kubernetes/pull/1803
clean backport