### PR TITLE
OCPBUGS-27947: [release-4.15] Fix LGW ETP=Local on IPv6

### DIFF
--- a/go-controller/pkg/ovn/controller/services/lb_config.go
+++ b/go-controller/pkg/ovn/controller/services/lb_config.go
@@ -645,7 +645,7 @@ func buildPerNodeLBs(service *v1.Service, configs []lbConfig, nodes []nodeInfo) 
 						mvip := conf.Gateway.MasqueradeIPs.V4HostETPLocalMasqueradeIP.String()
 						targetsETP := joinHostsPort(switchV4targetips, config.eps.Port)
 						if isv6 {
-							mvip = conf.Gateway.MasqueradeIPs.V6HostMasqueradeIP.String()
+							mvip = conf.Gateway.MasqueradeIPs.V6HostETPLocalMasqueradeIP.String()
 							targetsETP = joinHostsPort(switchV6targetips, config.eps.Port)
 						}
 						switchRules = append(switchRules, LBRule{


### PR DESCRIPTION
clean cherry pick of c22ddd42568f77934e08e89c95c8734eac82bfbb from main.
The service's node_switch LB was using the wrong address, breaking LGW IPv6 ETP=Local services.