### PR TITLE
OCPBUGS-25395: [release-4.15] Update namespace-owned port group (that used to be managed by multicast)

### DIFF
--- a/go-controller/pkg/libovsdb/ops/portgroup.go
+++ b/go-controller/pkg/libovsdb/ops/portgroup.go
@@ -75,6 +75,20 @@ func CreateOrUpdatePortGroups(nbClient libovsdbclient.Client, pgs ...*nbdb.PortG
 	return err
 }
 
+// CreatePortGroup creates the provided port group if it doesn't exist
+func CreatePortGroup(nbClient libovsdbclient.Client, portGroup *nbdb.PortGroup) error {
+	opModel := operationModel{
+		Model:          portGroup,
+		OnModelUpdates: onModelUpdatesNone(),
+		ErrNotFound:    false,
+		BulkOp:         false,
+	}
+
+	m := newModelClient(nbClient)
+	_, err := m.CreateOrUpdate(opModel)
+	return err
+}
+
 // GetPortGroup looks up a port group from the cache
 func GetPortGroup(nbClient libovsdbclient.Client, pg *nbdb.PortGroup) (*nbdb.PortGroup, error) {
 	found := []*nbdb.PortGroup{}

--- a/go-controller/pkg/ovn/base_network_controller_pods.go
+++ b/go-controller/pkg/ovn/base_network_controller_pods.go
@@ -1148,25 +1148,3 @@ func (bnc *BaseNetworkController) wasPodReleasedBeforeStartup(uid, nad string) b
 	}
 	return bnc.releasedPodsBeforeStartup[nad].Has(uid)
 }
-
-func (bnc *BaseNetworkController) getNamespaceLSPs(ns string) ([]*nbdb.LogicalSwitchPort, error) {
-	ports := []*nbdb.LogicalSwitchPort{}
-	pods, err := bnc.watchFactory.GetPods(ns)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get pods for namespace %q: %v", ns, err)
-	}
-	for _, pod := range pods {
-		if util.PodCompleted(pod) {
-			continue
-		}
-		portInfoMap, err := bnc.logicalPortCache.getAll(pod)
-		if err != nil {
-			klog.Errorf(err.Error())
-		} else {
-			for _, portInfo := range portInfoMap {
-				ports = append(ports, &nbdb.LogicalSwitchPort{UUID: portInfo.uuid})
-			}
-		}
-	}
-	return ports, nil
-}


### PR DESCRIPTION
clean backport of https://github.com/ovn-org/ovn-kubernetes/pull/4047
d/s merge https://github.com/openshift/ovn-kubernetes/pull/1990