### PR TITLE
[release-4.12] OCPBUGS-18353: Update bridge flow cache when the host address changes

### DIFF
--- a/go-controller/pkg/node/node_ip_handler_linux.go
+++ b/go-controller/pkg/node/node_ip_handler_linux.go
@@ -155,10 +155,8 @@ func (c *addressManager) runInternal(stopChan <-chan struct{}, doneWg *sync.Wait
 
 				if addrChanged || !c.doesNodeHostAddressesMatch() {
 					if err := util.SetNodeHostAddresses(c.nodeAnnotator, c.addresses); err != nil {
-						klog.Errorf("Failed to set node annotations: %v", err)
-						continue
-					}
-					if err := c.nodeAnnotator.Run(); err != nil {
+						klog.Errorf("Failed to set node host address: %v", err)
+					} else if err := c.nodeAnnotator.Run(); err != nil {
 						klog.Errorf("Failed to set node annotations: %v", err)
 					}
 					c.OnChanged()
@@ -275,5 +273,6 @@ func (c *addressManager) sync() {
 		} else if err := c.nodeAnnotator.Run(); err != nil {
 			klog.Errorf("Failed to set node annotations: %v", err)
 		}
+		c.OnChanged()
 	}
 }


### PR DESCRIPTION
When the addressManager detects changes in the node's address, it will update the node address annotations, but it was not reflecting the address changes in the OpenFlow rules within the node via openflowManager.updateBridgeFlowCache(). This could result in nodes having stale rules that affect functionalities such as hairpin.
