### PR TITLE
OCPBUGS-27852: [release-4.15] Full implementation of KEP-1669 ProxyTerminatingEndpoints + ETP=local fix

### DIFF
--- a/go-controller/pkg/node/default_node_network_controller.go
+++ b/go-controller/pkg/node/default_node_network_controller.go
@@ -1194,7 +1194,7 @@ func (nc *DefaultNodeNetworkController) reconcileConntrackUponEndpointSliceEvent
 				oldIPStr := utilnet.ParseIPSloppy(oldIP).String()
 				// upon an update event, remove conntrack entries for IP addresses that are no longer
 				// in the endpointslice, skip otherwise
-				if newEndpointSlice != nil && util.DoesEndpointSliceContainEndpoint(newEndpointSlice, oldIPStr, *oldPort.Port, *oldPort.Protocol, svc) {
+				if newEndpointSlice != nil && util.DoesEndpointSliceContainEligibleEndpoint(newEndpointSlice, oldIPStr, *oldPort.Port, *oldPort.Protocol, svc) {
 					continue
 				}
 				// upon update and delete events, flush conntrack only for UDP

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -586,7 +586,7 @@ func (npw *nodePortWatcher) AddService(service *kapi.Service) error {
 		hasLocalHostNetworkEp = false
 	} else {
 		nodeIPs := npw.nodeIPManager.ListAddresses()
-		localEndpoints = npw.GetLocalEndpointAddresses(epSlices, service)
+		localEndpoints = npw.GetLocalEligibleEndpointAddresses(epSlices, service)
 		hasLocalHostNetworkEp = util.HasLocalHostNetworkEndpoints(localEndpoints, nodeIPs)
 	}
 	// If something didn't already do it add correct Service rules
@@ -743,7 +743,7 @@ func (npw *nodePortWatcher) SyncServices(services []interface{}) error {
 			continue
 		}
 		nodeIPs := npw.nodeIPManager.ListAddresses()
-		localEndpoints := npw.GetLocalEndpointAddresses(epSlices, service)
+		localEndpoints := npw.GetLocalEligibleEndpointAddresses(epSlices, service)
 		hasLocalHostNetworkEp := util.HasLocalHostNetworkEndpoints(localEndpoints, nodeIPs)
 		npw.getAndSetServiceInfo(name, service, hasLocalHostNetworkEp, localEndpoints)
 
@@ -807,7 +807,7 @@ func (npw *nodePortWatcher) AddEndpointSlice(epSlice *discovery.EndpointSlice) e
 		// No need to continue adding the new endpoint slice, if we can't retrieve all slices for this service
 		return fmt.Errorf("error retrieving endpointslices for service %s/%s during endpointslice add: %w", svc.Namespace, svc.Name, err)
 	}
-	localEndpoints := npw.GetLocalEndpointAddresses(epSlices, svc)
+	localEndpoints := npw.GetLocalEligibleEndpointAddresses(epSlices, svc)
 	hasLocalHostNetworkEp := util.HasLocalHostNetworkEndpoints(localEndpoints, nodeIPs)
 
 	// Here we make sure the correct rules are programmed whenever an AddEndpointSlice event is
@@ -866,7 +866,7 @@ func (npw *nodePortWatcher) DeleteEndpointSlice(epSlice *discovery.EndpointSlice
 		return fmt.Errorf("error retrieving service %s/%s for endpointslice %s during endpointslice delete: %v",
 			namespacedName.Namespace, namespacedName.Name, epSlice.Name, err)
 	}
