### PR TITLE
OCPBUGS-16617, OCPBUGS-14709, OCPBUGS-18603: Bump to OVN 23.09

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -13,7 +13,7 @@ RUN dnf install -y --nodocs \
 	dnf clean all
 
 ARG ovsver=3.1.0-32.el9fdp
-ARG ovnver=23.06.0-51.el9fdp
+ARG ovnver=23.09.0-alpha.157.el9fdp
 
 RUN INSTALL_PKGS="iptables" && \
 	ovsver_short=$(echo "$ovsver" | cut -d'.' -f1,2) && \

--- a/go-controller/pkg/ovn/copp.go
+++ b/go-controller/pkg/ovn/copp.go
@@ -20,6 +20,7 @@ const (
 	OVNICMPV6ErrorsRateLimiter     = "icmp6-error"
 	OVNRejectRateLimiter           = "reject"
 	OVNTCPRSTRateLimiter           = "tcp-reset"
+	OVNServiceMonitorLimiter       = "svc-monitor"
 
 	// Default COPP object name
 	defaultCOPPName = "ovnkube-default"
@@ -34,6 +35,7 @@ var defaultProtocolNames = [...]string{
 	OVNICMPV6ErrorsRateLimiter,
 	OVNRejectRateLimiter,
 	OVNTCPRSTRateLimiter,
+	OVNServiceMonitorLimiter,
 }
 
 func getMeterNameForProtocol(protocol string) string {

--- a/go-controller/pkg/ovn/gateway_test.go
+++ b/go-controller/pkg/ovn/gateway_test.go
@@ -216,15 +216,15 @@ func generateGatewayInitExpectedNB(testData []libovsdb.TestData, expectedOVNClus
 		Rate:   int(25),
 	})
 	meters := map[string]string{
-		types.OVNARPRateLimiter:              getMeterNameForProtocol(types.OVNARPRateLimiter),
-		types.OVNARPResolveRateLimiter:       getMeterNameForProtocol(types.OVNARPResolveRateLimiter),
-		types.OVNBFDRateLimiter:              getMeterNameForProtocol(types.OVNBFDRateLimiter),
-		types.OVNControllerEventsRateLimiter: getMeterNameForProtocol(types.OVNControllerEventsRateLimiter),
-		types.OVNICMPV4ErrorsRateLimiter:     getMeterNameForProtocol(types.OVNICMPV4ErrorsRateLimiter),
-		types.OVNICMPV6ErrorsRateLimiter:     getMeterNameForProtocol(types.OVNICMPV6ErrorsRateLimiter),
-		types.OVNRejectRateLimiter:           getMeterNameForProtocol(types.OVNRejectRateLimiter),
-		types.OVNTCPRSTRateLimiter:           getMeterNameForProtocol(types.OVNTCPRSTRateLimiter),
-		types.OVNServiceMonitorLimiter:       getMeterNameForProtocol(types.OVNServiceMonitorLimiter),
+		OVNARPRateLimiter:              getMeterNameForProtocol(OVNARPRateLimiter),
+		OVNARPResolveRateLimiter:       getMeterNameForProtocol(OVNARPResolveRateLimiter),
+		OVNBFDRateLimiter:              getMeterNameForProtocol(OVNBFDRateLimiter),
+		OVNControllerEventsRateLimiter: getMeterNameForProtocol(OVNControllerEventsRateLimiter),
+		OVNICMPV4ErrorsRateLimiter:     getMeterNameForProtocol(OVNICMPV4ErrorsRateLimiter),
+		OVNICMPV6ErrorsRateLimiter:     getMeterNameForProtocol(OVNICMPV6ErrorsRateLimiter),
+		OVNRejectRateLimiter:           getMeterNameForProtocol(OVNRejectRateLimiter),
+		OVNTCPRSTRateLimiter:           getMeterNameForProtocol(OVNTCPRSTRateLimiter),
+		OVNServiceMonitorLimiter:       getMeterNameForProtocol(OVNServiceMonitorLimiter),
 	}
 	fairness := true
 	for _, v := range meters {

--- a/go-controller/pkg/ovn/gateway_test.go
+++ b/go-controller/pkg/ovn/gateway_test.go
@@ -224,6 +224,7 @@ func generateGatewayInitExpectedNB(testData []libovsdb.TestData, expectedOVNClus
 		types.OVNICMPV6ErrorsRateLimiter:     getMeterNameForProtocol(types.OVNICMPV6ErrorsRateLimiter),
 		types.OVNRejectRateLimiter:           getMeterNameForProtocol(types.OVNRejectRateLimiter),
 		types.OVNTCPRSTRateLimiter:           getMeterNameForProtocol(types.OVNTCPRSTRateLimiter),
+		types.OVNServiceMonitorLimiter:       getMeterNameForProtocol(types.OVNServiceMonitorLimiter),
 	}
 	fairness := true
 	for _, v := range meters {

--- a/go-controller/pkg/types/const.go
+++ b/go-controller/pkg/types/const.go
@@ -115,16 +115,6 @@ const (
 	PacketsPerSecond     = "pktps"
 	MeterAction          = "drop"
 
-	// Default Meters created on GRs.
-	OVNARPRateLimiter              = "arp"
-	OVNARPResolveRateLimiter       = "arp-resolve"
-	OVNBFDRateLimiter              = "bfd"
-	OVNControllerEventsRateLimiter = "event-elb"
-	OVNICMPV4ErrorsRateLimiter     = "icmp4-error"
-	OVNICMPV6ErrorsRateLimiter     = "icmp6-error"
-	OVNRejectRateLimiter           = "reject"
-	OVNTCPRSTRateLimiter           = "tcp-reset"
-
 	// OVN-K8S Topology Versions
 	OvnSingleJoinSwitchTopoVersion = 1
 	OvnNamespacedDenyPGTopoVersion = 2


### PR DESCRIPTION
OCP-relevant changes in 23.09 include:
    
- significant performance optimizations (IP for LSPs, PGs, Meters, and soon LBs)
- fix for skip_snat and affinity timeouts ( https://bugzilla.redhat.com/show_bug.cgi?id=2224260 )
- dynamic updating of MAC binding timestamps ( https://bugzilla.redhat.com/show_bug.cgi?id=2189924 )
- COPP for Service Monitors to fix CVE-2023-3153
