### PR TITLE
OCPBUGS-18807: [release-4.11] Ensure routes are not duplicated

### DIFF
--- a/go-controller/pkg/config/utils.go
+++ b/go-controller/pkg/config/utils.go
@@ -226,3 +226,21 @@ func (cs *configSubnets) checkIPFamilies() (usingIPv4, usingIPv6 bool, err error
 
 	return false, false, fmt.Errorf("illegal network configuration: %s", netConfig)
 }
+
+func ContainsJoinIP(ip net.IP) bool {
+	var joinSubnetsConfig []string
+	if IPv4Mode {
+		joinSubnetsConfig = append(joinSubnetsConfig, Gateway.V4JoinSubnet)
+	}
+	if IPv6Mode {
+		joinSubnetsConfig = append(joinSubnetsConfig, Gateway.V6JoinSubnet)
+	}
+
+	for _, subnet := range joinSubnetsConfig {
+		_, joinSubnet, _ := net.ParseCIDR(subnet)
+		if joinSubnet.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}

--- a/go-controller/pkg/libovsdbops/router.go
+++ b/go-controller/pkg/libovsdbops/router.go
@@ -501,7 +501,6 @@ func CreateOrUpdateLogicalRouterStaticRoutesWithPredicateOps(nbClient libovsdbcl
 	opModels := []operationModel{
 		{
 			Model:          lrsr,
-			ModelPredicate: p,
 			OnModelUpdates: fields,
 			DoAfter:        func() { router.StaticRoutes = []string{lrsr.UUID} },
 			ErrNotFound:    false,
@@ -516,22 +515,96 @@ func CreateOrUpdateLogicalRouterStaticRoutesWithPredicateOps(nbClient libovsdbcl
 		},
 	}
 
+	if p != nil {
+		opModels[0].ModelPredicate = p
+	}
+
 	m := newModelClient(nbClient)
 	return m.CreateOrUpdateOps(ops, opModels...)
 }
 
-// CreateOrUpdateLogicalRouterStaticRoutesWithPredicateOps looks up a logical
+// PolicyEqualPredicate determines if two static routes have the same routing policy (dst-ip or src-ip)
+// If policy is nil, OVN considers that as dst-ip
+func PolicyEqualPredicate(p1, p2 *nbdb.LogicalRouterStaticRoutePolicy) bool {
+	if p1 == nil {
+		return p2 == nil || (p2 != nil && *p2 == nbdb.LogicalRouterStaticRoutePolicyDstIP)
+	}
+
+	if p2 == nil {
+		return *p1 == nbdb.LogicalRouterStaticRoutePolicyDstIP
+	}
+
+	return *p1 == *p2
+}
+
+// CreateOrReplaceLogicalRouterStaticRouteWithPredicate looks up a logical
 // router static route from the cache based on a given predicate. If it does not
 // exist, it creates the provided logical router static route. If it does, it
 // updates it. The logical router static route is added to the provided logical
-// router
-func CreateOrUpdateLogicalRouterStaticRoutesWithPredicate(nbClient libovsdbclient.Client, routerName string,
+// router.
+// If more than one route matches the predicate on the router, the additional routes are removed.
+func CreateOrReplaceLogicalRouterStaticRouteWithPredicate(nbClient libovsdbclient.Client, routerName string,
 	lrsr *nbdb.LogicalRouterStaticRoute, p logicalRouterStaticRoutePredicate, fields ...interface{}) error {
-	ops, err := CreateOrUpdateLogicalRouterStaticRoutesWithPredicateOps(nbClient, nil, routerName, lrsr, p, fields...)
+
+	lr := &nbdb.LogicalRouter{Name: routerName}
+	router, err := GetLogicalRouter(nbClient, lr)
+	if err != nil {
+		return err
+	}
+	newPredicate := func(item *nbdb.LogicalRouterStaticRoute) bool {
+		for _, routeUUID := range router.StaticRoutes {
+			if routeUUID == item.UUID && p(item) {
+				return true
+			}
+		}
+		return false
+	}
+	routes, err := FindLogicalRouterStaticRoutesWithPredicate(nbClient, newPredicate)
 	if err != nil {
 		return err
 	}
 
+	var ops []libovsdb.Operation
+	m := newModelClient(nbClient)
+
+	if len(routes) > 0 {
+		lrsr.UUID = routes[0].UUID
+	}
+
+	if len(routes) > 1 {
+		// should only be a single route remove all except the first
+		routes = routes[1:]
+		opModels := make([]operationModel, 0, len(routes)+1)
+		router.StaticRoutes = []string{}
+		for _, route := range routes {
+			route := route
+			router.StaticRoutes = append(router.StaticRoutes, route.UUID)
+			opModel := operationModel{
+				Model:       route,
+				ErrNotFound: false,
+				BulkOp:      false,
+			}
+			opModels = append(opModels, opModel)
+		}
+		opModel := operationModel{
+			Model:            router,
+			ModelPredicate:   func(item *nbdb.LogicalRouter) bool { return item.Name == router.Name },
+			OnModelMutations: []interface{}{&router.StaticRoutes},
+			ErrNotFound:      true,
+			BulkOp:           false,
+		}
+		opModels = append(opModels, opModel)
+
+		ops, err = m.DeleteOps(nil, opModels...)
+		if err != nil {
+			return err
+		}
+	}
+
+	ops, err = CreateOrUpdateLogicalRouterStaticRoutesWithPredicateOps(nbClient, ops, routerName, lrsr, nil, fields...)
+	if err != nil {
+		return err
+	}
 	_, err = TransactAndCheck(nbClient, ops)
 	return err
 }
@@ -566,7 +639,7 @@ func DeleteLogicalRouterStaticRoutesWithPredicate(nbClient libovsdbclient.Client
 	return m.Delete(opModels...)
 }
 
-// DeleteLogicalRouterPolicies deletes the logical router static routes and
+// DeleteLogicalRouterStaticRoutes deletes the logical router static routes and
 // removes them from the provided logical router
 func DeleteLogicalRouterStaticRoutes(nbClient libovsdbclient.Client, routerName string, lrsrs ...*nbdb.LogicalRouterStaticRoute) error {
 	router := &nbdb.LogicalRouter{

--- a/go-controller/pkg/libovsdbops/router.go
+++ b/go-controller/pkg/libovsdbops/router.go
@@ -601,7 +601,7 @@ func CreateOrReplaceLogicalRouterStaticRouteWithPredicate(nbClient libovsdbclien
 		}
 	}
 
-	ops, err = CreateOrUpdateLogicalRouterStaticRoutesWithPredicateOps(nbClient, ops, routerName, lrsr, nil, fields...)
+	ops, err = CreateOrUpdateLogicalRouterStaticRoutesWithPredicateOps(nbClient, ops, routerName, lrsr, p, fields...)
 	if err != nil {
 		return err
 	}

--- a/go-controller/pkg/libovsdbops/router.go
+++ b/go-controller/pkg/libovsdbops/router.go
@@ -649,6 +649,7 @@ func DeleteLogicalRouterStaticRoutes(nbClient libovsdbclient.Client, routerName 
 
 	opModels := make([]operationModel, 0, len(lrsrs)+1)
 	for _, lrsr := range lrsrs {
+		lrsr := lrsr
 		router.StaticRoutes = append(router.StaticRoutes, lrsr.UUID)
 		opModel := operationModel{
 			Model:       lrsr,

--- a/go-controller/pkg/ovn/gateway_init.go
+++ b/go-controller/pkg/ovn/gateway_init.go
@@ -226,9 +226,10 @@ func (oc *Controller) gatewayInit(nodeName string, clusterIPSubnet []*net.IPNet,
 			Nexthop:  drLRPIfAddr.IP.String(),
 		}
 		p := func(item *nbdb.LogicalRouterStaticRoute) bool {
-			return item.IPPrefix == lrsr.IPPrefix && util.SliceHasStringItem(updatedLogicalRouter.StaticRoutes, item.UUID)
+			return item.IPPrefix == lrsr.IPPrefix && libovsdbops.PolicyEqualPredicate(item.Policy, lrsr.Policy) &&
+				util.SliceHasStringItem(updatedLogicalRouter.StaticRoutes, item.UUID)
 		}
-		err = libovsdbops.CreateOrUpdateLogicalRouterStaticRoutesWithPredicate(oc.nbClient, gatewayRouter, &lrsr, p,
+		err = libovsdbops.CreateOrReplaceLogicalRouterStaticRouteWithPredicate(oc.nbClient, gatewayRouter, &lrsr, p,
 			&lrsr.Nexthop)
 		if err != nil {
 			return fmt.Errorf("failed to add a static route %+v in GR %s with distributed router as the nexthop, err: %v", lrsr, gatewayRouter, err)
@@ -276,10 +277,11 @@ func (oc *Controller) gatewayInit(nodeName string, clusterIPSubnet []*net.IPNet,
 			OutputPort: &externalRouterPort,
 		}
 		p := func(item *nbdb.LogicalRouterStaticRoute) bool {
-			return item.OutputPort != nil && *item.OutputPort == *lrsr.OutputPort && item.IPPrefix == lrsr.IPPrefix
+			return item.OutputPort != nil && *item.OutputPort == *lrsr.OutputPort && item.IPPrefix == lrsr.IPPrefix &&
+				libovsdbops.PolicyEqualPredicate(lrsr.Policy, item.Policy)
 		}
-		err := libovsdbops.CreateOrUpdateLogicalRouterStaticRoutesWithPredicate(oc.nbClient, gatewayRouter, &lrsr, p,
-			&lrsr.Nexthop)
+		err := libovsdbops.CreateOrReplaceLogicalRouterStaticRouteWithPredicate(oc.nbClient, gatewayRouter, &lrsr,
+			p, &lrsr.Nexthop)
 		if err != nil {
 			return fmt.Errorf("error creating static route %+v in GR %s: %v", lrsr, gatewayRouter, err)
 		}
@@ -296,12 +298,13 @@ func (oc *Controller) gatewayInit(nodeName string, clusterIPSubnet []*net.IPNet,
 			Nexthop:  gwLRPIP.String(),
 		}
 		p := func(item *nbdb.LogicalRouterStaticRoute) bool {
-			return item.Nexthop == lrsr.Nexthop && item.IPPrefix == lrsr.IPPrefix
+			return item.IPPrefix == lrsr.IPPrefix &&
+				libovsdbops.PolicyEqualPredicate(lrsr.Policy, item.Policy)
 		}
-		err := libovsdbops.CreateOrUpdateLogicalRouterStaticRoutesWithPredicate(oc.nbClient, types.OVNClusterRouter,
-			&lrsr, p)
+		err := libovsdbops.CreateOrReplaceLogicalRouterStaticRouteWithPredicate(oc.nbClient,
+			types.OVNClusterRouter, &lrsr, p, &lrsr.Nexthop)
 		if err != nil {
-			return fmt.Errorf("error creating static route %+v in GR %s: %v", lrsr, gatewayRouter, err)
+			return fmt.Errorf("error creating static route %+v in %s: %v", lrsr, types.OVNClusterRouter, err)
 		}
 	}
 
@@ -320,25 +323,31 @@ func (oc *Controller) gatewayInit(nodeName string, clusterIPSubnet []*net.IPNet,
 			IPPrefix: hostSubnet.String(),
 			Nexthop:  gwLRPIP[0].String(),
 		}
-		p := func(item *nbdb.LogicalRouterStaticRoute) bool {
-			return item.Nexthop == lrsr.Nexthop && item.IPPrefix == lrsr.IPPrefix && item.Policy != nil && *item.Policy == *lrsr.Policy
-		}
+
 		if config.Gateway.Mode != config.GatewayModeLocal {
+			p := func(item *nbdb.LogicalRouterStaticRoute) bool {
+				return item.IPPrefix == lrsr.IPPrefix && libovsdbops.PolicyEqualPredicate(lrsr.Policy, item.Policy)
+			}
 			// If migrating from local to shared gateway, let's remove the static routes towards
 			// management port interface for the hostSubnet prefix before adding the routes
 			// towards join switch.
 			mgmtIfAddr := util.GetNodeManagementIfAddr(hostSubnet)
 			oc.staticRouteCleanup([]net.IP{mgmtIfAddr.IP})
 
-			err := libovsdbops.CreateOrUpdateLogicalRouterStaticRoutesWithPredicate(oc.nbClient, types.OVNClusterRouter,
-				&lrsr, p)
+			err := libovsdbops.CreateOrReplaceLogicalRouterStaticRouteWithPredicate(oc.nbClient, types.OVNClusterRouter,
+				&lrsr, p, &lrsr.Nexthop)
 			if err != nil {
 				return fmt.Errorf("error creating static route %+v in GR %s: %v", lrsr, types.OVNClusterRouter, err)
 			}
 		} else if config.Gateway.Mode == config.GatewayModeLocal {
 			// If migrating from shared to local gateway, let's remove the static routes towards
-			// join switch for the hostSubnet prefix before adding the routes
-			// towards management port which is done in syncNodeManagementPort.
+			// join switch for the hostSubnet prefix
+			// Note syncManagementPort happens before gateway sync so only remove things pointing to join subnet
+
+			p := func(item *nbdb.LogicalRouterStaticRoute) bool {
+				return item.IPPrefix == lrsr.IPPrefix && item.Policy != nil && *item.Policy == *lrsr.Policy &&
+					config.ContainsJoinIP(net.ParseIP(item.Nexthop))
+			}
 			err := libovsdbops.DeleteLogicalRouterStaticRoutesWithPredicate(oc.nbClient, types.OVNClusterRouter, p)
 			if err != nil {
 				return fmt.Errorf("error deleting static route %+v in GR %s: %v", lrsr, types.OVNClusterRouter, err)

--- a/go-controller/pkg/ovn/gateway_test.go
+++ b/go-controller/pkg/ovn/gateway_test.go
@@ -684,7 +684,7 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 			config.Gateway.DisableSNATMultipleGWs = true
 
 			var err error
-			fakeOvn.controller.defaultCOPPUUID, err = EnsureDefaultCOPP(fakeOvn.nbClient)
+			fakeOvn.controller.defaultGatewayCOPPUUID, err = EnsureDefaultCOPP(fakeOvn.nbClient)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			err = fakeOvn.controller.gatewayInit(
@@ -844,7 +844,7 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 			config.Gateway.DisableSNATMultipleGWs = true
 
 			var err error
-			fakeOvn.controller.defaultCOPPUUID, err = EnsureDefaultCOPP(fakeOvn.nbClient)
+			fakeOvn.controller.defaultGatewayCOPPUUID, err = EnsureDefaultCOPP(fakeOvn.nbClient)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			err = fakeOvn.controller.gatewayInit(

--- a/go-controller/pkg/ovn/gateway_test.go
+++ b/go-controller/pkg/ovn/gateway_test.go
@@ -608,15 +608,113 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 				"1400")
 			gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 		})
+
+		ginkgo.It("ensures only a single static route per node for ovn_cluster_router", func() {
+			joinLRPIPs := ovntest.MustParseIPNets("100.64.0.3/16")
+			hostSubnets := ovntest.MustParseIPNets("10.130.0.0/23")
+			badRouteName := "wrongRoute-UUID"
+			badRoute := &nbdb.LogicalRouterStaticRoute{
+				UUID:     badRouteName,
+				Policy:   &nbdb.LogicalRouterStaticRoutePolicySrcIP,
+				IPPrefix: hostSubnets[0].String(),
+				Nexthop:  "100.64.0.5",
+			}
+			badRouteName2 := "wrongRoute-UUID-2"
+			badRoute2 := &nbdb.LogicalRouterStaticRoute{
+				UUID:     badRouteName2,
+				Policy:   &nbdb.LogicalRouterStaticRoutePolicySrcIP,
+				IPPrefix: hostSubnets[0].String(),
+				Nexthop:  "100.64.0.6",
+			}
+			badRouteName3 := "wrongRoute-UUID-3"
+			badRoute3 := &nbdb.LogicalRouterStaticRoute{
+				UUID:     badRouteName3,
+				Policy:   &nbdb.LogicalRouterStaticRoutePolicySrcIP,
+				IPPrefix: hostSubnets[0].String(),
+				Nexthop:  "100.64.0.7",
+			}
+			// ignoreRoute has no policy, aka dst-ip. It should be ignored for removal
+			ignoreRouteName4 := "ignoreRoute-UUID"
+			ignoreRoute4 := &nbdb.LogicalRouterStaticRoute{
+				UUID:     ignoreRouteName4,
+				IPPrefix: hostSubnets[0].String(),
+				Nexthop:  "100.64.0.99",
+			}
+			expectedOVNClusterRouter := &nbdb.LogicalRouter{
+				UUID:         types.OVNClusterRouter + "-UUID",
+				Name:         types.OVNClusterRouter,
+				StaticRoutes: []string{badRouteName, badRouteName2, badRouteName3, ignoreRouteName4},
+			}
+			expectedNodeSwitch := &nbdb.LogicalSwitch{
+				UUID: nodeName + "-UUID",
+				Name: nodeName,
+			}
+			expectedClusterLBGroup := &nbdb.LoadBalancerGroup{
+				UUID: types.ClusterLBGroupName + "-UUID",
+				Name: types.ClusterLBGroupName,
+			}
+			fakeOvn.startWithDBSetup(libovsdbtest.TestSetup{
+				NBData: []libovsdbtest.TestData{
+					&nbdb.LogicalSwitch{
+						UUID: types.OVNJoinSwitch + "-UUID",
+						Name: types.OVNJoinSwitch,
+					},
+					badRoute,
+					badRoute2,
+					badRoute3,
+					ignoreRoute4,
+					expectedOVNClusterRouter,
+					expectedNodeSwitch,
+					expectedClusterLBGroup,
+				},
+			})
+			clusterIPSubnets := ovntest.MustParseIPNets("10.128.0.0/14")
+			defLRPIPs := ovntest.MustParseIPNets("100.64.0.1/16")
+			nodeName := "test-node"
+			l3GatewayConfig := &util.L3GatewayConfig{
+				Mode:           config.GatewayModeLocal,
+				ChassisID:      "SYSTEM-ID",
+				InterfaceID:    "INTERFACE-ID",
+				MACAddress:     ovntest.MustParseMAC("11:22:33:44:55:66"),
+				IPAddresses:    ovntest.MustParseIPNets("169.254.33.2/24"),
+				NextHops:       ovntest.MustParseIPs("169.254.33.1"),
+				NodePortEnable: true,
+			}
+			sctpSupport := false
+			config.Gateway.DisableSNATMultipleGWs = true
+
+			var err error
+			fakeOvn.controller.defaultCOPPUUID, err = EnsureDefaultCOPP(fakeOvn.nbClient)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			err = fakeOvn.controller.gatewayInit(
+				nodeName, clusterIPSubnets, hostSubnets, l3GatewayConfig, sctpSupport, joinLRPIPs, defLRPIPs, true)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			testData := []libovsdb.TestData{}
+			skipSnat := true
+
+			// remove bad route from expected data
+			expectedOVNClusterRouter.StaticRoutes = []string{ignoreRouteName4}
+			mgmtPortIP := ""
+			ginkgo.By("Gateway init should have removed bad route")
+			expectedDatabaseState := generateGatewayInitExpectedNB(testData, expectedOVNClusterRouter, expectedNodeSwitch,
+				nodeName, clusterIPSubnets, hostSubnets, l3GatewayConfig, joinLRPIPs, defLRPIPs, skipSnat, mgmtPortIP,
+				"1400")
+			expectedDatabaseState = append(expectedDatabaseState, ignoreRoute4)
+			gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+		})
 	})
 
 	ginkgo.Context("Gateway Create Operations Local Gateway Mode", func() {
 
 		ginkgo.BeforeEach(func() {
 			config.Gateway.Mode = config.GatewayModeLocal
+			config.IPv6Mode = false
 		})
 
 		ginkgo.It("creates a dual-stack gateway in OVN", func() {
+			config.IPv6Mode = true
 			// covers both IPv4, IPv6 single stack cases since path is the same.
 			routeUUID1 := "route1-UUID"
 			leftoverJoinRoute1 := &nbdb.LogicalRouterStaticRoute{
@@ -689,6 +787,77 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 			expectedOVNClusterRouter.StaticRoutes = []string{} // the leftover SGW route should have got deleted
 			// We don't set up the Allow from mgmt port ACL here
 			mgmtPortIP := ""
+			expectedDatabaseState := generateGatewayInitExpectedNB(testData, expectedOVNClusterRouter, expectedNodeSwitch,
+				nodeName, clusterIPSubnets, hostSubnets, l3GatewayConfig, joinLRPIPs, defLRPIPs, skipSnat, mgmtPortIP,
+				"1400")
+			gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+		})
+
+		ginkgo.It("ensures a leftover route on ovn_cluster_router to join subnet is removed", func() {
+			joinLRPIPs := ovntest.MustParseIPNets("100.64.0.3/16")
+			hostSubnets := ovntest.MustParseIPNets("10.130.0.0/23")
+			badRouteName := "wrongRoute-UUID"
+			badRoute := &nbdb.LogicalRouterStaticRoute{
+				UUID:     badRouteName,
+				Policy:   &nbdb.LogicalRouterStaticRoutePolicySrcIP,
+				IPPrefix: hostSubnets[0].String(),
+				Nexthop:  "100.64.0.5",
+			}
+			expectedOVNClusterRouter := &nbdb.LogicalRouter{
+				UUID:         types.OVNClusterRouter + "-UUID",
+				Name:         types.OVNClusterRouter,
+				StaticRoutes: []string{badRouteName},
+			}
+			expectedNodeSwitch := &nbdb.LogicalSwitch{
+				UUID: nodeName + "-UUID",
+				Name: nodeName,
+			}
+			expectedClusterLBGroup := &nbdb.LoadBalancerGroup{
+				UUID: types.ClusterLBGroupName + "-UUID",
+				Name: types.ClusterLBGroupName,
+			}
+			fakeOvn.startWithDBSetup(libovsdbtest.TestSetup{
+				NBData: []libovsdbtest.TestData{
+					&nbdb.LogicalSwitch{
+						UUID: types.OVNJoinSwitch + "-UUID",
+						Name: types.OVNJoinSwitch,
+					},
+					badRoute,
+					expectedOVNClusterRouter,
+					expectedNodeSwitch,
+					expectedClusterLBGroup,
+				},
+			})
+			clusterIPSubnets := ovntest.MustParseIPNets("10.128.0.0/14")
+			defLRPIPs := ovntest.MustParseIPNets("100.64.0.1/16")
+			nodeName := "test-node"
+			l3GatewayConfig := &util.L3GatewayConfig{
+				Mode:           config.GatewayModeLocal,
+				ChassisID:      "SYSTEM-ID",
+				InterfaceID:    "INTERFACE-ID",
+				MACAddress:     ovntest.MustParseMAC("11:22:33:44:55:66"),
+				IPAddresses:    ovntest.MustParseIPNets("169.254.33.2/24"),
+				NextHops:       ovntest.MustParseIPs("169.254.33.1"),
+				NodePortEnable: true,
+			}
+			sctpSupport := false
+			config.Gateway.DisableSNATMultipleGWs = true
+
+			var err error
+			fakeOvn.controller.defaultCOPPUUID, err = EnsureDefaultCOPP(fakeOvn.nbClient)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			err = fakeOvn.controller.gatewayInit(
+				nodeName, clusterIPSubnets, hostSubnets, l3GatewayConfig, sctpSupport, joinLRPIPs, defLRPIPs, true)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			testData := []libovsdb.TestData{}
+			skipSnat := true
+
+			// remove bad route from expected data
+			expectedOVNClusterRouter.StaticRoutes = []string{}
+			mgmtPortIP := ""
+			ginkgo.By("Gateway init should have removed bad route")
 			expectedDatabaseState := generateGatewayInitExpectedNB(testData, expectedOVNClusterRouter, expectedNodeSwitch,
 				nodeName, clusterIPSubnets, hostSubnets, l3GatewayConfig, joinLRPIPs, defLRPIPs, skipSnat, mgmtPortIP,
 				"1400")

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -509,7 +509,6 @@ func (oc *Controller) syncNodeManagementPort(node *kapi.Node, hostSubnets []*net
 		if !utilnet.IsIPv6CIDR(hostSubnet) {
 			v4Subnet = hostSubnet
 		}
-
 		if config.Gateway.Mode == config.GatewayModeLocal {
 			lrsr := nbdb.LogicalRouterStaticRoute{
 				Policy:   &nbdb.LogicalRouterStaticRoutePolicySrcIP,
@@ -517,10 +516,10 @@ func (oc *Controller) syncNodeManagementPort(node *kapi.Node, hostSubnets []*net
 				Nexthop:  mgmtIfAddr.IP.String(),
 			}
 			p := func(item *nbdb.LogicalRouterStaticRoute) bool {
-				return item.IPPrefix == lrsr.IPPrefix && item.Nexthop == lrsr.Nexthop && item.Policy != nil && *item.Policy == *lrsr.Policy
+				return item.IPPrefix == lrsr.IPPrefix && libovsdbops.PolicyEqualPredicate(lrsr.Policy, item.Policy)
 			}
-			err := libovsdbops.CreateOrUpdateLogicalRouterStaticRoutesWithPredicate(oc.nbClient, types.OVNClusterRouter,
-				&lrsr, p)
+			err := libovsdbops.CreateOrReplaceLogicalRouterStaticRouteWithPredicate(oc.nbClient, types.OVNClusterRouter,
+				&lrsr, p, &lrsr.Nexthop)
 			if err != nil {
 				return fmt.Errorf("error creating static route %+v on router %s: %v", lrsr, types.OVNClusterRouter, err)
 			}

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -1130,6 +1130,53 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 
+	ginkgo.It("clears stale ovn_cluster_router routes in local gw", func() {
+		app.Action = func(ctx *cli.Context) error {
+			_, err := config.InitConfig(ctx, nil, nil)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			clusterSubnets := startFakeController(oc, wg)
+
+			subnet := ovntest.MustParseIPNet(node1.NodeSubnet)
+			// add stale route
+			badRoute := &nbdb.LogicalRouterStaticRoute{
+				Policy:   &nbdb.LogicalRouterStaticRoutePolicySrcIP,
+				IPPrefix: subnet.String(),
+				Nexthop:  "10.244.0.6",
+			}
+			ginkgo.By("Creating stale route")
+			p := func(item *nbdb.LogicalRouterStaticRoute) bool { return false }
+			err = libovsdbops.CreateOrReplaceLogicalRouterStaticRouteWithPredicate(nbClient,
+				types.OVNClusterRouter, badRoute, p)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			ginkgo.By("Syncing node with OVNK")
+			node, err := oc.kube.GetNode(testNode.Name)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			err = oc.syncNodeManagementPort(node, []*net.IPNet{subnet})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			err = oc.syncGatewayLogicalNetwork(node, l3GatewayConfig, []*net.IPNet{subnet}, nodeHostAddrs)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			ginkgo.By("Stale route should have been removed")
+
+			skipSnat := false
+			expectedDatabaseState = generateGatewayInitExpectedNB(expectedDatabaseState, expectedOVNClusterRouter,
+				expectedNodeSwitch, node1.Name, clusterSubnets, []*net.IPNet{subnet}, l3GatewayConfig,
+				[]*net.IPNet{classBIPAddress(node1.LrpIP)}, []*net.IPNet{classBIPAddress(node1.DrLrpIP)},
+				skipSnat, node1.NodeMgmtPortIP, "1400")
+			gomega.Eventually(oc.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+
+			return nil
+		}
+
+		err := app.Run([]string{
+			app.Name,
+			"-cluster-subnets=" + clusterCIDR,
+			"--init-gateways",
+			"--gateway-local",
+			"--nodeport",
+		})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+
 	ginkgo.It("sets up a shared gateway", func() {
 
 		app.Action = func(ctx *cli.Context) error {


### PR DESCRIPTION
Backport of 4.12 PR https://github.com/openshift/ovn-kubernetes/pull/1503.

Resolved Conflicts: 
`go-controller/pkg/ovn/hybrid.go` -> `go-controller/hybrid-overlay/pkg/controller/master.go`

Also fixing the unit test with commit [6466661](https://github.com/openshift/ovn-kubernetes/pull/1937/commits/646666128e7602f909a062ed6f76646c71d5c8e2).