### PR TITLE
[release-4.13] OCPBUGS-24263: Bump OVN to 23.06.1-39.el9fdp

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -13,7 +13,7 @@ RUN dnf install -y --nodocs \
 	dnf clean all
 
 ARG ovsver=3.1.0-32.el9fdp
-ARG ovnver=23.06.1-8.el9fdp
+ARG ovnver=23.06.1-39.el9fdp
 
 RUN INSTALL_PKGS="iptables" && \
 	dnf install -y --nodocs $INSTALL_PKGS && \


### PR DESCRIPTION
Relevant fixes:

```
* Tue Oct 10 2023 Ales Musil <amusil@redhat.com> - 23.06.1-31
- northd: Allow need frag to be SNATed [Upstream: 56c05c437c0288ed79b30a8d62fe5660bf0ae706]

* Thu Sep 14 2023 Ales Musil <amusil@redhat.com> - 23.06.1-10
- ofctrl: Prevent conjunction duplication (#2175928) [Upstream: 4281178a8882d0194ce8edf35018227ab20fa80e]

* Thu Sep 14 2023 Ales Musil <amusil@redhat.com> - 23.06.1-9
- ofctrl: Do not try to program long flows (#1955167) [Upstream: f18bbbbc1ec0110cde8146ea4e2b34b1ec488ba7]
```

@trozet @tssurya 