### PR TITLE
Bump OVN to 23.06.0-69.el9fdp

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -13,7 +13,7 @@ RUN dnf install -y --nodocs \
 	dnf clean all
 
 ARG ovsver=3.1.0-32.el9fdp
-ARG ovnver=23.06.0-51.el9fdp
+ARG ovnver=23.06.0-69.el9fdp
 
 RUN INSTALL_PKGS="iptables" && \
 	dnf install -y --nodocs $INSTALL_PKGS && \


### PR DESCRIPTION
The following change is required for https://issues.redhat.com/browse/OCPBUGS-7406:
```
* Tue Aug 15 2023 Dumitru Ceara <dceara@redhat.com> - 23.06.0-61
- ovn-controller: Detect and use L4_SYM dp-hash if available. (#2188679) [Upstream: 1843e3aaa4f9b09327ec7b2a6043d964374f35d0]
```

Full changelog can be found in the commit message. 