### PR TITLE
metrics: Verbose the log when ParseFloat interfaceFieldValues failed

### DIFF
--- a/go-controller/pkg/metrics/ovs.go
+++ b/go-controller/pkg/metrics/ovs.go
@@ -545,7 +545,8 @@ func updateOvsInterfaceMetrics(ovsVsctl ovsClient) error {
 		}
 		statValue, err = strconv.ParseFloat(interfaceFieldValues[0], 64)
 		if err != nil {
-			return fmt.Errorf("expected string to contain an integer. Failed to get OVS interface metrics: %v", err)
+			return fmt.Errorf("expected string %q to contain an integer. Failed to get OVS interface metrics: %v",
+			interfaceFieldValues[0], err)
 		}
 		linkReset += statValue
 		interfaceCount++


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

This is a trivial change. Sometimes we see such error in ovn Pod:

```
EXXXX XX:XX:XX.XXXXXX XXXXXX ovs.go:497] Updating OVS interface metrics failed: expected string to contain an integer. Failed to get OVS interface metrics: strconv.ParseFloat: parsing "": invalid syntax
```

Verbose the log could help us troubleshoot the wrong output which is provided by ovs-vsctl command.

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->