### PR TITLE
[WIP] [DNM] Testing- Various fixes to hybrid overlay

### DIFF
--- a/go-controller/hybrid-overlay/pkg/controller/node_linux.go
+++ b/go-controller/hybrid-overlay/pkg/controller/node_linux.go
@@ -16,6 +16,7 @@ import (
 // This controller is running in ovnkube-node binary. It's responsible for local
 // node configuration and annotation.
 type NodeController struct {
+	sync.RWMutex
 	nodeName  string
 	initState hotypes.HybridInitState
 	drMAC     net.HardwareAddr

--- a/go-controller/hybrid-overlay/pkg/controller/ovn_node_linux.go
+++ b/go-controller/hybrid-overlay/pkg/controller/ovn_node_linux.go
@@ -94,6 +94,8 @@ func (n *NodeController) AddPod(pod *kapi.Pod) error {
 	// if the IP/MAC or Annotations have changed
 	ignoreLearn := true
 
+	n.RLock()
+	defer n.RUnlock()
 	if n.drMAC == nil || n.drIP == nil {
 		return fmt.Errorf("empty values for DR MAC: %s or DR IP: %s on node %s", n.drMAC, n.drIP, n.nodeName)
 	}
@@ -209,6 +211,8 @@ func (n *NodeController) hybridOverlayNodeUpdate(node *kapi.Node) error {
 			return fmt.Errorf("failed to lookup link %s: %v", types.K8sMgmtIntfName, err)
 		}
 
+		n.RLock()
+		defer n.RUnlock()
 		route := makeRoute(cidr, n.drIP, mgmtPortLink)
 		err = util.GetNetLinkOps().RouteAdd(route)
 		if err != nil && !os.IsExist(err) {
@@ -227,39 +231,43 @@ func (n *NodeController) AddNode(node *kapi.Node) error {
 	klog.Info("Add Node ", node.Name)
 	var err error
 
-	if n.drIP == nil {
-		hybridOverlayDRIP, ok := node.Annotations[hotypes.HybridOverlayDRIP]
-		if !ok {
-			return fmt.Errorf("hybrid overlay not initialized on %s, it was not assigned an interface address", node.Name)
-		}
-		drIP := net.ParseIP(hybridOverlayDRIP)
-		if drIP == nil {
-			return fmt.Errorf("hybrid overlay not initialized on %s, the the annotation %s = %s is not an IP address", node.Name, hotypes.HybridOverlayDRIP, hybridOverlayDRIP)
-		}
-	}
-
 	if node.Name == n.nodeName {
+		// Add local node and setup DR
 		// Retry hybrid overlay initialization if the master was
 		// slow to add the hybrid overlay logical network elements
 		err = n.EnsureHybridOverlayBridge(node)
-	} else {
-		klog.Infof("Add hybridOverlay Node %s", node.Name)
-		err = n.hybridOverlayNodeUpdate(node)
-	}
-	if atomic.LoadUint32(n.initState) == hotypes.DistributedRouterInitialized {
-		pods, err := n.localPodLister.List(labels.Everything())
 		if err != nil {
-			return fmt.Errorf("cannot fully initialize node %s for hybrid overlay, cannot list pods: %v", n.nodeName, err)
+			return err
 		}
-		for _, pod := range pods {
-			err := n.AddPod(pod)
-			if err != nil {
-				klog.Errorf("Cannot wire pod %s for hybrid overlay, %v", pod.Name, err)
-			}
-		}
-		atomic.StoreUint32(n.initState, hotypes.PodsInitialized)
 	}
-	return err
+
+	if atomic.LoadUint32(n.initState) >= hotypes.DistributedRouterInitialized {
+		if node.Name != n.nodeName {
+			// add remote node
+			klog.Infof("Add hybridOverlay remote Node %s", node.Name)
+			err = n.hybridOverlayNodeUpdate(node)
+			if err != nil {
+				return err
+			}
+		} else if atomic.LoadUint32(n.initState) < hotypes.PodsInitialized {
+			// add pods local to our node
+			pods, err := n.localPodLister.List(labels.Everything())
+			if err != nil {
+				return fmt.Errorf("cannot fully initialize node %s for hybrid overlay, cannot list pods: %v", n.nodeName, err)
+			}
+			for _, pod := range pods {
+				if pod.Spec.NodeName != n.nodeName {
+					continue
+				}
+				err := n.AddPod(pod)
+				if err != nil {
+					return fmt.Errorf("cannot wire pod %s for hybrid overlay, %w", pod.Name, err)
+				}
+			}
+			atomic.StoreUint32(n.initState, hotypes.PodsInitialized)
+		}
+	}
+	return nil
 }
 
 func (n *NodeController) deleteFlowsByCookie(cookie string) {
@@ -288,6 +296,8 @@ func (n *NodeController) DeleteNode(node *kapi.Node) error {
 		if err != nil {
 			return fmt.Errorf("failed to lookup link %s: %v", types.K8sMgmtIntfName, err)
 		}
+		n.RLock()
+		defer n.RUnlock()
 
 		route := makeRoute(cidr, n.drIP, mgmtPortLink)
 		err = util.GetNetLinkOps().RouteDel(route)
@@ -466,6 +476,8 @@ func (n *NodeController) handleHybridOverlayMACIPChange(node *kapi.Node) error {
 
 // EnsureHybridOverlayBridge sets up the hybrid overlay bridge
 func (n *NodeController) EnsureHybridOverlayBridge(node *kapi.Node) error {
+	n.Lock()
+	defer n.Unlock()
 	if atomic.LoadUint32(n.initState) >= hotypes.DistributedRouterInitialized {
 		if node.Annotations[hotypes.HybridOverlayDRIP] != n.drIP.String() ||
 			node.Annotations[hotypes.HybridOverlayDRMAC] != n.drMAC.String() {


### PR DESCRIPTION
Changes-Include:
 - Fixes data race where properties of the hybrid controller are read during node add, but may also be being written to at the same time (like n.drIP). Now there is a mutex on the controller, which is write locked when the local node add happens and the controller properties may be updated. On remote node or pod add, the controller is read locked.
 - During *every* node add, the code would attempt to add *every* pod in the cluster to this node's hybrid overlay. Modified this behavior so that this only happens when the state of our node is not PodsInitialized, as well as filtered out only pods local to our node.
 - During node add, if setting up hybrid overlay failed, we would still try to add pods. Additionally if adding a pod failed, we would not return error and then set the controller state to PodsInitialized. Modified this behavior so that errors are returned immediately and controller state is not updated upon failure.

Closes: #3924

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->