### PR TITLE
OCPBUGS-26023: Dockerfile: Bump OVN to ovn-23.09.0-100.el9fdp

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -13,7 +13,7 @@ RUN dnf install -y --nodocs \
 	dnf clean all
 
 ARG ovsver=3.1.0-32.el9fdp
-ARG ovnver=23.09.0-91.el9fdp
+ARG ovnver=23.09.0-100.el9fdp
 
 RUN INSTALL_PKGS="iptables" && \
 	ovsver_short=$(echo "$ovsver" | cut -d'.' -f1,2) && \


### PR DESCRIPTION
Includes the following relevant change:
- Make sure affinity learnt flows are auto deleted.
  [https://issues.redhat.com/browse/OCPBUGS-26023]
  [https://issues.redhat.com/browse/FDP-257]
