### PR TITLE
OCPBUGS-18057: [release-4.13] Create egress firewall with one db transaction

### DIFF
--- a/go-controller/pkg/ovn/address_set/address_set.go
+++ b/go-controller/pkg/ovn/address_set/address_set.go
@@ -291,10 +291,12 @@ func GetDbObjsForAS(dbIDs *libovsdbops.DbObjectIDs, ips []net.IP) (*nbdb.Address
 	v4set = buildAddressSet(dbIDs, ipv4InternalID)
 	uniqIPs := ipsToStringUnique(v4IPs)
 	v4set.Addresses = uniqIPs
+	v4set.UUID = v4set.Name + "-UUID"
 	// v6 address set
 	v6set = buildAddressSet(dbIDs, ipv6InternalID)
 	uniqIPs = ipsToStringUnique(v6IPs)
 	v6set.Addresses = uniqIPs
+	v6set.UUID = v6set.Name + "-UUID"
 	return v4set, v6set
 }
 


### PR DESCRIPTION
backport of https://github.com/ovn-org/ovn-kubernetes/pull/3847
downstream merge https://github.com/openshift/ovn-kubernetes/pull/1833

Conflicts:
	go-controller/pkg/ovn/egressfirewall.go - different func signatures
	go-controller/pkg/ovn/egressfirewall_test.go - uses fakeAddressSetFactory,
check address sets in asf instead of db