### PR TITLE
[release-4.13] OCPBUGS-25611: Avoid panic due to stale ACLs with 1013 priority

### DIFF
--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -329,7 +329,8 @@ func (oc *DefaultNetworkController) syncNetworkPolicies(networkPolicies []interf
 
 	// cleanup port groups based on acl search
 	p := func(item *nbdb.ACL) bool {
-		return item.ExternalIDs[policyACLExtIdKey] != "" || item.ExternalIDs[defaultDenyPolicyTypeACLExtIdKey] != ""
+		return item.ExternalIDs[policyACLExtIdKey] != "" || (item.ExternalIDs[defaultDenyPolicyTypeACLExtIdKey] != "" &&
+			item.Priority != types.DefaultRoutedMcastAllowPriority)
 	}
 	netpolACLs, err := libovsdbops.FindACLsWithPredicate(oc.nbClient, p)
 	if err != nil {
@@ -347,7 +348,7 @@ func (oc *DefaultNetworkController) syncNetworkPolicies(networkPolicies []interf
 					portGroupName, _ := getNetworkPolicyPGName(namespace, policyName)
 					stalePGs.Insert(portGroupName)
 				}
-			} else if netpolACL.ExternalIDs[defaultDenyPolicyTypeACLExtIdKey] != "" {
+			} else if netpolACL.ExternalIDs[defaultDenyPolicyTypeACLExtIdKey] != "" && netpolACL.Name != nil {
 				// default deny acl
 				// parse the namespace.Name from the ACL name (if ACL name is 63 chars, then it will fully be namespace.Name)
 				namespace := strings.Split(*netpolACL.Name, "_")[0]


### PR DESCRIPTION
**- What this PR does and why is it needed**

This PR is to take care of following things:

- Remove stale ACLs with priority 1013 and still present in Northbound database.
- Avoid panic due to null pointer. This may occur due to presence of an ACL without a name.

**- Special notes for reviewers**
Jira: https://issues.redhat.com/browse/OCPBUGS-25611


**- How to verify it**
- Create ACL with 1013 priority and no name:
  $ ovn-nbctl --no-leader acl-add clusterRtrPortGroup to-lport 1013 "outport == @ClusterRtrPortGroup && (ip4.mcast || mldv1 || mldv2 || (ip6.dst[120..127] == 0xff && ip6.dst[116] == 1))" allow
 $ ovn-nbctl --no-leader acl-add clusterRtrPortGroup from-lport 1013 "inport == @ClusterRtrPortGroup && (ip4.mcast || mldv1 || mldv2 || (ip6.dst[120..127] == 0xff && ip6.dst[116] == 1))" allow

- Restart ovnkube-master leader 

**- Description for the changelog**
- Remove ACL with priority 1013
- Unit test to validate that ACL with 1013 priority is being removed when syncNetworkPolicies function gets executed
- Avoid panic by checking content of the parameter before trying to access it by address