### PR TITLE
OCPBUGS-29397: 4.14 High CPU usage with APB CRD

### DIFF
--- a/go-controller/pkg/ovn/controller/apbroute/master_controller.go
+++ b/go-controller/pkg/ovn/controller/apbroute/master_controller.go
@@ -516,7 +516,7 @@ func (c *ExternalGatewayMasterController) updateStatusAPBExternalRoute(policyNam
 	}
 	successMessage := fmt.Sprintf("Configured external gateway IPs: %s", strings.Join(sets.List(gwIPs), ","))
 	var lastMessage, failedMessage string
-	if !status.LastTransitionTime.Time.IsZero() {
+	if len(status.Messages)>0 {
 		lastMessage = status.Messages[len(status.Messages)-1]
 	}
 	if processedError != nil {

--- a/go-controller/pkg/ovn/controller/apbroute/master_controller.go
+++ b/go-controller/pkg/ovn/controller/apbroute/master_controller.go
@@ -516,7 +516,7 @@ func (c *ExternalGatewayMasterController) updateStatusAPBExternalRoute(policyNam
 	}
 	successMessage := fmt.Sprintf("Configured external gateway IPs: %s", strings.Join(sets.List(gwIPs), ","))
 	var lastMessage, failedMessage string
-	if len(status.Messages)>0 {
+	if len(status.Messages) > 0 {
 		lastMessage = status.Messages[len(status.Messages)-1]
 	}
 	if processedError != nil {

--- a/go-controller/pkg/ovn/controller/apbroute/master_controller.go
+++ b/go-controller/pkg/ovn/controller/apbroute/master_controller.go
@@ -1,19 +1,16 @@
 package apbroute
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"net"
 	"reflect"
-	"strings"
 	"sync"
 	"time"
 
 	nettypes "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	libovsdbclient "github.com/ovn-org/libovsdb/client"
 	v1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -22,7 +19,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/util/retry"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
 
@@ -33,7 +29,6 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	libovsdbutil "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdb/util"
 	addressset "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/address_set"
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 )
 
 const (
@@ -499,32 +494,32 @@ func (c *ExternalGatewayMasterController) processNextPodWorkItem(wg *sync.WaitGr
 // updateStatusAPBExternalRoute updates the CR with the current status of the CR instance, including errors captured while processing the CR during its lifetime
 func (c *ExternalGatewayMasterController) updateStatusAPBExternalRoute(policyName string, gwIPs sets.Set[string],
 	processedError error) error {
-	if gwIPs == nil {
-		// policy doesn't exist anymore, nothing to do
-		return nil
-	}
+	// if gwIPs == nil {
+	// 	// policy doesn't exist anymore, nothing to do
+	// 	return nil
+	// }
 
-	resultErr := retry.RetryOnConflict(util.OvnConflictBackoff, func() error {
-		routePolicy, err := c.apbRoutePolicyClient.K8sV1().AdminPolicyBasedExternalRoutes().Get(context.TODO(), policyName, metav1.GetOptions{})
-		if err != nil {
-			if apierrors.IsNotFound(err) {
-				// policy doesn't exist, no need to update status
-				return nil
-			}
-			return err
-		}
+	// resultErr := retry.RetryOnConflict(util.OvnConflictBackoff, func() error {
+	// 	routePolicy, err := c.apbRoutePolicyClient.K8sV1().AdminPolicyBasedExternalRoutes().Get(context.TODO(), policyName, metav1.GetOptions{})
+	// 	if err != nil {
+	// 		if apierrors.IsNotFound(err) {
+	// 			// policy doesn't exist, no need to update status
+	// 			return nil
+	// 		}
+	// 		return err
+	// 	}
 
-		updateStatus(routePolicy, strings.Join(sets.List(gwIPs), ","), processedError)
+	// 	updateStatus(routePolicy, strings.Join(sets.List(gwIPs), ","), processedError)
 
-		_, err = c.apbRoutePolicyClient.K8sV1().AdminPolicyBasedExternalRoutes().UpdateStatus(context.TODO(), routePolicy, metav1.UpdateOptions{})
-		if !apierrors.IsNotFound(err) {
-			return err
-		}
-		return nil
-	})
-	if resultErr != nil {
-		return fmt.Errorf("failed to update AdminPolicyBasedExternalRoutes %s status: %v", policyName, resultErr)
-	}
+	// 	_, err = c.apbRoutePolicyClient.K8sV1().AdminPolicyBasedExternalRoutes().UpdateStatus(context.TODO(), routePolicy, metav1.UpdateOptions{})
+	// 	if !apierrors.IsNotFound(err) {
+	// 		return err
+	// 	}
+	// 	return nil
+	// })
+	// if resultErr != nil {
+	// 	return fmt.Errorf("failed to update AdminPolicyBasedExternalRoutes %s status: %v", policyName, resultErr)
+	// }
 	return nil
 }
 


### PR DESCRIPTION
Fixes an issue when using APB in a cluster with high number of pods where the APB controller would hit the KAPI for each pod event to update the APB status, causing a high cpu usage.
The fix resolves in checking if the last message in the APB status in the informer matches the same message generated for the pod event, and if different or different status (succeeded or failed) then proceed to request the latest copy of the APB CR from the KAPI server and update it.