### PR TITLE
[release-4.14] OCPBUGS-23395: Egressfirewall use port groups

### DIFF
--- a/go-controller/pkg/libovsdb/ops/portgroup.go
+++ b/go-controller/pkg/libovsdb/ops/portgroup.go
@@ -141,7 +141,7 @@ func DeletePortsFromPortGroupOps(nbClient libovsdbclient.Client, ops []libovsdb.
 	opModel := operationModel{
 		Model:            &pg,
 		OnModelMutations: []interface{}{&pg.Ports},
-		ErrNotFound:      true,
+		ErrNotFound:      false,
 		BulkOp:           false,
 	}
 
@@ -229,7 +229,7 @@ func DeleteACLsFromPortGroupOps(nbClient libovsdbclient.Client, ops []libovsdb.O
 	opModel := operationModel{
 		Model:            &pg,
 		OnModelMutations: []interface{}{&pg.ACLs},
-		ErrNotFound:      true,
+		ErrNotFound:      false,
 		BulkOp:           false,
 	}
 

--- a/go-controller/pkg/libovsdb/ops/portgroup.go
+++ b/go-controller/pkg/libovsdb/ops/portgroup.go
@@ -75,6 +75,20 @@ func CreateOrUpdatePortGroups(nbClient libovsdbclient.Client, pgs ...*nbdb.PortG
 	return err
 }
 
+// CreatePortGroup creates the provided port group if it doesn't exist
+func CreatePortGroup(nbClient libovsdbclient.Client, portGroup *nbdb.PortGroup) error {
+	opModel := operationModel{
+		Model:          portGroup,
+		OnModelUpdates: onModelUpdatesNone(),
+		ErrNotFound:    false,
+		BulkOp:         false,
+	}
+
+	m := newModelClient(nbClient)
+	_, err := m.CreateOrUpdate(opModel)
+	return err
+}
+
 // GetPortGroup looks up a port group from the cache
 func GetPortGroup(nbClient libovsdbclient.Client, pg *nbdb.PortGroup) (*nbdb.PortGroup, error) {
 	found := []*nbdb.PortGroup{}

--- a/go-controller/pkg/ovn/base_network_controller.go
+++ b/go-controller/pkg/ovn/base_network_controller.go
@@ -633,8 +633,8 @@ func (bnc *BaseNetworkController) getNamespaceLocked(ns string, readOnly bool) (
 }
 
 // deleteNamespaceLocked locks namespacesMutex, finds and deletes ns, and returns the
-// namespace, locked.
-func (bnc *BaseNetworkController) deleteNamespaceLocked(ns string) *namespaceInfo {
+// namespace, locked. If error != nil, namespaceInfo is nil.
+func (bnc *BaseNetworkController) deleteNamespaceLocked(ns string) (*namespaceInfo, error) {
 	// The locking here is the same as in getNamespaceLocked
 
 	bnc.namespacesMutex.Lock()
@@ -642,7 +642,7 @@ func (bnc *BaseNetworkController) deleteNamespaceLocked(ns string) *namespaceInf
 	bnc.namespacesMutex.Unlock()
 
 	if nsInfo == nil {
-		return nil
+		return nil, nil
 	}
 	nsInfo.Lock()
 
@@ -650,7 +650,7 @@ func (bnc *BaseNetworkController) deleteNamespaceLocked(ns string) *namespaceInf
 	defer bnc.namespacesMutex.Unlock()
 	if nsInfo != bnc.namespaces[ns] {
 		nsInfo.Unlock()
-		return nil
+		return nil, nil
 	}
 	if nsInfo.addressSet != nil {
 		// Empty the address set, then delete it after an interval.
@@ -684,9 +684,16 @@ func (bnc *BaseNetworkController) deleteNamespaceLocked(ns string) *namespaceInf
 			}
 		}()
 	}
+	if nsInfo.portGroupName != "" {
+		err := libovsdbops.DeletePortGroups(bnc.nbClient, nsInfo.portGroupName)
+		if err != nil {
+			nsInfo.Unlock()
+			return nil, err
+		}
+	}
 	delete(bnc.namespaces, ns)
 
-	return nsInfo
+	return nsInfo, nil
 }
 
 // WatchNodes starts the watching of the nodes resource and calls back the appropriate handler logic

--- a/go-controller/pkg/ovn/base_network_controller_pods.go
+++ b/go-controller/pkg/ovn/base_network_controller_pods.go
@@ -1019,25 +1019,3 @@ func (bnc *BaseNetworkController) shouldReleaseDeletedPod(expectedSwitchName, sw
 	}
 	return shouldRelease, nil
 }
-
-func (bnc *BaseNetworkController) getNamespaceLSPs(ns string) ([]*nbdb.LogicalSwitchPort, error) {
-	ports := []*nbdb.LogicalSwitchPort{}
-	pods, err := bnc.watchFactory.GetPods(ns)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get pods for namespace %q: %v", ns, err)
-	}
-	for _, pod := range pods {
-		if util.PodCompleted(pod) {
-			continue
-		}
-		portInfoMap, err := bnc.logicalPortCache.getAll(pod)
-		if err != nil {
-			klog.Errorf(err.Error())
-		} else {
-			for _, portInfo := range portInfoMap {
-				ports = append(ports, &nbdb.LogicalSwitchPort{UUID: portInfo.uuid})
-			}
-		}
-	}
-	return ports, nil
-}

