### PR TITLE
[DNM][HACK] NP: fix deleting peer pods IPs when pod is deleted and also other perf improvements when retrieving pod IPs

### DIFF
--- a/go-controller/pkg/ovn/gress_policy.go
+++ b/go-controller/pkg/ovn/gress_policy.go
@@ -196,7 +196,10 @@ func (gp *gressPolicy) addPeerPods(pods ...*v1.Pod) error {
 func (gp *gressPolicy) deletePeerPod(pod *v1.Pod) error {
 	ips, err := util.GetAllPodIPs(pod)
 	if err != nil {
-		return err
+		// if pod ips can't be fetched on delete, we don't expect that information about ips will ever be updated,
+		// therefore just log the error and return.
+		klog.Warningf("Could not find pod %s/%s IPs in-order to delete the pod IPs from peer address set: %v", pod.Namespace, pod.Name, err)
+		return nil
 	}
 	return gp.peerAddressSet.DeleteIPs(ips)
 }

--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -1531,7 +1531,7 @@ func (oc *Controller) handlePeerPodSelectorDelete(np *networkPolicy, gp *gressPo
 			return nil
 		}
 
-		collidingPod, err := oc.findPodWithIPAddresses(ips)
+		collidingPod, err := oc.findPodWithIPAddresses(ips, pod.Spec.NodeName)
 		if err != nil {
 			return fmt.Errorf("lookup for pods with the same IPs [%s] failed: %w", util.JoinIPs(ips, " "), err)
 		}


### PR DESCRIPTION
… found because pod IPs will never be found and there is no point returning an error that will be retried later.

This PR is created just to run the CI and ensure no regressions. 
It will not merge until later version patches are applied and backported. The code is very different in 4.14 and this issue may not exist. 

Also, some perf improvements for retrieving pod IPs - use kapi instead of annotations first - unmarshalling is costly.