-	localEndpoints := npw.GetLocalEndpointAddresses(epSlices, svc)
+	localEndpoints := npw.GetLocalEligibleEndpointAddresses(epSlices, svc)
 	if svcConfig, exists := npw.updateServiceInfo(namespacedName, nil, &hasLocalHostNetworkEp, localEndpoints); exists {
 		// Lock the cache mutex here so we don't miss a service delete during an endpoint delete
 		// we have to do this because deleting and adding iptables rules is slow.
@@ -885,8 +885,8 @@ func (npw *nodePortWatcher) DeleteEndpointSlice(epSlice *discovery.EndpointSlice
 }
 
 // GetLocalEndpointAddresses returns a list of eligible endpoints that are local to the node
-func (npw *nodePortWatcher) GetLocalEndpointAddresses(endpointSlices []*discovery.EndpointSlice, service *kapi.Service) sets.Set[string] {
-	return util.GetLocalEndpointAddresses(endpointSlices, service, npw.nodeIPManager.nodeName)
+func (npw *nodePortWatcher) GetLocalEligibleEndpointAddresses(endpointSlices []*discovery.EndpointSlice, service *kapi.Service) sets.Set[string] {
+	return util.GetLocalEligibleEndpointAddresses(endpointSlices, service, npw.nodeIPManager.nodeName)
 }
 
 func (npw *nodePortWatcher) UpdateEndpointSlice(oldEpSlice, newEpSlice *discovery.EndpointSlice) error {
@@ -906,8 +906,8 @@ func (npw *nodePortWatcher) UpdateEndpointSlice(oldEpSlice, newEpSlice *discover
 			namespacedName.Namespace, namespacedName.Name, newEpSlice.Name, err)
 	}
 
-	oldEndpointAddresses := util.GetEndpointAddresses([]*discovery.EndpointSlice{oldEpSlice}, svc)
-	newEndpointAddresses := util.GetEndpointAddresses([]*discovery.EndpointSlice{newEpSlice}, svc)
+	oldEndpointAddresses := util.GetEligibleEndpointAddresses([]*discovery.EndpointSlice{oldEpSlice}, svc)
+	newEndpointAddresses := util.GetEligibleEndpointAddresses([]*discovery.EndpointSlice{newEpSlice}, svc)
 	if reflect.DeepEqual(oldEndpointAddresses, newEndpointAddresses) {
 		return nil
 	}
@@ -947,8 +947,8 @@ func (npw *nodePortWatcher) UpdateEndpointSlice(oldEpSlice, newEpSlice *discover
 	// endpoints has changed. For this second comparison, check first between the old endpoint slice and all current
 	// endpointslices for this service. This is a partial comparison, in case serviceInfo is not set. When it is set, compare
 	// between /all/ old endpoint slices and all new ones.
-	oldLocalEndpoints := npw.GetLocalEndpointAddresses([]*discovery.EndpointSlice{oldEpSlice}, svc)
-	newLocalEndpoints := npw.GetLocalEndpointAddresses(epSlices, svc)
+	oldLocalEndpoints := npw.GetLocalEligibleEndpointAddresses([]*discovery.EndpointSlice{oldEpSlice}, svc)
+	newLocalEndpoints := npw.GetLocalEligibleEndpointAddresses(epSlices, svc)
 	hasLocalHostNetworkEpOld := util.HasLocalHostNetworkEndpoints(oldLocalEndpoints, nodeIPs)
 	hasLocalHostNetworkEpNew := util.HasLocalHostNetworkEndpoints(newLocalEndpoints, nodeIPs)
 

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -886,7 +886,7 @@ func (npw *nodePortWatcher) DeleteEndpointSlice(epSlice *discovery.EndpointSlice
 
 // GetLocalEndpointAddresses returns a list of eligible endpoints that are local to the node
 func (npw *nodePortWatcher) GetLocalEligibleEndpointAddresses(endpointSlices []*discovery.EndpointSlice, service *kapi.Service) sets.Set[string] {
-	return util.GetLocalEligibleEndpointAddresses(endpointSlices, service, npw.nodeIPManager.nodeName)
+	return util.GetLocalEligibleEndpointAddressesFromSlices(endpointSlices, service, npw.nodeIPManager.nodeName)
 }
 
 func (npw *nodePortWatcher) UpdateEndpointSlice(oldEpSlice, newEpSlice *discovery.EndpointSlice) error {
@@ -906,8 +906,8 @@ func (npw *nodePortWatcher) UpdateEndpointSlice(oldEpSlice, newEpSlice *discover
 			namespacedName.Namespace, namespacedName.Name, newEpSlice.Name, err)
 	}
 
-	oldEndpointAddresses := util.GetEligibleEndpointAddresses([]*discovery.EndpointSlice{oldEpSlice}, svc)
-	newEndpointAddresses := util.GetEligibleEndpointAddresses([]*discovery.EndpointSlice{newEpSlice}, svc)
+	oldEndpointAddresses := util.GetEligibleEndpointAddressesFromSlices([]*discovery.EndpointSlice{oldEpSlice}, svc)
+	newEndpointAddresses := util.GetEligibleEndpointAddressesFromSlices([]*discovery.EndpointSlice{newEpSlice}, svc)
 	if reflect.DeepEqual(oldEndpointAddresses, newEndpointAddresses) {
 		return nil
 	}

--- a/go-controller/pkg/ovn/controller/services/lb_config.go
+++ b/go-controller/pkg/ovn/controller/services/lb_config.go
@@ -13,6 +13,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/apis/core"
 	utilnet "k8s.io/utils/net"
@@ -29,7 +30,9 @@ type lbConfig struct {
 	vips     []string    // just ip or the special value "node" for the node's physical IPs (i.e. NodePort)
 	protocol v1.Protocol // TCP, UDP, or SCTP
 	inport   int32       // the incoming (virtual) port number
-	eps      util.LbEndpoints
+
+	clusterEndpoints lbEndpoints            // addresses of cluster-wide endpoints
+	nodeEndpoints    map[string]lbEndpoints // node -> addresses of local endpoints
 
 	// if true, then vips added on the router are in "local" mode
 	// that means, skipSNAT, and remove any non-local endpoints.
@@ -42,69 +45,91 @@ type lbConfig struct {
 	hasNodePort bool
 }
 
-func (c *lbConfig) makeNodeSwitchTargetIPs(service *v1.Service, node *nodeInfo, epIPs []string) (targetIPs []string, changed bool) {
-	targetIPs = epIPs
-	changed = false
+type lbEndpoints struct {
+	Port  int32
+	V4IPs []string
+	V6IPs []string
+}
 
-	if c.externalTrafficLocal {
-		// for ExternalTrafficPolicy=Local, remove non-local endpoints from the router/switch targets
+func makeNodeSwitchTargetIPs(service *v1.Service, node string, c *lbConfig) (targetIPsV4, targetIPsV6 []string, v4Changed, v6Changed bool) {
+	targetIPsV4 = c.clusterEndpoints.V4IPs
+	targetIPsV6 = c.clusterEndpoints.V6IPs
+
+	if c.externalTrafficLocal || c.internalTrafficLocal {
+		// For ExternalTrafficPolicy=Local, remove non-local endpoints from the router/switch targets
 		// NOTE: on the switches, filtered eps are used only by masqueradeVIP
-		targetIPs = util.FilterIPsSlice(targetIPs, node.nodeSubnets(), true)
-	}
-
-	if c.internalTrafficLocal {
 		// for InternalTrafficPolicy=Local, remove non-local endpoints from the switch targets only
-		targetIPs = util.FilterIPsSlice(targetIPs, node.nodeSubnets(), true)
+		localIPsV4 := []string{}
+		localIPsV6 := []string{}
+		if localEndpoints, ok := c.nodeEndpoints[node]; ok {
+			localIPsV4 = localEndpoints.V4IPs
+			localIPsV6 = localEndpoints.V6IPs
+		}
+		targetIPsV4 = localIPsV4
+		targetIPsV6 = localIPsV6
 	}
 
 	// OCP HACK BEGIN
 	if _, set := service.Annotations[localWithFallbackAnnotation]; set && c.externalTrafficLocal {
 		// if service is annotated and is ETP=local, fallback to ETP=cluster on nodes with no local endpoints:
 		// include endpoints from other nodes
-		if len(targetIPs) == 0 {
-			targetIPs = epIPs
+		if len(targetIPsV4) == 0 {
+			targetIPsV4 = c.clusterEndpoints.V4IPs
+		}
+		if len(targetIPsV6) == 0 {
+			targetIPsV6 = c.clusterEndpoints.V6IPs
 		}
 	}
 	// OCP HACK END
 
-	// We potentially only removed stuff from the original slice, so just
-	// comparing lenghts is enough.
-	if len(targetIPs) != len(epIPs) {
-		changed = true
-	}
+	// Local endpoints are a subset of cluster endpoints, so it is enough to compare their length
+	v4Changed = len(targetIPsV4) != len(c.clusterEndpoints.V4IPs)
+	v6Changed = len(targetIPsV6) != len(c.clusterEndpoints.V6IPs)
+
 	return
 }
 
-func (c *lbConfig) makeNodeRouterTargetIPs(service *v1.Service, node *nodeInfo, epIPs []string, hostMasqueradeIP string) (targetIPs []string, changed, zeroRouterLocalEndpoints bool) {
-	targetIPs = epIPs
-	changed = false
+func makeNodeRouterTargetIPs(service *v1.Service, node *nodeInfo, c *lbConfig, hostMasqueradeIPV4, hostMasqueradeIPV6 string) (targetIPsV4, targetIPsV6 []string, v4Changed, v6Changed bool, zeroRouterLocalEndpointsV4, zeroRouterLocalEndpointsV6 bool) {
+	targetIPsV4 = c.clusterEndpoints.V4IPs
+	targetIPsV6 = c.clusterEndpoints.V6IPs
 
 	if c.externalTrafficLocal {
-		// for ExternalTrafficPolicy=Local, remove non-local endpoints from the router/switch targets
+		// For ExternalTrafficPolicy=Local, remove non-local endpoints from the router/switch targets
 		// NOTE: on the switches, filtered eps are used only by masqueradeVIP
-		targetIPs = util.FilterIPsSlice(targetIPs, node.nodeSubnets(), true)
+		localIPsV4 := []string{}
+		localIPsV6 := []string{}
+		if localEndpoints, ok := c.nodeEndpoints[node.name]; ok {
+			localIPsV4 = localEndpoints.V4IPs
+			localIPsV6 = localEndpoints.V6IPs
+		}
+		targetIPsV4 = localIPsV4
+		targetIPsV6 = localIPsV6
 	}
 
 	// OCP HACK BEGIN
-	zeroRouterLocalEndpoints = false
 	if _, set := service.Annotations[localWithFallbackAnnotation]; set && c.externalTrafficLocal {
 		// if service is annotated and is ETP=local, fallback to ETP=cluster on nodes with no local endpoints:
 		// include endpoints from other nodes
-		if len(targetIPs) == 0 {
-			zeroRouterLocalEndpoints = true
-			targetIPs = epIPs
+		if len(targetIPsV4) == 0 {
+			zeroRouterLocalEndpointsV4 = true
+			targetIPsV4 = c.clusterEndpoints.V4IPs
+		}
+		if len(targetIPsV6) == 0 {
+			zeroRouterLocalEndpointsV6 = true
+			targetIPsV6 = c.clusterEndpoints.V6IPs
 		}
 	}
 	// OCP HACK END
 
-	// any targets local to the node need to have a special
+	// Any targets local to the node need to have a special
 	// harpin IP added, but only for the router LB
-	targetIPs, updated := util.UpdateIPsSlice(targetIPs, node.l3gatewayAddressesStr(), []string{hostMasqueradeIP})
+	targetIPsV4, v4Updated := util.UpdateIPsSlice(targetIPsV4, node.l3gatewayAddressesStr(), []string{hostMasqueradeIPV4})
+	targetIPsV6, v6Updated := util.UpdateIPsSlice(targetIPsV6, node.l3gatewayAddressesStr(), []string{hostMasqueradeIPV6})
 
-	// We either only removed stuff from the original slice, or updated some IPs.
-	if len(targetIPs) != len(epIPs) || updated {
-		changed = true
-	}
+	// Local endpoints are a subset of cluster endpoints, so it is enough to compare their length
+	v4Changed = len(targetIPsV4) != len(c.clusterEndpoints.V4IPs) || v4Updated
+	v6Changed = len(targetIPsV6) != len(c.clusterEndpoints.V6IPs) || v6Updated
+
 	return
 }
 
@@ -135,16 +160,25 @@ var protos = []v1.Protocol{
 // Template LBs will be created for
 //   - services with NodePort set but *without* ExternalTrafficPolicy=Local or
 //     affinity timeout set.
-func buildServiceLBConfigs(service *v1.Service, endpointSlices []*discovery.EndpointSlice, useLBGroup, useTemplates bool) (perNodeConfigs, templateConfigs, clusterConfigs []lbConfig) {
+func buildServiceLBConfigs(service *v1.Service, endpointSlices []*discovery.EndpointSlice, nodeInfos []nodeInfo, useLBGroup, useTemplates bool) (perNodeConfigs, templateConfigs, clusterConfigs []lbConfig) {
 	needsAffinityTimeout := hasSessionAffinityTimeOut(service)
 
-	// For each svcPort, determine if it will be applied per-node or cluster-wide
+	nodes := sets.New[string]()
+	for _, n := range nodeInfos {
+		nodes.Insert(n.name)
+	}
+	// get all the endpoints classified by port and by port,node
+	portToClusterEndpoints, portToNodeToEndpoints := getEndpointsForService(endpointSlices, service, nodes)
 	for _, svcPort := range service.Spec.Ports {
-		eps := util.GetLbEndpoints(endpointSlices, svcPort, service)
-
+		svcPortKey := getServicePortKey(svcPort.Protocol, svcPort.Name)
+		clusterEndpoints := portToClusterEndpoints[svcPortKey]
+		nodeEndpoints := portToNodeToEndpoints[svcPortKey]
+		if nodeEndpoints == nil {
+			nodeEndpoints = make(map[string]lbEndpoints)
+		}
 		// if ExternalTrafficPolicy or InternalTrafficPolicy is local, then we need to do things a bit differently
-		externalTrafficLocal := (service.Spec.ExternalTrafficPolicy == v1.ServiceExternalTrafficPolicyTypeLocal)
-		internalTrafficLocal := (service.Spec.InternalTrafficPolicy != nil) && (*service.Spec.InternalTrafficPolicy == v1.ServiceInternalTrafficPolicyLocal)
+		externalTrafficLocal := util.ServiceExternalTrafficPolicyLocal(service)
+		internalTrafficLocal := util.ServiceInternalTrafficPolicyLocal(service)
 
 		// NodePort services get a per-node load balancer, but with the node's physical IP as the vip
 		// Thus, the vip "node" will be expanded later.
@@ -154,15 +188,15 @@ func buildServiceLBConfigs(service *v1.Service, endpointSlices []*discovery.Endp
 				protocol:             svcPort.Protocol,
 				inport:               svcPort.NodePort,
 				vips:                 []string{placeholderNodeIPs}, // shortcut for all-physical-ips
-				eps:                  eps,
+				clusterEndpoints:     clusterEndpoints,
+				nodeEndpoints:        nodeEndpoints,
 				externalTrafficLocal: externalTrafficLocal,
 				internalTrafficLocal: false, // always false for non-ClusterIPs
 				hasNodePort:          true,
 			}
 			// Only "plain" NodePort services (no ETP, no affinity timeout)
 			// can use load balancer templates.
-			if !useLBGroup || !useTemplates || externalTrafficLocal ||
-				needsAffinityTimeout {
+			if !useLBGroup || !useTemplates || externalTrafficLocal || needsAffinityTimeout {
 				perNodeConfigs = append(perNodeConfigs, nodePortLBConfig)
 			} else {
 				templateConfigs = append(templateConfigs, nodePortLBConfig)
@@ -181,7 +215,8 @@ func buildServiceLBConfigs(service *v1.Service, endpointSlices []*discovery.Endp
 				protocol:             svcPort.Protocol,
 				inport:               svcPort.Port,
 				vips:                 externalVips,
-				eps:                  eps,
+				clusterEndpoints:     clusterEndpoints,
+				nodeEndpoints:        nodeEndpoints,
 				externalTrafficLocal: true,
 				internalTrafficLocal: false, // always false for non-ClusterIPs
 				hasNodePort:          false,
@@ -197,7 +232,8 @@ func buildServiceLBConfigs(service *v1.Service, endpointSlices []*discovery.Endp
 			protocol:             svcPort.Protocol,
 			inport:               svcPort.Port,
 			vips:                 vips,
-			eps:                  eps,
+			clusterEndpoints:     clusterEndpoints,
+			nodeEndpoints:        nodeEndpoints,
 			externalTrafficLocal: false, // always false for ClusterIPs
 			internalTrafficLocal: internalTrafficLocal,
 			hasNodePort:          false,
@@ -210,7 +246,7 @@ func buildServiceLBConfigs(service *v1.Service, endpointSlices []*discovery.Endp
 		// - OCP only HACK: It's an openshift-dns:default-dns service
 		//
 		// In that case, we need to create per-node LBs.
-		if hasHostEndpoints(eps.V4IPs) || hasHostEndpoints(eps.V6IPs) || internalTrafficLocal ||
+		if hasHostEndpoints(clusterEndpoints.V4IPs) || hasHostEndpoints(clusterEndpoints.V6IPs) || internalTrafficLocal ||
 			// OCP only hack begin
 			(service.Namespace == "openshift-dns" && service.Name == "dns-default") {
 			// OCP only hack end
@@ -286,19 +322,19 @@ func buildClusterLBs(service *v1.Service, configs []lbConfig, nodeInfos []nodeIn
 					service.Namespace, service.Name)
 			}
 
-			v4targets := make([]Addr, 0, len(config.eps.V4IPs))
-			for _, tgt := range config.eps.V4IPs {
+			v4targets := make([]Addr, 0, len(config.clusterEndpoints.V4IPs))
+			for _, targetIP := range config.clusterEndpoints.V4IPs {
 				v4targets = append(v4targets, Addr{
-					IP:   tgt,
-					Port: config.eps.Port,
+					IP:   targetIP,
+					Port: config.clusterEndpoints.Port,
 				})
 			}
 
-			v6targets := make([]Addr, 0, len(config.eps.V6IPs))
-			for _, tgt := range config.eps.V6IPs {
+			v6targets := make([]Addr, 0, len(config.clusterEndpoints.V6IPs))
+			for _, targetIP := range config.clusterEndpoints.V6IPs {
 				v6targets = append(v6targets, Addr{
-					IP:   tgt,
-					Port: config.eps.Port,
+					IP:   targetIP,
+					Port: config.clusterEndpoints.Port,
 				})
 			}
 
@@ -385,8 +421,11 @@ func buildTemplateLBs(service *v1.Service, configs []lbConfig, nodes []nodeInfo,
 						service, proto, config.inport,
 						optsV6.AddressFamily, "node_router_template"))
 
+			allV4TargetIPs := config.clusterEndpoints.V4IPs
+			allV6TargetIPs := config.clusterEndpoints.V6IPs
+
 			for range config.vips {
-				klog.V(5).Infof(" buildTemplateLBs() service %s/%s adding rules", service.Namespace, service.Name)
+				klog.V(5).Infof("buildTemplateLBs() service %s/%s adding rules", service.Namespace, service.Name)
 
 				// If all targets have exactly the same IPs on all nodes there's
 				// no need to use a template, just use the same list of explicit
@@ -397,42 +436,47 @@ func buildTemplateLBs(service *v1.Service, configs []lbConfig, nodes []nodeInfo,
 				routerV6TargetNeedsTemplate := false
 
 				for _, node := range nodes {
-					switchV4targetips, changed := config.makeNodeSwitchTargetIPs(service, &node, config.eps.V4IPs)
-					if !switchV4TargetNeedsTemplate && changed {
+
+					switchV4TargetIPs, switchV6TargetIPs, v4Changed, v6Changed := makeNodeSwitchTargetIPs(service, node.name, &config)
+					if !switchV4TargetNeedsTemplate && v4Changed {
 						switchV4TargetNeedsTemplate = true
 					}
-					switchV6targetips, changed := config.makeNodeSwitchTargetIPs(service, &node, config.eps.V6IPs)
-					if !switchV6TargetNeedsTemplate && changed {
+					if !switchV6TargetNeedsTemplate && v6Changed {
 						switchV6TargetNeedsTemplate = true
 					}
 
-					routerV4targetips, changed, _ := config.makeNodeRouterTargetIPs(service, &node, config.eps.V4IPs, conf.Gateway.MasqueradeIPs.V4HostMasqueradeIP.String())
-					if !routerV4TargetNeedsTemplate && changed {
+					routerV4TargetIPs, routerV6TargetIPs, v4Changed, v6Changed, _, _ := makeNodeRouterTargetIPs(
+						service,
+						&node,
+						&config,
+						conf.Gateway.MasqueradeIPs.V4HostMasqueradeIP.String(),
+						conf.Gateway.MasqueradeIPs.V6HostMasqueradeIP.String())
+
+					if !routerV4TargetNeedsTemplate && v4Changed {
 						routerV4TargetNeedsTemplate = true
 					}
-					routerV6targetips, changed, _ := config.makeNodeRouterTargetIPs(service, &node, config.eps.V6IPs, conf.Gateway.MasqueradeIPs.V6HostMasqueradeIP.String())
-					if !routerV6TargetNeedsTemplate && changed {
+					if !routerV6TargetNeedsTemplate && v6Changed {
 						routerV6TargetNeedsTemplate = true
 					}
 
 					switchV4TemplateTarget.Value[node.chassisID] = addrsToString(
-						joinHostsPort(switchV4targetips, config.eps.Port))
+						joinHostsPort(switchV4TargetIPs, config.clusterEndpoints.Port))
 					switchV6TemplateTarget.Value[node.chassisID] = addrsToString(
-						joinHostsPort(switchV6targetips, config.eps.Port))
+						joinHostsPort(switchV6TargetIPs, config.clusterEndpoints.Port))
 
 					routerV4TemplateTarget.Value[node.chassisID] = addrsToString(
-						joinHostsPort(routerV4targetips, config.eps.Port))
+						joinHostsPort(routerV4TargetIPs, config.clusterEndpoints.Port))
 					routerV6TemplateTarget.Value[node.chassisID] = addrsToString(
-						joinHostsPort(routerV6targetips, config.eps.Port))
+						joinHostsPort(routerV6TargetIPs, config.clusterEndpoints.Port))
 				}
 
 				sharedV4Targets := []Addr{}
 				sharedV6Targets := []Addr{}
 				if !switchV4TargetNeedsTemplate || !routerV4TargetNeedsTemplate {
-					sharedV4Targets = joinHostsPort(config.eps.V4IPs, config.eps.Port)
+					sharedV4Targets = joinHostsPort(allV4TargetIPs, config.clusterEndpoints.Port)
 				}
 				if !switchV6TargetNeedsTemplate || !routerV6TargetNeedsTemplate {
-					sharedV6Targets = joinHostsPort(config.eps.V6IPs, config.eps.Port)
+					sharedV6Targets = joinHostsPort(allV6TargetIPs, config.clusterEndpoints.Port)
 				}
 
 				for _, nodeIPv4Template := range nodeIPv4Templates.AsTemplates() {
@@ -555,8 +599,8 @@ func buildTemplateLBs(service *v1.Service, configs []lbConfig, nodes []nodeInfo,
 // buildPerNodeLBs takes a list of lbConfigs and expands them to one LB per protocol per node
 //
 // Per-node lbs are created for
-// - clusterip services with host-network endpoints are attached to each node's gateway router + switch
-// - nodeport services are attached to each node's gateway router + switch, vips are node's physical IPs (except if etp=local+ovnk backend pods)
+// - clusterip services with host-network endpoints, which are attached to each node's gateway router + switch
+// - nodeport services are attached to each node's gateway router + switch, vips are the node's physical IPs (except if etp=local+ovnk backend pods)
 // - any services with host-network endpoints
 // - services with external IPs / LoadBalancer Status IPs
 //
@@ -564,10 +608,10 @@ func buildTemplateLBs(service *v1.Service, configs []lbConfig, nodes []nodeInfo,
 // see https://github.com/ovn-org/ovn-kubernetes/blob/master/docs/design/host_to_services_OpenFlow.md
 // This is for host -> serviceip -> host hairpin
 //
-// For ExternalTrafficPolicy, all "External" IPs (NodePort, ExternalIPs, Loadbalancer Status) have:
+// For ExternalTrafficPolicy=local, all "External" IPs (NodePort, ExternalIPs, Loadbalancer Status) have:
 // - targets filtered to only local targets
 // - SkipSNAT enabled
-// - NP LB on the switch will have masqueradeIP as the vip to handle etp=local for LGW case.
+// - NodePort LB on the switch will have masqueradeIP as the vip to handle etp=local for LGW case.
 // This results in the creation of an additional load balancer on the GatewayRouters and NodeSwitches.
 func buildPerNodeLBs(service *v1.Service, configs []lbConfig, nodes []nodeInfo) []LB {
 	cbp := configsByProto(configs)
@@ -575,8 +619,7 @@ func buildPerNodeLBs(service *v1.Service, configs []lbConfig, nodes []nodeInfo) 
 
 	out := make([]LB, 0, len(nodes)*len(configs))
 
-	// output is one LB per node per protocol
-	// with one rule per vip
+	// output is one LB per node per protocol with one rule per vip
 	for _, node := range nodes {
 		for _, proto := range protos {
 			configs, ok := cbp[proto]
@@ -586,39 +629,43 @@ func buildPerNodeLBs(service *v1.Service, configs []lbConfig, nodes []nodeInfo) 
 
 			// attach to router & switch,
 			// rules may or may not be different
-			// localRouterRules are rules with no snat
 			routerRules := make([]LBRule, 0, len(configs))
 			noSNATRouterRules := make([]LBRule, 0)
 			switchRules := make([]LBRule, 0, len(configs))
 
 			for _, config := range configs {
-				switchV4targetips, _ := config.makeNodeSwitchTargetIPs(service, &node, config.eps.V4IPs)
-				switchV6targetips, _ := config.makeNodeSwitchTargetIPs(service, &node, config.eps.V6IPs)
 
-				routerV4targetips, _, zeroRouterV4LocalEndpoints := config.makeNodeRouterTargetIPs(service, &node, config.eps.V4IPs, conf.Gateway.MasqueradeIPs.V4HostMasqueradeIP.String())
-				routerV6targetips, _, zeroRouterV6LocalEndpoints := config.makeNodeRouterTargetIPs(service, &node, config.eps.V6IPs, conf.Gateway.MasqueradeIPs.V6HostMasqueradeIP.String())
+				switchV4TargetIPs, switchV6TargetIPs, _, _ := makeNodeSwitchTargetIPs(service, node.name, &config)
 
-				routerV4targets := joinHostsPort(routerV4targetips, config.eps.Port)
-				routerV6targets := joinHostsPort(routerV6targetips, config.eps.Port)
+				routerV4TargetIPs, routerV6TargetIPs, _, _, zeroRouterV4LocalEndpoints, zeroRouterV6LocalEndpoints := makeNodeRouterTargetIPs(
+					service,
+					&node,
+					&config,
+					conf.Gateway.MasqueradeIPs.V4HostMasqueradeIP.String(),
+					conf.Gateway.MasqueradeIPs.V6HostMasqueradeIP.String())
 
-				switchV4targets := joinHostsPort(config.eps.V4IPs, config.eps.Port)
-				switchV6targets := joinHostsPort(config.eps.V6IPs, config.eps.Port)
+				routerV4targets := joinHostsPort(routerV4TargetIPs, config.clusterEndpoints.Port)
+				routerV6targets := joinHostsPort(routerV6TargetIPs, config.clusterEndpoints.Port)
+
+				switchV4targets := joinHostsPort(config.clusterEndpoints.V4IPs, config.clusterEndpoints.Port)
+				switchV6targets := joinHostsPort(config.clusterEndpoints.V6IPs, config.clusterEndpoints.Port)
 
 				// OCP HACK begin
 				// TODO: Remove this hack once we add support for ITP:preferLocal and DNS operator starts using it.
 				if service.Namespace == "openshift-dns" && service.Name == "dns-default" {
-					// Filter out endpoints that are local to this node.
-					switchV4targetDNSips := util.FilterIPsSlice(config.eps.V4IPs, node.podSubnets, true)
-					switchV6targetDNSips := util.FilterIPsSlice(config.eps.V6IPs, node.podSubnets, true)
-					// If no local endpoints were found add all the endpoints as targets.
+					// Select endpoints that are local to this node.
+					switchV4targetDNSips := util.FilterIPsSlice(config.clusterEndpoints.V4IPs, node.podSubnets, true)
+					switchV6targetDNSips := util.FilterIPsSlice(config.clusterEndpoints.V6IPs, node.podSubnets, true)
+
+					// If no local endpoints were found, add all the endpoints as targets.
 					if len(switchV4targetDNSips) == 0 {
-						switchV4targetDNSips = config.eps.V4IPs
+						switchV4targetDNSips = config.clusterEndpoints.V4IPs
 					}
 					if len(switchV6targetDNSips) == 0 {
-						switchV6targetDNSips = config.eps.V6IPs
+						switchV6targetDNSips = config.clusterEndpoints.V6IPs
 					}
-					switchV4targets = joinHostsPort(switchV4targetDNSips, config.eps.Port)
-					switchV6targets = joinHostsPort(switchV6targetDNSips, config.eps.Port)
+					switchV4targets = joinHostsPort(switchV4targetDNSips, config.clusterEndpoints.Port)
+					switchV6targets = joinHostsPort(switchV6targetDNSips, config.clusterEndpoints.Port)
 				}
 				// OCP HACK end
 
@@ -644,10 +691,10 @@ func buildPerNodeLBs(service *v1.Service, configs []lbConfig, nodes []nodeInfo) 
 					if config.externalTrafficLocal && config.hasNodePort {
 						// add special masqueradeIP as a vip if its nodePort svc with ETP=local
 						mvip := conf.Gateway.MasqueradeIPs.V4HostETPLocalMasqueradeIP.String()
-						targetsETP := joinHostsPort(switchV4targetips, config.eps.Port)
+						targetsETP := joinHostsPort(switchV4TargetIPs, config.clusterEndpoints.Port)
 						if isv6 {
 							mvip = conf.Gateway.MasqueradeIPs.V6HostETPLocalMasqueradeIP.String()
-							targetsETP = joinHostsPort(switchV6targetips, config.eps.Port)
+							targetsETP = joinHostsPort(switchV6TargetIPs, config.clusterEndpoints.Port)
 						}
 						switchRules = append(switchRules, LBRule{
 							Source:  Addr{IP: mvip, Port: config.inport},
@@ -655,9 +702,9 @@ func buildPerNodeLBs(service *v1.Service, configs []lbConfig, nodes []nodeInfo) 
 						})
 					}
 					if config.internalTrafficLocal && util.IsClusterIP(vip) { // ITP only applicable to CIP
-						targetsITP := joinHostsPort(switchV4targetips, config.eps.Port)
+						targetsITP := joinHostsPort(switchV4TargetIPs, config.clusterEndpoints.Port)
 						if isv6 {
-							targetsITP = joinHostsPort(switchV6targetips, config.eps.Port)
+							targetsITP = joinHostsPort(switchV6TargetIPs, config.clusterEndpoints.Port)
 						}
 						switchRules = append(switchRules, LBRule{
 							Source:  Addr{IP: vip, Port: config.inport},
@@ -878,4 +925,118 @@ func joinHostsPort(ips []string, port int32) []Addr {
 		out = append(out, Addr{IP: ip, Port: port})
 	}
 	return out
+}
+
+func getServicePortKey(protocol v1.Protocol, name string) string {
+	return fmt.Sprintf("%s/%s", protocol, name)
+}
+
+// GetEndpointsForService takes a service, all its slices and the list of nodes in the OVN zone
+// and returns two maps that hold all the endpoint addresses for the service:
+// one classified by port, one classified by port,node. This second map is only filled in
+// when the service needs local (per-node) endpoints, that is when ETP=local or ITP=local.
+// The node list helps to keep the resulting map small, since we're only interested in local endpoints.
+func getEndpointsForService(slices []*discovery.EndpointSlice, service *v1.Service, nodes sets.Set[string]) (map[string]lbEndpoints, map[string]map[string]lbEndpoints) {
+	// classify endpoints
+	ports := map[string]int32{}
+	portToEndpoints := map[string][]discovery.Endpoint{}
+	portToNodeToEndpoints := map[string]map[string][]discovery.Endpoint{}
+	requiresLocalEndpoints := util.ServiceExternalTrafficPolicyLocal(service) || util.ServiceInternalTrafficPolicyLocal(service)
+
+	for _, port := range service.Spec.Ports {
+		name := getServicePortKey(port.Protocol, port.Name)
+		ports[name] = 0
+	}
+
+	for _, slice := range slices {
+
+		if slice.AddressType == discovery.AddressTypeFQDN {
+			continue // consider only v4 and v6, discard FQDN
+		}
+
+		slicePorts := make([]string, 0, len(slice.Ports))
+
+		for _, port := range slice.Ports {
+			// check if there's a service port matching the slice protocol/name
+			slicePortName := ""
+			if port.Name != nil {
+				slicePortName = *port.Name
+			}
+			name := getServicePortKey(*port.Protocol, slicePortName)
+			if _, hasPort := ports[name]; hasPort {
+				slicePorts = append(slicePorts, name)
+				ports[name] = *port.Port
+				continue
+			}
+			// service port name might be empty: check against slice protocol/""
+			noName := getServicePortKey(*port.Protocol, "")
+			if _, hasPort := ports[noName]; hasPort {
+				slicePorts = append(slicePorts, name)
+				ports[noName] = *port.Port
+			}
+		}
+		for _, endpoint := range slice.Endpoints {
+			for _, port := range slicePorts {
+
+				portToEndpoints[port] = append(portToEndpoints[port], endpoint)
+
+				// won't add items to portToNodeToEndpoints if  the service doesn't need it,
+				// the endpoint is not assigned to a node yet or the endpoint is not local to the OVN zone
+				if !requiresLocalEndpoints || endpoint.NodeName == nil || !nodes.Has(*endpoint.NodeName) {
+					continue
+				}
+				if portToNodeToEndpoints[port] == nil {
+					portToNodeToEndpoints[port] = make(map[string][]discovery.Endpoint, len(nodes))
+				}
+
+				if portToNodeToEndpoints[port][*endpoint.NodeName] == nil {
+					portToNodeToEndpoints[port][*endpoint.NodeName] = []discovery.Endpoint{}
+				}
+				portToNodeToEndpoints[port][*endpoint.NodeName] = append(portToNodeToEndpoints[port][*endpoint.NodeName], endpoint)
+			}
+		}
+	}
+
+	// get eligible endpoint addresses
+	portToLBEndpoints := make(map[string]lbEndpoints, len(portToEndpoints))
+	portToNodeToLBEndpoints := make(map[string]map[string]lbEndpoints, len(portToEndpoints))
+
+	for port, endpoints := range portToEndpoints {
+		addresses := util.GetEligibleEndpointAddresses(endpoints, service)
+		v4IPs, _ := util.MatchAllIPStringFamily(false, addresses)
+		v6IPs, _ := util.MatchAllIPStringFamily(true, addresses)
+		if len(v4IPs) > 0 || len(v6IPs) > 0 {
+			portToLBEndpoints[port] = lbEndpoints{
+				V4IPs: v4IPs,
+				V6IPs: v6IPs,
+				Port:  ports[port],
+			}
+		}
+	}
+	klog.V(5).Infof("Cluster endpoints for %s/%s are: %v", service.Namespace, service.Name, portToLBEndpoints)
+
+	for port, nodeToEndpoints := range portToNodeToEndpoints {
+		for node, endpoints := range nodeToEndpoints {
+			addresses := util.GetEligibleEndpointAddresses(endpoints, service)
+			v4IPs, _ := util.MatchAllIPStringFamily(false, addresses)
+			v6IPs, _ := util.MatchAllIPStringFamily(true, addresses)
+			if len(v4IPs) > 0 || len(v6IPs) > 0 {
+				if portToNodeToLBEndpoints[port] == nil {
+					portToNodeToLBEndpoints[port] = make(map[string]lbEndpoints, len(nodes))
+				}
+
+				portToNodeToLBEndpoints[port][node] = lbEndpoints{
+					V4IPs: v4IPs,
+					V6IPs: v6IPs,
+					Port:  ports[port],
+				}
+			}
+		}
+	}
+
+	if requiresLocalEndpoints {
+		klog.V(5).Infof("Local endpoints for %s/%s are: %v", service.Namespace, service.Name, portToNodeToLBEndpoints)
+	}
+
+	return portToLBEndpoints, portToNodeToLBEndpoints
 }

--- a/go-controller/pkg/ovn/controller/services/lb_config_test.go
+++ b/go-controller/pkg/ovn/controller/services/lb_config_test.go
@@ -7,16 +7,117 @@ import (
 	"time"
 
 	globalconfig "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	kube_test "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 	"github.com/stretchr/testify/assert"
 
 	v1 "k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/sets"
 	utilpointer "k8s.io/utils/pointer"
 )
+
+var (
+	nodeA        = "node-a"
+	nodeB        = "node-b"
+	defaultNodes = []nodeInfo{
+		{
+			name:               nodeA,
+			l3gatewayAddresses: []net.IP{net.ParseIP("10.0.0.1")},
+			hostAddresses:      []net.IP{net.ParseIP("10.0.0.1")},
+			gatewayRouterName:  "gr-node-a",
+			switchName:         "switch-node-a",
+		},
+		{
+			name:               nodeB,
+			l3gatewayAddresses: []net.IP{net.ParseIP("10.0.0.2")},
+			hostAddresses:      []net.IP{net.ParseIP("10.0.0.2")},
+			gatewayRouterName:  "gr-node-b",
+			switchName:         "switch-node-b",
+		},
+	}
+
+	tcpv1 = v1.ProtocolTCP
+	udpv1 = v1.ProtocolUDP
+
+	httpPortName    string = "http"
+	httpPortValue   int32  = int32(80)
+	httpsPortName   string = "https"
+	httpsPortValue  int32  = int32(443)
+	customPortName  string = "customApp"
+	customPortValue int32  = int32(10600)
+)
+
+func getSampleService(publishNotReadyAddresses bool) *v1.Service {
+	name := "service-test"
+	namespace := "test"
+	return &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:       k8stypes.UID(namespace),
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: v1.ServiceSpec{
+			PublishNotReadyAddresses: publishNotReadyAddresses,
+		},
+	}
+}
+
+func getServicePort(name string, targetPort int32, protocol v1.Protocol) v1.ServicePort {
+	return v1.ServicePort{
+		Name:       name,
+		TargetPort: intstr.FromInt(int(httpPortValue)),
+		Protocol:   protocol,
+	}
+}
+
+func getSampleServiceWithOnePort(name string, targetPort int32, protocol v1.Protocol) *v1.Service {
+	service := getSampleService(false)
+	service.Spec.Ports = []v1.ServicePort{getServicePort(name, targetPort, protocol)}
+	return service
+}
+
+func getSampleServiceWithOnePortAndETPLocal(name string, targetPort int32, protocol v1.Protocol) *v1.Service {
+	service := getSampleServiceWithOnePort(name, targetPort, protocol)
+	service.Spec.Type = v1.ServiceTypeLoadBalancer
+	service.Spec.ExternalTrafficPolicy = v1.ServiceExternalTrafficPolicyLocal
+	return service
+}
+
+// OCP hack begin
+func getSampleServiceWithOnePortAndITPLocal(name string, targetPort int32, protocol v1.Protocol) *v1.Service {
+	service := getSampleServiceWithOnePort(name, targetPort, protocol)
+	service.Spec.Type = v1.ServiceTypeLoadBalancer
+	local := v1.ServiceInternalTrafficPolicyLocal
+	service.Spec.InternalTrafficPolicy = &local
+	return service
+}
+
+// OCP hack end
+
+func getSampleServiceWithTwoPorts(name1, name2 string, targetPort1, targetPort2 int32, protocol1, protocol2 v1.Protocol) *v1.Service {
+	service := getSampleService(false)
+	service.Spec.Ports = []v1.ServicePort{
+		getServicePort(name1, targetPort1, protocol1),
+		getServicePort(name2, targetPort2, protocol2)}
+	return service
+}
+
+func getSampleServiceWithTwoPortsAndETPLocal(name1, name2 string, targetPort1, targetPort2 int32, protocol1, protocol2 v1.Protocol) *v1.Service {
+	service := getSampleServiceWithTwoPorts(name1, name2, targetPort1, targetPort2, protocol1, protocol2)
+	service.Spec.Type = v1.ServiceTypeLoadBalancer
+	service.Spec.ExternalTrafficPolicy = v1.ServiceExternalTrafficPolicyLocal
+	return service
+}
+
+func getSampleServiceWithOnePortAndPublishNotReadyAddresses(name string, targetPort int32, protocol v1.Protocol) *v1.Service {
+	service := getSampleServiceWithOnePort(name, targetPort, protocol)
+	service.Spec.PublishNotReadyAddresses = true
+	return service
+}
 
 func Test_buildServiceLBConfigs(t *testing.T) {
 	oldClusterSubnet := globalconfig.Default.ClusterSubnets
@@ -39,7 +140,6 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 	inport1 := int32(81)
 	outport1 := int32(8081)
 	outportstr := intstr.FromInt(int(outport))
-	emptyEPs := util.LbEndpoints{V4IPs: []string{}, V6IPs: []string{}, Port: 0}
 	tcp := v1.ProtocolTCP
 	udp := v1.ProtocolUDP
 
@@ -72,14 +172,7 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 					Name:     &portName,
 				}},
 				AddressType: discovery.AddressTypeIPv4,
-				Endpoints: []discovery.Endpoint{
-					{
-						Conditions: discovery.EndpointConditions{
-							Ready: utilpointer.Bool(true),
-						},
-						Addresses: v4ips,
-					},
-				},
+				Endpoints:   kube_test.MakeReadyEndpointList(nodeA, v4ips...),
 			})
 		}
 
@@ -107,18 +200,29 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 					Name:     &portName,
 				}},
 				AddressType: discovery.AddressTypeIPv6,
-				Endpoints: []discovery.Endpoint{
-					{
-						Conditions: discovery.EndpointConditions{
-							Ready: utilpointer.Bool(true),
-						},
-						Addresses: v6ips,
-					},
-				},
+				Endpoints:   kube_test.MakeReadyEndpointList(nodeA, v6ips...),
 			})
 		}
 
 		return out
+	}
+
+	makeV4SliceWithEndpoints := func(proto v1.Protocol, endpoints ...discovery.Endpoint) []*discovery.EndpointSlice {
+		e := &discovery.EndpointSlice{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      serviceName + "ab1",
+				Namespace: ns,
+				Labels:    map[string]string{discovery.LabelServiceName: serviceName},
+			},
+			Ports: []discovery.EndpointPort{{
+				Protocol: &proto,
+				Port:     &outport,
+				Name:     &portName,
+			}},
+			AddressType: discovery.AddressTypeIPv4,
+			Endpoints:   endpoints,
+		}
+		return []*discovery.EndpointSlice{e}
 	}
 
 	type args struct {
@@ -150,6 +254,7 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 						ClusterIP:  "192.168.1.1",
 						ClusterIPs: []string{"192.168.1.1"},
 						Ports: []v1.ServicePort{{
+							Name:       portName,
 							Port:       inport,
 							Protocol:   v1.ProtocolTCP,
 							TargetPort: outportstr,
@@ -158,10 +263,11 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 				},
 			},
 			resultSharedGatewayCluster: []lbConfig{{
-				vips:     []string{"192.168.1.1"},
-				protocol: v1.ProtocolTCP,
-				inport:   80,
-				eps:      emptyEPs,
+				vips:             []string{"192.168.1.1"},
+				protocol:         v1.ProtocolTCP,
+				inport:           80,
+				clusterEndpoints: lbEndpoints{},
+				nodeEndpoints:    map[string]lbEndpoints{},
 			}},
 			resultsSame: true,
 		},
@@ -176,6 +282,7 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 						ClusterIP:  "192.168.1.1",
 						ClusterIPs: []string{"192.168.1.1"},
 						Ports: []v1.ServicePort{{
+							Name:       portName,
 							Port:       inport,
 							Protocol:   v1.ProtocolTCP,
 							TargetPort: outportstr,
@@ -187,16 +294,53 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 				vips:     []string{"192.168.1.1"},
 				protocol: v1.ProtocolTCP,
 				inport:   inport,
-				eps: util.LbEndpoints{
+				clusterEndpoints: lbEndpoints{
 					V4IPs: []string{"10.128.0.2"},
-					V6IPs: []string{},
 					Port:  outport,
+				},
+				nodeEndpoints: map[string]lbEndpoints{}, // service is not ETP=local or ITP=local, so nodeEndpoints is not filled out
+			}},
+			resultsSame: true,
+		},
+		{
+			name: "v4 type=LoadBalancer, ETP=local, one port, endpoints",
+			args: args{
+				slices: makeSlices([]string{"10.128.0.2"}, nil, v1.ProtocolTCP),
+				service: &v1.Service{
+					ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: ns},
+					Spec: v1.ServiceSpec{
+						Type:                  v1.ServiceTypeLoadBalancer,
+						ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyLocal,
+						ClusterIP:             "192.168.1.1",
+						ClusterIPs:            []string{"192.168.1.1"},
+						Ports: []v1.ServicePort{{
+							Name:       portName,
+							Port:       inport,
+							Protocol:   v1.ProtocolTCP,
+							TargetPort: outportstr,
+						}},
+					},
+				},
+			},
+			resultSharedGatewayCluster: []lbConfig{{
+				vips:     []string{"192.168.1.1"},
+				protocol: v1.ProtocolTCP,
+				inport:   inport,
+				clusterEndpoints: lbEndpoints{
+					V4IPs: []string{"10.128.0.2"},
+					Port:  outport,
+				},
+				nodeEndpoints: map[string]lbEndpoints{ // service is ETP=local, so nodeEndpoints is filled out
+					nodeA: {
+						V4IPs: []string{"10.128.0.2"},
+						Port:  outport,
+					},
 				},
 			}},
 			resultsSame: true,
 		},
 		{
-			name: "v4 clusterip, two tcp ports, endpoints",
+			name: "v4 clusterip, two tcp ports, two endpoints",
 			args: args{
 				slices: []*discovery.EndpointSlice{
 					{
@@ -217,14 +361,7 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 							},
 						},
 						AddressType: discovery.AddressTypeIPv4,
-						Endpoints: []discovery.Endpoint{
-							{
-								Conditions: discovery.EndpointConditions{
-									Ready: utilpointer.Bool(true),
-								},
-								Addresses: []string{"10.128.0.2", "10.128.1.2"},
-							},
-						},
+						Endpoints:   kube_test.MakeReadyEndpointList(nodeA, "10.128.0.2", "10.128.1.2"),
 					},
 				},
 				service: &v1.Service{
@@ -256,26 +393,26 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 					vips:     []string{"192.168.1.1"},
 					protocol: v1.ProtocolTCP,
 					inport:   inport,
-					eps: util.LbEndpoints{
+					clusterEndpoints: lbEndpoints{
 						V4IPs: []string{"10.128.0.2", "10.128.1.2"},
-						V6IPs: []string{},
 						Port:  outport,
 					},
+					nodeEndpoints: map[string]lbEndpoints{},
 				},
 				{
 					vips:     []string{"192.168.1.1"},
 					protocol: v1.ProtocolTCP,
 					inport:   inport1,
-					eps: util.LbEndpoints{
+					clusterEndpoints: lbEndpoints{
 						V4IPs: []string{"10.128.0.2", "10.128.1.2"},
-						V6IPs: []string{},
 						Port:  outport1,
 					},
+					nodeEndpoints: map[string]lbEndpoints{},
 				},
 			},
 		},
 		{
-			name: "v4 clusterip, one tcp, one udp port, endpoints",
+			name: "v4 clusterip, one tcp, one udp port, two endpoints",
 			args: args{
 				slices: []*discovery.EndpointSlice{
 					{
@@ -296,14 +433,7 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 							},
 						},
 						AddressType: discovery.AddressTypeIPv4,
-						Endpoints: []discovery.Endpoint{
-							{
-								Conditions: discovery.EndpointConditions{
-									Ready: utilpointer.Bool(true),
-								},
-								Addresses: []string{"10.128.0.2", "10.128.1.2"},
-							},
-						},
+						Endpoints:   kube_test.MakeReadyEndpointList(nodeA, "10.128.0.2", "10.128.1.2"),
 					},
 				},
 				service: &v1.Service{
@@ -335,21 +465,21 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 					vips:     []string{"192.168.1.1"},
 					protocol: v1.ProtocolTCP,
 					inport:   inport,
-					eps: util.LbEndpoints{
+					clusterEndpoints: lbEndpoints{
 						V4IPs: []string{"10.128.0.2", "10.128.1.2"},
-						V6IPs: []string{},
 						Port:  outport,
 					},
+					nodeEndpoints: map[string]lbEndpoints{},
 				},
 				{
 					vips:     []string{"192.168.1.1"},
 					protocol: v1.ProtocolUDP,
 					inport:   inport,
-					eps: util.LbEndpoints{
+					clusterEndpoints: lbEndpoints{
 						V4IPs: []string{"10.128.0.2", "10.128.1.2"},
-						V6IPs: []string{},
 						Port:  outport,
 					},
+					nodeEndpoints: map[string]lbEndpoints{},
 				},
 			},
 		},
@@ -364,6 +494,7 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 						ClusterIP:  "192.168.1.1",
 						ClusterIPs: []string{"192.168.1.1", "2002::1"},
 						Ports: []v1.ServicePort{{
+							Name:       portName,
 							Port:       inport,
 							Protocol:   v1.ProtocolTCP,
 							TargetPort: outportstr,
@@ -376,11 +507,12 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 				vips:     []string{"192.168.1.1", "2002::1"},
 				protocol: v1.ProtocolTCP,
 				inport:   inport,
-				eps: util.LbEndpoints{
+				clusterEndpoints: lbEndpoints{
 					V4IPs: []string{"10.128.0.2"},
 					V6IPs: []string{"fe00::1:1"},
 					Port:  outport,
 				},
+				nodeEndpoints: map[string]lbEndpoints{},
 			}},
 		},
 		{
@@ -394,6 +526,7 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 						ClusterIP:  "192.168.1.1",
 						ClusterIPs: []string{"192.168.1.1", "2002::1"},
 						Ports: []v1.ServicePort{{
+							Name:       portName,
 							Port:       inport,
 							Protocol:   v1.ProtocolTCP,
 							TargetPort: outportstr,
@@ -414,15 +547,16 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 				vips:     []string{"192.168.1.1", "2002::1", "4.2.2.2", "42::42", "5.5.5.5"},
 				protocol: v1.ProtocolTCP,
 				inport:   inport,
-				eps: util.LbEndpoints{
+				clusterEndpoints: lbEndpoints{
 					V4IPs: []string{"10.128.0.2"},
 					V6IPs: []string{"fe00::1:1"},
 					Port:  outport,
 				},
+				nodeEndpoints: map[string]lbEndpoints{}, // ETP=cluster (default), so nodeEndpoints is not filled out
 			}},
 		},
 		{
-			name: "dual-stack clusterip, one port, endpoints, external ips + lb status, ExternalTrafficPolicy",
+			name: "dual-stack clusterip, one port, endpoints, external ips + lb status, ExternalTrafficPolicy=local",
 			args: args{
 				slices: makeSlices([]string{"10.128.0.2"}, []string{"fe00::1:1"}, v1.ProtocolTCP),
 				service: &v1.Service{
@@ -433,6 +567,7 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 						ClusterIPs:            []string{"192.168.1.1", "2002::1"},
 						ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeLocal,
 						Ports: []v1.ServicePort{{
+							Name:       portName,
 							Port:       inport,
 							Protocol:   v1.ProtocolTCP,
 							TargetPort: outportstr,
@@ -454,10 +589,17 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 					vips:     []string{"192.168.1.1", "2002::1"},
 					protocol: v1.ProtocolTCP,
 					inport:   inport,
-					eps: util.LbEndpoints{
+					clusterEndpoints: lbEndpoints{
 						V4IPs: []string{"10.128.0.2"},
 						V6IPs: []string{"fe00::1:1"},
 						Port:  outport,
+					},
+					nodeEndpoints: map[string]lbEndpoints{
+						nodeA: {
+							V4IPs: []string{"10.128.0.2"},
+							V6IPs: []string{"fe00::1:1"},
+							Port:  outport,
+						},
 					},
 				},
 			},
@@ -467,10 +609,17 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 					protocol:             v1.ProtocolTCP,
 					inport:               inport,
 					externalTrafficLocal: true,
-					eps: util.LbEndpoints{
+					clusterEndpoints: lbEndpoints{
 						V4IPs: []string{"10.128.0.2"},
 						V6IPs: []string{"fe00::1:1"},
 						Port:  outport,
+					},
+					nodeEndpoints: map[string]lbEndpoints{
+						nodeA: {
+							V4IPs: []string{"10.128.0.2"},
+							V6IPs: []string{"fe00::1:1"},
+							Port:  outport,
+						},
 					},
 				},
 			},
@@ -486,6 +635,7 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 						ClusterIP:  "192.168.1.1",
 						ClusterIPs: []string{"192.168.1.1", "2002::1"},
 						Ports: []v1.ServicePort{{
+							Name:       portName,
 							Port:       inport,
 							Protocol:   v1.ProtocolTCP,
 							TargetPort: outportstr,
@@ -499,22 +649,24 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 				vips:     []string{"192.168.1.1", "2002::1"},
 				protocol: v1.ProtocolTCP,
 				inport:   inport,
-				eps: util.LbEndpoints{
+				clusterEndpoints: lbEndpoints{
 					V4IPs: []string{"10.128.0.2"},
 					V6IPs: []string{"fe00::1:1"},
 					Port:  outport,
 				},
+				nodeEndpoints: map[string]lbEndpoints{},
 			}},
 			resultSharedGatewayTemplate: []lbConfig{{
 				vips:     []string{"node"},
 				protocol: v1.ProtocolTCP,
 				inport:   5,
-				eps: util.LbEndpoints{
+				clusterEndpoints: lbEndpoints{
 					V4IPs: []string{"10.128.0.2"},
 					V6IPs: []string{"fe00::1:1"},
 					Port:  outport,
 				},
-				hasNodePort: true,
+				nodeEndpoints: map[string]lbEndpoints{},
+				hasNodePort:   true,
 			}},
 		},
 		{
@@ -529,6 +681,7 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 						ClusterIP:  "192.168.1.1",
 						ClusterIPs: []string{"192.168.1.1", "2002::1"},
 						Ports: []v1.ServicePort{{
+							Name:       portName,
 							Port:       inport,
 							Protocol:   v1.ProtocolTCP,
 							TargetPort: outportstr,
@@ -543,11 +696,12 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 					vips:     []string{"192.168.1.1", "2002::1"},
 					protocol: v1.ProtocolTCP,
 					inport:   inport,
-					eps: util.LbEndpoints{
+					clusterEndpoints: lbEndpoints{
 						V4IPs: []string{"192.168.0.1"},
 						V6IPs: []string{"2001::1"},
 						Port:  outport,
 					},
+					nodeEndpoints: map[string]lbEndpoints{},
 				},
 			},
 			resultSharedGatewayTemplate: []lbConfig{
@@ -555,12 +709,13 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 					vips:     []string{"node"},
 					protocol: v1.ProtocolTCP,
 					inport:   5,
-					eps: util.LbEndpoints{
+					clusterEndpoints: lbEndpoints{
 						V4IPs: []string{"192.168.0.1"},
 						V6IPs: []string{"2001::1"},
 						Port:  outport,
 					},
-					hasNodePort: true,
+					nodeEndpoints: map[string]lbEndpoints{},
+					hasNodePort:   true,
 				},
 			},
 			// in local gateway mode, only nodePort is per-node
@@ -569,11 +724,12 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 					vips:     []string{"192.168.1.1", "2002::1"},
 					protocol: v1.ProtocolTCP,
 					inport:   inport,
-					eps: util.LbEndpoints{
+					clusterEndpoints: lbEndpoints{
 						V4IPs: []string{"192.168.0.1"},
 						V6IPs: []string{"2001::1"},
 						Port:  outport,
 					},
+					nodeEndpoints: map[string]lbEndpoints{},
 				},
 			},
 			resultLocalGatewayTemplate: []lbConfig{
@@ -581,12 +737,13 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 					vips:     []string{"node"},
 					protocol: v1.ProtocolTCP,
 					inport:   5,
-					eps: util.LbEndpoints{
+					clusterEndpoints: lbEndpoints{
 						V4IPs: []string{"192.168.0.1"},
 						V6IPs: []string{"2001::1"},
 						Port:  outport,
 					},
-					hasNodePort: true,
+					nodeEndpoints: map[string]lbEndpoints{},
+					hasNodePort:   true,
 				},
 			},
 		},
@@ -603,6 +760,7 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 						ClusterIPs:            []string{"192.168.1.1", "2002::1"},
 						ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeLocal,
 						Ports: []v1.ServicePort{{
+							Name:       portName,
 							Port:       inport,
 							Protocol:   v1.ProtocolTCP,
 							TargetPort: outportstr,
@@ -617,10 +775,17 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 					vips:     []string{"node"},
 					protocol: v1.ProtocolTCP,
 					inport:   5,
-					eps: util.LbEndpoints{
+					clusterEndpoints: lbEndpoints{
 						V4IPs: []string{"192.168.0.1"},
 						V6IPs: []string{"2001::1"},
 						Port:  outport,
+					},
+					nodeEndpoints: map[string]lbEndpoints{
+						nodeA: {
+							V4IPs: []string{"192.168.0.1"},
+							V6IPs: []string{"2001::1"},
+							Port:  outport,
+						},
 					},
 					externalTrafficLocal: true,
 					hasNodePort:          true,
@@ -629,10 +794,17 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 					vips:     []string{"192.168.1.1", "2002::1"},
 					protocol: v1.ProtocolTCP,
 					inport:   inport,
-					eps: util.LbEndpoints{
+					clusterEndpoints: lbEndpoints{
 						V4IPs: []string{"192.168.0.1"},
 						V6IPs: []string{"2001::1"},
 						Port:  outport,
+					},
+					nodeEndpoints: map[string]lbEndpoints{
+						nodeA: {
+							V4IPs: []string{"192.168.0.1"},
+							V6IPs: []string{"2001::1"},
+							Port:  outport,
+						},
 					},
 				},
 			},
@@ -641,10 +813,17 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 					vips:     []string{"node"},
 					protocol: v1.ProtocolTCP,
 					inport:   5,
-					eps: util.LbEndpoints{
+					clusterEndpoints: lbEndpoints{
 						V4IPs: []string{"192.168.0.1"},
 						V6IPs: []string{"2001::1"},
 						Port:  outport,
+					},
+					nodeEndpoints: map[string]lbEndpoints{
+						nodeA: {
+							V4IPs: []string{"192.168.0.1"},
+							V6IPs: []string{"2001::1"},
+							Port:  outport,
+						},
 					},
 					externalTrafficLocal: true,
 					hasNodePort:          true,
@@ -653,10 +832,17 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 					vips:     []string{"192.168.1.1", "2002::1"},
 					protocol: v1.ProtocolTCP,
 					inport:   inport,
-					eps: util.LbEndpoints{
+					clusterEndpoints: lbEndpoints{
 						V4IPs: []string{"192.168.0.1"},
 						V6IPs: []string{"2001::1"},
 						Port:  outport,
+					},
+					nodeEndpoints: map[string]lbEndpoints{
+						nodeA: {
+							V4IPs: []string{"192.168.0.1"},
+							V6IPs: []string{"2001::1"},
+							Port:  outport,
+						},
 					},
 				},
 			},
@@ -673,6 +859,7 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 						ClusterIP:  "192.168.1.1",
 						ClusterIPs: []string{"192.168.1.1", "2002::1"},
 						Ports: []v1.ServicePort{{
+							Name:       portName,
 							Port:       inport,
 							Protocol:   v1.ProtocolTCP,
 							TargetPort: outportstr,
@@ -686,11 +873,12 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 					vips:     []string{"192.168.1.1", "2002::1"},
 					protocol: v1.ProtocolTCP,
 					inport:   inport,
-					eps: util.LbEndpoints{
+					clusterEndpoints: lbEndpoints{
 						V4IPs: []string{"192.168.0.1"},
 						V6IPs: []string{"2001::1"},
 						Port:  outport,
 					},
+					nodeEndpoints: map[string]lbEndpoints{},
 				},
 			},
 			resultLocalGatewayNode: []lbConfig{
@@ -698,10 +886,299 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 					vips:     []string{"192.168.1.1", "2002::1"},
 					protocol: v1.ProtocolTCP,
 					inport:   inport,
-					eps: util.LbEndpoints{
+					clusterEndpoints: lbEndpoints{
 						V4IPs: []string{"192.168.0.1"},
 						V6IPs: []string{"2001::1"},
 						Port:  outport,
+					},
+					nodeEndpoints: map[string]lbEndpoints{},
+				},
+			},
+		},
+		{
+			name: "LB service with NodePort, one port, two endpoints, external ips + lb status, ExternalTrafficPolicy=local",
+			args: args{
+				slices: makeV4SliceWithEndpoints(
+					v1.ProtocolTCP,
+					kube_test.MakeReadyEndpoint(nodeA, "10.128.0.2"),
+					kube_test.MakeReadyEndpoint(nodeB, "10.128.1.2"),
+				),
+				service: &v1.Service{
+					ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: ns},
+					Spec: v1.ServiceSpec{
+						Type:                  v1.ServiceTypeLoadBalancer,
+						ClusterIP:             "192.168.1.1",
+						ClusterIPs:            []string{"192.168.1.1"},
+						ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeLocal,
+						Ports: []v1.ServicePort{{
+							Name:       portName,
+							Port:       inport,
+							Protocol:   v1.ProtocolTCP,
+							TargetPort: outportstr,
+							NodePort:   5,
+						}},
+						ExternalIPs: []string{"4.2.2.2"},
+					},
+					Status: v1.ServiceStatus{
+						LoadBalancer: v1.LoadBalancerStatus{
+							Ingress: []v1.LoadBalancerIngress{{
+								IP: "5.5.5.5",
+							}},
+						},
+					},
+				},
+			},
+			resultsSame: true,
+			resultSharedGatewayCluster: []lbConfig{
+				{
+					vips:     []string{"192.168.1.1"},
+					protocol: v1.ProtocolTCP,
+					inport:   inport,
+					clusterEndpoints: lbEndpoints{
+						V4IPs: []string{"10.128.0.2", "10.128.1.2"},
+						Port:  outport,
+					},
+					nodeEndpoints: map[string]lbEndpoints{
+						nodeA: {
+							V4IPs: []string{"10.128.0.2"},
+							Port:  outport,
+						},
+						nodeB: {
+							V4IPs: []string{"10.128.1.2"},
+							Port:  outport,
+						},
+					},
+				},
+			},
+			resultSharedGatewayNode: []lbConfig{
+				{
+					vips:                 []string{"node"},
+					protocol:             v1.ProtocolTCP,
+					inport:               5,
+					hasNodePort:          true,
+					externalTrafficLocal: true,
+					clusterEndpoints: lbEndpoints{
+						V4IPs: []string{"10.128.0.2", "10.128.1.2"},
+						Port:  outport,
+					},
+					nodeEndpoints: map[string]lbEndpoints{
+						nodeA: {
+							V4IPs: []string{"10.128.0.2"},
+							Port:  outport,
+						},
+						nodeB: {
+							V4IPs: []string{"10.128.1.2"},
+							Port:  outport,
+						},
+					},
+				},
+				{
+					vips:                 []string{"4.2.2.2", "5.5.5.5"},
+					protocol:             v1.ProtocolTCP,
+					inport:               inport,
+					hasNodePort:          false,
+					externalTrafficLocal: true,
+					clusterEndpoints: lbEndpoints{
+						V4IPs: []string{"10.128.0.2", "10.128.1.2"},
+						Port:  outport,
+					},
+					nodeEndpoints: map[string]lbEndpoints{
+						nodeA: {
+							V4IPs: []string{"10.128.0.2"},
+							Port:  outport,
+						},
+						nodeB: {
+							V4IPs: []string{"10.128.1.2"},
+							Port:  outport,
+						},
+					},
+				},
+			},
+		},
+		{
+			// The fallback to terminating&serving only if there are no ready endpoints
+			// is not done at this stage: we just include candidate endpoints, that is  ready + terminating&serving.
+			// The test below will just show both endpoints in its output.
+			name: "LB service with NodePort, port, two endpoints, external ips + lb status, ExternalTrafficPolicy=local, one endpoint is ready, the other one is terminating and serving",
+			args: args{
+				slices: makeV4SliceWithEndpoints(v1.ProtocolTCP,
+					kube_test.MakeReadyEndpoint(nodeA, "10.128.0.2"),
+					kube_test.MakeTerminatingServingEndpoint(nodeB, "10.128.1.2")),
+				service: &v1.Service{
+					ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: ns},
+					Spec: v1.ServiceSpec{
+						Type:                  v1.ServiceTypeLoadBalancer,
+						ClusterIP:             "192.168.1.1",
+						ClusterIPs:            []string{"192.168.1.1"},
+						ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeLocal,
+						Ports: []v1.ServicePort{{
+							Name:       portName,
+							Port:       inport,
+							Protocol:   v1.ProtocolTCP,
+							TargetPort: outportstr,
+							NodePort:   5,
+						}},
+						ExternalIPs: []string{"4.2.2.2"},
+					},
+					Status: v1.ServiceStatus{
+						LoadBalancer: v1.LoadBalancerStatus{
+							Ingress: []v1.LoadBalancerIngress{{
+								IP: "5.5.5.5",
+							}},
+						},
+					},
+				},
+			},
+			resultsSame: true,
+			resultSharedGatewayCluster: []lbConfig{
+				{
+					vips:     []string{"192.168.1.1"},
+					protocol: v1.ProtocolTCP,
+					inport:   inport,
+					clusterEndpoints: lbEndpoints{
+						V4IPs: []string{"10.128.0.2"},
+						Port:  outport,
+					},
+					nodeEndpoints: map[string]lbEndpoints{
+						nodeA: {
+							V4IPs: []string{"10.128.0.2"},
+							Port:  outport,
+						},
+						nodeB: {
+							V4IPs: []string{"10.128.1.2"}, // fallback to terminating & serving on nodeB
+							Port:  outport,
+						},
+					},
+				},
+			},
+			resultSharedGatewayNode: []lbConfig{
+				{
+					vips:                 []string{"node"},
+					protocol:             v1.ProtocolTCP,
+					inport:               5,
+					hasNodePort:          true,
+					externalTrafficLocal: true,
+					clusterEndpoints: lbEndpoints{
+						V4IPs: []string{"10.128.0.2"},
+						Port:  outport,
+					},
+					nodeEndpoints: map[string]lbEndpoints{
+						nodeA: {
+							V4IPs: []string{"10.128.0.2"},
+							Port:  outport,
+						},
+						nodeB: {
+							V4IPs: []string{"10.128.1.2"}, // fallback to terminating & serving on nodeB
+							Port:  outport,
+						},
+					},
+				},
+				{
+					vips:                 []string{"4.2.2.2", "5.5.5.5"},
+					protocol:             v1.ProtocolTCP,
+					inport:               inport,
+					hasNodePort:          false,
+					externalTrafficLocal: true,
+					clusterEndpoints: lbEndpoints{
+						V4IPs: []string{"10.128.0.2"},
+						Port:  outport,
+					},
+					nodeEndpoints: map[string]lbEndpoints{
+						nodeA: {
+							V4IPs: []string{"10.128.0.2"},
+							Port:  outport,
+						},
+						nodeB: {
+							V4IPs: []string{"10.128.1.2"}, // fallback to terminating & serving on nodeB
+							Port:  outport,
+						},
+					},
+				},
+			},
+		},
+		{
+			// Terminating & non-serving endpoints are filtered out by buildServiceLBConfigs
+			name: "LB service with NodePort, one port, two endpoints, external ips + lb status, ExternalTrafficPolicy=local, both endpoints terminating: one is serving, the other one is not",
+			args: args{
+				slices: makeV4SliceWithEndpoints(v1.ProtocolTCP,
+					kube_test.MakeTerminatingServingEndpoint(nodeA, "10.128.0.2"),
+					kube_test.MakeTerminatingNonServingEndpoint(nodeB, "10.128.1.2")),
+				service: &v1.Service{
+					ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: ns},
+					Spec: v1.ServiceSpec{
+						Type:                  v1.ServiceTypeLoadBalancer,
+						ClusterIP:             "192.168.1.1",
+						ClusterIPs:            []string{"192.168.1.1"},
+						ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeLocal,
+						Ports: []v1.ServicePort{{
+							Name:       portName,
+							Port:       inport,
+							Protocol:   v1.ProtocolTCP,
+							TargetPort: outportstr,
+							NodePort:   5,
+						}},
+						ExternalIPs: []string{"4.2.2.2"},
+					},
+					Status: v1.ServiceStatus{
+						LoadBalancer: v1.LoadBalancerStatus{
+							Ingress: []v1.LoadBalancerIngress{{
+								IP: "5.5.5.5",
+							}},
+						},
+					},
+				},
+			},
+			resultsSame: true,
+			resultSharedGatewayCluster: []lbConfig{
+				{
+					vips:     []string{"192.168.1.1"},
+					protocol: v1.ProtocolTCP,
+					inport:   inport,
+					clusterEndpoints: lbEndpoints{
+						V4IPs: []string{"10.128.0.2"},
+						Port:  outport,
+					},
+					nodeEndpoints: map[string]lbEndpoints{
+						nodeA: {
+							V4IPs: []string{"10.128.0.2"},
+							Port:  outport,
+						},
+					},
+				},
+			},
+			resultSharedGatewayNode: []lbConfig{
+				{
+					vips:                 []string{"node"},
+					protocol:             v1.ProtocolTCP,
+					inport:               5,
+					hasNodePort:          true,
+					externalTrafficLocal: true,
+					clusterEndpoints: lbEndpoints{
+						V4IPs: []string{"10.128.0.2"},
+						Port:  outport,
+					},
+					nodeEndpoints: map[string]lbEndpoints{
+						nodeA: {
+							V4IPs: []string{"10.128.0.2"},
+							Port:  outport,
+						},
+					},
+				},
+				{
+					vips:                 []string{"4.2.2.2", "5.5.5.5"},
+					protocol:             v1.ProtocolTCP,
+					inport:               inport,
+					hasNodePort:          false,
+					externalTrafficLocal: true,
+					clusterEndpoints: lbEndpoints{
+						V4IPs: []string{"10.128.0.2"},
+						Port:  outport,
+					},
+					nodeEndpoints: map[string]lbEndpoints{
+						nodeA: {
+							V4IPs: []string{"10.128.0.2"},
+							Port:  outport,
+						},
 					},
 				},
 			},
@@ -710,14 +1187,17 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 
 	for i, tt := range tests {
 		t.Run(fmt.Sprintf("%d_%s", i, tt.name), func(t *testing.T) {
+			// shared gateway mode
 			globalconfig.Gateway.Mode = globalconfig.GatewayModeShared
-			perNode, template, clusterWide := buildServiceLBConfigs(tt.args.service, tt.args.slices, true, true)
+			perNode, template, clusterWide := buildServiceLBConfigs(tt.args.service, tt.args.slices, defaultNodes, true, true)
+
 			assert.EqualValues(t, tt.resultSharedGatewayNode, perNode, "SGW per-node configs should be equal")
 			assert.EqualValues(t, tt.resultSharedGatewayTemplate, template, "SGW template configs should be equal")
 			assert.EqualValues(t, tt.resultSharedGatewayCluster, clusterWide, "SGW cluster-wide configs should be equal")
 
+			// local gateway mode
 			globalconfig.Gateway.Mode = globalconfig.GatewayModeLocal
-			perNode, template, clusterWide = buildServiceLBConfigs(tt.args.service, tt.args.slices, true, true)
+			perNode, template, clusterWide = buildServiceLBConfigs(tt.args.service, tt.args.slices, defaultNodes, true, true)
 			if tt.resultsSame {
 				assert.EqualValues(t, tt.resultSharedGatewayNode, perNode, "LGW per-node configs should be equal")
 				assert.EqualValues(t, tt.resultSharedGatewayTemplate, template, "LGW template configs should be equal")
@@ -748,23 +1228,6 @@ func Test_buildClusterLBs(t *testing.T) {
 		},
 	}
 
-	defaultNodes := []nodeInfo{
-		{
-			name:               "node-a",
-			l3gatewayAddresses: []net.IP{net.ParseIP("10.0.0.1")},
-			hostAddresses:      []net.IP{net.ParseIP("10.0.0.1")},
-			gatewayRouterName:  "gr-node-a",
-			switchName:         "switch-node-a",
-		},
-		{
-			name:               "node-b",
-			l3gatewayAddresses: []net.IP{net.ParseIP("10.0.0.2")},
-			hostAddresses:      []net.IP{net.ParseIP("10.0.0.2")},
-			gatewayRouterName:  "gr-node-b",
-			switchName:         "switch-node-b",
-		},
-	}
-
 	defaultExternalIDs := map[string]string{
 		types.LoadBalancerKindExternalID:  "Service",
 		types.LoadBalancerOwnerExternalID: fmt.Sprintf("%s/%s", namespace, name),
@@ -790,18 +1253,30 @@ func Test_buildClusterLBs(t *testing.T) {
 					vips:     []string{"1.2.3.4"},
 					protocol: v1.ProtocolTCP,
 					inport:   80,
-					eps: util.LbEndpoints{
+					clusterEndpoints: lbEndpoints{
 						V4IPs: []string{"192.168.0.1", "192.168.0.2"},
 						Port:  8080,
+					},
+					nodeEndpoints: map[string]lbEndpoints{
+						nodeA: {
+							V4IPs: []string{"192.168.0.1", "192.168.0.2"},
+							Port:  8080,
+						},
 					},
 				},
 				{
 					vips:     []string{"1.2.3.4"},
 					protocol: v1.ProtocolTCP,
 					inport:   443,
-					eps: util.LbEndpoints{
+					clusterEndpoints: lbEndpoints{
 						V4IPs: []string{"192.168.0.1"},
 						Port:  8043,
+					},
+					nodeEndpoints: map[string]lbEndpoints{
+						nodeA: {
+							V4IPs: []string{"192.168.0.1"},
+							Port:  8043,
+						},
 					},
 				},
 			},
@@ -837,18 +1312,30 @@ func Test_buildClusterLBs(t *testing.T) {
 					vips:     []string{"1.2.3.4"},
 					protocol: v1.ProtocolTCP,
 					inport:   80,
-					eps: util.LbEndpoints{
+					clusterEndpoints: lbEndpoints{
 						V4IPs: []string{"192.168.0.1", "192.168.0.2"},
 						Port:  8080,
+					},
+					nodeEndpoints: map[string]lbEndpoints{
+						nodeA: {
+							V4IPs: []string{"192.168.0.1", "192.168.0.2"},
+							Port:  8080,
+						},
 					},
 				},
 				{
 					vips:     []string{"1.2.3.4"},
 					protocol: v1.ProtocolUDP,
 					inport:   443,
-					eps: util.LbEndpoints{
+					clusterEndpoints: lbEndpoints{
 						V4IPs: []string{"192.168.0.1"},
 						Port:  8043,
+					},
+					nodeEndpoints: map[string]lbEndpoints{
+						nodeA: {
+							V4IPs: []string{"192.168.0.1"},
+							Port:  8043,
+						},
 					},
 				},
 			},
@@ -896,20 +1383,36 @@ func Test_buildClusterLBs(t *testing.T) {
 					vips:     []string{"1.2.3.4", "fe80::1"},
 					protocol: v1.ProtocolTCP,
 					inport:   80,
-					eps: util.LbEndpoints{
+					clusterEndpoints: lbEndpoints{
 						V4IPs: []string{"192.168.0.1", "192.168.0.2"},
 						V6IPs: []string{"fe90::1", "fe91::1"},
-						Port:  8080,
+
+						Port: 8080,
+					},
+					nodeEndpoints: map[string]lbEndpoints{
+						nodeA: {
+							V4IPs: []string{"192.168.0.1", "192.168.0.2"},
+							V6IPs: []string{"fe90::1", "fe91::1"},
+							Port:  8080,
+						},
 					},
 				},
 				{
 					vips:     []string{"1.2.3.4", "fe80::1"},
 					protocol: v1.ProtocolTCP,
 					inport:   443,
-					eps: util.LbEndpoints{
+					clusterEndpoints: lbEndpoints{
 						V4IPs: []string{"192.168.0.1"},
 						V6IPs: []string{"fe90::1"},
-						Port:  8043,
+
+						Port: 8043,
+					},
+					nodeEndpoints: map[string]lbEndpoints{
+						nodeA: {
+							V4IPs: []string{"192.168.0.1"},
+							V6IPs: []string{"fe90::1"},
+							Port:  8043,
+						},
 					},
 				},
 			},
@@ -946,7 +1449,6 @@ func Test_buildClusterLBs(t *testing.T) {
 			},
 		},
 	}
-
 	for i, tt := range tc {
 		t.Run(fmt.Sprintf("%d_%s", i, tt.name), func(t *testing.T) {
 			actual := buildClusterLBs(tt.service, tt.configs, tt.nodeInfos, true)
@@ -958,15 +1460,20 @@ func Test_buildClusterLBs(t *testing.T) {
 func Test_buildPerNodeLBs(t *testing.T) {
 	oldClusterSubnet := globalconfig.Default.ClusterSubnets
 	oldGwMode := globalconfig.Gateway.Mode
+	oldServiceCIDRs := globalconfig.Kubernetes.ServiceCIDRs
 	defer func() {
 		globalconfig.Gateway.Mode = oldGwMode
 		globalconfig.Default.ClusterSubnets = oldClusterSubnet
+		globalconfig.Kubernetes.ServiceCIDRs = oldServiceCIDRs
 	}()
+
 	_, cidr4, _ := net.ParseCIDR("10.128.0.0/16")
 	_, cidr6, _ := net.ParseCIDR("fe00::/64")
 	globalconfig.Default.ClusterSubnets = []globalconfig.CIDRNetworkEntry{{cidr4, 26}, {cidr6, 26}}
-	_, svcCIDRs, _ := net.ParseCIDR("192.168.0.0/24")
-	globalconfig.Kubernetes.ServiceCIDRs = []*net.IPNet{svcCIDRs}
+	_, svcCIDRv4, _ := net.ParseCIDR("192.168.0.0/24")
+	_, svcCIDRv6, _ := net.ParseCIDR("fd92::0/80")
+
+	globalconfig.Kubernetes.ServiceCIDRs = []*net.IPNet{svcCIDRv4}
 
 	name := "foo"
 	namespace := "testns"
@@ -980,7 +1487,7 @@ func Test_buildPerNodeLBs(t *testing.T) {
 
 	defaultNodes := []nodeInfo{
 		{
-			name:               "node-a",
+			name:               nodeA,
 			l3gatewayAddresses: []net.IP{net.ParseIP("10.0.0.1")},
 			hostAddresses:      []net.IP{net.ParseIP("10.0.0.1"), net.ParseIP("10.0.0.111")},
 			gatewayRouterName:  "gr-node-a",
@@ -988,12 +1495,31 @@ func Test_buildPerNodeLBs(t *testing.T) {
 			podSubnets:         []net.IPNet{{IP: net.ParseIP("10.128.0.0"), Mask: net.CIDRMask(24, 32)}},
 		},
 		{
-			name:               "node-b",
+			name:               nodeB,
 			l3gatewayAddresses: []net.IP{net.ParseIP("10.0.0.2")},
 			hostAddresses:      []net.IP{net.ParseIP("10.0.0.2")},
 			gatewayRouterName:  "gr-node-b",
 			switchName:         "switch-node-b",
 			podSubnets:         []net.IPNet{{IP: net.ParseIP("10.128.1.0"), Mask: net.CIDRMask(24, 32)}},
+		},
+	}
+
+	defaultNodesV6 := []nodeInfo{
+		{
+			name:               nodeA,
+			l3gatewayAddresses: []net.IP{net.ParseIP("fd00::1")},
+			hostAddresses:      []net.IP{net.ParseIP("fd00::1"), net.ParseIP("fd00::111")},
+			gatewayRouterName:  "gr-node-a",
+			switchName:         "switch-node-a",
+			podSubnets:         []net.IPNet{{IP: net.ParseIP("fe00:0:0:0:1::0"), Mask: net.CIDRMask(64, 64)}},
+		},
+		{
+			name:               nodeB,
+			l3gatewayAddresses: []net.IP{net.ParseIP("fd00::2")},
+			hostAddresses:      []net.IP{net.ParseIP("fd00::2")},
+			gatewayRouterName:  "gr-node-b",
+			switchName:         "switch-node-b",
+			podSubnets:         []net.IPNet{{IP: net.ParseIP("fe00:0:0:0:2::0"), Mask: net.CIDRMask(64, 64)}},
 		},
 	}
 
@@ -1021,9 +1547,15 @@ func Test_buildPerNodeLBs(t *testing.T) {
 					vips:     []string{"1.2.3.4"},
 					protocol: v1.ProtocolTCP,
 					inport:   80,
-					eps: util.LbEndpoints{
+					clusterEndpoints: lbEndpoints{
 						V4IPs: []string{"10.0.0.1"},
 						Port:  8080,
+					},
+					nodeEndpoints: map[string]lbEndpoints{
+						nodeA: {
+							V4IPs: []string{"10.0.0.1"},
+							Port:  8080,
+						},
 					},
 				},
 			},
@@ -1065,9 +1597,12 @@ func Test_buildPerNodeLBs(t *testing.T) {
 					vips:     []string{"node"},
 					protocol: v1.ProtocolTCP,
 					inport:   80,
-					eps: util.LbEndpoints{
+					clusterEndpoints: lbEndpoints{
 						V4IPs: []string{"10.128.0.2"},
 						Port:  8080,
+					},
+					nodeEndpoints: map[string]lbEndpoints{
+						nodeA: {V4IPs: []string{"10.128.0.2"}, Port: 8080},
 					},
 				},
 			},
@@ -1148,18 +1683,30 @@ func Test_buildPerNodeLBs(t *testing.T) {
 					vips:     []string{"192.168.0.1"},
 					protocol: v1.ProtocolTCP,
 					inport:   80,
-					eps: util.LbEndpoints{
+					clusterEndpoints: lbEndpoints{
 						V4IPs: []string{"10.0.0.1"},
 						Port:  8080,
+					},
+					nodeEndpoints: map[string]lbEndpoints{
+						nodeA: {
+							V4IPs: []string{"10.0.0.1"},
+							Port:  8080,
+						},
 					},
 				},
 				{
 					vips:     []string{"node"},
 					protocol: v1.ProtocolTCP,
 					inport:   80,
-					eps: util.LbEndpoints{
+					clusterEndpoints: lbEndpoints{
 						V4IPs: []string{"10.0.0.1"},
 						Port:  8080,
+					},
+					nodeEndpoints: map[string]lbEndpoints{
+						nodeA: {
+							V4IPs: []string{"10.0.0.1"},
+							Port:  8080,
+						},
 					},
 				},
 			},
@@ -1290,16 +1837,22 @@ func Test_buildPerNodeLBs(t *testing.T) {
 		},
 		{
 			// The most complicated case
-			name:    "nodeport service, host-network pod, ExternalTrafficPolicy",
+			name:    "nodeport service, host-network pod, ExternalTrafficPolicy=local",
 			service: defaultService,
 			configs: []lbConfig{
 				{
 					vips:     []string{"192.168.0.1"},
 					protocol: v1.ProtocolTCP,
 					inport:   80,
-					eps: util.LbEndpoints{
+					clusterEndpoints: lbEndpoints{
 						V4IPs: []string{"10.0.0.1"},
 						Port:  8080,
+					},
+					nodeEndpoints: map[string]lbEndpoints{
+						nodeA: {
+							V4IPs: []string{"10.0.0.1"},
+							Port:  8080,
+						},
 					},
 				},
 				{
@@ -1308,9 +1861,15 @@ func Test_buildPerNodeLBs(t *testing.T) {
 					inport:               80,
 					externalTrafficLocal: true,
 					hasNodePort:          true,
-					eps: util.LbEndpoints{
+					clusterEndpoints: lbEndpoints{
 						V4IPs: []string{"10.0.0.1"},
 						Port:  8080,
+					},
+					nodeEndpoints: map[string]lbEndpoints{
+						nodeA: {
+							V4IPs: []string{"10.0.0.1"},
+							Port:  8080,
+						},
 					},
 				},
 			},
@@ -1379,7 +1938,7 @@ func Test_buildPerNodeLBs(t *testing.T) {
 					Opts: defaultOpts,
 				},
 
-				// node-b has no service, 3 lbs
+				// node-b has no endpoint, 3 lbs
 				// router clusterip
 				// router nodeport = empty
 				// switch clusterip + nodeport
@@ -1432,18 +1991,38 @@ func Test_buildPerNodeLBs(t *testing.T) {
 					protocol:             v1.ProtocolTCP,
 					inport:               80,
 					internalTrafficLocal: true,
-					eps: util.LbEndpoints{
-						V4IPs: []string{"10.128.0.1", "10.128.1.1"}, // 1 ep on node-a and 1 ep on node-b
+					clusterEndpoints: lbEndpoints{
+						V4IPs: []string{"10.128.0.1", "10.128.1.1"},
 						Port:  8080,
+					},
+					nodeEndpoints: map[string]lbEndpoints{
+						nodeA: {
+							V4IPs: []string{"10.128.0.1"},
+							Port:  8080,
+						},
+						nodeB: {
+							V4IPs: []string{"10.128.1.1"},
+							Port:  8080,
+						},
 					},
 				},
 				{
 					vips:     []string{"1.2.3.4"}, // externalIP config
 					protocol: v1.ProtocolTCP,
 					inport:   80,
-					eps: util.LbEndpoints{
+					clusterEndpoints: lbEndpoints{
 						V4IPs: []string{"10.128.0.1", "10.128.1.1"},
 						Port:  8080,
+					},
+					nodeEndpoints: map[string]lbEndpoints{
+						nodeA: {
+							V4IPs: []string{"10.128.0.1"},
+							Port:  8080,
+						},
+						nodeB: {
+							V4IPs: []string{"10.128.1.1"},
+							Port:  8080,
+						},
 					},
 				},
 			},
@@ -1563,18 +2142,38 @@ func Test_buildPerNodeLBs(t *testing.T) {
 					protocol:             v1.ProtocolTCP,
 					inport:               80,
 					internalTrafficLocal: true,
-					eps: util.LbEndpoints{
-						V4IPs: []string{"10.0.0.1", "10.0.0.2"}, // 1 ep on node-a and 1 ep on node-b
+					clusterEndpoints: lbEndpoints{
+						V4IPs: []string{"10.0.0.1", "10.0.0.2"},
 						Port:  8080,
+					},
+					nodeEndpoints: map[string]lbEndpoints{
+						nodeA: {
+							V4IPs: []string{"10.0.0.1"},
+							Port:  8080,
+						},
+						nodeB: {
+							V4IPs: []string{"10.0.0.2"},
+							Port:  8080,
+						},
 					},
 				},
 				{
 					vips:     []string{"1.2.3.4"}, // externalIP config
 					protocol: v1.ProtocolTCP,
 					inport:   80,
-					eps: util.LbEndpoints{
+					clusterEndpoints: lbEndpoints{
 						V4IPs: []string{"10.0.0.1", "10.0.0.2"},
 						Port:  8080,
+					},
+					nodeEndpoints: map[string]lbEndpoints{
+						nodeA: {
+							V4IPs: []string{"10.0.0.1"},
+							Port:  8080,
+						},
+						nodeB: {
+							V4IPs: []string{"10.0.0.2"},
+							Port:  8080,
+						},
 					},
 				},
 			},
@@ -1730,9 +2329,15 @@ func Test_buildPerNodeLBs(t *testing.T) {
 					inport:               80,
 					internalTrafficLocal: true,
 					externalTrafficLocal: false, // ETP is applicable only to nodePorts and LBs
-					eps: util.LbEndpoints{
-						V4IPs: []string{"10.0.0.1"}, // only one ep on node-a
+					clusterEndpoints: lbEndpoints{
+						V4IPs: []string{"10.0.0.1"},
 						Port:  8080,
+					},
+					nodeEndpoints: map[string]lbEndpoints{
+						nodeA: {
+							V4IPs: []string{"10.0.0.1"}, // only one ep on node-a
+							Port:  8080,
+						},
 					},
 				},
 				{
@@ -1742,9 +2347,15 @@ func Test_buildPerNodeLBs(t *testing.T) {
 					externalTrafficLocal: true,
 					internalTrafficLocal: false, // ITP is applicable only to clusterIPs
 					hasNodePort:          true,
-					eps: util.LbEndpoints{
-						V4IPs: []string{"10.0.0.1"}, // only one ep on node-a
+					clusterEndpoints: lbEndpoints{
+						V4IPs: []string{"10.0.0.1"},
 						Port:  8080,
+					},
+					nodeEndpoints: map[string]lbEndpoints{
+						nodeA: {
+							V4IPs: []string{"10.0.0.1"}, // only one ep on node-a
+							Port:  8080,
+						},
 					},
 				},
 			},
@@ -1947,8 +2558,548 @@ func Test_buildPerNodeLBs(t *testing.T) {
 				},
 			},
 		},
+		// tests for endpoint selection with ExternalTrafficPolicy=local
+		{
+			name:    "LB service with NodePort, standard pods on different nodes, ExternalTrafficPolicy=local, both endpoints are ready",
+			service: defaultService,
+			configs: []lbConfig{
+				{
+					vips:                 []string{"node"},
+					protocol:             v1.ProtocolTCP,
+					inport:               5, // nodePort
+					hasNodePort:          true,
+					externalTrafficLocal: true,
+					clusterEndpoints: lbEndpoints{
+						V4IPs: []string{"10.128.0.2", "10.128.1.2"},
+						Port:  8080,
+					},
+					nodeEndpoints: map[string]lbEndpoints{
+						nodeA: {
+							V4IPs: []string{"10.128.0.2"},
+							Port:  8080,
+						},
+						nodeB: {
+							V4IPs: []string{"10.128.1.2"},
+							Port:  8080,
+						},
+					},
+				},
+				{
+					vips:                 []string{"4.2.2.2", "5.5.5.5"}, // externalIP + LB IP
+					protocol:             v1.ProtocolTCP,
+					inport:               80,
+					hasNodePort:          false,
+					externalTrafficLocal: true,
+					clusterEndpoints: lbEndpoints{
+						V4IPs: []string{"10.128.0.2", "10.128.1.2"},
+						Port:  8080,
+					},
+					nodeEndpoints: map[string]lbEndpoints{
+						nodeA: {
+							V4IPs: []string{"10.128.0.2"},
+							Port:  8080,
+						},
+						nodeB: {
+							V4IPs: []string{"10.128.1.2"},
+							Port:  8080,
+						},
+					},
+				},
+			},
+			expectedShared: []LB{
+				{
+					Name:        "Service_testns/foo_TCP_node_local_router_node-a",
+					Protocol:    "TCP",
+					ExternalIDs: defaultExternalIDs,
+					Opts:        LBOpts{SkipSNAT: true, Reject: true},
+
+					Rules: []LBRule{
+						{
+							Source:  Addr{IP: "10.0.0.1", Port: 5},
+							Targets: []Addr{{IP: "10.128.0.2", Port: 8080}}, // local endpoint (ready)
+						},
+						{
+							Source:  Addr{IP: "10.0.0.111", Port: 5},
+							Targets: []Addr{{IP: "10.128.0.2", Port: 8080}}, // local endpoint (ready)
+						},
+						{
+							Source:  Addr{IP: "4.2.2.2", Port: 80},
+							Targets: []Addr{{IP: "10.128.0.2", Port: 8080}}, // local endpoint (ready)
+						},
+						{
+							Source:  Addr{IP: "5.5.5.5", Port: 80},
+							Targets: []Addr{{IP: "10.128.0.2", Port: 8080}}, // local endpoint (ready)
+						},
+					},
+					Routers: []string{"gr-node-a"},
+				},
+				{
+					Name:        "Service_testns/foo_TCP_node_switch_node-a",
+					Protocol:    "TCP",
+					ExternalIDs: defaultExternalIDs,
+					Opts:        defaultOpts,
+					Rules: []LBRule{
+						{
+							Source:  Addr{IP: "169.254.169.3", Port: 5},
+							Targets: []Addr{{IP: "10.128.0.2", Port: 8080}},
+						},
+						{
+							Source:  Addr{IP: "10.0.0.1", Port: 5},
+							Targets: []Addr{{IP: "10.128.0.2", Port: 8080}, {IP: "10.128.1.2", Port: 8080}},
+						},
+						{
+							Source:  Addr{IP: "169.254.169.3", Port: 5},
+							Targets: []Addr{{IP: "10.128.0.2", Port: 8080}},
+						},
+						{
+							Source:  Addr{IP: "10.0.0.111", Port: 5},
+							Targets: []Addr{{IP: "10.128.0.2", Port: 8080}, {IP: "10.128.1.2", Port: 8080}},
+						},
+						{
+							Source:  Addr{IP: "4.2.2.2", Port: 80},
+							Targets: []Addr{{IP: "10.128.0.2", Port: 8080}, {IP: "10.128.1.2", Port: 8080}},
+						},
+						{
+							Source:  Addr{IP: "5.5.5.5", Port: 80},
+							Targets: []Addr{{IP: "10.128.0.2", Port: 8080}, {IP: "10.128.1.2", Port: 8080}},
+						},
+					},
+					Switches: []string{"switch-node-a"},
+				},
+				{
+					Name:        "Service_testns/foo_TCP_node_local_router_node-b",
+					Protocol:    "TCP",
+					ExternalIDs: defaultExternalIDs,
+					Opts:        LBOpts{SkipSNAT: true, Reject: true},
+					Rules: []LBRule{
+						{
+							Source:  Addr{IP: "10.0.0.2", Port: 5},
+							Targets: []Addr{{IP: "10.128.1.2", Port: 8080}}, // local endpoint (ready)
+						},
+						{
+							Source:  Addr{IP: "4.2.2.2", Port: 80},
+							Targets: []Addr{{IP: "10.128.1.2", Port: 8080}}, // local endpoint (ready)
+						},
+						{
+							Source:  Addr{IP: "5.5.5.5", Port: 80},
+							Targets: []Addr{{IP: "10.128.1.2", Port: 8080}}, // local endpoint (ready)
+						},
+					},
+					Routers: []string{"gr-node-b"},
+				},
+				{
+					Name:        "Service_testns/foo_TCP_node_switch_node-b",
+					Protocol:    "TCP",
+					ExternalIDs: defaultExternalIDs,
+					Opts:        defaultOpts,
+					Rules: []LBRule{
+						{
+							Source:  Addr{IP: "169.254.169.3", Port: 5},
+							Targets: []Addr{{IP: "10.128.1.2", Port: 8080}},
+						},
+						{
+							Source:  Addr{IP: "10.0.0.2", Port: 5},
+							Targets: []Addr{{IP: "10.128.0.2", Port: 8080}, {IP: "10.128.1.2", Port: 8080}},
+						},
+						{
+							Source:  Addr{IP: "4.2.2.2", Port: 80},
+							Targets: []Addr{{IP: "10.128.0.2", Port: 8080}, {IP: "10.128.1.2", Port: 8080}},
+						},
+						{
+							Source:  Addr{IP: "5.5.5.5", Port: 80},
+							Targets: []Addr{{IP: "10.128.0.2", Port: 8080}, {IP: "10.128.1.2", Port: 8080}},
+						},
+					},
+					Switches: []string{"switch-node-b"},
+				},
+			},
+		},
+		{
+			name:    "LB service with NodePort, standard pods on different nodes, ExternalTrafficPolicy=local, one endpoint is ready, the other one is terminating and serving",
+			service: defaultService,
+			configs: []lbConfig{
+				{
+					vips:                 []string{"node"},
+					protocol:             v1.ProtocolTCP,
+					inport:               5, // nodePort
+					hasNodePort:          true,
+					externalTrafficLocal: true,
+					clusterEndpoints: lbEndpoints{
+						V4IPs: []string{"10.128.0.2"},
+						Port:  8080,
+					},
+					nodeEndpoints: map[string]lbEndpoints{
+						nodeA: {V4IPs: []string{"10.128.0.2"}, Port: 8080},
+						nodeB: {V4IPs: []string{"10.128.1.2"}, Port: 8080},
+					},
+				},
+				{
+					vips:                 []string{"4.2.2.2", "5.5.5.5"}, // externalIP + LB IP
+					protocol:             v1.ProtocolTCP,
+					inport:               80,
+					hasNodePort:          false,
+					externalTrafficLocal: true,
+					clusterEndpoints: lbEndpoints{
+						V4IPs: []string{"10.128.0.2"},
+						Port:  8080,
+					},
+					nodeEndpoints: map[string]lbEndpoints{
+						nodeA: {V4IPs: []string{"10.128.0.2"}, Port: 8080},
+						nodeB: {V4IPs: []string{"10.128.1.2"}, Port: 8080},
+					},
+				},
+			},
+			expectedShared: []LB{
+				{
+					Name:        "Service_testns/foo_TCP_node_local_router_node-a",
+					Protocol:    "TCP",
+					ExternalIDs: defaultExternalIDs,
+					Opts:        LBOpts{SkipSNAT: true, Reject: true},
+
+					Rules: []LBRule{
+						{
+							Source:  Addr{IP: "10.0.0.1", Port: 5},
+							Targets: []Addr{{IP: "10.128.0.2", Port: 8080}}, // local endpoint
+						},
+						{
+							Source:  Addr{IP: "10.0.0.111", Port: 5},
+							Targets: []Addr{{IP: "10.128.0.2", Port: 8080}}, // local endpoint
+						},
+						{
+							Source:  Addr{IP: "4.2.2.2", Port: 80},
+							Targets: []Addr{{IP: "10.128.0.2", Port: 8080}}, // local endpoint
+						},
+						{
+							Source:  Addr{IP: "5.5.5.5", Port: 80},
+							Targets: []Addr{{IP: "10.128.0.2", Port: 8080}}, // local endpoint
+						},
+					},
+					Routers: []string{"gr-node-a"},
+				},
+				{
+					Name:        "Service_testns/foo_TCP_node_switch_node-a",
+					Protocol:    "TCP",
+					ExternalIDs: defaultExternalIDs,
+					Opts:        defaultOpts,
+					Rules: []LBRule{
+						{
+							Source:  Addr{IP: "169.254.169.3", Port: 5},
+							Targets: []Addr{{IP: "10.128.0.2", Port: 8080}},
+						},
+						{
+							Source:  Addr{IP: "10.0.0.1", Port: 5},
+							Targets: []Addr{{IP: "10.128.0.2", Port: 8080}}, // prefer endpoint on node1 since it's ready
+						},
+						{
+							Source:  Addr{IP: "169.254.169.3", Port: 5},
+							Targets: []Addr{{IP: "10.128.0.2", Port: 8080}},
+						},
+						{
+							Source:  Addr{IP: "10.0.0.111", Port: 5},
+							Targets: []Addr{{IP: "10.128.0.2", Port: 8080}}, // prefer endpoint on node1 since it's ready
+						},
+						{
+							Source:  Addr{IP: "4.2.2.2", Port: 80},
+							Targets: []Addr{{IP: "10.128.0.2", Port: 8080}}, // prefer endpoint on node1 since it's ready
+						},
+						{
+							Source:  Addr{IP: "5.5.5.5", Port: 80},
+							Targets: []Addr{{IP: "10.128.0.2", Port: 8080}}, // prefer endpoint on node1 since it's ready
+						},
+					},
+					Switches: []string{"switch-node-a"},
+				},
+				{
+					Name:        "Service_testns/foo_TCP_node_local_router_node-b",
+					Protocol:    "TCP",
+					ExternalIDs: defaultExternalIDs,
+					Opts:        LBOpts{SkipSNAT: true, Reject: true},
+					Rules: []LBRule{
+						{
+							Source:  Addr{IP: "10.0.0.2", Port: 5},
+							Targets: []Addr{{IP: "10.128.1.2", Port: 8080}}, // local endpoint (fallback to terminating and serving)
+						},
+						{
+							Source:  Addr{IP: "4.2.2.2", Port: 80},
+							Targets: []Addr{{IP: "10.128.1.2", Port: 8080}}, // local endpoint (fallback to terminating and serving)
+						},
+						{
+							Source:  Addr{IP: "5.5.5.5", Port: 80},
+							Targets: []Addr{{IP: "10.128.1.2", Port: 8080}}, // local endpoint (fallback to terminating and serving)
+						},
+					},
+					Routers: []string{"gr-node-b"},
+				},
+				{
+					Name:        "Service_testns/foo_TCP_node_switch_node-b",
+					Protocol:    "TCP",
+					ExternalIDs: defaultExternalIDs,
+					Opts:        defaultOpts,
+					Rules: []LBRule{
+						{
+							Source:  Addr{IP: "169.254.169.3", Port: 5},
+							Targets: []Addr{{IP: "10.128.1.2", Port: 8080}},
+						},
+						{
+							Source:  Addr{IP: "10.0.0.2", Port: 5},
+							Targets: []Addr{{IP: "10.128.0.2", Port: 8080}}, // prefer endpoint on node1 since it's ready
+						},
+						{
+							Source:  Addr{IP: "4.2.2.2", Port: 80},
+							Targets: []Addr{{IP: "10.128.0.2", Port: 8080}}, // prefer endpoint on node1 since it's ready
+						},
+						{
+							Source:  Addr{IP: "5.5.5.5", Port: 80},
+							Targets: []Addr{{IP: "10.128.0.2", Port: 8080}}, // prefer endpoint on node1 since it's ready
+						},
+					},
+					Switches: []string{"switch-node-b"},
+				},
+			},
+		},
 	}
 
+	// needs separate configuration variables for a V6 cluster
+	tcV6 := []struct {
+		name           string
+		service        *v1.Service
+		configs        []lbConfig
+		expectedShared []LB
+		expectedLocal  []LB
+	}{
+		// exactly the same as the v4 test under the same name
+		{
+			name:    "ipv6, nodeport service, standard pod",
+			service: defaultService,
+			configs: []lbConfig{
+				{
+					vips:     []string{"node"},
+					protocol: v1.ProtocolTCP,
+					inport:   80,
+					clusterEndpoints: lbEndpoints{
+						V6IPs: []string{"fe00:0:0:0:1::2"},
+						Port:  8080,
+					},
+					nodeEndpoints: map[string]lbEndpoints{
+						nodeA: {V6IPs: []string{"fe00:0:0:0:1::2"}, Port: 8080},
+					},
+				},
+			},
+			expectedShared: []LB{
+				{
+					Name:        "Service_testns/foo_TCP_node_router+switch_node-a",
+					ExternalIDs: defaultExternalIDs,
+					Routers:     []string{"gr-node-a"},
+					Switches:    []string{"switch-node-a"},
+					Protocol:    "TCP",
+					Rules: []LBRule{
+						{
+							Source:  Addr{IP: "fd00::1", Port: 80},
+							Targets: []Addr{{IP: "fe00:0:0:0:1::2", Port: 8080}},
+						},
+						{
+							Source:  Addr{IP: "fd00::111", Port: 80},
+							Targets: []Addr{{IP: "fe00:0:0:0:1::2", Port: 8080}},
+						},
+					},
+					Opts: defaultOpts,
+				},
+				{
+					Name:        "Service_testns/foo_TCP_node_router+switch_node-b",
+					ExternalIDs: defaultExternalIDs,
+					Routers:     []string{"gr-node-b"},
+					Switches:    []string{"switch-node-b"},
+					Protocol:    "TCP",
+					Rules: []LBRule{
+						{
+							Source:  Addr{IP: "fd00::2", Port: 80},
+							Targets: []Addr{{IP: "fe00:0:0:0:1::2", Port: 8080}},
+						},
+					},
+					Opts: defaultOpts,
+				},
+			},
+			expectedLocal: []LB{
+				{
+					Name:        "Service_testns/foo_TCP_node_router+switch_node-a",
+					ExternalIDs: defaultExternalIDs,
+					Routers:     []string{"gr-node-a"},
+					Switches:    []string{"switch-node-a"},
+					Protocol:    "TCP",
+					Rules: []LBRule{
+						{
+							Source:  Addr{IP: "fd00::1", Port: 80},
+							Targets: []Addr{{IP: "fe00:0:0:0:1::2", Port: 8080}},
+						},
+						{
+							Source:  Addr{IP: "fd00::111", Port: 80},
+							Targets: []Addr{{IP: "fe00:0:0:0:1::2", Port: 8080}},
+						},
+					},
+					Opts: defaultOpts,
+				},
+				{
+					Name:        "Service_testns/foo_TCP_node_router+switch_node-b",
+					ExternalIDs: defaultExternalIDs,
+					Routers:     []string{"gr-node-b"},
+					Switches:    []string{"switch-node-b"},
+					Protocol:    "TCP",
+					Rules: []LBRule{
+						{
+							Source:  Addr{IP: "fd00::2", Port: 80},
+							Targets: []Addr{{IP: "fe00:0:0:0:1::2", Port: 8080}},
+						},
+					},
+					Opts: defaultOpts,
+				},
+			},
+		},
+		{
+			// exactly the same as last test case for IPv4 but IPv6
+			name:    "IPv6, LB service with NodePort, standard pods on different nodes, ExternalTrafficPolicy=local, one endpoint is ready, the other one is terminating and serving",
+			service: defaultService,
+			configs: []lbConfig{
+				{
+					vips:                 []string{"node"},
+					protocol:             v1.ProtocolTCP,
+					inport:               5, // nodePort
+					hasNodePort:          true,
+					externalTrafficLocal: true,
+					clusterEndpoints: lbEndpoints{
+						V6IPs: []string{"fe00:0:0:0:1::2"},
+						Port:  8080,
+					},
+					nodeEndpoints: map[string]lbEndpoints{
+						nodeA: {V6IPs: []string{"fe00:0:0:0:1::2"}, Port: 8080},
+						nodeB: {V6IPs: []string{"fe00:0:0:0:2::2"}, Port: 8080},
+					},
+				},
+				{
+					vips:                 []string{"cafe::2", "abcd::5"}, // externalIP + LB IP
+					protocol:             v1.ProtocolTCP,
+					inport:               80,
+					hasNodePort:          false,
+					externalTrafficLocal: true,
+					clusterEndpoints: lbEndpoints{
+						V6IPs: []string{"fe00:0:0:0:1::2"},
+						Port:  8080,
+					},
+					nodeEndpoints: map[string]lbEndpoints{
+						nodeA: {V6IPs: []string{"fe00:0:0:0:1::2"}, Port: 8080},
+						nodeB: {V6IPs: []string{"fe00:0:0:0:2::2"}, Port: 8080},
+					},
+				},
+			},
+			expectedShared: []LB{
+				{
+					Name:        "Service_testns/foo_TCP_node_local_router_node-a",
+					Protocol:    "TCP",
+					ExternalIDs: defaultExternalIDs,
+					Opts:        LBOpts{SkipSNAT: true, Reject: true},
+
+					Rules: []LBRule{
+						{
+							Source:  Addr{IP: "fd00::1", Port: 5},
+							Targets: []Addr{{IP: "fe00:0:0:0:1::2", Port: 8080}}, // local endpoint
+						},
+						{
+							Source:  Addr{IP: "fd00::111", Port: 5},
+							Targets: []Addr{{IP: "fe00:0:0:0:1::2", Port: 8080}}, // local endpoint
+						},
+						{
+							Source:  Addr{IP: "cafe::2", Port: 80},
+							Targets: []Addr{{IP: "fe00:0:0:0:1::2", Port: 8080}}, // local endpoint
+						},
+						{
+							Source:  Addr{IP: "abcd::5", Port: 80},
+							Targets: []Addr{{IP: "fe00:0:0:0:1::2", Port: 8080}}, // local endpoint
+						},
+					},
+					Routers: []string{"gr-node-a"},
+				},
+				{
+					Name:        "Service_testns/foo_TCP_node_switch_node-a",
+					Protocol:    "TCP",
+					ExternalIDs: defaultExternalIDs,
+					Opts:        defaultOpts,
+					Rules: []LBRule{
+						{
+							Source:  Addr{IP: "fd69::3", Port: 5},
+							Targets: []Addr{{IP: "fe00:0:0:0:1::2", Port: 8080}},
+						},
+						{
+							Source:  Addr{IP: "fd00::1", Port: 5},
+							Targets: []Addr{{IP: "fe00:0:0:0:1::2", Port: 8080}}, // prefer endpoint on node1 since it's ready
+						},
+						{
+							Source:  Addr{IP: "fd69::3", Port: 5},
+							Targets: []Addr{{IP: "fe00:0:0:0:1::2", Port: 8080}},
+						},
+						{
+							Source:  Addr{IP: "fd00::111", Port: 5},
+							Targets: []Addr{{IP: "fe00:0:0:0:1::2", Port: 8080}}, // prefer endpoint on node1 since it's ready
+						},
+						{
+							Source:  Addr{IP: "cafe::2", Port: 80},
+							Targets: []Addr{{IP: "fe00:0:0:0:1::2", Port: 8080}}, // prefer endpoint on node1 since it's ready
+						},
+						{
+							Source:  Addr{IP: "abcd::5", Port: 80},
+							Targets: []Addr{{IP: "fe00:0:0:0:1::2", Port: 8080}}, // prefer endpoint on node1 since it's ready
+						},
+					},
+					Switches: []string{"switch-node-a"},
+				},
+				{
+					Name:        "Service_testns/foo_TCP_node_local_router_node-b",
+					Protocol:    "TCP",
+					ExternalIDs: defaultExternalIDs,
+					Opts:        LBOpts{SkipSNAT: true, Reject: true},
+					Rules: []LBRule{
+						{
+							Source:  Addr{IP: "fd00::2", Port: 5},
+							Targets: []Addr{{IP: "fe00:0:0:0:2::2", Port: 8080}}, // local endpoint (fallback to terminating and serving)
+						},
+						{
+							Source:  Addr{IP: "cafe::2", Port: 80},
+							Targets: []Addr{{IP: "fe00:0:0:0:2::2", Port: 8080}}, // local endpoint (fallback to terminating and serving)
+						},
+						{
+							Source:  Addr{IP: "abcd::5", Port: 80},
+							Targets: []Addr{{IP: "fe00:0:0:0:2::2", Port: 8080}}, // local endpoint (fallback to terminating and serving)
+						},
+					},
+					Routers: []string{"gr-node-b"},
+				},
+				{
+					Name:        "Service_testns/foo_TCP_node_switch_node-b",
+					Protocol:    "TCP",
+					ExternalIDs: defaultExternalIDs,
+					Opts:        defaultOpts,
+					Rules: []LBRule{
+						{
+							Source:  Addr{IP: "fd69::3", Port: 5},
+							Targets: []Addr{{IP: "fe00:0:0:0:2::2", Port: 8080}},
+						},
+						{
+							Source:  Addr{IP: "fd00::2", Port: 5},
+							Targets: []Addr{{IP: "fe00:0:0:0:1::2", Port: 8080}}, // prefer endpoint on node1 since it's ready
+						},
+						{
+							Source:  Addr{IP: "cafe::2", Port: 80},
+							Targets: []Addr{{IP: "fe00:0:0:0:1::2", Port: 8080}}, // prefer endpoint on node1 since it's ready
+						},
+						{
+							Source:  Addr{IP: "abcd::5", Port: 80},
+							Targets: []Addr{{IP: "fe00:0:0:0:1::2", Port: 8080}}, // prefer endpoint on node1 since it's ready
+						},
+					},
+					Switches: []string{"switch-node-b"},
+				},
+			},
+		},
+	}
+	// v4
 	for i, tt := range tc {
 		t.Run(fmt.Sprintf("%d_%s", i, tt.name), func(t *testing.T) {
 
@@ -1966,6 +3117,27 @@ func Test_buildPerNodeLBs(t *testing.T) {
 
 		})
 	}
+
+	// v6
+	globalconfig.Kubernetes.ServiceCIDRs = []*net.IPNet{svcCIDRv6}
+	for i, tt := range tcV6 {
+		t.Run(fmt.Sprintf("%d_%s", i, tt.name), func(t *testing.T) {
+
+			if tt.expectedShared != nil {
+				globalconfig.Gateway.Mode = globalconfig.GatewayModeShared
+				actual := buildPerNodeLBs(tt.service, tt.configs, defaultNodesV6)
+				assert.Equal(t, tt.expectedShared, actual, "shared gateway mode not as expected")
+			}
+
+			if tt.expectedLocal != nil {
+				globalconfig.Gateway.Mode = globalconfig.GatewayModeLocal
+				actual := buildPerNodeLBs(tt.service, tt.configs, defaultNodesV6)
+				assert.Equal(t, tt.expectedLocal, actual, "local gateway mode not as expected")
+			}
+
+		})
+	}
+
 }
 
 func Test_idledServices(t *testing.T) {
@@ -2036,6 +3208,1071 @@ func Test_idledServices(t *testing.T) {
 		t.Run(fmt.Sprintf("%d_%s", i, tt.name), func(t *testing.T) {
 			actualLbOpts := lbOpts(tt.service)
 			assert.Equal(t, tt.expected, actualLbOpts)
+		})
+	}
+}
+
+func Test_getEndpointsForService(t *testing.T) {
+	type args struct {
+		slices []*discovery.EndpointSlice
+		svc    *v1.Service
+		nodes  sets.Set[string]
+	}
+
+	tests := []struct {
+		name                 string
+		args                 args
+		wantClusterEndpoints map[string]lbEndpoints
+		wantNodeEndpoints    map[string]map[string]lbEndpoints
+	}{
+		{
+			name: "empty slices",
+			args: args{
+				slices: []*discovery.EndpointSlice{},
+				svc:    getSampleServiceWithOnePort(httpPortName, httpPortValue, tcpv1),
+			},
+			wantClusterEndpoints: map[string]lbEndpoints{},            // no cluster-wide endpoints
+			wantNodeEndpoints:    map[string]map[string]lbEndpoints{}, // no local endpoints
+		},
+		{
+			name: "slice with one local endpoint",
+			args: args{
+				slices: []*discovery.EndpointSlice{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab23",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     utilpointer.String("tcp-example"),
+								Protocol: &tcpv1,
+								Port:     utilpointer.Int32(80),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv4,
+						Endpoints:   kube_test.MakeReadyEndpointList(nodeA, "10.0.0.2"),
+					},
+				},
+				svc:   getSampleServiceWithOnePort("tcp-example", 80, tcpv1),
+				nodes: sets.New(nodeA), // one-node zone
+			},
+			wantClusterEndpoints: map[string]lbEndpoints{
+				getServicePortKey(tcpv1, "tcp-example"): {V4IPs: []string{"10.0.0.2"}, Port: 80}}, // one cluster-wide endpoint
+			wantNodeEndpoints: map[string]map[string]lbEndpoints{}, // no need for local endpoints, service is not ETP or ITP local
+		},
+		{
+			name: "slice with one local endpoint, ETP=local",
+			args: args{
+				slices: []*discovery.EndpointSlice{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab23",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     utilpointer.String("tcp-example"),
+								Protocol: &tcpv1,
+								Port:     utilpointer.Int32(80),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv4,
+						Endpoints:   kube_test.MakeReadyEndpointList(nodeA, "10.0.0.2"),
+					},
+				},
+				svc:   getSampleServiceWithOnePortAndETPLocal("tcp-example", 80, tcpv1),
+				nodes: sets.New(nodeA), // one-node zone
+			},
+			wantClusterEndpoints: map[string]lbEndpoints{
+				getServicePortKey(tcpv1, "tcp-example"): {V4IPs: []string{"10.0.0.2"}, Port: 80}}, // one cluster-wide endpoint
+			wantNodeEndpoints: map[string]map[string]lbEndpoints{
+				getServicePortKey(tcpv1, "tcp-example"): {nodeA: lbEndpoints{V4IPs: []string{"10.0.0.2"}, Port: 80}}}, // ETP=local, one local endpoint
+		},
+		{
+			name: "slice with one non-local endpoint, ETP=local",
+			args: args{
+				slices: []*discovery.EndpointSlice{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab23",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     utilpointer.String("tcp-example"),
+								Protocol: &tcpv1,
+								Port:     utilpointer.Int32(80),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv4,
+						Endpoints:   kube_test.MakeReadyEndpointList(nodeB, "10.0.0.2"),
+					},
+				},
+				svc:   getSampleServiceWithOnePortAndETPLocal("tcp-example", 80, tcpv1),
+				nodes: sets.New(nodeA), // one-node zone
+			},
+			wantClusterEndpoints: map[string]lbEndpoints{
+				getServicePortKey(tcpv1, "tcp-example"): {V4IPs: []string{"10.0.0.2"}, Port: 80}}, // one cluster-wide endpoint
+			wantNodeEndpoints: map[string]map[string]lbEndpoints{}, // ETP=local but no local endpoint
+		},
+		{
+			name: "slice of address type FQDN",
+			args: args{
+				slices: []*discovery.EndpointSlice{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab23",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     utilpointer.String("tcp-example"),
+								Protocol: &tcpv1,
+								Port:     utilpointer.Int32(80),
+							},
+						},
+						AddressType: discovery.AddressTypeFQDN,
+						Endpoints:   kube_test.MakeReadyEndpointList(nodeA, "example.com"),
+					},
+				},
+				svc:   getSampleServiceWithOnePort("tcp-example", 80, tcpv1),
+				nodes: sets.New(nodeA), // one-node zone
+			},
+			wantClusterEndpoints: map[string]lbEndpoints{},            // no endpoints
+			wantNodeEndpoints:    map[string]map[string]lbEndpoints{}, // no local endpoint
+		},
+		{
+			name: "slice with one endpoint, OVN zone with two nodes, ETP=local",
+			args: args{
+				slices: []*discovery.EndpointSlice{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab23",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     utilpointer.String("tcp-example"),
+								Protocol: &tcpv1,
+								Port:     utilpointer.Int32(80),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv4,
+						Endpoints:   kube_test.MakeReadyEndpointList(nodeB, "10.0.0.2"),
+					},
+				},
+				svc:   getSampleServiceWithOnePortAndETPLocal("tcp-example", 80, tcpv1),
+				nodes: sets.New(nodeA, nodeB), // one-node zone
+			},
+			wantClusterEndpoints: map[string]lbEndpoints{
+				getServicePortKey(tcpv1, "tcp-example"): {V4IPs: []string{"10.0.0.2"}, Port: 80}}, // one cluster-wide endpoint
+			wantNodeEndpoints: map[string]map[string]lbEndpoints{
+				getServicePortKey(tcpv1, "tcp-example"): {nodeB: lbEndpoints{V4IPs: []string{"10.0.0.2"}, Port: 80}}}, // endpoint on nodeB
+		},
+		{
+			name: "slice with different port name than the service",
+			args: args{
+				slices: []*discovery.EndpointSlice{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab23",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     utilpointer.String("tcp-example-wrong"),
+								Protocol: &tcp,
+								Port:     utilpointer.Int32(8080),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv4,
+						Endpoints:   kube_test.MakeReadyEndpointList(nodeA, "10.0.0.2"),
+					},
+				},
+				svc:   getSampleServiceWithOnePort("tcp-example", 80, tcpv1),
+				nodes: sets.New(nodeA), // one-node zone
+			},
+			wantClusterEndpoints: map[string]lbEndpoints{},            // no cluster-wide endpoints
+			wantNodeEndpoints:    map[string]map[string]lbEndpoints{}, // no local endpoints
+		},
+		{
+			name: "slice and service without a port name, ETP=local",
+			args: args{
+				slices: []*discovery.EndpointSlice{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab23",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Protocol: &tcpv1,
+								Port:     utilpointer.Int32(8080),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv4,
+						Endpoints:   kube_test.MakeReadyEndpointList(nodeA, "10.0.0.2"),
+					},
+				},
+				svc:   getSampleServiceWithOnePortAndETPLocal("", 80, tcpv1), // port with no name
+				nodes: sets.New(nodeA),                                       // one-node zone
+
+			},
+			wantClusterEndpoints: map[string]lbEndpoints{
+				getServicePortKey(tcpv1, ""): {V4IPs: []string{"10.0.0.2"}, Port: 8080}}, // one cluster-wide endpoint
+			wantNodeEndpoints: map[string]map[string]lbEndpoints{
+				getServicePortKey(tcpv1, ""): {nodeA: lbEndpoints{V4IPs: []string{"10.0.0.2"}, Port: 8080}}}, // one local endpoint
+		},
+		{
+			name: "slice with an IPv6 endpoint",
+			args: args{
+				slices: []*discovery.EndpointSlice{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab23",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     utilpointer.String("tcp-example"),
+								Protocol: &tcp,
+								Port:     utilpointer.Int32(80),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv6,
+						Endpoints:   kube_test.MakeReadyEndpointList(nodeA, "2001:db2::2"),
+					},
+				},
+				svc:   getSampleServiceWithOnePort("tcp-example", 80, tcpv1),
+				nodes: sets.New(nodeA), // one-node zone
+			},
+			wantClusterEndpoints: map[string]lbEndpoints{
+				getServicePortKey(tcpv1, "tcp-example"): {V6IPs: []string{"2001:db2::2"}, Port: 80}}, // one cluster-wide endpoint
+			wantNodeEndpoints: map[string]map[string]lbEndpoints{}, //  local endpoints not filled in, since service is not ETP or ITP local
+		},
+		{
+			name: "a slice with an IPv4 endpoint and a slice with an IPv6 endpoint (dualstack cluster), ETP=local",
+			args: args{
+				slices: []*discovery.EndpointSlice{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab23",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     utilpointer.String("tcp-example"),
+								Protocol: &tcp,
+								Port:     utilpointer.Int32(80),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv4,
+						Endpoints:   kube_test.MakeReadyEndpointList(nodeA, "10.0.0.2"),
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab24",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     utilpointer.String("tcp-example"),
+								Protocol: &tcp,
+								Port:     utilpointer.Int32(80),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv6,
+						Endpoints:   kube_test.MakeReadyEndpointList(nodeA, "2001:db2::2"),
+					},
+				},
+				svc:   getSampleServiceWithOnePortAndETPLocal("tcp-example", 80, tcpv1),
+				nodes: sets.New(nodeA), // one-node zone
+			},
+			wantClusterEndpoints: map[string]lbEndpoints{
+				getServicePortKey(tcpv1, "tcp-example"): {V4IPs: []string{"10.0.0.2"}, V6IPs: []string{"2001:db2::2"}, Port: 80}},
+			wantNodeEndpoints: map[string]map[string]lbEndpoints{
+				getServicePortKey(tcpv1, "tcp-example"): {nodeA: lbEndpoints{V4IPs: []string{"10.0.0.2"}, V6IPs: []string{"2001:db2::2"}, Port: 80}}},
+		},
+		{
+			name: "one slice with a duplicate address in the same endpoint",
+			args: args{
+				slices: []*discovery.EndpointSlice{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab23",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     utilpointer.String("tcp-example"),
+								Protocol: &tcp,
+								Port:     utilpointer.Int32(80),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv4,
+						Endpoints:   kube_test.MakeReadyEndpointList(nodeA, "10.0.0.2", "10.0.0.2"),
+					},
+				},
+				svc:   getSampleServiceWithOnePort("tcp-example", 80, tcpv1),
+				nodes: sets.New(nodeA), // one-node zone
+			},
+			wantClusterEndpoints: map[string]lbEndpoints{
+				getServicePortKey(tcpv1, "tcp-example"): {V4IPs: []string{"10.0.0.2"}, Port: 80}},
+			wantNodeEndpoints: map[string]map[string]lbEndpoints{}, // local endpoints not filled in, since service is not ETP or ITP local
+		},
+		{
+			name: "one slice with a duplicate address across two endpoints",
+			args: args{
+				slices: []*discovery.EndpointSlice{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab23",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     utilpointer.String("tcp-example"),
+								Protocol: &tcp,
+								Port:     utilpointer.Int32(80),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv4,
+						Endpoints:   []discovery.Endpoint{kube_test.MakeReadyEndpoint(nodeA, "10.0.0.2"), kube_test.MakeReadyEndpoint(nodeA, "10.0.0.2")},
+					},
+				},
+				svc:   getSampleServiceWithOnePort("tcp-example", 80, tcpv1),
+				nodes: sets.New(nodeA), // one-node zone
+			},
+			wantClusterEndpoints: map[string]lbEndpoints{
+				getServicePortKey(tcpv1, "tcp-example"): {V4IPs: []string{"10.0.0.2"}, Port: 80}},
+			wantNodeEndpoints: map[string]map[string]lbEndpoints{}, // local endpoints not filled in, since service is not ETP or ITP local
+		},
+		{
+			name: "multiples slices with a duplicate address, with both address being ready",
+			args: args{
+				slices: []*discovery.EndpointSlice{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab23",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     utilpointer.String("tcp-example"),
+								Protocol: &tcp,
+								Port:     utilpointer.Int32(80),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv4,
+						Endpoints:   kube_test.MakeReadyEndpointList(nodeA, "10.0.0.2", "10.1.1.2"),
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab24",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     utilpointer.String("tcp-example"),
+								Protocol: &tcp,
+								Port:     utilpointer.Int32(80),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv4,
+						Endpoints:   kube_test.MakeReadyEndpointList(nodeA, "10.0.0.2", "10.2.2.2"),
+					},
+				},
+				svc:   getSampleServiceWithOnePort("tcp-example", 80, tcpv1),
+				nodes: sets.New(nodeA), // one-node zone
+			},
+			wantClusterEndpoints: map[string]lbEndpoints{
+				getServicePortKey(tcpv1, "tcp-example"): {V4IPs: []string{"10.0.0.2", "10.1.1.2", "10.2.2.2"}, Port: 80}},
+			wantNodeEndpoints: map[string]map[string]lbEndpoints{}, // local endpoints not filled in, since service is not ETP or ITP local
+		},
+		{
+			name: "multiples slices with different ports, ETP=local",
+			args: args{
+				slices: []*discovery.EndpointSlice{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab23",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     utilpointer.String("tcp-example"),
+								Protocol: &tcp,
+								Port:     utilpointer.Int32(80),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv4,
+						Endpoints:   kube_test.MakeReadyEndpointList(nodeA, "10.0.0.2", "10.1.1.2"),
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab24",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     utilpointer.String("other-port"),
+								Protocol: &tcp,
+								Port:     utilpointer.Int32(8080),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv4,
+						Endpoints:   kube_test.MakeReadyEndpointList(nodeA, "10.0.0.3", "10.2.2.3"),
+					},
+				},
+				svc:   getSampleServiceWithTwoPortsAndETPLocal("tcp-example", "other-port", 80, 8080, tcpv1, tcpv1),
+				nodes: sets.New(nodeA), // one-node zone
+			},
+			wantClusterEndpoints: map[string]lbEndpoints{
+				getServicePortKey(tcpv1, "tcp-example"): {V4IPs: []string{"10.0.0.2", "10.1.1.2"}, Port: 80},
+				getServicePortKey(tcpv1, "other-port"):  {V4IPs: []string{"10.0.0.3", "10.2.2.3"}, Port: 8080}},
+			wantNodeEndpoints: map[string]map[string]lbEndpoints{
+				getServicePortKey(tcpv1, "tcp-example"): {nodeA: lbEndpoints{V4IPs: []string{"10.0.0.2", "10.1.1.2"}, Port: 80}},
+				getServicePortKey(tcpv1, "other-port"):  {nodeA: lbEndpoints{V4IPs: []string{"10.0.0.3", "10.2.2.3"}, Port: 8080}}},
+		},
+		{
+			name: "multiples slices with different ports, OVN zone with two nodes, ETP=local",
+			args: args{
+				slices: []*discovery.EndpointSlice{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab23",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     utilpointer.String("tcp-example"),
+								Protocol: &tcp,
+								Port:     utilpointer.Int32(80),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv4,
+						Endpoints:   kube_test.MakeReadyEndpointList(nodeA, "10.0.0.2", "10.1.1.2"),
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab24",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     utilpointer.String("other-port"),
+								Protocol: &tcp,
+								Port:     utilpointer.Int32(8080),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv4,
+						Endpoints:   kube_test.MakeReadyEndpointList(nodeB, "10.0.0.3", "10.2.2.3"),
+					},
+				},
+				svc:   getSampleServiceWithTwoPortsAndETPLocal("tcp-example", "other-port", 80, 8080, tcpv1, tcpv1),
+				nodes: sets.New(nodeA, nodeB), // zone with two nodes
+			},
+			wantClusterEndpoints: map[string]lbEndpoints{
+				getServicePortKey(tcpv1, "tcp-example"): {V4IPs: []string{"10.0.0.2", "10.1.1.2"}, Port: 80},
+				getServicePortKey(tcpv1, "other-port"):  {V4IPs: []string{"10.0.0.3", "10.2.2.3"}, Port: 8080}},
+			wantNodeEndpoints: map[string]map[string]lbEndpoints{
+				getServicePortKey(tcpv1, "tcp-example"): {nodeA: lbEndpoints{V4IPs: []string{"10.0.0.2", "10.1.1.2"}, Port: 80}},
+				getServicePortKey(tcpv1, "other-port"):  {nodeB: lbEndpoints{V4IPs: []string{"10.0.0.3", "10.2.2.3"}, Port: 8080}}},
+		},
+		{
+			name: "slice with a mix of ready and terminating (serving and non-serving) endpoints",
+			args: args{
+				slices: []*discovery.EndpointSlice{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab23",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     utilpointer.String("tcp-example"),
+								Protocol: &tcp,
+								Port:     utilpointer.Int32(80),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv6,
+						Endpoints: []discovery.Endpoint{
+							kube_test.MakeReadyEndpoint(nodeA, "2001:db2::2"),
+							kube_test.MakeReadyEndpoint(nodeA, "2001:db2::3"),
+							kube_test.MakeTerminatingServingEndpoint(nodeA, "2001:db2::4"),
+							kube_test.MakeTerminatingServingEndpoint(nodeA, "2001:db2::5"),
+							kube_test.MakeTerminatingNonServingEndpoint(nodeA, "2001:db2::6"), // ignored
+						},
+					},
+				},
+				svc:   getSampleServiceWithOnePort("tcp-example", 80, tcpv1),
+				nodes: sets.New(nodeA), // one-node zone
+
+			},
+			wantClusterEndpoints: map[string]lbEndpoints{
+				getServicePortKey(tcpv1, "tcp-example"): {V6IPs: []string{"2001:db2::2", "2001:db2::3"}, Port: 80}},
+			wantNodeEndpoints: map[string]map[string]lbEndpoints{}, // local endpoints not filled in, since service is not ETP or ITP local
+		},
+		{
+			name: "slice with a mix of terminating (serving and non-serving) endpoints and no ready endpoints",
+			args: args{
+				slices: []*discovery.EndpointSlice{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab23",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     utilpointer.String("tcp-example"),
+								Protocol: &tcp,
+								Port:     utilpointer.Int32(80),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv6,
+						Endpoints: []discovery.Endpoint{
+							kube_test.MakeTerminatingServingEndpoint(nodeA, "2001:db2::4"),
+							kube_test.MakeTerminatingServingEndpoint(nodeA, "2001:db2::5"),
+							kube_test.MakeTerminatingNonServingEndpoint(nodeA, "2001:db2::6"),
+							kube_test.MakeTerminatingNonServingEndpoint(nodeA, "2001:db2::7"),
+						},
+					},
+				},
+				svc:   getSampleServiceWithOnePort("tcp-example", 80, tcpv1),
+				nodes: sets.New(nodeA), // one-node zone
+			},
+			wantClusterEndpoints: map[string]lbEndpoints{
+				getServicePortKey(tcpv1, "tcp-example"): {V6IPs: []string{"2001:db2::4", "2001:db2::5"}, Port: 80}},
+			wantNodeEndpoints: map[string]map[string]lbEndpoints{}, // local endpoints not filled in, since service is not ETP or ITP local
+		},
+		{
+			name: "slice with only terminating non-serving endpoints",
+			args: args{
+				slices: []*discovery.EndpointSlice{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab23",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     utilpointer.String("tcp-example"),
+								Protocol: &tcp,
+								Port:     utilpointer.Int32(80),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv6,
+						Endpoints: []discovery.Endpoint{
+							kube_test.MakeTerminatingNonServingEndpoint(nodeA, "2001:db2::6"),
+							kube_test.MakeTerminatingNonServingEndpoint(nodeA, "2001:db2::7"),
+						},
+					},
+				},
+				svc:   getSampleServiceWithOnePort("tcp-example", 80, tcpv1),
+				nodes: sets.New(nodeA), // one-node zone
+			},
+			wantClusterEndpoints: map[string]lbEndpoints{},            // no cluster-wide endpoints
+			wantNodeEndpoints:    map[string]map[string]lbEndpoints{}, // local endpoints not filled in, since service is not ETP or ITP local
+
+		},
+		{
+			name: "multiple slices with a mix of terminating (serving and non-serving) endpoints and no ready endpoints",
+			args: args{
+				slices: []*discovery.EndpointSlice{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab23",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     utilpointer.String("tcp-example"),
+								Protocol: &tcp,
+								Port:     utilpointer.Int32(80),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv6,
+						Endpoints: []discovery.Endpoint{
+							kube_test.MakeTerminatingNonServingEndpoint(nodeA, "2001:db2::2"), // ignored
+							kube_test.MakeTerminatingServingEndpoint(nodeA, "2001:db2::3"),
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab24",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     utilpointer.String("tcp-example"),
+								Protocol: &tcp,
+								Port:     utilpointer.Int32(80),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv6,
+						Endpoints: []discovery.Endpoint{
+							kube_test.MakeTerminatingServingEndpoint(nodeA, "2001:db2::4"),
+							kube_test.MakeTerminatingNonServingEndpoint(nodeA, "2001:db2::5"), // ignored
+						},
+					},
+				},
+				svc:   getSampleServiceWithOnePort("tcp-example", 80, tcpv1),
+				nodes: sets.New(nodeA), // one-node zone
+			},
+			wantClusterEndpoints: map[string]lbEndpoints{
+				getServicePortKey(tcpv1, "tcp-example"): {V6IPs: []string{"2001:db2::3", "2001:db2::4"}, Port: 80}},
+			wantNodeEndpoints: map[string]map[string]lbEndpoints{}, // local endpoints not filled in, since service is not ETP or ITP local
+		},
+		{
+			name: "multiple slices with only terminating non-serving endpoints",
+			args: args{
+				slices: []*discovery.EndpointSlice{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab23",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     utilpointer.String("tcp-example"),
+								Protocol: &tcp,
+								Port:     utilpointer.Int32(80),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv6,
+						Endpoints: []discovery.Endpoint{
+							kube_test.MakeTerminatingNonServingEndpoint(nodeA, "2001:db2::2"),
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab24",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     utilpointer.String("tcp-example"),
+								Protocol: &tcp,
+								Port:     utilpointer.Int32(80),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv6,
+						Endpoints: []discovery.Endpoint{
+							kube_test.MakeTerminatingNonServingEndpoint(nodeA, "2001:db2::5"),
+						},
+					},
+				},
+				svc:   getSampleServiceWithOnePort("tcp-example", 80, tcpv1),
+				nodes: sets.New(nodeA), // one-node zone
+			},
+			wantClusterEndpoints: map[string]lbEndpoints{},            // no cluster-wide endpoints
+			wantNodeEndpoints:    map[string]map[string]lbEndpoints{}, // no local endpoints
+
+		},
+		{
+			name: "multiple slices with a mix of IPv4 and IPv6 ready and terminating (serving and non-serving) endpoints (dualstack cluster)",
+			args: args{
+				slices: []*discovery.EndpointSlice{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab23",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     utilpointer.String("tcp-example"),
+								Protocol: &tcp,
+								Port:     utilpointer.Int32(80),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv4,
+						Endpoints: []discovery.Endpoint{
+							kube_test.MakeReadyEndpoint(nodeA, "10.0.0.2"),
+							kube_test.MakeTerminatingServingEndpoint(nodeA, "10.0.0.3"),
+							kube_test.MakeTerminatingNonServingEndpoint(nodeA, "10.0.0.4"), // ignored
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab24",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     utilpointer.String("tcp-example"),
+								Protocol: &tcp,
+								Port:     utilpointer.Int32(80),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv6,
+						Endpoints: []discovery.Endpoint{
+							kube_test.MakeReadyEndpoint(nodeA, "2001:db2::2"),
+							kube_test.MakeTerminatingServingEndpoint(nodeA, "2001:db2::3"),
+							kube_test.MakeTerminatingNonServingEndpoint(nodeA, "2001:db2::4"), // ignored
+						},
+					},
+				},
+				svc:   getSampleServiceWithOnePort("tcp-example", 80, tcpv1),
+				nodes: sets.New(nodeA), // one-node zone
+			},
+			wantClusterEndpoints: map[string]lbEndpoints{
+				getServicePortKey(tcpv1, "tcp-example"): {V4IPs: []string{"10.0.0.2"}, V6IPs: []string{"2001:db2::2"}, Port: 80}},
+			wantNodeEndpoints: map[string]map[string]lbEndpoints{}, // local endpoints not filled in, since service is not ETP or ITP local
+		},
+		{
+			name: "multiple slices with a mix of IPv4 and IPv6 terminating (serving and non-serving) endpoints and no ready endpoints (dualstack cluster)",
+			args: args{
+				slices: []*discovery.EndpointSlice{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab23",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     utilpointer.String("tcp-example"),
+								Protocol: &tcp,
+								Port:     utilpointer.Int32(80),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv4,
+						Endpoints: []discovery.Endpoint{
+							kube_test.MakeTerminatingServingEndpoint(nodeA, "10.0.0.3"),
+							kube_test.MakeTerminatingNonServingEndpoint(nodeA, "10.0.0.4"),
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab24",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     utilpointer.String("tcp-example"),
+								Protocol: &tcp,
+								Port:     utilpointer.Int32(80),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv6,
+						Endpoints: []discovery.Endpoint{
+							kube_test.MakeTerminatingServingEndpoint(nodeA, "2001:db2::3"),
+							kube_test.MakeTerminatingNonServingEndpoint(nodeA, "2001:db2::4"),
+						},
+					},
+				},
+				svc:   getSampleServiceWithOnePort("tcp-example", 80, tcpv1),
+				nodes: sets.New(nodeA), // one-node zone
+			},
+			wantClusterEndpoints: map[string]lbEndpoints{
+				getServicePortKey(tcpv1, "tcp-example"): {V4IPs: []string{"10.0.0.3"}, V6IPs: []string{"2001:db2::3"}, Port: 80}},
+			wantNodeEndpoints: map[string]map[string]lbEndpoints{}, // local endpoints not filled in, since service is not ETP or ITP local
+		},
+		{
+			name: "multiple slices with a mix of IPv4 and IPv6 terminating non-serving endpoints (dualstack cluster)",
+			args: args{
+				slices: []*discovery.EndpointSlice{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab23",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     utilpointer.String("tcp-example"),
+								Protocol: &tcp,
+								Port:     utilpointer.Int32(80),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv4,
+						Endpoints: []discovery.Endpoint{
+							kube_test.MakeTerminatingNonServingEndpoint(nodeA, "10.0.0.4"), // ignored
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab24",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     utilpointer.String("tcp-example"),
+								Protocol: &tcp,
+								Port:     utilpointer.Int32(80),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv6,
+						Endpoints: []discovery.Endpoint{
+							kube_test.MakeTerminatingNonServingEndpoint(nodeA, "2001:db2::4"), // ignored
+						},
+					},
+				},
+				svc:   getSampleServiceWithOnePort("tcp-example", 80, tcpv1),
+				nodes: sets.New(nodeA), // one-node zone
+
+			},
+			wantClusterEndpoints: map[string]lbEndpoints{},            // no endpoints
+			wantNodeEndpoints:    map[string]map[string]lbEndpoints{}, // no endpoints
+		},
+		{
+			name: "multiple slices with a mix of IPv4 and IPv6 ready and terminating (serving and non-serving) endpoints (dualstack cluster) and service.PublishNotReadyAddresses=true",
+			args: args{
+				slices: []*discovery.EndpointSlice{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab23",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     utilpointer.String("tcp-example"),
+								Protocol: &tcp,
+								Port:     utilpointer.Int32(80),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv4,
+						Endpoints: []discovery.Endpoint{
+							kube_test.MakeReadyEndpoint(nodeA, "10.0.0.2"),                 // included
+							kube_test.MakeTerminatingServingEndpoint(nodeA, "10.0.0.3"),    // included
+							kube_test.MakeTerminatingNonServingEndpoint(nodeA, "10.0.0.4"), // included
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab24",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     utilpointer.String("tcp-example"),
+								Protocol: &tcp,
+								Port:     utilpointer.Int32(80),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv6,
+						Endpoints: []discovery.Endpoint{
+							kube_test.MakeReadyEndpoint(nodeA, "2001:db2::2"),                 // included
+							kube_test.MakeTerminatingServingEndpoint(nodeA, "2001:db2::3"),    // included
+							kube_test.MakeTerminatingNonServingEndpoint(nodeA, "2001:db2::4"), // included
+						},
+					},
+				},
+				svc:   getSampleServiceWithOnePortAndPublishNotReadyAddresses("tcp-example", 80, tcpv1), // <-- publishNotReadyAddresses=true
+				nodes: sets.New(nodeA),                                                                  // one-node zone
+			},
+			wantClusterEndpoints: map[string]lbEndpoints{
+				getServicePortKey(tcpv1, "tcp-example"): {
+					V4IPs: []string{"10.0.0.2", "10.0.0.3", "10.0.0.4"},
+					V6IPs: []string{"2001:db2::2", "2001:db2::3", "2001:db2::4"}, Port: 80}},
+
+			wantNodeEndpoints: map[string]map[string]lbEndpoints{}, // local endpoints not filled in, since service is not ETP or ITP local
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			portToClusterEndpoints, portToNodeToEndpoints := getEndpointsForService(tt.args.slices, tt.args.svc, tt.args.nodes)
+			assert.Equal(t, tt.wantClusterEndpoints, portToClusterEndpoints)
+			assert.Equal(t, tt.wantNodeEndpoints, portToNodeToEndpoints)
+
+		})
+	}
+}
+
+func Test_makeNodeSwitchTargetIPs(t *testing.T) {
+	// OCP HACK BEGIN
+	name := "foo"
+	namespace := "testns"
+
+	defaultService := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: v1.ServiceSpec{
+			Type: v1.ServiceTypeClusterIP,
+		},
+	}
+
+	addFallbackAnnotationToService := func(s *v1.Service) *v1.Service {
+		s.Annotations = map[string]string{localWithFallbackAnnotation: ""}
+		return s
+	}
+	// OCP HACK END
+
+	tc := []struct {
+		name                string
+		service             *v1.Service
+		config              *lbConfig
+		node                string
+		expectedTargetIPsV4 []string
+		expectedTargetIPsV6 []string
+		expectedV4Changed   bool
+		expectedV6Changed   bool
+	}{
+		{
+			name:    "cluster ip service", //ETP=cluster by default on all services
+			service: defaultService,
+			config: &lbConfig{
+				vips:     []string{"1.2.3.4", "fe10::1"},
+				protocol: v1.ProtocolTCP,
+				inport:   80,
+				clusterEndpoints: lbEndpoints{
+					V4IPs: []string{"192.168.0.1"},
+					V6IPs: []string{"fe00:0:0:0:1::2"},
+					Port:  8080,
+				},
+				nodeEndpoints: map[string]lbEndpoints{
+					nodeA: {
+						V4IPs: []string{"192.168.0.1"},
+						V6IPs: []string{"fe00:0:0:0:1::2"},
+						Port:  8080,
+					},
+				},
+			},
+			node:                nodeA,
+			expectedTargetIPsV4: []string{"192.168.0.1"},
+			expectedTargetIPsV6: []string{"fe00:0:0:0:1::2"},
+			expectedV4Changed:   false,
+			expectedV6Changed:   false,
+		},
+		{
+			name:    "LB service with ETP=local, endpoint count changes",
+			service: getSampleServiceWithOnePortAndETPLocal("tcp-example", 80, tcpv1),
+			config: &lbConfig{
+				vips:     []string{"1.2.3.4", "fe10::1"},
+				protocol: v1.ProtocolTCP,
+				inport:   80,
+				clusterEndpoints: lbEndpoints{
+					V4IPs: []string{"192.168.0.1", "192.168.1.1"},
+					V6IPs: []string{"fe00:0:0:0:1::2", "fe00:0:0:0:2::2"},
+
+					Port: 8080,
+				},
+				nodeEndpoints: map[string]lbEndpoints{
+					nodeA: {
+						V4IPs: []string{"192.168.0.1"},
+						V6IPs: []string{"fe00:0:0:0:1::2"},
+						Port:  8080,
+					},
+				},
+				externalTrafficLocal: true,
+			},
+			node:                nodeA,
+			expectedTargetIPsV4: []string{"192.168.0.1"}, // only the endpoint on nodeA is kept
+			expectedTargetIPsV6: []string{"fe00:0:0:0:1::2"},
+			expectedV4Changed:   true,
+			expectedV6Changed:   true,
+		},
+		{
+			name:    "LB service with ETP=local, endpoint count is the same",
+			service: getSampleServiceWithOnePortAndETPLocal("tcp-example", 80, tcpv1),
+			config: &lbConfig{
+				vips:     []string{"1.2.3.4", "fe10::1"},
+				protocol: v1.ProtocolTCP,
+				inport:   80,
+				clusterEndpoints: lbEndpoints{
+					V4IPs: []string{"192.168.0.1"},
+					V6IPs: []string{"fe00:0:0:0:1::2"},
+
+					Port: 8080,
+				},
+				nodeEndpoints: map[string]lbEndpoints{
+					nodeA: {
+						V4IPs: []string{"192.168.0.1"},
+						V6IPs: []string{"fe00:0:0:0:1::2"},
+						Port:  8080,
+					},
+				},
+				externalTrafficLocal: true,
+			},
+			node:                nodeA,
+			expectedTargetIPsV4: []string{"192.168.0.1"},
+			expectedTargetIPsV6: []string{"fe00:0:0:0:1::2"},
+			expectedV4Changed:   false,
+		},
+		{
+			name:    "LB service with ETP=local, no local endpoints left",
+			service: getSampleServiceWithOnePortAndETPLocal("tcp-example", 80, tcpv1),
+			config: &lbConfig{
+				vips:     []string{"1.2.3.4", "fe10::1"},
+				protocol: v1.ProtocolTCP,
+				inport:   80,
+				clusterEndpoints: lbEndpoints{
+					V4IPs: []string{"192.168.1.1"},     // on nodeB
+					V6IPs: []string{"fe00:0:0:0:2::2"}, // on nodeB
+					Port:  8080,
+				},
+				// nothing on nodeA
+				externalTrafficLocal: true,
+			},
+			node:                nodeA,
+			expectedTargetIPsV4: []string{},
+			expectedTargetIPsV6: []string{}, // no local endpoints
+			expectedV4Changed:   true,
+			expectedV6Changed:   true,
+		},
+		// OCP HACK BEGIN
+		{
+			name:    "LB service with ETP=local, no local endpoints left, localWithFallback annotation",
+			service: addFallbackAnnotationToService(getSampleServiceWithOnePortAndETPLocal("tcp-example", 80, tcpv1)),
+			config: &lbConfig{
+				vips:     []string{"1.2.3.4", "fe10::1"},
+				protocol: v1.ProtocolTCP,
+				inport:   80,
+				clusterEndpoints: lbEndpoints{
+					V4IPs: []string{"192.168.1.1"},     // on nodeB
+					V6IPs: []string{"fe00:0:0:0:2::2"}, // on nodeB
+					Port:  8080,
+				},
+				// nothing on nodeA
+				externalTrafficLocal: true,
+			},
+			node:                nodeA,
+			expectedTargetIPsV4: []string{"192.168.1.1"},     // fallback to cluster endpoints
+			expectedTargetIPsV6: []string{"fe00:0:0:0:2::2"}, // fallback to cluster endpoints
+			expectedV4Changed:   false,
+			expectedV6Changed:   false,
+		},
+		// OCP HACK END
+	}
+	for i, tt := range tc {
+		t.Run(fmt.Sprintf("%d_%s", i, tt.name), func(t *testing.T) {
+			actualTargetIPsV4, actualTargetIPsV6, actualV4Changed, actualV6Changed := makeNodeSwitchTargetIPs(tt.service, tt.node, tt.config)
+			assert.Equal(t, tt.expectedTargetIPsV4, actualTargetIPsV4)
+			assert.Equal(t, tt.expectedTargetIPsV6, actualTargetIPsV6)
+			assert.Equal(t, tt.expectedV4Changed, actualV4Changed)
+			assert.Equal(t, tt.expectedV6Changed, actualV6Changed)
+
 		})
 	}
 }

--- a/go-controller/pkg/ovn/controller/services/node_tracker.go
+++ b/go-controller/pkg/ovn/controller/services/node_tracker.go
@@ -75,27 +75,6 @@ func (ni *nodeInfo) l3gatewayAddressesStr() []string {
 	return out
 }
 
-// returns a list of all ip blocks "assigned" to this node
-// includes node IPs, still as a mask-1 net
-func (ni *nodeInfo) nodeSubnets() []net.IPNet {
-	out := append([]net.IPNet{}, ni.podSubnets...)
-	for _, ip := range ni.hostAddresses {
-		if ipv4 := ip.To4(); ipv4 != nil {
-			out = append(out, net.IPNet{
-				IP:   ip,
-				Mask: net.CIDRMask(32, 32),
-			})
-		} else {
-			out = append(out, net.IPNet{
-				IP:   ip,
-				Mask: net.CIDRMask(128, 128),
-			})
-		}
-	}
-
-	return out
-}
-
 func newNodeTracker(zone string, resyncFn func(nodes []nodeInfo)) *nodeTracker {
 	return &nodeTracker{
 		nodes:    map[string]nodeInfo{},

--- a/go-controller/pkg/ovn/controller/services/services_controller.go
+++ b/go-controller/pkg/ovn/controller/services/services_controller.go
@@ -409,16 +409,14 @@ func (c *Controller) syncService(key string) error {
 	}
 
 	// Build the abstract LB configs for this service
-	perNodeConfigs, templateConfigs, clusterConfigs := buildServiceLBConfigs(service, endpointSlices,
-		c.useLBGroups, c.useTemplates)
+	perNodeConfigs, templateConfigs, clusterConfigs := buildServiceLBConfigs(service, endpointSlices, c.nodeInfos, c.useLBGroups, c.useTemplates)
 	klog.V(5).Infof("Built service %s LB cluster-wide configs %#v", key, clusterConfigs)
 	klog.V(5).Infof("Built service %s LB per-node configs %#v", key, perNodeConfigs)
 	klog.V(5).Infof("Built service %s LB template configs %#v", key, templateConfigs)
 
 	// Convert the LB configs in to load-balancer objects
 	clusterLBs := buildClusterLBs(service, clusterConfigs, c.nodeInfos, c.useLBGroups)
-	templateLBs := buildTemplateLBs(service, templateConfigs, c.nodeInfos,
-		c.nodeIPv4Templates, c.nodeIPv6Templates)
+	templateLBs := buildTemplateLBs(service, templateConfigs, c.nodeInfos, c.nodeIPv4Templates, c.nodeIPv6Templates)
 	perNodeLBs := buildPerNodeLBs(service, perNodeConfigs, c.nodeInfos)
 	klog.V(5).Infof("Built service %s cluster-wide LB %#v", key, clusterLBs)
 	klog.V(5).Infof("Built service %s per-node LB %#v", key, perNodeLBs)

--- a/go-controller/pkg/testing/kube.go
+++ b/go-controller/pkg/testing/kube.go
@@ -1,0 +1,51 @@
+package testing
+
+import (
+	discovery "k8s.io/api/discovery/v1"
+	utilpointer "k8s.io/utils/pointer"
+)
+
+// USED ONLY FOR TESTING
+
+// makeReadyEndpointList returns a list of only one endpoint that carries the input addresses.
+func MakeReadyEndpointList(node string, addresses ...string) []discovery.Endpoint {
+	return []discovery.Endpoint{
+		MakeReadyEndpoint(node, addresses...),
+	}
+}
+
+func MakeReadyEndpoint(node string, addresses ...string) discovery.Endpoint {
+	return discovery.Endpoint{
+		Conditions: discovery.EndpointConditions{
+			Ready:       utilpointer.Bool(true),
+			Serving:     utilpointer.Bool(true),
+			Terminating: utilpointer.Bool(false),
+		},
+		Addresses: addresses,
+		NodeName:  &node,
+	}
+}
+
+func MakeTerminatingServingEndpoint(node string, addresses ...string) discovery.Endpoint {
+	return discovery.Endpoint{
+		Conditions: discovery.EndpointConditions{
+			Ready:       utilpointer.Bool(false),
+			Serving:     utilpointer.Bool(true),
+			Terminating: utilpointer.Bool(true),
+		},
+		Addresses: addresses,
+		NodeName:  &node,
+	}
+}
+
+func MakeTerminatingNonServingEndpoint(node string, addresses ...string) discovery.Endpoint {
+	return discovery.Endpoint{
+		Conditions: discovery.EndpointConditions{
+			Ready:       utilpointer.Bool(false),
+			Serving:     utilpointer.Bool(false),
+			Terminating: utilpointer.Bool(true),
+		},
+		Addresses: addresses,
+		NodeName:  &node,
+	}
+}

--- a/go-controller/pkg/util/kube.go
+++ b/go-controller/pkg/util/kube.go
@@ -593,86 +593,6 @@ func UseEndpointSlices(kubeClient kubernetes.Interface) bool {
 	return false
 }
 
-type LbEndpoints struct {
-	V4IPs []string
-	V6IPs []string
-	Port  int32
-}
-
-// GetLbEndpoints returns the IPv4 and IPv6 addresses of eligible endpoints from a
-// provided list of endpoint slices, for a given service and service port.
-func GetLbEndpoints(slices []*discovery.EndpointSlice, svcPort kapi.ServicePort, service *v1.Service) LbEndpoints {
-	var validSlices []*discovery.EndpointSlice
-	v4IPs := sets.NewString()
-	v6IPs := sets.NewString()
-	out := LbEndpoints{}
-
-	// return an empty object so the caller doesn't have to check for nil and can use it as an iterator
-	if len(slices) == 0 {
-		return out
-	}
-
-	for _, slice := range slices {
-		klog.V(5).Infof("Getting endpoints for slice %s/%s", slice.Namespace, slice.Name)
-
-		for _, slicePort := range slice.Ports {
-			// If Service port name is set, it must match the name field in the endpoint
-			// If Service port name is not set, we just use the endpoint port
-			if svcPort.Name != "" && svcPort.Name != *slicePort.Name {
-				klog.V(5).Infof("Slice %s with different Port name, requested: %s received: %s",
-					slice.Name, svcPort.Name, *slicePort.Name)
-				continue
-			}
-
-			// Skip ports that don't match the protocol
-			if *slicePort.Protocol != svcPort.Protocol {
-				klog.V(5).Infof("Slice %s with different Port protocol, requested: %s received: %s",
-					slice.Name, svcPort.Protocol, *slicePort.Protocol)
-				continue
-			}
-
-			out.Port = *slicePort.Port
-
-			if slice.AddressType == discovery.AddressTypeFQDN {
-				klog.V(5).Infof("Skipping FQDN slice %s/%s", slice.Namespace, slice.Name)
-			} else { // endpoints are here either IPv4 or IPv6
-				validSlices = append(validSlices, slice)
-			}
-		}
-	}
-
-	serviceStr := ""
-	if service != nil {
-		serviceStr = fmt.Sprintf(" for service %s/%s", service.Namespace, service.Name)
-	}
-	// separate IPv4 from IPv6 addresses for eligible endpoints
-	for _, endpoint := range getEligibleEndpoints(validSlices, service) {
-		for _, ip := range endpoint.Addresses {
-			if utilnet.IsIPv4String(ip) {
-				klog.V(5).Infof("Adding endpoint IPv4 address %s port %d%s",
-					ip, out.Port, serviceStr)
-				v4IPs.Insert(utilnet.ParseIPSloppy(ip).String())
-
-			} else if utilnet.IsIPv6String(ip) {
-				klog.V(5).Infof("Adding endpoint IPv6 address %s port %d%s",
-					ip, out.Port, serviceStr)
-				v6IPs.Insert(utilnet.ParseIPSloppy(ip).String())
-
-			} else {
-				klog.V(5).Infof("Skipping unrecognized address %s port %d%s",
-					ip, out.Port, serviceStr)
-			}
-		}
-	}
-
-	out.V4IPs = v4IPs.List()
-	out.V6IPs = v6IPs.List()
-	klog.V(5).Infof("LB Endpoints for %s/%s are: %v / %v on port: %d",
-		slices[0].Namespace, slices[0].Labels[discovery.LabelServiceName],
-		out.V4IPs, out.V6IPs, out.Port)
-	return out
-}
-
 type K8sObject interface {
 	metav1.Object
 	k8sruntime.Object
@@ -746,64 +666,54 @@ func NoHostSubnet(node *v1.Node) bool {
 // are always published.
 // Note that condFn, when specified, is used by utility functions to filter out non-local endpoints.
 // It's important to run it /before/ the eligible endpoint selection, since the order impacts the output.
-func getSelectedEligibleEndpoints(endpointSlices []*discovery.EndpointSlice, service *kapi.Service, condFn func(ep discovery.Endpoint) bool) []discovery.Endpoint {
+func getSelectedEligibleEndpoints(endpoints []discovery.Endpoint, service *kapi.Service, condFn func(ep discovery.Endpoint) bool) []discovery.Endpoint {
 	var readySelectedEndpoints []discovery.Endpoint
 	var servingTerminatingSelectedEndpoints []discovery.Endpoint
 	var eligibleEndpoints []discovery.Endpoint
 
 	includeAllEndpoints := service != nil && service.Spec.PublishNotReadyAddresses
 
-	for _, slice := range endpointSlices {
-		for _, endpoint := range slice.Endpoints {
-			// Apply precondition on endpoints, if provided
-			if condFn == nil || condFn(endpoint) {
-				// Assign to the ready or the serving&terminating slice for a later decision
-				if includeAllEndpoints || IsEndpointReady(endpoint) {
-					readySelectedEndpoints = append(readySelectedEndpoints, endpoint)
-				} else if IsEndpointServing(endpoint) && IsEndpointTerminating(endpoint) {
-					servingTerminatingSelectedEndpoints = append(servingTerminatingSelectedEndpoints, endpoint)
-				}
+	for _, endpoint := range endpoints {
+		// Apply precondition on endpoints, if provided
+		if condFn == nil || condFn(endpoint) {
+			// Assign to the ready or the serving&terminating slice for a later decision
+			if includeAllEndpoints || IsEndpointReady(endpoint) {
+				readySelectedEndpoints = append(readySelectedEndpoints, endpoint)
+			} else if IsEndpointServing(endpoint) && IsEndpointTerminating(endpoint) {
+				servingTerminatingSelectedEndpoints = append(servingTerminatingSelectedEndpoints, endpoint)
 			}
 		}
 	}
-	serviceStr := ""
-	if service != nil {
-		serviceStr = fmt.Sprintf(" (service %s/%s)", service.Namespace, service.Name)
-	}
-	klog.V(5).Infof("Endpoint selection%s: found %d ready endpoints", serviceStr, len(readySelectedEndpoints))
-
 	// Select eligible endpoints based on readiness
 	eligibleEndpoints = readySelectedEndpoints
 	// Fallback to serving terminating endpoints (ready=false, serving=true, terminating=true) only if none are ready
 	if len(readySelectedEndpoints) == 0 {
 		eligibleEndpoints = servingTerminatingSelectedEndpoints
-		klog.V(5).Infof("Endpoint selection%s: fallback to %d serving & terminating endpoints",
-			serviceStr, len(servingTerminatingSelectedEndpoints))
 	}
 
 	return eligibleEndpoints
 }
 
-func getLocalEligibleEndpoints(endpointSlices []*discovery.EndpointSlice, service *kapi.Service, nodeName string) []discovery.Endpoint {
-	return getSelectedEligibleEndpoints(endpointSlices, service, func(endpoint discovery.Endpoint) bool {
+func getLocalEligibleEndpoints(endpoints []discovery.Endpoint, service *kapi.Service, nodeName string) []discovery.Endpoint {
+	return getSelectedEligibleEndpoints(endpoints, service, func(endpoint discovery.Endpoint) bool {
 		return endpoint.NodeName != nil && *endpoint.NodeName == nodeName
 	})
 }
 
-func getEligibleEndpoints(endpointSlices []*discovery.EndpointSlice, service *kapi.Service) []discovery.Endpoint {
-	return getSelectedEligibleEndpoints(endpointSlices, service, nil)
+func getEligibleEndpoints(endpoints []discovery.Endpoint, service *kapi.Service) []discovery.Endpoint {
+	return getSelectedEligibleEndpoints(endpoints, service, nil)
 }
 
-// getEligibleEndpointAddresses takes a list of endpointSlices, a service and, optionally, a nodeName
+// getEligibleEndpointAddresses takes a list of endpoints, a service and, optionally, a nodeName
 // and applies the endpoint selection logic. It returns the IP addresses of eligible endpoints.
-func getEligibleEndpointAddresses(endpointSlices []*discovery.EndpointSlice, service *kapi.Service, nodeName string) sets.Set[string] {
+func getEligibleEndpointAddresses(endpoints []discovery.Endpoint, service *kapi.Service, nodeName string) []string {
 	endpointsAddresses := sets.New[string]()
 	var eligibleEndpoints []discovery.Endpoint
 
 	if nodeName != "" {
-		eligibleEndpoints = getLocalEligibleEndpoints(endpointSlices, service, nodeName)
+		eligibleEndpoints = getLocalEligibleEndpoints(endpoints, service, nodeName)
 	} else {
-		eligibleEndpoints = getEligibleEndpoints(endpointSlices, service)
+		eligibleEndpoints = getEligibleEndpoints(endpoints, service)
 	}
 	for _, endpoint := range eligibleEndpoints {
 		for _, ip := range endpoint.Addresses {
@@ -811,25 +721,31 @@ func getEligibleEndpointAddresses(endpointSlices []*discovery.EndpointSlice, ser
 		}
 	}
 
-	return endpointsAddresses
+	return sets.List(endpointsAddresses)
 }
 
-// GetEligibleEndpointAddresses returns a list of IP addresses of all eligible endpoints from the given endpoint slices.
-func GetEligibleEndpointAddresses(endpointSlices []*discovery.EndpointSlice, service *kapi.Service) sets.Set[string] {
-	return getEligibleEndpointAddresses(endpointSlices, service, "")
+func GetEligibleEndpointAddresses(endpoints []discovery.Endpoint, service *kapi.Service) []string {
+	return getEligibleEndpointAddresses(endpoints, service, "")
 }
 
-// GetLocalEligibleEndpointAddresses returns a list of IP address of endpoints that are local to the specified node
+// GetEligibleEndpointAddressesFromSlices returns a list of IP addresses of all eligible endpoints from the given endpoint slices.
+func GetEligibleEndpointAddressesFromSlices(endpointSlices []*discovery.EndpointSlice, service *kapi.Service) []string {
+	return getEligibleEndpointAddresses(getEndpointsFromEndpointSlices(endpointSlices), service, "")
+}
+
+// GetLocalEligibleEndpointAddressesFromSlices returns a set of IP addresses of endpoints that are local to the specified node
 // and are eligible.
-func GetLocalEligibleEndpointAddresses(endpointSlices []*discovery.EndpointSlice, service *kapi.Service, nodeName string) sets.Set[string] {
-	return getEligibleEndpointAddresses(endpointSlices, service, nodeName)
+func GetLocalEligibleEndpointAddressesFromSlices(endpointSlices []*discovery.EndpointSlice, service *kapi.Service, nodeName string) sets.Set[string] {
+	endpoints := getEligibleEndpointAddresses(getEndpointsFromEndpointSlices(endpointSlices), service, nodeName)
+	return sets.New(endpoints...)
 }
 
 // DoesEndpointSliceContainEndpoint returns true if the endpointslice
 // contains an endpoint with the given IP, port and Protocol and if this endpoint is considered eligible.
 func DoesEndpointSliceContainEligibleEndpoint(endpointSlice *discovery.EndpointSlice,
 	epIP string, epPort int32, protocol kapi.Protocol, service *kapi.Service) bool {
-	for _, ep := range getEligibleEndpoints([]*discovery.EndpointSlice{endpointSlice}, service) {
+	endpoints := getEndpointsFromEndpointSlices([]*discovery.EndpointSlice{endpointSlice})
+	for _, ep := range getEligibleEndpoints(endpoints, service) {
 		for _, ip := range ep.Addresses {
 			for _, port := range endpointSlice.Ports {
 				if utilnet.ParseIPSloppy(ip).String() == epIP && *port.Port == epPort && *port.Protocol == protocol {
@@ -877,4 +793,12 @@ func IsHostEndpoint(endpointIPstr string) bool {
 		}
 	}
 	return true
+}
+
+func getEndpointsFromEndpointSlices(endpointSlices []*discovery.EndpointSlice) []discovery.Endpoint {
+	endpoints := []discovery.Endpoint{}
+	for _, slice := range endpointSlices {
+		endpoints = append(endpoints, slice.Endpoints...)
+	}
+	return endpoints
 }

--- a/go-controller/pkg/util/kube_test.go
+++ b/go-controller/pkg/util/kube_test.go
@@ -8,17 +8,23 @@ import (
 	"testing"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	kube_test "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
+
 	"github.com/stretchr/testify/assert"
 	kapi "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/sets"
 	clientsetfake "k8s.io/client-go/kubernetes/fake"
 	utilpointer "k8s.io/utils/pointer"
+)
+
+var (
+	nodeA = "node-a"
+	nodeB = "node-b"
 )
 
 // Go Daddy Class 2 CA
@@ -420,1026 +426,6 @@ func makeNodeWithAddresses(name, internal, external string) *v1.Node {
 	return node
 }
 
-func Test_getLbEndpoints(t *testing.T) {
-	type args struct {
-		slices  []*discovery.EndpointSlice
-		svcPort v1.ServicePort
-		service *v1.Service
-	}
-	tests := []struct {
-		name string
-		args args
-		want LbEndpoints
-	}{
-		{
-			name: "empty slices",
-			args: args{
-				slices: []*discovery.EndpointSlice{},
-				svcPort: v1.ServicePort{
-					Name:       "tcp-example",
-					TargetPort: intstr.FromInt(80),
-					Protocol:   v1.ProtocolTCP,
-				},
-				service: getSampleService(false),
-			},
-			want: LbEndpoints{},
-		},
-		{
-			name: "slice with one endpoint",
-			args: args{
-				slices: []*discovery.EndpointSlice{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc-ab23",
-							Namespace: "ns",
-							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
-						},
-						Ports: []discovery.EndpointPort{
-							{
-								Name:     utilpointer.StringPtr("tcp-example"),
-								Protocol: protoPtr(v1.ProtocolTCP),
-								Port:     utilpointer.Int32Ptr(int32(80)),
-							},
-						},
-						AddressType: discovery.AddressTypeIPv4,
-						Endpoints: []discovery.Endpoint{
-							{
-								Conditions: discovery.EndpointConditions{
-									Ready: utilpointer.Bool(true),
-								},
-								Addresses: []string{"10.0.0.2"},
-							},
-						},
-					},
-				},
-				svcPort: v1.ServicePort{
-					Name:       "tcp-example",
-					TargetPort: intstr.FromInt(80),
-					Protocol:   v1.ProtocolTCP,
-				},
-				service: getSampleService(false),
-			},
-			want: LbEndpoints{[]string{"10.0.0.2"}, []string{}, 80},
-		},
-		{
-			name: "slice with different port name than the service",
-			args: args{
-				slices: []*discovery.EndpointSlice{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc-ab23",
-							Namespace: "ns",
-							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
-						},
-						Ports: []discovery.EndpointPort{
-							{
-								Name:     utilpointer.StringPtr("tcp-example-wrong"),
-								Protocol: protoPtr(v1.ProtocolTCP),
-								Port:     utilpointer.Int32Ptr(int32(8080)),
-							},
-						},
-						AddressType: discovery.AddressTypeIPv4,
-						Endpoints: []discovery.Endpoint{
-							{
-								Conditions: discovery.EndpointConditions{
-									Ready: utilpointer.Bool(true),
-								},
-								Addresses: []string{"10.0.0.2"},
-							},
-						},
-					},
-				},
-				svcPort: v1.ServicePort{
-					Name:       "tcp-example",
-					TargetPort: intstr.FromInt(80),
-					Protocol:   v1.ProtocolTCP,
-				},
-				service: getSampleService(false),
-			},
-			want: LbEndpoints{[]string{}, []string{}, 0},
-		},
-		{
-			name: "slice and service without a port name",
-			args: args{
-				slices: []*discovery.EndpointSlice{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc-ab23",
-							Namespace: "ns",
-							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
-						},
-						Ports: []discovery.EndpointPort{
-							{
-								Protocol: protoPtr(v1.ProtocolTCP),
-								Port:     utilpointer.Int32Ptr(int32(8080)),
-							},
-						},
-						AddressType: discovery.AddressTypeIPv4,
-						Endpoints: []discovery.Endpoint{
-							{
-								Conditions: discovery.EndpointConditions{
-									Ready: utilpointer.Bool(true),
-								},
-								Addresses: []string{"10.0.0.2"},
-							},
-						},
-					},
-				},
-				svcPort: v1.ServicePort{
-					TargetPort: intstr.FromInt(80),
-					Protocol:   v1.ProtocolTCP,
-				},
-				service: getSampleService(false),
-			},
-			want: LbEndpoints{[]string{"10.0.0.2"}, []string{}, 8080},
-		},
-		{
-			name: "slice with an IPv6 endpoint",
-			args: args{
-				slices: []*discovery.EndpointSlice{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc-ab23",
-							Namespace: "ns",
-							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
-						},
-						Ports: []discovery.EndpointPort{
-							{
-								Name:     utilpointer.StringPtr("tcp-example"),
-								Protocol: protoPtr(v1.ProtocolTCP),
-								Port:     utilpointer.Int32Ptr(int32(80)),
-							},
-						},
-						AddressType: discovery.AddressTypeIPv6,
-						Endpoints: []discovery.Endpoint{
-							{
-								Conditions: discovery.EndpointConditions{
-									Ready: utilpointer.Bool(true),
-								},
-								Addresses: []string{"2001:db2::2"},
-							},
-						},
-					},
-				},
-				svcPort: v1.ServicePort{
-					Name:       "tcp-example",
-					TargetPort: intstr.FromInt(80),
-					Protocol:   v1.ProtocolTCP,
-				},
-				service: getSampleService(false),
-			},
-			want: LbEndpoints{[]string{}, []string{"2001:db2::2"}, 80},
-		},
-		{
-			name: "a slice with an IPv4 endpoint and a slice with an IPv6 endpoint (dualstack cluster)",
-			args: args{
-				slices: []*discovery.EndpointSlice{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc-ab23",
-							Namespace: "ns",
-							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
-						},
-						Ports: []discovery.EndpointPort{
-							{
-								Name:     utilpointer.StringPtr("tcp-example"),
-								Protocol: protoPtr(v1.ProtocolTCP),
-								Port:     utilpointer.Int32Ptr(int32(80)),
-							},
-						},
-						AddressType: discovery.AddressTypeIPv4,
-						Endpoints: []discovery.Endpoint{
-							{
-								Conditions: discovery.EndpointConditions{
-									Ready: utilpointer.Bool(true),
-								},
-								Addresses: []string{"10.0.0.2"},
-							},
-						},
-					},
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc-ab24",
-							Namespace: "ns",
-							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
-						},
-						Ports: []discovery.EndpointPort{
-							{
-								Name:     utilpointer.StringPtr("tcp-example"),
-								Protocol: protoPtr(v1.ProtocolTCP),
-								Port:     utilpointer.Int32Ptr(int32(80)),
-							},
-						},
-						AddressType: discovery.AddressTypeIPv6,
-						Endpoints: []discovery.Endpoint{
-							{
-								Conditions: discovery.EndpointConditions{
-									Ready: utilpointer.Bool(true),
-								},
-								Addresses: []string{"2001:db2::2"},
-							},
-						},
-					},
-				},
-				svcPort: v1.ServicePort{
-					Name:       "tcp-example",
-					TargetPort: intstr.FromInt(80),
-					Protocol:   v1.ProtocolTCP,
-				},
-				service: getSampleService(false),
-			},
-			want: LbEndpoints{[]string{"10.0.0.2"}, []string{"2001:db2::2"}, 80},
-		},
-		{
-			name: "multiples slices with a duplicate endpoint",
-			args: args{
-				slices: []*discovery.EndpointSlice{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc-ab23",
-							Namespace: "ns",
-							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
-						},
-						Ports: []discovery.EndpointPort{
-							{
-								Name:     utilpointer.StringPtr("tcp-example"),
-								Protocol: protoPtr(v1.ProtocolTCP),
-								Port:     utilpointer.Int32Ptr(int32(80)),
-							},
-						},
-						AddressType: discovery.AddressTypeIPv4,
-						Endpoints: []discovery.Endpoint{
-							{
-								Conditions: discovery.EndpointConditions{
-									Ready: utilpointer.Bool(true),
-								},
-								Addresses: []string{"10.0.0.2", "10.1.1.2"},
-							},
-						},
-					},
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc-ab24",
-							Namespace: "ns",
-							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
-						},
-						Ports: []discovery.EndpointPort{
-							{
-								Name:     utilpointer.StringPtr("tcp-example"),
-								Protocol: protoPtr(v1.ProtocolTCP),
-								Port:     utilpointer.Int32Ptr(int32(80)),
-							},
-						},
-						AddressType: discovery.AddressTypeIPv4,
-						Endpoints: []discovery.Endpoint{
-							{
-								Conditions: discovery.EndpointConditions{
-									Ready: utilpointer.Bool(true),
-								},
-								Addresses: []string{"10.0.0.2", "10.2.2.2"},
-							},
-						},
-					},
-				},
-				svcPort: v1.ServicePort{
-					Name:       "tcp-example",
-					TargetPort: intstr.FromInt(80),
-					Protocol:   v1.ProtocolTCP,
-				},
-				service: getSampleService(false),
-			},
-			want: LbEndpoints{[]string{"10.0.0.2", "10.1.1.2", "10.2.2.2"}, []string{}, 80},
-		},
-		{
-			name: "multiples slices with different ports",
-			args: args{
-				slices: []*discovery.EndpointSlice{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc-ab23",
-							Namespace: "ns",
-							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
-						},
-						Ports: []discovery.EndpointPort{
-							{
-								Name:     utilpointer.StringPtr("tcp-example"),
-								Protocol: protoPtr(v1.ProtocolTCP),
-								Port:     utilpointer.Int32Ptr(int32(80)),
-							},
-						},
-						AddressType: discovery.AddressTypeIPv4,
-						Endpoints: []discovery.Endpoint{
-							{
-								Conditions: discovery.EndpointConditions{
-									Ready: utilpointer.Bool(true),
-								},
-								Addresses: []string{"10.0.0.2", "10.1.1.2"},
-							},
-						},
-					},
-					{ // this slice should be ignored, we're considering only one service port per execution
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc-ab24",
-							Namespace: "ns",
-							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
-						},
-						Ports: []discovery.EndpointPort{
-							{
-								Name:     utilpointer.StringPtr("other-port"),
-								Protocol: protoPtr(v1.ProtocolTCP),
-								Port:     utilpointer.Int32Ptr(int32(8080)),
-							},
-						},
-						AddressType: discovery.AddressTypeIPv4,
-						Endpoints: []discovery.Endpoint{
-							{
-								Conditions: discovery.EndpointConditions{
-									Ready: utilpointer.Bool(true),
-								},
-								Addresses: []string{"10.0.0.3", "10.2.2.3"},
-							},
-						},
-					},
-				},
-				svcPort: v1.ServicePort{
-					Name:       "tcp-example",
-					TargetPort: intstr.FromInt(80),
-					Protocol:   v1.ProtocolTCP,
-				},
-				service: getSampleService(false),
-			},
-			want: LbEndpoints{[]string{"10.0.0.2", "10.1.1.2"}, []string{}, 80},
-		},
-		{
-			name: "slice with a mix of ready and terminating (serving and non-serving) endpoints",
-			args: args{
-				slices: []*discovery.EndpointSlice{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc-ab23",
-							Namespace: "ns",
-							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
-						},
-						Ports: []discovery.EndpointPort{
-							{
-								Name:     utilpointer.StringPtr("tcp-example"),
-								Protocol: protoPtr(v1.ProtocolTCP),
-								Port:     utilpointer.Int32Ptr(int32(80)),
-							},
-						},
-						AddressType: discovery.AddressTypeIPv6,
-						Endpoints: []discovery.Endpoint{
-							{
-								Conditions: discovery.EndpointConditions{
-									Ready:       utilpointer.Bool(true),
-									Serving:     utilpointer.Bool(true),
-									Terminating: utilpointer.Bool(false),
-								},
-								Addresses: []string{"2001:db2::2"},
-							},
-							{
-								Conditions: discovery.EndpointConditions{
-									Ready:       utilpointer.Bool(true),
-									Serving:     utilpointer.Bool(true),
-									Terminating: utilpointer.Bool(false),
-								},
-								Addresses: []string{"2001:db2::3"},
-							},
-							{
-								Conditions: discovery.EndpointConditions{ // ignored
-									Ready:       utilpointer.Bool(false),
-									Serving:     utilpointer.Bool(true),
-									Terminating: utilpointer.Bool(true),
-								},
-								Addresses: []string{"2001:db2::4"},
-							},
-							{
-								Conditions: discovery.EndpointConditions{ // ignored
-									Ready:       utilpointer.Bool(false),
-									Serving:     utilpointer.Bool(true),
-									Terminating: utilpointer.Bool(true),
-								},
-								Addresses: []string{"2001:db2::5"},
-							},
-							{
-								Conditions: discovery.EndpointConditions{ // ignored
-									Ready:       utilpointer.Bool(false),
-									Serving:     utilpointer.Bool(false),
-									Terminating: utilpointer.Bool(true),
-								},
-								Addresses: []string{"2001:db2::6"},
-							},
-						},
-					},
-				},
-				svcPort: v1.ServicePort{
-					Name:       "tcp-example",
-					TargetPort: intstr.FromInt(80),
-					Protocol:   v1.ProtocolTCP,
-				},
-				service: getSampleService(false),
-			},
-			want: LbEndpoints{[]string{}, []string{"2001:db2::2", "2001:db2::3"}, 80},
-		},
-		{
-			name: "slice with a mix of terminating (serving and non-serving) endpoints and no ready endpoints",
-			args: args{
-				slices: []*discovery.EndpointSlice{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc-ab23",
-							Namespace: "ns",
-							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
-						},
-						Ports: []discovery.EndpointPort{
-							{
-								Name:     utilpointer.StringPtr("tcp-example"),
-								Protocol: protoPtr(v1.ProtocolTCP),
-								Port:     utilpointer.Int32Ptr(int32(80)),
-							},
-						},
-						AddressType: discovery.AddressTypeIPv6,
-						Endpoints: []discovery.Endpoint{
-							{
-								Conditions: discovery.EndpointConditions{
-									Ready:       utilpointer.Bool(false),
-									Serving:     utilpointer.Bool(true),
-									Terminating: utilpointer.Bool(true),
-								},
-								Addresses: []string{"2001:db2::4"},
-							},
-							{
-								Conditions: discovery.EndpointConditions{
-									Ready:       utilpointer.Bool(false),
-									Serving:     utilpointer.Bool(true),
-									Terminating: utilpointer.Bool(true),
-								},
-								Addresses: []string{"2001:db2::5"},
-							},
-							{
-								Conditions: discovery.EndpointConditions{ // ignored
-									Ready:       utilpointer.Bool(false),
-									Serving:     utilpointer.Bool(false),
-									Terminating: utilpointer.Bool(true),
-								},
-								Addresses: []string{"2001:db2::6"},
-							},
-							{
-								Conditions: discovery.EndpointConditions{ // ignored
-									Ready:       utilpointer.Bool(false),
-									Serving:     utilpointer.Bool(false),
-									Terminating: utilpointer.Bool(true),
-								},
-								Addresses: []string{"2001:db2::7"},
-							},
-						},
-					},
-				},
-				svcPort: v1.ServicePort{
-					Name:       "tcp-example",
-					TargetPort: intstr.FromInt(80),
-					Protocol:   v1.ProtocolTCP,
-				},
-				service: getSampleService(false),
-			},
-			want: LbEndpoints{[]string{}, []string{"2001:db2::4", "2001:db2::5"}, 80},
-		},
-		{
-			name: "slice with only terminating non-serving endpoints",
-			args: args{
-				slices: []*discovery.EndpointSlice{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc-ab23",
-							Namespace: "ns",
-							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
-						},
-						Ports: []discovery.EndpointPort{
-							{
-								Name:     utilpointer.StringPtr("tcp-example"),
-								Protocol: protoPtr(v1.ProtocolTCP),
-								Port:     utilpointer.Int32Ptr(int32(80)),
-							},
-						},
-						AddressType: discovery.AddressTypeIPv6,
-						Endpoints: []discovery.Endpoint{
-							{
-								Conditions: discovery.EndpointConditions{ // ignored
-									Ready:       utilpointer.Bool(false),
-									Serving:     utilpointer.Bool(false),
-									Terminating: utilpointer.Bool(true),
-								},
-								Addresses: []string{"2001:db2::6"},
-							},
-							{
-								Conditions: discovery.EndpointConditions{ // ignored
-									Ready:       utilpointer.Bool(false),
-									Serving:     utilpointer.Bool(false),
-									Terminating: utilpointer.Bool(true),
-								},
-								Addresses: []string{"2001:db2::7"},
-							},
-						},
-					},
-				},
-				svcPort: v1.ServicePort{
-					Name:       "tcp-example",
-					TargetPort: intstr.FromInt(80),
-					Protocol:   v1.ProtocolTCP,
-				},
-				service: getSampleService(false),
-			},
-			want: LbEndpoints{[]string{}, []string{}, 80},
-		},
-		{
-			name: "multiple slices with a mix terminating (serving and non-serving) endpoints and no ready endpoints",
-			args: args{
-				slices: []*discovery.EndpointSlice{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc-ab23",
-							Namespace: "ns",
-							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
-						},
-						Ports: []discovery.EndpointPort{
-							{
-								Name:     utilpointer.StringPtr("tcp-example"),
-								Protocol: protoPtr(v1.ProtocolTCP),
-								Port:     utilpointer.Int32Ptr(int32(80)),
-							},
-						},
-						AddressType: discovery.AddressTypeIPv6,
-						Endpoints: []discovery.Endpoint{
-							{
-								Conditions: discovery.EndpointConditions{ // ignored
-									Ready:       utilpointer.Bool(false),
-									Serving:     utilpointer.Bool(false),
-									Terminating: utilpointer.Bool(true),
-								},
-								Addresses: []string{"2001:db2::2"},
-							},
-							{
-								Conditions: discovery.EndpointConditions{
-									Ready:       utilpointer.Bool(false),
-									Serving:     utilpointer.Bool(true),
-									Terminating: utilpointer.Bool(true),
-								},
-								Addresses: []string{"2001:db2::3"},
-							},
-						},
-					},
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc-ab24",
-							Namespace: "ns",
-							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
-						},
-						Ports: []discovery.EndpointPort{
-							{
-								Name:     utilpointer.StringPtr("tcp-example"),
-								Protocol: protoPtr(v1.ProtocolTCP),
-								Port:     utilpointer.Int32Ptr(int32(80)),
-							},
-						},
-						AddressType: discovery.AddressTypeIPv6,
-						Endpoints: []discovery.Endpoint{
-							{
-								Conditions: discovery.EndpointConditions{
-									Ready:       utilpointer.Bool(false),
-									Serving:     utilpointer.Bool(true),
-									Terminating: utilpointer.Bool(true),
-								},
-								Addresses: []string{"2001:db2::4"},
-							},
-							{
-								Conditions: discovery.EndpointConditions{ // ignored
-									Ready:       utilpointer.Bool(false),
-									Serving:     utilpointer.Bool(false),
-									Terminating: utilpointer.Bool(true),
-								},
-								Addresses: []string{"2001:db2::5"},
-							},
-						},
-					},
-				},
-				svcPort: v1.ServicePort{
-					Name:       "tcp-example",
-					TargetPort: intstr.FromInt(80),
-					Protocol:   v1.ProtocolTCP,
-				},
-				service: getSampleService(false),
-			},
-			want: LbEndpoints{[]string{}, []string{"2001:db2::3", "2001:db2::4"}, 80},
-		},
-		{
-			name: "multiple slices with only terminating non-serving endpoints",
-			args: args{
-				slices: []*discovery.EndpointSlice{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc-ab23",
-							Namespace: "ns",
-							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
-						},
-						Ports: []discovery.EndpointPort{
-							{
-								Name:     utilpointer.StringPtr("tcp-example"),
-								Protocol: protoPtr(v1.ProtocolTCP),
-								Port:     utilpointer.Int32Ptr(int32(80)),
-							},
-						},
-						AddressType: discovery.AddressTypeIPv6,
-						Endpoints: []discovery.Endpoint{
-							{
-								Conditions: discovery.EndpointConditions{ // ignored
-									Ready:       utilpointer.Bool(false),
-									Serving:     utilpointer.Bool(false),
-									Terminating: utilpointer.Bool(true),
-								},
-								Addresses: []string{"2001:db2::2"},
-							},
-						},
-					},
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc-ab24",
-							Namespace: "ns",
-							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
-						},
-						Ports: []discovery.EndpointPort{
-							{
-								Name:     utilpointer.StringPtr("tcp-example"),
-								Protocol: protoPtr(v1.ProtocolTCP),
-								Port:     utilpointer.Int32Ptr(int32(80)),
-							},
-						},
-						AddressType: discovery.AddressTypeIPv6,
-						Endpoints: []discovery.Endpoint{
-							{
-								Conditions: discovery.EndpointConditions{ // ignored
-									Ready:       utilpointer.Bool(false),
-									Serving:     utilpointer.Bool(false),
-									Terminating: utilpointer.Bool(true),
-								},
-								Addresses: []string{"2001:db2::5"},
-							},
-						},
-					},
-				},
-				svcPort: v1.ServicePort{
-					Name:       "tcp-example",
-					TargetPort: intstr.FromInt(80),
-					Protocol:   v1.ProtocolTCP,
-				},
-				service: getSampleService(false),
-			},
-			want: LbEndpoints{[]string{}, []string{}, 80},
-		},
-		{
-			name: "multiple slices with a mix of IPv4 and IPv6 ready and terminating (serving and non-serving) endpoints (dualstack cluster)",
-			args: args{
-				slices: []*discovery.EndpointSlice{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc-ab23",
-							Namespace: "ns",
-							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
-						},
-						Ports: []discovery.EndpointPort{
-							{
-								Name:     utilpointer.StringPtr("tcp-example"),
-								Protocol: protoPtr(v1.ProtocolTCP),
-								Port:     utilpointer.Int32Ptr(int32(80)),
-							},
-						},
-						AddressType: discovery.AddressTypeIPv4,
-						Endpoints: []discovery.Endpoint{
-							{
-								Conditions: discovery.EndpointConditions{
-									Ready:       utilpointer.Bool(true),
-									Serving:     utilpointer.Bool(true),
-									Terminating: utilpointer.Bool(false),
-								},
-								Addresses: []string{"10.0.0.2"},
-							},
-							{
-								Conditions: discovery.EndpointConditions{ // ignored
-									Ready:       utilpointer.Bool(false),
-									Serving:     utilpointer.Bool(true),
-									Terminating: utilpointer.Bool(true),
-								},
-								Addresses: []string{"10.0.0.3"},
-							},
-							{
-								Conditions: discovery.EndpointConditions{ // ignored
-									Ready:       utilpointer.Bool(false),
-									Serving:     utilpointer.Bool(false),
-									Terminating: utilpointer.Bool(true),
-								},
-								Addresses: []string{"10.0.0.4"},
-							},
-						},
-					},
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc-ab24",
-							Namespace: "ns",
-							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
-						},
-						Ports: []discovery.EndpointPort{
-							{
-								Name:     utilpointer.StringPtr("tcp-example"),
-								Protocol: protoPtr(v1.ProtocolTCP),
-								Port:     utilpointer.Int32Ptr(int32(80)),
-							},
-						},
-						AddressType: discovery.AddressTypeIPv6,
-						Endpoints: []discovery.Endpoint{
-							{
-								Conditions: discovery.EndpointConditions{
-									Ready:       utilpointer.Bool(true),
-									Serving:     utilpointer.Bool(true),
-									Terminating: utilpointer.Bool(false),
-								},
-								Addresses: []string{"2001:db2::2"},
-							},
-							{
-								Conditions: discovery.EndpointConditions{ // ignored
-									Ready:       utilpointer.Bool(false),
-									Serving:     utilpointer.Bool(true),
-									Terminating: utilpointer.Bool(true),
-								},
-								Addresses: []string{"2001:db2::3"},
-							},
-							{
-								Conditions: discovery.EndpointConditions{ // ignored
-									Ready:       utilpointer.Bool(false),
-									Serving:     utilpointer.Bool(false),
-									Terminating: utilpointer.Bool(true),
-								},
-								Addresses: []string{"2001:db2::4"},
-							},
-						},
-					},
-				},
-				svcPort: v1.ServicePort{
-					Name:       "tcp-example",
-					TargetPort: intstr.FromInt(80),
-					Protocol:   v1.ProtocolTCP,
-				},
-				service: getSampleService(false),
-			},
-			want: LbEndpoints{[]string{"10.0.0.2"}, []string{"2001:db2::2"}, 80},
-		},
-		{
-			name: "multiple slices with a mix of IPv4 and IPv6 terminating (serving and non-serving) endpoints and no ready endpoints (dualstack cluster)",
-			args: args{
-				slices: []*discovery.EndpointSlice{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc-ab23",
-							Namespace: "ns",
-							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
-						},
-						Ports: []discovery.EndpointPort{
-							{
-								Name:     utilpointer.StringPtr("tcp-example"),
-								Protocol: protoPtr(v1.ProtocolTCP),
-								Port:     utilpointer.Int32Ptr(int32(80)),
-							},
-						},
-						AddressType: discovery.AddressTypeIPv4,
-						Endpoints: []discovery.Endpoint{
-							{
-								Conditions: discovery.EndpointConditions{
-									Ready:       utilpointer.Bool(false),
-									Serving:     utilpointer.Bool(true),
-									Terminating: utilpointer.Bool(true),
-								},
-								Addresses: []string{"10.0.0.3"},
-							},
-							{
-								Conditions: discovery.EndpointConditions{ // ignored
-									Ready:       utilpointer.Bool(false),
-									Serving:     utilpointer.Bool(false),
-									Terminating: utilpointer.Bool(true),
-								},
-								Addresses: []string{"10.0.0.4"},
-							},
-						},
-					},
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc-ab24",
-							Namespace: "ns",
-							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
-						},
-						Ports: []discovery.EndpointPort{
-							{
-								Name:     utilpointer.StringPtr("tcp-example"),
-								Protocol: protoPtr(v1.ProtocolTCP),
-								Port:     utilpointer.Int32Ptr(int32(80)),
-							},
-						},
-						AddressType: discovery.AddressTypeIPv6,
-						Endpoints: []discovery.Endpoint{
-							{
-								Conditions: discovery.EndpointConditions{
-									Ready:       utilpointer.Bool(false),
-									Serving:     utilpointer.Bool(true),
-									Terminating: utilpointer.Bool(true),
-								},
-								Addresses: []string{"2001:db2::3"},
-							},
-							{
-								Conditions: discovery.EndpointConditions{ // ignored
-									Ready:       utilpointer.Bool(false),
-									Serving:     utilpointer.Bool(false),
-									Terminating: utilpointer.Bool(true),
-								},
-								Addresses: []string{"2001:db2::4"},
-							},
-						},
-					},
-				},
-				svcPort: v1.ServicePort{
-					Name:       "tcp-example",
-					TargetPort: intstr.FromInt(80),
-					Protocol:   v1.ProtocolTCP,
-				},
-				service: getSampleService(false),
-			},
-			want: LbEndpoints{[]string{"10.0.0.3"}, []string{"2001:db2::3"}, 80},
-		},
-		{
-			name: "multiple slices with a mix of IPv4 and IPv6 terminating non-serving endpoints (dualstack cluster)",
-			args: args{
-				slices: []*discovery.EndpointSlice{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc-ab23",
-							Namespace: "ns",
-							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
-						},
-						Ports: []discovery.EndpointPort{
-							{
-								Name:     utilpointer.StringPtr("tcp-example"),
-								Protocol: protoPtr(v1.ProtocolTCP),
-								Port:     utilpointer.Int32Ptr(int32(80)),
-							},
-						},
-						AddressType: discovery.AddressTypeIPv4,
-						Endpoints: []discovery.Endpoint{
-							{
-								Conditions: discovery.EndpointConditions{ // ignored
-									Ready:       utilpointer.Bool(false),
-									Serving:     utilpointer.Bool(false),
-									Terminating: utilpointer.Bool(true),
-								},
-								Addresses: []string{"10.0.0.4"},
-							},
-						},
-					},
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc-ab24",
-							Namespace: "ns",
-							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
-						},
-						Ports: []discovery.EndpointPort{
-							{
-								Name:     utilpointer.StringPtr("tcp-example"),
-								Protocol: protoPtr(v1.ProtocolTCP),
-								Port:     utilpointer.Int32Ptr(int32(80)),
-							},
-						},
-						AddressType: discovery.AddressTypeIPv6,
-						Endpoints: []discovery.Endpoint{
-							{
-								Conditions: discovery.EndpointConditions{ // ignored
-									Ready:       utilpointer.Bool(false),
-									Serving:     utilpointer.Bool(false),
-									Terminating: utilpointer.Bool(true),
-								},
-								Addresses: []string{"2001:db2::4"},
-							},
-						},
-					},
-				},
-				svcPort: v1.ServicePort{
-					Name:       "tcp-example",
-					TargetPort: intstr.FromInt(80),
-					Protocol:   v1.ProtocolTCP,
-				},
-				service: getSampleService(false),
-			},
-			want: LbEndpoints{[]string{}, []string{}, 80},
-		},
-		{
-			name: "multiple slices with a mix of IPv4 and IPv6 ready and terminating (serving and non-serving) endpoints (dualstack cluster) and service.PublishNotReadyAddresses=true",
-			args: args{
-				slices: []*discovery.EndpointSlice{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc-ab23",
-							Namespace: "ns",
-							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
-						},
-						Ports: []discovery.EndpointPort{
-							{
-								Name:     utilpointer.StringPtr("tcp-example"),
-								Protocol: protoPtr(v1.ProtocolTCP),
-								Port:     utilpointer.Int32Ptr(int32(80)),
-							},
-						},
-						AddressType: discovery.AddressTypeIPv4,
-						Endpoints: []discovery.Endpoint{
-							{
-								Conditions: discovery.EndpointConditions{ // included
-									Ready:       utilpointer.Bool(true),
-									Serving:     utilpointer.Bool(true),
-									Terminating: utilpointer.Bool(false),
-								},
-								Addresses: []string{"10.0.0.2"},
-							},
-							{
-								Conditions: discovery.EndpointConditions{ // included
-									Ready:       utilpointer.Bool(false),
-									Serving:     utilpointer.Bool(true),
-									Terminating: utilpointer.Bool(true),
-								},
-								Addresses: []string{"10.0.0.3"},
-							},
-							{
-								Conditions: discovery.EndpointConditions{ // included
-									Ready:       utilpointer.Bool(false),
-									Serving:     utilpointer.Bool(false),
-									Terminating: utilpointer.Bool(true),
-								},
-								Addresses: []string{"10.0.0.4"},
-							},
-						},
-					},
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc-ab24",
-							Namespace: "ns",
-							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
-						},
-						Ports: []discovery.EndpointPort{
-							{
-								Name:     utilpointer.StringPtr("tcp-example"),
-								Protocol: protoPtr(v1.ProtocolTCP),
-								Port:     utilpointer.Int32Ptr(int32(80)),
-							},
-						},
-						AddressType: discovery.AddressTypeIPv6,
-						Endpoints: []discovery.Endpoint{
-							{
-								Conditions: discovery.EndpointConditions{ // included
-									Ready:       utilpointer.Bool(true),
-									Serving:     utilpointer.Bool(true),
-									Terminating: utilpointer.Bool(false),
-								},
-								Addresses: []string{"2001:db2::2"},
-							},
-							{
-								Conditions: discovery.EndpointConditions{ // included
-									Ready:       utilpointer.Bool(false),
-									Serving:     utilpointer.Bool(true),
-									Terminating: utilpointer.Bool(true),
-								},
-								Addresses: []string{"2001:db2::3"},
-							},
-							{
-								Conditions: discovery.EndpointConditions{ // included
-									Ready:       utilpointer.Bool(false),
-									Serving:     utilpointer.Bool(false),
-									Terminating: utilpointer.Bool(true),
-								},
-								Addresses: []string{"2001:db2::4"},
-							},
-						},
-					},
-				},
-				svcPort: v1.ServicePort{
-					Name:       "tcp-example",
-					TargetPort: intstr.FromInt(80),
-					Protocol:   v1.ProtocolTCP,
-				},
-				service: getSampleService(true), // <-- publishNotReadyAddresses=true
-			},
-			want: LbEndpoints{[]string{"10.0.0.2", "10.0.0.3", "10.0.0.4"}, []string{"2001:db2::2", "2001:db2::3", "2001:db2::4"}, 80},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := GetLbEndpoints(tt.args.slices, tt.args.svcPort, tt.args.service)
-			assert.Equal(t, tt.want, got)
-		})
-	}
-}
-
 // protoPtr takes a Protocol and returns a pointer to it.
 func protoPtr(proto v1.Protocol) *v1.Protocol {
 	return &proto
@@ -1513,6 +499,8 @@ var (
 	tcpv1      v1.Protocol = v1.ProtocolTCP
 	udpv1      v1.Protocol = v1.ProtocolUDP
 
+	httpPortName    string = "http"
+	httpPortValue   int32  = int32(80)
 	httpsPortName   string = "https"
 	httpsPortValue  int32  = int32(443)
 	customPortName  string = "customApp"
@@ -1532,14 +520,6 @@ func getSampleService(publishNotReadyAddresses bool) *v1.Service {
 			PublishNotReadyAddresses: publishNotReadyAddresses,
 		},
 	}
-}
-
-func getSampleEndpointSliceOnAnotherNode(service *kapi.Service) *discovery.EndpointSlice {
-	endpointSlice := getSampleEndpointSlice(service)
-	for i := range endpointSlice.Endpoints {
-		endpointSlice.Endpoints[i].NodeName = &otherNode
-	}
-	return endpointSlice
 }
 
 // returns an endpoint slice with three endpoints, two of which belong to the expected local node
