### PR TITLE
OCPBUGS-29851: Egress IP, Services: use all node IP addresses

### DIFF
--- a/go-controller/pkg/ovn/controller/egress_services/egress_services_controller.go
+++ b/go-controller/pkg/ovn/controller/egress_services/egress_services_controller.go
@@ -40,10 +40,8 @@ const (
 
 type InitClusterEgressPoliciesFunc func(client libovsdbclient.Client, addressSetFactory addressset.AddressSetFactory,
 	controllerName string) error
-type CreateNoRerouteNodePoliciesFunc func(client libovsdbclient.Client, addressSetFactory addressset.AddressSetFactory,
-	node *corev1.Node, controllerName string) error
-type DeleteNoRerouteNodePoliciesFunc func(addressSetFactory addressset.AddressSetFactory, nodeName string,
-	v4NodeAddr, v6NodeAddr net.IP, controllerName string) error
+type EnsureNoRerouteNodePoliciesFunc func(client libovsdbclient.Client, addressSetFactory addressset.AddressSetFactory,
+	controllerName string, nodeLister corelisters.NodeLister) error
 type DeleteLegacyDefaultNoRerouteNodePoliciesFunc func(libovsdbclient.Client, string) error
 
 type Controller struct {
@@ -54,8 +52,7 @@ type Controller struct {
 	sync.Mutex
 
 	initClusterEgressPolicies                InitClusterEgressPoliciesFunc
-	createNoRerouteNodePolicies              CreateNoRerouteNodePoliciesFunc
-	deleteNoRerouteNodePolicies              DeleteNoRerouteNodePoliciesFunc
+	ensureNoRerouteNodePolicies              EnsureNoRerouteNodePoliciesFunc
 	deleteLegacyDefaultNoRerouteNodePolicies DeleteLegacyDefaultNoRerouteNodePoliciesFunc
 	IsReachable                              func(nodeName string, mgmtIPs []net.IP, healthClient healthcheck.EgressIPHealthClient) bool // TODO: make a universal cache instead
 
@@ -91,17 +88,15 @@ type svcState struct {
 }
 
 type nodeState struct {
-	name             string
-	labels           map[string]string
-	mgmtIPs          []net.IP
-	v4MgmtIP         net.IP
-	v6MgmtIP         net.IP
-	v4InternalNodeIP net.IP
-	v6InternalNodeIP net.IP
-	healthClient     healthcheck.EgressIPHealthClient
-	allocations      map[string]*svcState // svc key -> state
-	reachable        bool
-	draining         bool
+	name         string
+	labels       map[string]string
+	mgmtIPs      []net.IP
+	v4MgmtIP     net.IP
+	v6MgmtIP     net.IP
+	healthClient healthcheck.EgressIPHealthClient
+	allocations  map[string]*svcState // svc key -> state
+	reachable    bool
+	draining     bool
 }
 
 func NewController(
@@ -110,8 +105,7 @@ func NewController(
 	nbClient libovsdbclient.Client,
 	addressSetFactory addressset.AddressSetFactory,
 	initClusterEgressPolicies InitClusterEgressPoliciesFunc,
-	createNoRerouteNodePolicies CreateNoRerouteNodePoliciesFunc,
-	deleteNoRerouteNodePolicies DeleteNoRerouteNodePoliciesFunc,
+	ensureNoRerouteNodePolicies EnsureNoRerouteNodePoliciesFunc,
 	deleteLegacyDefaultNoRerouteNodePolicies DeleteLegacyDefaultNoRerouteNodePoliciesFunc,
 	isReachable func(nodeName string, mgmtIPs []net.IP, healthClient healthcheck.EgressIPHealthClient) bool,
 	stopCh <-chan struct{},
@@ -125,8 +119,7 @@ func NewController(
 		nbClient:                                 nbClient,
 		addressSetFactory:                        addressSetFactory,
 		initClusterEgressPolicies:                initClusterEgressPolicies,
-		createNoRerouteNodePolicies:              createNoRerouteNodePolicies,
-		deleteNoRerouteNodePolicies:              deleteNoRerouteNodePolicies,
+		ensureNoRerouteNodePolicies:              ensureNoRerouteNodePolicies,
 		deleteLegacyDefaultNoRerouteNodePolicies: deleteLegacyDefaultNoRerouteNodePolicies,
 		IsReachable:                              isReachable,
 		stopCh:                                   stopCh,

--- a/go-controller/pkg/ovn/controller/egress_services/egress_services_node.go
+++ b/go-controller/pkg/ovn/controller/egress_services/egress_services_node.go
@@ -102,9 +102,11 @@ func (c *Controller) onNodeUpdate(oldObj, newObj interface{}) {
 	oldNodeReady := nodeIsReady(oldNode)
 	newNodeReady := nodeIsReady(newNode)
 
-	// We only care about node updates that relate to readiness or label changes
+	// We only care about node updates that relate to readiness, labels or
+	// addresses
 	if labels.Equals(oldNodeLabels, newNodeLabels) &&
-		oldNodeReady == newNodeReady {
+		oldNodeReady == newNodeReady &&
+		!util.NodeHostAddressesAnnotationChanged(oldNode, newNode) {
 		return
 	}
 
@@ -175,6 +177,13 @@ func (c *Controller) syncNode(key string) error {
 		return err
 	}
 
+	// We ensure node no re-route policies contemplating possible node IP
+	// address changes regardless of allocated services.
+	err = c.ensureNoRerouteNodePolicies(c.nbClient, c.addressSetFactory, c.controllerName, c.nodeLister)
+	if err != nil {
+		return err
+	}
+
 	n, err := c.nodeLister.Get(nodeName)
 	if err != nil && !apierrors.IsNotFound(err) {
 		return err
@@ -196,21 +205,10 @@ func (c *Controller) syncNode(key string) error {
 			}
 			delete(c.nodes, nodeName)
 			state.healthClient.Disconnect()
-		} else {
-			// we don't have a node at this point (node deleted?) and we don't have its cache
-			// entry (state==nil) as well. Maybe state was deleted when node became nodeReady or unreachable
-			// nothing to sync here
-			return nil
 		}
 
-		return c.deleteNoRerouteNodePolicies(c.addressSetFactory, nodeName, state.v4InternalNodeIP,
-			state.v6InternalNodeIP, c.controllerName)
-	}
-
-	// We create the per-node reroute policies as long as it has a resource (n != nil at this point),
-	// regardless if it was allocated services or not.
-	if err := c.createNoRerouteNodePolicies(c.nbClient, c.addressSetFactory, n, c.controllerName); err != nil {
-		return err
+		// nothing to sync here
+		return nil
 	}
 
 	nodeReady := nodeIsReady(n)
@@ -316,9 +314,7 @@ func (c *Controller) nodeStateFor(name string) (*nodeState, error) {
 		v6IP = ip
 	}
 
-	v4NodeAddr, v6NodeAddr := util.GetNodeInternalAddrs(node)
-
-	return &nodeState{name: name, mgmtIPs: mgmtIPs, v4MgmtIP: v4IP, v6MgmtIP: v6IP, v4InternalNodeIP: v4NodeAddr, v6InternalNodeIP: v6NodeAddr,
+	return &nodeState{name: name, mgmtIPs: mgmtIPs, v4MgmtIP: v4IP, v6MgmtIP: v6IP,
 		healthClient: healthcheck.NewEgressIPHealthClient(name), allocations: map[string]*svcState{}, labels: node.Labels,
 		reachable: true, draining: false}, nil
 }

--- a/go-controller/pkg/ovn/default_network_controller.go
+++ b/go-controller/pkg/ovn/default_network_controller.go
@@ -132,8 +132,6 @@ type DefaultNetworkController struct {
 	retryEgressNodes *retry.RetryFramework
 	// retry framework for Egress Firewall Nodes
 	retryEgressFwNodes *retry.RetryFramework
-	// EgressIP Node-specific syncMap used by egressip node event handler
-	addEgressNodeFailed sync.Map
 
 	// Node-specific syncMaps used by node event handler
 	gatewaysFailed              sync.Map
@@ -200,6 +198,7 @@ func newDefaultNetworkControllerCommon(cnci *CommonNetworkControllerInfo,
 		eIPC: egressIPController{
 			egressIPAssignmentMutex:           &sync.Mutex{},
 			podAssignmentMutex:                &sync.Mutex{},
+			nodeIPUpdateMutex:                 &sync.Mutex{},
 			podAssignment:                     make(map[string]*podAssignmentState),
 			pendingCloudPrivateIPConfigsMutex: &sync.Mutex{},
 			pendingCloudPrivateIPConfigsOps:   make(map[string]map[string]*cloudPrivateIPConfigOp),
@@ -786,26 +785,7 @@ func (h *defaultNetworkControllerEventHandler) AddResource(obj interface{}, from
 
 	case factory.EgressNodeType:
 		node := obj.(*kapi.Node)
-		if err := h.oc.setupNodeForEgress(node); err != nil {
-			return err
-		}
-		nodeEgressLabel := util.GetNodeEgressLabel()
-		nodeLabels := node.GetLabels()
-		_, hasEgressLabel := nodeLabels[nodeEgressLabel]
-		if hasEgressLabel {
-			h.oc.setNodeEgressAssignable(node.Name, true)
-		}
-		isReady := h.oc.isEgressNodeReady(node)
-		if isReady {
-			h.oc.setNodeEgressReady(node.Name, true)
-		}
-		isReachable := h.oc.isEgressNodeReachable(node)
-		if hasEgressLabel && isReachable && isReady {
-			h.oc.setNodeEgressReachable(node.Name, true)
-			if err := h.oc.addEgressNode(node.Name); err != nil {
-				return err
-			}
-		}
+		return h.oc.reconcileNodeForEgressIP(nil, node)
 
 	case factory.EgressFwNodeType:
 		node := obj.(*kapi.Node)
@@ -896,79 +876,7 @@ func (h *defaultNetworkControllerEventHandler) UpdateResource(oldObj, newObj int
 	case factory.EgressNodeType:
 		oldNode := oldObj.(*kapi.Node)
 		newNode := newObj.(*kapi.Node)
-
-		// Check if the node's internal addresses changed. If so,
-		// delete and readd the node for egress to update LR policies.
-		// We are only interested in the IPs here, not the subnet information.
-		oldV4Addr, oldV6Addr := util.GetNodeInternalAddrs(oldNode)
-		newV4Addr, newV6Addr := util.GetNodeInternalAddrs(newNode)
-		if !oldV4Addr.Equal(newV4Addr) || !oldV6Addr.Equal(newV6Addr) {
-			klog.Infof("Egress IP detected IP address change. Recreating node %s for Egress IP.", newNode.Name)
-			if err := h.oc.deleteNodeForEgress(oldNode); err != nil {
-				klog.Error(err)
-			}
-			if err := h.oc.setupNodeForEgress(newNode); err != nil {
-				klog.Error(err)
-			}
-		}
-
-		// Initialize the allocator on every update,
-		// ovnkube-node/cloud-network-config-controller will make sure to
-		// annotate the node with the egressIPConfig, but that might have
-		// happened after we processed the ADD for that object, hence keep
-		// retrying for all UPDATEs.
-		if err := h.oc.initEgressIPAllocator(newNode); err != nil {
-			klog.Warningf("Egress node initialization error: %v", err)
-		}
-		nodeEgressLabel := util.GetNodeEgressLabel()
-		oldLabels := oldNode.GetLabels()
-		newLabels := newNode.GetLabels()
-		_, oldHadEgressLabel := oldLabels[nodeEgressLabel]
-		_, newHasEgressLabel := newLabels[nodeEgressLabel]
-		// If the node is not labeled for egress assignment, just return
-		// directly, we don't really need to set the ready / reachable
-		// status on this node if the user doesn't care about using it.
-		if !oldHadEgressLabel && !newHasEgressLabel {
-			return nil
-		}
-		h.oc.setNodeEgressAssignable(newNode.Name, newHasEgressLabel)
-		if oldHadEgressLabel && !newHasEgressLabel {
-			klog.Infof("Node: %s has been un-labeled, deleting it from egress assignment", newNode.Name)
-			return h.oc.deleteEgressNode(oldNode.Name)
-		}
-		isOldReady := h.oc.isEgressNodeReady(oldNode)
-		isNewReady := h.oc.isEgressNodeReady(newNode)
-		isNewReachable := h.oc.isEgressNodeReachable(newNode)
-		h.oc.setNodeEgressReady(newNode.Name, isNewReady)
-		if !oldHadEgressLabel && newHasEgressLabel {
-			klog.Infof("Node: %s has been labeled, adding it for egress assignment", newNode.Name)
-			if isNewReady && isNewReachable {
-				h.oc.setNodeEgressReachable(newNode.Name, isNewReachable)
-				if err := h.oc.addEgressNode(newNode.Name); err != nil {
-					return err
-				}
-			} else {
-				klog.Warningf("Node: %s has been labeled, but node is not ready"+
-					" and reachable, cannot use it for egress assignment", newNode.Name)
-			}
-			return nil
-		}
-		if isOldReady == isNewReady {
-			return nil
-		}
-		if !isNewReady {
-			klog.Warningf("Node: %s is not ready, deleting it from egress assignment", newNode.Name)
-			if err := h.oc.deleteEgressNode(newNode.Name); err != nil {
-				return err
-			}
-		} else if isNewReady && isNewReachable {
-			klog.Infof("Node: %s is ready and reachable, adding it for egress assignment", newNode.Name)
-			h.oc.setNodeEgressReachable(newNode.Name, isNewReachable)
-			if err := h.oc.addEgressNode(newNode.Name); err != nil {
-				return err
-			}
-		}
-		return nil
+		return h.oc.reconcileNodeForEgressIP(oldNode, newNode)
 
 	case factory.EgressFwNodeType:
 		oldNode := oldObj.(*kapi.Node)
@@ -1057,17 +965,7 @@ func (h *defaultNetworkControllerEventHandler) DeleteResource(obj, cachedObj int
 
 	case factory.EgressNodeType:
 		node := obj.(*kapi.Node)
-		if err := h.oc.deleteNodeForEgress(node); err != nil {
-			return err
-		}
-		nodeEgressLabel := util.GetNodeEgressLabel()
-		nodeLabels := node.GetLabels()
-		if _, hasEgressLabel := nodeLabels[nodeEgressLabel]; hasEgressLabel {
-			if err := h.oc.deleteEgressNode(node.Name); err != nil {
-				return err
-			}
-		}
-		return nil
+		return h.oc.reconcileNodeForEgressIP(node, nil)
 
 	case factory.EgressFwNodeType:
 		node, ok := obj.(*kapi.Node)

--- a/go-controller/pkg/ovn/egressip.go
+++ b/go-controller/pkg/ovn/egressip.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
+	listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
 	utilnet "k8s.io/utils/net"
@@ -1966,13 +1967,6 @@ func (oc *DefaultNetworkController) setNodeEgressReachable(nodeName string, isRe
 
 func (oc *DefaultNetworkController) addEgressNode(nodeName string) error {
 	var errors []error
-	// Check if EgressIP node create failed and if does try adding it again
-	if node, ok := oc.addEgressNodeFailed.Load(nodeName); ok {
-		failedNode := node.(*kapi.Node)
-		if err := oc.setupNodeForEgress(failedNode); err != nil {
-			return err
-		}
-	}
 	klog.V(5).Infof("Egress node: %s about to be initialized", nodeName)
 	// This option will program OVN to start sending GARPs for all external IPS
 	// that the logical switch port has been configured to use. This is
@@ -2107,28 +2101,101 @@ func (oc *DefaultNetworkController) initEgressIPAllocator(node *kapi.Node) (err 
 	return nil
 }
 
-// setupNodeForEgress sets up default logical router policy for every node and
-// initiates the allocator cache for the node in question, if the node has the
-// necessary annotation.
-func (oc *DefaultNetworkController) setupNodeForEgress(node *v1.Node) error {
-	if err := CreateDefaultNoRerouteNodePolicies(oc.nbClient, oc.addressSetFactory, node, oc.controllerName); err != nil {
-		oc.addEgressNodeFailed.Store(node.Name, node)
-		return err
+// reconcileNodeForEgressIP with respect and old and new status of a node
+func (oc *DefaultNetworkController) reconcileNodeForEgressIP(oldNode, newNode *v1.Node) error {
+	// Check if the node's addresses changed. If so, update LR policies.
+	if oldNode == nil || newNode == nil || util.NodeHostAddressesAnnotationChanged(oldNode, newNode) {
+		klog.Infof("Egress IP detected IP address change. Updating no re-route policies")
+		err := oc.ensureDefaultNoRerouteNodePolicies()
+		if err != nil {
+			return err
+		}
 	}
-	oc.addEgressNodeFailed.Delete(node.Name)
-	if err := oc.initEgressIPAllocator(node); err != nil {
-		klog.V(5).Infof("Egress node initialization error: %v", err)
+
+	nodeEgressLabel := util.GetNodeEgressLabel()
+	var oldLabels map[string]string
+	var newLabels map[string]string
+	var isOldReady, isNewReady, isNewReachable bool
+	var nodeName string
+	if oldNode != nil {
+		oldLabels = oldNode.GetLabels()
+		isOldReady = oc.isEgressNodeReady(oldNode)
+		nodeName = oldNode.Name
 	}
+	if newNode != nil {
+		// Initialize the allocator on every update,
+		// ovnkube-node/cloud-network-config-controller will make sure to
+		// annotate the node with the egressIPConfig, but that might have
+		// happened after we processed the ADD for that object, hence keep
+		// retrying for all UPDATEs.
+		if err := oc.initEgressIPAllocator(newNode); err != nil {
+			klog.Warningf("Egress node initialization error: %v", err)
+		}
+
+		newLabels = newNode.GetLabels()
+		isNewReady = oc.isEgressNodeReady(newNode)
+		isNewReachable = oc.isEgressNodeReachable(newNode)
+		nodeName = newNode.Name
+	} else if oldNode != nil {
+		err := oc.deleteEgressIPAllocator(oldNode)
+		if err != nil {
+			return nil
+		}
+	}
+
+	_, oldHadEgressLabel := oldLabels[nodeEgressLabel]
+	_, newHasEgressLabel := newLabels[nodeEgressLabel]
+	oc.setNodeEgressAssignable(nodeName, newHasEgressLabel)
+	oc.setNodeEgressReady(nodeName, isNewReady)
+
+	// If the node is not labeled for egress assignment, just return
+	// directly, we don't really need to set the ready / reachable
+	// status on this node if the user doesn't care about using it.
+	if !oldHadEgressLabel && !newHasEgressLabel {
+		return nil
+	}
+
+	if oldHadEgressLabel && !newHasEgressLabel {
+		klog.Infof("Node: %s has been un-labeled, deleting it from egress assignment", nodeName)
+		return oc.deleteEgressNode(nodeName)
+	}
+
+	if !oldHadEgressLabel && newHasEgressLabel {
+		klog.Infof("Node: %s has been labeled, adding it for egress assignment", nodeName)
+		if isNewReady && isNewReachable {
+			oc.setNodeEgressReachable(nodeName, isNewReachable)
+			if err := oc.addEgressNode(nodeName); err != nil {
+				return err
+			}
+		} else {
+			klog.Warningf("Node: %s has been labeled, but node is not ready"+
+				" and reachable, cannot use it for egress assignment", nodeName)
+		}
+		return nil
+	}
+
+	if isOldReady == isNewReady {
+		return nil
+	}
+
+	if !isNewReady {
+		klog.Warningf("Node: %s is not ready, deleting it from egress assignment", nodeName)
+		if err := oc.deleteEgressNode(nodeName); err != nil {
+			return err
+		}
+	} else if isNewReady && isNewReachable {
+		klog.Infof("Node: %s is ready and reachable, adding it for egress assignment", nodeName)
+		oc.setNodeEgressReachable(nodeName, isNewReachable)
+		if err := oc.addEgressNode(nodeName); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 
-// deleteNodeForEgress remove the default allow logical router policies for the
-// node and removes the node from the allocator cache.
-func (oc *DefaultNetworkController) deleteNodeForEgress(node *v1.Node) error {
-	v4NodeAddr, v6NodeAddr := util.GetNodeInternalAddrs(node)
-	if err := DeleteDefaultNoRerouteNodePolicies(oc.addressSetFactory, node.Name, v4NodeAddr, v6NodeAddr, oc.controllerName); err != nil {
-		return err
-	}
+// deleteEgressIPAllocator removes the node from the allocator cache.
+func (oc *DefaultNetworkController) deleteEgressIPAllocator(node *v1.Node) error {
 	oc.eIPC.allocator.Lock()
 	if eNode, exists := oc.eIPC.allocator.cache[node.Name]; exists {
 		eNode.healthClient.Disconnect()
@@ -2262,6 +2329,9 @@ type egressIPController struct {
 	// Currently WatchEgressIP, WatchEgressNamespace and WatchEgressPod could
 	// all access that map simultaneously, hence why this guard is needed.
 	podAssignmentMutex *sync.Mutex
+	// nodeIPUpdateMutex is used to ensure safe handling of node ip address
+	// updates. VIP addresses are dynamic and might move across nodes.
+	nodeIPUpdateMutex *sync.Mutex
 	// podAssignment is a cache used for keeping track of which egressIP status
 	// has been setup for each pod. The key is defined by getPodKey
 	podAssignment map[string]*podAssignmentState
@@ -2858,32 +2928,45 @@ func createDefaultNoReroutePodPolicies(nbClient libovsdbclient.Client, v4Cluster
 	return nil
 }
 
-// createDefaultNoRerouteNodePolicies ensures egress pods east<->west traffic with hostNetwork pods,
+func (oc *DefaultNetworkController) ensureDefaultNoRerouteNodePolicies() error {
+	oc.eIPC.nodeIPUpdateMutex.Lock()
+	defer oc.eIPC.nodeIPUpdateMutex.Unlock()
+	nodeLister := listers.NewNodeLister(oc.watchFactory.NodeInformer().GetIndexer())
+	return ensureDefaultNoRerouteNodePolicies(oc.nbClient, oc.addressSetFactory, oc.controllerName, nodeLister)
+}
+
+// ensureDefaultNoRerouteNodePolicies ensures egress pods east<->west traffic with hostNetwork pods,
 // i.e: ensuring that an egress pod can still communicate with a hostNetwork pod / service backed by hostNetwork pods
 // without using egressIPs.
 // sample: 101 ip4.src == $a12749576804119081385 && ip4.dst == $a11079093880111560446 allow pkt_mark=1008
-func CreateDefaultNoRerouteNodePolicies(nbClient libovsdbclient.Client, addressSetFactory addressset.AddressSetFactory, node *kapi.Node, controllerName string) error {
-	v4NodeAddr, v6NodeAddr := util.GetNodeInternalAddrs(node)
+// All the cluster node's addresses are considered. This is to avoid race conditions after a VIP moves from one node
+// to another where we might process events out of order. For the same reason this function needs to be called under
+// lock.
+func ensureDefaultNoRerouteNodePolicies(nbClient libovsdbclient.Client, addressSetFactory addressset.AddressSetFactory, controllerName string, nodeLister listers.NodeLister) error {
+	nodes, err := nodeLister.List(labels.Everything())
+	if err != nil {
+		return err
+	}
+
+	v4NodeAddrs, v6NodeAddrs, err := util.GetNodeAddresses(config.IPv4Mode, config.IPv6Mode, nodes...)
+	if err != nil {
+		return err
+	}
+
+	allAddresses := make([]net.IP, 0, len(v4NodeAddrs)+len(v6NodeAddrs))
+	allAddresses = append(allAddresses, v4NodeAddrs...)
+	allAddresses = append(allAddresses, v6NodeAddrs...)
+
 	var as addressset.AddressSet
-	var err error
 	dbIDs := getEgressIPAddrSetDbIDs(NodeIPAddrSetName, controllerName)
 	if as, err = addressSetFactory.GetAddressSet(dbIDs); err != nil {
 		return fmt.Errorf("cannot ensure that addressSet %s exists %v", NodeIPAddrSetName, err)
 	}
-	if v4NodeAddr != nil {
-		// add the nodeIP to the nodeIP address-set
-		if err = as.AddIPs([]net.IP{v4NodeAddr}); err != nil {
-			return fmt.Errorf("unable to add nodeIPs %s/%s for node %s: to the address set %s, err: %v",
-				v4NodeAddr.String(), v6NodeAddr.String(), node.Name, NodeIPAddrSetName, err)
-		}
+
+	if err = as.SetIPs(allAddresses); err != nil {
+		return fmt.Errorf("unable to set IPs to no re-route address set %s: %w", NodeIPAddrSetName, err)
 	}
-	if v6NodeAddr != nil {
-		// add the nodeIP to the nodeIP address-set
-		if err = as.AddIPs([]net.IP{v6NodeAddr}); err != nil {
-			return fmt.Errorf("unable to add nodeIPs %s/%s for node %s: to the address set %s, err: %v",
-				v4NodeAddr.String(), v6NodeAddr.String(), node.Name, NodeIPAddrSetName, err)
-		}
-	}
+
 	ipv4ClusterNodeIPAS, ipv6ClusterNodeIPAS := as.GetASHashNames()
 	// fetch the egressIP pods address-set
 	dbIDs = getEgressIPAddrSetDbIDs(EgressIPServedPodsAddrSetName, controllerName)
@@ -2901,11 +2984,11 @@ func CreateDefaultNoRerouteNodePolicies(nbClient libovsdbclient.Client, addressS
 
 	var matchV4, matchV6 string
 	// construct the policy match
-	if v4NodeAddr != nil {
+	if len(v4NodeAddrs) > 0 {
 		matchV4 = fmt.Sprintf(`(ip4.src == $%s || ip4.src == $%s) && ip4.dst == $%s`,
 			ipv4EgressIPServedPodsAS, ipv4EgressServiceServedPodsAS, ipv4ClusterNodeIPAS)
 	}
-	if v6NodeAddr != nil {
+	if len(v6NodeAddrs) > 0 {
 		matchV6 = fmt.Sprintf(`(ip6.src == $%s || ip6.src == $%s) && ip6.dst == $%s`,
 			ipv6EgressIPServedPodsAS, ipv6EgressServiceServedPodsAS, ipv6ClusterNodeIPAS)
 	}
@@ -2920,33 +3003,6 @@ func CreateDefaultNoRerouteNodePolicies(nbClient libovsdbclient.Client, addressS
 	if matchV6 != "" {
 		if err := createLogicalRouterPolicy(nbClient, matchV6, types.DefaultNoRereoutePriority, nil, options); err != nil {
 			return fmt.Errorf("unable to create IPv6 no-reroute node policies, err: %v", err)
-		}
-	}
-	return nil
-}
-
-// DeleteDefaultNoRerouteNodePolicies deletes the EIP node IP from the global node address-set
-// NOTE: We haven't added logic to fully delete the policy because there can never be a cluster with 0 nodes
-// So once created this policy will exist forever
-func DeleteDefaultNoRerouteNodePolicies(addressSetFactory addressset.AddressSetFactory, nodeName string, v4NodeAddr, v6NodeAddr net.IP, controllerName string) error {
-	var as addressset.AddressSet
-	var err error
-	dbIDs := getEgressIPAddrSetDbIDs(NodeIPAddrSetName, controllerName)
-	if as, err = addressSetFactory.GetAddressSet(dbIDs); err != nil {
-		return fmt.Errorf("cannot ensure that addressSet %s exists %v", NodeIPAddrSetName, err)
-	}
-	if v4NodeAddr != nil {
-		// remove the nodeIP from the nodeIP address-set
-		if err = as.DeleteIPs([]net.IP{v4NodeAddr}); err != nil {
-			return fmt.Errorf("unable to delete nodeIPs %s/%s for node %s: to the address set %s, err: %v",
-				v4NodeAddr.String(), v6NodeAddr.String(), nodeName, NodeIPAddrSetName, err)
-		}
-	}
-	if v6NodeAddr != nil {
-		// remove the nodeIP from the nodeIP address-set
-		if err = as.DeleteIPs([]net.IP{v6NodeAddr}); err != nil {
-			return fmt.Errorf("unable to delete nodeIPs %s/%s for node %s: to the address set %s, err: %v",
-				v4NodeAddr.String(), v6NodeAddr.String(), nodeName, NodeIPAddrSetName, err)
 		}
 	}
 	return nil

--- a/go-controller/pkg/ovn/egressip_test.go
+++ b/go-controller/pkg/ovn/egressip_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	egressipv1 "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressip/v1"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
+	addressset "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/address_set"
+	egresssvc "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/controller/egress_services"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/healthcheck"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/retry"
 	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
@@ -1069,6 +1071,143 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 				}
 
 				gomega.Eventually(fakeOvn.nbClient, inspectTimeout).Should(libovsdbtest.HaveData(expectedDatabaseState))
+
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+
+		ginkgo.It("should update node no-reroute policy address set", func() {
+			app.Action = func(ctx *cli.Context) error {
+
+				config.IPv6Mode = true
+				node1IPv4 := "192.168.126.202"
+				node1IPv6 := "fc00:f853:ccd:e793::1"
+				node2IPv4 := "192.168.126.51"
+				node2IPv6 := "fc00:f853:ccd:e793::2"
+				vipIPv4 := "192.168.126.10"
+				vipIPv6 := "fc00:f853:ccd:e793::10"
+
+				node1 := v1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: node1Name,
+						Annotations: map[string]string{
+							"k8s.ovn.org/host-addresses": fmt.Sprintf("[\"%s\", \"%s\", \"%s\", \"%s\"]", node1IPv4, node1IPv6, vipIPv4, vipIPv6),
+						},
+					},
+					Status: v1.NodeStatus{
+						Conditions: []v1.NodeCondition{
+							{
+								Type:   v1.NodeReady,
+								Status: v1.ConditionTrue,
+							},
+						},
+					},
+				}
+				node2 := v1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: node2Name,
+						Annotations: map[string]string{
+							"k8s.ovn.org/host-addresses": fmt.Sprintf("[\"%s\", \"%s\"]", node2IPv4, node2IPv6),
+						},
+					},
+					Status: v1.NodeStatus{
+						Conditions: []v1.NodeCondition{
+							{
+								Type:   v1.NodeReady,
+								Status: v1.ConditionTrue,
+							},
+						},
+					},
+				}
+
+				fakeOvn.startWithDBSetup(
+					libovsdbtest.TestSetup{
+						NBData: []libovsdbtest.TestData{
+							&nbdb.LogicalRouter{
+								Name: ovntypes.OVNClusterRouter,
+								UUID: ovntypes.OVNClusterRouter + "-UUID",
+							},
+						},
+					},
+					&v1.NodeList{
+						Items: []v1.Node{node1, node2},
+					},
+				)
+
+				err := fakeOvn.controller.WatchEgressNodes()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				nodeIPsASdbIDs := getEgressIPAddrSetDbIDs(NodeIPAddrSetName, DefaultNetworkControllerName)
+				fakeOvn.asf.EventuallyExpectAddressSetWithIPs(nodeIPsASdbIDs, []string{node1IPv4, node2IPv4, node1IPv6, node2IPv6, vipIPv4, vipIPv6})
+
+				egressSvcPodsV4, egressSvcPodsV6 := addressset.GetHashNamesForAS(egresssvc.GetEgressServiceAddrSetDbIDs(DefaultNetworkControllerName))
+				egressipPodsV4, egressipPodsV6 := addressset.GetHashNamesForAS(getEgressIPAddrSetDbIDs(EgressIPServedPodsAddrSetName, DefaultNetworkControllerName))
+				nodeIPsV4, nodeIPsV6 := addressset.GetHashNamesForAS(nodeIPsASdbIDs)
+				expectedDatabaseState := []libovsdbtest.TestData{
+					&nbdb.LogicalRouterPolicy{
+						Priority: types.DefaultNoRereoutePriority,
+						Match:    "ip4.src == 10.128.0.0/14 && ip4.dst == 10.128.0.0/14",
+						Action:   nbdb.LogicalRouterPolicyActionAllow,
+						UUID:     "default-no-reroute-UUID",
+					},
+					&nbdb.LogicalRouterPolicy{
+						Priority: types.DefaultNoRereoutePriority,
+						Match:    fmt.Sprintf("ip4.src == 10.128.0.0/14 && ip4.dst == %s", config.Gateway.V4JoinSubnet),
+						Action:   nbdb.LogicalRouterPolicyActionAllow,
+						UUID:     "no-reroute-service-UUID",
+					},
+					&nbdb.LogicalRouterPolicy{
+						Priority: types.DefaultNoRereoutePriority,
+						Match: fmt.Sprintf("(ip4.src == $%s || ip4.src == $%s) && ip4.dst == $%s",
+							egressipPodsV4, egressSvcPodsV4, nodeIPsV4),
+						Action:  nbdb.LogicalRouterPolicyActionAllow,
+						UUID:    "default-no-reroute-node-UUID",
+						Options: map[string]string{"pkt_mark": "1008"},
+					},
+					&nbdb.LogicalRouterPolicy{
+						Priority: types.DefaultNoRereoutePriority,
+						Match: fmt.Sprintf("(ip6.src == $%s || ip6.src == $%s) && ip6.dst == $%s",
+							egressipPodsV6, egressSvcPodsV6, nodeIPsV6),
+						Action:  nbdb.LogicalRouterPolicyActionAllow,
+						UUID:    "default-v6-no-reroute-node-UUID",
+						Options: map[string]string{"pkt_mark": "1008"},
+					},
+					&nbdb.LogicalRouter{
+						Name: ovntypes.OVNClusterRouter,
+						UUID: ovntypes.OVNClusterRouter + "-UUID",
+						Policies: []string{
+							"default-no-reroute-UUID",
+							"no-reroute-service-UUID",
+							"default-no-reroute-node-UUID",
+							"default-v6-no-reroute-node-UUID",
+						},
+					},
+				}
+
+				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+
+				node1.ObjectMeta.Annotations["k8s.ovn.org/host-addresses"] = fmt.Sprintf("[\"%s\", \"%s\"]", node1IPv4, node1IPv6)
+				_, err = fakeOvn.fakeClient.KubeClient.CoreV1().Nodes().Update(context.TODO(), &node1, metav1.UpdateOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				fakeOvn.asf.EventuallyExpectAddressSetWithIPs(nodeIPsASdbIDs, []string{node1IPv4, node2IPv4, node1IPv6, node2IPv6})
+				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+
+				node2.ObjectMeta.Annotations["k8s.ovn.org/host-addresses"] = fmt.Sprintf("[\"%s\", \"%s\", \"%s\", \"%s\"]", node2IPv4, node2IPv6, vipIPv4, vipIPv6)
+				_, err = fakeOvn.fakeClient.KubeClient.CoreV1().Nodes().Update(context.TODO(), &node2, metav1.UpdateOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				fakeOvn.asf.EventuallyExpectAddressSetWithIPs(nodeIPsASdbIDs, []string{node1IPv4, node2IPv4, node1IPv6, node2IPv6, vipIPv4, vipIPv6})
+				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+
+				err = fakeOvn.fakeClient.KubeClient.CoreV1().Nodes().Delete(context.TODO(), node1.Name, metav1.DeleteOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				fakeOvn.asf.EventuallyExpectAddressSetWithIPs(nodeIPsASdbIDs, []string{node2IPv4, node2IPv6, vipIPv4, vipIPv6})
+				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 
 				return nil
 			}

--- a/go-controller/pkg/ovn/egressservices_test.go
+++ b/go-controller/pkg/ovn/egressservices_test.go
@@ -33,17 +33,20 @@ var _ = ginkgo.Describe("OVN Egress Service Operations", func() {
 		fakeOVN *FakeOVN
 	)
 	const (
-		node1Name       string = "node1"
-		node1IPv4       string = "100.100.100.0"
-		node1IPv6       string = "fc00:f853:ccd:e793::1"
-		node1IPv4Subnet string = "10.128.1.0/24"
-		node1IPv6Subnet string = "fe00:10:128:1::/64"
-		node2Name       string = "node2"
-		node2IPv4       string = "200.200.200.0"
-		node2IPv6       string = "fc00:f853:ccd:e793::2"
-		node2IPv4Subnet string = "10.128.2.0/24"
-		node2IPv6Subnet string = "fe00:10:128:2::/64"
-		controllerName         = DefaultNetworkControllerName
+		node1Name            string = "node1"
+		node1IPv4            string = "100.100.100.0"
+		node1IPv6            string = "fc00:f853:ccd:e793::1"
+		node1IPv4Subnet      string = "10.128.1.0/24"
+		node1IPv6Subnet      string = "fe00:10:128:1::/64"
+		node2Name            string = "node2"
+		node2IPv4            string = "200.200.200.0"
+		node2IPv6            string = "fc00:f853:ccd:e793::2"
+		node2IPv4Subnet      string = "10.128.2.0/24"
+		node2IPv6Subnet      string = "fe00:10:128:2::/64"
+		vipIPv4              string = "192.168.126.10"
+		vipIPv6              string = "fc00:f853:ccd:e793::10"
+		controllerName              = DefaultNetworkControllerName
+		egressSVCLabelPrefix string = "egress-service.k8s.ovn.org"
 	)
 
 	ginkgo.BeforeEach(func() {
@@ -1341,7 +1344,7 @@ var _ = ginkgo.Describe("OVN Egress Service Operations", func() {
 	})
 
 	ginkgo.Context("on nodes changes", func() {
-		ginkgo.It("should create/update/delete logical router policies, labels and annotations", func() {
+		ginkgo.It("should create/update/delete logical router policies, address sets, labels and status", func() {
 			app.Action = func(ctx *cli.Context) error {
 				namespaceT := *newNamespace("testns")
 				config.IPv6Mode = true
@@ -1617,6 +1620,33 @@ var _ = ginkgo.Describe("OVN Egress Service Operations", func() {
 				}
 				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 
+				ginkgo.By("updating the second node host addresses the node ip no re-route address set will be updated")
+				nodeIPsASdbIDs := getEgressIPAddrSetDbIDs(NodeIPAddrSetName, DefaultNetworkControllerName)
+				fakeOVN.asf.EventuallyExpectAddressSetWithIPs(nodeIPsASdbIDs, []string{node1IPv4, node2IPv4, node1IPv6, node2IPv6})
+
+				node2.ObjectMeta.Annotations["k8s.ovn.org/host-addresses"] = fmt.Sprintf("[\"%s\", \"%s\", \"%s\", \"%s\"]", node2IPv4, node2IPv6, vipIPv4, vipIPv6)
+				node2.ResourceVersion = "3"
+				_, err = fakeOVN.fakeClient.KubeClient.CoreV1().Nodes().Update(context.TODO(), node2, metav1.UpdateOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				fakeOVN.asf.EventuallyExpectAddressSetWithIPs(nodeIPsASdbIDs, []string{node1IPv4, node2IPv4, node1IPv6, node2IPv6, vipIPv4, vipIPv6})
+				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+
+				node2.ObjectMeta.Annotations["k8s.ovn.org/host-addresses"] = fmt.Sprintf("[\"%s\", \"%s\"]", node2IPv4, node2IPv6)
+				node2.ResourceVersion = "4"
+				_, err = fakeOVN.fakeClient.KubeClient.CoreV1().Nodes().Update(context.TODO(), node2, metav1.UpdateOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				fakeOVN.asf.EventuallyExpectAddressSetWithIPs(nodeIPsASdbIDs, []string{node1IPv4, node2IPv4, node1IPv6, node2IPv6})
+				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+
+				ginkgo.By("deleting the first node, the node ip no re-route address set will be updated")
+				err = fakeOVN.fakeClient.KubeClient.CoreV1().Nodes().Delete(context.TODO(), node1.Name, metav1.DeleteOptions{})
+				gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+				fakeOVN.asf.EventuallyExpectAddressSetWithIPs(nodeIPsASdbIDs, []string{node2IPv4, node2IPv6})
+				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+
 				ginkgo.By("deleting the second node the second service's resources will be deleted")
 				err = fakeOVN.fakeClient.KubeClient.CoreV1().Nodes().Delete(context.TODO(), node2.Name, metav1.DeleteOptions{})
 				gomega.Expect(err).ToNot(gomega.HaveOccurred())
@@ -1630,6 +1660,7 @@ var _ = ginkgo.Describe("OVN Egress Service Operations", func() {
 					clusterRouter.Policies = append(clusterRouter.Policies, lrp.UUID)
 				}
 				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+				fakeOVN.asf.EventuallyExpectEmptyAddressSetExist(nodeIPsASdbIDs)
 
 				return nil
 			}
@@ -1959,6 +1990,7 @@ func nodeFor(name, ipv4, ipv6, v4subnet, v6subnet string) *v1.Node {
 			Name: name,
 			Annotations: map[string]string{
 				"k8s.ovn.org/node-primary-ifaddr": fmt.Sprintf("{\"ipv4\": \"%s\", \"ipv6\": \"%s\"}", ipv4, ipv6),
+				"k8s.ovn.org/host-addresses":      fmt.Sprintf("[\"%s\", \"%s\"]", ipv4, ipv6),
 				"k8s.ovn.org/node-subnets":        fmt.Sprintf("{\"default\":[\"%s\",\"%s\"]}", v4subnet, v6subnet),
 			},
 			Labels: map[string]string{

--- a/go-controller/pkg/util/node_annotations.go
+++ b/go-controller/pkg/util/node_annotations.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 
 	kapi "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
@@ -538,6 +539,10 @@ func GetNodeEgressLabel() string {
 
 func SetNodeHostAddresses(nodeAnnotator kube.Annotator, addresses sets.Set[string]) error {
 	return nodeAnnotator.Set(ovnNodeHostAddresses, addresses.UnsortedList())
+}
+
+func NodeHostAddressesAnnotationChanged(oldNode, newNode *v1.Node) bool {
+	return oldNode.Annotations[ovnNodeHostAddresses] != newNode.Annotations[ovnNodeHostAddresses]
 }
 
 // ParseNodeHostAddresses returns the parsed host addresses living on a node

--- a/go-controller/pkg/util/util.go
+++ b/go-controller/pkg/util/util.go
@@ -25,6 +25,7 @@ import (
 	discovery "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 	utilnet "k8s.io/utils/net"
@@ -129,6 +130,33 @@ func GetNodeInternalAddrs(node *v1.Node) (net.IP, net.IP) {
 		}
 	}
 	return v4Addr, v6Addr
+}
+
+// GetNodeAddresses returns all of the node's IPv4 and/or IPv6 annotated
+// addresses as requested. Note that nodes not annotated will be ignored.
+func GetNodeAddresses(ipv4, ipv6 bool, nodes ...*v1.Node) (ipsv4 []net.IP, ipsv6 []net.IP, err error) {
+	allips := sets.Set[string]{}
+	for _, node := range nodes {
+		ips, err := ParseNodeHostAddresses(node)
+		if IsAnnotationNotSetError(err) {
+			continue
+		}
+		if err != nil {
+			return nil, nil, err
+		}
+		allips = allips.Insert(ips.UnsortedList()...)
+	}
+
+	for _, ip := range allips.UnsortedList() {
+		ip := utilnet.ParseIPSloppy(ip)
+		if ipv4 && utilnet.IsIPv4(ip) {
+			ipsv4 = append(ipsv4, ip)
+		} else if ipv6 && utilnet.IsIPv6(ip) {
+			ipsv6 = append(ipsv6, ip)
+		}
+	}
+
+	return
 }
 
 // GetNodeChassisID returns the machine's OVN chassis ID

--- a/test/e2e/egress_services.go
+++ b/test/e2e/egress_services.go
@@ -171,7 +171,24 @@ var _ = ginkgo.Describe("Egress Services", func() {
 					break
 				}
 			}
-			ginkgo.By("Creating host-networked pod, on non-egress node to act as \"another node\"")
+			ginkgo.By("By setting a secondary IP on non-egress node acting as \"another node\"")
+			var otherDstIP string
+			if protocol == v1.IPv6Protocol {
+				otherDstIP = "fc00:f853:ccd:e793:ffff::1"
+			} else {
+				otherDstIP = "172.18.1.1"
+			}
+			_, err = runCommand(containerRuntime, "exec", dstNode.Name, "ip", "addr", "add", otherDstIP, "dev", "breth0")
+			if err != nil {
+				framework.Failf("failed to add address to node %s: %v", dstNode.Name, err)
+			}
+			defer func() {
+				_, err = runCommand(containerRuntime, "exec", dstNode.Name, "ip", "addr", "delete", otherDstIP, "dev", "breth0")
+				if err != nil {
+					framework.Failf("failed to remove address from node %s: %v", dstNode.Name, err)
+				}
+			}()
+			ginkgo.By("Creating host-networked pod on non-egress node acting as \"another node\"")
 			_, err = createPod(f, hostNetPod, dstNode.Name, f.Namespace.Name, []string{"/agnhost", "netexec", fmt.Sprintf("--http-port=%d", podHTTPPort)}, map[string]string{}, func(p *v1.Pod) {
 				p.Spec.HostNetwork = true
 			})
@@ -197,7 +214,10 @@ var _ = ginkgo.Describe("Egress Services", func() {
 				}
 				gomega.Consistently(func() error {
 					return curlAgnHostClientIPFromPod(f.Namespace.Name, pod, expectedsrcIP, dstIP, podHTTPPort)
-				}, 1*time.Second, 200*time.Millisecond).ShouldNot(gomega.HaveOccurred(), "failed to reach other node with node's ip")
+				}, 1*time.Second, 200*time.Millisecond).ShouldNot(gomega.HaveOccurred(), "failed to reach other node with node's primary ip")
+				gomega.Consistently(func() error {
+					return curlAgnHostClientIPFromPod(f.Namespace.Name, pod, expectedsrcIP, otherDstIP, podHTTPPort)
+				}, 1*time.Second, 200*time.Millisecond).ShouldNot(gomega.HaveOccurred(), "failed to reach other node with node's secondary ip")
 			}
 		},
 		ginkgotable.Entry("ipv4 pods", v1.IPv4Protocol),

--- a/test/e2e/egressip.go
+++ b/test/e2e/egressip.go
@@ -594,29 +594,34 @@ spec:
 		)
 	})
 
-	// Validate the egress IP by creating a httpd container on the kind networking
-	// (effectively seen as "outside" the cluster) and curl it from a pod in the cluster
-	// which matches the egress IP stanza. Aim is to check if the SNATs towards nodeIP versus
-	// SNATs towards egressIPs are being correctly deleted and recreated.
+	// Validate the egress IP by creating a httpd container on the kind
+	// networking (effectively seen as "outside" the cluster) and curl it from a
+	// pod in the cluster which matches the egress IP stanza. Aim is to check
+	// that the SNATs to egressIPs are being correctly deleted and recreated
+	// but not used for intra-cluster traffic.
 
 	/* This test does the following:
 	   0. Add the "k8s.ovn.org/egress-assignable" label to egress1Node
-	   1. Creating host-networked pod, on non-egress node (egress2Node) to act as "another node"
-	   2. Create an EgressIP object with one egress IP defined
-	   3. Check that the status is of length one and that it is assigned to egress1Node
-	   4. Create one pod matching the EgressIP: running on egress1Node
-	   5. Check connectivity from pod to an external "node" and verify that the srcIP is the expected egressIP
-	   6. Check connectivity from pod to another node (egress2Node) and verify that the srcIP is the expected nodeIP
-	   7. Add the "k8s.ovn.org/egress-assignable" label to egress2Node
-	   8. Remove the "k8s.ovn.org/egress-assignable" label from egress1Node
-	   9. Check that the status is of length one and that it is assigned to egress2Node
-	   10. Check connectivity from pod to an external "node" and verify that the srcIP is the expected egressIP
-	   11. Check connectivity from pod to another node (egress2Node) and verify that the srcIP is the expected nodeIP
-	   12. Create second pod not matching the EgressIP: running on egress1Node
-	   13. Check connectivity from second pod to external node and verify that the srcIP is the expected nodeIP
-	   14. Add pod selector label to make second pod egressIP managed
-	   15. Check connectivity from second pod to external node and verify that the srcIP is the expected egressIP
-	   16. Check connectivity from second pod to another node (egress2Node) and verify that the srcIP is the expected nodeIP (this verifies SNAT's towards nodeIP are not deleted for pods unless pod is on its own egressNode)
+	   1. Setting a secondary IP on non-egress node acting as "another node"
+	   2. Creating host-networked pod on non-egress node (egress2Node) acting as "another node"
+	   3. Create an EgressIP object with one egress IP defined
+	   4. Check that the status is of length one and that it is assigned to egress1Node
+	   5. Create one pod matching the EgressIP: running on egress1Node
+	   6. Check connectivity from pod to an external "node" and verify that the srcIP is the expected egressIP
+	   7. Check connectivity from pod to another node (egress2Node) primary IP and verify that the srcIP is the expected nodeIP
+	   8. Check connectivity from pod to another node (egress2Node) secondary IP and verify that the srcIP is the expected nodeIP
+	   9. Add the "k8s.ovn.org/egress-assignable" label to egress2Node
+	   10. Remove the "k8s.ovn.org/egress-assignable" label from egress1Node
+	   11. Check that the status is of length one and that it is assigned to egress2Node
+	   12. Check connectivity from pod to an external "node" and verify that the srcIP is the expected egressIP
+	   13. Check connectivity from pod to another node (egress2Node) primary IP and verify that the srcIP is the expected nodeIP
+	   14. Check connectivity from pod to another node (egress2Node) secondary IP and verify that the srcIP is the expected nodeIP
+	   15. Create second pod not matching the EgressIP: running on egress1Node
+	   16. Check connectivity from second pod to external node and verify that the srcIP is the expected nodeIP
+	   17. Add pod selector label to make second pod egressIP managed
+	   18. Check connectivity from second pod to external node and verify that the srcIP is the expected egressIP
+	   19. Check connectivity from second pod to another node (egress2Node) primary IP and verify that the srcIP is the expected nodeIP (this verifies SNAT's towards nodeIP are not deleted for pods unless pod is on its own egressNode)
+	   20. Check connectivity from second pod to another node (egress2Node) secondary IP and verify that the srcIP is the expected nodeIP (this verifies SNAT's towards nodeIP are not deleted for pods unless pod is on its own egressNode)
 	*/
 	ginkgo.It("Should validate the egress IP SNAT functionality against host-networked pods", func() {
 
@@ -627,8 +632,30 @@ spec:
 		framework.Logf("Added egress-assignable label to node %s", egress1Node.name)
 		framework.ExpectNodeHasLabel(f.ClientSet, egress1Node.name, "k8s.ovn.org/egress-assignable", "dummy")
 
-		ginkgo.By("1. Creating host-networked pod, on non-egress node to act as \"another node\"")
-		_, err := createPod(f, egress2Node.name+"-host-net-pod", egress2Node.name, f.Namespace.Name, []string{}, map[string]string{}, func(p *v1.Pod) {
+		ginkgo.By("1. By setting a secondary IP on non-egress node acting as \"another node\"")
+		var otherDstIP string
+		if utilnet.IsIPv6String(egress2Node.nodeIP) {
+			otherDstIP = "fc00:f853:ccd:e793:ffff::1"
+		} else {
+			otherDstIP = "172.18.1.1"
+		}
+		_, err := runCommand(containerRuntime, "exec", egress2Node.name, "ip", "addr", "add", otherDstIP, "dev", "breth0")
+		if err != nil {
+			framework.Failf("failed to add address to node %s: %v", egress2Node.name, err)
+		}
+		defer func() {
+			_, err = runCommand(containerRuntime, "exec", egress2Node.name, "ip", "addr", "delete", otherDstIP, "dev", "breth0")
+			if err != nil {
+				framework.Failf("failed to remove address from node %s: %v", egress2Node.name, err)
+			}
+		}()
+		otherHostNetPodIP := node{
+			name:   egress2Node.name + "-host-net-pod",
+			nodeIP: otherDstIP,
+		}
+
+		ginkgo.By("2. Creating host-networked pod, on non-egress node acting as \"another node\"")
+		_, err = createPod(f, egress2Node.name+"-host-net-pod", egress2Node.name, f.Namespace.Name, []string{}, map[string]string{}, func(p *v1.Pod) {
 			p.Spec.HostNetwork = true
 			p.Spec.Containers[0].Image = "docker.io/httpd"
 		})
@@ -645,7 +672,7 @@ spec:
 		}
 		updateNamespace(f, podNamespace)
 
-		ginkgo.By("2. Create an EgressIP object with one egress IP defined")
+		ginkgo.By("3. Create an EgressIP object with one egress IP defined")
 		// Assign the egress IP without conflicting with any node IP,
 		// the kind subnet is /16 or /64 so the following should be fine.
 		egressNodeIP := net.ParseIP(egress1Node.nodeIP)
@@ -678,13 +705,13 @@ spec:
 		framework.Logf("Create the EgressIP configuration")
 		framework.RunKubectlOrDie("default", "create", "-f", egressIPYaml)
 
-		ginkgo.By("3. Check that the status is of length one and that it is assigned to egress1Node")
+		ginkgo.By("4. Check that the status is of length one and that it is assigned to egress1Node")
 		statuses := verifyEgressIPStatusLengthEquals(1, nil)
 		if statuses[0].Node != egress1Node.name {
-			framework.Failf("Step 2. Check that the status is of length one and that it is assigned to egress1Node, failed")
+			framework.Failf("Step 4. Check that the status is of length one and that it is assigned to egress1Node, failed")
 		}
 
-		ginkgo.By("4. Create one pod matching the EgressIP: running on egress1Node")
+		ginkgo.By("5. Create one pod matching the EgressIP: running on egress1Node")
 		createGenericPodWithLabel(f, pod1Name, pod2Node.name, f.Namespace.Name, command, podEgressLabel)
 
 		err = wait.PollImmediate(retryInterval, retryTimeout, func() (bool, error) {
@@ -695,43 +722,51 @@ spec:
 			}
 			return true, nil
 		})
-		framework.ExpectNoError(err, "Step 4. Create one pod matching the EgressIP: running on egress1Node, failed, err: %v", err)
+		framework.ExpectNoError(err, "Step 5. Create one pod matching the EgressIP: running on egress1Node, failed, err: %v", err)
 		framework.Logf("Created pod %s on node %s", pod1Name, pod2Node.name)
 
-		ginkgo.By("5. Check connectivity from pod to an external node and verify that the srcIP is the expected egressIP")
+		ginkgo.By("6. Check connectivity from pod to an external node and verify that the srcIP is the expected egressIP")
 		err = wait.PollImmediate(retryInterval, retryTimeout, targetExternalContainerAndTest(targetNode, pod1Name, podNamespace.Name, true, []string{egressIP1.String()}))
 		framework.ExpectNoError(err, "Step 5. Check connectivity from pod to an external node and verify that the srcIP is the expected egressIP, failed: %v", err)
 
-		ginkgo.By("6. Check connectivity from pod to another node and verify that the srcIP is the expected nodeIP")
+		ginkgo.By("7. Check connectivity from pod to another node primary IP and verify that the srcIP is the expected nodeIP")
 		err = wait.PollImmediate(retryInterval, retryTimeout, targetExternalContainerAndTest(hostNetPod, pod1Name, podNamespace.Name, true, []string{egressNodeIP.String()}))
 		framework.ExpectNoError(err, "Step 6. Check connectivity from pod to another node and verify that the srcIP is the expected nodeIP, failed: %v", err)
 
-		ginkgo.By("7. Add the \"k8s.ovn.org/egress-assignable\" label to egress2Node")
+		ginkgo.By("8. Check connectivity from pod to another node secondary IP and verify that the srcIP is the expected nodeIP")
+		err = wait.PollImmediate(retryInterval, retryTimeout, targetExternalContainerAndTest(otherHostNetPodIP, pod1Name, podNamespace.Name, true, []string{egressNodeIP.String()}))
+		framework.ExpectNoError(err, "Step 6. Check connectivity from pod to another node and verify that the srcIP is the expected nodeIP, failed: %v", err)
+
+		ginkgo.By("9. Add the \"k8s.ovn.org/egress-assignable\" label to egress2Node")
 		framework.AddOrUpdateLabelOnNode(f.ClientSet, egress2Node.name, "k8s.ovn.org/egress-assignable", "dummy")
 		framework.Logf("Added egress-assignable label to node %s", egress2Node.name)
 		framework.ExpectNodeHasLabel(f.ClientSet, egress2Node.name, "k8s.ovn.org/egress-assignable", "dummy")
 
-		ginkgo.By("8. Remove the \"k8s.ovn.org/egress-assignable\" label from egress1Node")
+		ginkgo.By("10. Remove the \"k8s.ovn.org/egress-assignable\" label from egress1Node")
 		framework.RemoveLabelOffNode(f.ClientSet, egress1Node.name, "k8s.ovn.org/egress-assignable")
 
-		ginkgo.By("9. Check that the status is of length one and that it is assigned to egress2Node")
+		ginkgo.By("11. Check that the status is of length one and that it is assigned to egress2Node")
 		// There is sometimes a slight delay for the EIP fail over to happen,
 		// so let's use the pollimmediate struct to check if eventually egress2Node becomes the egress node
 		err = wait.PollImmediate(retryInterval, retryTimeout, func() (bool, error) {
 			statuses := getEgressIPStatusItems()
 			return (len(statuses) == 1) && (statuses[0].Node == egress2Node.name), nil
 		})
-		framework.ExpectNoError(err, "Step 9. Check that the status is of length one and that it is assigned to egress2Node, failed: %v", err)
+		framework.ExpectNoError(err, "Step 11. Check that the status is of length one and that it is assigned to egress2Node, failed: %v", err)
 
-		ginkgo.By("10. Check connectivity from pod to an external \"node\" and verify that the srcIP is the expected egressIP")
+		ginkgo.By("12. Check connectivity from pod to an external \"node\" and verify that the srcIP is the expected egressIP")
 		err = wait.PollImmediate(retryInterval, retryTimeout, targetExternalContainerAndTest(targetNode, pod1Name, podNamespace.Name, true, []string{egressIP1.String()}))
-		framework.ExpectNoError(err, "Step 10. Check connectivity from pod to an external \"node\" and verify that the srcIP is the expected egressIP, failed, err: %v", err)
+		framework.ExpectNoError(err, "Step 12. Check connectivity from pod to an external \"node\" and verify that the srcIP is the expected egressIP, failed, err: %v", err)
 
-		ginkgo.By("11. Check connectivity from pod to another node and verify that the srcIP is the expected nodeIP")
+		ginkgo.By("13. Check connectivity from pod to another node primary IP and verify that the srcIP is the expected nodeIP")
 		err = wait.PollImmediate(retryInterval, retryTimeout, targetExternalContainerAndTest(hostNetPod, pod1Name, podNamespace.Name, true, []string{egressNodeIP.String()}))
-		framework.ExpectNoError(err, "Step 11. Check connectivity from pod to another node and verify that the srcIP is the expected nodeIP, failed: %v", err)
+		framework.ExpectNoError(err, "Step 13. Check connectivity from pod to another node and verify that the srcIP is the expected nodeIP, failed: %v", err)
 
-		ginkgo.By("12. Create second pod not matching the EgressIP: running on egress1Node")
+		ginkgo.By("14. Check connectivity from pod to another node secondary IP and verify that the srcIP is the expected nodeIP")
+		err = wait.PollImmediate(retryInterval, retryTimeout, targetExternalContainerAndTest(otherHostNetPodIP, pod1Name, podNamespace.Name, true, []string{egressNodeIP.String()}))
+		framework.ExpectNoError(err, "Step 14. Check connectivity from pod to another node and verify that the srcIP is the expected nodeIP, failed: %v", err)
+
+		ginkgo.By("15. Create second pod not matching the EgressIP: running on egress1Node")
 		createGenericPodWithLabel(f, pod2Name, pod2Node.name, f.Namespace.Name, command, map[string]string{})
 		err = wait.PollImmediate(retryInterval, retryTimeout, func() (bool, error) {
 			kubectlOut := getPodAddress(pod2Name, f.Namespace.Name)
@@ -741,25 +776,29 @@ spec:
 			}
 			return true, nil
 		})
-		framework.ExpectNoError(err, "Step 12. Create second pod not matching the EgressIP: running on egress1Node, failed, err: %v", err)
+		framework.ExpectNoError(err, "Step 15. Create second pod not matching the EgressIP: running on egress1Node, failed, err: %v", err)
 		framework.Logf("Created pod %s on node %s", pod2Name, pod2Node.name)
 
-		ginkgo.By("13. Check connectivity from second pod to external node and verify that the srcIP is the expected nodeIP")
+		ginkgo.By("16. Check connectivity from second pod to external node and verify that the srcIP is the expected nodeIP")
 		err = wait.PollImmediate(retryInterval, retryTimeout, targetExternalContainerAndTest(targetNode, pod2Name, podNamespace.Name, true, []string{egressNodeIP.String()}))
-		framework.ExpectNoError(err, "Step 13. Check connectivity from second pod to external node and verify that the srcIP is the expected nodeIP, failed: %v", err)
+		framework.ExpectNoError(err, "Step 16. Check connectivity from second pod to external node and verify that the srcIP is the expected nodeIP, failed: %v", err)
 
-		ginkgo.By("14. Add pod selector label to make second pod egressIP managed")
+		ginkgo.By("17. Add pod selector label to make second pod egressIP managed")
 		pod2 := getPod(f, pod2Name)
 		pod2.Labels = podEgressLabel
 		updatePod(f, pod2)
 
-		ginkgo.By("15. Check connectivity from second pod to external node and verify that the srcIP is the expected egressIP")
+		ginkgo.By("18. Check connectivity from second pod to external node and verify that the srcIP is the expected egressIP")
 		err = wait.PollImmediate(retryInterval, retryTimeout, targetExternalContainerAndTest(targetNode, pod2Name, podNamespace.Name, true, []string{egressIP1.String()}))
-		framework.ExpectNoError(err, "Step 15. Check connectivity from second pod to external node and verify that the srcIP is the expected egressIP, failed: %v", err)
+		framework.ExpectNoError(err, "Step 18. Check connectivity from second pod to external node and verify that the srcIP is the expected egressIP, failed: %v", err)
 
-		ginkgo.By("16. Check connectivity from second pod to another node and verify that the srcIP is the expected nodeIP (this verifies SNAT's towards nodeIP are not deleted unless node is egressNode)")
+		ginkgo.By("19. Check connectivity from second pod to another node primary IP and verify that the srcIP is the expected nodeIP (this verifies SNAT's towards nodeIP are not deleted unless node is egressNode)")
 		err = wait.PollImmediate(retryInterval, retryTimeout, targetExternalContainerAndTest(hostNetPod, pod2Name, podNamespace.Name, true, []string{egressNodeIP.String()}))
 		framework.ExpectNoError(err, "Step 16. Check connectivity from second pod to another node and verify that the srcIP is the expected nodeIP (this verifies SNAT's towards nodeIP are not deleted unless node is egressNode), failed: %v", err)
+
+		ginkgo.By("20. Check connectivity from second pod to another node secondary IP and verify that the srcIP is the expected nodeIP (this verifies SNAT's towards nodeIP are not deleted unless node is egressNode)")
+		err = wait.PollImmediate(retryInterval, retryTimeout, targetExternalContainerAndTest(otherHostNetPodIP, pod2Name, podNamespace.Name, true, []string{egressNodeIP.String()}))
+		framework.ExpectNoError(err, "Step 20. Check connectivity from second pod to another node and verify that the srcIP is the expected nodeIP (this verifies SNAT's towards nodeIP are not deleted unless node is egressNode), failed: %v", err)
 	})
 
 	// Validate the egress IP with stateful sets or pods recreated with same name


### PR DESCRIPTION
Manual cherry-pick of 4.14 commit 5c6edd6271697912d2fd732fc796a60a88981954.

Resolved conflicts:

```
go-controller/pkg/ovn/egressservices_test.go
go-controller/pkg/ovn/ovn.go
go-controller/pkg/util/node_annotations.go
go-controller/pkg/util/util.go
```


Match on all node's IP addresses on the no re-route policies so that intra cluster traffic is not routed through the egress or service IP even when the destination IP address is a secondary node IP.

Secondary node IPs might be VIPs that move across nodes.

Signed-off-by: Jaime Caamaño Ruiz <jcaamano@redhat.com>
(cherry picked from commit 5c6edd6271697912d2fd732fc796a60a88981954)