### PR TITLE
OCPBUGS-31591: Use masquerade default gateway when no default gw is found

### DIFF
--- a/go-controller/pkg/node/gateway_init.go
+++ b/go-controller/pkg/node/gateway_init.go
@@ -183,10 +183,19 @@ func getGatewayNextHops() ([]net.IP, string, error) {
 			}
 			gatewayIntf = defaultGatewayIntf
 		} else {
+			if gatewayIntf != defaultGatewayIntf {
+				// Mismatch between configured interface and actual default gateway interface detected
+				klog.Warningf("Found default gateway interface: %q does not match provided interface from config: %q", defaultGatewayIntf, gatewayIntf)
+			} else if len(defaultGatewayNextHops) == 0 {
+				// Gateway interface found, but no next hops identified in a default route
+				klog.Warning("No default route identified in the host. Egress features may not function correctly! " +
+					"Egress Pod traffic in shared gateway mode may not function correctly!")
+			}
+
 			if gatewayIntf != defaultGatewayIntf || len(defaultGatewayNextHops) == 0 {
-				if config.Gateway.Mode == config.GatewayModeLocal && config.Gateway.AllowNoUplink {
-					// For local gw, if not default gateway is available or the provide gateway interface is not the host gateway interface
-					// use nexthop masquerade IP as GR default gw to steer traffic to the gateway bridge
+				if config.Gateway.Mode == config.GatewayModeLocal {
+					// For local gw, if there is no valid gateway interface found, or no valid nexthops, then
+					// use nexthop masquerade IP as GR default gw to steer traffic to the gateway bridge, and then the host for routing
 					if needIPv4NextHop {
 						nexthop := config.Gateway.MasqueradeIPs.V4DummyNextHopMasqueradeIP
 						gatewayNextHops = append(gatewayNextHops, nexthop)

--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -1854,7 +1854,6 @@ var _ = Describe("Gateway unit tests", func() {
 				gwIPs := []net.IP{config.Gateway.MasqueradeIPs.V4DummyNextHopMasqueradeIP}
 				config.Gateway.Interface = dummyBridgeName
 				config.Gateway.Mode = config.GatewayModeLocal
-				config.Gateway.AllowNoUplink = true
 
 				gatewayNextHops, gatewayIntf, err := getGatewayNextHops()
 				Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
When no default gateway is found, OVNK will still come up. This behavior was intentional: 3eeb930791e04824b76b03172f64a1db21d9c377

The goal was that with design changes, host->service traffic would work without the need for a default gateway to be detected. This works, in most cases, but there is a case we did not consider. If a user has deployed a cluster with local gateway mode, and is using a different interface/network for kapi traffic (not the gateway bridge interface), then endpoints to the kubernetes service will reside on this other network. In this case when a host tries to talk to kube API service, the traffic would go to the GR, it would be DNAT'ed to an IP address not on any known network, and be dropped by OVN routing when there is no default gateway route.

When the configuration parameter AllowNoUplink is set, we will set the default route to be the masquerade IP, which solves this problem. This commit changes the behavior to not require AllowNoUplink to be set in order to achieve the same behavior, as services should work in this scenario even without a default gw.

Signed-off-by: Tim Rozet <trozet@redhat.com>
(cherry picked from commit 7072d9890b282973949ffef0ca28581069d0e3bc)

