### PR TITLE
[release-4.12] OCPBUGS-19089,OCPBUGS-19904,OCPBUGS-19906,OCPBUGS-14708: Dockerfile: bump OVN to ovn22.12-22.12.1-18.el8fdp

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -13,7 +13,7 @@ RUN yum install -y  \
 	yum clean all
 
 ARG ovsver=2.17.0-62.el8fdp
-ARG ovnver=22.12.0-18.el8fdp
+ARG ovnver=22.12.1-18.el8fdp
 
 RUN \
     yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False "openvswitch2.17 = $ovsver" "python3-openvswitch2.17 = $ovsver" && \

--- a/go-controller/pkg/ovn/gateway_copp.go
+++ b/go-controller/pkg/ovn/gateway_copp.go
@@ -20,6 +20,7 @@ const (
 	OVNICMPV6ErrorsRateLimiter     = "icmp6-error"
 	OVNRejectRateLimiter           = "reject"
 	OVNTCPRSTRateLimiter           = "tcp-reset"
+	OVNServiceMonitorLimiter       = "svc-monitor"
 
 	// Default COPP object name
 	defaultCOPPName = "ovnkube-default"
@@ -34,6 +35,7 @@ var defaultProtocolNames = [...]string{
 	OVNICMPV6ErrorsRateLimiter,
 	OVNRejectRateLimiter,
 	OVNTCPRSTRateLimiter,
+	OVNServiceMonitorLimiter,
 }
 
 func getMeterNameForProtocol(protocol string) string {

--- a/go-controller/pkg/ovn/gateway_test.go
+++ b/go-controller/pkg/ovn/gateway_test.go
@@ -226,6 +226,7 @@ func generateGatewayInitExpectedNB(testData []libovsdb.TestData, expectedOVNClus
 		types.OVNICMPV6ErrorsRateLimiter:     getMeterNameForProtocol(types.OVNICMPV6ErrorsRateLimiter),
 		types.OVNRejectRateLimiter:           getMeterNameForProtocol(types.OVNRejectRateLimiter),
 		types.OVNTCPRSTRateLimiter:           getMeterNameForProtocol(types.OVNTCPRSTRateLimiter),
+		types.OVNServiceMonitorLimiter:       getMeterNameForProtocol(types.OVNServiceMonitorLimiter),
 	}
 	fairness := true
 	for _, v := range meters {

--- a/go-controller/pkg/types/const.go
+++ b/go-controller/pkg/types/const.go
@@ -108,6 +108,7 @@ const (
 	OVNICMPV6ErrorsRateLimiter     = "icmp6-error"
 	OVNRejectRateLimiter           = "reject"
 	OVNTCPRSTRateLimiter           = "tcp-reset"
+	OVNServiceMonitorLimiter       = "svc-monitor"
 
 	// OVN-K8S Address Sets Names
 	HybridRoutePolicyPrefix = "hybrid-route-pods-"


### PR DESCRIPTION
Includes the following relevant changes:

- Always CT commit ECMP traffic in original direction to reduce OVS CPU usage in benchmark testing
https://issues.redhat.com/browse/OCPBUGS-19010

- service monitor MAC flow is not rate limited
https://bugzilla.redhat.com/show_bug.cgi?id=2213296

- northd: Make sure that skip_snat=true is evaluated before force_snat
https://bugzilla.redhat.com/show_bug.cgi?id=2224260

- binding: fixed ovn-installed not properly removed (recomputes)
Related: https://bugzilla.redhat.com/show_bug.cgi?id=2150905
- binding: fixed ovn-installed not properly removed (migration)
Related: https://bugzilla.redhat.com/show_bug.cgi?id=2150905

- ofctrl-seqno: Do not truncate the last acked value
https://bugzilla.redhat.com/show_bug.cgi?id=2074019

- northd: prevents sending packet to conntrack for router ports
https://bugzilla.redhat.com/show_bug.cgi?id=2062431

- ovn-controller: Detect and use L4_SYM dp-hash if available
https://bugzilla.redhat.com/show_bug.cgi?id=2188679