### PR TITLE
OCPBUGS-32154: Custom v4 and v6 transit switch subnets while creating kind cluster

### DIFF
--- a/contrib/kind.sh
+++ b/contrib/kind.sh
@@ -576,6 +576,8 @@ set_default_params() {
   JOIN_SUBNET_IPV6=${JOIN_SUBNET_IPV6:-fd98::/64}
   MASQUERADE_SUBNET_IPV4=${MASQUERADE_SUBNET_IPV4:-169.254.169.0/29}
   MASQUERADE_SUBNET_IPV6=${MASQUERADE_SUBNET_IPV6:-fd69::/125}
+  TRANSIT_SWITCH_SUBNET_IPV4=${TRANSIT_SWITCH_SUBNET_IPV4:-100.88.0.0/16}
+  TRANSIT_SWITCH_SUBNET_IPV6=${TRANSIT_SWITCH_SUBNET_IPV6:-fd97::/64}
   KIND_NUM_MASTER=1
   OVN_ENABLE_INTERCONNECT=${OVN_ENABLE_INTERCONNECT:-false}
   OVN_ENABLE_OVNKUBE_IDENTITY=${OVN_ENABLE_OVNKUBE_IDENTITY:-true}
@@ -892,6 +894,8 @@ create_ovn_kube_manifests() {
     --v6-join-subnet="${JOIN_SUBNET_IPV6}" \
     --v4-masquerade-subnet="${MASQUERADE_SUBNET_IPV4}" \
     --v6-masquerade-subnet="${MASQUERADE_SUBNET_IPV6}" \
+    --v4-transit-switch-subnet="${TRANSIT_SWITCH_SUBNET_IPV4}" \
+    --v6-transit-switch-subnet="${TRANSIT_SWITCH_SUBNET_IPV6}" \
     --ex-gw-network-interface="${OVN_EX_GW_NETWORK_INTERFACE}" \
     --multi-network-enable="${ENABLE_MULTI_NET}" \
     --ovnkube-metrics-scale-enable="${OVN_METRICS_SCALE_ENABLE}" \

--- a/dist/images/daemonset.sh
+++ b/dist/images/daemonset.sh
@@ -74,6 +74,8 @@ OVN_V4_JOIN_SUBNET=""
 OVN_V6_JOIN_SUBNET=""
 OVN_V4_MASQUERADE_SUBNET=""
 OVN_V6_MASQUERADE_SUBNET=""
+OVN_V4_TRANSIT_SWITCH_SUBNET=""
+OVN_V6_TRANSIT_SWITCH_SUBNET=""
 OVN_NETFLOW_TARGETS=""
 OVN_SFLOW_TARGETS=""
 OVN_IPFIX_TARGETS=""
@@ -271,6 +273,12 @@ while [ "$1" != "" ]; do
   --v6-masquerade-subnet)
     OVN_V6_MASQUERADE_SUBNET=$VALUE
     ;;
+  --v4-transit-switch-subnet)
+    OVN_V4_TRANSIT_SWITCH_SUBNET=$VALUE
+    ;; 
+  --v6-transit-switch-subnet)
+    OVN_V6_TRANSIT_SWITCH_SUBNET=$VALUE
+    ;; 
   --netflow-targets)
     OVN_NETFLOW_TARGETS=$VALUE
     ;;
@@ -465,6 +473,10 @@ ovn_v4_masquerade_subnet=${OVN_V4_MASQUERADE_SUBNET}
 echo "ovn_v4_masquerade_subnet: ${ovn_v4_masquerade_subnet}"
 ovn_v6_masquerade_subnet=${OVN_V6_MASQUERADE_SUBNET}
 echo "ovn_v6_masquerade_subnet: ${ovn_v6_masquerade_subnet}"
+ovn_v4_transit_switch_subnet=${OVN_V4_TRANSIT_SWITCH_SUBNET}
+echo "ovn_v4_transit_switch_subnet: ${ovn_v4_transit_switch_subnet}"
+ovn_v6_transit_switch_subnet=${OVN_V6_TRANSIT_SWITCH_SUBNET}
+echo "ovn_v6_transit_switch_subnet: ${ovn_v6_transit_switch_subnet}"
 ovn_netflow_targets=${OVN_NETFLOW_TARGETS}
 echo "ovn_netflow_targets: ${ovn_netflow_targets}"
 ovn_sflow_targets=${OVN_SFLOW_TARGETS}
@@ -716,6 +728,8 @@ ovn_image=${ovnkube_image} \
   ovn_enable_interconnect=${ovn_enable_interconnect} \
   ovn_enable_multi_external_gateway=${ovn_enable_multi_external_gateway} \
   ovn_enable_ovnkube_identity=${ovn_enable_ovnkube_identity} \
+  ovn_v4_transit_switch_subnet=${ovn_v4_transit_switch_subnet} \
+  ovn_v6_transit_switch_subnet=${ovn_v6_transit_switch_subnet} \
   jinjanate ../templates/ovnkube-control-plane.yaml.j2 -o ${output_dir}/ovnkube-control-plane.yaml
 
 ovn_image=${image} \

