### PR TITLE
OCPBUGS-18652: Do not return error if pod IP cannot be retrieved for podSelectorPodNeedsDelete and perf improvements

### DIFF
--- a/go-controller/pkg/ovn/gress_policy.go
+++ b/go-controller/pkg/ovn/gress_policy.go
@@ -196,7 +196,10 @@ func (gp *gressPolicy) addPeerPods(pods ...*v1.Pod) error {
 func (gp *gressPolicy) deletePeerPod(pod *v1.Pod) error {
 	ips, err := util.GetAllPodIPs(pod)
 	if err != nil {
-		return err
+		// if pod ips can't be fetched on delete, we don't expect that information about ips will ever be updated,
+		// therefore just log the error and return.
+		klog.Warningf("Could not find pod %s/%s IPs in-order to delete the pod IPs from peer address set: %v", pod.Namespace, pod.Name, err)
+		return nil
 	}
 	return gp.peerAddressSet.DeleteIPs(ips)
 }

--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -1531,7 +1531,7 @@ func (oc *Controller) handlePeerPodSelectorDelete(np *networkPolicy, gp *gressPo
 			return nil
 		}
 
-		collidingPod, err := oc.findPodWithIPAddresses(ips)
+		collidingPod, err := oc.findPodWithIPAddresses(ips, pod.Spec.NodeName)
 		if err != nil {
 			return fmt.Errorf("lookup for pods with the same IPs [%s] failed: %w", util.JoinIPs(ips, " "), err)
 		}


### PR DESCRIPTION
Do not return error if pod IP cannot be retrieved for `podPeerPod` and perf improvements for retrieving the pod IPs.