### PR TITLE
OCPBUGS-19886,OCPBUGS-19889,OCPBUGS-19887,OCPBUGS-19888: EIP fixes, remove ippool dupe call, allow gw mtu in webhook and ovnkube node can set mgt port for dpu

### DIFF
--- a/dist/templates/k8s.ovn.org_egressfirewalls.yaml.j2
+++ b/dist/templates/k8s.ovn.org_egressfirewalls.yaml.j2
@@ -3,7 +3,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.3
+  creationTimestamp: null
   name: egressfirewalls.k8s.ovn.org
 spec:
   group: k8s.ovn.org

--- a/dist/templates/k8s.ovn.org_egressips.yaml.j2
+++ b/dist/templates/k8s.ovn.org_egressips.yaml.j2
@@ -3,7 +3,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.3
+  creationTimestamp: null
   name: egressips.k8s.ovn.org
 spec:
   group: k8s.ovn.org
@@ -168,15 +169,11 @@ spec:
                     egressIP:
                       description: Assigned egress IP
                       type: string
-                    network:
-                      description: Assigned network
-                      type: string
                     node:
                       description: Assigned node name
                       type: string
                   required:
                   - egressIP
-                  - network
                   - node
                   type: object
                 type: array

--- a/dist/templates/k8s.ovn.org_egressqoses.yaml.j2
+++ b/dist/templates/k8s.ovn.org_egressqoses.yaml.j2
@@ -3,7 +3,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.3
+  creationTimestamp: null
   name: egressqoses.k8s.ovn.org
 spec:
   group: k8s.ovn.org

--- a/go-controller/pkg/clustermanager/egressip_controller.go
+++ b/go-controller/pkg/clustermanager/egressip_controller.go
@@ -1189,7 +1189,7 @@ func (eIPC *egressIPClusterController) assignEgressIPs(name string, egressIPs []
 				Name: name,
 			}
 			eIPC.recorder.Eventf(&eIPRef, v1.EventTypeWarning, "EgressIPConflict", "Egress IP %s with IP "+
-				"%s is conflicting with a host (%s) IP address and will not be assigned", name, eIP.String(), conflictedHost, name)
+				"%v is conflicting with a host (%s) IP address and will not be assigned", name, eIP, conflictedHost)
 			klog.Errorf("Egress IP: %v address is already assigned on an interface on node %s", eIP, conflictedHost)
 			return assignments
 		}

--- a/go-controller/pkg/clustermanager/egressip_controller.go
+++ b/go-controller/pkg/clustermanager/egressip_controller.go
@@ -1274,6 +1274,8 @@ func (eIPC *egressIPClusterController) assignEgressIPs(name string, egressIPs []
 			// if the EIP is hosted by a non OVN managed network, then restrict the assignable nodes to the set of nodes that
 			// may host the non-OVN managed network
 			if len(assignableNodesWithSecondaryNet) > 0 {
+				klog.V(5).Infof("Restricting the number of assignable nodes from %d to %d because EgressIP %s IP %s "+
+					"is going to be hosted by a non-OVN managed network", len(assignableNodes), len(assignableNodesWithSecondaryNet), name, eIP.String())
 				assignableNodes = assignableNodesWithSecondaryNet
 			}
 		}
@@ -1324,7 +1326,7 @@ func (eIPC *egressIPClusterController) assignEgressIPs(name string, egressIPs []
 			})
 			eNode.allocations[eIP.String()] = name
 			assignmentSuccessful = true
-			klog.Infof("Successful assignment of egress IP: %s on node: %+v", egressIP, eNode)
+			klog.Infof("Successful assignment of egress IP: %s to network %s on node: %+v", egressIP, egressIPNetwork, eNode)
 			break
 		}
 	}

--- a/go-controller/pkg/crd/egressip/v1/types.go
+++ b/go-controller/pkg/crd/egressip/v1/types.go
@@ -41,8 +41,6 @@ type EgressIPStatusItem struct {
 	Node string `json:"node"`
 	// Assigned egress IP
 	EgressIP string `json:"egressIP"`
-	// Assigned network
-	Network string `json:"network"`
 }
 
 // EgressIPSpec is a desired state description of EgressIP.

--- a/go-controller/pkg/node/controllers/egressip/egressip.go
+++ b/go-controller/pkg/node/controllers/egressip/egressip.go
@@ -452,6 +452,9 @@ func (c *Controller) getConfigAndUpdateRefs(eIP *eipv1.EgressIP, updateRefs bool
 		}
 		c.referencedObjects[eIP.Name] = refObjs
 	}
