### PR TITLE
[wip] Fix duplicate routes after HO route sync

### DIFF
--- a/dist/images/Dockerfile.fedora
+++ b/dist/images/Dockerfile.fedora
@@ -46,6 +46,8 @@ RUN rpm -Uhv --nodeps --force *.rpm
 RUN mkdir -p /usr/libexec/cni/
 COPY ovnkube ovn-kube-util ovndbchecker /usr/bin/
 COPY ovn-k8s-cni-overlay /usr/libexec/cni/ovn-k8s-cni-overlay
+RUN mkdir -p /usr/libexec/cni/rhel9
+RUN ln -s /usr/libexec/cni/{,rhel9/}ovn-k8s-cni-overlay
 
 # ovnkube.sh is the entry point. This script examines environment
 # variables to direct operation and configure ovn

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -61,12 +61,11 @@ func (oc *DefaultNetworkController) syncPods(pods []interface{}) error {
 
 		// delete the outdated hybrid overlay subnet route if it exists
 		newRoutes := []util.PodRoute{}
-		for _, subnet := range oc.lsManager.GetSwitchSubnets(pod.Spec.NodeName) {
-			hybridOverlayIFAddr := util.GetNodeHybridOverlayIfAddr(subnet).IP
-			for _, route := range annotations.Routes {
-				if !route.NextHop.Equal(hybridOverlayIFAddr) {
-					newRoutes = append(newRoutes, route)
-				}
+		// HO is IPv4 only
+		ipv4Subnets := util.MatchAllIPNetFamily(false, oc.lsManager.GetSwitchSubnets(pod.Spec.NodeName))
+		for _, route := range annotations.Routes {
+			if !util.IsNodeHybridOverlayIfAddr(route.NextHop, ipv4Subnets) {
+				newRoutes = append(newRoutes, route)
 			}
 		}
 		// checking the length because cannot compare the slices directly and if routes are removed

--- a/go-controller/pkg/ovn/pods_test.go
+++ b/go-controller/pkg/ovn/pods_test.go
@@ -253,6 +253,7 @@ func (p testPod) getAnnotationsJson() string {
 		TunnelID int        `json:"tunnel_id,omitempty"`
 	}
 
+	var address string
 	addresses := []string{}
 	for _, podIP := range strings.Split(p.podIP, " ") {
 		if utilnet.IsIPv4String(podIP) {
@@ -262,8 +263,15 @@ func (p testPod) getAnnotationsJson() string {
 		}
 		addresses = append(addresses, podIP)
 	}
+	if len(addresses) == 1 {
+		address = addresses[0]
+	}
 
 	nodeGWIPs := strings.Split(p.nodeGWIP, " ")
+	var nodeGWIP string
+	if len(nodeGWIPs) == 1 {
+		nodeGWIP = nodeGWIPs[0]
+	}
 
 	var routes []podRoute
 	for _, route := range p.routes {
@@ -273,9 +281,9 @@ func (p testPod) getAnnotationsJson() string {
 	podAnnotations := map[string]podAnnotation{
 		"default": {
 			MAC:      p.podMAC,
-			IP:       addresses[0],
+			IP:       address,
 			IPs:      addresses,
-			Gateway:  nodeGWIPs[0],
+			Gateway:  nodeGWIP,
 			Gateways: nodeGWIPs,
 			Routes:   routes,
 		},
@@ -2171,6 +2179,80 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 				gomega.Expect(err).NotTo(gomega.BeNil())
 				myPod1Key, err := retry.GetResourceKey(pod)
 				retry.CheckRetryObjectEventually(myPod1Key, true, fakeOvn.controller.retryPods)
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+
+		ginkgo.It("deletes an outdated hybrid overlay subnet route in dual stack configuration", func() {
+			app.Action = func(ctx *cli.Context) error {
+
+				namespaceT := *newNamespace("namespace1")
+				t := newTPod(
+					"node1",
+					"10.128.1.0/24 fd11::/64",
+					"",
+					"10.128.1.1 fd11::1",
+					"myPod",
+					"10.128.1.30 fd11::30",
+					"0a:58:0a:80:01:03",
+					namespaceT.Name,
+				)
+
+				// annotations without HO route
+				expectedAnnotations := t.getAnnotationsJson()
+
+				// add HO route
+				t.routes = append(
+					t.routes,
+					util.PodRoute{
+						Dest:    ovntest.MustParseIPNet("10.128.10.0/24"),
+						NextHop: ovntest.MustParseIP("10.128.1.3"),
+					},
+				)
+
+				// set annotattions on pod with the oudated HO route
+				pod := newPod(t.namespace, t.podName, t.nodeName, t.podIP)
+				setPodAnnotations(pod, t)
+
+				fakeOvn.startWithDBSetup(initialDB,
+					&v1.NamespaceList{
+						Items: []v1.Namespace{
+							namespaceT,
+						},
+					},
+					&v1.NodeList{
+						Items: []v1.Node{
+							*newNode(node1Name, "192.168.126.202/24"),
+						},
+					},
+					&v1.PodList{
+						Items: []v1.Pod{
+							*pod,
+						},
+					},
+				)
+				t.populateLogicalSwitchCache(fakeOvn)
+
+				// pod exists with the expected annotation including the oudated HO route
+				gomega.Eventually(func() string {
+					return getPodAnnotations(fakeOvn.fakeClient.KubeClient, t.namespace, t.podName)
+				}, 2).Should(gomega.MatchJSON(t.getAnnotationsJson()))
+
+				err := fakeOvn.controller.WatchNamespaces()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				err = fakeOvn.controller.WatchPods()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				// check that after start the HO route has been removed
+				gomega.Eventually(func() string {
+					return getPodAnnotations(fakeOvn.fakeClient.KubeClient, t.namespace, t.podName)
+				}, 2).Should(gomega.MatchJSON(expectedAnnotations))
+
+				gomega.Eventually(fakeOvn.nbClient).Should(
+					libovsdbtest.HaveData(getExpectedDataPodsAndSwitches([]testPod{t}, []string{"node1"})))
 				return nil
 			}
 

--- a/go-controller/pkg/util/net.go
+++ b/go-controller/pkg/util/net.go
@@ -63,6 +63,17 @@ func GetNodeHybridOverlayIfAddr(subnet *net.IPNet) *net.IPNet {
 	return &net.IPNet{IP: iputils.NextIP(mgmtIfAddr.IP), Mask: subnet.Mask}
 }
 
+// IsNodeHybridOverlayIfAddr returns whether the provided IP is a node hybrid
+// overlay address on any of the provided subnets
+func IsNodeHybridOverlayIfAddr(ip net.IP, subnets []*net.IPNet) bool {
+	for _, subnet := range subnets {
+		if ip.Equal(GetNodeHybridOverlayIfAddr(subnet).IP) {
+			return true
+		}
+	}
+	return false
+}
+
 // JoinHostPortInt32 is like net.JoinHostPort(), but with an int32 for the port
 func JoinHostPortInt32(host string, port int32) string {
 	return net.JoinHostPort(host, strconv.Itoa(int(port)))


### PR DESCRIPTION
This is a temporary PR for downstream, while we wait for upstream https://github.com/ovn-org/ovn-kubernetes/pull/3828
to merge and get backported.

Ref: https://issues.redhat.com/browse/OCPBUGS-17248?focusedId=22805492&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-22805492


On syncPods there is an hybryd overlay route sync to clear out an outdated route. The logic is not matching on IP family so it ends up duplicating routes in dual stack configurations.
