### PR TITLE
[release-4.14] OCPBUGS-18584: Check libovsdbclient.ErrNotFound on wrapped errors

### DIFF
--- a/go-controller/pkg/libovsdb/ops/router.go
+++ b/go-controller/pkg/libovsdb/ops/router.go
@@ -2,6 +2,7 @@ package ops
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 
@@ -461,7 +462,7 @@ func DeleteNextHopsFromLogicalRouterPolicies(nbClient libovsdbclient.Client, rou
 	for _, lrp := range lrps {
 		nextHops := lrp.Nexthops
 		lrp, err := GetLogicalRouterPolicy(nbClient, lrp)
-		if err == libovsdbclient.ErrNotFound {
+		if errors.Is(err, libovsdbclient.ErrNotFound) {
 			continue
 		}
 		if err != nil {
@@ -1005,7 +1006,7 @@ func GetRouterNATs(nbClient libovsdbclient.Client, router *nbdb.LogicalRouter) (
 	nats := []*nbdb.NAT{}
 	for _, uuid := range r.Nat {
 		nat, err := GetNAT(nbClient, &nbdb.NAT{UUID: uuid})
-		if err == libovsdbclient.ErrNotFound {
+		if errors.Is(err, libovsdbclient.ErrNotFound) {
 			continue
 		}
 		if err != nil {
@@ -1075,7 +1076,7 @@ func CreateOrUpdateNATs(nbClient libovsdbclient.Client, router *nbdb.LogicalRout
 // logical router and returns the corresponding ops
 func DeleteNATsOps(nbClient libovsdbclient.Client, ops []libovsdb.Operation, router *nbdb.LogicalRouter, nats ...*nbdb.NAT) ([]libovsdb.Operation, error) {
 	routerNats, err := GetRouterNATs(nbClient, router)
-	if err == libovsdbclient.ErrNotFound {
+	if errors.Is(err, libovsdbclient.ErrNotFound) {
 		return ops, nil
 	}
 	if err != nil {

--- a/go-controller/pkg/libovsdb/ops/router_test.go
+++ b/go-controller/pkg/libovsdb/ops/router_test.go
@@ -152,6 +152,13 @@ func TestDeleteNATsFromRouter(t *testing.T) {
 			expectedNbdb: initialNbdb,
 		},
 		{
+			desc:         "no router -- with a name",
+			routerName:   "doesNotExistRouter",
+			expectErr:    false,
+			nats:         []*nbdb.NAT{fakeNAT1.DeepCopy(), fakeNAT2.DeepCopy(), fakeNAT3.DeepCopy(), fakeNAT4.DeepCopy()},
+			expectedNbdb: initialNbdb,
+		},
+		{
 			desc:         "no deletes: no matching nats",
 			routerName:   "rtr1",
 			nats:         []*nbdb.NAT{fakeNAT2.DeepCopy(), fakeNAT3.DeepCopy(), fakeNAT4.DeepCopy()},

--- a/go-controller/pkg/libovsdb/util/switch.go
+++ b/go-controller/pkg/libovsdb/util/switch.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"sync"
@@ -35,7 +36,7 @@ func UpdateNodeSwitchExcludeIPs(nbClient libovsdbclient.Client, nodeName string,
 	haveManagementPort := true
 	managmentPort := &nbdb.LogicalSwitchPort{Name: types.K8sPrefix + nodeName}
 	_, err := libovsdbops.GetLogicalSwitchPort(nbClient, managmentPort)
-	if err == libovsdbclient.ErrNotFound {
+	if errors.Is(err, libovsdbclient.ErrNotFound) {
 		klog.V(5).Infof("Management port does not exist for node %s", nodeName)
 		haveManagementPort = false
 	} else if err != nil {
@@ -45,7 +46,7 @@ func UpdateNodeSwitchExcludeIPs(nbClient libovsdbclient.Client, nodeName string,
 	haveHybridOverlayPort := true
 	HOPort := &nbdb.LogicalSwitchPort{Name: types.HybridOverlayPrefix + nodeName}
 	_, err = libovsdbops.GetLogicalSwitchPort(nbClient, HOPort)
-	if err == libovsdbclient.ErrNotFound {
+	if errors.Is(err, libovsdbclient.ErrNotFound) {
 		klog.V(5).Infof("Hybridoverlay port does not exist for node %s", nodeName)
 		haveHybridOverlayPort = false
 	} else if err != nil {

--- a/go-controller/pkg/metrics/ovnkube_controller.go
+++ b/go-controller/pkg/metrics/ovnkube_controller.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"errors"
 	"fmt"
 	"hash/fnv"
 	"math"
@@ -1350,7 +1351,7 @@ func getGlobalOptionsValue(client libovsdbclient.Client, field string) float64 {
 	sbGlobal := sbdb.SBGlobal{}
 
 	if dbName == "OVN_Northbound" {
-		if nbGlobal, err := libovsdbops.GetNBGlobal(client, &nbGlobal); err != nil && err != libovsdbclient.ErrNotFound {
+		if nbGlobal, err := libovsdbops.GetNBGlobal(client, &nbGlobal); err != nil && !errors.Is(err, libovsdbclient.ErrNotFound) {
 			klog.Errorf("Failed to get NB_Global table err: %v", err)
 			return 0
 		} else {
@@ -1359,7 +1360,7 @@ func getGlobalOptionsValue(client libovsdbclient.Client, field string) float64 {
 	}
 
 	if dbName == "OVN_Southbound" {
-		if sbGlobal, err := libovsdbops.GetSBGlobal(client, &sbGlobal); err != nil && err != libovsdbclient.ErrNotFound {
+		if sbGlobal, err := libovsdbops.GetSBGlobal(client, &sbGlobal); err != nil && !errors.Is(err, libovsdbclient.ErrNotFound) {
 			klog.Errorf("Failed to get SB_Global table err: %v", err)
 			return 0
 		} else {

--- a/go-controller/pkg/ovn/base_network_controller.go
+++ b/go-controller/pkg/ovn/base_network_controller.go
@@ -11,6 +11,7 @@ import (
 
 	libovsdbclient "github.com/ovn-org/libovsdb/client"
 	"github.com/ovn-org/libovsdb/ovsdb"
+	"github.com/pkg/errors"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/allocator/pod"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
@@ -560,10 +561,10 @@ func (bnc *BaseNetworkController) determineOVNTopoVersionFromOVN() error {
 func (bnc *BaseNetworkController) getOVNTopoVersionFromLogicalRouter(clusterRouterName string) (int, error) {
 	logicalRouter := &nbdb.LogicalRouter{Name: clusterRouterName}
 	logicalRouter, err := libovsdbops.GetLogicalRouter(bnc.nbClient, logicalRouter)
-	if err != nil && err != libovsdbclient.ErrNotFound {
+	if err != nil && !errors.Is(err, libovsdbclient.ErrNotFound) {
 		return 0, fmt.Errorf("error getting router %s: %v", clusterRouterName, err)
 	}
-	if err == libovsdbclient.ErrNotFound {
+	if errors.Is(err, libovsdbclient.ErrNotFound) {
 		// no OVNClusterRouter exists, DB is empty, nothing to upgrade
 		return math.MaxInt32, nil
 	}
@@ -582,10 +583,10 @@ func (bnc *BaseNetworkController) getOVNTopoVersionFromLogicalRouter(clusterRout
 func (bnc *BaseNetworkController) getOVNTopoVersionFromLogicalSwitch(switchName string) (int, error) {
 	logicalSwitch := &nbdb.LogicalSwitch{Name: switchName}
 	logicalSwitch, err := libovsdbops.GetLogicalSwitch(bnc.nbClient, logicalSwitch)
-	if err != nil && err != libovsdbclient.ErrNotFound {
+	if err != nil && !errors.Is(err, libovsdbclient.ErrNotFound) {
 		return 0, fmt.Errorf("error getting switch %s: %v", switchName, err)
 	}
-	if err == libovsdbclient.ErrNotFound {
+	if errors.Is(err, libovsdbclient.ErrNotFound) {
 		// no switch exists, DB is empty, nothing to upgrade
 		return math.MaxInt32, nil
 	}

--- a/go-controller/pkg/ovn/gateway_init.go
+++ b/go-controller/pkg/ovn/gateway_init.go
@@ -154,7 +154,7 @@ func (oc *DefaultNetworkController) gatewayInit(nodeName string, clusterIPSubnet
 	// so let's save the old value before we update the router for later use
 	var oldExtIPs []net.IP
 	oldLogicalRouter, err := libovsdbops.GetLogicalRouter(oc.nbClient, &logicalRouter)
-	if err != nil && err != libovsdbclient.ErrNotFound {
+	if err != nil && !errors.Is(err, libovsdbclient.ErrNotFound) {
 		return fmt.Errorf("failed in retrieving %s, error: %v", gatewayRouter, err)
 	}
 

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -124,7 +124,7 @@ func (oc *DefaultNetworkController) SetupMaster(existingNodeNames []string) erro
 		Name: types.ClusterPortGroupNameBase,
 	}
 	pg, err = libovsdbops.GetPortGroup(oc.nbClient, pg)
-	if err != nil && err != libovsdbclient.ErrNotFound {
+	if err != nil && !errors.Is(err, libovsdbclient.ErrNotFound) {
 		return err
 	}
 	if pg == nil {
@@ -142,7 +142,7 @@ func (oc *DefaultNetworkController) SetupMaster(existingNodeNames []string) erro
 		Name: types.ClusterRtrPortGroupNameBase,
 	}
 	pg, err = libovsdbops.GetPortGroup(oc.nbClient, pg)
-	if err != nil && err != libovsdbclient.ErrNotFound {
+	if err != nil && !errors.Is(err, libovsdbclient.ErrNotFound) {
 		return err
 	}
 	if pg == nil {


### PR DESCRIPTION
Instead of looking explicitly for libovsdbclient.ErrNotFound, checking logic should account for cases when error has been wrapped.

In particular, this change addresses the logic in: func DeleteNATsOps()
https://github.com/ovn-org/ovn-kubernetes/blob/247483c8d1167072e04cf63e1c6e45264a25310e/go-controller/pkg/libovsdb/ops/router.go#L1078

when the error began to be wrapped as follows:
https://github.com/ovn-org/ovn-kubernetes/pull/3646/commits/25d892cc9e318d19738d9519e0e20fbab28f7eae#r1317615944