### PR TITLE
[release 4.14]OCPBUGS-24343: 4.14 fail louder

### DIFF
--- a/go-controller/pkg/ovn/base_network_controller_pods.go
+++ b/go-controller/pkg/ovn/base_network_controller_pods.go
@@ -37,6 +37,8 @@ func (bnc *BaseNetworkController) allocatePodIPs(pod *kapi.Pod,
 	return bnc.allocatePodIPsOnSwitch(pod, annotations, nadName, switchName)
 }
 
+var nodeNotFoundError = errors.New("node not found")
+
 // allocatePodIPsForSwitch will allocate the the ip from pod annotation at
 // a specified switch, this switch can be different than the one the pod is
 // attachted to, for example hypershift kubevirt provider live migration.
@@ -50,6 +52,7 @@ func (bnc *BaseNetworkController) allocatePodIPsOnSwitch(pod *kapi.Pod,
 	if bnc.lsManager.IsNonHostSubnetSwitch(switchName) {
 		return "", nil
 	}
+
 	expectedLogicalPortName = bnc.GetLogicalPortName(pod, nadName)
 	// it is possible to try to add a pod here that has no node. For example if a pod was deleted with
 	// a finalizer, and then the node was removed. In this case the pod will still exist in a running state.
@@ -67,8 +70,7 @@ func (bnc *BaseNetworkController) allocatePodIPsOnSwitch(pod *kapi.Pod,
 		}
 	}
 	if err := bnc.waitForNodeLogicalSwitchSubnetsInCache(switchName); err != nil {
-		return expectedLogicalPortName, fmt.Errorf("failed to wait for switch %s to be added to cache. IP allocation may fail!",
-			switchName)
+		return expectedLogicalPortName, err
 	}
 	if err = bnc.lsManager.AllocateIPs(switchName, annotations.IPs); err != nil {
 		if err == ipallocator.ErrAllocated {
@@ -374,7 +376,7 @@ func (bnc *BaseNetworkController) waitForNodeLogicalSwitchSubnetsInCache(switchN
 		subnets = bnc.lsManager.GetSwitchSubnets(switchName)
 		return subnets != nil, nil
 	}); err != nil {
-		return fmt.Errorf("timed out waiting for logical switch %q subnet: %v", switchName, err)
+		return fmt.Errorf("timed out waiting for logical switch %q subnet: %w", switchName, nodeNotFoundError)
 	}
 	return nil
 }

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -1,6 +1,7 @@
 package ovn
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"sync/atomic"
@@ -29,6 +30,7 @@ func (oc *DefaultNetworkController) syncPods(pods []interface{}) error {
 	expectedLogicalPorts := make(map[string]bool)
 	vms := make(map[ktypes.NamespacedName]bool)
 	var err error
+	switchesNotFound := make(map[string]bool)
 	for _, podInterface := range pods {
 		pod, ok := podInterface.(*kapi.Pod)
 		if !ok {
@@ -43,7 +45,17 @@ func (oc *DefaultNetworkController) syncPods(pods []interface{}) error {
 				return err
 			}
 		} else if oc.isPodScheduledinLocalZone(pod) {
+			if switchesNotFound[pod.Spec.NodeName] {
+				klog.Warningf("Cannot allocate IPs for %s/%s, node was not found after 30 seconds", pod.Namespace, pod.Name)
+				continue
+			}
 			expectedLogicalPortName, annotations, err = oc.allocateSyncPodsIPs(pod)
+
+			if errors.Is(err, nodeNotFoundError) {
+				klog.Warningf("Cannot allocate IPs for %s/%s, node was not found after 30 seconds", pod.Namespace, pod.Name)
+				switchesNotFound[pod.Spec.NodeName] = true
+				continue
+			}
 			if err != nil {
 				return err
 			}

--- a/go-controller/pkg/ovn/pods_test.go
+++ b/go-controller/pkg/ovn/pods_test.go
@@ -2305,5 +2305,46 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 			err := app.Run([]string{app.Name})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		})
+		ginkgo.It("should correctly handle a pod running on no node", func() {
+			app.Action = func(ctx *cli.Context) error {
+				namespaceT := *newNamespace("namespace1")
+				t := newTPod(
+					"node1",
+					"10.128.1.0/24",
+					"10.128.1.2",
+					"10.128.1.1",
+					"myPod",
+					"10.128.1.3",
+					"0a:58:0a:80:01:03",
+					namespaceT.Name,
+				)
+				myPod := newPod(t.namespace, t.podName, t.nodeName, t.podIP)
+				myPod.Status.Phase = v1.PodRunning
+				setPodAnnotations(myPod, t)
+				initialDB = libovsdbtest.TestSetup{
+					NBData: []libovsdbtest.TestData{},
+				}
+				fakeOvn.startWithDBSetup(initialDB,
+					&v1.NamespaceList{
+						Items: []v1.Namespace{
+							namespaceT,
+						},
+					},
+					&v1.NodeList{
+						Items: []v1.Node{},
+					},
+					&v1.PodList{
+						Items: []v1.Pod{*myPod},
+					},
+				)
+
+				fakeOvn.controller.localZoneNodes = nil
+				err := fakeOvn.controller.WatchPods()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				return nil
+			}
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
 	})
 })


### PR DESCRIPTION
Backport of https://github.com/ovn-org/ovn-kubernetes/pull/3945 with conflicts in
base_network_controller_pods.go and pods_test.go