@@ -1629,88 +609,38 @@ func setEndpointsToAMixOfStatusConditions(endpointSlice *discovery.EndpointSlice
 	return endpointSlice
 }
 
-func setNodeEndpointsToReady(endpointSlice *discovery.EndpointSlice, nodeName string) *discovery.EndpointSlice {
-	for i := range endpointSlice.Endpoints {
-		if *endpointSlice.Endpoints[i].NodeName == nodeName {
-			setEndpointToReady(&endpointSlice.Endpoints[i])
-		}
-	}
-	return endpointSlice
-}
-func setNodeEndpointsToTerminatingAndServing(endpointSlice *discovery.EndpointSlice, nodeName string) *discovery.EndpointSlice {
-	for i := range endpointSlice.Endpoints {
-		if *endpointSlice.Endpoints[i].NodeName == nodeName {
-			setEndpointToTerminatingAndServing(&endpointSlice.Endpoints[i])
-		}
-	}
-	return endpointSlice
-}
-
-func setNodeEndpointsToTerminatingAndNotServing(endpointSlice *discovery.EndpointSlice, nodeName string) *discovery.EndpointSlice {
-	for i := range endpointSlice.Endpoints {
-		if *endpointSlice.Endpoints[i].NodeName == testNode {
-			setEndpointToTerminatingAndNotServing(&endpointSlice.Endpoints[i])
-		}
-	}
-	return endpointSlice
-}
-
-func setLocalEndpointsToReady(endpointSlice *discovery.EndpointSlice) *discovery.EndpointSlice {
-	return setNodeEndpointsToReady(endpointSlice, testNode)
-}
-
-func setLocalEndpointsToTerminatingAndServing(endpointSlice *discovery.EndpointSlice) *discovery.EndpointSlice {
-	return setNodeEndpointsToTerminatingAndServing(endpointSlice, testNode)
-}
-
-func setLocalEndpointsToTerminatingAndNotServing(endpointSlice *discovery.EndpointSlice) *discovery.EndpointSlice {
-	return setNodeEndpointsToTerminatingAndNotServing(endpointSlice, testNode)
-}
-
-func setRemoteEndpointsToReady(endpointSlice *discovery.EndpointSlice) *discovery.EndpointSlice {
-	return setNodeEndpointsToReady(endpointSlice, otherNode)
-}
-
-func setRemoteEndpointsToTerminatingAndServing(endpointSlice *discovery.EndpointSlice) *discovery.EndpointSlice {
-	return setNodeEndpointsToTerminatingAndServing(endpointSlice, otherNode)
-}
-
-func setRemoteEndpointsToTerminatingAndNotServing(endpointSlice *discovery.EndpointSlice) *discovery.EndpointSlice {
-	return setNodeEndpointsToTerminatingAndNotServing(endpointSlice, otherNode)
-}
-
 func TestGetEndpointAddresses(t *testing.T) {
 	service := getSampleService(false)
 	var tests = []struct {
 		name          string
 		endpointSlice *discovery.EndpointSlice
-		want          sets.Set[string]
+		want          []string
 	}{
 		{
 			"Tests an endpointslice with all ready endpoints",
 			setAllEndpointsToReady(getSampleEndpointSlice(service)),
-			sets.New(ep1Address, ep2Address, ep3Address),
+			[]string{ep1Address, ep2Address, ep3Address},
 		},
 		{
 			"Tests an endpointslice with all non-ready, serving, terminating endpoints",
 			setAllEndpointsToTerminatingAndServing(getSampleEndpointSlice(service)),
-			sets.New(ep1Address, ep2Address, ep3Address), // with no ready endpoints, we fallback to terminating serving endpoints
+			[]string{ep1Address, ep2Address, ep3Address}, // with no ready endpoints, we fallback to terminating serving endpoints
 		},
 		{
 			"Tests an endpointslice with all non-ready, non-serving, terminating endpoints",
 			setAllEndpointsToTerminatingAndNotServing(getSampleEndpointSlice(service)),
-			sets.New[string](),
+			[]string{},
 		},
 		{
 			"Tests an endpointslice with endpoints showing a mix of status conditions",
 			setEndpointsToAMixOfStatusConditions(getSampleEndpointSlice(service)),
-			sets.New(ep1Address), // only the ready endpoint is included
+			[]string{ep1Address}, // only the ready endpoint is included
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			answer := GetEligibleEndpointAddresses([]*discovery.EndpointSlice{tt.endpointSlice}, service)
+			answer := GetEligibleEndpointAddressesFromSlices([]*discovery.EndpointSlice{tt.endpointSlice}, service)
 			if !reflect.DeepEqual(answer, tt.want) {
 				t.Errorf("got %v, want %v", answer, tt.want)
 			}
@@ -1756,68 +686,159 @@ func TestHasLocalHostNetworkEndpoints(t *testing.T) {
 	}
 }
 
-func TestGetLocalEligibleEndpointAddresses(t *testing.T) {
+func TestGetEligibleEndpointAddresses(t *testing.T) {
 	service := getSampleService(false)
 	var tests = []struct {
-		name          string
-		endpointSlice *discovery.EndpointSlice
-		want          sets.Set[string]
+		name      string
+		endpoints []discovery.Endpoint
+		node      string
+		want      []string
 	}{
 		{
-			"Tests an endpointslice with all ready endpoints, one of which is on a different node",
-			setAllEndpointsToReady(getSampleEndpointSlice(service)),
-			sets.New(ep1Address, ep2Address),
+			"Get all eligible endpoints from an endpointslice with all ready endpoints, one of which is on a different node",
+			[]discovery.Endpoint{
+				kube_test.MakeReadyEndpoint(testNode, ep1Address),
+				kube_test.MakeReadyEndpoint(testNode, ep2Address),
+				kube_test.MakeReadyEndpoint(otherNode, ep3Address),
+			},
+			"", // get all endpoints
+			[]string{ep1Address, ep2Address, ep3Address},
 		},
 		{
-			"Tests an endpointslice with all ready endpoints, all of which are on a different node",
-			setAllEndpointsToReady(getSampleEndpointSliceOnAnotherNode(service)),
-			sets.New[string](),
+			"Get all eligible local endpoints from an endpointslice with all ready endpoints, one of which is on a different node",
+			[]discovery.Endpoint{
+				kube_test.MakeReadyEndpoint(testNode, ep1Address),
+				kube_test.MakeReadyEndpoint(testNode, ep2Address),
+				kube_test.MakeReadyEndpoint(otherNode, ep3Address),
+			},
+			testNode,
+			[]string{ep1Address, ep2Address},
 		},
 		{
-			"Tests an endpointslice with all non-ready, serving, terminating endpoints, one of which is on a different node",
-			setAllEndpointsToTerminatingAndServing(getSampleEndpointSlice(service)),
-			sets.New(ep1Address, ep2Address), // with no ready endpoints, we fallback to terminating serving endpoints
+			"Get all eligible local endpoints from an endpointslice with all ready endpoints, all of which are on another node",
+			[]discovery.Endpoint{
+				kube_test.MakeReadyEndpoint(otherNode, ep1Address),
+				kube_test.MakeReadyEndpoint(otherNode, ep2Address),
+				kube_test.MakeReadyEndpoint(otherNode, ep3Address),
+			},
+			testNode,
+			[]string{},
 		},
 		{
-			"Tests an endpointslice with all non-ready, serving, terminating endpoints, all of which are on a different node",
-			setAllEndpointsToTerminatingAndServing(getSampleEndpointSliceOnAnotherNode(service)),
-			sets.New[string](),
+			"Get all eligible endpoints from an endpointslice with all non-ready, serving, terminating endpoints, one of which is on a different node",
+			[]discovery.Endpoint{
+				kube_test.MakeTerminatingServingEndpoint(testNode, ep1Address),
+				kube_test.MakeTerminatingServingEndpoint(testNode, ep2Address),
+				kube_test.MakeTerminatingServingEndpoint(otherNode, ep3Address),
+			},
+			"",
+			[]string{ep1Address, ep2Address, ep3Address}, // with no ready endpoints, we fallback to terminating serving endpoints
 		},
 		{
-			"Tests an endpointslice with all non-ready, non-serving, terminating endpoints, one of which is on a different node",
-			setAllEndpointsToTerminatingAndNotServing(getSampleEndpointSlice(service)),
-			sets.New[string](),
+			"Get all eligible local endpoints from an endpointslice with all non-ready, serving, terminating endpoints, one of which is on a different node",
+			[]discovery.Endpoint{
+				kube_test.MakeTerminatingServingEndpoint(testNode, ep1Address),
+				kube_test.MakeTerminatingServingEndpoint(testNode, ep2Address),
+				kube_test.MakeTerminatingServingEndpoint(otherNode, ep3Address),
+			},
+			testNode,
+			[]string{ep1Address, ep2Address}, // with no ready endpoints, we fallback to terminating serving endpoints
 		},
 		{
-			"Tests an endpointslice with all non-ready, non-serving, terminating endpoints, all of which are on a different node",
-			setAllEndpointsToTerminatingAndNotServing(getSampleEndpointSliceOnAnotherNode(service)),
-			sets.New[string](),
+			"Get all eligible local endpoints from an endpointslice with all non-ready, serving, terminating endpoints, all of which are on a different node",
+			[]discovery.Endpoint{
+				kube_test.MakeTerminatingServingEndpoint(otherNode, ep1Address),
+				kube_test.MakeTerminatingServingEndpoint(otherNode, ep2Address),
+				kube_test.MakeTerminatingServingEndpoint(otherNode, ep3Address),
+			},
+			testNode,
+			[]string{},
 		},
 		{
-			"Tests an endpointslice with endpoints showing a mix of status conditions, one of which is on a different node",
-			setEndpointsToAMixOfStatusConditions(getSampleEndpointSlice(service)),
-			sets.New(ep1Address), // only the ready endpoint is included
+			"Get all eligible endpoints from an endpointslice with all non-ready, non-serving, terminating endpoints, one of which is on a different node",
+			[]discovery.Endpoint{
+				kube_test.MakeTerminatingNonServingEndpoint(testNode, ep1Address),
+				kube_test.MakeTerminatingNonServingEndpoint(testNode, ep2Address),
+				kube_test.MakeTerminatingNonServingEndpoint(otherNode, ep3Address),
+			},
+			"",
+			[]string{},
 		},
 		{
-			"Tests an endpointslice with endpoints showing a mix of status conditions, all of which are on a different node",
-			setEndpointsToAMixOfStatusConditions(getSampleEndpointSliceOnAnotherNode(service)),
-			sets.New[string](),
+			"Get all eligible local endpoints from an endpointslice with all non-ready, non-serving, terminating endpoints, one of which is on a different node",
+			[]discovery.Endpoint{
+				kube_test.MakeTerminatingNonServingEndpoint(testNode, ep1Address),
+				kube_test.MakeTerminatingNonServingEndpoint(testNode, ep2Address),
+				kube_test.MakeTerminatingNonServingEndpoint(otherNode, ep3Address),
+			},
+			testNode,
+			[]string{},
 		},
 		{
-			"Tests an endpointslice where all local endpoints are serving and terminating and a remote endpoint is ready",
-			setLocalEndpointsToTerminatingAndServing(setRemoteEndpointsToReady(getSampleEndpointSlice(service))),
-			sets.New(ep1Address, ep2Address), // fallback to serving&terminating should apply
+			"Get all eligible local endpoints from an endpointslice with endpoints showing a mix of status conditions, one of which is on a different node",
+			[]discovery.Endpoint{
+				kube_test.MakeReadyEndpoint(testNode, ep1Address),
+				kube_test.MakeTerminatingServingEndpoint(testNode, ep2Address),
+				kube_test.MakeTerminatingNonServingEndpoint(otherNode, ep3Address),
+			},
+			testNode,
+			[]string{ep1Address}, // only the ready endpoint is included
 		},
 		{
-			"Tests an endpointslice where all local endpoints are terminating and not serving and a remote endpoint is ready",
-			setLocalEndpointsToTerminatingAndNotServing(setRemoteEndpointsToReady(getSampleEndpointSlice(service))),
-			sets.New[string](),
+			"Get all eligible local endpoints from an endpointslice with endpoints showing a mix of status conditions, all of which are on a different node",
+			[]discovery.Endpoint{
+				kube_test.MakeReadyEndpoint(otherNode, ep1Address),
+				kube_test.MakeTerminatingServingEndpoint(otherNode, ep2Address),
+				kube_test.MakeTerminatingNonServingEndpoint(otherNode, ep3Address),
+			},
+			testNode,
+			[]string{},
+		},
+		{
+			"Get all eligible endpoints from an endpointslice where all local endpoints are serving and terminating and a remote endpoint is ready",
+			[]discovery.Endpoint{
+				kube_test.MakeTerminatingServingEndpoint(testNode, ep1Address),
+				kube_test.MakeTerminatingServingEndpoint(testNode, ep2Address),
+				kube_test.MakeReadyEndpoint(otherNode, ep3Address),
+			},
+			"",
+			[]string{ep3Address}, // fallback to serving&terminating should apply
+		},
+		{
+			"Get all eligible local endpoints from an endpointslice where all local endpoints are serving and terminating and a remote endpoint is ready",
+			[]discovery.Endpoint{
+				kube_test.MakeTerminatingServingEndpoint(testNode, ep1Address),
+				kube_test.MakeTerminatingServingEndpoint(testNode, ep2Address),
+				kube_test.MakeReadyEndpoint(otherNode, ep3Address),
+			},
+			testNode,
+			[]string{ep1Address, ep2Address}, // fallback to serving&terminating should apply
+		},
+		{
+			"Get all eligible endpoints from an endpointslice where all local endpoints are terminating and not serving and a remote endpoint is ready",
+			[]discovery.Endpoint{
+				kube_test.MakeTerminatingNonServingEndpoint(testNode, ep1Address),
+				kube_test.MakeTerminatingNonServingEndpoint(testNode, ep2Address),
+				kube_test.MakeReadyEndpoint(otherNode, ep3Address),
+			},
+			"",
+			[]string{ep3Address},
+		},
+		{
+			"Get all eligible local endpoints from an endpointslice where all local endpoints are terminating and not serving and a remote endpoint is ready",
+			[]discovery.Endpoint{
+				kube_test.MakeTerminatingNonServingEndpoint(testNode, ep1Address),
+				kube_test.MakeTerminatingNonServingEndpoint(testNode, ep2Address),
+				kube_test.MakeReadyEndpoint(otherNode, ep3Address),
+			},
+			testNode,
+			[]string{},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			answer := GetLocalEligibleEndpointAddresses([]*discovery.EndpointSlice{tt.endpointSlice}, service, testNode)
+			answer := getEligibleEndpointAddresses(tt.endpoints, service, tt.node)
 			if !reflect.DeepEqual(answer, tt.want) {
 				t.Errorf("got %v, want %v", answer, tt.want)
 			}


### PR DESCRIPTION
- clean cherry pick of first commit (32d2ce19dd0f9e76eb2a1ca5b966d02507779f0e) from master branch
- cherry pick of ETP=local fix (e2faa152408d9cad1f6cc8dcf0318ab9f4ae6d8c) from master branch, applying the exact same changes we have on master for the affected OCP hacks. I had to replace all calls to `k8s.io/utils/ptr` (e.g. `ptr.To(true)`) with calls to the older library `k8s.io/utils/pointer` (e.g. `utilpointer.Bool(true)`), since that's new code that we only vendor in 4.16.

**First commit:**
The previous implementation was an approximation of KEP-1669 ProxyTerminatingEndpoints: we simply included terminating serving endpoints (ready=false, serving=true, terminating=true) along with ready ones in the endpoint selection logic. Let's fully implement KEP-1669 and only include terminating endpoints if none are ready. The selection follows two simple steps: 1) Take all ready endpoints
2) If no ready endpoints were found, take all serving terminating endpoints.

This should also help with an issue found in a production cluster (https://issues.redhat.com/browse/OCPBUGS-24363) where, due to infrequent readiness probes, terminating endpoints were declared as non-serving (that is, their readiness probe failed) only quite late and were included as valid endpoints for quite a bit, while the existing ready endpoints should have been preferred.

Extended the test cases to include testing against multiple slices and dual stack scenarios.

Signed-off-by: Riccardo Ravaioli <rravaiol@redhat.com>
(cherry picked from commit 418043c1f528213ff2f1afabc4cec66c73f7b815)

**Second commit:**
Fix endpoint selection for externalTrafficPolicy=local
Fix the case for "all endpoints terminating on a node when traffic policy is local":
"When the traffic policy is "Local" and all endpoints are terminating within a single node, then traffic should be routed to any terminating endpoint that is ready on that node."
https://github.com/kubernetes/enhancements/blob/master/keps/sig-network/1669-proxy-terminating-endpoints/README.md#example-all-endpoints-terminating-on-a-node-when-traffic-policy-is-local

The endpoint selection logic in the services controller is now entirely implemented in getEndpointsForService, which computes for a given service and each service port all its cluster-wide endpoints and per-node local endpoints. We first apply a cluster-wide vs local endpoint selection and only then we apply readiness-based filtering with getEligibleEndpointAddresses.

Added unit tests for the new logic.