+	if eIPConfig == nil || podIPConfigs == nil {
+		return nil, nil
+	}
 	return &config{
 		namespacesWithPods: namespacePods,
 		eIPConfig:          eIPConfig,
@@ -464,8 +467,6 @@ func (c *Controller) getConfigAndUpdateRefs(eIP *eipv1.EgressIP, updateRefs bool
 // that can host one of the EIP IPs returning egress IP configuration, selected namespaces and pods
 func (c *Controller) processEIP(eip *eipv1.EgressIP) (*eIPConfig, *podIPConfigList, sets.Set[string], sets.Set[ktypes.NamespacedName],
 	map[string]map[ktypes.NamespacedName]*corev1.Pod, error) {
-	podIPConfigs := newPodIPConfigList()
-	eIPConfig := newEIPConfig()
 	selectedNamespaces := sets.Set[string]{}
 	selectedPods := sets.Set[ktypes.NamespacedName]{}
 	selectedPodIPs := make(map[ktypes.NamespacedName][]net.IP)
@@ -474,12 +475,12 @@ func (c *Controller) processEIP(eip *eipv1.EgressIP) (*eIPConfig, *podIPConfigLi
 	// namespace selector is mandatory for EIP
 	namespaces, err := c.listNamespacesBySelector(&eip.Spec.NamespaceSelector)
 	if err != nil {
-		return eIPConfig, podIPConfigs, selectedNamespaces, selectedPods, selectedNamespacesPods, fmt.Errorf("failed to list namespaces: %w", err)
+		return nil, nil, selectedNamespaces, selectedPods, selectedNamespacesPods, fmt.Errorf("failed to list namespaces: %w", err)
 	}
 	for _, namespace := range namespaces {
 		pods, err := c.listPodsByNamespaceAndSelector(namespace.Name, &eip.Spec.PodSelector)
 		if err != nil {
-			return eIPConfig, podIPConfigs, selectedNamespaces, selectedPods, selectedNamespacesPods, fmt.Errorf("failed to list pods in namespace %s: %w",
+			return nil, nil, selectedNamespaces, selectedPods, selectedNamespacesPods, fmt.Errorf("failed to list pods in namespace %s: %w",
 				namespace.Name, err)
 		}
 		podsNsName := map[ktypes.NamespacedName]*corev1.Pod{}
@@ -490,7 +491,7 @@ func (c *Controller) processEIP(eip *eipv1.EgressIP) (*eIPConfig, *podIPConfigLi
 			}
 			ips, err := util.DefaultNetworkPodIPs(pod)
 			if err != nil {
-				return eIPConfig, podIPConfigs, selectedNamespaces, selectedPods, selectedNamespacesPods, fmt.Errorf("failed to get pod ips: %w", err)
+				return nil, nil, selectedNamespaces, selectedPods, selectedNamespacesPods, fmt.Errorf("failed to get pod ips: %w", err)
 			}
 			if len(ips) == 0 {
 				continue
@@ -504,16 +505,16 @@ func (c *Controller) processEIP(eip *eipv1.EgressIP) (*eIPConfig, *podIPConfigLi
 		selectedNamespaces.Insert(namespace.Name)
 	}
 	if selectedPods.Len() == 0 {
-		return eIPConfig, podIPConfigs, selectedNamespaces, selectedPods, selectedNamespacesPods, nil
+		return nil, nil, selectedNamespaces, selectedPods, selectedNamespacesPods, nil
 	}
 	node, err := c.nodeLister.Get(c.nodeName)
 	if err != nil {
-		return eIPConfig, podIPConfigs, selectedNamespaces, selectedPods, selectedNamespacesPods,
+		return nil, nil, selectedNamespaces, selectedPods, selectedNamespacesPods,
 			fmt.Errorf("failed to find this node %q kubernetes Node object: %v", c.nodeName, err)
 	}
 	parsedNodeEIPConfig, err := util.GetNodeEIPConfig(node)
 	if err != nil {
-		return eIPConfig, podIPConfigs, selectedNamespaces, selectedPods, selectedNamespacesPods,
+		return nil, nil, selectedNamespaces, selectedPods, selectedNamespacesPods,
 			fmt.Errorf("failed to determine egress IP config for node %s: %w", node.Name, err)
 	}
 	// max of 1 EIP IP is selected. Return when 1 is found.
@@ -523,7 +524,7 @@ func (c *Controller) processEIP(eip *eipv1.EgressIP) (*eIPConfig, *podIPConfigLi
 		}
 		eIPNet, err := util.GetIPNetFullMask(status.EgressIP)
 		if err != nil {
-			return eIPConfig, podIPConfigs, selectedNamespaces, selectedPods, selectedNamespacesPods,
+			return nil, nil, selectedNamespaces, selectedPods, selectedNamespacesPods,
 				fmt.Errorf("failed to generate mask for EgressIP %s IP %s: %v", eip.Name, status.EgressIP, err)
 		}
 		if util.IsOVNManagedNetwork(parsedNodeEIPConfig, eIPNet.IP) {
@@ -532,7 +533,7 @@ func (c *Controller) processEIP(eip *eipv1.EgressIP) (*eIPConfig, *podIPConfigLi
 		isEIPV6 := utilnet.IsIPv6(eIPNet.IP)
 		found, link, err := findLinkOnSameNetworkAsIP(eIPNet.IP, c.v4, c.v6)
 		if err != nil {
-			return eIPConfig, podIPConfigs, selectedNamespaces, selectedPods, selectedNamespacesPods,
+			return nil, nil, selectedNamespaces, selectedPods, selectedNamespacesPods,
 				fmt.Errorf("failed to find a network to host EgressIP %s IP %s: %v", eip.Name, status.EgressIP, err)
 		}
 		if !found {
@@ -542,11 +543,11 @@ func (c *Controller) processEIP(eip *eipv1.EgressIP) (*eIPConfig, *podIPConfigLi
 			eip.Name, status.EgressIP, link.Attrs().Name)
 		// go through all selected pods and build a config per pod IP. We know there are at least one pod and these the
 		// pod(s) have IP(s).
-		eIPConfig, podIPConfigs = generateEIPConfigForPods(selectedPodIPs, link, eIPNet, isEIPV6)
+		eIPConfig, podIPConfigs := generateEIPConfigForPods(selectedPodIPs, link, eIPNet, isEIPV6)
 		// ignore other EIP IPs. Multiple EIP IPs cannot be assigned to the same node
-		break
+		return eIPConfig, podIPConfigs, selectedNamespaces, selectedPods, selectedNamespacesPods, nil
 	}
-	return eIPConfig, podIPConfigs, selectedNamespaces, selectedPods, selectedNamespacesPods, nil
+	return nil, nil, selectedNamespaces, selectedPods, selectedNamespacesPods, nil
 }
 
 func generateEIPConfigForPods(pods map[ktypes.NamespacedName][]net.IP, link netlink.Link, eIPNet *net.IPNet, isEIPV6 bool) (*eIPConfig, *podIPConfigList) {

--- a/go-controller/pkg/node/controllers/egressip/egressip.go
+++ b/go-controller/pkg/node/controllers/egressip/egressip.go
@@ -1009,11 +1009,11 @@ func (c *Controller) removeStaleIPTableRules(proto utiliptables.Protocol, staleR
 	return nil
 }
 
-func (c *Controller) isIPSupported(ip net.IP) bool {
-	if ip.To4() != nil && c.v4 {
+func (c *Controller) isIPSupported(isIPV6 bool) bool {
+	if !isIPV6 && c.v4 {
 		return true
 	}
-	if ip.To4() == nil && c.v6 {
+	if isIPV6 && c.v6 {
 		return true
 	}
 	return false
@@ -1105,17 +1105,17 @@ func getDefaultRoute(linkIdx int, v6 bool) routemanager.Route {
 
 // generateIPRules generates IP rules at a predefined priority for each pod IP with a custom routing table based
 // from the links 'ifindex'
-func generateIPRule(srcIP net.IP, ifIndex int) netlink.Rule {
+func generateIPRule(srcIP net.IP, isIPv6 bool, ifIndex int) netlink.Rule {
 	r := *netlink.NewRule()
 	r.Table = getRouteTableID(ifIndex)
 	r.Priority = rulePriority
 	var ipFullMask string
-	if srcIP.To4() != nil { // v4
-		ipFullMask = fmt.Sprintf("%s/32", srcIP.String())
-		r.Family = netlink.FAMILY_V4
-	} else { // v6
+	if isIPv6 {
 		ipFullMask = fmt.Sprintf("%s/128", srcIP.String())
 		r.Family = netlink.FAMILY_V6
+	} else {
+		ipFullMask = fmt.Sprintf("%s/32", srcIP.String())
+		r.Family = netlink.FAMILY_V4
 	}
 	_, ipNet, _ := net.ParseCIDR(ipFullMask)
 	r.Src = ipNet
@@ -1141,12 +1141,12 @@ func getPodNamespacedName(pod *corev1.Pod) ktypes.NamespacedName {
 	return ktypes.NamespacedName{Namespace: pod.Namespace, Name: pod.Name}
 }
 
-func generateIPTablesSNATRuleArg(srcIP net.IP, infName, snatIP string) iptables.RuleArg {
+func generateIPTablesSNATRuleArg(srcIP net.IP, isIPv6 bool, infName, snatIP string) iptables.RuleArg {
 	var srcIPFullMask string
-	if srcIP.To4() != nil { // v4
-		srcIPFullMask = fmt.Sprintf("%s/32", srcIP.String())
-	} else { // v6
+	if isIPv6 {
 		srcIPFullMask = fmt.Sprintf("%s/128", srcIP.String())
+	} else {
+		srcIPFullMask = fmt.Sprintf("%s/32", srcIP.String())
 	}
 	return iptables.RuleArg{Args: []string{"-s", srcIPFullMask, "-o", infName, "-j", "SNAT", "--to-source", snatIP}}
 }

--- a/go-controller/pkg/node/controllers/egressip/egressip.go
+++ b/go-controller/pkg/node/controllers/egressip/egressip.go
@@ -537,6 +537,8 @@ func (c *Controller) processEIP(eip *eipv1.EgressIP) (*eIPConfig, *podIPConfigLi
 		if !found {
 			continue
 		}
+		klog.Infof("Generating config for EgressIP %s IP %s which is hosted by a non-OVN managed interface (name %s)",
+			eip.Name, status.EgressIP, link.Attrs().Name)
 		// go through all selected pods and build a config per pod IP. We know there are at least one pod and these the
 		// pod(s) have IP(s).
 		eIPConfig, podIPConfigs = generateEIPConfigForPods(selectedPodIPs, link, eIPNet, isV6)

--- a/go-controller/pkg/node/controllers/egressip/egressip.go
+++ b/go-controller/pkg/node/controllers/egressip/egressip.go
@@ -542,30 +542,28 @@ func (c *Controller) processEIP(eip *eipv1.EgressIP) (*eIPConfig, *podIPConfigLi
 			eip.Name, status.EgressIP, link.Attrs().Name)
 		// go through all selected pods and build a config per pod IP. We know there are at least one pod and these the
 		// pod(s) have IP(s).
-		eIPConfig, podIPConfigs = generateEIPConfigForPods(selectedPodIPs, link, eIPNet, isV6)
+		eIPConfig, podIPConfigs = generateEIPConfigForPods(selectedPodIPs, link, eIPNet, isEIPV6)
 		// ignore other EIP IPs. Multiple EIP IPs cannot be assigned to the same node
 		break
 	}
 	return eIPConfig, podIPConfigs, selectedNamespaces, selectedPods, selectedNamespacesPods, nil
 }
 
-func generateEIPConfigForPods(pods map[ktypes.NamespacedName][]net.IP, link netlink.Link, eIPNet *net.IPNet, v6 bool) (*eIPConfig, *podIPConfigList) {
+func generateEIPConfigForPods(pods map[ktypes.NamespacedName][]net.IP, link netlink.Link, eIPNet *net.IPNet, isEIPV6 bool) (*eIPConfig, *podIPConfigList) {
 	eipConfig := newEIPConfig()
 	newPodIPConfigs := newPodIPConfigList()
-	eipConfig.routeLink = getDefaultRouteForLink(link, v6)
+	eipConfig.routeLink = getDefaultRouteForLink(link, isEIPV6)
 	eipConfig.ip = getNetlinkAddressWithLabel(eIPNet, link.Attrs().Index, link.Attrs().Name)
-	for _, ips := range pods {
-		for _, ip := range ips {
-			isPodIPv6 := utilnet.IsIPv6(ip)
+	for _, podIPs := range pods {
+		for _, podIP := range podIPs {
+			isPodIPv6 := utilnet.IsIPv6(podIP)
 			if isPodIPv6 != isEIPV6 {
 				continue
 			}
 			ipConfig := newPodIPConfig()
-			ipConfig.ipTableRule = generateIPTablesSNATRuleArg(ip, link.Attrs().Name, eIPNet.IP.String())
-			ipConfig.ipRule = generateIPRule(ip, link.Attrs().Index)
-			if ip.To4() == nil {
-				ipConfig.v6 = true
-			}
+			ipConfig.ipTableRule = generateIPTablesSNATRuleArg(podIP, isPodIPv6, link.Attrs().Name, eIPNet.IP.String())
+			ipConfig.ipRule = generateIPRule(podIP, isPodIPv6, link.Attrs().Index)
+			ipConfig.v6 = isPodIPv6
 			newPodIPConfigs.elems = append(newPodIPConfigs.elems, ipConfig)
 		}
 	}
@@ -866,7 +864,7 @@ func (c *Controller) RepairNode() error {
 			}
 			linkIdx := link.Attrs().Index
 			linkName := link.Attrs().Name
-			expectedIPRoutes.Insert(getDefaultRoute(linkIdx, isV6).String())
+			expectedIPRoutes.Insert(getDefaultRoute(linkIdx, isEIPV6).String())
 			expectedAddrs.Insert(getNetlinkAddressWithLabel(eIPNet, linkIdx, linkName).String())
 			namespaceSelector, err := metav1.LabelSelectorAsSelector(&egressIP.Spec.NamespaceSelector)
 			if err != nil {
@@ -897,21 +895,21 @@ func (c *Controller) RepairNode() error {
 						if err != nil {
 							return err
 						}
-						for _, ip := range podIPs {
-							isPodIPV6 := utilnet.IsIPv6(ip)
+						for _, podIP := range podIPs {
+							isPodIPV6 := utilnet.IsIPv6(podIP)
 							if isPodIPV6 != isEIPV6 {
 								continue
 							}
-							if !c.isIPSupported(ip) {
+							if !c.isIPSupported(isPodIPV6) {
 								continue
 							}
-							ipTableRule := strings.Join(generateIPTablesSNATRuleArg(ip, linkName, status.EgressIP).Args, " ")
-							if ip.To4() != nil {
-								expectedIPTableV4Rules.Insert(ipTableRule)
-							} else {
+							ipTableRule := strings.Join(generateIPTablesSNATRuleArg(podIP, isPodIPV6, linkName, status.EgressIP).Args, " ")
+							if isPodIPV6 {
 								expectedIPTableV6Rules.Insert(ipTableRule)
+							} else {
+								expectedIPTableV4Rules.Insert(ipTableRule)
 							}
-							expectedIPRules.Insert(generateIPRule(ip, link.Attrs().Index).String())
+							expectedIPRules.Insert(generateIPRule(podIP, isPodIPV6, link.Attrs().Index).String())
 						}
 					}
 				}

--- a/go-controller/pkg/node/controllers/egressip/egressip.go
+++ b/go-controller/pkg/node/controllers/egressip/egressip.go
@@ -937,9 +937,6 @@ func isEIPStatusItemValid(status eipv1.EgressIPStatusItem, nodeName string) bool
 	if status.EgressIP == "" {
 		return false
 	}
-	if status.Network == "" {
-		return false
-	}
 	return true
 }
 

--- a/go-controller/pkg/node/controllers/egressip/egressip.go
+++ b/go-controller/pkg/node/controllers/egressip/egressip.go
@@ -10,6 +10,9 @@ import (
 	"sync"
 	"time"
 
+	eipv1 "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressip/v1"
+	egressipinformer "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressip/v1/apis/informers/externalversions/egressip/v1"
+	egressiplisters "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressip/v1/apis/listers/egressip/v1"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/iprulemanager"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/iptables"
@@ -17,10 +20,8 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/routemanager"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/syncmap"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	utilnet "k8s.io/utils/net"
 
-	eipv1 "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressip/v1"
-	egressipinformer "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressip/v1/apis/informers/externalversions/egressip/v1"
-	egressiplisters "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressip/v1/apis/listers/egressip/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -555,6 +556,10 @@ func generateEIPConfigForPods(pods map[ktypes.NamespacedName][]net.IP, link netl
 	eipConfig.ip = getNetlinkAddressWithLabel(eIPNet, link.Attrs().Index, link.Attrs().Name)
 	for _, ips := range pods {
 		for _, ip := range ips {
+			isPodIPv6 := utilnet.IsIPv6(ip)
+			if isPodIPv6 != isEIPV6 {
+				continue
+			}
 			ipConfig := newPodIPConfig()
 			ipConfig.ipTableRule = generateIPTablesSNATRuleArg(ip, link.Attrs().Name, eIPNet.IP.String())
 			ipConfig.ipRule = generateIPRule(ip, link.Attrs().Index)
@@ -893,6 +898,10 @@ func (c *Controller) RepairNode() error {
 							return err
 						}
 						for _, ip := range podIPs {
+							isPodIPV6 := utilnet.IsIPv6(ip)
+							if isPodIPV6 != isEIPV6 {
+								continue
+							}
 							if !c.isIPSupported(ip) {
 								continue
 							}

--- a/go-controller/pkg/node/controllers/egressip/egressip.go
+++ b/go-controller/pkg/node/controllers/egressip/egressip.go
@@ -529,7 +529,7 @@ func (c *Controller) processEIP(eip *eipv1.EgressIP) (*eIPConfig, *podIPConfigLi
 		if util.IsOVNManagedNetwork(parsedNodeEIPConfig, eIPNet.IP) {
 			continue
 		}
-		isV6 := eIPNet.IP.To4() == nil
+		isEIPV6 := utilnet.IsIPv6(eIPNet.IP)
 		found, link, err := findLinkOnSameNetworkAsIP(eIPNet.IP, c.v4, c.v6)
 		if err != nil {
 			return eIPConfig, podIPConfigs, selectedNamespaces, selectedPods, selectedNamespacesPods,
@@ -855,7 +855,7 @@ func (c *Controller) RepairNode() error {
 			if util.IsOVNManagedNetwork(parsedNodeEIPConfig, eIPNet.IP) {
 				continue
 			}
-			isV6 := eIPNet.IP.To4() == nil
+			isEIPV6 := utilnet.IsIPv6(eIPNet.IP)
 			found, link, err := findLinkOnSameNetworkAsIP(eIPNet.IP, c.v4, c.v6)
 			if err != nil {
 				return fmt.Errorf("failed to find a network to host EgressIP %s IP %s: %v", egressIP.Name,

--- a/go-controller/pkg/node/controllers/egressip/egressip_test.go
+++ b/go-controller/pkg/node/controllers/egressip/egressip_test.go
@@ -417,7 +417,7 @@ var _ = table.XDescribeTable("EgressIP selectors",
 						if status.Node != node1Name {
 							continue
 						}
-						if status.Network == "" || status.EgressIP == "" {
+						if status.EgressIP == "" {
 							continue
 						}
 						// FIXME: we assume all EIPs are hosted by non-OVN managed network. Skip OVN managed EIPs.
@@ -521,7 +521,7 @@ var _ = table.XDescribeTable("EgressIP selectors",
 	table.Entry("configures nothing when EIPs dont select anything",
 		[]testEIPConfig{
 			{
-				newEgressIP(egressIP1Name, egressIP1IP, dummy1IPv4CIDRNetwork, node1Name, namespace1Label, egressPodLabel),
+				newEgressIP(egressIP1Name, egressIP1IP, node1Name, namespace1Label, egressPodLabel),
 				testConfig{},
 			},
 		},
@@ -534,7 +534,7 @@ var _ = table.XDescribeTable("EgressIP selectors",
 	table.Entry("configures one EIP and one Pod",
 		[]testEIPConfig{
 			{
-				newEgressIP(egressIP1Name, egressIP1IP, dummy1IPv4CIDRNetwork, node1Name, namespace1Label, egressPodLabel),
+				newEgressIP(egressIP1Name, egressIP1IP, node1Name, namespace1Label, egressPodLabel),
 				testConfig{ // expected config for EIP
 					getExpectedDefaultRoute(getLinkIndex(dummyLink1Name)),
 					getExpectedLinkAddr(egressIP1IP),
@@ -559,7 +559,7 @@ var _ = table.XDescribeTable("EgressIP selectors",
 		// Test pod and namespace selection -
 		[]testEIPConfig{
 			{
-				newEgressIP(egressIP1Name, egressIP1IP, dummy1IPv4CIDRNetwork, node1Name, namespace1Label, egressPodLabel),
+				newEgressIP(egressIP1Name, egressIP1IP, node1Name, namespace1Label, egressPodLabel),
 				testConfig{ // expected config for EIP
 					getExpectedDefaultRoute(getLinkIndex(dummyLink1Name)),
 					getExpectedLinkAddr(egressIP1IP),
@@ -590,7 +590,7 @@ var _ = table.XDescribeTable("EgressIP selectors",
 	table.Entry("configures one EIP and multiple namespaces and multiple pods",
 		[]testEIPConfig{
 			{
-				newEgressIP(egressIP1Name, egressIP1IP, dummy1IPv4CIDRNetwork, node1Name, namespace1Label, egressPodLabel),
+				newEgressIP(egressIP1Name, egressIP1IP, node1Name, namespace1Label, egressPodLabel),
 				testConfig{ // expected config for EIP
 					getExpectedDefaultRoute(getLinkIndex(dummyLink1Name)),
 					getExpectedLinkAddr(egressIP1IP),
@@ -623,7 +623,7 @@ var _ = table.XDescribeTable("EgressIP selectors",
 	table.Entry("configures one EIP and multiple namespaces and multiple pods",
 		[]testEIPConfig{
 			{
-				newEgressIP(egressIP1Name, egressIP1IP, dummy1IPv4CIDRNetwork, node1Name, namespace1Label, egressPodLabel),
+				newEgressIP(egressIP1Name, egressIP1IP, node1Name, namespace1Label, egressPodLabel),
 				testConfig{ // expected config for EIP
 					getExpectedDefaultRoute(getLinkIndex(dummyLink1Name)),
 					getExpectedLinkAddr(egressIP1IP),
@@ -655,7 +655,7 @@ var _ = table.XDescribeTable("EgressIP selectors",
 	table.Entry("configures multiple EIPs and multiple namespaces and multiple pods",
 		[]testEIPConfig{
 			{
-				newEgressIP(egressIP1Name, egressIP1IP, dummy1IPv4CIDRNetwork, node1Name, namespace1Label, egressPodLabel),
+				newEgressIP(egressIP1Name, egressIP1IP, node1Name, namespace1Label, egressPodLabel),
 				testConfig{ // expected config for EIP
 					getExpectedDefaultRoute(getLinkIndex(dummyLink1Name)),
 					getExpectedLinkAddr(egressIP1IP),
@@ -675,7 +675,7 @@ var _ = table.XDescribeTable("EgressIP selectors",
 				},
 			},
 			{
-				newEgressIP(egressIP2Name, egressIP2IP, dummy2IPv4CIDRNetwork, node1Name, namespace2Label, egressPodLabel),
+				newEgressIP(egressIP2Name, egressIP2IP, node1Name, namespace2Label, egressPodLabel),
 				testConfig{ // expected config for EIP
 					getExpectedDefaultRoute(getLinkIndex(dummyLink2Name)),
 					getExpectedLinkAddr(egressIP1IP),
@@ -769,7 +769,7 @@ var _ = table.XDescribeTable("repair node", func(expectedStateFollowingClean []t
 }, table.Entry("should not fail when node is clean and nothing to apply",
 	[]testEIPConfig{
 		{
-			newEgressIP(egressIP1Name, egressIP1IP, dummy1IPv4CIDRNetwork, node1Name, namespace1Label, egressPodLabel),
+			newEgressIP(egressIP1Name, egressIP1IP, node1Name, namespace1Label, egressPodLabel),
 			testConfig{}, // no expected config
 		},
 	},
@@ -782,7 +782,7 @@ var _ = table.XDescribeTable("repair node", func(expectedStateFollowingClean []t
 	table.Entry("should remove stale route",
 		[]testEIPConfig{
 			{
-				newEgressIP(egressIP1Name, egressIP1IP, dummy1IPv4CIDRNetwork, node1Name, namespace1Label, egressPodLabel),
+				newEgressIP(egressIP1Name, egressIP1IP, node1Name, namespace1Label, egressPodLabel),
 				testConfig{
 					inf: dummyLink2Name,
 				}, // no expected config
@@ -805,7 +805,7 @@ var _ = table.XDescribeTable("repair node", func(expectedStateFollowingClean []t
 	table.XEntry("should remove stale address",
 		[]testEIPConfig{
 			{
-				newEgressIP(egressIP1Name, egressIP1IP, dummy1IPv4CIDRNetwork, node1Name, namespace1Label, egressPodLabel),
+				newEgressIP(egressIP1Name, egressIP1IP, node1Name, namespace1Label, egressPodLabel),
 				testConfig{
 					inf: dummyLink2Name,
 				}, // no expected config
@@ -972,11 +972,7 @@ func newEgressIPMeta(name string) metav1.ObjectMeta {
 	}
 }
 
-func newEgressIP(name, ip, network, node string, namespaceLabels, podLabels map[string]string) egressipv1.EgressIP {
-	_, ipnet, err := net.ParseCIDR(network)
-	if err != nil {
-		panic(err.Error())
-	}
+func newEgressIP(name, ip, node string, namespaceLabels, podLabels map[string]string) egressipv1.EgressIP {
 	return egressipv1.EgressIP{
 		ObjectMeta: newEgressIPMeta(name),
 		Spec: egressipv1.EgressIPSpec{
@@ -992,7 +988,6 @@ func newEgressIP(name, ip, network, node string, namespaceLabels, podLabels map[
 			Items: []egressipv1.EgressIPStatusItem{{
 				node,
 				ip,
-				ipnet.String(),
 			}},
 		},
 	}

--- a/go-controller/pkg/node/controllers/egressip/egressip_test.go
+++ b/go-controller/pkg/node/controllers/egressip/egressip_test.go
@@ -21,6 +21,7 @@ import (
 	ovniptables "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/iptables"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/routemanager"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	utilnet "k8s.io/utils/net"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -461,7 +462,8 @@ var _ = table.XDescribeTable("EgressIP selectors",
 					ips, err := util.DefaultNetworkPodIPs(pod)
 					gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 					for _, ip := range ips {
-						expectedRules = append(expectedRules, generateIPRule(ip, getLinkIndex(expectedEIPConfig.inf)))
+
+						expectedRules = append(expectedRules, generateIPRule(ip, utilnet.IsIPv6(ip), getLinkIndex(expectedEIPConfig.inf)))
 					}
 				}
 			}

--- a/go-controller/pkg/node/linkmanager/link_network_manager.go
+++ b/go-controller/pkg/node/linkmanager/link_network_manager.go
@@ -189,7 +189,7 @@ func (c *Controller) delAddressFromStore(linkName string, address netlink.Addr) 
 	temp := addressesSaved[:0]
 	for _, addressSaved := range addressesSaved {
 		if !addressSaved.Equal(address) {
-			temp = append(temp, address)
+			temp = append(temp, addressSaved)
 		}
 	}
 	c.store[linkName] = temp

--- a/go-controller/pkg/ovn/egressip.go
+++ b/go-controller/pkg/ovn/egressip.go
@@ -1361,20 +1361,10 @@ func (e egressStatuses) contains(potentialStatus egressipv1.EgressIPStatusItem) 
 	if _, exists := e.statusMap[potentialStatus]; exists {
 		return true
 	}
-	// handle the case where not network is populated. This may occur if an EIP obj was considered by a cluster
-	// manager egress IP controller that did not support the network field
-	potentialStatus.Network = ""
-	if _, exists := e.statusMap[potentialStatus]; exists {
-		return true
-	}
 	return false
 }
 
 func (e egressStatuses) delete(deleteStatus egressipv1.EgressIPStatusItem) {
-	delete(e.statusMap, deleteStatus)
-	// also remove any keys without networks set. This is may occur when upgrading from a version that didn't set the
-	// network field
-	deleteStatus.Network = ""
 	delete(e.statusMap, deleteStatus)
 }
 

--- a/go-controller/pkg/ovn/egressip_test.go
+++ b/go-controller/pkg/ovn/egressip_test.go
@@ -278,8 +278,6 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						{
 							Node:     node1Name,
 							EgressIP: egressIP,
-							// blank network
-							Network: "",
 						},
 					},
 				},
@@ -446,8 +444,6 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						{
 							Node:     node1Name,
 							EgressIP: egressIP,
-							// blank network
-							Network: "",
 						},
 					},
 				},
@@ -621,7 +617,6 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 								{
 									Node:     node1Name,
 									EgressIP: egressIP,
-									Network:  node1IPv4OVNManagedNet,
 								},
 							},
 						},
@@ -6240,7 +6235,6 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						{
 							Node:     node1Name,
 							EgressIP: egressIP3,
-							Network:  node1IPv4Net,
 						},
 					}
 					err = fakeOvn.controller.patchReplaceEgressIPStatus(egressIP2Name, status)

--- a/go-controller/pkg/ovn/logical_switch_manager/logical_switch_manager.go
+++ b/go-controller/pkg/ovn/logical_switch_manager/logical_switch_manager.go
@@ -34,10 +34,6 @@ func NewL2SwitchManager() *LogicalSwitchManager {
 // AddOrUpdateSwitch adds/updates a switch to the logical switch manager for subnet
 // and IPAM management.
 func (manager *LogicalSwitchManager) AddOrUpdateSwitch(switchName string, hostSubnets []*net.IPNet, excludeSubnets ...*net.IPNet) error {
-	err := manager.allocator.AddOrUpdateSubnet(switchName, hostSubnets)
-	if err != nil {
-		return err
-	}
 	if manager.reserveIPs {
 		for _, hostSubnet := range hostSubnets {
 			for _, ip := range []*net.IPNet{util.GetNodeGatewayIfAddr(hostSubnet), util.GetNodeManagementIfAddr(hostSubnet)} {

--- a/go-controller/pkg/ovn/ovn_test.go
+++ b/go-controller/pkg/ovn/ovn_test.go
@@ -429,7 +429,6 @@ func (o *FakeOVN) patchEgressIPObj(nodeName, egressIPName, egressIP, network str
 		{
 			Node:     nodeName,
 			EgressIP: egressIP,
-			Network:  network,
 		},
 	}
 	err := o.controller.patchReplaceEgressIPStatus(egressIPName, status)

--- a/go-controller/pkg/ovnwebhook/nodeadmission.go
+++ b/go-controller/pkg/ovnwebhook/nodeadmission.go
@@ -29,6 +29,7 @@ var commonNodeAnnotationChecks = map[string]checkNodeAnnot{
 	util.OvnNodeL3GatewayConfig:          nil,
 	util.OvnNodeManagementPortMacAddress: nil,
 	util.OvnNodeIfAddr:                   nil,
+	util.OvnNodeGatewayMtuSupport:        nil,
 	util.OvnNodeChassisID: func(v annotationChange, nodeName string) error {
 		if v.action == removed {
 			return fmt.Errorf("%s cannot be removed", util.OvnNodeChassisID)

--- a/go-controller/pkg/ovnwebhook/nodeadmission.go
+++ b/go-controller/pkg/ovnwebhook/nodeadmission.go
@@ -30,6 +30,7 @@ var commonNodeAnnotationChecks = map[string]checkNodeAnnot{
 	util.OvnNodeManagementPortMacAddress: nil,
 	util.OvnNodeIfAddr:                   nil,
 	util.OvnNodeGatewayMtuSupport:        nil,
+	util.OvnNodeManagementPort:           nil,
 	util.OvnNodeChassisID: func(v annotationChange, nodeName string) error {
 		if v.action == removed {
 			return fmt.Errorf("%s cannot be removed", util.OvnNodeChassisID)

--- a/go-controller/pkg/ovnwebhook/nodeadmission_test.go
+++ b/go-controller/pkg/ovnwebhook/nodeadmission_test.go
@@ -251,6 +251,44 @@ func TestNodeAdmission_ValidateUpdate(t *testing.T) {
 			},
 		},
 		{
+			name: "ovnkube-node can set util.OvnNodeManagementPort",
+			ctx: admission.NewContextWithRequest(context.TODO(), admission.Request{
+				AdmissionRequest: v1.AdmissionRequest{UserInfo: authenticationv1.UserInfo{
+					Username: userName,
+				}},
+			}),
+			oldObj: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: nodeName,
+				},
+			},
+			newObj: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        nodeName,
+					Annotations: map[string]string{util.OvnNodeManagementPort: `{"PfId":1,"FuncId":1}`},
+				},
+			},
+		},
+		{
+			name: "ovnkube-node can set util.OvnNodeGatewayMtuSupport",
+			ctx: admission.NewContextWithRequest(context.TODO(), admission.Request{
+				AdmissionRequest: v1.AdmissionRequest{UserInfo: authenticationv1.UserInfo{
+					Username: userName,
+				}},
+			}),
+			oldObj: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: nodeName,
+				},
+			},
+			newObj: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        nodeName,
+					Annotations: map[string]string{util.OvnNodeGatewayMtuSupport: "false"},
+				},
+			},
+		},
+		{
 			name: "ovnkube-node can add util.OvnNodeZoneName with <nodeName> value",
 			ctx: admission.NewContextWithRequest(context.TODO(), admission.Request{
 				AdmissionRequest: v1.AdmissionRequest{UserInfo: authenticationv1.UserInfo{

--- a/go-controller/pkg/util/node_annotations.go
+++ b/go-controller/pkg/util/node_annotations.go
@@ -56,8 +56,8 @@ const (
 	// OvnDefaultNetworkGateway captures L3 gateway config for default OVN network interface
 	ovnDefaultNetworkGateway = "default"
 
-	// ovnNodeManagementPort is the constant string representing the annotation key
-	ovnNodeManagementPort = "k8s.ovn.org/node-mgmt-port"
+	// OvnNodeManagementPort is the constant string representing the annotation key
+	OvnNodeManagementPort = "k8s.ovn.org/node-mgmt-port"
 
 	// OvnNodeManagementPortMacAddress is the constant string representing the annotation key
 	OvnNodeManagementPortMacAddress = "k8s.ovn.org/node-mgmt-port-mac-address"
@@ -371,14 +371,14 @@ func SetNodeManagementPortAnnotation(nodeAnnotator kube.Annotator, PfId int, Fun
 	if err != nil {
 		return fmt.Errorf("failed to marshal mgmtPortDetails with PfId '%v', FuncId '%v'", PfId, FuncId)
 	}
-	return nodeAnnotator.Set(ovnNodeManagementPort, string(bytes))
+	return nodeAnnotator.Set(OvnNodeManagementPort, string(bytes))
 }
 
-// ParseNodeManagementPort returns the parsed host addresses living on a node
+// ParseNodeManagementPortAnnotation returns the parsed host addresses living on a node
 func ParseNodeManagementPortAnnotation(node *kapi.Node) (int, int, error) {
-	mgmtPortAnnotation, ok := node.Annotations[ovnNodeManagementPort]
+	mgmtPortAnnotation, ok := node.Annotations[OvnNodeManagementPort]
 	if !ok {
-		return -1, -1, newAnnotationNotSetError("%s annotation not found for node %q", ovnNodeManagementPort, node.Name)
+		return -1, -1, newAnnotationNotSetError("%s annotation not found for node %q", OvnNodeManagementPort, node.Name)
 	}
 
 	cfg := ManagementPortDetails{}

--- a/go-controller/pkg/util/node_annotations.go
+++ b/go-controller/pkg/util/node_annotations.go
@@ -50,8 +50,8 @@ const (
 	// OvnNodeL3GatewayConfig is the constant string representing the l3 gateway annotation key
 	OvnNodeL3GatewayConfig = "k8s.ovn.org/l3-gateway-config"
 
-	// ovnNodeGatewayMtuSupport determines if option:gateway_mtu shall be set for GR router ports.
-	ovnNodeGatewayMtuSupport = "k8s.ovn.org/gateway-mtu-support"
+	// OvnNodeGatewayMtuSupport determines if option:gateway_mtu shall be set for GR router ports.
+	OvnNodeGatewayMtuSupport = "k8s.ovn.org/gateway-mtu-support"
 
 	// OvnDefaultNetworkGateway captures L3 gateway config for default OVN network interface
 	ovnDefaultNetworkGateway = "default"
@@ -301,16 +301,16 @@ func SetL3GatewayConfig(nodeAnnotator kube.Annotator, cfg *L3GatewayConfig) erro
 // this node.
 func SetGatewayMTUSupport(nodeAnnotator kube.Annotator, set bool) error {
 	if set {
-		nodeAnnotator.Delete(ovnNodeGatewayMtuSupport)
+		nodeAnnotator.Delete(OvnNodeGatewayMtuSupport)
 		return nil
 	}
-	return nodeAnnotator.Set(ovnNodeGatewayMtuSupport, "false")
+	return nodeAnnotator.Set(OvnNodeGatewayMtuSupport, "false")
 }
 
 // ParseNodeGatewayMTUSupport parses annotation "k8s.ovn.org/gateway-mtu-support". The default behavior should be true,
 // therefore only an explicit string of "false" will make this function return false.
 func ParseNodeGatewayMTUSupport(node *kapi.Node) bool {
-	return node.Annotations[ovnNodeGatewayMtuSupport] != "false"
+	return node.Annotations[OvnNodeGatewayMtuSupport] != "false"
 }
 
 // ParseNodeL3GatewayAnnotation returns the parsed l3-gateway-config annotation


### PR DESCRIPTION
Batch fixes from 4.15.

No conflicts except trivial one line in test file `go-controller/pkg/node/controllers/egressip/egressip_test.go`

/cc @kyrtapz @trozet @wizhaoredhat 