### PR TITLE
[release-4.14] OCPBUGS-19087: Dockerfile: bump OVN to ovn23.09-23.09.0-beta.31.el9fdp

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -13,7 +13,7 @@ RUN dnf install -y --nodocs \
 	dnf clean all
 
 ARG ovsver=3.1.0-32.el9fdp
-ARG ovnver=23.09.0-alpha.157.el9fdp
+ARG ovnver=23.09.0-beta.31.el9fdp
 
 RUN INSTALL_PKGS="iptables" && \
 	ovsver_short=$(echo "$ovsver" | cut -d'.' -f1,2) && \


### PR DESCRIPTION
Includes the following relevant changes:

- LoadBalancer incremental processing to reduce CPU usage in Service-heavy scenarios
https://issues.redhat.com/browse/OCPBUGS-19004

- Always CT commit ECMP traffic in original direction to reduce OVS CPU usage in benchmark testing
https://issues.redhat.com/browse/OCPBUGS-19010
