### PR TITLE
[release-4.14] OCPBUGS-23257: Update leaderelection config to allow retries

### DIFF
--- a/go-controller/cmd/ovnkube/ovnkube.go
+++ b/go-controller/cmd/ovnkube/ovnkube.go
@@ -422,7 +422,12 @@ func startOvnKube(ctx *cli.Context, cancel context.CancelFunc) error {
 	return nil
 }
 
-func runOvnKube(ctx context.Context, runMode *ovnkubeRunMode, ovnClientset *util.OVNClientset, eventRecorder record.EventRecorder) error {
+func runOvnKube(ctx context.Context, runMode *ovnkubeRunMode, ovnClientset *util.OVNClientset, eventRecorder record.EventRecorder) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("recovering from a panic in runOvnKube: %v", r)
+		}
+	}()
 	startTime := time.Now()
 
 	if runMode.cleanupNode {
@@ -437,7 +442,6 @@ func runOvnKube(ctx context.Context, runMode *ovnkubeRunMode, ovnClientset *util
 	}()
 
 	var masterWatchFactory *factory.WatchFactory
-	var err error
 
 	if runMode.ovnkubeController {
 		// create factory and start the controllers asked for

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -152,18 +152,21 @@ var (
 		},
 	}
 
+	// Set Leaderelection config values based on
+	// https://github.com/openshift/enhancements/blame/84e894ead7b188a1013556e0ba6973b8463995f1/CONVENTIONS.md#L183
+
 	// MasterHA holds master HA related config options.
 	MasterHA = HAConfig{
-		ElectionLeaseDuration: 60,
-		ElectionRenewDeadline: 30,
-		ElectionRetryPeriod:   20,
+		ElectionRetryPeriod:   26,
+		ElectionRenewDeadline: 107,
+		ElectionLeaseDuration: 137,
 	}
 
 	// ClusterMgrHA holds cluster manager HA related config options.
 	ClusterMgrHA = HAConfig{
-		ElectionLeaseDuration: 60,
-		ElectionRenewDeadline: 30,
-		ElectionRetryPeriod:   20,
+		ElectionRetryPeriod:   26,
+		ElectionRenewDeadline: 107,
+		ElectionLeaseDuration: 137,
 	}
 
 	// HybridOverlay holds hybrid overlay feature config options.


### PR DESCRIPTION
Backport of https://github.com/ovn-org/ovn-kubernetes/pull/3959
downstream merge: https://github.com/openshift/ovn-kubernetes/pull/1952