### PR TITLE
[release-4.14] OCPBUGS-28726: Update netpol namespace address sets usage to the old ways

### DIFF
--- a/go-controller/pkg/ovn/base_network_controller_policy.go
+++ b/go-controller/pkg/ovn/base_network_controller_policy.go
@@ -1045,6 +1045,14 @@ func (bnc *BaseNetworkController) createNetworkPolicy(policy *knet.NetworkPolicy
 	return np, err
 }
 
+// this method makes nil and empty PodSelectors behave differently (it shouldn't be the case,
+// but this is a legacy behaviour that customers rely on).
+// nil selector will use namespace address sets, a side-effect of this is hostNetwork pods won't be selected, and
+// config.Kubernetes.HostNetworkNamespace will be included with empty NamespaceSelector.
+func useNamespaceAddrSet(peer knet.NetworkPolicyPeer) bool {
+	return peer.NamespaceSelector != nil && peer.PodSelector == nil
+}
+
 func (bnc *BaseNetworkController) setupGressPolicy(np *networkPolicy, gp *gressPolicy,
 	peer knet.NetworkPolicyPeer) (*policyHandler, error) {
 	// Add IPBlock to ingress network policy
@@ -1059,49 +1067,30 @@ func (bnc *BaseNetworkController) setupGressPolicy(np *networkPolicy, gp *gressP
 	}
 	gp.hasPeerSelector = true
 
+	if useNamespaceAddrSet(peer) {
+		// namespace selector, use namespace address sets
+		handler := &policyHandler{
+			gress:             gp,
+			namespaceSelector: peer.NamespaceSelector,
+		}
+		return handler, nil
+	}
+	// use podSelector address set
 	podSelector := peer.PodSelector
 	if podSelector == nil {
 		// nil pod selector is equivalent to empty pod selector, which selects all
 		podSelector = &metav1.LabelSelector{}
 	}
-	podSel, _ := metav1.LabelSelectorAsSelector(podSelector)
-	nsSel, _ := metav1.LabelSelectorAsSelector(peer.NamespaceSelector)
+	// np.namespace will be used when fromJSON.NamespaceSelector = nil
+	asKey, ipv4as, ipv6as, err := bnc.EnsurePodSelectorAddressSet(
+		podSelector, peer.NamespaceSelector, np.namespace, np.getKeyWithKind())
+	// even if GetPodSelectorAddressSet failed, add key for future cleanup or retry.
+	np.peerAddressSets = append(np.peerAddressSets, asKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to ensure pod selector address set %s: %v", asKey, err)
+	}
+	gp.addPeerAddressSets(ipv4as, ipv6as)
 
-	if podSel.Empty() && (peer.NamespaceSelector == nil || !nsSel.Empty()) {
-		// namespace-based filtering
-		if peer.NamespaceSelector == nil {
-			// nil namespace selector means same namespace
-			_, err := gp.addNamespaceAddressSet(np.namespace, bnc.addressSetFactory)
-			if err != nil {
-				return nil, fmt.Errorf("failed to add namespace address set for gress policy: %w", err)
-			}
-		} else if !nsSel.Empty() {
-			// namespace selector, use namespace address sets
-			handler := &policyHandler{
-				gress:             gp,
-				namespaceSelector: peer.NamespaceSelector,
-			}
-			return handler, nil
-		}
-	} else {
-		// use podSelector address set
-		// np.namespace will be used when fromJSON.NamespaceSelector = nil
-		asKey, ipv4as, ipv6as, err := bnc.EnsurePodSelectorAddressSet(
-			podSelector, peer.NamespaceSelector, np.namespace, np.getKeyWithKind())
-		// even if GetPodSelectorAddressSet failed, add key for future cleanup or retry.
-		np.peerAddressSets = append(np.peerAddressSets, asKey)
-		if err != nil {
-			return nil, fmt.Errorf("failed to ensure pod selector address set %s: %v", asKey, err)
-		}
-		gp.addPeerAddressSets(ipv4as, ipv6as)
-	}
-	if podSel.Empty() && nsSel.Empty() && config.Kubernetes.HostNetworkNamespace != "" {
-		// all namespaces selector, add hostnetwork address set
-		_, err := gp.addNamespaceAddressSet(config.Kubernetes.HostNetworkNamespace, bnc.addressSetFactory)
-		if err != nil {
-			return nil, fmt.Errorf("failed to add namespace address set for gress policy: %w", err)
-		}
-	}
 	return nil, nil
 }
 

