### PR TITLE
OCPBUGS-27093: Dockerfile: Bump OVN to ovn-23.09.0-112.el9fdp

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -13,7 +13,7 @@ RUN dnf install -y --nodocs \
 	dnf clean all
 
 ARG ovsver=3.1.0-73.el9fdp
-ARG ovnver=23.09.0-100.el9fdp
+ARG ovnver=23.09.0-112.el9fdp
 
 RUN INSTALL_PKGS="iptables" && \
 	ovsver_short=$(echo "$ovsver" | cut -d'.' -f1,2) && \


### PR DESCRIPTION
Includes the following relevant changes:
- actions: Use random port selection for SNAT with external_port_range.
  [https://issues.redhat.com/browse/FDP-301]
  [https://issues.redhat.com/browse/RFE-4980]
- northd: Make sure that affinity flows match on VIP.
  [https://issues.redhat.com/browse/FDP-290]
- ovn: Add tunnel PMTUD support.
  [https://bugzilla.redhat.com/show_bug.cgi?id=2241711]
- northd: Use proper field for lookup_nd
  [https://issues.redhat.com/browse/FDP-283]
  [https://issues.redhat.com/browse/OCPBUGS-27093]
- northd: Remove the protocol match from ECMP symmetric reply flows.
  [https://issues.redhat.com/browse/FDP-358]
- northd: Explicitly handle SNAT for ICMP need frag.
  [https://issues.redhat.com/browse/FDP-159]
