### PR TITLE
[release-4.14] OCPBUGS-23387: Ignore completed virt-launcher pods

### DIFF
--- a/go-controller/pkg/kubevirt/pod.go
+++ b/go-controller/pkg/kubevirt/pod.go
@@ -122,11 +122,14 @@ func EnsurePodAnnotationForVM(watchFactory *factory.WatchFactory, kube *kube.Kub
 	return podAnnotation, nil
 }
 
-// IsMigratedSourcePodStale return true if there are other pods related to
-// to it and any of them has newer creation timestamp.
+// IsMigratedSourcePodStale return false if the pod is live migratable,
+// not completed and is the running VM pod with newest creation timestamp
 func IsMigratedSourcePodStale(client *factory.WatchFactory, pod *corev1.Pod) (bool, error) {
 	if !IsPodLiveMigratable(pod) {
 		return false, nil
+	}
+	if util.PodCompleted(pod) {
+		return true, nil
 	}
 	vmPods, err := findVMRelatedPods(client, pod)
 	if err != nil {

--- a/go-controller/pkg/kubevirt/router.go
+++ b/go-controller/pkg/kubevirt/router.go
@@ -75,7 +75,7 @@ func EnsureLocalZonePodAddressesToNodeRoute(watchFactory *factory.WatchFactory, 
 	}
 	podAnnotation, err := util.UnmarshalPodAnnotation(pod.Annotations, nadName)
 	if err != nil {
-		return fmt.Errorf("failed reading ovn annotation: %v", err)
+		return fmt.Errorf("failed reading ovn annotation at local zone: %v", err)
 	}
 
 	nodeOwningSubnet, _ := ZoneContainsPodSubnet(lsManager, podAnnotation)
@@ -180,7 +180,7 @@ func EnsureRemoteZonePodAddressesToNodeRoute(controllerName string, watchFactory
 
 	podAnnotation, err := util.UnmarshalPodAnnotation(pod.Annotations, nadName)
 	if err != nil {
-		return fmt.Errorf("failed reading ovn annotation: %v", err)
+		return fmt.Errorf("failed reading ovn annotation at remote zone: %v", err)
 	}
 
 	vmRunningAtNodeOwningSubnet, err := nodeContainsPodSubnet(watchFactory, pod.Spec.NodeName, podAnnotation, nadName)

--- a/go-controller/pkg/ovn/base_network_controller.go
+++ b/go-controller/pkg/ovn/base_network_controller.go
@@ -407,7 +407,6 @@ func (bnc *BaseNetworkController) createNodeLogicalSwitch(nodeName string, hostS
 			return err
 		}
 	}
-
 	// Add the switch to the logical switch cache
 	return bnc.lsManager.AddOrUpdateSwitch(logicalSwitch.Name, hostSubnets)
 }

--- a/go-controller/pkg/ovn/kubevirt_test.go
+++ b/go-controller/pkg/ovn/kubevirt_test.go
@@ -73,6 +73,7 @@ var _ = Describe("OVN Kubevirt Operations", func() {
 		suffix                                                   string
 		skipPodAnnotations                                       bool
 		extraLabels, extraAnnotations                            map[string]string
+		updatePhase                                              *corev1.PodPhase
 	}
 	type testMigrationTarget struct {
 		testVirtLauncherPod
@@ -150,6 +151,17 @@ var _ = Describe("OVN Kubevirt Operations", func() {
 			return strings.Split(network, "/")[0]
 		}
 
+		phasePointer = func(phase corev1.PodPhase) *corev1.PodPhase {
+			return &phase
+		}
+
+		virtLauncherCompleted = func(t testVirtLauncherPod) bool {
+			if t.updatePhase == nil {
+				return false
+			}
+			return *t.updatePhase == corev1.PodSucceeded || *t.updatePhase == corev1.PodFailed
+		}
+
 		externalIDs = func(namespace, vmName, ovnZone string) map[string]string {
 			if vmName == "" {
 				return nil
@@ -188,11 +200,15 @@ var _ = Describe("OVN Kubevirt Operations", func() {
 			testPods := []testPod{}
 			nodeSet := map[string]bool{t.nodeName: true}
 			if t.podName != "" && isLocalNode(t, t.nodeName) {
-				testPods = append(testPods, t.testPod)
+				if !virtLauncherCompleted(t.testVirtLauncherPod) {
+					testPods = append(testPods, t.testPod)
+				}
 			}
 			if t.migrationTarget.nodeName != "" && isLocalNode(t, t.migrationTarget.nodeName) {
-				testVirtLauncherPods = append(testVirtLauncherPods, t.migrationTarget.testVirtLauncherPod)
-				testPods = append(testPods, t.migrationTarget.testVirtLauncherPod.testPod)
+				if !virtLauncherCompleted(t.migrationTarget.testVirtLauncherPod) {
+					testVirtLauncherPods = append(testVirtLauncherPods, t.migrationTarget.testVirtLauncherPod)
+					testPods = append(testPods, t.migrationTarget.testVirtLauncherPod.testPod)
+				}
 				nodeSet[t.migrationTarget.nodeName] = true
 			}
 
@@ -586,9 +602,10 @@ var _ = Describe("OVN Kubevirt Operations", func() {
 			}
 
 			pods := []v1.Pod{}
-			sourcePod := newPodFromTestVirtLauncherPod(t.testVirtLauncherPod)
+			sourceVirtLauncherPod := t.testVirtLauncherPod
+			sourcePod := newPodFromTestVirtLauncherPod(sourceVirtLauncherPod)
 			if sourcePod != nil {
-				addOVNPodAnnotations(sourcePod, t.testVirtLauncherPod)
+				addOVNPodAnnotations(sourcePod, sourceVirtLauncherPod)
 				if t.migrationTarget.nodeName != "" {
 					pods = append(pods, *sourcePod)
 				}
@@ -648,10 +665,12 @@ var _ = Describe("OVN Kubevirt Operations", func() {
 				Expect(fakeOvn.controller.WatchNamespaces()).ToNot(HaveOccurred())
 				Expect(fakeOvn.controller.WatchPods()).ToNot(HaveOccurred())
 
+				virtLauncherPodToCreate := sourceVirtLauncherPod
 				podToCreate := sourcePod
 				if podToCreate != nil {
 					if t.migrationTarget.nodeName != "" {
-						podToCreate = newPodFromTestVirtLauncherPod(t.migrationTarget.testVirtLauncherPod)
+						virtLauncherPodToCreate = t.migrationTarget.testVirtLauncherPod
+						podToCreate = newPodFromTestVirtLauncherPod(virtLauncherPodToCreate)
 						podToCreate.Labels = t.migrationTarget.labels
 						podToCreate.Annotations = t.migrationTarget.annotations
 					}
@@ -668,6 +687,21 @@ var _ = Describe("OVN Kubevirt Operations", func() {
 						WithTimeout(time.Minute).
 						WithPolling(time.Second).
 						Should(Succeed(), "should fill in the cache with the pod")
+
+					// Change the phase by updating to emulate the logic of transition
+					if virtLauncherPodToCreate.updatePhase != nil {
+						podToCreate.Status.Phase = *virtLauncherPodToCreate.updatePhase
+						_, err = fakeOvn.fakeClient.KubeClient.CoreV1().Pods(t.namespace).UpdateStatus(context.TODO(), podToCreate, metav1.UpdateOptions{})
+						Expect(err).NotTo(HaveOccurred())
+						Eventually(func() (corev1.PodPhase, error) {
+							updatedPod, err := fakeOvn.controller.watchFactory.GetPod(podToCreate.Namespace, podToCreate.Name)
+							return updatedPod.Status.Phase, err
+						}).
+							WithTimeout(time.Minute).
+							WithPolling(time.Second).
+							Should(Equal(podToCreate.Status.Phase), "should be in the updated phase")
+
+					}
 				}
 
 				expectedOVN := []libovsdbtest.TestData{}
@@ -1179,6 +1213,120 @@ var _ = Describe("OVN Kubevirt Operations", func() {
 					dns:      dnsServiceIPv6,
 					hostname: vm1,
 				}},
+			}),
+			Entry("for failing live migration", testData{
+				ipv4:          true,
+				ipv6:          true,
+				lrpNetworks:   []string{nodeByName[node2].lrpNetworkIPv4, nodeByName[node2].lrpNetworkIPv6},
+				dnsServiceIPs: []string{dnsServiceIPv4, dnsServiceIPv6},
+				testVirtLauncherPod: testVirtLauncherPod{
+					suffix: "1",
+					testPod: testPod{
+						nodeName: node2,
+					},
+					vmName:             vm1,
+					skipPodAnnotations: false, /* add ovn pod annotation */
+				},
+				migrationTarget: testMigrationTarget{
+					lrpNetworks: []string{nodeByName[node1].lrpNetworkIPv4, nodeByName[node1].lrpNetworkIPv6},
+					testVirtLauncherPod: testVirtLauncherPod{
+						suffix:             "2",
+						testPod:            testPod{nodeName: node1},
+						vmName:             vm1,
+						skipPodAnnotations: true,
+						extraLabels:        map[string]string{kubevirtv1.NodeNameLabel: node2},
+						updatePhase:        phasePointer(corev1.PodSucceeded),
+					},
+				},
+				expectedDhcpv4: []testDHCPOptions{{
+					cidr:     nodeByName[node1].subnetIPv4,
+					dns:      dnsServiceIPv4,
+					hostname: vm1,
+				}},
+				expectedDhcpv6: []testDHCPOptions{{
+					cidr:     nodeByName[node1].subnetIPv6,
+					dns:      dnsServiceIPv6,
+					hostname: vm1,
+				}},
+				expectedPolicies: []testPolicy{
+					{
+						match:   "ip4.src == " + vmByName[vm1].addressIPv4,
+						nexthop: lrpIP(nodeByName[node2].lrpNetworkIPv4),
+					},
+					{
+						match:   "ip6.src == " + vmByName[vm1].addressIPv6,
+						nexthop: lrpIP(nodeByName[node2].lrpNetworkIPv6),
+					},
+				},
+				expectedStaticRoutes: []testStaticRoute{
+					{
+						prefix:     vmByName[vm1].addressIPv4,
+						nexthop:    vmByName[vm1].addressIPv4,
+						outputPort: ovntypes.RouterToSwitchPrefix + node2,
+					},
+					{
+						prefix:     vmByName[vm1].addressIPv6,
+						nexthop:    vmByName[vm1].addressIPv6,
+						outputPort: ovntypes.RouterToSwitchPrefix + node2,
+					},
+				},
+			}),
+			Entry("for failing target virt-launcher after live migration", testData{
+				ipv4:          true,
+				ipv6:          true,
+				lrpNetworks:   []string{nodeByName[node2].lrpNetworkIPv4, nodeByName[node2].lrpNetworkIPv6},
+				dnsServiceIPs: []string{dnsServiceIPv4, dnsServiceIPv6},
+				testVirtLauncherPod: testVirtLauncherPod{
+					suffix: "1",
+					testPod: testPod{
+						nodeName: node2,
+					},
+					vmName:             vm1,
+					skipPodAnnotations: false, /* add ovn pod annotation */
+				},
+				migrationTarget: testMigrationTarget{
+					lrpNetworks: []string{nodeByName[node1].lrpNetworkIPv4, nodeByName[node1].lrpNetworkIPv6},
+					testVirtLauncherPod: testVirtLauncherPod{
+						suffix:             "2",
+						testPod:            testPod{nodeName: node1},
+						vmName:             vm1,
+						skipPodAnnotations: true,
+						extraLabels:        map[string]string{kubevirtv1.NodeNameLabel: node2},
+						updatePhase:        phasePointer(corev1.PodFailed),
+					},
+				},
+				expectedDhcpv4: []testDHCPOptions{{
+					cidr:     nodeByName[node1].subnetIPv4,
+					dns:      dnsServiceIPv4,
+					hostname: vm1,
+				}},
+				expectedDhcpv6: []testDHCPOptions{{
+					cidr:     nodeByName[node1].subnetIPv6,
+					dns:      dnsServiceIPv6,
+					hostname: vm1,
+				}},
+				expectedPolicies: []testPolicy{
+					{
+						match:   "ip4.src == " + vmByName[vm1].addressIPv4,
+						nexthop: lrpIP(nodeByName[node2].lrpNetworkIPv4),
+					},
+					{
+						match:   "ip6.src == " + vmByName[vm1].addressIPv6,
+						nexthop: lrpIP(nodeByName[node2].lrpNetworkIPv6),
+					},
+				},
+				expectedStaticRoutes: []testStaticRoute{
+					{
+						prefix:     vmByName[vm1].addressIPv4,
+						nexthop:    vmByName[vm1].addressIPv4,
+						outputPort: ovntypes.RouterToSwitchPrefix + node2,
+					},
+					{
+						prefix:     vmByName[vm1].addressIPv6,
+						nexthop:    vmByName[vm1].addressIPv6,
+						outputPort: ovntypes.RouterToSwitchPrefix + node2,
+					},
+				},
 			}),
 			Entry("should remove orphan routes and policies and keep not kubevirt related on startup", testData{
 				ipv4: true,


### PR DESCRIPTION
**- What this PR does and why is it needed**
When a live migration fails at completed virt-launcher pod with newer
creation timestamp is lingering in the system so the virt-launcher that
is really running the VM is hidden by it and routes are wrongly
reconstructed. This change take into account if the pod is completed to
ignore it marking it as stale.

closes [OCPBUGS-23387](https://issues.redhat.com/browse/OCPBUGS-23387)

**- How to verify it**
It includes a unit test that emulate the result of failing migration, completed virt-launcher pod with newer creation timestamp.

**- Description for the changelog**
kubevirt: Ignore completed virt-launcher pods