### PR TITLE
[release-4.12] OCPBUGS-23981: Netpol retryFramework cleanup

### DIFF
--- a/go-controller/pkg/factory/factory.go
+++ b/go-controller/pkg/factory/factory.go
@@ -365,8 +365,13 @@ func NewNodeWatchFactory(ovnClientset *util.OVNClientset, nodeName string) (*Wat
 	return wf, nil
 }
 
-func (wf *WatchFactory) WaitForWatchFactoryStopChannel(stopChan chan struct{}) {
-	<-wf.stopChan
+// WaitForWatchFactoryStopChannel closes given stopChan when either watch factory stopChan is closed or
+// a given externalStopChan is closed
+func (wf *WatchFactory) WaitForWatchFactoryStopChannel(stopChan chan struct{}, externalStopChan <-chan struct{}) {
+	select {
+	case <-wf.stopChan:
+	case <-externalStopChan:
+	}
 	close(stopChan)
 }
 

--- a/go-controller/pkg/ovn/obj_retry_master.go
+++ b/go-controller/pkg/ovn/obj_retry_master.go
@@ -46,7 +46,8 @@ type masterEventHandler struct {
 func (oc *Controller) newRetryFrameworkMasterWithParameters(
 	objectType reflect.Type,
 	syncFunc func([]interface{}) error,
-	extraParameters interface{}) *retry.RetryFramework {
+	extraParameters interface{},
+	stopChan <-chan struct{}) *retry.RetryFramework {
 	resourceHandler := &retry.ResourceHandler{
 		HasUpdateFunc:          hasResourceAnUpdateFunc(objectType),
 		NeedsUpdateDuringRetry: needsUpdateDuringRetry(objectType),
@@ -58,9 +59,10 @@ func (oc *Controller) newRetryFrameworkMasterWithParameters(
 			syncFunc:        syncFunc,
 		},
 	}
-	r := retry.NewRetryFramework(
+	r := retry.NewRetryFrameworkWithStopChan(
 		oc.watchFactory,
 		resourceHandler,
+		stopChan,
 	)
 	return r
 }
@@ -73,7 +75,7 @@ func (oc *Controller) newRetryFrameworkMasterWithParameters(
 // This is true for all resource types except for those that are dynamically created when
 // adding a network policy.
 func (oc *Controller) newRetryFrameworkMaster(objectType reflect.Type) *retry.RetryFramework {
-	return oc.newRetryFrameworkMasterWithParameters(objectType, nil, nil)
+	return oc.newRetryFrameworkMasterWithParameters(objectType, nil, nil, nil)
 }
 
 // hasResourceAnUpdateFunc returns true if the given resource type has a dedicated update function.


### PR DESCRIPTION
Kind of a backport of https://github.com/openshift/ovn-kubernetes/pull/1957
But with a full re-implementation because of 4.12 vs 4.13 differences
