### PR TITLE
OCPBUGS-27285: Dockerfile: Bump OVS to openvswitch3.1-3.1.0-73.el9fdp

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -12,7 +12,7 @@ RUN dnf install -y --nodocs \
 	selinux-policy procps-ng && \
 	dnf clean all
 
-ARG ovsver=3.1.0-32.el9fdp
+ARG ovsver=3.1.0-73.el9fdp
 ARG ovnver=23.09.0-91.el9fdp
 
 RUN INSTALL_PKGS="iptables" && \


### PR DESCRIPTION
Includes the following relevant changes
    d4d068fef6 ovsdb-server: Fix excessive memory usage on DB open.
    - https://bugzilla.redhat.com/show_bug.cgi?id=2228464

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->