### PR TITLE
Reuse node-subnet from cache if exists

### DIFF
--- a/go-controller/pkg/clustermanager/node/subnet_allocator.go
+++ b/go-controller/pkg/clustermanager/node/subnet_allocator.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/klog/v2"
 	utilnet "k8s.io/utils/net"
 )
 
@@ -359,6 +360,18 @@ func (snr *subnetAllocatorRange) markAllocatedNetwork(owner string, network *net
 
 // allocateNetwork returns a new subnet, or nil if the range is full
 func (snr *subnetAllocatorRange) allocateNetwork(owner string) *net.IPNet {
+	// Return an already allocated subnet instead of creating a new one if a
+	// combination of subnet and node name already exists in the cache
+	for nodeSubnet, nodeName := range snr.allocMap {
+		if nodeName == owner {
+			_, subnet, err := net.ParseCIDR(nodeSubnet)
+			if err != nil {
+				klog.Errorf("Failed to parse subnet %s for node %s: %w", nodeSubnet, nodeName, err)
+				continue
+			}
+			return subnet
+		}
+	}
 	netMaskSize, addrLen := snr.network.Mask.Size()
 	numSubnets := uint32(1) << snr.subnetBits
 	if snr.subnetBits > 24 {


### PR DESCRIPTION
This PR is to return an already allocated subnet instead of creating a new one if a combination of subnet and node name already exists in the cache.

This PR is to stop multiple allocation of node-subnet from ClusterNetwork CIDR for any node if addition of
'k8s.ovn.org/node-subnets' annotation gets delayed but does not reach default BackOff[1] time limit for retry framework and meanwhile syncNodeNetworkAnnotations[2] gets executed multiple times.

JIRA: https://issues.redhat.com/browse/OCPBUGS-25733
[1] - https://github.com/kubernetes/client-go/blob/v0.26.1/util/retry/util.go#L38
[2] - https://github.com/ovn-org/ovn-kubernetes/blob/master/go-controller/pkg/clustermanager/node/node_allocator.go#L178

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->