--- a/go-controller/pkg/ovn/base_network_controller_pods.go
+++ b/go-controller/pkg/ovn/base_network_controller_pods.go
@@ -679,9 +679,8 @@ func (bnc *BaseNetworkController) deletePodFromNamespace(ns string, podIfAddrs [
 		}
 	}
 
-	// Remove the port from the multicast allow policy.
-	if bnc.multicastSupport && nsInfo.multicastEnabled && len(portUUID) > 0 {
-		if err = bnc.podDeleteAllowMulticastPolicy(ns, portUUID); err != nil {
+	if nsInfo.portGroupName != "" && len(portUUID) > 0 {
+		if ops, err = libovsdbops.DeletePortsFromPortGroupOps(bnc.nbClient, ops, nsInfo.portGroupName, portUUID); err != nil {
 			return nil, err
 		}
 	}
@@ -1019,4 +1018,26 @@ func (bnc *BaseNetworkController) shouldReleaseDeletedPod(expectedSwitchName, sw
 		return false, fmt.Errorf("cannot determine if IPs are safe to release for completed pod: %s: %w", podDesc, err)
 	}
 	return shouldRelease, nil
+}
+
+func (bnc *BaseNetworkController) getNamespaceLSPs(ns string) ([]*nbdb.LogicalSwitchPort, error) {
+	ports := []*nbdb.LogicalSwitchPort{}
+	pods, err := bnc.watchFactory.GetPods(ns)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get pods for namespace %q: %v", ns, err)
+	}
+	for _, pod := range pods {
+		if util.PodCompleted(pod) {
+			continue
+		}
+		portInfoMap, err := bnc.logicalPortCache.getAll(pod)
+		if err != nil {
+			klog.Errorf(err.Error())
+		} else {
+			for _, portInfo := range portInfoMap {
+				ports = append(ports, &nbdb.LogicalSwitchPort{UUID: portInfo.uuid})
+			}
+		}
+	}
+	return ports, nil
 }

