### PR TITLE
OCPBUGS-18054: Emit node events only when retry failure

### DIFF
--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -1251,9 +1251,7 @@ func (oc *Controller) addUpdateNodeEvent(node *kapi.Node, nSyncs *nodeSyncs) err
 			oc.mgmtPortFailed.Store(node.Name, true)
 			oc.gatewaysFailed.Store(node.Name, true)
 			oc.hybridOverlayFailed.Store(node.Name, config.HybridOverlay.Enabled)
-			err = fmt.Errorf("nodeAdd: error adding node %q: %w", node.Name, err)
-			oc.recordNodeErrorEvent(node, err)
-			return err
+			return fmt.Errorf("nodeAdd: error adding node %q: %w", node.Name, err)
 		}
 		oc.addNodeFailed.Delete(node.Name)
 	}
@@ -1347,12 +1345,7 @@ func (oc *Controller) addUpdateNodeEvent(node *kapi.Node, nSyncs *nodeSyncs) err
 		}
 	}
 
-	err = kerrors.NewAggregate(errs)
-	if err != nil {
-		oc.recordNodeErrorEvent(node, err)
-	}
-
-	return err
+	return kerrors.NewAggregate(errs)
 }
 
 func (oc *Controller) recordNodeErrorEvent(node *kapi.Node, nodeErr error) {

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -1434,18 +1434,6 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 				gomega.BeNil(),             // oldObj should be nil
 				gomega.Not(gomega.BeNil()), // newObj should not be nil
 			)
-
-			// check that a node event was posted
-			gomega.Eventually(func() []string {
-				eventsLock.Lock()
-				defer eventsLock.Unlock()
-				eventsCopy := make([]string, 0, len(events))
-				for _, e := range events {
-					eventsCopy = append(eventsCopy, e)
-				}
-				return eventsCopy
-			}, 10).Should(gomega.ContainElement(gomega.ContainSubstring("Warning ErrorReconcilingNode error creating gateway for node node1")))
-
 			connCtx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout)
 			defer cancel()
 			ginkgo.By("bring up NBDB")

--- a/go-controller/pkg/ovn/obj_retry_master.go
+++ b/go-controller/pkg/ovn/obj_retry_master.go
@@ -330,13 +330,17 @@ func (h *masterEventHandler) RecordSuccessEvent(obj interface{}) {
 }
 
 // Given an object and its type, RecordErrorEvent records an error event on this object.
-// Only used for pods now.
+// Only used for pods and nodes now.
 func (h *masterEventHandler) RecordErrorEvent(obj interface{}, err error) {
 	switch h.objType {
 	case factory.PodType:
 		pod := obj.(*kapi.Pod)
 		klog.V(5).Infof("Recording error event on pod %s/%s", pod.Namespace, pod.Name)
 		h.oc.recordPodEvent(err, pod)
+	case factory.NodeType:
+		node := obj.(*kapi.Node)
+		klog.V(5).Infof("Recording error event for node %s", node.Name)
+		h.oc.recordNodeEvent(err, node)
 	}
 }
 

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -505,6 +505,16 @@ func (oc *Controller) recordPodEvent(addErr error, pod *kapi.Pod) {
 	}
 }
 
+func (oc *Controller) recordNodeEvent(addErr error, node *kapi.Node) {
+	nodeRef, err := ref.GetReference(scheme.Scheme, node)
+	if err != nil {
+		klog.Errorf("Couldn't get a reference to node %s to post an event: '%v'", node.Name, err)
+	} else {
+		klog.V(5).Infof("Posting a %s event for node %s", kapi.EventTypeWarning, node.Name)
+		oc.recorder.Eventf(nodeRef, kapi.EventTypeWarning, "RetryFailed", addErr.Error())
+	}
+}
+
 func exGatewayAnnotationsChanged(oldPod, newPod *kapi.Pod) bool {
 	return oldPod.Annotations[util.RoutingNamespaceAnnotation] != newPod.Annotations[util.RoutingNamespaceAnnotation] ||
 		oldPod.Annotations[util.RoutingNetworkAnnotation] != newPod.Annotations[util.RoutingNetworkAnnotation] ||

--- a/go-controller/pkg/retry/obj_retry.go
+++ b/go-controller/pkg/retry/obj_retry.go
@@ -225,6 +225,9 @@ func (r *RetryFramework) resourceRetry(objKey string, now time.Time) {
 			klog.Warningf("Dropping retry entry for %s %s: exceeded number of failed attempts",
 				r.ResourceHandler.ObjType, objKey)
 			r.DeleteRetryObj(key)
+			if entry.newObj != nil {
+				r.ResourceHandler.RecordErrorEvent(entry.newObj, fmt.Errorf("failed to reconcile and retried %d times for object: %v", MaxFailedAttempts, entry.newObj))
+			}
 			return
 		}
 		forceRetry := false


### PR DESCRIPTION
Nodes obj is configured via distributed software
components and previous to this patch, we are
sending numerous kubernetes events of error level warning when infact everything is proceeding normally..

Only emit warning events when we fail to configure a node. This is after 15 retry attempts - ~7m currently.

We continue logging every node add/update/delete failure to logs.

Signed-off-by: Martin Kennelly <mkennell@redhat.com>
(cherry picked from commit 8889f47c8e5d259fded984b7552f5813213c83c9) (cherry picked from commit dada90de959c2c7d2e45749a947cac08cc4e2c2e)
