### PR TITLE
[release-4.12] OCPBUGS-18681: Check libovsdbclient.ErrNotFound on wrapped errors

### DIFF
--- a/go-controller/pkg/libovsdbops/model_client.go
+++ b/go-controller/pkg/libovsdbops/model_client.go
@@ -27,9 +27,9 @@ func newModelClient(client client.Client) modelClient {
 }
 
 /*
- extractUUIDsFromModels is a helper function which constructs a mutation
- for the specified field and mutator extracting the UUIDs of the provided
- models as the value for the mutation.
+extractUUIDsFromModels is a helper function which constructs a mutation
+for the specified field and mutator extracting the UUIDs of the provided
+models as the value for the mutation.
 */
 func extractUUIDsFromModels(models interface{}) []string {
 	ids := []string{}
@@ -121,8 +121,8 @@ func buildMutationsFromFields(fields []interface{}, mutator ovsdb.Mutator) ([]mo
 }
 
 /*
- operationModel is a struct which uses reflection to determine and perform
- idempotent operations against OVS DB (NB DB by default).
+operationModel is a struct which uses reflection to determine and perform
+idempotent operations against OVS DB (NB DB by default).
 */
 type operationModel struct {
 	// Model specifies the model to be created, or to look up in the cache
@@ -161,25 +161,25 @@ func onModelUpdatesAllNonDefault() []interface{} {
 }
 
 /*
- CreateOrUpdate performs idempotent operations against libovsdb according to the
- following logic:
+CreateOrUpdate performs idempotent operations against libovsdb according to the
+following logic:
 
- a) performs a lookup of the models in the cache by ModelPredicate if provided,
- or by Model otherwise. If the models do not exist and ErrNotFound is set,
- it returns ErrNotFound
+a) performs a lookup of the models in the cache by ModelPredicate if provided,
+or by Model otherwise. If the models do not exist and ErrNotFound is set,
+it returns ErrNotFound
 
- b) if OnModelUpdates is specified; it performs a direct update of the model if
- it exists.
+b) if OnModelUpdates is specified; it performs a direct update of the model if
+it exists.
 
- c) if b) is not true, but OnModelMutations is specified; it performs a direct
- mutation (insert) of the Model if it exists.
+c) if b) is not true, but OnModelMutations is specified; it performs a direct
+mutation (insert) of the Model if it exists.
 
- d) if b) and c) are not true, but Model is provided, it creates the Model
- if it does not exist.
+d) if b) and c) are not true, but Model is provided, it creates the Model
+if it does not exist.
 
- e) if none of the above are true, ErrNotFound is returned.
+e) if none of the above are true, ErrNotFound is returned.
 
- If BulkOp is set, update or mutate can happen accross multiple models found.
+If BulkOp is set, update or mutate can happen accross multiple models found.
 */
 func (m *modelClient) CreateOrUpdate(opModels ...operationModel) ([]ovsdb.OperationResult, error) {
 	created, ops, err := m.createOrUpdateOps(nil, opModels...)
@@ -229,19 +229,19 @@ func (m *modelClient) createOrUpdateOps(ops []ovsdb.Operation, opModels ...opera
 }
 
 /*
- Delete performs idempotent delete operations against libovsdb according to the
- following logic:
+Delete performs idempotent delete operations against libovsdb according to the
+following logic:
 
- a) performs a lookup of the models in the cache by ModelPredicate if provided,
- or by Model otherwise. If the models do not exist and ErrNotFound is set
- it returns ErrNotFound.
+a) performs a lookup of the models in the cache by ModelPredicate if provided,
+or by Model otherwise. If the models do not exist and ErrNotFound is set
+it returns ErrNotFound.
 
- b) if OnModelMutations is specified; it performs a direct mutation (delete) of the
- Model if it exists.
+b) if OnModelMutations is specified; it performs a direct mutation (delete) of the
+Model if it exists.
 
- c) if b) is not true; it performs a direct delete of the Model if it exists.
+c) if b) is not true; it performs a direct delete of the Model if it exists.
 
- If BulkOp is set, delete or mutate can happen accross multiple models found.
+If BulkOp is set, delete or mutate can happen accross multiple models found.
 */
 func (m *modelClient) Delete(opModels ...operationModel) error {
 	ops, err := m.DeleteOps(nil, opModels...)
@@ -274,8 +274,8 @@ func (m *modelClient) buildOps(ops []ovsdb.Operation, doWhenFound opModelToOpMap
 	for _, opModel := range opModels {
 		// do lookup
 		err := m.lookup(&opModel)
-		if err != nil && err != client.ErrNotFound {
-			return nil, nil, fmt.Errorf("unable to lookup model %+v: %v", opModel, err)
+		if err != nil && !errors.Is(err, client.ErrNotFound) {
+			return nil, nil, fmt.Errorf("unable to lookup model %+v: %w", opModel, err)
 		}
 
 		// do updates
@@ -326,10 +326,10 @@ func (m *modelClient) buildOps(ops []ovsdb.Operation, doWhenFound opModelToOpMap
 }
 
 /*
- create does a bit more than just "create". create needs to set the generated
- UUID (because if this function is called we know the item does not exists yet)
- then create the item. Generates an until clause and uses a wait operation to avoid
- https://bugzilla.redhat.com/show_bug.cgi?id=2042001
+create does a bit more than just "create". create needs to set the generated
+UUID (because if this function is called we know the item does not exists yet)
+then create the item. Generates an until clause and uses a wait operation to avoid
+https://bugzilla.redhat.com/show_bug.cgi?id=2042001
 */
 func (m *modelClient) create(opModel *operationModel) ([]ovsdb.Operation, error) {
 	uuid := getUUID(opModel.Model)
@@ -339,7 +339,7 @@ func (m *modelClient) create(opModel *operationModel) ([]ovsdb.Operation, error)
 
 	ops, err := m.client.Create(opModel.Model)
 	if err != nil {
-		return nil, fmt.Errorf("unable to create model, err: %v", err)
+		return nil, fmt.Errorf("unable to create model, err: %w", err)
 	}
 
 	klog.V(5).Infof("Create operations generated as: %+v", ops)
@@ -349,7 +349,7 @@ func (m *modelClient) create(opModel *operationModel) ([]ovsdb.Operation, error)
 func (m *modelClient) update(lookUpModel interface{}, opModel *operationModel) (o []ovsdb.Operation, err error) {
 	o, err = m.client.Where(lookUpModel).Update(opModel.Model, opModel.OnModelUpdates...)
 	if err != nil {
-		return nil, fmt.Errorf("unable to update model, err: %v", err)
+		return nil, fmt.Errorf("unable to update model, err: %w", err)
 	}
 	klog.V(5).Infof("Update operations generated as: %+v", o)
 	return o, nil
@@ -365,7 +365,7 @@ func (m *modelClient) mutate(lookUpModel interface{}, opModel *operationModel, m
 	}
 	o, err = m.client.Where(lookUpModel).Mutate(opModel.Model, modelMutations...)
 	if err != nil {
-		return nil, fmt.Errorf("unable to mutate model, err: %v", err)
+		return nil, fmt.Errorf("unable to mutate model, err: %w", err)
 	}
 	klog.V(5).Infof("Mutate operations generated as: %+v", o)
 	return o, nil
@@ -374,7 +374,7 @@ func (m *modelClient) mutate(lookUpModel interface{}, opModel *operationModel, m
 func (m *modelClient) delete(lookUpModel interface{}, opModel *operationModel) (o []ovsdb.Operation, err error) {
 	o, err = m.client.Where(lookUpModel).Delete()
 	if err != nil {
-		return nil, fmt.Errorf("unable to delete model, err: %v", err)
+		return nil, fmt.Errorf("unable to delete model, err: %w", err)
 	}
 	klog.V(5).Infof("Delete operations generated as: %+v", o)
 	return o, nil
@@ -395,7 +395,7 @@ func (m *modelClient) lookup(opModel *operationModel) error {
 	var err error
 	if opModel.Model != nil && !opModel.BulkOp {
 		err = m.get(opModel)
-		if err == nil || err != client.ErrNotFound {
+		if err == nil || !errors.Is(err, client.ErrNotFound) {
 			return err
 		}
 	}
@@ -410,11 +410,11 @@ func (m *modelClient) lookup(opModel *operationModel) error {
 }
 
 /*
- get copies the model, since this function ends up being called from update /
- mutate, and Get'ing the model will modify the object to the one currently
- existing in the DB, thus overridding all new fields we are trying to set. Do
- return the retrived object though, in case the caller needs to act on the
- object's UUID
+get copies the model, since this function ends up being called from update /
+mutate, and Get'ing the model will modify the object to the one currently
+existing in the DB, thus overridding all new fields we are trying to set. Do
+return the retrived object though, in case the caller needs to act on the
+object's UUID
 */
 func (m *modelClient) get(opModel *operationModel) error {
 	copy := copyIndexes(opModel.Model)

--- a/go-controller/pkg/libovsdbops/router.go
+++ b/go-controller/pkg/libovsdbops/router.go
@@ -2,6 +2,7 @@ package libovsdbops
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 
@@ -419,7 +420,7 @@ func DeleteNextHopsFromLogicalRouterPolicies(nbClient libovsdbclient.Client, rou
 	for _, lrp := range lrps {
 		nextHops := lrp.Nexthops
 		lrp, err := GetLogicalRouterPolicy(nbClient, lrp)
-		if err == libovsdbclient.ErrNotFound {
+		if errors.Is(err, libovsdbclient.ErrNotFound) {
 			continue
 		}
 		if err != nil {
@@ -938,7 +939,7 @@ func GetRouterNATs(nbClient libovsdbclient.Client, router *nbdb.LogicalRouter) (
 	nats := []*nbdb.NAT{}
 	for _, uuid := range r.Nat {
 		nat, err := GetNAT(nbClient, &nbdb.NAT{UUID: uuid})
-		if err == libovsdbclient.ErrNotFound {
+		if errors.Is(err, libovsdbclient.ErrNotFound) {
 			continue
 		}
 		if err != nil {
@@ -1008,7 +1009,7 @@ func CreateOrUpdateNATs(nbClient libovsdbclient.Client, router *nbdb.LogicalRout
 // logical router and returns the corresponding ops
 func DeleteNATsOps(nbClient libovsdbclient.Client, ops []libovsdb.Operation, router *nbdb.LogicalRouter, nats ...*nbdb.NAT) ([]libovsdb.Operation, error) {
 	routerNats, err := GetRouterNATs(nbClient, router)
-	if err == libovsdbclient.ErrNotFound {
+	if errors.Is(err, libovsdbclient.ErrNotFound) {
 		return ops, nil
 	}
 	if err != nil {

--- a/go-controller/pkg/libovsdbops/router_test.go
+++ b/go-controller/pkg/libovsdbops/router_test.go
@@ -147,7 +147,8 @@ func TestDeleteNATsFromRouter(t *testing.T) {
 	}{
 		{
 			desc:         "no router",
-			expectErr:    true,
+			routerName:   "doesNotExistRouter",
+			expectErr:    false,
 			nats:         []*nbdb.NAT{fakeNAT1.DeepCopy(), fakeNAT2.DeepCopy(), fakeNAT3.DeepCopy(), fakeNAT4.DeepCopy()},
 			expectedNbdb: initialNbdb,
 		},
@@ -206,6 +207,8 @@ func TestDeleteNATsFromRouter(t *testing.T) {
 			err = DeleteNATs(nbClient, &logicalRouter, tt.nats...)
 			if err != nil && !tt.expectErr {
 				t.Fatal(fmt.Errorf("DeleteNATsFromRouter() error = %v", err))
+			} else if err == nil && tt.expectErr {
+				t.Fatal(fmt.Errorf("DeleteNATsFromRouter() no error, but an error was expected"))
 			}
 
 			matcher := libovsdbtest.HaveData(tt.expectedNbdb.NBData)

--- a/go-controller/pkg/metrics/master.go
+++ b/go-controller/pkg/metrics/master.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"errors"
 	"fmt"
 	"hash/fnv"
 	"math"
@@ -1423,7 +1424,7 @@ func getGlobalOptionsValue(client libovsdbclient.Client, field string) float64 {
 	sbGlobal := sbdb.SBGlobal{}
 
 	if dbName == "OVN_Northbound" {
-		if nbGlobal, err := libovsdbops.GetNBGlobal(client, &nbGlobal); err != nil && err != libovsdbclient.ErrNotFound {
+		if nbGlobal, err := libovsdbops.GetNBGlobal(client, &nbGlobal); err != nil && !errors.Is(err, libovsdbclient.ErrNotFound) {
 			klog.Errorf("Failed to get NB_Global table err: %v", err)
 			return 0
 		} else {
@@ -1432,7 +1433,7 @@ func getGlobalOptionsValue(client libovsdbclient.Client, field string) float64 {
 	}
 
 	if dbName == "OVN_Southbound" {
-		if sbGlobal, err := libovsdbops.GetSBGlobal(client, &sbGlobal); err != nil && err != libovsdbclient.ErrNotFound {
+		if sbGlobal, err := libovsdbops.GetSBGlobal(client, &sbGlobal); err != nil && !errors.Is(err, libovsdbclient.ErrNotFound) {
 			klog.Errorf("Failed to get SB_Global table err: %v", err)
 			return 0
 		} else {

--- a/go-controller/pkg/ovn/egressgw.go
+++ b/go-controller/pkg/ovn/egressgw.go
@@ -592,7 +592,7 @@ func deletePodSNATOps(nbClient libovsdbclient.Client, ops []ovsdb.Operation, nod
 		Name: types.GWRouterPrefix + nodeName,
 	}
 	ops, err = libovsdbops.DeleteNATsOps(nbClient, ops, &logicalRouter, nats...)
-	if err != nil {
+	if err != nil && !errors.Is(err, libovsdbclient.ErrNotFound) {
 		return nil, fmt.Errorf("failed create operation for deleting SNAT rule for pod on gateway router %s: %v", logicalRouter.Name, err)
 	}
 	return ops, nil

--- a/go-controller/pkg/ovn/gateway_init.go
+++ b/go-controller/pkg/ovn/gateway_init.go
@@ -133,7 +133,7 @@ func (oc *Controller) gatewayInit(nodeName string, clusterIPSubnet []*net.IPNet,
 	// so let's save the old value before we update the router for later use
 	var oldExtIPs []net.IP
 	oldLogicalRouter, err := libovsdbops.GetLogicalRouter(oc.nbClient, &logicalRouter)
-	if err != nil && err != libovsdbclient.ErrNotFound {
+	if err != nil && !errors.Is(err, libovsdbclient.ErrNotFound) {
 		return fmt.Errorf("failed in retrieving %s, error: %v", gatewayRouter, err)
 	}
 

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -364,7 +364,7 @@ func (oc *Controller) SetupMaster(existingNodeNames []string) error {
 		Name: types.ClusterPortGroupName,
 	}
 	pg, err = libovsdbops.GetPortGroup(oc.nbClient, pg)
-	if err != nil && err != libovsdbclient.ErrNotFound {
+	if err != nil && !errors.Is(err, libovsdbclient.ErrNotFound) {
 		return err
 	}
 	if pg == nil {
@@ -382,7 +382,7 @@ func (oc *Controller) SetupMaster(existingNodeNames []string) error {
 		Name: types.ClusterRtrPortGroupName,
 	}
 	pg, err = libovsdbops.GetPortGroup(oc.nbClient, pg)
-	if err != nil && err != libovsdbclient.ErrNotFound {
+	if err != nil && !errors.Is(err, libovsdbclient.ErrNotFound) {
 		return err
 	}
 	if pg == nil {

--- a/go-controller/pkg/ovn/topology_version.go
+++ b/go-controller/pkg/ovn/topology_version.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
 	addressset "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/address_set"
 	ovntypes "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
+	"github.com/pkg/errors"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -106,7 +107,7 @@ func (oc *Controller) cleanTopologyAnnotation() error {
 func (oc *Controller) determineOVNTopoVersionFromOVN() (int, error) {
 	logicalRouter := &nbdb.LogicalRouter{Name: ovntypes.OVNClusterRouter}
 	logicalRouter, err := libovsdbops.GetLogicalRouter(oc.nbClient, logicalRouter)
-	if err != nil && err != libovsdbclient.ErrNotFound {
+	if err != nil && !errors.Is(err, libovsdbclient.ErrNotFound) {
 		return 0, fmt.Errorf("error getting router %s: %v", ovntypes.OVNClusterRouter, err)
 	}
 	if err == libovsdbclient.ErrNotFound {

--- a/go-controller/pkg/util/util.go
+++ b/go-controller/pkg/util/util.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"errors"
 	"fmt"
 	"hash/fnv"
 	"net"
@@ -260,7 +261,7 @@ func UpdateNodeSwitchExcludeIPs(nbClient libovsdbclient.Client, nodeName string,
 	haveManagementPort := true
 	managmentPort := &nbdb.LogicalSwitchPort{Name: types.K8sPrefix + nodeName}
 	_, err := libovsdbops.GetLogicalSwitchPort(nbClient, managmentPort)
-	if err == libovsdbclient.ErrNotFound {
+	if errors.Is(err, libovsdbclient.ErrNotFound) {
 		klog.V(5).Infof("Management port does not exist for node %s", nodeName)
 		haveManagementPort = false
 	} else if err != nil {
@@ -270,7 +271,7 @@ func UpdateNodeSwitchExcludeIPs(nbClient libovsdbclient.Client, nodeName string,
 	haveHybridOverlayPort := true
 	HOPort := &nbdb.LogicalSwitchPort{Name: types.HybridOverlayPrefix + nodeName}
 	_, err = libovsdbops.GetLogicalSwitchPort(nbClient, HOPort)
-	if err == libovsdbclient.ErrNotFound {
+	if errors.Is(err, libovsdbclient.ErrNotFound) {
 		klog.V(5).Infof("Hybridoverlay port does not exist for node %s", nodeName)
 		haveHybridOverlayPort = false
 	} else if err != nil {


### PR DESCRIPTION
Instead of looking explicitly for libovsdbclient.ErrNotFound, checking logic should account for cases when error has been wrapped.

In particular, this change addresses the logic in: func DeleteNATsOps()
https://github.com/ovn-org/ovn-kubernetes/blob/247483c8d1167072e04cf63e1c6e45264a25310e/go-controller/pkg/libovsdb/ops/router.go#L1078

when the error began to be wrapped as follows:
https://github.com/ovn-org/ovn-kubernetes/pull/3646/commits/25d892cc9e318d19738d9519e0e20fbab28f7eae#r1317615944
