### PR TITLE
OCPBUGS-17675: Don't return error on delete event that doesn't ave a chance to succeed.

### DIFF
--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -1525,7 +1525,10 @@ func (oc *Controller) handlePeerPodSelectorDelete(np *networkPolicy, gp *gressPo
 	if util.PodCompleted(pod) {
 		ips, err := util.GetAllPodIPs(pod)
 		if err != nil {
-			return fmt.Errorf("can't get pod IPs %s/%s: %w", pod.Namespace, pod.Name, err)
+			// if pod ips can't be fetched on delete, we don't expect that information about ips will ever be updated,
+			// therefore just log the error and return.
+			klog.Warningf("Could not find pod %s/%s IPs to delete from pod selector address set: %v", pod.Namespace, pod.Name, err)
+			return nil
 		}
 
 		collidingPod, err := oc.findPodWithIPAddresses(ips)


### PR DESCRIPTION
Besides unneeded logging it may cause update event that was received after delete event to be never handled, since retry framework will not proceed to the update handler until delete handler succeeds. Was fixed in newer versions with 120140fd670d8358959e6ea062564edd9d7d8841 (pod_selector_address_set)
Merged downstream here https://github.com/openshift/ovn-kubernetes/pull/1603 (4.13), https://github.com/openshift/ovn-kubernetes/pull/1603/files#diff-7375899468809f8394c8c50f436167aa32368e3dac1eb0c25d05e6b9b0e2cbe3R354-R359 
loglevel was updated to warning here https://github.com/ovn-org/ovn-kubernetes/commit/8e95a642698a763fb885fe318d3e9b20d8502205