### PR TITLE
Dockerfile: Bump OVN to ovn-23.09.0-106.el9fdp

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -13,7 +13,7 @@ RUN dnf install -y --nodocs \
 	dnf clean all
 
 ARG ovsver=3.1.0-73.el9fdp
-ARG ovnver=23.09.0-100.el9fdp
+ARG ovnver=23.09.0-106.el9fdp
 
 RUN INSTALL_PKGS="iptables" && \
 	ovsver_short=$(echo "$ovsver" | cut -d'.' -f1,2) && \


### PR DESCRIPTION
Includes the following relevant changes:
- northd: Make sure that affinity flows match on VIP.
  [https://issues.redhat.com/browse/FDP-290]
- ovn: Add tunnel PMTUD support.
  [https://bugzilla.redhat.com/show_bug.cgi?id=2241711]
- northd: Use proper field for lookup_nd
  [https://issues.redhat.com/browse/FDP-283]
  [https://issues.redhat.com/browse/OCPBUGS-27093]
