### PR TITLE
[release-4.14] OCPBUGS-29207: Ignore hybrid-overlay nodes from EgressIP controller

### DIFF
--- a/go-controller/pkg/clustermanager/egressip_controller.go
+++ b/go-controller/pkg/clustermanager/egressip_controller.go
@@ -1388,6 +1388,10 @@ func (eIPC *egressIPClusterController) isEgressIPAddrConflict(egressIP net.IP) (
 	// iterate through the nodes and ensure no host IP address conflicts with EIP. Note that host-cidrs annotation
 	// does not contain EgressIPs that are assigned to interfaces.
 	for _, node := range nodes {
+		// EgressIP is not supported on hybrid overlay nodes, and OVNNodeHostCIDRs annotation is not present
+		if util.NoHostSubnet(node) {
+			continue
+		}
 		nodeHostAddrsSet, err := util.ParseNodeHostCIDRsDropNetMask(node)
 		if err != nil {
 			return false, "", fmt.Errorf("failed to parse node host cidrs for node %s: %v", node.Name, err)

--- a/go-controller/pkg/clustermanager/egressip_controller_test.go
+++ b/go-controller/pkg/clustermanager/egressip_controller_test.go
@@ -516,6 +516,105 @@ var _ = ginkgo.Describe("OVN cluster-manager EgressIP Operations", func() {
 			table.Entry("Non-OVN managed network", "7.7.7.100", "7.7.0.0/16"),
 			table.Entry("Non-OVN managed network", "7.7.8.100", "7.7.0.0/16"),
 		)
+		ginkgo.It("should assign EgressIPs to a linux node when there are windows nodes in the cluster", func() {
+			app.Action = func(ctx *cli.Context) error {
+				node1IPv4OVNManaged := "192.168.126.202/24"
+				node1IPv4NonOVNManaged := "10.10.10.3/24"
+				node1Ipv4NonOVNManaged2 := "7.7.7.7/16"
+				egressIP := "192.168.126.101"
+				egressNamespace := newNamespace(namespace)
+
+				config.Kubernetes.NoHostSubnetNodes = &metav1.LabelSelector{
+					MatchLabels: map[string]string{"kubernetes.io/os": "windows"},
+				}
+
+				node1 := v1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: node1Name,
+						Annotations: map[string]string{
+							"k8s.ovn.org/node-primary-ifaddr": fmt.Sprintf("{\"ipv4\": \"%s\", \"ipv6\": \"%s\"}", node1IPv4OVNManaged, ""),
+							"k8s.ovn.org/node-subnets":        fmt.Sprintf("{\"default\":\"%s\"}", v4NodeSubnet),
+							util.OVNNodeHostCIDRs:             fmt.Sprintf("[\"%s\",\"%s\",\"%s\"]", node1IPv4OVNManaged, node1IPv4NonOVNManaged, node1Ipv4NonOVNManaged2),
+						},
+						Labels: map[string]string{
+							"k8s.ovn.org/egress-assignable": "",
+						},
+					},
+					Status: v1.NodeStatus{
+						Conditions: []v1.NodeCondition{
+							{
+								Type:   v1.NodeReady,
+								Status: v1.ConditionTrue,
+							},
+						},
+					},
+				}
+				hybridOverlayNode := v1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "hybridOverlayNode",
+						Annotations: map[string]string{
+							"k8s.ovn.org/hybrid-overlay-distributed-router-gateway-mac": "00-15-5D-7B-E7-D2",
+							"k8s.ovn.org/hybrid-overlay-node-subnet":                    "10.132.0.0/24",
+						},
+						Labels: map[string]string{
+							"kubernetes.io/os": "windows",
+						},
+					},
+					Status: v1.NodeStatus{
+						Conditions: []v1.NodeCondition{
+							{
+								Type:   v1.NodeReady,
+								Status: v1.ConditionTrue,
+							},
+						},
+					},
+				}
+
+				eIP := egressipv1.EgressIP{
+					ObjectMeta: newEgressIPMeta(egressIPName),
+					Spec: egressipv1.EgressIPSpec{
+						EgressIPs: []string{egressIP},
+						PodSelector: metav1.LabelSelector{
+							MatchLabels: egressPodLabel,
+						},
+						NamespaceSelector: metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"name": egressNamespace.Name,
+							},
+						},
+					},
+					Status: egressipv1.EgressIPStatus{
+						Items: []egressipv1.EgressIPStatusItem{},
+					},
+				}
+				fakeClusterManagerOVN.start(
+					&egressipv1.EgressIPList{
+						Items: []egressipv1.EgressIP{eIP},
+					},
+					&v1.NodeList{
+						Items: []v1.Node{node1, hybridOverlayNode},
+					},
+				)
+				_, err := fakeClusterManagerOVN.eIPC.WatchEgressNodes()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				_, err = fakeClusterManagerOVN.eIPC.WatchEgressIP()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				gomega.Eventually(getEgressIPAllocatorSizeSafely).Should(gomega.Equal(1))
+				gomega.Expect(fakeClusterManagerOVN.eIPC.allocator.cache).To(gomega.HaveKey(node1.Name))
+				gomega.Eventually(isEgressAssignableNode(node1.Name)).Should(gomega.BeTrue())
+
+				gomega.Eventually(getEgressIPStatusLen(egressIPName)).Should(gomega.Equal(1))
+				egressIPs, nodes := getEgressIPStatus(egressIPName)
+				gomega.Expect(nodes[0]).To(gomega.Equal(node1.Name))
+				gomega.Expect(egressIPs[0]).To(gomega.Equal(egressIP))
+
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
 	})
 
 	ginkgo.Context("WatchEgressNodes", func() {

--- a/go-controller/pkg/clustermanager/egressip_event_handler.go
+++ b/go-controller/pkg/clustermanager/egressip_event_handler.go
@@ -31,6 +31,11 @@ func (h *egressIPClusterControllerEventHandler) AddResource(obj interface{}, fro
 	switch h.objType {
 	case factory.EgressNodeType:
 		node := obj.(*v1.Node)
+		// EgressIP is not supported on hybrid overlay nodes
+		if util.NoHostSubnet(node) {
+			return nil
+		}
+
 		// Initialize the allocator on every update,
 		// ovnkube-node/cloud-network-config-controller will make sure to
 		// annotate the node with the egressIPConfig, but that might have
@@ -80,6 +85,12 @@ func (h *egressIPClusterControllerEventHandler) UpdateResource(oldObj, newObj in
 	case factory.EgressNodeType:
 		oldNode := oldObj.(*v1.Node)
 		newNode := newObj.(*v1.Node)
+
+		// EgressIP is not supported on hybrid overlay nodes
+		if util.NoHostSubnet(newNode) {
+			return nil
+		}
+
 		// Initialize the allocator on every update,
 		// ovnkube-node/cloud-network-config-controller will make sure to
 		// annotate the node with the egressIPConfig, but that might have
@@ -162,6 +173,10 @@ func (h *egressIPClusterControllerEventHandler) DeleteResource(obj, cachedObj in
 		return h.eIPC.reconcileEgressIP(eIP, nil)
 	case factory.EgressNodeType:
 		node := obj.(*v1.Node)
+		// EgressIP is not supported on hybrid overlay nodes
+		if util.NoHostSubnet(node) {
+			return nil
+		}
 		h.eIPC.deleteNodeForEgress(node)
 		nodeEgressLabel := util.GetNodeEgressLabel()
 		nodeLabels := node.GetLabels()


### PR DESCRIPTION
This is a cherry-pick of https://github.com/openshift/ovn-kubernetes/pull/2040
Modified unit-tests to match 4.14 api.

(cherry picked from commit 63641aa8b5faa50be2e7f33b49a6d95c1eacf36e)