--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -234,6 +234,10 @@ ovn_v6_join_subnet=${OVN_V6_JOIN_SUBNET:-}
 ovn_v4_masquerade_subnet=${OVN_V4_MASQUERADE_SUBNET:-}
 # OVN_V6_MASQUERADE_SUBNET - v6 masquerade subnet
 ovn_v6_masquerade_subnet=${OVN_V6_MASQUERADE_SUBNET:-}
+# OVN_V4_TRANSIT_SWITCH_SUBNET - v4 Transit switch subnet
+ovn_v4_transit_switch_subnet=${OVN_V4_TRANSIT_SWITCH_SUBNET:-}
+# OVN_V6_TRANSIT_SWITCH_SUBNET - v6 Transit switch subnet
+ovn_v6_transit_switch_subnet=${OVN_V6_TRANSIT_SWITCH_SUBNET:-}
 #OVN_REMOTE_PROBE_INTERVAL - ovn remote probe interval in ms (default 100000)
 ovn_remote_probe_interval=${OVN_REMOTE_PROBE_INTERVAL:-100000}
 #OVN_MONITOR_ALL - ovn-controller monitor all data in SB DB
@@ -2011,6 +2015,18 @@ ovn-cluster-manager() {
   fi
   echo "ovn_v6_masquerade_subnet_opt=${ovn_v6_masquerade_subnet_opt}"
 
+  ovn_v4_transit_switch_subnet_opt=
+  if [[ -n ${ovn_v4_transit_switch_subnet} ]]; then
+      ovn_v4_transit_switch_subnet_opt="--cluster-manager-v4-transit-switch-subnet=${ovn_v4_transit_switch_subnet}"
+  fi
+  echo "ovn_v4_transit_switch_subnet_opt=${ovn_v4_transit_switch_subnet}"
+
+  ovn_v6_transit_switch_subnet_opt=
+  if [[ -n ${ovn_v6_transit_switch_subnet} ]]; then
+      ovn_v6_transit_switch_subnet_opt="--cluster-manager-v6-transit-switch-subnet=${ovn_v6_transit_switch_subnet}"
+  fi
+  echo "ovn_v6_transit_switch_subnet_opt=${ovn_v6_transit_switch_subnet}"
+
   multicast_enabled_flag=
   if [[ ${ovn_multicast_enable} == "true" ]]; then
       multicast_enabled_flag="--enable-multicast"
@@ -2071,6 +2087,8 @@ ovn-cluster-manager() {
     ${ovn_v4_masquerade_subnet_opt} \
     ${ovn_v6_join_subnet_opt} \
     ${ovn_v6_masquerade_subnet_opt} \
+    ${ovn_v4_transit_switch_subnet_opt} \
+    ${ovn_v6_transit_switch_subnet_opt} \
     --cluster-subnets ${net_cidr} --k8s-service-cidr=${svc_cidr} \
     --host-network-namespace ${ovn_host_network_namespace} \
     --logfile-maxage=${ovnkube_logfile_maxage} \

--- a/dist/templates/ovnkube-control-plane.yaml.j2
+++ b/dist/templates/ovnkube-control-plane.yaml.j2
@@ -171,6 +171,10 @@ spec:
           value: "{{ ovn_enable_interconnect }}"
         - name: OVN_ENABLE_MULTI_EXTERNAL_GATEWAY
           value: "{{ ovn_enable_multi_external_gateway }}"
+        - name: OVN_V4_TRANSIT_SWITCH_SUBNET
+          value: "{{ ovn_v4_transit_switch_subnet }}"
+        - name: OVN_V6_TRANSIT_SWITCH_SUBNET
+          value: "{{ ovn_v6_transit_switch_subnet }}"
       # end of container
 
       volumes:

--- a/docs/ovnkube.1
+++ b/docs/ovnkube.1
@@ -153,6 +153,12 @@ Show help.
 .TP
 \fB\--version\fR, \fB\-v\fR
 Print the version.
+.TP
+\fB\--cluster-manager-v4-transit-switch-subnet\fR string
+The v4 transit switch subnet to use for assigning transit switch IPv4 addresses\fR.
+.TP
+\fB\--cluster-manager-v6-transit-switch-subnet\fR string
+The v6 transit switch subnet to use for assigning transit switch IPv6 addresses\fR.
 
 .SH "SEE ALSO"
 .BR ovn-k8s-overlay (1),

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -2011,7 +2011,7 @@ func completeClusterManagerConfig() error {
 
 	v6IP, _, err := net.ParseCIDR(ClusterManager.V6TransitSwitchSubnet)
 	if err != nil || !utilnet.IsIPv6(v6IP) {
-		return fmt.Errorf("invalid transit switch v4 join subnet specified, subnet: %s: error: %v", ClusterManager.V6TransitSwitchSubnet, err)
+		return fmt.Errorf("invalid transit switch v6 subnet specified, subnet: %s: error: %v", ClusterManager.V6TransitSwitchSubnet, err)
 	}
 
 	return nil


### PR DESCRIPTION
CLEAN cherry pick from #2089

"v4-transit-switch-subnet" and "v6-transit-switch-subnet" flags were added via commit[1]. However some configurations were still missing to allow setting custom subnets while creating a kind cluster.

This PR is to allow overriding default v4 and v6 transit switch subnet while creating a kind cluster.

[1] - https://github.com/ovn-org/ovn-kubernetes/commit/ae27492e2ecdbb6139c2deba9919ca9da51d32cc

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->