### PR TITLE
OCPBUGS-19449: Do not return error if pod IP cannot be retrieved for `podSelectorPodNeedsDelete` and perf improvements

### DIFF
--- a/go-controller/pkg/ovn/gateway_init.go
+++ b/go-controller/pkg/ovn/gateway_init.go
@@ -64,7 +64,7 @@ func (oc *DefaultNetworkController) cleanupStalePodSNATs(nodeName string, nodeIP
 			continue
 		}
 		if util.PodCompleted(&pod) {
-			collidingPod, err := oc.findPodWithIPAddresses([]net.IP{utilnet.ParseIPSloppy(pod.Status.PodIP)}) //even if a pod is completed we should still delete the nat if the ip is not in use anymore
+			collidingPod, err := oc.findPodWithIPAddresses([]net.IP{utilnet.ParseIPSloppy(pod.Status.PodIP)}, "") //even if a pod is completed we should still delete the nat if the ip is not in use anymore
 			if err != nil {
 				return fmt.Errorf("lookup for pods with same ip as %s %s failed: %w", pod.Namespace, pod.Name, err)
 			}

--- a/go-controller/pkg/ovn/pod_selector_address_set.go
+++ b/go-controller/pkg/ovn/pod_selector_address_set.go
@@ -442,7 +442,7 @@ func (oc *DefaultNetworkController) podSelectorPodNeedsDelete(pod *kapi.Pod, pod
 		return "", fmt.Errorf("can't get pod IPs %s/%s: %w", pod.Namespace, pod.Name, err)
 	}
 	// completed pod be deleted a long time ago, check if there is a new pod with that same ip
-	collidingPod, err := oc.findPodWithIPAddresses(ips)
+	collidingPod, err := oc.findPodWithIPAddresses(ips, pod.Spec.NodeName)
 	if err != nil {
 		return "", fmt.Errorf("lookup for pods with the same IPs [%s] failed: %w", util.JoinIPs(ips, " "), err)
 	}


### PR DESCRIPTION
Do not return error if pod IP cannot be retrieved for `podSelectorPodNeedsDelete` and perf improvements for retrieving the pod IPs.
