### PR TITLE
OCPBUGS-27925: dont quit if node does not have subnet annotation

### DIFF
--- a/go-controller/pkg/node/default_node_network_controller.go
+++ b/go-controller/pkg/node/default_node_network_controller.go
@@ -871,6 +871,10 @@ func (nc *DefaultNodeNetworkController) Start(ctx context.Context) error {
 					if nc.name != node.Name && util.GetNodeZone(&node) != config.Default.Zone && !houtil.IsHybridOverlayNode(&node) {
 						nodeSubnets, err := util.ParseNodeHostSubnetAnnotation(&node, types.DefaultNetworkName)
 						if err != nil {
+							if util.IsAnnotationNotSetError(err) {
+								klog.Infof("Skipping node %q. k8s.ovn.org/node-subnets annotation was not found", node.Name)
+								continue
+							}
 							err1 = fmt.Errorf("unable to fetch node-subnet annotation for node %s: err, %v", node.Name, err)
 							return false, nil
 						}
@@ -883,9 +887,9 @@ func (nc *DefaultNodeNetworkController) Start(ctx context.Context) error {
 						}
 					}
 				}
+				klog.Infof("Upgrade Hack: Syncing nodes took %v", time.Since(start))
 				syncNodes = true
 			}
-			klog.Infof("Upgrade Hack: Syncing nodes took %v", time.Since(start))
 			// we loop through all existing services in the cluster and ensure ovnkube-controller has finished creating LoadBalancers required for services to work
 			if !syncServices {
 				services, err := nc.watchFactory.GetServices()
@@ -903,9 +907,9 @@ func (nc *DefaultNodeNetworkController) Start(ctx context.Context) error {
 						return false, nil
 					}
 				}
+				klog.Infof("Upgrade Hack: Syncing services took %v", time.Since(start))
 				syncServices = true
 			}
-			klog.Infof("Upgrade Hack: Syncing services took %v", time.Since(start))
 			if !syncPods {
 				pods, err := nc.watchFactory.GetAllPods()
 				if err != nil {
@@ -924,9 +928,9 @@ func (nc *DefaultNodeNetworkController) Start(ctx context.Context) error {
 						return false, nil
 					}
 				}
+				klog.Infof("Upgrade Hack: Syncing pods took %v", time.Since(start))
 				syncPods = true
 			}
-			klog.Infof("Upgrade Hack: Syncing pods took %v", time.Since(start))
 			return true, nil
 		})
 		if err != nil {


### PR DESCRIPTION
in some cases, multiple nodes will have to sync and we may not have enough subnets available for all of them. In that case we don't want to quit the sync on other nodes if one is found to not have the subnet annotation as the others may still have it.

Also moves log message for duration of different syncs to the end of their sync so it will only print once.

JIRA: https://issues.redhat.com/browse/OCPBUGS-18598

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->