### PR TITLE
OCPBUGS-32985,SDN-4436: Dockerfile.base: Bump OVN to ovn24.03-24.03.1-36.el9fdp

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -13,7 +13,7 @@ RUN dnf install -y --nodocs \
 	dnf clean all
 
 ARG ovsver=3.1.0-73.el9fdp
-ARG ovnver=23.09.0-139.el9fdp
+ARG ovnver=24.03.1-36.el9fdp
 
 RUN INSTALL_PKGS="iptables nftables" && \
 	ovsver_short=$(echo "$ovsver" | cut -d'.' -f1,2) && \


### PR DESCRIPTION
Relevant OVN features/performance improvements:
- ovn-northd logical flow incremental processing
- improved RBAC for Southbound BFD, IGMP_Group tables
- QoS packet marking:
  https://issues.redhat.com/browse/FDP-42
- BFD support for ECMP policy routes
  https://issues.redhat.com/browse/FDP-234
- Support new LSP enable_router_port_acl option to enable conntrack for router ports

OCP relevant fixes:
- a349ec5c14 northd: sync lb applied to logical routers in sb db lb table
  https://bugzilla.redhat.com/show_bug.cgi?id=2193323
  - allows using OVN's LB conntrack flushing feature on backend removal
- 6eff687d5f acl-log: Properly log the "pass" verdict.
  https://issues.redhat.com/browse/FDP-442

Other relevant fixes:
- 69e90f664a northd: fix infinite loop in ovn_allocate_tnlid()
- 72390c4fea pinctrl: Fixed 100% cpu on ovs connection loss.
- 6b1618a96f ofctrl: Wait at S_WAIT_BEFORE_CLEAR only once.
- b213cb641a ovn-controller: Fix busy loop when ofctrl is disconnected.
- 17b6a12fa2 ovn-controller: Support VIF-based local encap IPs selection.
- 41eefcb280 encaps: Create separate tunnels for multiple local encap IPs.
- 325c7b203d controller: split mg action in table 39 and 40 to fit kernel netlink buffer size
  https://bugzilla.redhat.com/show_bug.cgi?id=2232152
- c16e5da803 controller: disable OpenFlow inactivity probing
  https://mail.openvswitch.org/pipermail/ovs-dev/2023-May/404625.html
- ab7a8fe4c0 northd: introduce ls_datapath_group column in lb sb db table
