### PR TITLE
CARRY: Dockerfile.fedora - Copy ovn-k8s-cni-overlay to rhel9

### DIFF
--- a/dist/images/Dockerfile.fedora
+++ b/dist/images/Dockerfile.fedora
@@ -46,6 +46,8 @@ RUN rpm -Uhv --nodeps --force *.rpm
 RUN mkdir -p /usr/libexec/cni/
 COPY ovnkube ovn-kube-util ovndbchecker /usr/bin/
 COPY ovn-k8s-cni-overlay /usr/libexec/cni/ovn-k8s-cni-overlay
+RUN mkdir -p /usr/libexec/cni/rhel9
+RUN ln -s /usr/libexec/cni/{,rhel9/}ovn-k8s-cni-overlay
 
 # ovnkube.sh is the entry point. This script examines environment
 # variables to direct operation and configure ovn


### PR DESCRIPTION
With the FIPs changes ( https://github.com/openshift/cluster-network-operator/pull/1901 ), the Cluster Network Operator (CNO) now expects ovn-k8s-cni-overlay one level deeper in the directory tree.

For OCP 4.14 and later, ovn-k8s-cni-overlay's location is updated to: /usr/libexec/cni/rhel9/ovn-k8s-cni-overlay, instead of /usr/libexec/cni/ovn-k8s-cni-overlay.

This adjustment proves useful when replacing locally built ovnk images for OCP deployments.

And avoid:
```
...
+ sourcedir=/usr/libexec/cni/
+ case "${rhelmajor}" in
+ sourcedir=/usr/libexec/cni/rhel9
+ cp -f /usr/libexec/cni/rhel9/ovn-k8s-cni-overlay /cni-bin-dir/ cp: cannot stat '/usr/libexec/cni/rhel9/ovn-k8s-cni-overlay': No such file or directory
```