### PR TITLE
OCPBUGS-18058: [release-4.12] Create egress firewall with one db transaction

### DIFF
--- a/go-controller/pkg/ovn/egressfirewall.go
+++ b/go-controller/pkg/ovn/egressfirewall.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"sync"
 
+	libovsdb "github.com/ovn-org/libovsdb/ovsdb"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	egressfirewallapi "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressfirewall/v1"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdbops"
@@ -310,6 +311,8 @@ func (oc *Controller) updateEgressFirewallStatusWithRetry(egressfirewall *egress
 }
 
 func (oc *Controller) addEgressFirewallRules(ef *egressFirewall, hashedAddressSetNameIPv4, hashedAddressSetNameIPv6 string, efStartPriority int, aclLogging *ACLLoggingLevels) error {
+	var ops []libovsdb.Operation
+	var err error
 	for _, rule := range ef.egressRules {
 		var action string
 		var matchTargets []matchTarget
@@ -339,17 +342,21 @@ func (oc *Controller) addEgressFirewallRules(ef *egressFirewall, hashedAddressSe
 			}
 		}
 		match := generateMatch(hashedAddressSetNameIPv4, hashedAddressSetNameIPv6, matchTargets, rule.ports)
-		err := oc.createEgressFirewallRules(efStartPriority-rule.id, match, action, ef.namespace, aclLogging)
+		ops, err = oc.createEgressFirewallACLOps(ops, efStartPriority-rule.id, match, action, ef.namespace, aclLogging)
 		if err != nil {
 			return err
 		}
 	}
+	_, err = libovsdbops.TransactAndCheck(oc.nbClient, ops)
+	if err != nil {
+		return fmt.Errorf("failed to transact egressFirewall ACL: %v", err)
+	}
 	return nil
 }
 
-// createEgressFirewallRules uses the previously generated elements and creates the
+// createEgressFirewallACLOps uses the previously generated elements and creates the
 // acls for all node switches
