### PR TITLE
OCPBUGS-17522: [release-4.12] libovsdb: give monitor setup time to process than normal transactions

### DIFF
--- a/go-controller/pkg/libovsdb/libovsdb.go
+++ b/go-controller/pkg/libovsdb/libovsdb.go
@@ -96,7 +96,7 @@ func NewSBClientWithConfig(cfg config.OvnAuthConfig, promRegistry prometheus.Reg
 		return nil, err
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout*2)
 	go func() {
 		<-stopCh
 		cancel()
@@ -158,7 +158,7 @@ func NewNBClientWithConfig(cfg config.OvnAuthConfig, promRegistry prometheus.Reg
 		return nil, err
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout*2)
 	go func() {
 		<-stopCh
 		cancel()


### PR DESCRIPTION
clean backport of https://github.com/openshift/ovn-kubernetes/pull/1807
image `quay.io/npinaeva/ovn-k:db-timer-workaround` is based on this PR