### PR TITLE
DNM/TEST: dont quit if node does not have subnet annotation

### DIFF
--- a/go-controller/pkg/node/default_node_network_controller.go
+++ b/go-controller/pkg/node/default_node_network_controller.go
@@ -872,7 +872,7 @@ func (nc *DefaultNodeNetworkController) Start(ctx context.Context) error {
 						nodeSubnets, err := util.ParseNodeHostSubnetAnnotation(&node, types.DefaultNetworkName)
 						if err != nil {
 							err1 = fmt.Errorf("unable to fetch node-subnet annotation for node %s: err, %v", node.Name, err)
-							return false, nil
+							continue
 						}
 						for _, nodeSubnet := range nodeSubnets {
 							klog.Infof("Upgrade Hack: node %s, subnet %s", node.Name, nodeSubnet)


### PR DESCRIPTION
in some cases, multiple nodes will have to sync and we may not have enough subnets available for all of them. In that case we don't want to quit the sync on other nodes if one is found to not have the subnet annotation as the others may still have it.

JIRA: https://issues.redhat.com/browse/OCPBUGS-18598

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->