--- a/go-controller/pkg/ovn/policy_test.go
+++ b/go-controller/pkg/ovn/policy_test.go
@@ -298,14 +298,12 @@ func getGressACLs(gressIdx int, namespace, policyName string, peerNamespaces []s
 	ipBlocks := []string{}
 	for _, peer := range peers {
 		// follow the algorithm from setupGressPolicy
-		podSelector := peer.PodSelector
-		if podSelector == nil {
-			// nil pod selector is equivalent to empty pod selector, which selects all
-			podSelector = &metav1.LabelSelector{}
-		}
-		podSel, _ := metav1.LabelSelectorAsSelector(peer.PodSelector)
-		nsSel, _ := metav1.LabelSelectorAsSelector(peer.NamespaceSelector)
-		if !((peer.PodSelector == nil || podSel.Empty()) && (peer.NamespaceSelector == nil || !nsSel.Empty())) {
+		if (peer.NamespaceSelector != nil || peer.PodSelector != nil) && !useNamespaceAddrSet(peer) {
+			podSelector := peer.PodSelector
+			if podSelector == nil {
+				// nil pod selector is equivalent to empty pod selector, which selects all
+				podSelector = &metav1.LabelSelector{}
+			}
 			peerIndex := getPodSelectorAddrSetDbIDs(getPodSelectorKey(podSelector, peer.NamespaceSelector, namespace), controllerName)
 			asv4, _ := addressset.GetHashNamesForAS(peerIndex)
 			hashedASNames = append(hashedASNames, asv4)
@@ -666,13 +664,16 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 		format.MaxLength = gomegaFormatMaxLength
 	})
 
-	startOvn := func(dbSetup libovsdbtest.TestSetup, namespaces []v1.Namespace, networkPolicies []knet.NetworkPolicy,
-		pods []testPod, podLabels map[string]string) {
+	startOvnWithHostNetPods := func(dbSetup libovsdbtest.TestSetup, namespaces []v1.Namespace, networkPolicies []knet.NetworkPolicy,
+		pods []testPod, podLabels map[string]string, hostNetPods bool) {
 		var podsList []v1.Pod
 		for _, testPod := range pods {
 			knetPod := newPod(testPod.namespace, testPod.podName, testPod.nodeName, testPod.podIP)
 			if len(podLabels) > 0 {
 				knetPod.Labels = podLabels
+			}
+			if hostNetPods {
+				knetPod.Spec.HostNetwork = true
 			}
 			podsList = append(podsList, *knetPod)
 		}
@@ -706,6 +707,11 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 		}
 		err = fakeOvn.controller.WatchNetworkPolicy()
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	}
+
+	startOvn := func(dbSetup libovsdbtest.TestSetup, namespaces []v1.Namespace, networkPolicies []knet.NetworkPolicy,
+		pods []testPod, podLabels map[string]string) {
+		startOvnWithHostNetPods(dbSetup, namespaces, networkPolicies, pods, podLabels, false)
 	}
 
 	getUpdatedInitialDB := func(tPods []testPod) []libovsdbtest.TestData {
@@ -1082,11 +1088,11 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 					initialDB.NBData)
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedData...))
 			},