--- a/go-controller/pkg/ovn/base_network_controller_secondary.go
+++ b/go-controller/pkg/ovn/base_network_controller_secondary.go
@@ -539,7 +539,10 @@ func (bsnc *BaseSecondaryNetworkController) updateNamespaceForSecondaryNetwork(o
 func (bsnc *BaseSecondaryNetworkController) deleteNamespace4SecondaryNetwork(ns *kapi.Namespace) error {
 	klog.Infof("[%s] deleting namespace for network %s", ns.Name, bsnc.GetNetworkName())
 
-	nsInfo := bsnc.deleteNamespaceLocked(ns.Name)
+	nsInfo, err := bsnc.deleteNamespaceLocked(ns.Name)
+	if err != nil {
+		return err
+	}
 	if nsInfo == nil {
 		return nil
 	}

--- a/go-controller/pkg/ovn/namespace_test.go
+++ b/go-controller/pkg/ovn/namespace_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
+	libovsdbutil "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdb/util"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
 	addressset "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/address_set"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/controller/apbroute"
@@ -135,6 +136,8 @@ var _ = ginkgo.Describe("OVN Namespace Operations", func() {
 		})
 
 		ginkgo.It("reconciles an existing namespace with pods", func() {
+			// this flag will create namespaced port group
+			config.OVNKubernetesFeature.EnableEgressFirewall = true
 			namespaceT := *newNamespace(namespaceName)
 			tP := newTPod(
 				"node1",
@@ -175,9 +178,21 @@ var _ = ginkgo.Describe("OVN Namespace Operations", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			fakeOvn.asf.EventuallyExpectAddressSetWithIPs(namespaceName, []string{tP.podIP})
+
+			// port group is empty, because it will be filled by pod add logic
+			pg := fakeOvn.controller.buildPortGroup(
+				libovsdbutil.HashedPortGroup(namespaceName),
+				namespaceName,
+				nil,
+				nil,
+			)
+			pg.UUID = pg.Name + "-UUID"
+			gomega.Eventually(fakeOvn.nbClient).Should(libovsdb.HaveData([]libovsdb.TestData{pg}))
 		})
 
-		ginkgo.It("creates an empty address set for the namespace without pods", func() {
+		ginkgo.It("creates an empty address set and port group for the namespace without pods", func() {
+			// this flag will create namespaced port group
+			config.OVNKubernetesFeature.EnableEgressFirewall = true
 			fakeOvn.start(&v1.NamespaceList{
 				Items: []v1.Namespace{
 					*newNamespace(namespaceName),
@@ -190,6 +205,15 @@ var _ = ginkgo.Describe("OVN Namespace Operations", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			fakeOvn.asf.ExpectEmptyAddressSet(namespaceName)
+
+			pg := fakeOvn.controller.buildPortGroup(
+				libovsdbutil.HashedPortGroup(namespaceName),
+				namespaceName,
+				nil,
+				nil,
+			)
+			pg.UUID = pg.Name + "-UUID"
+			gomega.Eventually(fakeOvn.nbClient).Should(libovsdb.HaveData([]libovsdb.TestData{pg}))
 		})
 
 		ginkgo.It("creates an address set for existing nodes when the host network traffic namespace is created", func() {
@@ -334,6 +358,91 @@ var _ = ginkgo.Describe("OVN Namespace Operations", func() {
 				allowIPs = append(allowIPs, lrpIP.IP.String())
 			}
 			fakeOvn.asf.EventuallyExpectAddressSetWithIPs(hostNetworkNamespace, allowIPs)
+		})
+
+		ginkgo.It("reconciles an existing namespace port group, without updating it", func() {
+			// this flag will create namespaced port group
+			config.OVNKubernetesFeature.EnableEgressFirewall = true
+			namespaceT := *newNamespace(namespaceName)
+			pg := &nbdb.PortGroup{
+				Name:        libovsdbutil.HashedPortGroup(namespaceName),
+				ExternalIDs: map[string]string{"name": namespaceName},
+				ACLs:        []string{"test-UUID"},
+				Ports:       []string{"test-UUID"},
+			}
+			pg.UUID = pg.Name + "-UUID"
+			initialData := []libovsdb.TestData{pg}
+
+			fakeOvn.startWithDBSetup(libovsdbtest.TestSetup{NBData: initialData},
+				&v1.NamespaceList{
+					Items: []v1.Namespace{
+						namespaceT,
+					},
+				},
+				&v1.NodeList{
+					Items: []v1.Node{
+						*newNode("node1", "192.168.126.202/24"),
+					},
+				},
+			)
+
+			err := fakeOvn.controller.WatchNamespaces()
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			fakeOvn.asf.EventuallyExpectAddressSetWithIPs(namespaceName, []string{})
+			gomega.Eventually(fakeOvn.nbClient).Should(libovsdb.HaveData(initialData))
+		})
+		ginkgo.It("deletes an existing namespace port group when egress firewall and multicast are disabled", func() {
+			namespaceT := *newNamespace(namespaceName)
+			pg := &nbdb.PortGroup{
+				Name:        libovsdbutil.HashedPortGroup(namespaceName),
+				ExternalIDs: nil,
+				ACLs:        []string{"test-UUID"},
+				Ports:       []string{"test-UUID"},
+			}
+			pg.UUID = pg.Name + "-UUID"
+			initialData := []libovsdb.TestData{pg}
+
+			fakeOvn.startWithDBSetup(libovsdbtest.TestSetup{NBData: initialData},
+				&v1.NamespaceList{
+					Items: []v1.Namespace{
+						namespaceT,
+					},
+				},
+				&v1.NodeList{
+					Items: []v1.Node{
+						*newNode("node1", "192.168.126.202/24"),
+					},
+				},
+			)
+
+			err := fakeOvn.controller.WatchNamespaces()
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Eventually(fakeOvn.nbClient).Should(libovsdb.HaveData([]libovsdb.TestData{}))
+		})
+		ginkgo.It("deletes an existing namespace port group when there are no namespaces", func() {
+			// this flag will create namespaced port group
+			config.OVNKubernetesFeature.EnableEgressFirewall = true
+			pg := &nbdb.PortGroup{
+				Name:        libovsdbutil.HashedPortGroup(namespaceName),
+				ExternalIDs: nil,
+				ACLs:        []string{"test-UUID"},
+				Ports:       []string{"test-UUID"},
+			}
+			pg.UUID = pg.Name + "-UUID"
+			initialData := []libovsdb.TestData{pg}
+
+			fakeOvn.startWithDBSetup(libovsdbtest.TestSetup{NBData: initialData},
+				&v1.NodeList{
+					Items: []v1.Node{
+						*newNode("node1", "192.168.126.202/24"),
+					},
+				},
+			)
+
+			err := fakeOvn.controller.WatchNamespaces()
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Eventually(fakeOvn.nbClient).Should(libovsdb.HaveData([]libovsdb.TestData{}))
 		})
 	})
 

--- a/go-controller/pkg/ovn/ovn_test.go
+++ b/go-controller/pkg/ovn/ovn_test.go
@@ -183,7 +183,7 @@ func (o *FakeOVN) init(nadList []nettypes.NetworkAttachmentDefinition) {
 		o.nbClient, o.sbClient,
 		o.fakeRecorder, o.wg)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-	o.controller.multicastSupport = true
+	o.controller.multicastSupport = config.EnableMulticast
 	o.controller.clusterLoadBalancerGroupUUID = types.ClusterLBGroupName + "-UUID"
 	o.controller.switchLoadBalancerGroupUUID = types.ClusterSwitchLBGroupName + "-UUID"
 	o.controller.routerLoadBalancerGroupUUID = types.ClusterRouterLBGroupName + "-UUID"

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -188,7 +188,7 @@ func (oc *DefaultNetworkController) addLogicalPort(pod *kapi.Pod) (err error) {
 	}
 
 	// Ensure the namespace/nsInfo exists
-	routingExternalGWs, routingPodGWs, addOps, err := oc.addPodToNamespace(pod.Namespace, podAnnotation.IPs)
+	routingExternalGWs, routingPodGWs, addOps, err := oc.addLocalPodToNamespace(pod.Namespace, podAnnotation.IPs, lsp.UUID)
 	if err != nil {
 		return err
 	}
@@ -255,20 +255,7 @@ func (oc *DefaultNetworkController) addLogicalPort(pod *kapi.Pod) (err error) {
 	}
 
 	// Add the pod's logical switch port to the port cache
-	portInfo := oc.logicalPortCache.add(pod, switchName, ovntypes.DefaultNetworkName, lsp.UUID, podAnnotation.MAC, podAnnotation.IPs)
-
-	// If multicast is allowed and enabled for the namespace, add the port to the allow policy.
-	// FIXME: there's a race here with the Namespace multicastUpdateNamespace() handler, but
-	// it's rare and easily worked around for now.
-	ns, err := oc.watchFactory.GetNamespace(pod.Namespace)
-	if err != nil {
-		return err
-	}
-	if oc.multicastSupport && isNamespaceMulticastEnabled(ns.Annotations) {
-		if err := oc.podAddAllowMulticastPolicy(pod.Namespace, portInfo); err != nil {
-			return err
-		}
-	}
+	_ = oc.logicalPortCache.add(pod, switchName, ovntypes.DefaultNetworkName, lsp.UUID, podAnnotation.MAC, podAnnotation.IPs)
 
 	if kubevirt.IsPodLiveMigratable(pod) {
 		if err := kubevirt.EnsureDHCPOptionsForMigratablePod(oc.controllerName, oc.nbClient, oc.watchFactory, pod, podAnnotation.IPs, lsp); err != nil {

--- a/go-controller/pkg/ovn/pods_test.go
+++ b/go-controller/pkg/ovn/pods_test.go
@@ -13,6 +13,7 @@ import (
 	ipallocator "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/allocator/ip"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	libovsdbops "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdb/ops"
+	libovsdbutil "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdb/util"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/retry"
 	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
 	ovntypes "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
@@ -365,6 +366,10 @@ func setPodAnnotations(podObj *v1.Pod, testPod testPod) {
 }
 
 func getExpectedDataPodsAndSwitches(pods []testPod, nodes []string) []libovsdbtest.TestData {
+	return getExpectedDataPodsSwitchesPortGroup(pods, nodes, "")
+}
+
+func getExpectedDataPodsSwitchesPortGroup(pods []testPod, nodes []string, namespacedPortGroup string) []libovsdbtest.TestData {
 	nodeslsps := make(map[string][]string)
 	var logicalSwitchPorts []*nbdb.LogicalSwitchPort
 	for _, pod := range pods {
@@ -412,6 +417,18 @@ func getExpectedDataPodsAndSwitches(pods []testPod, nodes []string) []libovsdbte
 	for _, ls := range logicalSwitches {
 		data = append(data, ls)
 	}
+	if namespacedPortGroup != "" {
+		// namespace port group is created
+		fakeController := getFakeController(DefaultNetworkControllerName)
+		pg := fakeController.buildPortGroup(
+			libovsdbutil.HashedPortGroup(namespacedPortGroup),
+			namespacedPortGroup,
+			logicalSwitchPorts,
+			nil,
+		)
+		pg.UUID = pg.Name + "-UUID"
+		data = append(data, pg)
+	}
 
 	return data
 }
@@ -455,7 +472,8 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 
 		ginkgo.It("reconciles an existing pod", func() {
 			app.Action = func(ctx *cli.Context) error {
-
+				// this flag will create namespaced port group
+				config.OVNKubernetesFeature.EnableEgressFirewall = true
 				namespaceT := *newNamespace("namespace1")
 				// Setup an unassigned pod, perform an update later on which assigns it.
 				t := newTPod(
@@ -521,7 +539,9 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 				gomega.Eventually(func() string {
 					return getPodAnnotations(fakeOvn.fakeClient.KubeClient, t.namespace, t.podName)
 				}, 2).Should(gomega.MatchJSON(t.getAnnotationsJson()))
-				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(getExpectedDataPodsAndSwitches([]testPod{t}, []string{"node1"})))
+
+				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(
+					getExpectedDataPodsSwitchesPortGroup([]testPod{t}, []string{"node1"}, namespaceT.Name)))
 
 				return nil
 			}

--- a/go-controller/pkg/util/batching/batch.go
+++ b/go-controller/pkg/util/batching/batch.go
@@ -2,6 +2,7 @@ package batching
 
 import "fmt"
 
+// Batch splits values in `data` in batches of size `batchSize`, and calls `eachFn` for each batch.
 func Batch[T any](batchSize int, data []T, eachFn func([]T) error) error {
 	if batchSize < 1 {
 		return fmt.Errorf("batchSize should be > 0, got %d", batchSize)
@@ -18,6 +19,52 @@ func Batch[T any](batchSize int, data []T, eachFn func([]T) error) error {
 			return err
 		}
 		start = end
+	}
+	return nil
+}
+
+// BatchMap splits values in `data` in batches of size `batchSize`, and calls `eachFn` for each batch.
+// Values of a specific key may be split into different batches, make sure `eachFn` can handle that case.
+func BatchMap[T any](batchSize int, data map[string][]T, eachFn func(map[string][]T) error) error {
+	if batchSize < 1 {
+		return fmt.Errorf("batchSize should be > 0, got %d", batchSize)
+	}
+	batchCounter := 0
+	batchMap := map[string][]T{}
+
+	for key, value := range data {
+		// a given value may need to be split into multiple batches.
+		// allElemsBatched is true when all value elements are added to the batchMap.
+		allElemsBatched := false
+		for !allElemsBatched {
+			if batchCounter+len(value) >= batchSize {
+				leftSpace := batchSize - batchCounter
+				batchMap[key] = value[:leftSpace]
+
+				err := eachFn(batchMap)
+				if err != nil {
+					return err
+				}
+				// reset batch
+				batchMap = map[string][]T{}
+				batchCounter = 0
+
+				// update value to what's left
+				value = value[leftSpace:]
+				allElemsBatched = len(value) == 0
+			} else {
+				batchMap[key] = value
+				batchCounter += len(value)
+				allElemsBatched = true
+			}
+		}
+	}
+	if len(batchMap) > 0 {
+		// process last batch
+		err := eachFn(batchMap)
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/go-controller/pkg/util/batching/batch_test.go
+++ b/go-controller/pkg/util/batching/batch_test.go
@@ -13,7 +13,6 @@ type batchTestData struct {
 	name      string
 	batchSize int
 	data      []int
-	result    []int
 	expectErr string
 }
 
@@ -76,6 +75,152 @@ func TestBatch(t *testing.T) {
 		// tCase.data/tCase.batchSize round up
 		expectedBatchNum := (len(tCase.data) + tCase.batchSize - 1) / tCase.batchSize
 		g.Expect(batchNum).To(gomega.Equal(expectedBatchNum))
+		g.Expect(result).To(gomega.Equal(tCase.data))
+	}
+}
+
+type batchMapTestData struct {
+	name               string
+	batchSize          int
+	data               map[string][]int
+	expectErr          string
+	expectedBatchesNum int
+}
+
+func TestBatchMap(t *testing.T) {
+	tt := []batchMapTestData{
+		{
+			name:      "batch size should be > 0",
+			batchSize: 0,
+			data:      map[string][]int{"a": {1, 2, 3}},
+			expectErr: "batchSize should be > 0",
+		},
+		{
+			name:      "batchSize = 1",
+			batchSize: 1,
+			data: map[string][]int{
+				"a": {1},
+				"b": {2},
+				"c": {3},
+			},
+			expectedBatchesNum: 3,
+		},
+		{
+			name:      "batchSize = 1, nil value",
+			batchSize: 1,
+			data: map[string][]int{
+				"a": nil,
+				"b": nil,
+			},
+			expectedBatchesNum: 1,
+		},
+		{
+			name:      "batchSize = 1, empty value",
+			batchSize: 1,
+			data: map[string][]int{
+				"a": {},
+				"b": {},
+			},
+			expectedBatchesNum: 1,
+		},
+		{
+			name:      "batchSize = 1, len(value) > 1",
+			batchSize: 1,
+			data: map[string][]int{
+				"a": {1, 2, 3},
+				"b": {4},
+			},
+			expectedBatchesNum: 4,
+		},
+		{
+			name:      "batchSize > 1",
+			batchSize: 2,
+			data: map[string][]int{
+				"a": {1},
+				"b": {2},
+				"c": {3},
+			},
+			expectedBatchesNum: 2,
+		},
+		{
+			name:               "number of batches = 0",
+			batchSize:          2,
+			data:               map[string][]int{},
+			expectedBatchesNum: 0,
+		},
+		{
+			name:      "number of batches = 1, same key",
+			batchSize: 2,
+			data: map[string][]int{
+				"a": {1, 2},
+			},
+			expectedBatchesNum: 1,
+		},
+		{
+			name:      "number of batches = 1, different keys",
+			batchSize: 2,
+			data: map[string][]int{
+				"a": {1},
+				"b": {2},
+			},
+			expectedBatchesNum: 1,
+		},
+		{
+			name:      "number of batches > 1, different keys",
+			batchSize: 2,
+			data: map[string][]int{
+				"a": {1, 2},
+				"b": {3},
+				"c": {4},
+			},
+			expectedBatchesNum: 2,
+		},
+		{
+			name:      "number of batches > 2, different keys",
+			batchSize: 3,
+			data: map[string][]int{
+				"a": {1, 2},
+				"b": {3, 4, 5},
+				"c": {6, 7},
+			},
+			expectedBatchesNum: 3,
+		},
+		{
+			name:      "number of batches = 2, split values",
+			batchSize: 3,
+			data: map[string][]int{
+				"a": {1, 2},
+				"b": {3, 4, 5},
+				"c": {6},
+			},
+			expectedBatchesNum: 2,
+		},
+	}
+
+	for _, tCase := range tt {
+		g := gomega.NewGomegaWithT(t)
+		ginkgo.By(tCase.name)
+		result := map[string][]int{}
+		batchNum := 0
+		err := BatchMap[int](tCase.batchSize, tCase.data, func(l map[string][]int) error {
+			batchNum += 1
+			for key, value := range l {
+				// this is needed to handle empty list vs nil, since appending empty list to a nil returns nil.
+				if len(value) == 0 {
+					result[key] = value
+				} else {
+					result[key] = append(result[key], value...)
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			if tCase.expectErr != "" && strings.Contains(err.Error(), tCase.expectErr) {
+				continue
+			}
+			t.Fatal(fmt.Sprintf("test %s failed: %v", tCase.name, err))
+		}
+		g.Expect(batchNum).To(gomega.Equal(tCase.expectedBatchesNum))
 		g.Expect(result).To(gomega.Equal(tCase.data))
 	}
 }


### PR DESCRIPTION
Backport of 
[upstream] https://github.com/ovn-org/ovn-kubernetes/pull/3968,  [4.15] https://github.com/openshift/ovn-kubernetes/pull/1952
https://github.com/openshift/ovn-kubernetes/pull/1952

minor conflict to remove new function that were added in 4.15