### PR TITLE
[release-4.14] OCPBUGS-18977: Update bridge flow cache when the host address changes

### DIFF
--- a/go-controller/pkg/node/node_ip_handler_linux.go
+++ b/go-controller/pkg/node/node_ip_handler_linux.go
@@ -467,5 +467,6 @@ func (c *addressManager) sync() {
 		if err != nil {
 			klog.Errorf("Address Manager failed to update node address annotations: %v", err)
 		}
+		c.OnChanged()
 	}
 }


### PR DESCRIPTION
When the addressManager detects changes in the node's address, it will update the node address annotations, but it was not reflecting the address changes in the OpenFlow rules within the node via openflowManager.updateBridgeFlowCache(). This could result in nodes having stale rules that affect functionalities such as hairpin.