-			table.Entry("for empty pod selector => use netpol namespace address set",
+			table.Entry("empty pod selector => use pod selector",
 				knet.NetworkPolicyPeer{
 					PodSelector: &metav1.LabelSelector{},
-				}, []string{namespaceName1}),
-			table.Entry("namespace selector with empty pod selector => use a set of selected namespace address sets",
+				}, nil),
+			table.Entry("namespace selector with nil pod selector => use a set of selected namespace address sets",
 				knet.NetworkPolicyPeer{
 					NamespaceSelector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{
@@ -1818,7 +1824,6 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 		ginkgo.It("references all namespace address sets for empty namespace selector, even if they don't have pods (HostNetworkNamespace)", func() {
 			app.Action = func(ctx *cli.Context) error {
 				hostNamespaceName := "host-network"
-				config.Kubernetes.HostNetworkNamespace = hostNamespaceName
 				hostNamespace := *newNamespace(hostNamespaceName)
 
 				namespace1 := *newNamespace(namespaceName1)
@@ -1854,7 +1859,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				fakeOvn.asf.ExpectAddressSetWithIPs(hostNamespaceName, []string{"10.244.0.2"})
 
 				gressPolicyExpectedData := getPolicyData(networkPolicy, []string{nPodTest.portUUID},
-					[]string{hostNamespace.Name}, nil)
+					[]string{hostNamespace.Name, namespaceName1}, nil)
 				defaultDenyExpectedData := getDefaultDenyData(networkPolicy, []string{nPodTest.portUUID})
 				expectedData := getUpdatedInitialDB([]testPod{nPodTest})
 				expectedData = append(expectedData, gressPolicyExpectedData...)
@@ -1901,6 +1906,99 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				gomega.Eventually(func() int {
 					return runtime.NumGoroutine()
 				}).Should(gomega.Equal(goroutinesNumInit))
+
+				return nil
+			}
+
+			gomega.Expect(app.Run([]string{app.Name})).To(gomega.Succeed())
+		})
+
+		ginkgo.It("correctly creates networkpolicy targeting hostNetwork pods with non-nil podSelector", func() {
+			// check useNamespaceAddrSet function comments to explain this behaviour
+			app.Action = func(ctx *cli.Context) error {
+				namespace1 := *newNamespace(namespaceName1)
+				namespace1.Labels = map[string]string{labelName: labelVal}
+				nPodTest := getTestPod(namespace1.Name, nodeName)
+
+				networkPolicy := newNetworkPolicy(netPolicyName1, namespace1.Name,
+					metav1.LabelSelector{},
+					nil,
+					[]knet.NetworkPolicyEgressRule{{
+						To: []knet.NetworkPolicyPeer{{
+							NamespaceSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{labelName: labelVal},
+							},
+							PodSelector: &metav1.LabelSelector{},
+						}},
+					}},
+					knet.PolicyTypeEgress,
+				)
+
+				startOvnWithHostNetPods(initialDB, []v1.Namespace{namespace1}, []knet.NetworkPolicy{*networkPolicy},
+					[]testPod{nPodTest}, nil, true)
+
+				ginkgo.By("Check networkPolicy includes hostNetwork")
+				_, err := fakeOvn.fakeClient.KubeClient.NetworkingV1().NetworkPolicies(networkPolicy.Namespace).
+					Get(context.TODO(), networkPolicy.Name, metav1.GetOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				// namespaced address set won't have hostNet pod ip
+				fakeOvn.asf.EventuallyExpectEmptyAddressSetExist(namespaceName1)
+				// netpol peer address set will
+				eventuallyExpectAddressSetsWithIP(fakeOvn, networkPolicy.Spec.Egress[0].To[0],
+					networkPolicy.Namespace, nPodTest.podIP)
+
+				gressPolicy1ExpectedData := getPolicyData(networkPolicy, nil, nil, nil)
+				defaultDenyExpectedData := getDefaultDenyData(networkPolicy, nil)
+				expectedData := initialDB.NBData
+				expectedData = append(expectedData, gressPolicy1ExpectedData...)
+				expectedData = append(expectedData, defaultDenyExpectedData...)
+				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedData...))
+
+				return nil
+			}
+
+			gomega.Expect(app.Run([]string{app.Name})).To(gomega.Succeed())
+		})
+
+		ginkgo.It("correctly creates networkpolicy ignoring hostNetwork pods with nil podSelector", func() {
+			// check useNamespaceAddrSet function comments to explain this behaviour
+			app.Action = func(ctx *cli.Context) error {
+				namespace1 := *newNamespace(namespaceName1)
+				namespace1.Labels = map[string]string{labelName: labelVal}
+				nPodTest := getTestPod(namespace1.Name, nodeName)
+
+				networkPolicy := newNetworkPolicy(netPolicyName1, namespace1.Name,
+					metav1.LabelSelector{},
+					nil,
+					[]knet.NetworkPolicyEgressRule{{
+						To: []knet.NetworkPolicyPeer{{
+							NamespaceSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{labelName: labelVal},
+							},
+						}},
+					}},
+					knet.PolicyTypeEgress,
+				)
+
+				startOvnWithHostNetPods(initialDB, []v1.Namespace{namespace1}, []knet.NetworkPolicy{*networkPolicy},
+					[]testPod{nPodTest}, nil, true)
+
+				ginkgo.By("Check networkPolicy doesn't select hostNetwork pods")
+				_, err := fakeOvn.fakeClient.KubeClient.NetworkingV1().NetworkPolicies(networkPolicy.Namespace).
+					Get(context.TODO(), networkPolicy.Name, metav1.GetOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				// namespaced address set won't have hostNet pod ip
+				fakeOvn.asf.EventuallyExpectEmptyAddressSetExist(namespaceName1)
+				// netpol peer address set doesn't exist
+				eventuallyExpectNoAddressSets(fakeOvn, networkPolicy.Spec.Egress[0].To[0],
+					networkPolicy.Namespace)
+
+				gressPolicy1ExpectedData := getPolicyData(networkPolicy, nil, []string{namespace1.Name}, nil)
+				defaultDenyExpectedData := getDefaultDenyData(networkPolicy, nil)
+				expectedData := initialDB.NBData
+				expectedData = append(expectedData, gressPolicy1ExpectedData...)
+				expectedData = append(expectedData, defaultDenyExpectedData...)
+				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedData...))
 
 				return nil
 			}


### PR DESCRIPTION
cherry-pick of https://github.com/openshift/ovn-kubernetes/pull/2050
conflicts are related to error checks added in 4.15 https://github.com/openshift/ovn-kubernetes/commit/810ed6ad1cf4a160a87a5a0dcc33081f1230397b, but these function calls were just removed by the change