### PR TITLE
[WIP] [release-4.14] Separate timeout for handler sync from informer sync

### DIFF
--- a/go-controller/pkg/ovn/controller/services/services_controller.go
+++ b/go-controller/pkg/ovn/controller/services/services_controller.go
@@ -169,9 +169,12 @@ func (c *Controller) Run(workers int, stopCh <-chan struct{}, runRepair, useLBGr
 	}
 	// We need node cache to be synced first, as we rely on it to properly reprogram initial per node load balancers
 	klog.Info("Waiting for node tracker caches to sync")
-	if !util.WaitForNamedCacheSyncWithTimeout(nodeControllerName, stopCh, nodeHandler.HasSynced) {
+	start := time.Now()
+	if !util.WaitForHandlerSyncWithTimeout(nodeControllerName, stopCh, nodeHandler.HasSynced) {
 		return fmt.Errorf("error syncing cache")
 	}
+	elapsed := time.Since(start)
+	klog.Infof("rravaiol: Node tracker sync took %s", elapsed)
 
 	klog.Info("Setting up event handlers for services")
 	svcHandler, err := c.serviceInformer.Informer().AddEventHandler(factory.WithUpdateHandlingForObjReplace(cache.ResourceEventHandlerFuncs{

--- a/go-controller/pkg/types/const.go
+++ b/go-controller/pkg/types/const.go
@@ -189,7 +189,12 @@ const (
 	// Logical Switch or Router Port
 	MaxLogicalPortTunnelKey = 32767
 
-	// InformerSyncTimeout is used to wait from the initial informer cache sync.
+	// InformerSyncTimeout is used when waiting for the initial informer cache sync
+	// (i.e. all existing objects should be listed by the informer).
 	// It allows ~4 list() retries with the default reflector exponential backoff config
 	InformerSyncTimeout = 20 * time.Second
+
+	// HandlerSyncTimeout is used when waiting for initial object handler sync.
+	// (i.e. all the ADD events should be processed for the existing objects by the event handler)
+	HandlerSyncTimeout = 120 * time.Second
 )

--- a/go-controller/pkg/util/sync.go
+++ b/go-controller/pkg/util/sync.go
@@ -30,3 +30,7 @@ func GetChildStopChanWithTimeout(parentStopChan <-chan struct{}, duration time.D
 func WaitForNamedCacheSyncWithTimeout(controllerName string, stopCh <-chan struct{}, cacheSyncs ...cache.InformerSynced) bool {
 	return cache.WaitForNamedCacheSync(controllerName, GetChildStopChanWithTimeout(stopCh, types.InformerSyncTimeout), cacheSyncs...)
 }
+
+func WaitForHandlerSyncWithTimeout(controllerName string, stopCh <-chan struct{}, handlerSyncs ...cache.InformerSynced) bool {
+	return cache.WaitForNamedCacheSync(controllerName, GetChildStopChanWithTimeout(stopCh, types.HandlerSyncTimeout), handlerSyncs...)
+}


### PR DESCRIPTION
The informer sync consists of completing a LIST operation for the informer cache for a given object type, while the handler sync consists of processing all the initial ADD operations we get at startup for a given event handler. 

We were using `WaitForNamedCacheSyncWithTimeout` in both cases with a timeout of 20 seconds, but the handler sync might take significantly longer, especially in large clusters where we saw that the node tracker sync timed out.

Let's increase the timeout to an arbitrary 2 minutes and, while debugging this, print how long the node tracker handler sync took to complete.
