### PR TITLE
Support permanent session affinity

### DIFF
--- a/go-controller/pkg/libovsdbops/loadbalancer.go
+++ b/go-controller/pkg/libovsdbops/loadbalancer.go
@@ -47,13 +47,14 @@ func getNonZeroLoadBalancerMutableFields(lb *nbdb.LoadBalancer) []interface{} {
 }
 
 // BuildLoadBalancer builds a load balancer
-func BuildLoadBalancer(name string, protocol nbdb.LoadBalancerProtocol, vips, options, externalIds map[string]string) *nbdb.LoadBalancer {
+func BuildLoadBalancer(name string, protocol nbdb.LoadBalancerProtocol, selectionFields []nbdb.LoadBalancerSelectionFields, vips, options, externalIds map[string]string) *nbdb.LoadBalancer {
 	return &nbdb.LoadBalancer{
-		Name:        name,
-		Protocol:    &protocol,
-		Vips:        vips,
-		Options:     options,
-		ExternalIDs: externalIds,
+		Name:            name,
+		Protocol:        &protocol,
+		Vips:            vips,
+		SelectionFields: selectionFields,
+		Options:         options,
+		ExternalIDs:     externalIds,
 	}
 }
 

--- a/go-controller/pkg/ovn/controller/services/lb_config.go
+++ b/go-controller/pkg/ovn/controller/services/lb_config.go
@@ -768,7 +768,7 @@ func getSessionAffinityTimeOut(service *v1.Service) int32 {
 
 func hasSessionAffinityTimeOut(service *v1.Service) bool {
 	return service.Spec.SessionAffinity == v1.ServiceAffinityClientIP &&
-		getSessionAffinityTimeOut(service) > 0
+		getSessionAffinityTimeOut(service) != 86000
 }
 
 // lbOpts generates the OVN load balancer options from the kubernetes Service.


### PR DESCRIPTION
OVN drops the first packet from a given client
for every new session which is undesirable and
a regression compared to how SDN behaves (it can
be argued that this is an implementation detail
but ultimately users want same behaviour and no
drops). This is a complicated fix and will take
time.
The OVN fix will take time and in K8s there is no
affinity without a timeout unfortunately. So in
OVNKube we will introduce permanent session affinity as an alternative. Hence if user sets 86000 which is the highest timeout value it would mean no timeout. This is not how the K8s definition works, this will be an ovnkube implementation detail.
There is no harm in changing what a 1 day timeout means from it being a day to it being infinite affinity because either ways OVN only supports upto 18hours of timeout value max (UINT_MAX). So currently range 18-24 is not used and is configured as 18 itself in OVN.
So from this change forward, if timeout is set to 86000 by the user, they will get permanent session affinity.

Signed-off-by: Surya Seetharaman <suryaseetharaman.9@gmail.com>
(cherry picked from commit 357f63ac91fc44b7873e910b8a9c7837f7063e17)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
A service with affinity timeout set to 86000:
```
_uuid               : 820724ad-1d5d-4575-a8d6-0bf4a04c791e
external_ids        : {"k8s.ovn.org/kind"=Service, "k8s.ovn.org/owner"="foo/hello-world-2"}
health_check        : []
ip_port_mappings    : {}
name                : "Service_foo/hello-world-2_TCP_cluster"
options             : {event="false", hairpin_snat_ip="169.254.169.5 fd69::5", neighbor_responder=none, reject="true", skip_snat="false"}
protocol            : tcp
selection_fields    : [ip_dst, ip_src]
vips                : {"10.96.253.40:80"="10.244.0.6:8080,10.244.1.3:8080,10.244.2.3:8080"}
```
A service with timeout set to any other number:
```
_uuid               : 6094234e-251d-41ca-88b5-95b0984b25d4
external_ids        : {"k8s.ovn.org/kind"=Service, "k8s.ovn.org/owner"="foo1/hello-world-2"}
health_check        : []
ip_port_mappings    : {}
name                : "Service_foo1/hello-world-2_TCP_cluster"
options             : {affinity_timeout="10800", event="false", hairpin_snat_ip="169.254.169.5 fd69::5", neighbor_responder=none, reject="true", skip_snat="false"}
protocol            : tcp
selection_fields    : []
vips                : {"10.96.128.49:80"="10.244.0.7:8080,10.244.1.4:8080,10.244.2.4:8080"}
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->