### PR TITLE
[release-4.12] OCPBUGS-19975: Update OVN Encap IP when node primary IP address changes

### DIFF
--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -131,6 +131,17 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 			Cmd:    "ovs-vsctl --timeout=15 get interface eth0 ofport",
 			Output: "7",
 		})
+		if setNodeIP {
+			fexec.AddFakeCmdsNoOutputNoError([]string{
+				"ovs-vsctl --timeout=15 get Open_vSwitch . external_ids:ovn-encap-ip",
+			})
+			fexec.AddFakeCmdsNoOutputNoError([]string{
+				"ovs-vsctl --timeout=15 set Open_vSwitch . external_ids:ovn-encap-ip=192.168.1.10",
+			})
+			fexec.AddFakeCmdsNoOutputNoError([]string{
+				"ovn-appctl --timeout=5 -t ovn-controller exit --restart",
+			})
+		}
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 			Cmd:    "ip route replace table 7 172.16.1.0/24 via 10.1.1.1 dev ovn-k8s-mp0",
 			Output: "0",
@@ -491,6 +502,15 @@ func shareGatewayInterfaceDPUTest(app *cli.App, testNS ns.NetNS,
 			Cmd:    "ovs-vsctl --timeout=15 get interface " + hostRep + " ofport",
 			Output: "9",
 		})
+		fexec.AddFakeCmdsNoOutputNoError([]string{
+			"ovs-vsctl --timeout=15 get Open_vSwitch . external_ids:ovn-encap-ip",
+		})
+		fexec.AddFakeCmdsNoOutputNoError([]string{
+			"ovs-vsctl --timeout=15 set Open_vSwitch . external_ids:ovn-encap-ip=192.168.1.101",
+		})
+		fexec.AddFakeCmdsNoOutputNoError([]string{
+			"ovn-appctl --timeout=5 -t ovn-controller exit --restart",
+		})
 		// cleanup flows
 		fexec.AddFakeCmdsNoOutputNoError([]string{
 			"ovs-ofctl -O OpenFlow13 --bundle replace-flows " + brphys + " -",
@@ -822,6 +842,11 @@ func localGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 			Cmd:    "ovs-vsctl --timeout=15 get interface eth0 ofport",
 			Output: "7",
+		})
+		// IP already configured, do not try to set it or restart ovn-controller
+		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+			Cmd:    "ovs-vsctl --timeout=15 get Open_vSwitch . external_ids:ovn-encap-ip",
+			Output: "192.168.1.10",
 		})
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 			Cmd:    "ip route replace table 7 172.16.1.0/24 via 10.1.1.1 dev ovn-k8s-mp0",


### PR DESCRIPTION
When a node joined to the cluster, kubelet temporarily picked up secondary interface IP address as node's primary IP address into node.Status.Addresses (InternalIP) which made ovnkube-node to use it for OVN Encap IP address for geneve tunnel though kubelet changed to use primary interface IP address a bit later.

Hence this commit watches for node update event in address manager and when there is an update in node's primary ip address, then it would update ovn encap ip address via ovs command.

Manual backport of portion of changes from 4ce2fede6ede6c64fb1554424cf844366e35804c, 4622d618699ad5c16db28e3e099acf22a16caf7c and upstream unmerged change [fd9dac373add8fba54fa4d5955d2a411d6b40099](https://github.com/ovn-org/ovn-kubernetes/pull/3754).