### PR TITLE
[DNM] Mgnt port: remove possibility of stale MAC before adding neigh entry

### DIFF
--- a/go-controller/pkg/util/net_linux.go
+++ b/go-controller/pkg/util/net_linux.go
@@ -416,6 +416,22 @@ func LinkNeighExists(link netlink.Link, neighIP net.IP, neighMAC net.HardwareAdd
 	return false, nil
 }
 
+// LinkNeighIPExists checks to see if the IP exists in IP neighbour cache
+func LinkNeighIPExists(link netlink.Link, neighIP net.IP) (bool, error) {
+	neighs, err := netLinkOps.NeighList(link.Attrs().Index, getFamily(neighIP))
+	if err != nil {
+		return false, fmt.Errorf("failed to get the list of neighbour entries for link %s",
+			link.Attrs().Name)
+	}
+
+	for _, neigh := range neighs {
+		if neigh.IP.Equal(neighIP) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 func DeleteConntrack(ip string, port int32, protocol kapi.Protocol, ipFilterType netlink.ConntrackFilterType, labels [][]byte) error {
 	ipAddress := net.ParseIP(ip)
 	if ipAddress == nil {


### PR DESCRIPTION
..otherwise, error: "file exists" may occur if we attempt to add while an existing entry (with stale mac) is present.

Seen when converting from primary v6 dualstack to v6 single stack, but this may occur also in other "conversion" scenarios.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->