### PR TITLE
OCPBUGS-25395: [release-4.15] Update namespace-owned port group (that used to be managed by multicast)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN cd go-controller; CGO_ENABLED=1 make
 RUN cd go-controller; CGO_ENABLED=1 make windows
 
 # Build RHEL-8 binaries (for upgrades from 4.12 and earlier)
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-4.15 AS rhel8
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.15 AS rhel8
 WORKDIR /go/src/github.com/openshift/ovn-kubernetes
 COPY . .
 RUN cd go-controller; CGO_ENABLED=1 make


### PR DESCRIPTION
clean backport of https://github.com/ovn-org/ovn-kubernetes/pull/4047
d/s merge https://github.com/openshift/ovn-kubernetes/pull/1990