### PR TITLE
[release-4.13] OCPBUGS-27257: Ensure session affinity cleanup on backend removal

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -13,7 +13,7 @@ RUN dnf install -y --nodocs \
 	dnf clean all
 
 ARG ovsver=3.1.0-32.el9fdp
-ARG ovnver=23.06.1-39.el9fdp
+ARG ovnver=23.06.1-82.el9fdp
 
 RUN INSTALL_PKGS="iptables" && \
 	dnf install -y --nodocs $INSTALL_PKGS && \


### PR DESCRIPTION
Backport of https://github.com/openshift/ovn-kubernetes/pull/2021
Use ovn version 23.06.1-82.el9fdp