### PR TITLE
OCPBUGS-24465: Removes Interconnect references from e2e tests

### DIFF
--- a/test/e2e/pod.go
+++ b/test/e2e/pod.go
@@ -228,9 +228,6 @@ var _ = ginkgo.Describe("Pod to external server PMTUD", func() {
 						for _, ovnKubeNodePod := range ovnKubeNodePods.Items {
 							framework.Logf("Flushing the ip route cache on %s", ovnKubeNodePod.Name)
 							containerName := "ovnkube-node"
-							if isInterconnectEnabled() {
-								containerName = "ovnkube-controller"
-							}
 							_, err := framework.RunKubectl(ovnNs, "exec", ovnKubeNodePod.Name, "--container", containerName, "--",
 								"ip", "route", "flush", "cache")
 							framework.ExpectNoError(err, "Flushing the ip route cache failed")

--- a/test/e2e/service.go
+++ b/test/e2e/service.go
@@ -361,9 +361,6 @@ var _ = ginkgo.Describe("Services", func() {
 							for _, ovnKubeNodePod := range ovnKubeNodePods.Items {
 								framework.Logf("Flushing the ip route cache on %s", ovnKubeNodePod.Name)
 								containerName := "ovnkube-node"
-								if isInterconnectEnabled() {
-									containerName = "ovnkube-controller"
-								}
 								_, err := framework.RunKubectl(ovnNs, "exec", ovnKubeNodePod.Name, "--container", containerName, "--",
 									"ip", "route", "flush", "cache")
 								framework.ExpectNoError(err, "Flushing the ip route cache failed")


### PR DESCRIPTION
IC doesn't exist in 4.13 and these functions were accidentally backported to 4.13.

