### PR TITLE
OCPBUGS-25224: [release-4.13] fixes MTU configuration on gateway router

### DIFF
--- a/go-controller/pkg/ovn/gateway_init.go
+++ b/go-controller/pkg/ovn/gateway_init.go
@@ -30,6 +30,7 @@ import (
 // We don't have to worry about missing SNATs that should be added because addLogicalPort takes care of this for all pods
 // when RequestRetryObjs is called for each node add.
 // This is executed only when disableSNATMultipleGateways = true
+// SNATs configured for the join subnet are ignored.
 //
 // NOTE: On startup libovsdb adds back all the pods and this should normally update all existing SNATs
 // accordingly. Due to a stale egressIP cache bug https://issues.redhat.com/browse/OCPBUGS-1520 we ended up adding
@@ -95,7 +96,8 @@ func (oc *DefaultNetworkController) cleanupStalePodSNATs(nodeName string, nodeIP
 			continue
 		}
 		for _, nodeIP := range nodeIPs {
-			if routerNat.ExternalIP == nodeIP.IP.String() && !podIPsOnNode.Has(routerNat.LogicalIP) {
+			logicalIP := net.ParseIP(routerNat.LogicalIP)
+			if routerNat.ExternalIP == nodeIP.IP.String() && !config.ContainsJoinIP(logicalIP) && !podIPsOnNode.Has(routerNat.LogicalIP) {
 				natsToDelete = append(natsToDelete, routerNat)
 			}
 		}
@@ -342,6 +344,7 @@ func (oc *DefaultNetworkController) gatewayInit(nodeName string, clusterIPSubnet
 	// to the same gateway router
 	//
 	// This can be removed once https://bugzilla.redhat.com/show_bug.cgi?id=1891516 is fixed.
+	// FIXME(trozet): if LRP IP is changed, we do not remove stale instances of these routes
 	for _, gwLRPIP := range gwLRPIPs {
 		lrsr := nbdb.LogicalRouterStaticRoute{
 			IPPrefix: gwLRPIP.String(),
@@ -414,30 +417,87 @@ func (oc *DefaultNetworkController) gatewayInit(nodeName string, clusterIPSubnet
 	}
 	var natsToUpdate []*nbdb.NAT
 	// If l3gatewayAnnotation.IPAddresses changed, we need to update the SNATs on the GR
-	if len(oldExtIPs) > 0 {
+	oldNATs := []*nbdb.NAT{}
+	if oldLogicalRouter != nil {
+		oldNATs, err = libovsdbops.GetRouterNATs(oc.nbClient, oldLogicalRouter)
+		if err != nil && errors.Is(err, libovsdbclient.ErrNotFound) {
+			return fmt.Errorf("unable to get NAT entries for router on node %s: %w", nodeName, err)
+		}
+	}
+
+	for _, nat := range oldNATs {
+		nat := nat
+		natModified := false
+
+		// if not type snat, we don't need to update as we only configure snat types
+		if nat.Type != nbdb.NATTypeSNAT {
+			continue
+		}
+		// check external ip changed
 		for _, externalIP := range externalIPs {
-			oldExternalIP, err := util.MatchIPFamily(utilnet.IsIPv6(externalIP), oldExtIPs)
+			oldExternalIP, err := util.MatchFirstIPFamily(utilnet.IsIPv6(externalIP), oldExtIPs)
 			if err != nil {
 				return fmt.Errorf("failed to update GW SNAT rule for pods on router %s error: %v", gatewayRouter, err)
 			}
-			if externalIP.String() != oldExternalIP[0].String() {
-				predicate := func(item *nbdb.NAT) bool {
-					return item.ExternalIP == oldExternalIP[0].String() && item.Type == nbdb.NATTypeSNAT
-				}
-				natsToUpdate, err = libovsdbops.FindNATsWithPredicate(oc.nbClient, predicate)
-				if err != nil {
-					return fmt.Errorf("failed to update GW SNAT rule for pods on router %s error: %v", gatewayRouter, err)
-				}
-				for i := 0; i < len(natsToUpdate); i++ {
-					natsToUpdate[i].ExternalIP = externalIP.String()
-				}
+			if externalIP.String() == oldExternalIP.String() {
+				// no external ip change, skip
+				continue
+			}
+			if nat.ExternalIP == oldExternalIP.String() {
+				// needs to be updated
+				natModified = true
+				nat.ExternalIP = externalIP.String()
+			}
+
+		}
+		// note, nat.LogicalIP may be a CIDR or IP, we don't care unless it's an IP
+		parsedLogicalIP := net.ParseIP(nat.LogicalIP)
+		// check if join ip changed
+		if config.ContainsJoinIP(parsedLogicalIP) {
+			// is a join SNAT, check if IP needs updating
+			joinIP, err := util.MatchFirstIPFamily(utilnet.IsIPv6(parsedLogicalIP), gwLRPIPs)
+			if err != nil {
+				return fmt.Errorf("failed to find valid IP family match for join subnet IP: %s on "+
+					"gateway router: %s, provided IPs: %#v", parsedLogicalIP, gatewayRouter, gwLRPIPs)
+			}
+			if nat.LogicalIP != joinIP.String() {
+				// needs to be updated
+				natModified = true
+				nat.LogicalIP = joinIP.String()
 			}
 		}
-		err := libovsdbops.CreateOrUpdateNATs(oc.nbClient, &logicalRouter, natsToUpdate...)
+		if natModified {
+			natsToUpdate = append(natsToUpdate, nat)
+		}
+	}
+
+	if len(natsToUpdate) > 0 {
+		err = libovsdbops.CreateOrUpdateNATs(oc.nbClient, &logicalRouter, natsToUpdate...)
 		if err != nil {
 			return fmt.Errorf("failed to update GW SNAT rule for pod on router %s error: %v", gatewayRouter, err)
 		}
 	}
+
+	// REMOVEME(trozet) workaround - create join subnet SNAT to handle ICMP needs frag return
+	joinNATs := make([]*nbdb.NAT, 0, len(gwLRPIPs))
+	for _, gwLRPIP := range gwLRPIPs {
+		externalIP, err := util.MatchIPFamily(utilnet.IsIPv6(gwLRPIP), externalIPs)
+		if err != nil {
+			return fmt.Errorf("failed to find valid external IP family match for join subnet IP: %s on "+
+				"gateway router: %s", gwLRPIP, gatewayRouter)
+		}
+		joinIPNet, err := util.GetIPNetFullMask(gwLRPIP.String())
+		if err != nil {
+			return fmt.Errorf("failed to parse full CIDR mask for join subnet IP: %s", gwLRPIP)
+		}
+		nat := libovsdbops.BuildSNAT(&externalIP[0], joinIPNet, "", nil)
+		joinNATs = append(joinNATs, nat)
+	}
+	err = libovsdbops.CreateOrUpdateNATs(oc.nbClient, &logicalRouter, joinNATs...)
+	if err != nil {
+		return fmt.Errorf("failed to create SNAT rule for join subnet on router %s error: %v", gatewayRouter, err)
+	}
+
 	nats := make([]*nbdb.NAT, 0, len(clusterIPSubnet))
 	var nat *nbdb.NAT
 	if !config.Gateway.DisableSNATMultipleGWs {

--- a/go-controller/pkg/ovn/gateway_init.go
+++ b/go-controller/pkg/ovn/gateway_init.go
@@ -265,8 +265,7 @@ func (oc *DefaultNetworkController) gatewayInit(nodeName string, clusterIPSubnet
 		l3GatewayConfig.MACAddress.String(),
 		types.PhysicalNetworkName,
 		l3GatewayConfig.IPAddresses,
-		l3GatewayConfig.VLANID,
-		enableGatewayMTU); err != nil {
+		l3GatewayConfig.VLANID); err != nil {
 		return err
 	}
 
@@ -278,8 +277,7 @@ func (oc *DefaultNetworkController) gatewayInit(nodeName string, clusterIPSubnet
 			l3GatewayConfig.EgressGWMACAddress.String(),
 			types.PhysicalNetworkExGwName,
 			l3GatewayConfig.EgressGWIPAddresses,
-			nil,
-			enableGatewayMTU); err != nil {
+			nil); err != nil {
 			return err
 		}
 	}
@@ -482,10 +480,7 @@ func (oc *DefaultNetworkController) gatewayInit(nodeName string, clusterIPSubnet
 
 // addExternalSwitch creates a switch connected to the external bridge and connects it to
 // the gateway router
-// enableGatewayMTU enables options:gateway_mtu for gateway routers. Setting it on
-// the external ports of the GR will mimic the older behaviour of using br-ex flows
-func (oc *DefaultNetworkController) addExternalSwitch(prefix, interfaceID, nodeName, gatewayRouter, macAddress, physNetworkName string,
-	ipAddresses []*net.IPNet, vlanID *uint, enableGatewayMTU bool) error {
+func (oc *DefaultNetworkController) addExternalSwitch(prefix, interfaceID, nodeName, gatewayRouter, macAddress, physNetworkName string, ipAddresses []*net.IPNet, vlanID *uint) error {
 	// Create the GR port that connects to external_switch with mac address of
 	// external interface and that IP address. In the case of `local` gateway
 	// mode, whenever ovnkube-node container restarts a new br-local bridge will
@@ -496,12 +491,6 @@ func (oc *DefaultNetworkController) addExternalSwitch(prefix, interfaceID, nodeN
 	for _, ip := range ipAddresses {
 		externalRouterPortNetworks = append(externalRouterPortNetworks, ip.String())
 	}
-	var options map[string]string
-	if enableGatewayMTU {
-		options = map[string]string{
-			"gateway_mtu": strconv.Itoa(config.Default.MTU),
-		}
-	}
 	externalLogicalRouterPort := nbdb.LogicalRouterPort{
 		MAC: macAddress,
 		ExternalIDs: map[string]string{
@@ -509,14 +498,12 @@ func (oc *DefaultNetworkController) addExternalSwitch(prefix, interfaceID, nodeN
 		},
 		Networks: externalRouterPortNetworks,
 		Name:     externalRouterPort,
-		Options:  options,
 	}
 	logicalRouter := nbdb.LogicalRouter{Name: gatewayRouter}
 
 	err := libovsdbops.CreateOrUpdateLogicalRouterPort(oc.nbClient, &logicalRouter,
 		&externalLogicalRouterPort, nil, &externalLogicalRouterPort.MAC,
-		&externalLogicalRouterPort.Networks, &externalLogicalRouterPort.ExternalIDs,
-		&externalLogicalRouterPort.Options)
+		&externalLogicalRouterPort.Networks, &externalLogicalRouterPort.ExternalIDs)
 	if err != nil {
 		return fmt.Errorf("failed to add logical router port %+v to router %s: %v", externalLogicalRouterPort, gatewayRouter, err)
 	}

--- a/go-controller/pkg/ovn/gateway_init.go
+++ b/go-controller/pkg/ovn/gateway_init.go
@@ -563,7 +563,8 @@ func (oc *DefaultNetworkController) addExternalSwitch(prefix, interfaceID, nodeN
 
 	err := libovsdbops.CreateOrUpdateLogicalRouterPort(oc.nbClient, &logicalRouter,
 		&externalLogicalRouterPort, nil, &externalLogicalRouterPort.MAC,
-		&externalLogicalRouterPort.Networks, &externalLogicalRouterPort.ExternalIDs)
+		&externalLogicalRouterPort.Networks, &externalLogicalRouterPort.ExternalIDs,
+		&externalLogicalRouterPort.Options)
 	if err != nil {
 		return fmt.Errorf("failed to add logical router port %+v to router %s: %v", externalLogicalRouterPort, gatewayRouter, err)
 	}

--- a/go-controller/pkg/ovn/gateway_test.go
+++ b/go-controller/pkg/ovn/gateway_test.go
@@ -1376,6 +1376,114 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 			gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 		})
 
+		ginkgo.It("ensures a leftover mtu on rtoe port is cleared", func() {
+			nodeName := "test-node"
+			joinLRPIPs := ovntest.MustParseIPNets("100.64.0.3/16")
+			hostSubnets := ovntest.MustParseIPNets("10.130.0.0/23")
+
+			expectedOVNClusterRouter := &nbdb.LogicalRouter{
+				UUID: types.OVNClusterRouter + "-UUID",
+				Name: types.OVNClusterRouter,
+			}
+			expectedNodeSwitch := &nbdb.LogicalSwitch{
+				UUID: nodeName + "-UUID",
+				Name: nodeName,
+			}
+
+			expectedGR := &nbdb.LogicalRouter{
+				Name:         types.GWRouterPrefix + nodeName,
+				UUID:         types.GWRouterPrefix + nodeName + "-UUID",
+				LoadBalancer: []string{},
+				Ports: []string{
+					types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + nodeName + "-UUID",
+					types.GWRouterToExtSwitchPrefix + types.GWRouterPrefix + nodeName + "-UUID",
+				},
+			}
+			expectedClusterLBGroup := &nbdb.LoadBalancerGroup{
+				UUID: types.ClusterLBGroupName + "-UUID",
+				Name: types.ClusterLBGroupName,
+			}
+			expectedSwitchLBGroup := &nbdb.LoadBalancerGroup{
+				UUID: types.ClusterSwitchLBGroupName + "-UUID",
+				Name: types.ClusterSwitchLBGroupName,
+			}
+			expectedRouterLBGroup := &nbdb.LoadBalancerGroup{
+				UUID: types.ClusterRouterLBGroupName + "-UUID",
+				Name: types.ClusterRouterLBGroupName,
+			}
+
+			fakeOvn.startWithDBSetup(libovsdbtest.TestSetup{
+				NBData: []libovsdbtest.TestData{
+					&nbdb.LogicalRouterPort{
+						Name:     types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + nodeName,
+						UUID:     types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + nodeName + "-UUID",
+						Networks: []string{"100.64.0.1/16"},
+					},
+					&nbdb.StaticMACBinding{
+						IP:          config.Gateway.MasqueradeIPs.V4DummyNextHopMasqueradeIP.String(),
+						LogicalPort: types.GWRouterToExtSwitchPrefix + types.GWRouterPrefix + nodeName,
+					},
+					&nbdb.LogicalRouterPort{
+						UUID:    types.GWRouterToExtSwitchPrefix + types.GWRouterPrefix + nodeName + "-UUID",
+						Name:    types.GWRouterToExtSwitchPrefix + types.GWRouterPrefix + nodeName,
+						Options: map[string]string{"gateway_mtu": "1400"},
+					},
+					expectedGR,
+					expectedOVNClusterRouter,
+					&nbdb.LogicalSwitchPort{
+						Name: types.JoinSwitchToGWRouterPrefix + types.GWRouterPrefix + nodeName,
+						UUID: types.JoinSwitchToGWRouterPrefix + types.GWRouterPrefix + nodeName + "-UUID",
+					},
+					&nbdb.LogicalSwitch{
+						UUID: types.OVNJoinSwitch + "-UUID",
+						Name: types.OVNJoinSwitch,
+					},
+					&nbdb.LogicalSwitch{
+						Name: types.ExternalSwitchPrefix + nodeName,
+						UUID: types.ExternalSwitchPrefix + nodeName + "-UUID ",
+					},
+					expectedNodeSwitch,
+					expectedClusterLBGroup,
+					expectedSwitchLBGroup,
+					expectedRouterLBGroup,
+				},
+			})
+			clusterIPSubnets := ovntest.MustParseIPNets("10.128.0.0/14")
+			defLRPIPs := ovntest.MustParseIPNets("100.64.0.1/16")
+			l3GatewayConfig := &util.L3GatewayConfig{
+				Mode:           config.GatewayModeLocal,
+				ChassisID:      "SYSTEM-ID",
+				InterfaceID:    "INTERFACE-ID",
+				MACAddress:     ovntest.MustParseMAC("11:22:33:44:55:66"),
+				IPAddresses:    ovntest.MustParseIPNets("169.254.33.2/24"),
+				NextHops:       ovntest.MustParseIPs("169.254.33.1"),
+				NodePortEnable: true,
+			}
+			sctpSupport := false
+			config.Gateway.DisableSNATMultipleGWs = true
+
+			var err error
+			fakeOvn.controller.defaultCOPPUUID, err = EnsureDefaultCOPP(fakeOvn.nbClient)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			expectedOVNClusterRouter.StaticRoutes = []string{}
+			err = fakeOvn.controller.gatewayInit(
+				nodeName, clusterIPSubnets, hostSubnets, l3GatewayConfig, sctpSupport, joinLRPIPs, defLRPIPs, true)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			testData := []libovsdb.TestData{}
+			skipSnat := true
+
+			mgmtPortIP := ""
+
+			//expectedGR.Ports = []string{}
+			ginkgo.By("Gateway init should have cleared stale MTU on rtoe port")
+			expectedDatabaseState := generateGatewayInitExpectedNB(testData, expectedOVNClusterRouter, expectedNodeSwitch,
+				nodeName, clusterIPSubnets, hostSubnets, l3GatewayConfig, joinLRPIPs, defLRPIPs, skipSnat, mgmtPortIP,
+				"1400")
+			gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+		})
+
 	})
 
 	ginkgo.Context("Gateway Cleanup Operations", func() {

--- a/go-controller/pkg/ovn/gateway_test.go
+++ b/go-controller/pkg/ovn/gateway_test.go
@@ -1420,16 +1420,18 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 				Name: types.ClusterRouterLBGroupName,
 			}
 
+			gr := types.GWRouterPrefix + nodeName
+			datapath := &sbdb.DatapathBinding{
+				UUID:        gr + "-UUID",
+				ExternalIDs: map[string]string{"logical-router": gr + "-UUID", "name": gr},
+			}
+
 			fakeOvn.startWithDBSetup(libovsdbtest.TestSetup{
 				NBData: []libovsdbtest.TestData{
 					&nbdb.LogicalRouterPort{
 						Name:     types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + nodeName,
 						UUID:     types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + nodeName + "-UUID",
 						Networks: []string{"100.64.0.1/16"},
-					},
-					&nbdb.StaticMACBinding{
-						IP:          config.Gateway.MasqueradeIPs.V4DummyNextHopMasqueradeIP.String(),
-						LogicalPort: types.GWRouterToExtSwitchPrefix + types.GWRouterPrefix + nodeName,
 					},
 					&nbdb.LogicalRouterPort{
 						UUID:    types.GWRouterToExtSwitchPrefix + types.GWRouterPrefix + nodeName + "-UUID",
@@ -1454,6 +1456,9 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 					expectedClusterLBGroup,
 					expectedSwitchLBGroup,
 					expectedRouterLBGroup,
+				},
+				SBData: []libovsdbtest.TestData{
+					datapath,
 				},
 			})
 			clusterIPSubnets := ovntest.MustParseIPNets("10.128.0.0/14")

--- a/go-controller/pkg/ovn/gateway_test.go
+++ b/go-controller/pkg/ovn/gateway_test.go
@@ -210,6 +210,19 @@ func generateGatewayInitExpectedNB(testData []libovsdb.TestData, expectedOVNClus
 		}
 	}
 
+	for i, physicalIP := range l3GatewayConfig.IPAddresses {
+		natUUID := fmt.Sprintf("nat-join-%d-UUID", i)
+		natUUIDs = append(natUUIDs, natUUID)
+		joinLRPIP, _ := util.MatchFirstIPNetFamily(utilnet.IsIPv6CIDR(physicalIP), joinLRPIPs)
+		testData = append(testData, &nbdb.NAT{
+			UUID:       natUUID,
+			ExternalIP: physicalIP.IP.String(),
+			LogicalIP:  joinLRPIP.IP.String(),
+			Options:    map[string]string{"stateless": "false"},
+			Type:       nbdb.NATTypeSNAT,
+		})
+	}
+
 	testData = append(testData, &nbdb.MeterBand{
 		UUID:   "25-pktps-rate-limiter-UUID",
 		Action: types.MeterAction,
@@ -624,6 +637,99 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 			testData = []libovsdb.TestData{datapath}
 			expectedSBDatabaseState := generateGatewayInitExpectedSB(testData, nodeName)
 			gomega.Eventually(fakeOvn.sbClient).Should(libovsdbtest.HaveData(expectedSBDatabaseState))
+		})
+
+		ginkgo.It("updates SNAT when join IP changes", func() {
+			expectedOVNClusterRouter := &nbdb.LogicalRouter{
+				UUID:         types.OVNClusterRouter + "-UUID",
+				Name:         types.OVNClusterRouter,
+				StaticRoutes: []string{},
+			}
+			expectedNodeSwitch := &nbdb.LogicalSwitch{
+				UUID: nodeName + "-UUID",
+				Name: nodeName,
+			}
+			expectedClusterLBGroup := &nbdb.LoadBalancerGroup{
+				UUID: types.ClusterLBGroupName + "-UUID",
+				Name: types.ClusterLBGroupName,
+			}
+			expectedSwitchLBGroup := &nbdb.LoadBalancerGroup{
+				UUID: types.ClusterSwitchLBGroupName + "-UUID",
+				Name: types.ClusterSwitchLBGroupName,
+			}
+			expectedRouterLBGroup := &nbdb.LoadBalancerGroup{
+				UUID: types.ClusterRouterLBGroupName + "-UUID",
+				Name: types.ClusterRouterLBGroupName,
+			}
+			fakeOvn.startWithDBSetup(libovsdbtest.TestSetup{
+				NBData: []libovsdbtest.TestData{
+					&nbdb.LogicalSwitch{
+						UUID: types.OVNJoinSwitch + "-UUID",
+						Name: types.OVNJoinSwitch,
+					},
+					expectedOVNClusterRouter,
+					expectedNodeSwitch,
+					expectedClusterLBGroup,
+					expectedSwitchLBGroup,
+					expectedRouterLBGroup,
+				},
+			})
+
+			clusterIPSubnets := ovntest.MustParseIPNets("10.128.0.0/14")
+			hostSubnets := ovntest.MustParseIPNets("10.130.0.0/23")
+			joinLRPIPs := ovntest.MustParseIPNets("100.64.0.3/16")
+			defLRPIPs := ovntest.MustParseIPNets("100.64.0.1/16")
+			l3GatewayConfig := &util.L3GatewayConfig{
+				Mode:           config.GatewayModeLocal,
+				ChassisID:      "SYSTEM-ID",
+				InterfaceID:    "INTERFACE-ID",
+				MACAddress:     ovntest.MustParseMAC("11:22:33:44:55:66"),
+				IPAddresses:    ovntest.MustParseIPNets("169.254.33.2/24"),
+				NextHops:       ovntest.MustParseIPs("169.254.33.1"),
+				NodePortEnable: true,
+			}
+			sctpSupport := false
+
+			var err error
+			fakeOvn.controller.defaultCOPPUUID, err = EnsureDefaultCOPP(fakeOvn.nbClient)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			testData := []libovsdb.TestData{}
+			skipSnat := false
+			expectedOVNClusterRouter.StaticRoutes = []string{}
+			// We don't set up the Allow from mgmt port ACL here
+			mgmtPortIP := ""
+
+			err = fakeOvn.controller.gatewayInit(
+				nodeName, clusterIPSubnets, hostSubnets, l3GatewayConfig, sctpSupport, joinLRPIPs, defLRPIPs, false)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			expectedDatabaseState := generateGatewayInitExpectedNB(testData, expectedOVNClusterRouter, expectedNodeSwitch,
+				nodeName, clusterIPSubnets, hostSubnets, l3GatewayConfig, joinLRPIPs, defLRPIPs, skipSnat, mgmtPortIP,
+				"")
+			gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+
+			ginkgo.By("modifying the node join IP")
+			oldJoinLRPIPs := joinLRPIPs
+			joinLRPIPs = ovntest.MustParseIPNets("100.64.0.99/16")
+			expectedOVNClusterRouter.StaticRoutes = []string{}
+			err = fakeOvn.controller.gatewayInit(
+				nodeName, clusterIPSubnets, hostSubnets, l3GatewayConfig, sctpSupport, joinLRPIPs, defLRPIPs, true)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			expectedDatabaseState = generateGatewayInitExpectedNB(testData, expectedOVNClusterRouter, expectedNodeSwitch,
+				nodeName, clusterIPSubnets, hostSubnets, l3GatewayConfig, joinLRPIPs, defLRPIPs, skipSnat, mgmtPortIP,
+				"1400")
+			// FIXME(trozet): we do not clean up stale routes after join IP changes
+			for i, joinLRPIP := range oldJoinLRPIPs {
+				joinStaticRouteNamedUUID := fmt.Sprintf("hack-join-static-route-ovn-cluster-router-%v-UUID", i)
+				expectedOVNClusterRouter.StaticRoutes = append(expectedOVNClusterRouter.StaticRoutes, joinStaticRouteNamedUUID)
+				expectedDatabaseState = append(expectedDatabaseState, &nbdb.LogicalRouterStaticRoute{
+					UUID:     joinStaticRouteNamedUUID,
+					IPPrefix: joinLRPIP.IP.String(),
+					Nexthop:  joinLRPIP.IP.String(),
+				})
+			}
+			gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 		})
 
 		ginkgo.It("creates an IPv6 gateway in OVN", func() {

--- a/go-controller/pkg/ovn/gateway_test.go
+++ b/go-controller/pkg/ovn/gateway_test.go
@@ -192,7 +192,6 @@ func generateGatewayInitExpectedNB(testData []libovsdb.TestData, expectedOVNClus
 			"gateway-physical-ip": "yes",
 		},
 		Networks: networks,
-		Options:  options,
 	})
 
 	natUUIDs := make([]string, 0, len(clusterIPSubnets))

--- a/go-controller/pkg/ovn/gateway_test.go
+++ b/go-controller/pkg/ovn/gateway_test.go
@@ -661,6 +661,11 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 				UUID: types.ClusterRouterLBGroupName + "-UUID",
 				Name: types.ClusterRouterLBGroupName,
 			}
+			gr := types.GWRouterPrefix + nodeName
+			datapath := &sbdb.DatapathBinding{
+				UUID:        gr + "-UUID",
+				ExternalIDs: map[string]string{"logical-router": gr + "-UUID", "name": gr},
+			}
 			fakeOvn.startWithDBSetup(libovsdbtest.TestSetup{
 				NBData: []libovsdbtest.TestData{
 					&nbdb.LogicalSwitch{
@@ -672,6 +677,9 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 					expectedClusterLBGroup,
 					expectedSwitchLBGroup,
 					expectedRouterLBGroup,
+				},
+				SBData: []libovsdbtest.TestData{
+					datapath,
 				},
 			})
 

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -1223,11 +1223,12 @@ var _ = ginkgo.Describe("Default network controller operations", func() {
 			expectedNBDatabaseState = append(expectedNBDatabaseState,
 				newNodeSNAT("stale-nodeNAT-UUID-3", "10.0.0.3", externalIP.String()), // won't be deleted since pod exists on this node
 				newNodeSNAT("stale-nodeNAT-UUID-4", "10.0.0.3", "172.16.16.3"))       // won't be deleted on this node but will be deleted on the node whose IP is 172.16.16.3 since this pod belongs to this node
+			newNodeSNAT("nat-join-0-UUID", node1.LrpIP, externalIP.String()) // join subnet SNAT won't be affected by sync
 			for _, testObj := range expectedNBDatabaseState {
 				uuid := reflect.ValueOf(testObj).Elem().FieldByName("UUID").Interface().(string)
 				if uuid == types.GWRouterPrefix+node1.Name+"-UUID" {
 					GR := testObj.(*nbdb.LogicalRouter)
-					GR.Nat = []string{"stale-nodeNAT-UUID-3", "stale-nodeNAT-UUID-4"}
+					GR.Nat = []string{"stale-nodeNAT-UUID-3", "stale-nodeNAT-UUID-4", "nat-join-0-UUID"}
 					*testObj.(*nbdb.LogicalRouter) = *GR
 					break
 				}

--- a/go-controller/pkg/util/util.go
+++ b/go-controller/pkg/util/util.go
@@ -62,6 +62,22 @@ func StringArg(context *cli.Context, name string) (string, error) {
 	return val, nil
 }
 
+// GetIPNetFullMask returns an IPNet object for IPV4 or IPV6 address with a full subnet mask
+func GetIPNetFullMask(ipStr string) (*net.IPNet, error) {
+	ip := net.ParseIP(ipStr)
+	if ip == nil {
+		return nil, fmt.Errorf("failed to parse IP %q", ipStr)
+	}
+	mask := net.CIDRMask(32, 32)
+	if utilnet.IsIPv6(ip) {
+		mask = net.CIDRMask(128, 128)
+	}
+	return &net.IPNet{
+		IP:   ip,
+		Mask: mask,
+	}, nil
+}
+
 // GetIPFullMask returns /32 if ip is IPV4 family and /128 if ip is IPV6 family
 func GetIPFullMask(ip string) string {
 	const (

--- a/test/e2e/service.go
+++ b/test/e2e/service.go
@@ -330,9 +330,7 @@ var _ = ginkgo.Describe("Services", func() {
 									return fmt.Errorf("stdout does not match payloads[%s], %s != %s", size, stdout, echoPayloads[size])
 								}
 
-								if size == "large" && !hostNetwork {
-									ginkgo.By("Making sure that the ip route cache contains an MTU route")
-									// Get IP route cache and make sure that it contains an MTU route.
+								if size == "large" {
 									cmd = fmt.Sprintf("ip route get %s", serviceNodeIP)
 									stdout, err = framework.RunHostCmd(
 										clientPod.Namespace,
@@ -341,8 +339,23 @@ var _ = ginkgo.Describe("Services", func() {
 									if err != nil {
 										return fmt.Errorf("could not list IP route cache, err: %q", err)
 									}
-									if !echoMtuRegex.Match([]byte(stdout)) {
-										return fmt.Errorf("cannot find MTU cache entry in route: %s", stdout)
+									if !hostNetwork || isLocalGWModeEnabled() {
+										// with local gateway mode the packet will be sent:
+										// client -> intermediary node -> server
+										// With local gw mode, the packet will go into the host of intermediary node, where
+										// nodeport will be DNAT'ed to cluster IP service, and then hit the MTU 1400 route
+										// and trigger ICMP needs frag.
+										// MTU 1400 should be removed after bumping to OVS with https://bugzilla.redhat.com/show_bug.cgi?id=2170920
+										// fixed.
+										ginkgo.By("Making sure that the ip route cache contains an MTU route")
+										if !echoMtuRegex.Match([]byte(stdout)) {
+											return fmt.Errorf("cannot find MTU cache entry in route: %s", stdout)
+										}
+									} else {
+										ginkgo.By("Making sure that the ip route cache does NOT contain an MTU route")
+										if echoMtuRegex.Match([]byte(stdout)) {
+											framework.Failf("found unexpected MTU cache route: %s", stdout)
+										}
 									}
 								}
 								return nil

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -1060,3 +1060,8 @@ func randStr(n int) string {
 	}
 	return string(b)
 }
+
+func isLocalGWModeEnabled() bool {
+	val, present := os.LookupEnv("OVN_GATEWAY_MODE")
+	return present && val == "local"
+}


### PR DESCRIPTION
Trivial conflicts with references to things that pertain to IC or code comments that dont exist in 4.13 code. Only significant conflict was missing the GetIPNetFullMask function which I had to make slightly different from upstream due to function dependencies.