### PR TITLE
OCPBUGS-17979: Fix egress firewall CRD

### DIFF
--- a/dist/templates/k8s.ovn.org_egressfirewalls.yaml.j2
+++ b/dist/templates/k8s.ovn.org_egressfirewalls.yaml.j2
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.11.3
   creationTimestamp: null
   name: egressfirewalls.k8s.ovn.org
 spec:
@@ -66,7 +66,10 @@ spec:
                         type: object
                       type: array
                     to:
-                      description: to is the target that traffic is allowed/denied to
+                      description: to is the target that traffic is allowed/denied
+                        to
+                      maxProperties: 1
+                      minProperties: 1
                       properties:
                         cidrSelector:
                           description: cidrSelector is the CIDR range to allow/deny traffic to. If this is set, dnsName must be unset.

--- a/go-controller/hack/update-codegen.sh
+++ b/go-controller/hack/update-codegen.sh
@@ -81,11 +81,6 @@ echo "Editing egressFirewall CRD"
 ## metav1.ObjectMeta it is required that we add it after the generation of the CRD.
 sed -i -e':begin;$!N;s/.*metadata:\n.*type: object/&\n            properties:\n              name:\n                type: string\n                pattern: ^default$/;P;D' \
 	_output/crds/k8s.ovn.org_egressfirewalls.yaml
-## It is also required that we restrict the number of properties on the 'to' section of the egressfirewall
-## so that either 'dnsName' or 'cidrSelector is set in the crd and currently kubebuilder does not support
-## adding validation to objects only to the fields
-sed -i -e ':begin;$!N;s/                          type: string\n.*type: object/&\n                      minProperties: 1\n                      maxProperties: 1/;P;D' \
-	_output/crds/k8s.ovn.org_egressfirewalls.yaml
 
 echo "Editing EgressQoS CRD"
 ## We desire that only EgressQoS with the name "default" are accepted by the apiserver.

--- a/go-controller/pkg/crd/egressfirewall/v1/apis/clientset/versioned/fake/register.go
+++ b/go-controller/pkg/crd/egressfirewall/v1/apis/clientset/versioned/fake/register.go
@@ -37,14 +37,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/go-controller/pkg/crd/egressfirewall/v1/apis/clientset/versioned/scheme/register.go
+++ b/go-controller/pkg/crd/egressfirewall/v1/apis/clientset/versioned/scheme/register.go
@@ -37,14 +37,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/go-controller/pkg/crd/egressfirewall/v1/types.go
+++ b/go-controller/pkg/crd/egressfirewall/v1/types.go
@@ -65,7 +65,9 @@ type EgressFirewallPort struct {
 	Port int32 `json:"port"`
 }
 
-// EgressFirewallDestination is the endpoint that traffic is either allowed or denied to
+// +kubebuilder:validation:MinProperties:=1
+// +kubebuilder:validation:MaxProperties:=1
+// EgressFirewallDestination is the target that traffic is either allowed or denied to
 type EgressFirewallDestination struct {
 	// cidrSelector is the CIDR range to allow/deny traffic to. If this is set, dnsName must be unset.
 	CIDRSelector string `json:"cidrSelector,omitempty"`


### PR DESCRIPTION
As @tssurya found the min/max of 1 for destinations was hardcoded in the crd j2 file and was never in the types.go.

Fixed commit to remove node-selector feature which doesn't apply in 4.12

Signed-off-by: Tim Rozet <trozet@redhat.com>
Co-authored-by: Aniket Bhat <anbhat@redhat.com>
(cherry picked from commit 41046e8c27715bd08ce8090ac8ae06d3cfc9e75c)