### PR TITLE
OCPBUGS-23259: [release-4.12] Update leaderelection config to allow retries

### DIFF
--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -131,11 +131,14 @@ var (
 		V6JoinSubnet: "fd98::/64",
 	}
 
+	// Set Leaderelection config values based on
+	// https://github.com/openshift/enhancements/blame/84e894ead7b188a1013556e0ba6973b8463995f1/CONVENTIONS.md#L183
+
 	// MasterHA holds master HA related config options.
 	MasterHA = MasterHAConfig{
-		ElectionLeaseDuration: 60,
-		ElectionRenewDeadline: 30,
-		ElectionRetryPeriod:   20,
+		ElectionRetryPeriod:   26,
+		ElectionRenewDeadline: 107,
+		ElectionLeaseDuration: 137,
 	}
 
 	// HybridOverlay holds hybrid overlay feature config options.


### PR DESCRIPTION
cherry-pick of https://github.com/openshift/ovn-kubernetes/pull/1992

Conflicts:
	go-controller/cmd/ovnkube/ovnkube.go - remove crash handling
	go-controller/pkg/config/config.go - remove clusterManager