### PR TITLE
[release-4.13] OCPBUGS-28630: Synchronize node primary address update

### DIFF
--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -129,6 +129,9 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 		})
 		if setNodeIP {
 			fexec.AddFakeCmdsNoOutputNoError([]string{
+				"ovs-vsctl --timeout=15 get Open_vSwitch . external_ids:ovn-encap-ip",
+			})
+			fexec.AddFakeCmdsNoOutputNoError([]string{
 				"ovs-vsctl --timeout=15 set Open_vSwitch . external_ids:ovn-encap-ip=192.168.1.10",
 			})
 			fexec.AddFakeCmdsNoOutputNoError([]string{
@@ -491,6 +494,9 @@ func shareGatewayInterfaceDPUTest(app *cli.App, testNS ns.NetNS,
 			Output: "9",
 		})
 		fexec.AddFakeCmdsNoOutputNoError([]string{
+			"ovs-vsctl --timeout=15 get Open_vSwitch . external_ids:ovn-encap-ip",
+		})
+		fexec.AddFakeCmdsNoOutputNoError([]string{
 			"ovs-vsctl --timeout=15 set Open_vSwitch . external_ids:ovn-encap-ip=192.168.1.101",
 		})
 		fexec.AddFakeCmdsNoOutputNoError([]string{
@@ -821,11 +827,10 @@ func localGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 			Cmd:    "ovs-vsctl --timeout=15 get interface eth0 ofport",
 			Output: "7",
 		})
-		fexec.AddFakeCmdsNoOutputNoError([]string{
-			"ovs-vsctl --timeout=15 set Open_vSwitch . external_ids:ovn-encap-ip=192.168.1.10",
-		})
-		fexec.AddFakeCmdsNoOutputNoError([]string{
-			"ovn-appctl --timeout=5 -t ovn-controller exit --restart",
+		// IP already configured, do not try to set it or restart ovn-controller
+		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+			Cmd:    "ovs-vsctl --timeout=15 get Open_vSwitch . external_ids:ovn-encap-ip",
+			Output: "192.168.1.10",
 		})
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 			Cmd:    "ip route replace table 7 172.16.1.0/24 via 10.1.1.1 dev ovn-k8s-mp0",

--- a/go-controller/pkg/node/node_ip_handler_linux.go
+++ b/go-controller/pkg/node/node_ip_handler_linux.go
@@ -137,7 +137,7 @@ func (c *addressManager) runInternal(stopChan <-chan struct{}, doneWg *sync.Wait
 	nodeInformer := c.watchFactory.NodeInformer()
 	_, err := nodeInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		UpdateFunc: func(old, new interface{}) {
-			c.handleNodeChanges(new)
+			c.handleNodePrimaryAddrChange()
 		},
 	})
 	if err != nil {
@@ -173,14 +173,7 @@ func (c *addressManager) runInternal(stopChan <-chan struct{}, doneWg *sync.Wait
 					addrChanged = c.delAddr(a.LinkAddress.IP)
 				}
 
-				nodePrimaryAddrChanged, err := c.nodePrimaryAddrChanged()
-				if err != nil {
-					klog.Error("Address Manager failed to check node primary address change: %v", err)
-				}
-				if nodePrimaryAddrChanged {
-					klog.Infof("Node primary address changed to %v. Updating OVN encap IP.", c.nodePrimaryAddr)
-					c.updateOVNEncapIPAndReconnect()
-				}
+				c.handleNodePrimaryAddrChange()
 				if addrChanged || !c.doesNodeHostAddressesMatch() {
 					klog.Infof("Host addresses changed to %v. Updating node address annotation.", c.addresses)
 					err := c.updateNodeAddressAnnotations()
@@ -207,10 +200,8 @@ func (c *addressManager) runInternal(stopChan <-chan struct{}, doneWg *sync.Wait
 	klog.Info("Node IP manager is running")
 }
 
-// handleNodeChanges takes a node obj, extracts its name and determines if the node's address changed. If so, it
-// updates the node's OVS encapsulation IP.
-func (c *addressManager) handleNodeChanges(obj interface{}) {
-	var err error
+// updates OVN's EncapIP if the node IP changed
+func (c *addressManager) handleNodePrimaryAddrChange() {
 	nodePrimaryAddrChanged, err := c.nodePrimaryAddrChanged()
 	if err != nil {
 		klog.Errorf("Address Manager failed to check node primary address change: %v", err)
@@ -410,14 +401,7 @@ func (c *addressManager) sync() {
 	}
 
 	addrChanged := c.assignAddresses(currAddresses)
-	nodePrimaryAddrChanged, err := c.nodePrimaryAddrChanged()
-	if err != nil {
-		klog.Errorf("Address Manager failed to check node primary address change: %v", err)
-	}
-	if nodePrimaryAddrChanged {
-		klog.Infof("Node primary address changed to %v. Updating OVN encap IP.", c.nodePrimaryAddr)
-		c.updateOVNEncapIPAndReconnect()
-	}
+	c.handleNodePrimaryAddrChange()
 	if addrChanged || !c.doesNodeHostAddressesMatch() {
 		klog.Infof("Node address changed to %v. Updating annotations.", currAddresses)
 		err := c.updateNodeAddressAnnotations()

--- a/go-controller/pkg/node/node_ip_handler_linux.go
+++ b/go-controller/pkg/node/node_ip_handler_linux.go
@@ -6,6 +6,7 @@ package node
 import (
 	"fmt"
 	"net"
+	"strings"
 	"sync"
 	"time"
 
@@ -322,13 +323,31 @@ func (c *addressManager) nodePrimaryAddrChanged() (bool, error) {
 
 // updateOVNEncapIP updates encap IP to OVS when the node primary IP changed.
 func (c *addressManager) updateOVNEncapIPAndReconnect() {
-	cmd := []string{
+	checkCmd := []string{
+		"get",
+		"Open_vSwitch",
+		".",
+		"external_ids:ovn-encap-ip",
+	}
+	encapIP, stderr, err := util.RunOVSVsctl(checkCmd...)
+	if err != nil {
+		klog.Warningf("Unable to retrieve configured ovn-encap-ip from OVS: %v, %q", err, stderr)
+	} else {
+		encapIP = strings.TrimSuffix(encapIP, "\n")
+		if len(encapIP) > 0 && c.nodePrimaryAddr.String() == encapIP {
+			klog.V(4).Infof("Will not update encap IP, value: %s is the already configured", c.nodePrimaryAddr)
+			return
+		}
+	}
+
+	confCmd := []string{
 		"set",
 		"Open_vSwitch",
 		".",
 		fmt.Sprintf("external_ids:ovn-encap-ip=%s", c.nodePrimaryAddr),
 	}
-	_, stderr, err := util.RunOVSVsctl(cmd...)
+
+	_, stderr, err = util.RunOVSVsctl(confCmd...)
 	if err != nil {
 		klog.Errorf("Error setting OVS encap IP: %v  %q", err, stderr)
 		return

--- a/go-controller/pkg/node/node_ip_handler_linux.go
+++ b/go-controller/pkg/node/node_ip_handler_linux.go
@@ -203,6 +203,8 @@ func (c *addressManager) runInternal(stopChan <-chan struct{}, doneWg *sync.Wait
 
 // updates OVN's EncapIP if the node IP changed
 func (c *addressManager) handleNodePrimaryAddrChange() {
+	c.Lock()
+	defer c.Unlock()
 	nodePrimaryAddrChanged, err := c.nodePrimaryAddrChanged()
 	if err != nil {
 		klog.Errorf("Address Manager failed to check node primary address change: %v", err)
@@ -210,7 +212,7 @@ func (c *addressManager) handleNodePrimaryAddrChange() {
 	}
 	if nodePrimaryAddrChanged {
 		klog.Infof("Node primary address changed to %v. Updating OVN encap IP.", c.nodePrimaryAddr)
-		c.updateOVNEncapIPAndReconnect()
+		updateOVNEncapIPAndReconnect(c.nodePrimaryAddr)
 	}
 }
 
@@ -321,48 +323,6 @@ func (c *addressManager) nodePrimaryAddrChanged() (bool, error) {
 	return true, nil
 }
 
-// updateOVNEncapIP updates encap IP to OVS when the node primary IP changed.
-func (c *addressManager) updateOVNEncapIPAndReconnect() {
-	checkCmd := []string{
-		"get",
-		"Open_vSwitch",
-		".",
-		"external_ids:ovn-encap-ip",
-	}
-	encapIP, stderr, err := util.RunOVSVsctl(checkCmd...)
-	if err != nil {
-		klog.Warningf("Unable to retrieve configured ovn-encap-ip from OVS: %v, %q", err, stderr)
-	} else {
-		encapIP = strings.TrimSuffix(encapIP, "\n")
-		if len(encapIP) > 0 && c.nodePrimaryAddr.String() == encapIP {
-			klog.V(4).Infof("Will not update encap IP, value: %s is the already configured", c.nodePrimaryAddr)
-			return
-		}
-	}
-
-	confCmd := []string{
-		"set",
-		"Open_vSwitch",
-		".",
-		fmt.Sprintf("external_ids:ovn-encap-ip=%s", c.nodePrimaryAddr),
-	}
-
-	_, stderr, err = util.RunOVSVsctl(confCmd...)
-	if err != nil {
-		klog.Errorf("Error setting OVS encap IP: %v  %q", err, stderr)
-		return
-	}
-
-	// force ovn-controller to reconnect SB with new encap IP immediately.
-	// otherwise there will be a max delay of 200s due to the 100s
-	// ovn-controller inactivity probe.
-	_, stderr, err = util.RunOVNAppctlWithTimeout(5, "-t", "ovn-controller", "exit", "--restart")
-	if err != nil {
-		klog.Errorf("Failed to exit ovn-controller %v %q", err, stderr)
-		return
-	}
-}
-
 // detects if the IP is valid for a node
 // excludes things like local IPs, mgmt port ip, special masquerade IP
 func (c *addressManager) isValidNodeIP(addr net.IP) bool {
@@ -428,5 +388,47 @@ func (c *addressManager) sync() {
 			klog.Errorf("Address Manager failed to update node address annotations: %v", err)
 		}
 		c.OnChanged()
+	}
+}
+
+// updateOVNEncapIPAndReconnect updates encap IP to OVS when the node primary IP changed.
+func updateOVNEncapIPAndReconnect(newIP net.IP) {
+	checkCmd := []string{
+		"get",
+		"Open_vSwitch",
+		".",
+		"external_ids:ovn-encap-ip",
+	}
+	encapIP, stderr, err := util.RunOVSVsctl(checkCmd...)
+	if err != nil {
+		klog.Warningf("Unable to retrieve configured ovn-encap-ip from OVS: %v, %q", err, stderr)
+	} else {
+		encapIP = strings.TrimSuffix(encapIP, "\n")
+		if len(encapIP) > 0 && newIP.String() == encapIP {
+			klog.V(4).Infof("Will not update encap IP %s - it is already configured", newIP.String())
+			return
+		}
+	}
+
+	confCmd := []string{
+		"set",
+		"Open_vSwitch",
+		".",
+		fmt.Sprintf("external_ids:ovn-encap-ip=%s", newIP),
+	}
+
+	_, stderr, err = util.RunOVSVsctl(confCmd...)
+	if err != nil {
+		klog.Errorf("Error setting OVS encap IP %s: %v %q", newIP.String(), err, stderr)
+		return
+	}
+
+	// force ovn-controller to reconnect SB with new encap IP immediately.
+	// otherwise there will be a max delay of 200s due to the 100s
+	// ovn-controller inactivity probe.
+	_, stderr, err = util.RunOVNAppctlWithTimeout(5, "-t", "ovn-controller", "exit", "--restart")
+	if err != nil {
+		klog.Errorf("Failed to exit ovn-controller %v %q", err, stderr)
+		return
 	}
 }


### PR DESCRIPTION
Manual backport of 4.14 commits 77aaa9693266edf131489d36c5deef24fee9977c, 4622d618699ad5c16db28e3e099acf22a16caf7c and 4e6fbc60c1334534d25c75cceaaa636fdd78532a.

Conflicts:
`go-controller/pkg/node/node_ip_handler_linux.go`