### PR TITLE
[release-4.14] OCPBUGS-29342: AdminPolicyBasedExternalRoute CRD failing to watch and reconcile routes for later pods

### DIFF
--- a/go-controller/pkg/ovn/controller/apbroute/external_controller_namespace_test.go
+++ b/go-controller/pkg/ovn/controller/apbroute/external_controller_namespace_test.go
@@ -106,7 +106,6 @@ func newNamespaceWithPods(nsName string, pods ...*corev1.Pod) *namespaceWithPods
 		pods:   pods,
 	}
 }
-
 func expectedPolicyStateAndRefs(targetNamespaces []*namespaceWithPods, staticGWIPs []string,
 	dynamicGws []*namespaceWithPods, bfdEnabled bool) (*routePolicyState, *policyReferencedObjects) {
 	routeState := newRoutePolicyState()

--- a/go-controller/pkg/ovn/controller/apbroute/external_controller_policy_test.go
+++ b/go-controller/pkg/ovn/controller/apbroute/external_controller_policy_test.go
@@ -28,15 +28,22 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 )
 
-func newPod(podName, namespace, hostIP string, labels map[string]string) *corev1.Pod {
-	return &corev1.Pod{
+func newPod(podName, namespace, podIP string, labels map[string]string) *corev1.Pod {
+	return newPodWithPhaseAndIP(podName, namespace, corev1.PodRunning, podIP, labels)
+}
+
+func newPodWithPhaseAndIP(podName, namespace string, phase corev1.PodPhase, podIP string, labels map[string]string) *corev1.Pod {
+	p := &corev1.Pod{
 		ObjectMeta: v1.ObjectMeta{Name: podName, Namespace: namespace,
-			Labels:      labels,
-			Annotations: map[string]string{nettypes.NetworkStatusAnnot: fmt.Sprintf(network_status, hostIP)},
-		},
+			Labels: labels},
 		Spec:   corev1.PodSpec{NodeName: "node"},
-		Status: corev1.PodStatus{PodIPs: []corev1.PodIP{{IP: hostIP}}, Phase: corev1.PodRunning},
+		Status: corev1.PodStatus{Phase: phase},
 	}
+	if len(podIP) > 0 {
+		p.Annotations = map[string]string{nettypes.NetworkStatusAnnot: fmt.Sprintf(network_status, podIP)}
+		p.Status.PodIPs = []corev1.PodIP{{IP: podIP}}
+	}
+	return p
 }
 
 func listRoutePolicyInCache() []string {

--- a/go-controller/pkg/ovn/controller/apbroute/gateway_info/gateway_info.go
+++ b/go-controller/pkg/ovn/controller/apbroute/gateway_info/gateway_info.go
@@ -154,7 +154,7 @@ type GatewayInfo struct {
 }
 
 func (g *GatewayInfo) String() string {
-	return fmt.Sprintf("BFDEnabled: %t, Gateways: %+v", g.BFDEnabled, g.Gateways)
+	return fmt.Sprintf("BFDEnabled: %t, Gateways: %+v, failedToApply: %t", g.BFDEnabled, g.Gateways, g.failedToApply)
 }
 
 func NewGatewayInfo(items sets.Set[string], bfdEnabled bool) *GatewayInfo {

--- a/go-controller/pkg/ovn/controller/apbroute/master_controller.go
+++ b/go-controller/pkg/ovn/controller/apbroute/master_controller.go
@@ -228,11 +228,11 @@ func (c *ExternalGatewayMasterController) processNextPolicyWorkItem(wg *sync.Wai
 	}
 	if err != nil {
 		if c.routeQueue.NumRequeues(key) < maxRetries {
-			klog.V(4).Infof("Error found while processing policy %s: %w", key, err)
+			klog.V(4).Infof("Error found while processing policy %s: %v", key, err)
 			c.routeQueue.AddRateLimited(key)
 			return true
 		}
-		klog.Warningf("Dropping policy %q out of the queue: %w", key, err)
+		klog.Warningf("Dropping policy %q out of the queue: %v", key, err)
 		utilruntime.HandleError(err)
 	}
 	c.routeQueue.Forget(key)


### PR DESCRIPTION
Fix backported from 4.15 and merged in https://github.com/ovn-org/ovn-kubernetes/pull/3934

The issue is that pods that don't have an `IP` in their status when being processed by the APB controller fail to trigger a new reconciliation loop, thus missing the logic that adds their configuration to the north bound DB.

@npinaeva @jcaamano PTAL.

@josecastillolema FYI.

