### PR TITLE
[release-4.13] OCPBUGS-19088,OCPBUGS-7406,OCPBUGS-18791,OCPBUGS-18792: Dockerfile: bump OVN to ovn23.06-23.06.1-8.el9fdp

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -13,7 +13,7 @@ RUN dnf install -y --nodocs \
 	dnf clean all
 
 ARG ovsver=3.1.0-32.el9fdp
-ARG ovnver=23.06.0-51.el9fdp
+ARG ovnver=23.06.1-8.el9fdp
 
 RUN INSTALL_PKGS="iptables" && \
 	dnf install -y --nodocs $INSTALL_PKGS && \

--- a/go-controller/pkg/ovn/copp.go
+++ b/go-controller/pkg/ovn/copp.go
@@ -20,6 +20,7 @@ const (
 	OVNICMPV6ErrorsRateLimiter     = "icmp6-error"
 	OVNRejectRateLimiter           = "reject"
 	OVNTCPRSTRateLimiter           = "tcp-reset"
+	OVNServiceMonitorLimiter       = "svc-monitor"
 
 	// Default COPP object name
 	defaultCOPPName = "ovnkube-default"
@@ -34,6 +35,7 @@ var defaultProtocolNames = [...]string{
 	OVNICMPV6ErrorsRateLimiter,
 	OVNRejectRateLimiter,
 	OVNTCPRSTRateLimiter,
+	OVNServiceMonitorLimiter,
 }
 
 func getMeterNameForProtocol(protocol string) string {

--- a/go-controller/pkg/ovn/gateway_test.go
+++ b/go-controller/pkg/ovn/gateway_test.go
@@ -225,6 +225,7 @@ func generateGatewayInitExpectedNB(testData []libovsdb.TestData, expectedOVNClus
 		types.OVNICMPV6ErrorsRateLimiter:     getMeterNameForProtocol(types.OVNICMPV6ErrorsRateLimiter),
 		types.OVNRejectRateLimiter:           getMeterNameForProtocol(types.OVNRejectRateLimiter),
 		types.OVNTCPRSTRateLimiter:           getMeterNameForProtocol(types.OVNTCPRSTRateLimiter),
+		types.OVNServiceMonitorLimiter:       getMeterNameForProtocol(types.OVNServiceMonitorLimiter),
 	}
 	fairness := true
 	for _, v := range meters {

--- a/go-controller/pkg/types/const.go
+++ b/go-controller/pkg/types/const.go
@@ -122,6 +122,7 @@ const (
 	OVNICMPV6ErrorsRateLimiter     = "icmp6-error"
 	OVNRejectRateLimiter           = "reject"
 	OVNTCPRSTRateLimiter           = "tcp-reset"
+	OVNServiceMonitorLimiter       = "svc-monitor"
 
 	// OVN-K8S Topology Versions
 	OvnSingleJoinSwitchTopoVersion = 1


### PR DESCRIPTION
Includes the following relevant changes:

- Always CT commit ECMP traffic in original direction to reduce OVS CPU usage in benchmark testing
https://issues.redhat.com/browse/OCPBUGS-19010

- service monitor MAC flow is not rate limited
https://bugzilla.redhat.com/show_bug.cgi?id=2213296

- ovn-controller: Detect and use L4_SYM dp-hash if available
https://bugzilla.redhat.com/show_bug.cgi?id=2188679

- northd: Make sure that skip_snat=true is evaluated before force_snat
https://bugzilla.redhat.com/show_bug.cgi?id=2224260