-func (oc *Controller) createEgressFirewallRules(priority int, match, action, externalID string, aclLogging *ACLLoggingLevels) error {
+func (oc *Controller) createEgressFirewallACLOps(ops []libovsdb.Operation, priority int, match, action, externalID string, aclLogging *ACLLoggingLevels) ([]libovsdb.Operation, error) {
 	// a name is needed for logging purposes - the name must be unique, so make it
 	// egressFirewall_<namespace name>_<priority>
 	aclName := buildEgressFwAclName(externalID, priority)
@@ -367,24 +374,21 @@ func (oc *Controller) createEgressFirewallRules(priority int, match, action, ext
 			egressFirewallACLPriorityKey: fmt.Sprintf("%d", priority),
 		},
 	)
-	ops, err := libovsdbops.CreateOrUpdateACLsOps(oc.nbClient, nil, egressFirewallACL)
+	var err error
+	ops, err = libovsdbops.CreateOrUpdateACLsOps(oc.nbClient, ops, egressFirewallACL)
 	if err != nil {
-		return fmt.Errorf("failed to create egressFirewall ACL %v: %v", egressFirewallACL, err)
+		return ops, fmt.Errorf("failed to create egressFirewall ACL %v: %v", egressFirewallACL, err)
 	}
 
 	// Applying ACLs on types.ClusterPortGroupName is equivalent to applying on every node switch, since
 	// types.ClusterPortGroupName contains management port from every switch.
 	ops, err = libovsdbops.AddACLsToPortGroupOps(oc.nbClient, ops, types.ClusterPortGroupName, egressFirewallACL)
 	if err != nil {
-		return fmt.Errorf("failed to add egressFirewall ACL %v to port group %s: %v",
+		return ops, fmt.Errorf("failed to add egressFirewall ACL %v to port group %s: %v",
 			egressFirewallACL, types.ClusterPortGroupName, err)
 	}
-	_, err = libovsdbops.TransactAndCheck(oc.nbClient, ops)
-	if err != nil {
-		return fmt.Errorf("failed to transact egressFirewall ACL: %v", err)
-	}
 
-	return nil
+	return ops, nil
 }
 
 // deleteEgressFirewallRules delete egress firewall Acls

--- a/go-controller/pkg/ovn/egressfirewall_test.go
+++ b/go-controller/pkg/ovn/egressfirewall_test.go
@@ -14,7 +14,6 @@ import (
 	egressfirewallapi "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressfirewall/v1"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdbops"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
-	addressset "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/address_set"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/retry"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
 	libovsdbtest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
@@ -1159,21 +1158,24 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 				config.Gateway.Mode = gwMode
 				app.Action = func(ctx *cli.Context) error {
 					namespace1 := *newNamespace("namespace1")
+					dnsName := "a.b.c"
+					resolvedIP := "2.2.2.2"
 					egressFirewall := newEgressFirewallObject("default", namespace1.Name, []egressfirewallapi.EgressFirewallRule{
 						{
 							Type: "Deny",
 							To: egressfirewallapi.EgressFirewallDestination{
-								CIDRSelector: "1.2.3.4/23",
-							},
-						},
-						{
-							Type: "Deny",
-							To: egressfirewallapi.EgressFirewallDestination{
-								DNSName: "a.b.c",
+								DNSName: dnsName,
 							},
 						},
 					})
-					fakeOVN.startWithDBSetup(dbSetup,
+					initialData = []libovsdbtest.TestData{
+						nodeSwitch,
+						joinSwitch,
+						// delete clusterPortGroup to fail db transaction
+						//clusterPortGroup,
+						clusterRouter,
+					}
+					fakeOVN.startWithDBSetup(libovsdbtest.TestSetup{NBData: initialData},
 						&v1.NamespaceList{
 							Items: []v1.Namespace{
 								namespace1,
@@ -1184,15 +1186,10 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 					err = fakeOVN.controller.WatchEgressFirewall()
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-					// dns-based rule creation will fail, because addressset factory is nil
-					fakeOVN.controller.egressFirewallDNS = &EgressDNS{
-						dnsEntries:        make(map[string]*dnsEntry),
-						addressSetFactory: nil,
-
-						added:    make(chan struct{}),
-						deleted:  make(chan string, 1),
-						stopChan: make(chan struct{}),
-					}
+					setDNSOpsMock(dnsName, resolvedIP)
+					fakeOVN.controller.egressFirewallDNS, err = NewEgressDNS(fakeOVN.controller.addressSetFactory,
+						fakeOVN.controller.stopChan)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 					_, err = fakeOVN.fakeClient.EgressFirewallClient.K8sV1().EgressFirewalls(egressFirewall.Namespace).
 						Create(context.TODO(), egressFirewall, metav1.CreateOptions{})
@@ -1203,29 +1200,11 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 					retry.CheckRetryObjectEventually(efKey, true, fakeOVN.controller.retryEgressFirewalls)
 
-					// check first acl was successfully created
-					acl := libovsdbops.BuildACL(
-						buildEgressFwAclName(namespace1.Name, t.EgressFirewallStartPriority),
-						nbdb.ACLDirectionToLport,
-						t.EgressFirewallStartPriority,
-						"(ip4.dst == 1.2.3.4/23) && ip4.src == $a10481622940199974102",
-						nbdb.ACLActionDrop,
-						t.OvnACLLoggingMeter,
-						"",
-						false,
-						map[string]string{
-							egressFirewallACLExtIdKey:    namespace1.Name,
-							egressFirewallACLPriorityKey: fmt.Sprintf("%d", t.EgressFirewallStartPriority),
-						},
-						nil,
-					)
+					// check dns address set was created, db didn't change
+					fakeOVN.asf.EventuallyExpectAddressSetWithIPs(dnsName, []string{resolvedIP})
+					gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(initialData))
 
-					acl.UUID = "acl-UUID"
-					clusterPortGroup.ACLs = []string{acl.UUID}
-					expectedDatabaseState := append(initialData, acl)
-					gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
-
-					// delete wrong object
+					// delete failed object
 					err = fakeOVN.fakeClient.EgressFirewallClient.K8sV1().EgressFirewalls(egressFirewall.Namespace).
 						Delete(context.TODO(), egressFirewall.Name, metav1.DeleteOptions{})
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -1234,11 +1213,9 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 						return retry.CheckRetryObj(efKey, fakeOVN.controller.retryEgressFirewalls)
 					}, time.Second).Should(gomega.BeFalse())
 
-					// check created acl will be cleaned up on delete
-					// acl will be dereferenced, but not deleted by the test server
-					clusterPortGroup.ACLs = []string{}
-					expectedDatabaseState = append(initialData, acl)
-					gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+					// check dns address set is cleaned up on delete
+					fakeOVN.asf.EventuallyExpectNoAddressSet(dnsName)
+					gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(initialData))
 					return nil
 				}
 				err := app.Run([]string{app.Name})
@@ -1590,17 +1567,3 @@ var _ = ginkgo.Describe("OVN test basic functions", func() {
 		}
 	})
 })
-
-//helper functions to help test egressfirewallDNS
-
-// Create an EgressDNS object without the Sync function
-// To make it easier to mock EgressFirewall functionality create an egressFirewall
-// without the go routine of the sync function
-
-// GetDNSEntryForTest Gets a dnsEntry from a EgressDNS object for testing
-func (e *EgressDNS) GetDNSEntryForTest(dnsName string) (map[string]struct{}, []net.IP, addressset.AddressSet, error) {
-	if e.dnsEntries[dnsName] == nil {
-		return nil, nil, nil, fmt.Errorf("there is no dnsEntry for dnsName: %s", dnsName)
-	}
-	return e.dnsEntries[dnsName].namespaces, e.dnsEntries[dnsName].dnsResolves, e.dnsEntries[dnsName].dnsAddressSet, nil
-}


### PR DESCRIPTION
backport of https://github.com/openshift/ovn-kubernetes/pull/1834

Conflicts:
	go-controller/pkg/ovn/address_set/address_set.go - no need for this change
	go-controller/pkg/ovn/egressfirewall.go - auto-resolved conflicts
	go-controller/pkg/ovn/egressfirewall_test.go - use address set name, no
DbIDs exist here