### PR TITLE
OCPBUGS-33422: [release-4.12] Full implementation of KEP-1669 ProxyTerminatingEndpoints + ETP=local fix

### DIFF
--- a/go-controller/pkg/node/gateway_localnet_linux_test.go
+++ b/go-controller/pkg/node/gateway_localnet_linux_test.go
@@ -2227,6 +2227,7 @@ var _ = Describe("Node Operations", func() {
 
 				ep1 := discovery.Endpoint{
 					Addresses: []string{"192.168.18.15"}, // host-networked endpoint local to this node
+					NodeName:  &fakeNodeName,
 				}
 				epPort1 := discovery.EndpointPort{
 					Name: &epPortName,
@@ -2518,6 +2519,7 @@ var _ = Describe("Node Operations", func() {
 				)
 				ep1 := discovery.Endpoint{
 					Addresses: []string{"192.168.18.15"}, // host-networked endpoint local to this node
+					NodeName:  &fakeNodeName,
 				}
 				epPort1 := discovery.EndpointPort{
 					Name: &epPortName,
@@ -2692,6 +2694,7 @@ var _ = Describe("Node Operations", func() {
 				// host-networked endpoint, should not have an SNAT rule created
 				ep2 := discovery.Endpoint{
 					Addresses: []string{"192.168.18.15"},
+					NodeName:  &fakeNodeName,
 				}
 				// endpointSlice.Endpoints is ovn-networked so this will
 				// come under !hasLocalHostNetEp case

--- a/go-controller/pkg/node/gateway_localnet_linux_test.go
+++ b/go-controller/pkg/node/gateway_localnet_linux_test.go
@@ -549,6 +549,7 @@ var _ = Describe("Node Operations", func() {
 				)
 				ep1 := discovery.Endpoint{
 					Addresses: []string{"10.244.0.3"},
+					NodeName:  &fakeNodeName,
 				}
 				epPort1 := discovery.EndpointPort{
 					Name: &epPortName,
@@ -1940,6 +1941,7 @@ var _ = Describe("Node Operations", func() {
 				)
 				ep1 := discovery.Endpoint{
 					Addresses: []string{"10.244.0.3"},
+					NodeName:  &fakeNodeName,
 				}
 				epPort1 := discovery.EndpointPort{
 					Name: &epPortName,
@@ -2080,6 +2082,7 @@ var _ = Describe("Node Operations", func() {
 
 				ep1 := discovery.Endpoint{
 					Addresses: []string{"10.244.0.3"},
+					NodeName:  &fakeNodeName,
 				}
 				epPort1 := discovery.EndpointPort{
 					Name: &epPortName,
@@ -2372,6 +2375,7 @@ var _ = Describe("Node Operations", func() {
 				)
 				ep1 := discovery.Endpoint{
 					Addresses: []string{"10.244.0.3"},
+					NodeName:  &fakeNodeName,
 				}
 				epPort1 := discovery.EndpointPort{
 					Name: &epPortName,
@@ -2685,6 +2689,7 @@ var _ = Describe("Node Operations", func() {
 
 				ep1 := discovery.Endpoint{
 					Addresses: []string{"10.128.0.3"},
+					NodeName:  &fakeNodeName,
 				}
 				epPort := discovery.EndpointPort{
 					Name: &epPortName,

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -557,7 +557,7 @@ func (npw *nodePortWatcher) AddService(service *kapi.Service) error {
 		hasLocalHostNetworkEp = false
 	} else {
 		nodeIPs := npw.nodeIPManager.ListAddresses()
-		localEndpoints = npw.GetLocalEndpointAddresses(epSlices, service)
+		localEndpoints = npw.GetLocalEligibleEndpointAddresses(epSlices, service)
 		hasLocalHostNetworkEp = util.HasLocalHostNetworkEndpoints(localEndpoints, nodeIPs)
 	}
 	// If something didn't already do it add correct Service rules
@@ -714,7 +714,7 @@ func (npw *nodePortWatcher) SyncServices(services []interface{}) error {
 			continue
 		}
 		nodeIPs := npw.nodeIPManager.ListAddresses()
-		localEndpoints := npw.GetLocalEndpointAddresses(epSlices, service)
+		localEndpoints := npw.GetLocalEligibleEndpointAddresses(epSlices, service)
 		hasLocalHostNetworkEp := util.HasLocalHostNetworkEndpoints(localEndpoints, nodeIPs)
 		npw.getAndSetServiceInfo(name, service, hasLocalHostNetworkEp, localEndpoints)
 
@@ -807,7 +807,7 @@ func (npw *nodePortWatcher) AddEndpointSlice(epSlice *discovery.EndpointSlice) e
 		// No need to continue adding the new endpoint slice, if we can't retrieve all slices for this service
 		return fmt.Errorf("error retrieving endpointslices for service %s/%s during endpointslice add: %w", svc.Namespace, svc.Name, err)
 	}
-	localEndpoints := npw.GetLocalEndpointAddresses(epSlices, svc)
+	localEndpoints := npw.GetLocalEligibleEndpointAddresses(epSlices, svc)
 	hasLocalHostNetworkEp := util.HasLocalHostNetworkEndpoints(localEndpoints, nodeIPs)
 
 	// Here we make sure the correct rules are programmed whenever an AddEndpointSlice event is
@@ -875,7 +875,7 @@ func (npw *nodePortWatcher) DeleteEndpointSlice(epSlice *discovery.EndpointSlice
 		return fmt.Errorf("error retrieving service %s/%s for endpointslice %s during endpointslice delete: %v",
 			namespacedName.Namespace, namespacedName.Name, epSlice.Name, err)
 	}
-	localEndpoints := npw.GetLocalEndpointAddresses(epSlices, svc)
+	localEndpoints := npw.GetLocalEligibleEndpointAddresses(epSlices, svc)
 	if svcConfig, exists := npw.updateServiceInfo(namespacedName, nil, &hasLocalHostNetworkEp, localEndpoints); exists {
 		// Lock the cache mutex here so we don't miss a service delete during an endpoint delete
 		// we have to do this because deleting and adding iptables rules is slow.
@@ -894,8 +894,8 @@ func (npw *nodePortWatcher) DeleteEndpointSlice(epSlice *discovery.EndpointSlice
 }
 
 // GetLocalEndpointAddresses returns a list of eligible endpoints that are local to the node
-func (npw *nodePortWatcher) GetLocalEndpointAddresses(endpointSlices []*discovery.EndpointSlice, service *kapi.Service) sets.String {
-	return util.GetLocalEndpointAddresses(endpointSlices, service, npw.nodeIPManager.nodeName)
+func (npw *nodePortWatcher) GetLocalEligibleEndpointAddresses(endpointSlices []*discovery.EndpointSlice, service *kapi.Service) sets.String {
+	return util.GetLocalEligibleEndpointAddresses(endpointSlices, service, npw.nodeIPManager.nodeName)
 }
 
 func (npw *nodePortWatcher) UpdateEndpointSlice(oldEpSlice, newEpSlice *discovery.EndpointSlice) error {
@@ -915,8 +915,8 @@ func (npw *nodePortWatcher) UpdateEndpointSlice(oldEpSlice, newEpSlice *discover
 			namespacedName.Namespace, namespacedName.Name, newEpSlice.Name, err)
 	}
 
-	oldEndpointAddresses := util.GetEndpointAddresses([]*discovery.EndpointSlice{oldEpSlice}, svc)
-	newEndpointAddresses := util.GetEndpointAddresses([]*discovery.EndpointSlice{newEpSlice}, svc)
+	oldEndpointAddresses := util.GetEligibleEndpointAddresses([]*discovery.EndpointSlice{oldEpSlice}, svc)
+	newEndpointAddresses := util.GetEligibleEndpointAddresses([]*discovery.EndpointSlice{newEpSlice}, svc)
 	if reflect.DeepEqual(oldEndpointAddresses, newEndpointAddresses) {
 		return nil
 	}
@@ -955,8 +955,8 @@ func (npw *nodePortWatcher) UpdateEndpointSlice(oldEpSlice, newEpSlice *discover
 	// endpoints has changed. For this second comparison, check first between the old endpoint slice and all current
 	// endpointslices for this service. This is a partial comparison, in case serviceInfo is not set. When it is set, compare
 	// between /all/ old endpoint slices and all new ones.
-	oldLocalEndpoints := npw.GetLocalEndpointAddresses([]*discovery.EndpointSlice{oldEpSlice}, svc)
-	newLocalEndpoints := npw.GetLocalEndpointAddresses(epSlices, svc)
+	oldLocalEndpoints := npw.GetLocalEligibleEndpointAddresses([]*discovery.EndpointSlice{oldEpSlice}, svc)
+	newLocalEndpoints := npw.GetLocalEligibleEndpointAddresses(epSlices, svc)
 	hasLocalHostNetworkEpOld := util.HasLocalHostNetworkEndpoints(oldLocalEndpoints, nodeIPs)
 	hasLocalHostNetworkEpNew := util.HasLocalHostNetworkEndpoints(newLocalEndpoints, nodeIPs)
 

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -552,7 +552,7 @@ func (npw *nodePortWatcher) AddService(service *kapi.Service) error {
 		hasLocalHostNetworkEp = false
 	} else {
 		nodeIPs := npw.nodeIPManager.ListAddresses()
-		hasLocalHostNetworkEp = hasLocalHostNetworkEndpoints(epSlices, nodeIPs)
+		hasLocalHostNetworkEp = hasLocalHostNetworkEndpoints(epSlices, nodeIPs, service)
 	}
 	localEndpoints := npw.GetLocalEndpointAddresses(epSlices, service)
 	// If something didn't already do it add correct Service rules
@@ -705,7 +705,7 @@ func (npw *nodePortWatcher) SyncServices(services []interface{}) error {
 			continue
 		}
 		nodeIPs := npw.nodeIPManager.ListAddresses()
-		hasLocalHostNetworkEp := hasLocalHostNetworkEndpoints(epSlices, nodeIPs)
+		hasLocalHostNetworkEp := hasLocalHostNetworkEndpoints(epSlices, nodeIPs, service)
 		localEndPoints := npw.GetLocalEndpointAddresses(epSlices, service)
 		npw.getAndSetServiceInfo(name, service, hasLocalHostNetworkEp, localEndPoints)
 		// Delete OF rules for service if they exist
@@ -787,7 +787,7 @@ func (npw *nodePortWatcher) AddEndpointSlice(epSlice *discovery.EndpointSlice) e
 
 	klog.V(5).Infof("Adding endpointslice %s in namespace %s", epSlice.Name, epSlice.Namespace)
 	nodeIPs := npw.nodeIPManager.ListAddresses()
-	hasLocalHostNetworkEp := hasLocalHostNetworkEndpoints([]*discovery.EndpointSlice{epSlice}, nodeIPs)
+	hasLocalHostNetworkEp := hasLocalHostNetworkEndpoints([]*discovery.EndpointSlice{epSlice}, nodeIPs, svc)
 
 	epSlices, err := npw.watchFactory.GetEndpointSlices(svc.Namespace, svc.Name)
 	if err != nil {
@@ -942,8 +942,8 @@ func (npw *nodePortWatcher) UpdateEndpointSlice(oldEpSlice, newEpSlice *discover
 
 	// Update rules and service cache if hasHostNetworkEndpoints status changed or localEndpoints changed
 	nodeIPs := npw.nodeIPManager.ListAddresses()
-	hasLocalHostNetworkEpOld := hasLocalHostNetworkEndpoints([]*discovery.EndpointSlice{oldEpSlice}, nodeIPs)
-	hasLocalHostNetworkEpNew := hasLocalHostNetworkEndpoints([]*discovery.EndpointSlice{newEpSlice}, nodeIPs)
+	hasLocalHostNetworkEpOld := hasLocalHostNetworkEndpoints([]*discovery.EndpointSlice{oldEpSlice}, nodeIPs, svc)
+	hasLocalHostNetworkEpNew := hasLocalHostNetworkEndpoints([]*discovery.EndpointSlice{newEpSlice}, nodeIPs, svc)
 	epSlices, err := npw.watchFactory.GetEndpointSlices(newEpSlice.Namespace, newEpSlice.Labels[discovery.LabelServiceName])
 	if err != nil {
 		klog.V(5).Infof("Could not fetch endpointslices for service %s during endpointSliceDelete", namespacedName)

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -560,6 +560,7 @@ func (npw *nodePortWatcher) AddService(service *kapi.Service) error {
 		localEndpoints = npw.GetLocalEligibleEndpointAddresses(epSlices, service)
 		hasLocalHostNetworkEp = util.HasLocalHostNetworkEndpoints(localEndpoints, nodeIPs)
 	}
+
 	// If something didn't already do it add correct Service rules
 	if exists := npw.addOrSetServiceInfo(name, service, hasLocalHostNetworkEp, localEndpoints); !exists {
 		klog.V(5).Infof("Service Add %s event in namespace %s came before endpoint event setting svcConfig",
@@ -893,9 +894,9 @@ func (npw *nodePortWatcher) DeleteEndpointSlice(epSlice *discovery.EndpointSlice
 	return nil
 }
 
-// GetLocalEndpointAddresses returns a list of eligible endpoints that are local to the node
+// GetLocalEligibleEndpointAddresses returns a list of eligible endpoints that are local to the node
 func (npw *nodePortWatcher) GetLocalEligibleEndpointAddresses(endpointSlices []*discovery.EndpointSlice, service *kapi.Service) sets.String {
-	return util.GetLocalEligibleEndpointAddresses(endpointSlices, service, npw.nodeIPManager.nodeName)
+	return util.GetLocalEligibleEndpointAddressesFromSlices(endpointSlices, service, npw.nodeIPManager.nodeName)
 }
 
 func (npw *nodePortWatcher) UpdateEndpointSlice(oldEpSlice, newEpSlice *discovery.EndpointSlice) error {
@@ -915,8 +916,8 @@ func (npw *nodePortWatcher) UpdateEndpointSlice(oldEpSlice, newEpSlice *discover
 			namespacedName.Namespace, namespacedName.Name, newEpSlice.Name, err)
 	}
 
-	oldEndpointAddresses := util.GetEligibleEndpointAddresses([]*discovery.EndpointSlice{oldEpSlice}, svc)
-	newEndpointAddresses := util.GetEligibleEndpointAddresses([]*discovery.EndpointSlice{newEpSlice}, svc)
+	oldEndpointAddresses := util.GetEligibleEndpointAddressesFromSlices([]*discovery.EndpointSlice{oldEpSlice}, svc)
+	newEndpointAddresses := util.GetEligibleEndpointAddressesFromSlices([]*discovery.EndpointSlice{newEpSlice}, svc)
 	if reflect.DeepEqual(oldEndpointAddresses, newEndpointAddresses) {
 		return nil
 	}

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -537,6 +537,7 @@ func serviceUpdateNotNeeded(old, new *kapi.Service) bool {
 
 // AddService handles configuring shared gateway bridge flows to steer External IP, Node Port, Ingress LB traffic into OVN
 func (npw *nodePortWatcher) AddService(service *kapi.Service) error {
+	var localEndpoints sets.String
 	var hasLocalHostNetworkEp bool
 	if !util.ServiceTypeHasClusterIP(service) || !util.IsClusterIPSet(service) {
 		return nil
@@ -546,15 +547,19 @@ func (npw *nodePortWatcher) AddService(service *kapi.Service) error {
 	name := ktypes.NamespacedName{Namespace: service.Namespace, Name: service.Name}
 	epSlices, err := npw.watchFactory.GetEndpointSlices(service.Namespace, service.Name)
 	if err != nil {
+		if !kerrors.IsNotFound(err) {
+			return fmt.Errorf("error retrieving all endpointslices for service %s/%s during service add: %w",
+				service.Namespace, service.Name, err)
+		}
 		klog.V(5).Infof("No endpointslice found for service %s in namespace %s during service Add",
 			service.Name, service.Namespace)
 		// No endpoint object exists yet so default to false
 		hasLocalHostNetworkEp = false
 	} else {
 		nodeIPs := npw.nodeIPManager.ListAddresses()
-		hasLocalHostNetworkEp = hasLocalHostNetworkEndpoints(epSlices, nodeIPs, service)
+		localEndpoints = npw.GetLocalEndpointAddresses(epSlices, service)
+		hasLocalHostNetworkEp = util.HasLocalHostNetworkEndpoints(localEndpoints, nodeIPs)
 	}
-	localEndpoints := npw.GetLocalEndpointAddresses(epSlices, service)
 	// If something didn't already do it add correct Service rules
 	if exists := npw.addOrSetServiceInfo(name, service, hasLocalHostNetworkEp, localEndpoints); !exists {
 		klog.V(5).Infof("Service Add %s event in namespace %s came before endpoint event setting svcConfig",
@@ -701,13 +706,18 @@ func (npw *nodePortWatcher) SyncServices(services []interface{}) error {
 
 		epSlices, err := npw.watchFactory.GetEndpointSlices(service.Namespace, service.Name)
 		if err != nil {
+			if !kerrors.IsNotFound(err) {
+				return fmt.Errorf("error retrieving all endpointslices for service %s/%s during SyncServices: %w",
+					service.Namespace, service.Name, err)
+			}
 			klog.V(5).Infof("No endpointslice found for service %s in namespace %s during sync", service.Name, service.Namespace)
 			continue
 		}
 		nodeIPs := npw.nodeIPManager.ListAddresses()
-		hasLocalHostNetworkEp := hasLocalHostNetworkEndpoints(epSlices, nodeIPs, service)
-		localEndPoints := npw.GetLocalEndpointAddresses(epSlices, service)
-		npw.getAndSetServiceInfo(name, service, hasLocalHostNetworkEp, localEndPoints)
+		localEndpoints := npw.GetLocalEndpointAddresses(epSlices, service)
+		hasLocalHostNetworkEp := util.HasLocalHostNetworkEndpoints(localEndpoints, nodeIPs)
+		npw.getAndSetServiceInfo(name, service, hasLocalHostNetworkEp, localEndpoints)
+
 		// Delete OF rules for service if they exist
 		if err = npw.updateServiceFlowCache(service, false, hasLocalHostNetworkEp); err != nil {
 			errors = append(errors, err)
@@ -717,7 +727,7 @@ func (npw *nodePortWatcher) SyncServices(services []interface{}) error {
 		}
 		// Add correct iptables rules only for Full mode
 		if !npw.dpuMode {
-			keepIPTRules = append(keepIPTRules, getGatewayIPTRules(service, localEndPoints.List(), hasLocalHostNetworkEp)...)
+			keepIPTRules = append(keepIPTRules, getGatewayIPTRules(service, localEndpoints.List(), hasLocalHostNetworkEp)...)
 		}
 
 		if !npw.dpuMode && shouldConfigureEgressSVC(service, npw) {
@@ -736,7 +746,7 @@ func (npw *nodePortWatcher) SyncServices(services []interface{}) error {
 				for _, ep := range epSlice.Endpoints {
 					for _, ip := range ep.Addresses {
 						ipStr := utilnet.ParseIPSloppy(ip).String()
-						if !isHostEndpoint(ipStr) {
+						if !util.IsHostEndpoint(ipStr) {
 							epsToInsert.Insert(ipStr)
 						}
 					}
@@ -775,9 +785,14 @@ func (npw *nodePortWatcher) AddEndpointSlice(epSlice *discovery.EndpointSlice) e
 	svcName := epSlice.Labels[discovery.LabelServiceName]
 	svc, err = npw.watchFactory.GetService(epSlice.Namespace, svcName)
 	if err != nil {
+		if !kerrors.IsNotFound(err) {
+			return fmt.Errorf("error retrieving service %s/%s during endpointslice add: %w",
+				epSlice.Namespace, svcName, err)
+		}
 		// This is not necessarily an error. For e.g when there are endpoints
 		// without a corresponding service.
-		klog.V(5).Infof("No service found for endpointslice %s in namespace %s during add", epSlice.Name, epSlice.Namespace)
+		klog.V(5).Infof("No service found for endpointslice %s in namespace %s during endpointslice add",
+			epSlice.Name, epSlice.Namespace)
 		return nil
 	}
 
@@ -787,17 +802,18 @@ func (npw *nodePortWatcher) AddEndpointSlice(epSlice *discovery.EndpointSlice) e
 
 	klog.V(5).Infof("Adding endpointslice %s in namespace %s", epSlice.Name, epSlice.Namespace)
 	nodeIPs := npw.nodeIPManager.ListAddresses()
-	hasLocalHostNetworkEp := hasLocalHostNetworkEndpoints([]*discovery.EndpointSlice{epSlice}, nodeIPs, svc)
-
 	epSlices, err := npw.watchFactory.GetEndpointSlices(svc.Namespace, svc.Name)
 	if err != nil {
-		klog.V(5).Infof("Could not fetch endpointslices for service %s/%s during endpointSliceAdd", svc.Name, svc.Namespace)
+		// No need to continue adding the new endpoint slice, if we can't retrieve all slices for this service
+		return fmt.Errorf("error retrieving endpointslices for service %s/%s during endpointslice add: %w", svc.Namespace, svc.Name, err)
 	}
 	localEndpoints := npw.GetLocalEndpointAddresses(epSlices, svc)
+	hasLocalHostNetworkEp := util.HasLocalHostNetworkEndpoints(localEndpoints, nodeIPs)
+
 	// Here we make sure the correct rules are programmed whenever an AddEndpointSlice event is
 	// received, only alter flows if we need to, i.e if cache wasn't set or if it was and
 	// hasLocalHostNetworkEp or localEndpoints state (for LB svc where NPs=0) changed, to prevent flow churn
-	namespacedName, err := serviceNamespacedNameFromEndpointSlice(epSlice)
+	namespacedName, err := util.ServiceNamespacedNameFromEndpointSlice(epSlice)
 	if err != nil {
 		return fmt.Errorf("cannot add %s/%s to nodePortWatcher: %v", epSlice.Namespace, epSlice.Name, err)
 	}
@@ -838,19 +854,26 @@ func (npw *nodePortWatcher) DeleteEndpointSlice(epSlice *discovery.EndpointSlice
 
 	klog.V(5).Infof("Deleting endpointslice %s in namespace %s", epSlice.Name, epSlice.Namespace)
 	// remove rules for endpoints and add back normal ones
-	namespacedName, err := serviceNamespacedNameFromEndpointSlice(epSlice)
+	namespacedName, err := util.ServiceNamespacedNameFromEndpointSlice(epSlice)
 	if err != nil {
 		return fmt.Errorf("cannot delete %s/%s from nodePortWatcher: %v", epSlice.Namespace, epSlice.Name, err)
 	}
 	epSlices, err := npw.watchFactory.GetEndpointSlices(epSlice.Namespace, epSlice.Labels[discovery.LabelServiceName])
 	if err != nil {
-		return fmt.Errorf("could not fetch endpointslices for service %s during endpointSliceDelete: %v", namespacedName, err)
+		if !kerrors.IsNotFound(err) {
+			return fmt.Errorf("error retrieving all endpointslices for service %s/%s during endpointslice delete on %s: %w",
+				namespacedName.Namespace, namespacedName.Name, epSlice.Name, err)
+		}
+		// an endpoint slice that we retry to delete will be gone from the api server, so don't return here
+		klog.V(5).Infof("No endpointslices found for service %s/%s during endpointslice delete on %s (did we previously fail to delete it?)",
+			namespacedName.Namespace, namespacedName.Name, epSlice.Name)
+		epSlices = []*discovery.EndpointSlice{epSlice}
 	}
 
 	svc, err := npw.watchFactory.GetService(namespacedName.Namespace, namespacedName.Name)
 	if err != nil && !kerrors.IsNotFound(err) {
-		return fmt.Errorf("error while retrieving service for endpointslice %s/%s during delete: %v",
-			epSlice.Namespace, epSlice.Name, err)
+		return fmt.Errorf("error retrieving service %s/%s for endpointslice %s during endpointslice delete: %v",
+			namespacedName.Namespace, namespacedName.Name, epSlice.Name, err)
 	}
 	localEndpoints := npw.GetLocalEndpointAddresses(epSlices, svc)
 	if svcConfig, exists := npw.updateServiceInfo(namespacedName, nil, &hasLocalHostNetworkEp, localEndpoints); exists {
@@ -870,33 +893,9 @@ func (npw *nodePortWatcher) DeleteEndpointSlice(epSlice *discovery.EndpointSlice
 	return nil
 }
 
-// GetLocalEndpointAddresses returns a list of endpoints that are local to the node
+// GetLocalEndpointAddresses returns a list of eligible endpoints that are local to the node
 func (npw *nodePortWatcher) GetLocalEndpointAddresses(endpointSlices []*discovery.EndpointSlice, service *kapi.Service) sets.String {
-	localEndpoints := sets.NewString()
-	includeTerminating := service != nil && service.Spec.PublishNotReadyAddresses
-	for _, endpointSlice := range endpointSlices {
-		for _, endpoint := range endpointSlice.Endpoints {
-			if util.IsEndpointValid(endpoint, includeTerminating) &&
-				endpoint.NodeName != nil &&
-				*endpoint.NodeName == npw.nodeIPManager.nodeName {
-				localEndpoints.Insert(endpoint.Addresses...)
-			}
-		}
-	}
-	return localEndpoints
-}
-
-func getEndpointAddresses(endpointSlice *discovery.EndpointSlice, service *kapi.Service) []string {
-	endpointsAddress := make([]string, 0)
-	includeTerminating := service != nil && service.Spec.PublishNotReadyAddresses
-	for _, endpoint := range endpointSlice.Endpoints {
-		if util.IsEndpointValid(endpoint, includeTerminating) {
-			for _, ip := range endpoint.Addresses {
-				endpointsAddress = append(endpointsAddress, utilnet.ParseIPSloppy(ip).String())
-			}
-		}
-	}
-	return endpointsAddress
+	return util.GetLocalEndpointAddresses(endpointSlices, service, npw.nodeIPManager.nodeName)
 }
 
 func (npw *nodePortWatcher) UpdateEndpointSlice(oldEpSlice, newEpSlice *discovery.EndpointSlice) error {
@@ -906,19 +905,19 @@ func (npw *nodePortWatcher) UpdateEndpointSlice(oldEpSlice, newEpSlice *discover
 	var err error
 	var errors []error
 
-	namespacedName, err := serviceNamespacedNameFromEndpointSlice(newEpSlice)
+	namespacedName, err := util.ServiceNamespacedNameFromEndpointSlice(newEpSlice)
 	if err != nil {
 		return fmt.Errorf("cannot update %s/%s in nodePortWatcher: %v", newEpSlice.Namespace, newEpSlice.Name, err)
 	}
 	svc, err := npw.watchFactory.GetService(namespacedName.Namespace, namespacedName.Name)
 	if err != nil && !kerrors.IsNotFound(err) {
-		return fmt.Errorf("error while retrieving service for endpointslice %s/%s during update: %v",
-			oldEpSlice.Namespace, oldEpSlice.Name, err)
+		return fmt.Errorf("error retrieving service %s/%s for endpointslice %s during endpointslice update: %v",
+			namespacedName.Namespace, namespacedName.Name, newEpSlice.Name, err)
 	}
 
-	oldEpAddr := getEndpointAddresses(oldEpSlice, svc)
-	newEpAddr := getEndpointAddresses(newEpSlice, svc)
-	if reflect.DeepEqual(oldEpAddr, newEpAddr) {
+	oldEndpointAddresses := util.GetEndpointAddresses([]*discovery.EndpointSlice{oldEpSlice}, svc)
+	newEndpointAddresses := util.GetEndpointAddresses([]*discovery.EndpointSlice{newEpSlice}, svc)
+	if reflect.DeepEqual(oldEndpointAddresses, newEndpointAddresses) {
 		return nil
 	}
 
@@ -932,7 +931,7 @@ func (npw *nodePortWatcher) UpdateEndpointSlice(oldEpSlice, newEpSlice *discover
 		if err = npw.AddEndpointSlice(newEpSlice); err != nil {
 			errors = append(errors, err)
 		}
-	} else if len(newEpAddr) == 0 {
+	} else if len(newEndpointAddresses) == 0 {
 		// With no endpoint addresses in new endpointslice, delete old endpoint rules
 		// and add normal ones back
 		if err = npw.DeleteEndpointSlice(oldEpSlice); err != nil {
@@ -942,16 +941,30 @@ func (npw *nodePortWatcher) UpdateEndpointSlice(oldEpSlice, newEpSlice *discover
 
 	// Update rules and service cache if hasHostNetworkEndpoints status changed or localEndpoints changed
 	nodeIPs := npw.nodeIPManager.ListAddresses()
-	hasLocalHostNetworkEpOld := hasLocalHostNetworkEndpoints([]*discovery.EndpointSlice{oldEpSlice}, nodeIPs, svc)
-	hasLocalHostNetworkEpNew := hasLocalHostNetworkEndpoints([]*discovery.EndpointSlice{newEpSlice}, nodeIPs, svc)
 	epSlices, err := npw.watchFactory.GetEndpointSlices(newEpSlice.Namespace, newEpSlice.Labels[discovery.LabelServiceName])
 	if err != nil {
-		klog.V(5).Infof("Could not fetch endpointslices for service %s during endpointSliceDelete", namespacedName)
+		if !kerrors.IsNotFound(err) {
+			return fmt.Errorf("error retrieving all endpointslices for service %s/%s during endpointslice update on %s: %w",
+				namespacedName.Namespace, namespacedName.Name, newEpSlice.Name, err)
+		}
+		klog.V(5).Infof("No endpointslices found for service %s/%s during endpointslice update on %s: %v",
+			namespacedName.Namespace, namespacedName.Name, newEpSlice.Name, err)
 	}
 
+	// Delete old endpoint slice and add new one when local endpoints have changed or the presence of local host-network
+	// endpoints has changed. For this second comparison, check first between the old endpoint slice and all current
+	// endpointslices for this service. This is a partial comparison, in case serviceInfo is not set. When it is set, compare
+	// between /all/ old endpoint slices and all new ones.
+	oldLocalEndpoints := npw.GetLocalEndpointAddresses([]*discovery.EndpointSlice{oldEpSlice}, svc)
 	newLocalEndpoints := npw.GetLocalEndpointAddresses(epSlices, svc)
-	if hasLocalHostNetworkEpOld != hasLocalHostNetworkEpNew ||
-		(serviceInfo != nil && !reflect.DeepEqual(serviceInfo.localEndpoints, newLocalEndpoints)) {
+	hasLocalHostNetworkEpOld := util.HasLocalHostNetworkEndpoints(oldLocalEndpoints, nodeIPs)
+	hasLocalHostNetworkEpNew := util.HasLocalHostNetworkEndpoints(newLocalEndpoints, nodeIPs)
+
+	localEndpointsHaveChanged := serviceInfo != nil && !reflect.DeepEqual(serviceInfo.localEndpoints, newLocalEndpoints)
+	localHostNetworkEndpointsPresenceHasChanged := hasLocalHostNetworkEpOld != hasLocalHostNetworkEpNew ||
+		serviceInfo != nil && serviceInfo.hasLocalHostNetworkEp != hasLocalHostNetworkEpNew
+
+	if localEndpointsHaveChanged || localHostNetworkEndpointsPresenceHasChanged {
 		if err = npw.DeleteEndpointSlice(oldEpSlice); err != nil {
 			errors = append(errors, err)
 		}
@@ -965,15 +978,9 @@ func (npw *nodePortWatcher) UpdateEndpointSlice(oldEpSlice, newEpSlice *discover
 	npw.egressServiceInfoLock.Lock()
 	_, found := npw.egressServiceInfo[namespacedName]
 	npw.egressServiceInfoLock.Unlock()
-	if found && !npw.dpuMode {
-		svc, err := npw.watchFactory.GetService(namespacedName.Namespace, namespacedName.Name)
-		if err != nil {
-			errors = append(errors, fmt.Errorf("failed to get service %s/%s while updating endpoint slice %s/%s",
-				namespacedName.Namespace, namespacedName.Name, oldEpSlice.Namespace, oldEpSlice.Name))
-		} else {
-			if err = updateEgressSVCIptRules(svc, npw); err != nil {
-				errors = append(errors, err)
-			}
+	if found && !npw.dpuMode && svc != nil {
+		if err = updateEgressSVCIptRules(svc, npw); err != nil {
+			errors = append(errors, err)
 		}
 	}
 	return apierrors.NewAggregate(errors)

--- a/go-controller/pkg/node/gateway_shared_intf_linux.go
+++ b/go-controller/pkg/node/gateway_shared_intf_linux.go
@@ -114,7 +114,7 @@ func updateEgressSVCIptRules(svc *kapi.Service, npw *nodePortWatcher) error {
 		for _, ep := range epSlice.Endpoints {
 			for _, ip := range ep.Addresses {
 				ipStr := utilnet.ParseIPSloppy(ip).String()
-				if !isHostEndpoint(ipStr) {
+				if !util.IsHostEndpoint(ipStr) {
 					epsToInsert.Insert(ipStr)
 				}
 			}

--- a/go-controller/pkg/node/healthcheck_service.go
+++ b/go-controller/pkg/node/healthcheck_service.go
@@ -174,10 +174,11 @@ func (l *loadBalancerHealthChecker) CountLocalEndpointAddresses(endpointSlices [
 // hasLocalHostNetworkEndpoints returns true if there is at least one host-networked endpoint
 // in the provided list that is local to this node.
 // It returns false if none of the endpoints are local host-networked endpoints or if ep.Subsets is nil.
-func hasLocalHostNetworkEndpoints(epSlices []*discovery.EndpointSlice, nodeAddresses []net.IP) bool {
+func hasLocalHostNetworkEndpoints(epSlices []*discovery.EndpointSlice, nodeAddresses []net.IP, service *kapi.Service) bool {
+	includeTerminating := service != nil && service.Spec.PublishNotReadyAddresses
 	for _, epSlice := range epSlices {
 		for _, endpoint := range epSlice.Endpoints {
-			if !util.IsEndpointReady(endpoint) {
+			if !util.IsEndpointValid(endpoint, includeTerminating) {
 				continue
 			}
 			for _, ip := range endpoint.Addresses {

--- a/go-controller/pkg/node/healthcheck_service.go
+++ b/go-controller/pkg/node/healthcheck_service.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube/healthcheck"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 
 	kapi "k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1"
@@ -162,7 +163,7 @@ func (l *loadBalancerHealthChecker) CountLocalEndpointAddresses(endpointSlices [
 	for _, endpointSlice := range endpointSlices {
 		for _, endpoint := range endpointSlice.Endpoints {
 			isLocal := endpoint.NodeName != nil && *endpoint.NodeName == l.nodeName
-			if isEndpointReady(endpoint) && isLocal {
+			if util.IsEndpointReady(endpoint) && isLocal {
 				localEndpointAddresses.Insert(endpoint.Addresses...)
 			}
 		}
@@ -176,7 +177,7 @@ func (l *loadBalancerHealthChecker) CountLocalEndpointAddresses(endpointSlices [
 func hasLocalHostNetworkEndpoints(epSlices []*discovery.EndpointSlice, nodeAddresses []net.IP) bool {
 	for _, epSlice := range epSlices {
 		for _, endpoint := range epSlice.Endpoints {
-			if !isEndpointReady(endpoint) {
+			if !util.IsEndpointReady(endpoint) {
 				continue
 			}
 			for _, ip := range endpoint.Addresses {
@@ -199,13 +200,6 @@ func isHostEndpoint(endpointIP string) bool {
 		}
 	}
 	return true
-}
-
-// discovery.EndpointSlice reports in the same slice all endpoints along with their status.
-// isEndpointReady takes an endpoint from an endpoint slice and returns true if the endpoint is
-// to be considered ready.
-func isEndpointReady(endpoint discovery.Endpoint) bool {
-	return endpoint.Conditions.Ready == nil || *endpoint.Conditions.Ready
 }
 
 func serviceNamespacedNameFromEndpointSlice(epSlice *discovery.EndpointSlice) (ktypes.NamespacedName, error) {

--- a/go-controller/pkg/node/healthcheck_service.go
+++ b/go-controller/pkg/node/healthcheck_service.go
@@ -2,10 +2,8 @@ package node
 
 import (
 	"fmt"
-	"net"
 	"sync"
 
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube/healthcheck"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
@@ -15,7 +13,6 @@ import (
 	ktypes "k8s.io/apimachinery/pkg/types"
 	apierrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
-	utilnet "k8s.io/utils/net"
 )
 
 // initLoadBalancerHealthChecker initializes the health check server for
@@ -56,7 +53,7 @@ func (l *loadBalancerHealthChecker) AddService(svc *kapi.Service) error {
 				svc.Namespace, svc.Name, err)
 		}
 		namespacedName := ktypes.NamespacedName{Namespace: svc.Namespace, Name: svc.Name}
-		l.endpoints[namespacedName] = l.CountLocalEndpointAddresses(epSlices)
+		l.endpoints[namespacedName] = l.CountLocalReadyEndpointAddresses(epSlices)
 		if err = l.server.SyncEndpoints(l.endpoints); err != nil {
 			return fmt.Errorf("unable to sync endpoint slice %v; err: %v", name, err)
 		}
@@ -102,7 +99,7 @@ func (l *loadBalancerHealthChecker) SyncServices(svcs []interface{}) error {
 }
 
 func (l *loadBalancerHealthChecker) SyncEndPointSlices(epSlice *discovery.EndpointSlice) error {
-	namespacedName, err := serviceNamespacedNameFromEndpointSlice(epSlice)
+	namespacedName, err := util.ServiceNamespacedNameFromEndpointSlice(epSlice)
 	if err != nil {
 		return fmt.Errorf("skipping %s/%s: %v", epSlice.Namespace, epSlice.Name, err)
 	}
@@ -112,7 +109,7 @@ func (l *loadBalancerHealthChecker) SyncEndPointSlices(epSlice *discovery.Endpoi
 		return fmt.Errorf("could not fetch all endpointslices for service %s during health check", namespacedName.String())
 	}
 
-	localEndpointAddressCount := l.CountLocalEndpointAddresses(epSlices)
+	localEndpointAddressCount := l.CountLocalReadyEndpointAddresses(epSlices)
 	if len(epSlices) == 0 {
 		// let's delete it from cache and wait for the next update;
 		// this will show as 0 endpoints for health checks
@@ -124,7 +121,7 @@ func (l *loadBalancerHealthChecker) SyncEndPointSlices(epSlice *discovery.Endpoi
 }
 
 func (l *loadBalancerHealthChecker) AddEndpointSlice(epSlice *discovery.EndpointSlice) error {
-	namespacedName, err := serviceNamespacedNameFromEndpointSlice(epSlice)
+	namespacedName, err := util.ServiceNamespacedNameFromEndpointSlice(epSlice)
 	if err != nil {
 		return fmt.Errorf("cannot add %s/%s to loadBalancerHealthChecker: %v", epSlice.Namespace, epSlice.Name, err)
 	}
@@ -137,7 +134,7 @@ func (l *loadBalancerHealthChecker) AddEndpointSlice(epSlice *discovery.Endpoint
 }
 
 func (l *loadBalancerHealthChecker) UpdateEndpointSlice(oldEpSlice, newEpSlice *discovery.EndpointSlice) error {
-	namespacedName, err := serviceNamespacedNameFromEndpointSlice(newEpSlice)
+	namespacedName, err := util.ServiceNamespacedNameFromEndpointSlice(newEpSlice)
 	if err != nil {
 		return fmt.Errorf("cannot update %s/%s in loadBalancerHealthChecker: %v",
 			newEpSlice.Namespace, newEpSlice.Name, err)
@@ -156,9 +153,14 @@ func (l *loadBalancerHealthChecker) DeleteEndpointSlice(epSlice *discovery.Endpo
 	return l.SyncEndPointSlices(epSlice)
 }
 
-// CountLocalEndpointAddresses returns the number of IP addresses from ready endpoints that are local
-// to the node for a service
-func (l *loadBalancerHealthChecker) CountLocalEndpointAddresses(endpointSlices []*discovery.EndpointSlice) int {
+// CountLocalReadyEndpointAddresses returns the number of IP addresses from ready
+// endpoints that are local to the node for a service. This is used to determine the
+// response to LB health checks for services with externalTrafficPolicy=local. We consider
+// the ready field for health checks and the serving field for setting up services and endpoints,
+// so that we can steer traffic to a local terminating endpoint (ready=false, serving=true, terminating=true),
+// while responding negatively to its service health checks, giving time to LBs to update their
+// cache of available nodes.
+func (l *loadBalancerHealthChecker) CountLocalReadyEndpointAddresses(endpointSlices []*discovery.EndpointSlice) int {
 	localEndpointAddresses := sets.NewString()
 	for _, endpointSlice := range endpointSlices {
 		for _, endpoint := range endpointSlice.Endpoints {
@@ -169,49 +171,4 @@ func (l *loadBalancerHealthChecker) CountLocalEndpointAddresses(endpointSlices [
 		}
 	}
 	return len(localEndpointAddresses)
-}
-
-// hasLocalHostNetworkEndpoints returns true if there is at least one host-networked endpoint
-// in the provided list that is local to this node.
-// It returns false if none of the endpoints are local host-networked endpoints or if ep.Subsets is nil.
-func hasLocalHostNetworkEndpoints(epSlices []*discovery.EndpointSlice, nodeAddresses []net.IP, service *kapi.Service) bool {
-	includeTerminating := service != nil && service.Spec.PublishNotReadyAddresses
-	for _, epSlice := range epSlices {
-		for _, endpoint := range epSlice.Endpoints {
-			if !util.IsEndpointValid(endpoint, includeTerminating) {
-				continue
-			}
-			for _, ip := range endpoint.Addresses {
-				for _, nodeIP := range nodeAddresses {
-					if nodeIP.String() == utilnet.ParseIPSloppy(ip).String() {
-						return true
-					}
-				}
-			}
-		}
-	}
-	return false
-}
-
-// isHostEndpoint determines if the given endpoint ip belongs to a host networked pod
-func isHostEndpoint(endpointIP string) bool {
-	for _, clusterNet := range config.Default.ClusterSubnets {
-		if clusterNet.CIDR.Contains(net.ParseIP(endpointIP)) {
-			return false
-		}
-	}
-	return true
-}
-
-func serviceNamespacedNameFromEndpointSlice(epSlice *discovery.EndpointSlice) (ktypes.NamespacedName, error) {
-	// Return the namespaced name of the corresponding service
-	var serviceNamespacedName ktypes.NamespacedName
-	svcName := epSlice.Labels[discovery.LabelServiceName]
-	if svcName == "" {
-		// should not happen, since the informer already filters out endpoint slices with an empty service label
-		return serviceNamespacedName,
-			fmt.Errorf("endpointslice %s/%s: empty value for label %s",
-				epSlice.Namespace, epSlice.Name, discovery.LabelServiceName)
-	}
-	return ktypes.NamespacedName{Namespace: epSlice.Namespace, Name: svcName}, nil
 }

--- a/go-controller/pkg/node/node.go
+++ b/go-controller/pkg/node/node.go
@@ -734,7 +734,7 @@ func (n *OvnNode) reconcileConntrackUponEndpointSliceEvents(oldEndpointSlice, ne
 				oldIPStr := utilnet.ParseIPSloppy(oldIP).String()
 				// upon an update event, remove conntrack entries for IP addresses that are no longer
 				// in the endpointslice, skip otherwise
-				if newEndpointSlice != nil && util.DoesEndpointSliceContainEndpoint(newEndpointSlice, oldIPStr, *oldPort.Port, *oldPort.Protocol, svc) {
+				if newEndpointSlice != nil && util.DoesEndpointSliceContainEligibleEndpoint(newEndpointSlice, oldIPStr, *oldPort.Port, *oldPort.Protocol, svc) {
 					continue
 				}
 				// upon update and delete events, flush conntrack only for UDP

--- a/go-controller/pkg/node/node.go
+++ b/go-controller/pkg/node/node.go
@@ -716,7 +716,7 @@ func (n *OvnNode) reconcileConntrackUponEndpointSliceEvents(oldEndpointSlice, ne
 		// nothing to do upon an add event
 		return nil
 	}
-	namespacedName, err := serviceNamespacedNameFromEndpointSlice(oldEndpointSlice)
+	namespacedName, err := util.ServiceNamespacedNameFromEndpointSlice(oldEndpointSlice)
 	if err != nil {
 		return fmt.Errorf("cannot reconcile conntrack: %v", err)
 	}
@@ -734,7 +734,7 @@ func (n *OvnNode) reconcileConntrackUponEndpointSliceEvents(oldEndpointSlice, ne
 				oldIPStr := utilnet.ParseIPSloppy(oldIP).String()
 				// upon an update event, remove conntrack entries for IP addresses that are no longer
 				// in the endpointslice, skip otherwise
-				if newEndpointSlice != nil && doesEndpointSliceContainValidEndpoint(newEndpointSlice, oldIPStr, *oldPort.Port, *oldPort.Protocol, svc) {
+				if newEndpointSlice != nil && util.DoesEndpointSliceContainEndpoint(newEndpointSlice, oldIPStr, *oldPort.Port, *oldPort.Protocol, svc) {
 					continue
 				}
 				// upon update and delete events, flush conntrack only for UDP
@@ -883,26 +883,6 @@ func (n *OvnNode) validateVTEPInterfaceMTU() error {
 	klog.V(2).Infof("MTU (%d) of network interface %s is big enough to deal with Geneve header overhead (sum %d). ",
 		mtu, interfaceName, requiredMTU)
 	return nil
-}
-
-// doesEndpointSliceContainValidEndpoint returns true if the endpointslice
-// contains an endpoint with the given IP/Port/Protocol and this endpoint is considered valid
-func doesEndpointSliceContainValidEndpoint(epSlice *discovery.EndpointSlice,
-	epIP string, epPort int32, protocol kapi.Protocol, service *kapi.Service) bool {
-	includeTerminating := service != nil && service.Spec.PublishNotReadyAddresses
-	for _, port := range epSlice.Ports {
-		for _, endpoint := range epSlice.Endpoints {
-			if !util.IsEndpointValid(endpoint, includeTerminating) {
-				continue
-			}
-			for _, ip := range endpoint.Addresses {
-				if utilnet.ParseIPSloppy(ip).String() == epIP && *port.Port == epPort && *port.Protocol == protocol {
-					return true
-				}
-			}
-		}
-	}
-	return false
 }
 
 func configureSvcRouteViaBridge(bridge string) error {

--- a/go-controller/pkg/ovn/controller/services/load_balancer.go
+++ b/go-controller/pkg/ovn/controller/services/load_balancer.go
@@ -11,6 +11,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
 	utilnet "k8s.io/utils/net"
 )
@@ -26,7 +27,9 @@ type lbConfig struct {
 	vips     []string    // just ip or the special value "node" for the node's physical IPs (i.e. NodePort)
 	protocol v1.Protocol // TCP, UDP, or SCTP
 	inport   int32       // the incoming (virtual) port number
-	eps      util.LbEndpoints
+
+	clusterEndpoints lbEndpoints            // addresses of cluster-wide endpoints
+	nodeEndpoints    map[string]lbEndpoints // node -> addresses of local endpoints
 
 	// if true, then vips added on the router are in "local" mode
 	// that means, skipSNAT, and remove any non-local endpoints.
@@ -37,6 +40,86 @@ type lbConfig struct {
 	internalTrafficLocal bool
 	// indicates if this LB is configuring service of type NodePort.
 	hasNodePort bool
+}
+
+type lbEndpoints struct {
+	Port  int32
+	V4IPs []string
+	V6IPs []string
+}
+
+func makeNodeSwitchTargetIPs(service *v1.Service, node string, c *lbConfig) (targetIPsV4, targetIPsV6 []string) {
+	targetIPsV4 = c.clusterEndpoints.V4IPs
+	targetIPsV6 = c.clusterEndpoints.V6IPs
+
+	if c.externalTrafficLocal || c.internalTrafficLocal {
+		// For ExternalTrafficPolicy=Local, remove non-local endpoints from the router/switch targets
+		// NOTE: on the switches, filtered eps are used only by masqueradeVIP
+		// for InternalTrafficPolicy=Local, remove non-local endpoints from the switch targets only
+		localIPsV4 := []string{}
+		localIPsV6 := []string{}
+		if localEndpoints, ok := c.nodeEndpoints[node]; ok {
+			localIPsV4 = localEndpoints.V4IPs
+			localIPsV6 = localEndpoints.V6IPs
+		}
+		targetIPsV4 = localIPsV4
+		targetIPsV6 = localIPsV6
+	}
+
+	// OCP HACK BEGIN
+	if _, set := service.Annotations[localWithFallbackAnnotation]; set && c.externalTrafficLocal {
+		// if service is annotated and is ETP=local, fallback to ETP=cluster on nodes with no local endpoints:
+		// include endpoints from other nodes
+		if len(targetIPsV4) == 0 {
+			targetIPsV4 = c.clusterEndpoints.V4IPs
+		}
+		if len(targetIPsV6) == 0 {
+			targetIPsV6 = c.clusterEndpoints.V6IPs
+		}
+	}
+	// OCP HACK END
+
+	return
+}
+
+func makeNodeRouterTargetIPs(service *v1.Service, node *nodeInfo, c *lbConfig, hostMasqueradeIPV4, hostMasqueradeIPV6 string) (targetIPsV4, targetIPsV6 []string, zeroRouterLocalEndpointsV4, zeroRouterLocalEndpointsV6 bool) {
+	targetIPsV4 = c.clusterEndpoints.V4IPs
+	targetIPsV6 = c.clusterEndpoints.V6IPs
+
+	if c.externalTrafficLocal {
+		// For ExternalTrafficPolicy=Local, remove non-local endpoints from the router/switch targets
+		// NOTE: on the switches, filtered eps are used only by masqueradeVIP
+		localIPsV4 := []string{}
+		localIPsV6 := []string{}
+		if localEndpoints, ok := c.nodeEndpoints[node.name]; ok {
+			localIPsV4 = localEndpoints.V4IPs
+			localIPsV6 = localEndpoints.V6IPs
+		}
+		targetIPsV4 = localIPsV4
+		targetIPsV6 = localIPsV6
+	}
+
+	// OCP HACK BEGIN
+	if _, set := service.Annotations[localWithFallbackAnnotation]; set && c.externalTrafficLocal {
+		// if service is annotated and is ETP=local, fallback to ETP=cluster on nodes with no local endpoints:
+		// include endpoints from other nodes
+		if len(targetIPsV4) == 0 {
+			zeroRouterLocalEndpointsV4 = true
+			targetIPsV4 = c.clusterEndpoints.V4IPs
+		}
+		if len(targetIPsV6) == 0 {
+			zeroRouterLocalEndpointsV6 = true
+			targetIPsV6 = c.clusterEndpoints.V6IPs
+		}
+	}
+	// OCP HACK END
+
+	// Any targets local to the node need to have a special
+	// harpin IP added, but only for the router LB
+	targetIPsV4 = util.UpdateIPsSlice(targetIPsV4, node.nodeIPs, []string{hostMasqueradeIPV4})
+	targetIPsV6 = util.UpdateIPsSlice(targetIPsV6, node.nodeIPs, []string{hostMasqueradeIPV6})
+
+	return
 }
 
 // just used for consistent ordering
@@ -61,14 +144,24 @@ var protos = []v1.Protocol{
 // - services with host-network endpoints
 // - services with ExternalTrafficPolicy=Local
 // - services with InternalTrafficPolicy=Local
-func buildServiceLBConfigs(service *v1.Service, endpointSlices []*discovery.EndpointSlice) (perNodeConfigs []lbConfig, clusterConfigs []lbConfig) {
+func buildServiceLBConfigs(service *v1.Service, endpointSlices []*discovery.EndpointSlice, nodeInfos []nodeInfo) (perNodeConfigs []lbConfig, clusterConfigs []lbConfig) {
+	nodes := sets.NewString()
+	for _, n := range nodeInfos {
+		nodes.Insert(n.name)
+	}
+	// get all the endpoints classified by port and by port,node
+	portToClusterEndpoints, portToNodeToEndpoints := getEndpointsForService(endpointSlices, service, nodes)
 	// For each svcPort, determine if it will be applied per-node or cluster-wide
 	for _, svcPort := range service.Spec.Ports {
-		eps := util.GetLbEndpoints(endpointSlices, svcPort, service)
-
+		svcPortKey := getServicePortKey(svcPort.Protocol, svcPort.Name)
+		clusterEndpoints := portToClusterEndpoints[svcPortKey]
+		nodeEndpoints := portToNodeToEndpoints[svcPortKey]
+		if nodeEndpoints == nil {
+			nodeEndpoints = make(map[string]lbEndpoints)
+		}
 		// if ExternalTrafficPolicy or InternalTrafficPolicy is local, then we need to do things a bit differently
-		externalTrafficLocal := (service.Spec.ExternalTrafficPolicy == v1.ServiceExternalTrafficPolicyTypeLocal)
-		internalTrafficLocal := (service.Spec.InternalTrafficPolicy != nil) && (*service.Spec.InternalTrafficPolicy == v1.ServiceInternalTrafficPolicyLocal)
+		externalTrafficLocal := util.ServiceExternalTrafficPolicyLocal(service)
+		internalTrafficLocal := util.ServiceInternalTrafficPolicyLocal(service)
 
 		// NodePort services get a per-node load balancer, but with the node's physical IP as the vip
 		// Thus, the vip "node" will be expanded later.
@@ -78,7 +171,8 @@ func buildServiceLBConfigs(service *v1.Service, endpointSlices []*discovery.Endp
 				protocol:             svcPort.Protocol,
 				inport:               svcPort.NodePort,
 				vips:                 []string{placeholderNodeIPs}, // shortcut for all-physical-ips
-				eps:                  eps,
+				clusterEndpoints:     clusterEndpoints,
+				nodeEndpoints:        nodeEndpoints,
 				externalTrafficLocal: externalTrafficLocal,
 				internalTrafficLocal: false, // always false for non-ClusterIPs
 				hasNodePort:          true,
@@ -98,7 +192,8 @@ func buildServiceLBConfigs(service *v1.Service, endpointSlices []*discovery.Endp
 				protocol:             svcPort.Protocol,
 				inport:               svcPort.Port,
 				vips:                 externalVips,
-				eps:                  eps,
+				clusterEndpoints:     clusterEndpoints,
+				nodeEndpoints:        nodeEndpoints,
 				externalTrafficLocal: true,
 				internalTrafficLocal: false, // always false for non-ClusterIPs
 				hasNodePort:          false,
@@ -114,7 +209,8 @@ func buildServiceLBConfigs(service *v1.Service, endpointSlices []*discovery.Endp
 			protocol:             svcPort.Protocol,
 			inport:               svcPort.Port,
 			vips:                 vips,
-			eps:                  eps,
+			clusterEndpoints:     clusterEndpoints,
+			nodeEndpoints:        nodeEndpoints,
 			externalTrafficLocal: false, // always false for ClusterIPs
 			internalTrafficLocal: internalTrafficLocal,
 			hasNodePort:          false,
@@ -127,7 +223,7 @@ func buildServiceLBConfigs(service *v1.Service, endpointSlices []*discovery.Endp
 		// - OCP only HACK: It's an openshift-dns:default-dns service
 		//
 		// In that case, we need to create per-node LBs.
-		if hasHostEndpoints(eps.V4IPs) || hasHostEndpoints(eps.V6IPs) || internalTrafficLocal ||
+		if hasHostEndpoints(clusterEndpoints.V4IPs) || hasHostEndpoints(clusterEndpoints.V6IPs) || internalTrafficLocal ||
 			// OCP only hack begin
 			(service.Namespace == "openshift-dns" && service.Name == "dns-default") {
 			// OCP only hack end
@@ -203,19 +299,19 @@ func buildClusterLBs(service *v1.Service, configs []lbConfig, nodeInfos []nodeIn
 					service.Namespace, service.Name)
 			}
 
-			v4targets := make([]ovnlb.Addr, 0, len(config.eps.V4IPs))
-			for _, tgt := range config.eps.V4IPs {
+			v4targets := make([]ovnlb.Addr, 0, len(config.clusterEndpoints.V4IPs))
+			for _, targetIP := range config.clusterEndpoints.V4IPs {
 				v4targets = append(v4targets, ovnlb.Addr{
-					IP:   tgt,
-					Port: config.eps.Port,
+					IP:   targetIP,
+					Port: config.clusterEndpoints.Port,
 				})
 			}
 
-			v6targets := make([]ovnlb.Addr, 0, len(config.eps.V6IPs))
-			for _, tgt := range config.eps.V6IPs {
+			v6targets := make([]ovnlb.Addr, 0, len(config.clusterEndpoints.V6IPs))
+			for _, targetIP := range config.clusterEndpoints.V6IPs {
 				v6targets = append(v6targets, ovnlb.Addr{
-					IP:   tgt,
-					Port: config.eps.Port,
+					IP:   targetIP,
+					Port: config.clusterEndpoints.Port,
 				})
 			}
 
@@ -250,8 +346,8 @@ func buildClusterLBs(service *v1.Service, configs []lbConfig, nodeInfos []nodeIn
 // buildPerNodeLBs takes a list of lbConfigs and expands them to one LB per protocol per node
 //
 // Per-node lbs are created for
-// - clusterip services with host-network endpoints are attached to each node's gateway router + switch
-// - nodeport services are attached to each node's gateway router + switch, vips are node's physical IPs (except if etp=local+ovnk backend pods)
+// - clusterip services with host-network endpoints, which are attached to each node's gateway router + switch
+// - nodeport services are attached to each node's gateway router + switch, vips are the node's physical IPs (except if etp=local+ovnk backend pods)
 // - any services with host-network endpoints
 // - services with external IPs / LoadBalancer Status IPs
 //
@@ -259,10 +355,10 @@ func buildClusterLBs(service *v1.Service, configs []lbConfig, nodeInfos []nodeIn
 // see https://github.com/ovn-org/ovn-kubernetes/blob/master/docs/design/host_to_services_OpenFlow.md
 // This is for host -> serviceip -> host hairpin
 //
-// For ExternalTrafficPolicy, all "External" IPs (NodePort, ExternalIPs, Loadbalancer Status) have:
+// For ExternalTrafficPolicy=local, all "External" IPs (NodePort, ExternalIPs, Loadbalancer Status) have:
 // - targets filtered to only local targets
 // - SkipSNAT enabled
-// - NP LB on the switch will have masqueradeIP as the vip to handle etp=local for LGW case.
+// - NodePort LB on the switch will have masqueradeIP as the vip to handle etp=local for LGW case.
 // This results in the creation of an additional load balancer on the GatewayRouters and NodeSwitches.
 func buildPerNodeLBs(service *v1.Service, configs []lbConfig, nodes []nodeInfo) []ovnlb.LB {
 	cbp := configsByProto(configs)
@@ -270,8 +366,7 @@ func buildPerNodeLBs(service *v1.Service, configs []lbConfig, nodes []nodeInfo) 
 
 	out := make([]ovnlb.LB, 0, len(nodes)*len(configs))
 
-	// output is one LB per node per protocol
-	// with one rule per vip
+	// output is one LB per node per protocol with one rule per vip
 	for _, node := range nodes {
 		for _, proto := range protos {
 			configs, ok := cbp[proto]
@@ -287,82 +382,44 @@ func buildPerNodeLBs(service *v1.Service, configs []lbConfig, nodes []nodeInfo) 
 			switchRules := make([]ovnlb.LBRule, 0, len(configs))
 
 			for _, config := range configs {
-				vips := config.vips
 
-				routerV4targetips := config.eps.V4IPs
-				routerV6targetips := config.eps.V6IPs
-				switchV4targetips := config.eps.V4IPs
-				switchV6targetips := config.eps.V6IPs
+				switchV4TargetIPs, switchV6TargetIPs := makeNodeSwitchTargetIPs(service, node.name, &config)
 
-				if config.externalTrafficLocal {
-					// for ExternalTrafficPolicy=Local, remove non-local endpoints from the router/switch targets
-					// NOTE: on the switches, filtered eps are used only by masqueradeVIP
-					routerV4targetips = util.FilterIPsSlice(routerV4targetips, node.nodeSubnets(), true)
-					routerV6targetips = util.FilterIPsSlice(routerV6targetips, node.nodeSubnets(), true)
-					switchV4targetips = util.FilterIPsSlice(switchV4targetips, node.nodeSubnets(), true)
-					switchV6targetips = util.FilterIPsSlice(switchV6targetips, node.nodeSubnets(), true)
-				}
-				if config.internalTrafficLocal {
-					// for InternalTrafficPolicy=Local, remove non-local endpoints from the switch targets only
-					switchV4targetips = util.FilterIPsSlice(switchV4targetips, node.nodeSubnets(), true)
-					switchV6targetips = util.FilterIPsSlice(switchV6targetips, node.nodeSubnets(), true)
-				}
-				// OCP HACK BEGIN
-				zeroRouterV4LocalEndpoints := false
-				zeroRouterV6LocalEndpoints := false
-				if _, set := service.Annotations[localWithFallbackAnnotation]; set && config.externalTrafficLocal {
-					// if service is annotated and is ETP=local, fallback to ETP=cluster on nodes with no local endpoints:
-					// include endpoints from other nodes
-					if len(routerV4targetips) == 0 {
-						zeroRouterV4LocalEndpoints = true
-						routerV4targetips = config.eps.V4IPs
-					}
-					if len(routerV6targetips) == 0 {
-						zeroRouterV6LocalEndpoints = true
-						routerV6targetips = config.eps.V6IPs
-					}
-					if len(switchV4targetips) == 0 {
-						switchV4targetips = config.eps.V4IPs
-					}
-					if len(switchV6targetips) == 0 {
-						switchV6targetips = config.eps.V6IPs
-					}
-				}
-				// OCP HACK END
-				// at this point, the targets may be empty
+				routerV4TargetIPs, routerV6TargetIPs, zeroRouterV4LocalEndpoints, zeroRouterV6LocalEndpoints := makeNodeRouterTargetIPs(
+					service,
+					&node,
+					&config,
+					types.V4HostMasqueradeIP,
+					types.V6HostMasqueradeIP)
 
-				// any targets local to the node need to have a special
-				// harpin IP added, but only for the router LB
-				routerV4targetips = util.UpdateIPsSlice(routerV4targetips, node.nodeIPs, []string{types.V4HostMasqueradeIP})
-				routerV6targetips = util.UpdateIPsSlice(routerV6targetips, node.nodeIPs, []string{types.V6HostMasqueradeIP})
+				routerV4targets := joinHostsPort(routerV4TargetIPs, config.clusterEndpoints.Port)
+				routerV6targets := joinHostsPort(routerV6TargetIPs, config.clusterEndpoints.Port)
 
-				routerV4targets := ovnlb.JoinHostsPort(routerV4targetips, config.eps.Port)
-				routerV6targets := ovnlb.JoinHostsPort(routerV6targetips, config.eps.Port)
-
-				switchV4Targets := ovnlb.JoinHostsPort(config.eps.V4IPs, config.eps.Port)
-				switchV6Targets := ovnlb.JoinHostsPort(config.eps.V6IPs, config.eps.Port)
+				switchV4Targets := joinHostsPort(config.clusterEndpoints.V4IPs, config.clusterEndpoints.Port)
+				switchV6Targets := joinHostsPort(config.clusterEndpoints.V6IPs, config.clusterEndpoints.Port)
 
 				// OCP HACK begin
 				// TODO: Remove this hack once we add support for ITP:preferLocal and DNS operator starts using it.
 				if service.Namespace == "openshift-dns" && service.Name == "dns-default" {
-					// Filter out endpoints that are local to this node.
-					switchV4targetDNSips := util.FilterIPsSlice(config.eps.V4IPs, node.podSubnets, true)
-					switchV6targetDNSips := util.FilterIPsSlice(config.eps.V6IPs, node.podSubnets, true)
-					// If no local endpoints were found add all the endpoints as targets.
+					// Select endpoints that are local to this node.
+					switchV4targetDNSips := util.FilterIPsSlice(config.clusterEndpoints.V4IPs, node.podSubnets, true)
+					switchV6targetDNSips := util.FilterIPsSlice(config.clusterEndpoints.V6IPs, node.podSubnets, true)
+
+					// If no local endpoints were found, add all the endpoints as targets.
 					if len(switchV4targetDNSips) == 0 {
-						switchV4targetDNSips = config.eps.V4IPs
+						switchV4targetDNSips = config.clusterEndpoints.V4IPs
 					}
 					if len(switchV6targetDNSips) == 0 {
-						switchV6targetDNSips = config.eps.V6IPs
+						switchV6targetDNSips = config.clusterEndpoints.V6IPs
 					}
-					switchV4Targets = ovnlb.JoinHostsPort(switchV4targetDNSips, config.eps.Port)
-					switchV6Targets = ovnlb.JoinHostsPort(switchV6targetDNSips, config.eps.Port)
+					switchV4Targets = joinHostsPort(switchV4targetDNSips, config.clusterEndpoints.Port)
+					switchV6Targets = joinHostsPort(switchV6targetDNSips, config.clusterEndpoints.Port)
 				}
 				// OCP HACK end
 
 				// Substitute the special vip "node" for the node's physical ips
 				// This is used for nodeport
-				vips = make([]string, 0, len(vips))
+				vips := make([]string, 0, len(config.vips))
 				for _, vip := range config.vips {
 					if vip == placeholderNodeIPs {
 						vips = append(vips, node.nodeIPs...)
@@ -382,10 +439,10 @@ func buildPerNodeLBs(service *v1.Service, configs []lbConfig, nodes []nodeInfo) 
 					if config.externalTrafficLocal && config.hasNodePort {
 						// add special masqueradeIP as a vip if its nodePort svc with ETP=local
 						mvip := types.V4HostETPLocalMasqueradeIP
-						targetsETP := ovnlb.JoinHostsPort(switchV4targetips, config.eps.Port)
+						targetsETP := ovnlb.JoinHostsPort(switchV4TargetIPs, config.clusterEndpoints.Port)
 						if isv6 {
 							mvip = types.V6HostETPLocalMasqueradeIP
-							targetsETP = ovnlb.JoinHostsPort(switchV6targetips, config.eps.Port)
+							targetsETP = ovnlb.JoinHostsPort(switchV6TargetIPs, config.clusterEndpoints.Port)
 						}
 						switchRules = append(switchRules, ovnlb.LBRule{
 							Source:  ovnlb.Addr{IP: mvip, Port: config.inport},
@@ -393,9 +450,9 @@ func buildPerNodeLBs(service *v1.Service, configs []lbConfig, nodes []nodeInfo) 
 						})
 					}
 					if config.internalTrafficLocal && util.IsClusterIP(vip) { // ITP only applicable to CIP
-						targetsITP := ovnlb.JoinHostsPort(switchV4targetips, config.eps.Port)
+						targetsITP := ovnlb.JoinHostsPort(switchV4TargetIPs, config.clusterEndpoints.Port)
 						if isv6 {
-							targetsITP = ovnlb.JoinHostsPort(switchV6targetips, config.eps.Port)
+							targetsITP = ovnlb.JoinHostsPort(switchV6TargetIPs, config.clusterEndpoints.Port)
 						}
 						switchRules = append(switchRules, ovnlb.LBRule{
 							Source:  ovnlb.Addr{IP: vip, Port: config.inport},
@@ -571,4 +628,127 @@ func canMergeLB(a, b ovnlb.LB) bool {
 	// While rules are actually a set, we generate all our lbConfigs from a single source
 	// so the ordering will be the same. Thus, we can cheat and just reflect.DeepEqual
 	return reflect.DeepEqual(a.Rules, b.Rules)
+}
+
+// joinHostsPort takes a list of IPs and a port and converts it to a list of Addrs
+func joinHostsPort(ips []string, port int32) []ovnlb.Addr {
+	out := make([]ovnlb.Addr, 0, len(ips))
+	for _, ip := range ips {
+		out = append(out, ovnlb.Addr{IP: ip, Port: port})
+	}
+	return out
+}
+
+func getServicePortKey(protocol v1.Protocol, name string) string {
+	return fmt.Sprintf("%s/%s", protocol, name)
+}
+
+// GetEndpointsForService takes a service, all its slices and the list of nodes in the OVN zone
+// and returns two maps that hold all the endpoint addresses for the service:
+// one classified by port, one classified by port,node. This second map is only filled in
+// when the service needs local (per-node) endpoints, that is when ETP=local or ITP=local.
+// The node list helps to keep the resulting map small, since we're only interested in local endpoints.
+func getEndpointsForService(slices []*discovery.EndpointSlice, service *v1.Service, nodes sets.String) (map[string]lbEndpoints, map[string]map[string]lbEndpoints) {
+	// classify endpoints
+	ports := map[string]int32{}
+	portToEndpoints := map[string][]discovery.Endpoint{}
+	portToNodeToEndpoints := map[string]map[string][]discovery.Endpoint{}
+	requiresLocalEndpoints := util.ServiceExternalTrafficPolicyLocal(service) || util.ServiceInternalTrafficPolicyLocal(service)
+
+	for _, port := range service.Spec.Ports {
+		name := getServicePortKey(port.Protocol, port.Name)
+		ports[name] = 0
+	}
+
+	for _, slice := range slices {
+
+		if slice.AddressType == discovery.AddressTypeFQDN {
+			continue // consider only v4 and v6, discard FQDN
+		}
+
+		slicePorts := make([]string, 0, len(slice.Ports))
+
+		for _, port := range slice.Ports {
+			// check if there's a service port matching the slice protocol/name
+			slicePortName := ""
+			if port.Name != nil {
+				slicePortName = *port.Name
+			}
+			name := getServicePortKey(*port.Protocol, slicePortName)
+			if _, hasPort := ports[name]; hasPort {
+				slicePorts = append(slicePorts, name)
+				ports[name] = *port.Port
+				continue
+			}
+			// service port name might be empty: check against slice protocol/""
+			noName := getServicePortKey(*port.Protocol, "")
+			if _, hasPort := ports[noName]; hasPort {
+				slicePorts = append(slicePorts, name)
+				ports[noName] = *port.Port
+			}
+		}
+		for _, endpoint := range slice.Endpoints {
+			for _, port := range slicePorts {
+
+				portToEndpoints[port] = append(portToEndpoints[port], endpoint)
+
+				// won't add items to portToNodeToEndpoints if  the service doesn't need it,
+				// the endpoint is not assigned to a node yet or the endpoint is not local to the OVN zone
+				if !requiresLocalEndpoints || endpoint.NodeName == nil || !nodes.Has(*endpoint.NodeName) {
+					continue
+				}
+				if portToNodeToEndpoints[port] == nil {
+					portToNodeToEndpoints[port] = make(map[string][]discovery.Endpoint, len(nodes))
+				}
+
+				if portToNodeToEndpoints[port][*endpoint.NodeName] == nil {
+					portToNodeToEndpoints[port][*endpoint.NodeName] = []discovery.Endpoint{}
+				}
+				portToNodeToEndpoints[port][*endpoint.NodeName] = append(portToNodeToEndpoints[port][*endpoint.NodeName], endpoint)
+			}
+		}
+	}
+
+	// get eligible endpoint addresses
+	portToLBEndpoints := make(map[string]lbEndpoints, len(portToEndpoints))
+	portToNodeToLBEndpoints := make(map[string]map[string]lbEndpoints, len(portToEndpoints))
+
+	for port, endpoints := range portToEndpoints {
+		addresses := util.GetEligibleEndpointAddresses(endpoints, service)
+		v4IPs, _ := util.MatchAllIPStringFamily(false, addresses)
+		v6IPs, _ := util.MatchAllIPStringFamily(true, addresses)
+		if len(v4IPs) > 0 || len(v6IPs) > 0 {
+			portToLBEndpoints[port] = lbEndpoints{
+				V4IPs: v4IPs,
+				V6IPs: v6IPs,
+				Port:  ports[port],
+			}
+		}
+	}
+	klog.V(5).Infof("Cluster endpoints for %s/%s are: %v", service.Namespace, service.Name, portToLBEndpoints)
+
+	for port, nodeToEndpoints := range portToNodeToEndpoints {
+		for node, endpoints := range nodeToEndpoints {
+			addresses := util.GetEligibleEndpointAddresses(endpoints, service)
+			v4IPs, _ := util.MatchAllIPStringFamily(false, addresses)
+			v6IPs, _ := util.MatchAllIPStringFamily(true, addresses)
+			if len(v4IPs) > 0 || len(v6IPs) > 0 {
+				if portToNodeToLBEndpoints[port] == nil {
+					portToNodeToLBEndpoints[port] = make(map[string]lbEndpoints, len(nodes))
+				}
+
+				portToNodeToLBEndpoints[port][node] = lbEndpoints{
+					V4IPs: v4IPs,
+					V6IPs: v6IPs,
+					Port:  ports[port],
+				}
+			}
+		}
+	}
+
+	if requiresLocalEndpoints {
+		klog.V(5).Infof("Local endpoints for %s/%s are: %v", service.Namespace, service.Name, portToNodeToLBEndpoints)
+	}
+
+	return portToLBEndpoints, portToNodeToLBEndpoints
 }

--- a/go-controller/pkg/ovn/controller/services/load_balancer.go
+++ b/go-controller/pkg/ovn/controller/services/load_balancer.go
@@ -64,7 +64,7 @@ var protos = []v1.Protocol{
 func buildServiceLBConfigs(service *v1.Service, endpointSlices []*discovery.EndpointSlice) (perNodeConfigs []lbConfig, clusterConfigs []lbConfig) {
 	// For each svcPort, determine if it will be applied per-node or cluster-wide
 	for _, svcPort := range service.Spec.Ports {
-		eps := util.GetLbEndpoints(endpointSlices, svcPort, service.Spec.PublishNotReadyAddresses)
+		eps := util.GetLbEndpoints(endpointSlices, svcPort, service)
 
 		// if ExternalTrafficPolicy or InternalTrafficPolicy is local, then we need to do things a bit differently
 		externalTrafficLocal := (service.Spec.ExternalTrafficPolicy == v1.ServiceExternalTrafficPolicyTypeLocal)

--- a/go-controller/pkg/ovn/controller/services/load_balancer_ocphack_test.go
+++ b/go-controller/pkg/ovn/controller/services/load_balancer_ocphack_test.go
@@ -1,0 +1,438 @@
+package services
+
+import (
+	"fmt"
+	"net"
+	"testing"
+
+	globalconfig "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	ovnlb "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/loadbalancer"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+// OCP hack begin
+
+func Test_buildPerNodeLBs_OCPHackForDNS(t *testing.T) {
+	oldClusterSubnet := globalconfig.Default.ClusterSubnets
+	oldGwMode := globalconfig.Gateway.Mode
+	defer func() {
+		globalconfig.Gateway.Mode = oldGwMode
+		globalconfig.Default.ClusterSubnets = oldClusterSubnet
+	}()
+	_, cidr4, _ := net.ParseCIDR("10.128.0.0/16")
+	_, cidr6, _ := net.ParseCIDR("fe00::/64")
+	globalconfig.Default.ClusterSubnets = []globalconfig.CIDRNetworkEntry{{cidr4, 26}, {cidr6, 26}}
+
+	name := "dns-default"
+	namespace := "openshift-dns"
+
+	defaultService := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: v1.ServiceSpec{
+			Type: v1.ServiceTypeClusterIP,
+		},
+	}
+
+	defaultNodes := []nodeInfo{
+		{
+			name:              nodeA,
+			nodeIPs:           []string{"10.0.0.1"},
+			gatewayRouterName: "gr-node-a",
+			switchName:        "switch-node-a",
+			podSubnets:        []net.IPNet{{IP: net.ParseIP("10.128.0.0"), Mask: net.CIDRMask(24, 32)}},
+		},
+		{
+			name:              nodeB,
+			nodeIPs:           []string{"10.0.0.2"},
+			gatewayRouterName: "gr-node-b",
+			switchName:        "switch-node-b",
+			podSubnets:        []net.IPNet{{IP: net.ParseIP("10.128.1.0"), Mask: net.CIDRMask(24, 32)}},
+		},
+	}
+
+	defaultExternalIDs := map[string]string{
+		"k8s.ovn.org/kind":  "Service",
+		"k8s.ovn.org/owner": fmt.Sprintf("%s/%s", namespace, name),
+	}
+
+	//defaultRouters := []string{"gr-node-a", "gr-node-b"}
+	//defaultSwitches := []string{"switch-node-a", "switch-node-b"}
+
+	defaultOpts := ovnlb.LBOpts{}
+
+	tc := []struct {
+		name     string
+		service  *v1.Service
+		configs  []lbConfig
+		expected []ovnlb.LB
+	}{
+		{
+			name:    "clusterIP service, standard pods",
+			service: defaultService,
+			configs: []lbConfig{
+				{
+					vips:     []string{"192.168.1.1"},
+					protocol: v1.ProtocolTCP,
+					inport:   80,
+					clusterEndpoints: lbEndpoints{
+						V4IPs: []string{"10.128.0.2", "10.128.1.2"},
+						Port:  8080,
+					},
+				},
+			},
+			expected: []ovnlb.LB{
+				{
+					Name:        "Service_openshift-dns/dns-default_TCP_node_router_node-a_merged",
+					ExternalIDs: defaultExternalIDs,
+					Routers:     []string{"gr-node-a", "gr-node-b"},
+					Protocol:    "TCP",
+					Rules: []ovnlb.LBRule{
+						{
+							Source:  ovnlb.Addr{IP: "192.168.1.1", Port: 80},
+							Targets: []ovnlb.Addr{{IP: "10.128.0.2", Port: 8080}, {IP: "10.128.1.2", Port: 8080}},
+						},
+					},
+					Opts: defaultOpts,
+				},
+				{
+					Name:        "Service_openshift-dns/dns-default_TCP_node_switch_node-a",
+					ExternalIDs: defaultExternalIDs,
+					Switches:    []string{"switch-node-a"},
+					Protocol:    "TCP",
+					Rules: []ovnlb.LBRule{
+						{
+							Source:  ovnlb.Addr{IP: "192.168.1.1", Port: 80},
+							Targets: []ovnlb.Addr{{IP: "10.128.0.2", Port: 8080}},
+						},
+					},
+					Opts: defaultOpts,
+				},
+				{
+					Name:        "Service_openshift-dns/dns-default_TCP_node_switch_node-b",
+					ExternalIDs: defaultExternalIDs,
+					Switches:    []string{"switch-node-b"},
+					Protocol:    "TCP",
+					Rules: []ovnlb.LBRule{
+						{
+							Source:  ovnlb.Addr{IP: "192.168.1.1", Port: 80},
+							Targets: []ovnlb.Addr{{IP: "10.128.1.2", Port: 8080}},
+						},
+					},
+					Opts: defaultOpts,
+				},
+			},
+		},
+	}
+
+	for i, tt := range tc {
+		t.Run(fmt.Sprintf("%d_%s", i, tt.name), func(t *testing.T) {
+
+			globalconfig.Gateway.Mode = globalconfig.GatewayModeShared
+			actual := buildPerNodeLBs(tt.service, tt.configs, defaultNodes)
+			assert.Equal(t, tt.expected, actual, "shared gateway mode not as expected")
+
+			globalconfig.Gateway.Mode = globalconfig.GatewayModeLocal
+			actual = buildPerNodeLBs(tt.service, tt.configs, defaultNodes)
+			assert.Equal(t, tt.expected, actual, "local gateway mode not as expected")
+		})
+	}
+}
+
+func Test_buildPerNodeLBs_OCPHackForLocalWithFallback(t *testing.T) {
+	oldClusterSubnet := globalconfig.Default.ClusterSubnets
+	oldGwMode := globalconfig.Gateway.Mode
+	defer func() {
+		globalconfig.Gateway.Mode = oldGwMode
+		globalconfig.Default.ClusterSubnets = oldClusterSubnet
+	}()
+	_, cidr4, _ := net.ParseCIDR("10.128.0.0/16")
+	globalconfig.Default.ClusterSubnets = []globalconfig.CIDRNetworkEntry{{cidr4, 26}}
+
+	name := "router-default"
+	namespace := "openshift-ingress"
+	inport := int32(80)
+	outport := int32(8080)
+
+	defaultService := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   namespace,
+			Annotations: map[string]string{localWithFallbackAnnotation: ""}, // code checks for this annotation
+		},
+		Spec: v1.ServiceSpec{
+			Type:                  v1.ServiceTypeLoadBalancer,
+			ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeLocal,
+			// add ingress IP
+			ClusterIP:  "192.168.1.1",
+			ClusterIPs: []string{"192.168.1.1"},
+			Ports: []v1.ServicePort{ // don't consider https for simplicity
+				{
+					Name:       "http",
+					Port:       80,
+					Protocol:   v1.ProtocolTCP,
+					TargetPort: intstr.FromInt(80),
+					NodePort:   5,
+				},
+			},
+		},
+		Status: v1.ServiceStatus{
+			LoadBalancer: v1.LoadBalancerStatus{
+				Ingress: []v1.LoadBalancerIngress{{
+					IP: "5.5.5.5",
+				}},
+			},
+		},
+	}
+
+	defaultNodes := []nodeInfo{
+		{
+			name:              nodeA,
+			nodeIPs:           []string{"10.0.0.1"},
+			gatewayRouterName: "gr-node-a",
+			switchName:        "switch-node-a",
+			podSubnets:        []net.IPNet{{IP: net.ParseIP("10.128.0.0"), Mask: net.CIDRMask(24, 32)}},
+		},
+		{
+			name:              nodeB,
+			nodeIPs:           []string{"10.0.0.2"},
+			gatewayRouterName: "gr-node-b",
+			switchName:        "switch-node-b",
+			podSubnets:        []net.IPNet{{IP: net.ParseIP("10.128.1.0"), Mask: net.CIDRMask(24, 32)}},
+		},
+	}
+
+	defaultExternalIDs := map[string]string{
+		"k8s.ovn.org/kind":  "Service",
+		"k8s.ovn.org/owner": fmt.Sprintf("%s/%s", namespace, name),
+	}
+
+	defaultOpts := ovnlb.LBOpts{}
+	noSNATOpts := ovnlb.LBOpts{SkipSNAT: true}
+
+	tc := []struct {
+		name     string
+		service  *v1.Service
+		configs  []lbConfig
+		expected []ovnlb.LB
+	}{
+		{
+			name:    "Load Balancer service with ETP local and local-with-fallback annotation, ovn-networked endpoints, all endpoints are up: no fallback",
+			service: defaultService,
+			configs: []lbConfig{
+				{
+					vips:                 []string{"node"}, //  placeholder for node IP
+					protocol:             v1.ProtocolTCP,
+					inport:               5, // node port
+					externalTrafficLocal: true,
+					hasNodePort:          true,
+					clusterEndpoints: lbEndpoints{
+						V4IPs: []string{"10.128.0.2", "10.128.1.2"},
+						Port:  outport,
+					},
+					nodeEndpoints: map[string]lbEndpoints{
+						nodeA: {V4IPs: []string{"10.128.0.2"}, Port: outport},
+						nodeB: {V4IPs: []string{"10.128.1.2"}, Port: outport},
+					},
+				},
+				{
+					vips:                 []string{"5.5.5.5"}, // external VIP
+					protocol:             v1.ProtocolTCP,
+					inport:               inport,
+					externalTrafficLocal: true,
+					clusterEndpoints: lbEndpoints{
+						V4IPs: []string{"10.128.0.2", "10.128.1.2"},
+						Port:  outport,
+					},
+					nodeEndpoints: map[string]lbEndpoints{
+						nodeA: {V4IPs: []string{"10.128.0.2"}, Port: outport},
+						nodeB: {V4IPs: []string{"10.128.1.2"}, Port: outport},
+					},
+				},
+			},
+			expected: []ovnlb.LB{
+				{
+					Name:        "Service_openshift-ingress/router-default_TCP_node_local_router_node-a",
+					Protocol:    "TCP",
+					ExternalIDs: defaultExternalIDs,
+					Opts:        noSNATOpts,
+					Routers:     []string{"gr-node-a"},
+					Rules: []ovnlb.LBRule{
+						{
+							Source:  ovnlb.Addr{IP: "10.0.0.1", Port: 5},
+							Targets: []ovnlb.Addr{{IP: "10.128.0.2", Port: 8080}}},
+						{
+							Source:  ovnlb.Addr{IP: "5.5.5.5", Port: 80},
+							Targets: []ovnlb.Addr{{IP: "10.128.0.2", Port: 8080}}}},
+				},
+				{
+					Name:        "Service_openshift-ingress/router-default_TCP_node_switch_node-a",
+					Protocol:    "TCP",
+					ExternalIDs: defaultExternalIDs,
+					Opts:        defaultOpts,
+					Switches:    []string{"switch-node-a"},
+					Rules: []ovnlb.LBRule{
+						{
+							Source:  ovnlb.Addr{IP: "169.254.169.3", Port: 5},
+							Targets: []ovnlb.Addr{{IP: "10.128.0.2", Port: 8080}}},
+						{
+							Source:  ovnlb.Addr{IP: "10.0.0.1", Port: 5},
+							Targets: []ovnlb.Addr{{IP: "10.128.0.2", Port: 8080}, {IP: "10.128.1.2", Port: 8080}}},
+						{
+							Source:  ovnlb.Addr{IP: "5.5.5.5", Port: 80},
+							Targets: []ovnlb.Addr{{IP: "10.128.0.2", Port: 8080}, {IP: "10.128.1.2", Port: 8080}}}},
+				},
+				{
+					Name:        "Service_openshift-ingress/router-default_TCP_node_local_router_node-b",
+					Protocol:    "TCP",
+					ExternalIDs: defaultExternalIDs,
+					Opts:        noSNATOpts,
+					Routers:     []string{"gr-node-b"},
+					Rules: []ovnlb.LBRule{
+						{
+							Source:  ovnlb.Addr{IP: "10.0.0.2", Port: 5},
+							Targets: []ovnlb.Addr{{IP: "10.128.1.2", Port: 8080}}},
+						{
+							Source:  ovnlb.Addr{IP: "5.5.5.5", Port: 80},
+							Targets: []ovnlb.Addr{{IP: "10.128.1.2", Port: 8080}}}},
+				},
+				{
+					Name:        "Service_openshift-ingress/router-default_TCP_node_switch_node-b",
+					Protocol:    "TCP",
+					ExternalIDs: defaultExternalIDs,
+					Opts:        defaultOpts,
+					Rules: []ovnlb.LBRule{
+						{
+							Source:  ovnlb.Addr{IP: "169.254.169.3", Port: 5},
+							Targets: []ovnlb.Addr{{IP: "10.128.1.2", Port: 8080}}},
+						{
+							Source:  ovnlb.Addr{IP: "10.0.0.2", Port: 5},
+							Targets: []ovnlb.Addr{{IP: "10.128.0.2", Port: 8080}, {IP: "10.128.1.2", Port: 8080}}},
+						{
+							Source:  ovnlb.Addr{IP: "5.5.5.5", Port: 80},
+							Targets: []ovnlb.Addr{{IP: "10.128.0.2", Port: 8080}, {IP: "10.128.1.2", Port: 8080}}}},
+					Switches: []string{"switch-node-b"},
+				},
+			},
+		},
+		{
+			name:    "Load Balancer service with ETP local and local-with-fallback annotation, ovn-networked endpoints, endpoint on node-a is down: fallback to ETP Cluster",
+			service: defaultService,
+			configs: []lbConfig{
+				{
+					vips:                 []string{"node"}, //  placeholder for node IP
+					protocol:             v1.ProtocolTCP,
+					inport:               5, // node port
+					externalTrafficLocal: true,
+					hasNodePort:          true,
+					clusterEndpoints: lbEndpoints{
+						V4IPs: []string{"10.128.1.2"}, // only endpoint on node-b is running
+						Port:  outport,
+					},
+					nodeEndpoints: map[string]lbEndpoints{
+						nodeB: {V4IPs: []string{"10.128.1.2"}, Port: outport},
+					},
+				},
+				{
+					vips:                 []string{"5.5.5.5"}, // external VIP
+					protocol:             v1.ProtocolTCP,
+					inport:               inport,
+					externalTrafficLocal: true,
+					clusterEndpoints: lbEndpoints{
+						V4IPs: []string{"10.128.1.2"},
+						Port:  outport,
+					},
+					nodeEndpoints: map[string]lbEndpoints{
+						nodeB: {V4IPs: []string{"10.128.1.2"}, Port: outport},
+					},
+				},
+			},
+			expected: []ovnlb.LB{
+				{
+					Name:        "Service_openshift-ingress/router-default_TCP_node_router_node-a", // fallback, because no local endpoints left
+					Protocol:    "TCP",
+					ExternalIDs: defaultExternalIDs,
+					Opts:        defaultOpts,
+					Routers:     []string{"gr-node-a"},
+					Rules: []ovnlb.LBRule{
+						{
+							Source:  ovnlb.Addr{IP: "10.0.0.1", Port: 5},
+							Targets: []ovnlb.Addr{{IP: "10.128.1.2", Port: 8080}}, // forwarding to endpoint on node-b, as if ETP=Cluster
+						},
+						{
+							Source:  ovnlb.Addr{IP: "5.5.5.5", Port: 80},
+							Targets: []ovnlb.Addr{{IP: "10.128.1.2", Port: 8080}}, // forwarding to endpoint on node-b, as if ETP=Cluster
+						},
+					},
+				},
+				{
+					Name:        "Service_openshift-ingress/router-default_TCP_node_switch_node-a",
+					Protocol:    "TCP",
+					ExternalIDs: defaultExternalIDs,
+					Opts:        defaultOpts,
+					Switches:    []string{"switch-node-a"},
+					Rules: []ovnlb.LBRule{
+						{
+							Source:  ovnlb.Addr{IP: "169.254.169.3", Port: 5},
+							Targets: []ovnlb.Addr{{IP: "10.128.1.2", Port: 8080}}},
+						{
+							Source:  ovnlb.Addr{IP: "10.0.0.1", Port: 5},
+							Targets: []ovnlb.Addr{{IP: "10.128.1.2", Port: 8080}}},
+						{
+							Source:  ovnlb.Addr{IP: "5.5.5.5", Port: 80},
+							Targets: []ovnlb.Addr{{IP: "10.128.1.2", Port: 8080}}}},
+				},
+
+				{
+					Name:        "Service_openshift-ingress/router-default_TCP_node_local_router_node-b",
+					Protocol:    "TCP",
+					ExternalIDs: defaultExternalIDs,
+					Opts:        noSNATOpts,
+					Rules: []ovnlb.LBRule{
+						{
+							Source:  ovnlb.Addr{IP: "10.0.0.2", Port: 5},
+							Targets: []ovnlb.Addr{{IP: "10.128.1.2", Port: 8080}}}, // endpoint is on node-b, so eTP=local is respected
+						{
+							Source:  ovnlb.Addr{IP: "5.5.5.5", Port: 80},
+							Targets: []ovnlb.Addr{{IP: "10.128.1.2", Port: 8080}}}}, // endpoint is on node-b, so eTP=local is respected
+					Switches: []string(nil), Routers: []string{"gr-node-b"},
+				},
+				{
+					Name:        "Service_openshift-ingress/router-default_TCP_node_switch_node-b",
+					UUID:        "",
+					Protocol:    "TCP",
+					ExternalIDs: defaultExternalIDs,
+					Opts:        defaultOpts,
+					Rules: []ovnlb.LBRule{
+						{
+							Source:  ovnlb.Addr{IP: "169.254.169.3", Port: 5},
+							Targets: []ovnlb.Addr{{IP: "10.128.1.2", Port: 8080}}},
+						{
+							Source:  ovnlb.Addr{IP: "10.0.0.2", Port: 5},
+							Targets: []ovnlb.Addr{{IP: "10.128.1.2", Port: 8080}}},
+						{
+							Source:  ovnlb.Addr{IP: "5.5.5.5", Port: 80},
+							Targets: []ovnlb.Addr{{IP: "10.128.1.2", Port: 8080}}}},
+					Switches: []string{"switch-node-b"},
+				},
+			},
+		},
+	}
+
+	for i, tt := range tc {
+		t.Run(fmt.Sprintf("%d_%s", i, tt.name), func(t *testing.T) {
+
+			globalconfig.Gateway.Mode = globalconfig.GatewayModeShared
+			actual := buildPerNodeLBs(tt.service, tt.configs, defaultNodes)
+			assert.Equal(t, tt.expected, actual, "shared gateway mode not as expected")
+
+			globalconfig.Gateway.Mode = globalconfig.GatewayModeLocal
+			actual = buildPerNodeLBs(tt.service, tt.configs, defaultNodes)
+			assert.Equal(t, tt.expected, actual, "local gateway mode not as expected")
+		})
+	}
+}
+
+// OCP hack end

--- a/go-controller/pkg/ovn/controller/services/load_balancer_test.go
+++ b/go-controller/pkg/ovn/controller/services/load_balancer_test.go
@@ -7,15 +7,114 @@ import (
 
 	globalconfig "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	ovnlb "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/loadbalancer"
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	kube_test "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
 	"github.com/stretchr/testify/assert"
 
 	v1 "k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/sets"
 	utilpointer "k8s.io/utils/pointer"
 )
+
+var (
+	nodeA        = "node-a"
+	nodeB        = "node-b"
+	defaultNodes = []nodeInfo{
+		{
+			name:              nodeA,
+			nodeIPs:           []string{"10.0.0.1"},
+			gatewayRouterName: "gr-node-a",
+			switchName:        "switch-node-a",
+		},
+		{
+			name:              nodeB,
+			nodeIPs:           []string{"10.0.0.2"},
+			gatewayRouterName: "gr-node-b",
+			switchName:        "switch-node-b",
+		},
+	}
+
+	tcpv1 = v1.ProtocolTCP
+	udpv1 = v1.ProtocolUDP
+
+	httpPortName    string = "http"
+	httpPortValue   int32  = int32(80)
+	httpsPortName   string = "https"
+	httpsPortValue  int32  = int32(443)
+	customPortName  string = "customApp"
+	customPortValue int32  = int32(10600)
+)
+
+func getSampleService(publishNotReadyAddresses bool) *v1.Service {
+	name := "service-test"
+	namespace := "test"
+	return &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:       k8stypes.UID(namespace),
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: v1.ServiceSpec{
+			PublishNotReadyAddresses: publishNotReadyAddresses,
+		},
+	}
+}
+
+func getServicePort(name string, targetPort int32, protocol v1.Protocol) v1.ServicePort {
+	return v1.ServicePort{
+		Name:       name,
+		TargetPort: intstr.FromInt(int(httpPortValue)),
+		Protocol:   protocol,
+	}
+}
+
+func getSampleServiceWithOnePort(name string, targetPort int32, protocol v1.Protocol) *v1.Service {
+	service := getSampleService(false)
+	service.Spec.Ports = []v1.ServicePort{getServicePort(name, targetPort, protocol)}
+	return service
+}
+
+func getSampleServiceWithOnePortAndETPLocal(name string, targetPort int32, protocol v1.Protocol) *v1.Service {
+	service := getSampleServiceWithOnePort(name, targetPort, protocol)
+	service.Spec.Type = v1.ServiceTypeLoadBalancer
+	service.Spec.ExternalTrafficPolicy = v1.ServiceExternalTrafficPolicyTypeLocal
+	return service
+}
+
+// OCP hack begin
+func getSampleServiceWithOnePortAndITPLocal(name string, targetPort int32, protocol v1.Protocol) *v1.Service {
+	service := getSampleServiceWithOnePort(name, targetPort, protocol)
+	service.Spec.Type = v1.ServiceTypeLoadBalancer
+	local := v1.ServiceInternalTrafficPolicyLocal
+	service.Spec.InternalTrafficPolicy = &local
+	return service
+}
+
+// OCP hack end
+
+func getSampleServiceWithTwoPorts(name1, name2 string, targetPort1, targetPort2 int32, protocol1, protocol2 v1.Protocol) *v1.Service {
+	service := getSampleService(false)
+	service.Spec.Ports = []v1.ServicePort{
+		getServicePort(name1, targetPort1, protocol1),
+		getServicePort(name2, targetPort2, protocol2)}
+	return service
+}
+
+func getSampleServiceWithTwoPortsAndETPLocal(name1, name2 string, targetPort1, targetPort2 int32, protocol1, protocol2 v1.Protocol) *v1.Service {
+	service := getSampleServiceWithTwoPorts(name1, name2, targetPort1, targetPort2, protocol1, protocol2)
+	service.Spec.Type = v1.ServiceTypeLoadBalancer
+	service.Spec.ExternalTrafficPolicy = v1.ServiceExternalTrafficPolicyTypeLocal
+	return service
+}
+
+func getSampleServiceWithOnePortAndPublishNotReadyAddresses(name string, targetPort int32, protocol v1.Protocol) *v1.Service {
+	service := getSampleServiceWithOnePort(name, targetPort, protocol)
+	service.Spec.PublishNotReadyAddresses = true
+	return service
+}
 
 func Test_buildServiceLBConfigs(t *testing.T) {
 	oldClusterSubnet := globalconfig.Default.ClusterSubnets
@@ -38,7 +137,6 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 	inport1 := int32(81)
 	outport1 := int32(8081)
 	outportstr := intstr.FromInt(int(outport))
-	emptyEPs := util.LbEndpoints{V4IPs: []string{}, V6IPs: []string{}, Port: 0}
 	tcp := v1.ProtocolTCP
 	udp := v1.ProtocolUDP
 
@@ -71,14 +169,7 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 					Name:     &portName,
 				}},
 				AddressType: discovery.AddressTypeIPv4,
-				Endpoints: []discovery.Endpoint{
-					{
-						Conditions: discovery.EndpointConditions{
-							Ready: utilpointer.BoolPtr(true),
-						},
-						Addresses: v4ips,
-					},
-				},
+				Endpoints:   kube_test.MakeReadyEndpointList(nodeA, v4ips...),
 			})
 		}
 
@@ -106,18 +197,29 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 					Name:     &portName,
 				}},
 				AddressType: discovery.AddressTypeIPv6,
-				Endpoints: []discovery.Endpoint{
-					{
-						Conditions: discovery.EndpointConditions{
-							Ready: utilpointer.BoolPtr(true),
-						},
-						Addresses: v6ips,
-					},
-				},
+				Endpoints:   kube_test.MakeReadyEndpointList(nodeA, v6ips...),
 			})
 		}
 
 		return out
+	}
+
+	makeV4SliceWithEndpoints := func(proto v1.Protocol, endpoints ...discovery.Endpoint) []*discovery.EndpointSlice {
+		e := &discovery.EndpointSlice{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      serviceName + "ab1",
+				Namespace: ns,
+				Labels:    map[string]string{discovery.LabelServiceName: serviceName},
+			},
+			Ports: []discovery.EndpointPort{{
+				Protocol: &proto,
+				Port:     &outport,
+				Name:     &portName,
+			}},
+			AddressType: discovery.AddressTypeIPv4,
+			Endpoints:   endpoints,
+		}
+		return []*discovery.EndpointSlice{e}
 	}
 
 	type args struct {
@@ -147,6 +249,7 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 						ClusterIP:  "192.168.1.1",
 						ClusterIPs: []string{"192.168.1.1"},
 						Ports: []v1.ServicePort{{
+							Name:       portName,
 							Port:       inport,
 							Protocol:   v1.ProtocolTCP,
 							TargetPort: outportstr,
@@ -155,10 +258,11 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 				},
 			},
 			resultSharedGatewayCluster: []lbConfig{{
-				vips:     []string{"192.168.1.1"},
-				protocol: v1.ProtocolTCP,
-				inport:   80,
-				eps:      emptyEPs,
+				vips:             []string{"192.168.1.1"},
+				protocol:         v1.ProtocolTCP,
+				inport:           80,
+				clusterEndpoints: lbEndpoints{},
+				nodeEndpoints:    map[string]lbEndpoints{},
 			}},
 			resultsSame: true,
 		},
@@ -173,6 +277,7 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 						ClusterIP:  "192.168.1.1",
 						ClusterIPs: []string{"192.168.1.1"},
 						Ports: []v1.ServicePort{{
+							Name:       portName,
 							Port:       inport,
 							Protocol:   v1.ProtocolTCP,
 							TargetPort: outportstr,
@@ -184,16 +289,53 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 				vips:     []string{"192.168.1.1"},
 				protocol: v1.ProtocolTCP,
 				inport:   inport,
-				eps: util.LbEndpoints{
+				clusterEndpoints: lbEndpoints{
 					V4IPs: []string{"10.128.0.2"},
-					V6IPs: []string{},
 					Port:  outport,
+				},
+				nodeEndpoints: map[string]lbEndpoints{}, // service is not ETP=local or ITP=local, so nodeEndpoints is not filled out
+			}},
+			resultsSame: true,
+		},
+		{
+			name: "v4 type=LoadBalancer, ETP=local, one port, endpoints",
+			args: args{
+				slices: makeSlices([]string{"10.128.0.2"}, nil, v1.ProtocolTCP),
+				service: &v1.Service{
+					ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: ns},
+					Spec: v1.ServiceSpec{
+						Type:                  v1.ServiceTypeLoadBalancer,
+						ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeLocal,
+						ClusterIP:             "192.168.1.1",
+						ClusterIPs:            []string{"192.168.1.1"},
+						Ports: []v1.ServicePort{{
+							Name:       portName,
+							Port:       inport,
+							Protocol:   v1.ProtocolTCP,
+							TargetPort: outportstr,
+						}},
+					},
+				},
+			},
+			resultSharedGatewayCluster: []lbConfig{{
+				vips:     []string{"192.168.1.1"},
+				protocol: v1.ProtocolTCP,
+				inport:   inport,
+				clusterEndpoints: lbEndpoints{
+					V4IPs: []string{"10.128.0.2"},
+					Port:  outport,
+				},
+				nodeEndpoints: map[string]lbEndpoints{ // service is ETP=local, so nodeEndpoints is filled out
+					nodeA: {
+						V4IPs: []string{"10.128.0.2"},
+						Port:  outport,
+					},
 				},
 			}},
 			resultsSame: true,
 		},
 		{
-			name: "v4 clusterip, two tcp ports, endpoints",
+			name: "v4 clusterip, two tcp ports, two endpoints",
 			args: args{
 				slices: []*discovery.EndpointSlice{
 					{
@@ -214,14 +356,7 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 							},
 						},
 						AddressType: discovery.AddressTypeIPv4,
-						Endpoints: []discovery.Endpoint{
-							{
-								Conditions: discovery.EndpointConditions{
-									Ready: utilpointer.BoolPtr(true),
-								},
-								Addresses: []string{"10.128.0.2", "10.128.1.2"},
-							},
-						},
+						Endpoints:   kube_test.MakeReadyEndpointList(nodeA, "10.128.0.2", "10.128.1.2"),
 					},
 				},
 				service: &v1.Service{
@@ -253,26 +388,26 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 					vips:     []string{"192.168.1.1"},
 					protocol: v1.ProtocolTCP,
 					inport:   inport,
-					eps: util.LbEndpoints{
+					clusterEndpoints: lbEndpoints{
 						V4IPs: []string{"10.128.0.2", "10.128.1.2"},
-						V6IPs: []string{},
 						Port:  outport,
 					},
+					nodeEndpoints: map[string]lbEndpoints{},
 				},
 				{
 					vips:     []string{"192.168.1.1"},
 					protocol: v1.ProtocolTCP,
 					inport:   inport1,
-					eps: util.LbEndpoints{
+					clusterEndpoints: lbEndpoints{
 						V4IPs: []string{"10.128.0.2", "10.128.1.2"},
-						V6IPs: []string{},
 						Port:  outport1,
 					},
+					nodeEndpoints: map[string]lbEndpoints{},
 				},
 			},
 		},
 		{
-			name: "v4 clusterip, one tcp, one udp port, endpoints",
+			name: "v4 clusterip, one tcp, one udp port, two endpoints",
 			args: args{
 				slices: []*discovery.EndpointSlice{
 					{
@@ -293,14 +428,7 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 							},
 						},
 						AddressType: discovery.AddressTypeIPv4,
-						Endpoints: []discovery.Endpoint{
-							{
-								Conditions: discovery.EndpointConditions{
-									Ready: utilpointer.BoolPtr(true),
-								},
-								Addresses: []string{"10.128.0.2", "10.128.1.2"},
-							},
-						},
+						Endpoints:   kube_test.MakeReadyEndpointList(nodeA, "10.128.0.2", "10.128.1.2"),
 					},
 				},
 				service: &v1.Service{
@@ -332,21 +460,21 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 					vips:     []string{"192.168.1.1"},
 					protocol: v1.ProtocolTCP,
 					inport:   inport,
-					eps: util.LbEndpoints{
+					clusterEndpoints: lbEndpoints{
 						V4IPs: []string{"10.128.0.2", "10.128.1.2"},
-						V6IPs: []string{},
 						Port:  outport,
 					},
+					nodeEndpoints: map[string]lbEndpoints{},
 				},
 				{
 					vips:     []string{"192.168.1.1"},
 					protocol: v1.ProtocolUDP,
 					inport:   inport,
-					eps: util.LbEndpoints{
+					clusterEndpoints: lbEndpoints{
 						V4IPs: []string{"10.128.0.2", "10.128.1.2"},
-						V6IPs: []string{},
 						Port:  outport,
 					},
+					nodeEndpoints: map[string]lbEndpoints{},
 				},
 			},
 		},
@@ -361,6 +489,7 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 						ClusterIP:  "192.168.1.1",
 						ClusterIPs: []string{"192.168.1.1", "2002::1"},
 						Ports: []v1.ServicePort{{
+							Name:       portName,
 							Port:       inport,
 							Protocol:   v1.ProtocolTCP,
 							TargetPort: outportstr,
@@ -373,11 +502,12 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 				vips:     []string{"192.168.1.1", "2002::1"},
 				protocol: v1.ProtocolTCP,
 				inport:   inport,
-				eps: util.LbEndpoints{
+				clusterEndpoints: lbEndpoints{
 					V4IPs: []string{"10.128.0.2"},
 					V6IPs: []string{"fe00::1:1"},
 					Port:  outport,
 				},
+				nodeEndpoints: map[string]lbEndpoints{},
 			}},
 		},
 		{
@@ -391,6 +521,7 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 						ClusterIP:  "192.168.1.1",
 						ClusterIPs: []string{"192.168.1.1", "2002::1"},
 						Ports: []v1.ServicePort{{
+							Name:       portName,
 							Port:       inport,
 							Protocol:   v1.ProtocolTCP,
 							TargetPort: outportstr,
@@ -411,15 +542,16 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 				vips:     []string{"192.168.1.1", "2002::1", "4.2.2.2", "42::42", "5.5.5.5"},
 				protocol: v1.ProtocolTCP,
 				inport:   inport,
-				eps: util.LbEndpoints{
+				clusterEndpoints: lbEndpoints{
 					V4IPs: []string{"10.128.0.2"},
 					V6IPs: []string{"fe00::1:1"},
 					Port:  outport,
 				},
+				nodeEndpoints: map[string]lbEndpoints{}, // ETP=cluster (default), so nodeEndpoints is not filled out
 			}},
 		},
 		{
-			name: "dual-stack clusterip, one port, endpoints, external ips + lb status, ExternalTrafficPolicy",
+			name: "dual-stack clusterip, one port, endpoints, external ips + lb status, ExternalTrafficPolicy=local",
 			args: args{
 				slices: makeSlices([]string{"10.128.0.2"}, []string{"fe00::1:1"}, v1.ProtocolTCP),
 				service: &v1.Service{
@@ -430,6 +562,7 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 						ClusterIPs:            []string{"192.168.1.1", "2002::1"},
 						ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeLocal,
 						Ports: []v1.ServicePort{{
+							Name:       portName,
 							Port:       inport,
 							Protocol:   v1.ProtocolTCP,
 							TargetPort: outportstr,
@@ -451,10 +584,17 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 					vips:     []string{"192.168.1.1", "2002::1"},
 					protocol: v1.ProtocolTCP,
 					inport:   inport,
-					eps: util.LbEndpoints{
+					clusterEndpoints: lbEndpoints{
 						V4IPs: []string{"10.128.0.2"},
 						V6IPs: []string{"fe00::1:1"},
 						Port:  outport,
+					},
+					nodeEndpoints: map[string]lbEndpoints{
+						nodeA: {
+							V4IPs: []string{"10.128.0.2"},
+							V6IPs: []string{"fe00::1:1"},
+							Port:  outport,
+						},
 					},
 				},
 			},
@@ -464,10 +604,17 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 					protocol:             v1.ProtocolTCP,
 					inport:               inport,
 					externalTrafficLocal: true,
-					eps: util.LbEndpoints{
+					clusterEndpoints: lbEndpoints{
 						V4IPs: []string{"10.128.0.2"},
 						V6IPs: []string{"fe00::1:1"},
 						Port:  outport,
+					},
+					nodeEndpoints: map[string]lbEndpoints{
+						nodeA: {
+							V4IPs: []string{"10.128.0.2"},
+							V6IPs: []string{"fe00::1:1"},
+							Port:  outport,
+						},
 					},
 				},
 			},
@@ -483,6 +630,7 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 						ClusterIP:  "192.168.1.1",
 						ClusterIPs: []string{"192.168.1.1", "2002::1"},
 						Ports: []v1.ServicePort{{
+							Name:       portName,
 							Port:       inport,
 							Protocol:   v1.ProtocolTCP,
 							TargetPort: outportstr,
@@ -496,22 +644,24 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 				vips:     []string{"192.168.1.1", "2002::1"},
 				protocol: v1.ProtocolTCP,
 				inport:   inport,
-				eps: util.LbEndpoints{
+				clusterEndpoints: lbEndpoints{
 					V4IPs: []string{"10.128.0.2"},
 					V6IPs: []string{"fe00::1:1"},
 					Port:  outport,
 				},
+				nodeEndpoints: map[string]lbEndpoints{},
 			}},
 			resultSharedGatewayNode: []lbConfig{{
 				vips:     []string{"node"},
 				protocol: v1.ProtocolTCP,
 				inport:   5,
-				eps: util.LbEndpoints{
+				clusterEndpoints: lbEndpoints{
 					V4IPs: []string{"10.128.0.2"},
 					V6IPs: []string{"fe00::1:1"},
 					Port:  outport,
 				},
-				hasNodePort: true,
+				nodeEndpoints: map[string]lbEndpoints{},
+				hasNodePort:   true,
 			}},
 		},
 		{
@@ -526,6 +676,7 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 						ClusterIP:  "192.168.1.1",
 						ClusterIPs: []string{"192.168.1.1", "2002::1"},
 						Ports: []v1.ServicePort{{
+							Name:       portName,
 							Port:       inport,
 							Protocol:   v1.ProtocolTCP,
 							TargetPort: outportstr,
@@ -540,22 +691,24 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 					vips:     []string{"node"},
 					protocol: v1.ProtocolTCP,
 					inport:   5,
-					eps: util.LbEndpoints{
+					clusterEndpoints: lbEndpoints{
 						V4IPs: []string{"192.168.0.1"},
 						V6IPs: []string{"2001::1"},
 						Port:  outport,
 					},
-					hasNodePort: true,
+					nodeEndpoints: map[string]lbEndpoints{},
+					hasNodePort:   true,
 				},
 				{
 					vips:     []string{"192.168.1.1", "2002::1"},
 					protocol: v1.ProtocolTCP,
 					inport:   inport,
-					eps: util.LbEndpoints{
+					clusterEndpoints: lbEndpoints{
 						V4IPs: []string{"192.168.0.1"},
 						V6IPs: []string{"2001::1"},
 						Port:  outport,
 					},
+					nodeEndpoints: map[string]lbEndpoints{},
 				},
 			},
 			// in local gateway mode, only nodePort is per-node
@@ -564,22 +717,24 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 					vips:     []string{"node"},
 					protocol: v1.ProtocolTCP,
 					inport:   5,
-					eps: util.LbEndpoints{
+					clusterEndpoints: lbEndpoints{
 						V4IPs: []string{"192.168.0.1"},
 						V6IPs: []string{"2001::1"},
 						Port:  outport,
 					},
-					hasNodePort: true,
+					nodeEndpoints: map[string]lbEndpoints{},
+					hasNodePort:   true,
 				},
 				{
 					vips:     []string{"192.168.1.1", "2002::1"},
 					protocol: v1.ProtocolTCP,
 					inport:   inport,
-					eps: util.LbEndpoints{
+					clusterEndpoints: lbEndpoints{
 						V4IPs: []string{"192.168.0.1"},
 						V6IPs: []string{"2001::1"},
 						Port:  outport,
 					},
+					nodeEndpoints: map[string]lbEndpoints{},
 				},
 			},
 		},
@@ -596,6 +751,7 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 						ClusterIPs:            []string{"192.168.1.1", "2002::1"},
 						ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeLocal,
 						Ports: []v1.ServicePort{{
+							Name:       portName,
 							Port:       inport,
 							Protocol:   v1.ProtocolTCP,
 							TargetPort: outportstr,
@@ -610,10 +766,17 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 					vips:     []string{"node"},
 					protocol: v1.ProtocolTCP,
 					inport:   5,
-					eps: util.LbEndpoints{
+					clusterEndpoints: lbEndpoints{
 						V4IPs: []string{"192.168.0.1"},
 						V6IPs: []string{"2001::1"},
 						Port:  outport,
+					},
+					nodeEndpoints: map[string]lbEndpoints{
+						nodeA: {
+							V4IPs: []string{"192.168.0.1"},
+							V6IPs: []string{"2001::1"},
+							Port:  outport,
+						},
 					},
 					externalTrafficLocal: true,
 					hasNodePort:          true,
@@ -622,10 +785,17 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 					vips:     []string{"192.168.1.1", "2002::1"},
 					protocol: v1.ProtocolTCP,
 					inport:   inport,
-					eps: util.LbEndpoints{
+					clusterEndpoints: lbEndpoints{
 						V4IPs: []string{"192.168.0.1"},
 						V6IPs: []string{"2001::1"},
 						Port:  outport,
+					},
+					nodeEndpoints: map[string]lbEndpoints{
+						nodeA: {
+							V4IPs: []string{"192.168.0.1"},
+							V6IPs: []string{"2001::1"},
+							Port:  outport,
+						},
 					},
 				},
 			},
@@ -634,10 +804,17 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 					vips:     []string{"node"},
 					protocol: v1.ProtocolTCP,
 					inport:   5,
-					eps: util.LbEndpoints{
+					clusterEndpoints: lbEndpoints{
 						V4IPs: []string{"192.168.0.1"},
 						V6IPs: []string{"2001::1"},
 						Port:  outport,
+					},
+					nodeEndpoints: map[string]lbEndpoints{
+						nodeA: {
+							V4IPs: []string{"192.168.0.1"},
+							V6IPs: []string{"2001::1"},
+							Port:  outport,
+						},
 					},
 					externalTrafficLocal: true,
 					hasNodePort:          true,
@@ -646,10 +823,17 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 					vips:     []string{"192.168.1.1", "2002::1"},
 					protocol: v1.ProtocolTCP,
 					inport:   inport,
-					eps: util.LbEndpoints{
+					clusterEndpoints: lbEndpoints{
 						V4IPs: []string{"192.168.0.1"},
 						V6IPs: []string{"2001::1"},
 						Port:  outport,
+					},
+					nodeEndpoints: map[string]lbEndpoints{
+						nodeA: {
+							V4IPs: []string{"192.168.0.1"},
+							V6IPs: []string{"2001::1"},
+							Port:  outport,
+						},
 					},
 				},
 			},
@@ -666,6 +850,7 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 						ClusterIP:  "192.168.1.1",
 						ClusterIPs: []string{"192.168.1.1", "2002::1"},
 						Ports: []v1.ServicePort{{
+							Name:       portName,
 							Port:       inport,
 							Protocol:   v1.ProtocolTCP,
 							TargetPort: outportstr,
@@ -679,11 +864,12 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 					vips:     []string{"192.168.1.1", "2002::1"},
 					protocol: v1.ProtocolTCP,
 					inport:   inport,
-					eps: util.LbEndpoints{
+					clusterEndpoints: lbEndpoints{
 						V4IPs: []string{"192.168.0.1"},
 						V6IPs: []string{"2001::1"},
 						Port:  outport,
 					},
+					nodeEndpoints: map[string]lbEndpoints{},
 				},
 			},
 			resultLocalGatewayNode: []lbConfig{
@@ -691,10 +877,299 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 					vips:     []string{"192.168.1.1", "2002::1"},
 					protocol: v1.ProtocolTCP,
 					inport:   inport,
-					eps: util.LbEndpoints{
+					clusterEndpoints: lbEndpoints{
 						V4IPs: []string{"192.168.0.1"},
 						V6IPs: []string{"2001::1"},
 						Port:  outport,
+					},
+					nodeEndpoints: map[string]lbEndpoints{},
+				},
+			},
+		},
+		{
+			name: "LB service with NodePort, one port, two endpoints, external ips + lb status, ExternalTrafficPolicy=local",
+			args: args{
+				slices: makeV4SliceWithEndpoints(
+					v1.ProtocolTCP,
+					kube_test.MakeReadyEndpoint(nodeA, "10.128.0.2"),
+					kube_test.MakeReadyEndpoint(nodeB, "10.128.1.2"),
+				),
+				service: &v1.Service{
+					ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: ns},
+					Spec: v1.ServiceSpec{
+						Type:                  v1.ServiceTypeLoadBalancer,
+						ClusterIP:             "192.168.1.1",
+						ClusterIPs:            []string{"192.168.1.1"},
+						ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeLocal,
+						Ports: []v1.ServicePort{{
+							Name:       portName,
+							Port:       inport,
+							Protocol:   v1.ProtocolTCP,
+							TargetPort: outportstr,
+							NodePort:   5,
+						}},
+						ExternalIPs: []string{"4.2.2.2"},
+					},
+					Status: v1.ServiceStatus{
+						LoadBalancer: v1.LoadBalancerStatus{
+							Ingress: []v1.LoadBalancerIngress{{
+								IP: "5.5.5.5",
+							}},
+						},
+					},
+				},
+			},
+			resultsSame: true,
+			resultSharedGatewayCluster: []lbConfig{
+				{
+					vips:     []string{"192.168.1.1"},
+					protocol: v1.ProtocolTCP,
+					inport:   inport,
+					clusterEndpoints: lbEndpoints{
+						V4IPs: []string{"10.128.0.2", "10.128.1.2"},
+						Port:  outport,
+					},
+					nodeEndpoints: map[string]lbEndpoints{
+						nodeA: {
+							V4IPs: []string{"10.128.0.2"},
+							Port:  outport,
+						},
+						nodeB: {
+							V4IPs: []string{"10.128.1.2"},
+							Port:  outport,
+						},
+					},
+				},
+			},
+			resultSharedGatewayNode: []lbConfig{
+				{
+					vips:                 []string{"node"},
+					protocol:             v1.ProtocolTCP,
+					inport:               5,
+					hasNodePort:          true,
+					externalTrafficLocal: true,
+					clusterEndpoints: lbEndpoints{
+						V4IPs: []string{"10.128.0.2", "10.128.1.2"},
+						Port:  outport,
+					},
+					nodeEndpoints: map[string]lbEndpoints{
+						nodeA: {
+							V4IPs: []string{"10.128.0.2"},
+							Port:  outport,
+						},
+						nodeB: {
+							V4IPs: []string{"10.128.1.2"},
+							Port:  outport,
+						},
+					},
+				},
+				{
+					vips:                 []string{"4.2.2.2", "5.5.5.5"},
+					protocol:             v1.ProtocolTCP,
+					inport:               inport,
+					hasNodePort:          false,
+					externalTrafficLocal: true,
+					clusterEndpoints: lbEndpoints{
+						V4IPs: []string{"10.128.0.2", "10.128.1.2"},
+						Port:  outport,
+					},
+					nodeEndpoints: map[string]lbEndpoints{
+						nodeA: {
+							V4IPs: []string{"10.128.0.2"},
+							Port:  outport,
+						},
+						nodeB: {
+							V4IPs: []string{"10.128.1.2"},
+							Port:  outport,
+						},
+					},
+				},
+			},
+		},
+		{
+			// The fallback to terminating&serving only if there are no ready endpoints
+			// is not done at this stage: we just include candidate endpoints, that is  ready + terminating&serving.
+			// The test below will just show both endpoints in its output.
+			name: "LB service with NodePort, port, two endpoints, external ips + lb status, ExternalTrafficPolicy=local, one endpoint is ready, the other one is terminating and serving",
+			args: args{
+				slices: makeV4SliceWithEndpoints(v1.ProtocolTCP,
+					kube_test.MakeReadyEndpoint(nodeA, "10.128.0.2"),
+					kube_test.MakeTerminatingServingEndpoint(nodeB, "10.128.1.2")),
+				service: &v1.Service{
+					ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: ns},
+					Spec: v1.ServiceSpec{
+						Type:                  v1.ServiceTypeLoadBalancer,
+						ClusterIP:             "192.168.1.1",
+						ClusterIPs:            []string{"192.168.1.1"},
+						ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeLocal,
+						Ports: []v1.ServicePort{{
+							Name:       portName,
+							Port:       inport,
+							Protocol:   v1.ProtocolTCP,
+							TargetPort: outportstr,
+							NodePort:   5,
+						}},
+						ExternalIPs: []string{"4.2.2.2"},
+					},
+					Status: v1.ServiceStatus{
+						LoadBalancer: v1.LoadBalancerStatus{
+							Ingress: []v1.LoadBalancerIngress{{
+								IP: "5.5.5.5",
+							}},
+						},
+					},
+				},
+			},
+			resultsSame: true,
+			resultSharedGatewayCluster: []lbConfig{
+				{
+					vips:     []string{"192.168.1.1"},
+					protocol: v1.ProtocolTCP,
+					inport:   inport,
+					clusterEndpoints: lbEndpoints{
+						V4IPs: []string{"10.128.0.2"},
+						Port:  outport,
+					},
+					nodeEndpoints: map[string]lbEndpoints{
+						nodeA: {
+							V4IPs: []string{"10.128.0.2"},
+							Port:  outport,
+						},
+						nodeB: {
+							V4IPs: []string{"10.128.1.2"}, // fallback to terminating & serving on nodeB
+							Port:  outport,
+						},
+					},
+				},
+			},
+			resultSharedGatewayNode: []lbConfig{
+				{
+					vips:                 []string{"node"},
+					protocol:             v1.ProtocolTCP,
+					inport:               5,
+					hasNodePort:          true,
+					externalTrafficLocal: true,
+					clusterEndpoints: lbEndpoints{
+						V4IPs: []string{"10.128.0.2"},
+						Port:  outport,
+					},
+					nodeEndpoints: map[string]lbEndpoints{
+						nodeA: {
+							V4IPs: []string{"10.128.0.2"},
+							Port:  outport,
+						},
+						nodeB: {
+							V4IPs: []string{"10.128.1.2"}, // fallback to terminating & serving on nodeB
+							Port:  outport,
+						},
+					},
+				},
+				{
+					vips:                 []string{"4.2.2.2", "5.5.5.5"},
+					protocol:             v1.ProtocolTCP,
+					inport:               inport,
+					hasNodePort:          false,
+					externalTrafficLocal: true,
+					clusterEndpoints: lbEndpoints{
+						V4IPs: []string{"10.128.0.2"},
+						Port:  outport,
+					},
+					nodeEndpoints: map[string]lbEndpoints{
+						nodeA: {
+							V4IPs: []string{"10.128.0.2"},
+							Port:  outport,
+						},
+						nodeB: {
+							V4IPs: []string{"10.128.1.2"}, // fallback to terminating & serving on nodeB
+							Port:  outport,
+						},
+					},
+				},
+			},
+		},
+		{
+			// Terminating & non-serving endpoints are filtered out by buildServiceLBConfigs
+			name: "LB service with NodePort, one port, two endpoints, external ips + lb status, ExternalTrafficPolicy=local, both endpoints terminating: one is serving, the other one is not",
+			args: args{
+				slices: makeV4SliceWithEndpoints(v1.ProtocolTCP,
+					kube_test.MakeTerminatingServingEndpoint(nodeA, "10.128.0.2"),
+					kube_test.MakeTerminatingNonServingEndpoint(nodeB, "10.128.1.2")),
+				service: &v1.Service{
+					ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: ns},
+					Spec: v1.ServiceSpec{
+						Type:                  v1.ServiceTypeLoadBalancer,
+						ClusterIP:             "192.168.1.1",
+						ClusterIPs:            []string{"192.168.1.1"},
+						ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeLocal,
+						Ports: []v1.ServicePort{{
+							Name:       portName,
+							Port:       inport,
+							Protocol:   v1.ProtocolTCP,
+							TargetPort: outportstr,
+							NodePort:   5,
+						}},
+						ExternalIPs: []string{"4.2.2.2"},
+					},
+					Status: v1.ServiceStatus{
+						LoadBalancer: v1.LoadBalancerStatus{
+							Ingress: []v1.LoadBalancerIngress{{
+								IP: "5.5.5.5",
+							}},
+						},
+					},
+				},
+			},
+			resultsSame: true,
+			resultSharedGatewayCluster: []lbConfig{
+				{
+					vips:     []string{"192.168.1.1"},
+					protocol: v1.ProtocolTCP,
+					inport:   inport,
+					clusterEndpoints: lbEndpoints{
+						V4IPs: []string{"10.128.0.2"},
+						Port:  outport,
+					},
+					nodeEndpoints: map[string]lbEndpoints{
+						nodeA: {
+							V4IPs: []string{"10.128.0.2"},
+							Port:  outport,
+						},
+					},
+				},
+			},
+			resultSharedGatewayNode: []lbConfig{
+				{
+					vips:                 []string{"node"},
+					protocol:             v1.ProtocolTCP,
+					inport:               5,
+					hasNodePort:          true,
+					externalTrafficLocal: true,
+					clusterEndpoints: lbEndpoints{
+						V4IPs: []string{"10.128.0.2"},
+						Port:  outport,
+					},
+					nodeEndpoints: map[string]lbEndpoints{
+						nodeA: {
+							V4IPs: []string{"10.128.0.2"},
+							Port:  outport,
+						},
+					},
+				},
+				{
+					vips:                 []string{"4.2.2.2", "5.5.5.5"},
+					protocol:             v1.ProtocolTCP,
+					inport:               inport,
+					hasNodePort:          false,
+					externalTrafficLocal: true,
+					clusterEndpoints: lbEndpoints{
+						V4IPs: []string{"10.128.0.2"},
+						Port:  outport,
+					},
+					nodeEndpoints: map[string]lbEndpoints{
+						nodeA: {
+							V4IPs: []string{"10.128.0.2"},
+							Port:  outport,
+						},
 					},
 				},
 			},
@@ -703,13 +1178,17 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 
 	for i, tt := range tests {
 		t.Run(fmt.Sprintf("%d_%s", i, tt.name), func(t *testing.T) {
+			// shared gateway mode
 			globalconfig.Gateway.Mode = globalconfig.GatewayModeShared
-			perNode, clusterWide := buildServiceLBConfigs(tt.args.service, tt.args.slices)
+			perNode, clusterWide := buildServiceLBConfigs(tt.args.service, tt.args.slices, defaultNodes)
+
 			assert.EqualValues(t, tt.resultSharedGatewayNode, perNode, "SGW per-node configs should be equal")
+
 			assert.EqualValues(t, tt.resultSharedGatewayCluster, clusterWide, "SGW cluster-wide configs should be equal")
 
+			// local gateway mode
 			globalconfig.Gateway.Mode = globalconfig.GatewayModeLocal
-			perNode, clusterWide = buildServiceLBConfigs(tt.args.service, tt.args.slices)
+			perNode, clusterWide = buildServiceLBConfigs(tt.args.service, tt.args.slices, defaultNodes)
 			if tt.resultsSame {
 				assert.EqualValues(t, tt.resultSharedGatewayNode, perNode, "LGW per-node configs should be equal")
 				assert.EqualValues(t, tt.resultSharedGatewayCluster, clusterWide, "LGW cluster-wide configs should be equal")
@@ -738,21 +1217,6 @@ func Test_buildClusterLBs(t *testing.T) {
 		},
 	}
 
-	defaultNodes := []nodeInfo{
-		{
-			name:              "node-a",
-			nodeIPs:           []string{"10.0.0.1"},
-			gatewayRouterName: "gr-node-a",
-			switchName:        "switch-node-a",
-		},
-		{
-			name:              "node-b",
-			nodeIPs:           []string{"10.0.0.2"},
-			gatewayRouterName: "gr-node-b",
-			switchName:        "switch-node-b",
-		},
-	}
-
 	defaultExternalIDs := map[string]string{
 		"k8s.ovn.org/kind":  "Service",
 		"k8s.ovn.org/owner": fmt.Sprintf("%s/%s", namespace, name),
@@ -777,18 +1241,30 @@ func Test_buildClusterLBs(t *testing.T) {
 					vips:     []string{"1.2.3.4"},
 					protocol: v1.ProtocolTCP,
 					inport:   80,
-					eps: util.LbEndpoints{
+					clusterEndpoints: lbEndpoints{
 						V4IPs: []string{"192.168.0.1", "192.168.0.2"},
 						Port:  8080,
+					},
+					nodeEndpoints: map[string]lbEndpoints{
+						nodeA: {
+							V4IPs: []string{"192.168.0.1", "192.168.0.2"},
+							Port:  8080,
+						},
 					},
 				},
 				{
 					vips:     []string{"1.2.3.4"},
 					protocol: v1.ProtocolTCP,
 					inport:   443,
-					eps: util.LbEndpoints{
+					clusterEndpoints: lbEndpoints{
 						V4IPs: []string{"192.168.0.1"},
 						Port:  8043,
+					},
+					nodeEndpoints: map[string]lbEndpoints{
+						nodeA: {
+							V4IPs: []string{"192.168.0.1"},
+							Port:  8043,
+						},
 					},
 				},
 			},
@@ -800,12 +1276,12 @@ func Test_buildClusterLBs(t *testing.T) {
 					ExternalIDs: defaultExternalIDs,
 					Rules: []ovnlb.LBRule{
 						{
-							Source:  ovnlb.Addr{"1.2.3.4", 80},
-							Targets: []ovnlb.Addr{{"192.168.0.1", 8080}, {"192.168.0.2", 8080}},
+							Source:  ovnlb.Addr{IP: "1.2.3.4", Port: 80},
+							Targets: []ovnlb.Addr{{IP: "192.168.0.1", Port: 8080}, {IP: "192.168.0.2", Port: 8080}},
 						},
 						{
-							Source:  ovnlb.Addr{"1.2.3.4", 443},
-							Targets: []ovnlb.Addr{{"192.168.0.1", 8043}},
+							Source:  ovnlb.Addr{IP: "1.2.3.4", Port: 443},
+							Targets: []ovnlb.Addr{{IP: "192.168.0.1", Port: 8043}},
 						},
 					},
 
@@ -823,18 +1299,30 @@ func Test_buildClusterLBs(t *testing.T) {
 					vips:     []string{"1.2.3.4"},
 					protocol: v1.ProtocolTCP,
 					inport:   80,
-					eps: util.LbEndpoints{
+					clusterEndpoints: lbEndpoints{
 						V4IPs: []string{"192.168.0.1", "192.168.0.2"},
 						Port:  8080,
+					},
+					nodeEndpoints: map[string]lbEndpoints{
+						nodeA: {
+							V4IPs: []string{"192.168.0.1", "192.168.0.2"},
+							Port:  8080,
+						},
 					},
 				},
 				{
 					vips:     []string{"1.2.3.4"},
 					protocol: v1.ProtocolUDP,
 					inport:   443,
-					eps: util.LbEndpoints{
+					clusterEndpoints: lbEndpoints{
 						V4IPs: []string{"192.168.0.1"},
 						Port:  8043,
+					},
+					nodeEndpoints: map[string]lbEndpoints{
+						nodeA: {
+							V4IPs: []string{"192.168.0.1"},
+							Port:  8043,
+						},
 					},
 				},
 			},
@@ -880,20 +1368,36 @@ func Test_buildClusterLBs(t *testing.T) {
 					vips:     []string{"1.2.3.4", "fe80::1"},
 					protocol: v1.ProtocolTCP,
 					inport:   80,
-					eps: util.LbEndpoints{
+					clusterEndpoints: lbEndpoints{
 						V4IPs: []string{"192.168.0.1", "192.168.0.2"},
 						V6IPs: []string{"fe90::1", "fe91::1"},
-						Port:  8080,
+
+						Port: 8080,
+					},
+					nodeEndpoints: map[string]lbEndpoints{
+						nodeA: {
+							V4IPs: []string{"192.168.0.1", "192.168.0.2"},
+							V6IPs: []string{"fe90::1", "fe91::1"},
+							Port:  8080,
+						},
 					},
 				},
 				{
 					vips:     []string{"1.2.3.4", "fe80::1"},
 					protocol: v1.ProtocolTCP,
 					inport:   443,
-					eps: util.LbEndpoints{
+					clusterEndpoints: lbEndpoints{
 						V4IPs: []string{"192.168.0.1"},
 						V6IPs: []string{"fe90::1"},
-						Port:  8043,
+
+						Port: 8043,
+					},
+					nodeEndpoints: map[string]lbEndpoints{
+						nodeA: {
+							V4IPs: []string{"192.168.0.1"},
+							V6IPs: []string{"fe90::1"},
+							Port:  8043,
+						},
 					},
 				},
 			},
@@ -929,7 +1433,6 @@ func Test_buildClusterLBs(t *testing.T) {
 			},
 		},
 	}
-
 	for i, tt := range tc {
 		t.Run(fmt.Sprintf("%d_%s", i, tt.name), func(t *testing.T) {
 			actual := buildClusterLBs(tt.service, tt.configs, tt.nodeInfos, true)
@@ -941,15 +1444,20 @@ func Test_buildClusterLBs(t *testing.T) {
 func Test_buildPerNodeLBs(t *testing.T) {
 	oldClusterSubnet := globalconfig.Default.ClusterSubnets
 	oldGwMode := globalconfig.Gateway.Mode
+	oldServiceCIDRs := globalconfig.Kubernetes.ServiceCIDRs
 	defer func() {
 		globalconfig.Gateway.Mode = oldGwMode
 		globalconfig.Default.ClusterSubnets = oldClusterSubnet
+		globalconfig.Kubernetes.ServiceCIDRs = oldServiceCIDRs
 	}()
+
 	_, cidr4, _ := net.ParseCIDR("10.128.0.0/16")
 	_, cidr6, _ := net.ParseCIDR("fe00::/64")
 	globalconfig.Default.ClusterSubnets = []globalconfig.CIDRNetworkEntry{{cidr4, 26}, {cidr6, 26}}
-	_, svcCIDRs, _ := net.ParseCIDR("192.168.0.0/24")
-	globalconfig.Kubernetes.ServiceCIDRs = []*net.IPNet{svcCIDRs}
+	_, svcCIDRv4, _ := net.ParseCIDR("192.168.0.0/24")
+	_, svcCIDRv6, _ := net.ParseCIDR("fd92::0/80")
+
+	globalconfig.Kubernetes.ServiceCIDRs = []*net.IPNet{svcCIDRv4}
 
 	name := "foo"
 	namespace := "testns"
@@ -963,18 +1471,35 @@ func Test_buildPerNodeLBs(t *testing.T) {
 
 	defaultNodes := []nodeInfo{
 		{
-			name:              "node-a",
-			nodeIPs:           []string{"10.0.0.1"},
+			name:              nodeA,
+			nodeIPs:           []string{"10.0.0.1", "10.0.0.111"},
 			gatewayRouterName: "gr-node-a",
 			switchName:        "switch-node-a",
 			podSubnets:        []net.IPNet{{IP: net.ParseIP("10.128.0.0"), Mask: net.CIDRMask(24, 32)}},
 		},
 		{
-			name:              "node-b",
+			name:              nodeB,
 			nodeIPs:           []string{"10.0.0.2"},
 			gatewayRouterName: "gr-node-b",
 			switchName:        "switch-node-b",
 			podSubnets:        []net.IPNet{{IP: net.ParseIP("10.128.1.0"), Mask: net.CIDRMask(24, 32)}},
+		},
+	}
+
+	defaultNodesV6 := []nodeInfo{
+		{
+			name:              nodeA,
+			nodeIPs:           []string{"fd00::1", "fd00::111"},
+			gatewayRouterName: "gr-node-a",
+			switchName:        "switch-node-a",
+			podSubnets:        []net.IPNet{{IP: net.ParseIP("fe00:0:0:0:1::0"), Mask: net.CIDRMask(64, 64)}},
+		},
+		{
+			name:              nodeB,
+			nodeIPs:           []string{"fd00::2"},
+			gatewayRouterName: "gr-node-b",
+			switchName:        "switch-node-b",
+			podSubnets:        []net.IPNet{{IP: net.ParseIP("fe00:0:0:0:2::0"), Mask: net.CIDRMask(64, 64)}},
 		},
 	}
 
@@ -1001,9 +1526,15 @@ func Test_buildPerNodeLBs(t *testing.T) {
 					vips:     []string{"1.2.3.4"},
 					protocol: v1.ProtocolTCP,
 					inport:   80,
-					eps: util.LbEndpoints{
+					clusterEndpoints: lbEndpoints{
 						V4IPs: []string{"10.0.0.1"},
 						Port:  8080,
+					},
+					nodeEndpoints: map[string]lbEndpoints{
+						nodeA: {
+							V4IPs: []string{"10.0.0.1"},
+							Port:  8080,
+						},
 					},
 				},
 			},
@@ -1043,9 +1574,12 @@ func Test_buildPerNodeLBs(t *testing.T) {
 					vips:     []string{"node"},
 					protocol: v1.ProtocolTCP,
 					inport:   80,
-					eps: util.LbEndpoints{
+					clusterEndpoints: lbEndpoints{
 						V4IPs: []string{"10.128.0.2"},
 						Port:  8080,
+					},
+					nodeEndpoints: map[string]lbEndpoints{
+						nodeA: {V4IPs: []string{"10.128.0.2"}, Port: 8080},
 					},
 				},
 			},
@@ -1060,6 +1594,10 @@ func Test_buildPerNodeLBs(t *testing.T) {
 						{
 							Source:  ovnlb.Addr{"10.0.0.1", 80},
 							Targets: []ovnlb.Addr{{"10.128.0.2", 8080}},
+						},
+						{
+							Source:  ovnlb.Addr{IP: "10.0.0.111", Port: 80},
+							Targets: []ovnlb.Addr{{IP: "10.128.0.2", Port: 8080}},
 						},
 					},
 				},
@@ -1088,6 +1626,10 @@ func Test_buildPerNodeLBs(t *testing.T) {
 						{
 							Source:  ovnlb.Addr{"10.0.0.1", 80},
 							Targets: []ovnlb.Addr{{"10.128.0.2", 8080}},
+						},
+						{
+							Source:  ovnlb.Addr{IP: "10.0.0.111", Port: 80},
+							Targets: []ovnlb.Addr{{IP: "10.128.0.2", Port: 8080}},
 						},
 					},
 				},
@@ -1114,18 +1656,30 @@ func Test_buildPerNodeLBs(t *testing.T) {
 					vips:     []string{"192.168.0.1"},
 					protocol: v1.ProtocolTCP,
 					inport:   80,
-					eps: util.LbEndpoints{
+					clusterEndpoints: lbEndpoints{
 						V4IPs: []string{"10.0.0.1"},
 						Port:  8080,
+					},
+					nodeEndpoints: map[string]lbEndpoints{
+						nodeA: {
+							V4IPs: []string{"10.0.0.1"},
+							Port:  8080,
+						},
 					},
 				},
 				{
 					vips:     []string{"node"},
 					protocol: v1.ProtocolTCP,
 					inport:   80,
-					eps: util.LbEndpoints{
+					clusterEndpoints: lbEndpoints{
 						V4IPs: []string{"10.0.0.1"},
 						Port:  8080,
+					},
+					nodeEndpoints: map[string]lbEndpoints{
+						nodeA: {
+							V4IPs: []string{"10.0.0.1"},
+							Port:  8080,
+						},
 					},
 				},
 			},
@@ -1144,6 +1698,10 @@ func Test_buildPerNodeLBs(t *testing.T) {
 							Source:  ovnlb.Addr{"10.0.0.1", 80},
 							Targets: []ovnlb.Addr{{"169.254.169.2", 8080}},
 						},
+						{
+							Source:  ovnlb.Addr{IP: "10.0.0.111", Port: 80},
+							Targets: []ovnlb.Addr{{IP: "169.254.169.2", Port: 8080}},
+						},
 					},
 				},
 				{
@@ -1159,6 +1717,10 @@ func Test_buildPerNodeLBs(t *testing.T) {
 						{
 							Source:  ovnlb.Addr{"10.0.0.1", 80},
 							Targets: []ovnlb.Addr{{"10.0.0.1", 8080}},
+						},
+						{
+							Source:  ovnlb.Addr{IP: "10.0.0.111", Port: 80},
+							Targets: []ovnlb.Addr{{IP: "10.0.0.1", Port: 8080}},
 						},
 					},
 				},
@@ -1195,6 +1757,10 @@ func Test_buildPerNodeLBs(t *testing.T) {
 							Source:  ovnlb.Addr{"10.0.0.1", 80},
 							Targets: []ovnlb.Addr{{"169.254.169.2", 8080}},
 						},
+						{
+							Source:  ovnlb.Addr{IP: "10.0.0.111", Port: 80},
+							Targets: []ovnlb.Addr{{IP: "169.254.169.2", Port: 8080}},
+						},
 					},
 				},
 				{
@@ -1210,6 +1776,10 @@ func Test_buildPerNodeLBs(t *testing.T) {
 						{
 							Source:  ovnlb.Addr{"10.0.0.1", 80},
 							Targets: []ovnlb.Addr{{"10.0.0.1", 8080}},
+						},
+						{
+							Source:  ovnlb.Addr{IP: "10.0.0.111", Port: 80},
+							Targets: []ovnlb.Addr{{IP: "10.0.0.1", Port: 8080}},
 						},
 					},
 				},
@@ -1234,16 +1804,22 @@ func Test_buildPerNodeLBs(t *testing.T) {
 		},
 		{
 			// The most complicated case
-			name:    "nodeport service, host-network pod, ExternalTrafficPolicy",
+			name:    "nodeport service, host-network pod, ExternalTrafficPolicy=local",
 			service: defaultService,
 			configs: []lbConfig{
 				{
 					vips:     []string{"192.168.0.1"},
 					protocol: v1.ProtocolTCP,
 					inport:   80,
-					eps: util.LbEndpoints{
+					clusterEndpoints: lbEndpoints{
 						V4IPs: []string{"10.0.0.1"},
 						Port:  8080,
+					},
+					nodeEndpoints: map[string]lbEndpoints{
+						nodeA: {
+							V4IPs: []string{"10.0.0.1"},
+							Port:  8080,
+						},
 					},
 				},
 				{
@@ -1252,9 +1828,15 @@ func Test_buildPerNodeLBs(t *testing.T) {
 					inport:               80,
 					externalTrafficLocal: true,
 					hasNodePort:          true,
-					eps: util.LbEndpoints{
+					clusterEndpoints: lbEndpoints{
 						V4IPs: []string{"10.0.0.1"},
 						Port:  8080,
+					},
+					nodeEndpoints: map[string]lbEndpoints{
+						nodeA: {
+							V4IPs: []string{"10.0.0.1"},
+							Port:  8080,
+						},
 					},
 				},
 			},
@@ -1286,6 +1868,10 @@ func Test_buildPerNodeLBs(t *testing.T) {
 							Source:  ovnlb.Addr{"10.0.0.1", 80},
 							Targets: []ovnlb.Addr{{"169.254.169.2", 8080}},
 						},
+						{
+							Source:  ovnlb.Addr{IP: "10.0.0.111", Port: 80},
+							Targets: []ovnlb.Addr{{IP: "169.254.169.2", Port: 8080}},
+						},
 					},
 				},
 				{
@@ -1306,10 +1892,18 @@ func Test_buildPerNodeLBs(t *testing.T) {
 							Source:  ovnlb.Addr{"10.0.0.1", 80},
 							Targets: []ovnlb.Addr{{"10.0.0.1", 8080}},
 						},
+						{
+							Source:  ovnlb.Addr{IP: "169.254.169.3", Port: 80},
+							Targets: []ovnlb.Addr{{IP: "10.0.0.1", Port: 8080}},
+						},
+						{
+							Source:  ovnlb.Addr{IP: "10.0.0.111", Port: 80},
+							Targets: []ovnlb.Addr{{IP: "10.0.0.1", Port: 8080}},
+						},
 					},
 				},
 
-				// node-b has no service, 3 lbs
+				// node-b has no endpoint, 3 lbs
 				// router clusterip
 				// router nodeport = empty
 				// switch clusterip + nodeport
@@ -1360,18 +1954,38 @@ func Test_buildPerNodeLBs(t *testing.T) {
 					protocol:             v1.ProtocolTCP,
 					inport:               80,
 					internalTrafficLocal: true,
-					eps: util.LbEndpoints{
-						V4IPs: []string{"10.128.0.1", "10.128.1.1"}, // 1 ep on node-a and 1 ep on node-b
+					clusterEndpoints: lbEndpoints{
+						V4IPs: []string{"10.128.0.1", "10.128.1.1"},
 						Port:  8080,
+					},
+					nodeEndpoints: map[string]lbEndpoints{
+						nodeA: {
+							V4IPs: []string{"10.128.0.1"},
+							Port:  8080,
+						},
+						nodeB: {
+							V4IPs: []string{"10.128.1.1"},
+							Port:  8080,
+						},
 					},
 				},
 				{
 					vips:     []string{"1.2.3.4"}, // externalIP config
 					protocol: v1.ProtocolTCP,
 					inport:   80,
-					eps: util.LbEndpoints{
+					clusterEndpoints: lbEndpoints{
 						V4IPs: []string{"10.128.0.1", "10.128.1.1"},
 						Port:  8080,
+					},
+					nodeEndpoints: map[string]lbEndpoints{
+						nodeA: {
+							V4IPs: []string{"10.128.0.1"},
+							Port:  8080,
+						},
+						nodeB: {
+							V4IPs: []string{"10.128.1.1"},
+							Port:  8080,
+						},
 					},
 				},
 			},
@@ -1485,18 +2099,38 @@ func Test_buildPerNodeLBs(t *testing.T) {
 					protocol:             v1.ProtocolTCP,
 					inport:               80,
 					internalTrafficLocal: true,
-					eps: util.LbEndpoints{
-						V4IPs: []string{"10.0.0.1", "10.0.0.2"}, // 1 ep on node-a and 1 ep on node-b
+					clusterEndpoints: lbEndpoints{
+						V4IPs: []string{"10.0.0.1", "10.0.0.2"},
 						Port:  8080,
+					},
+					nodeEndpoints: map[string]lbEndpoints{
+						nodeA: {
+							V4IPs: []string{"10.0.0.1"},
+							Port:  8080,
+						},
+						nodeB: {
+							V4IPs: []string{"10.0.0.2"},
+							Port:  8080,
+						},
 					},
 				},
 				{
 					vips:     []string{"1.2.3.4"}, // externalIP config
 					protocol: v1.ProtocolTCP,
 					inport:   80,
-					eps: util.LbEndpoints{
+					clusterEndpoints: lbEndpoints{
 						V4IPs: []string{"10.0.0.1", "10.0.0.2"},
 						Port:  8080,
+					},
+					nodeEndpoints: map[string]lbEndpoints{
+						nodeA: {
+							V4IPs: []string{"10.0.0.1"},
+							Port:  8080,
+						},
+						nodeB: {
+							V4IPs: []string{"10.0.0.2"},
+							Port:  8080,
+						},
 					},
 				},
 			},
@@ -1644,9 +2278,15 @@ func Test_buildPerNodeLBs(t *testing.T) {
 					inport:               80,
 					internalTrafficLocal: true,
 					externalTrafficLocal: false, // ETP is applicable only to nodePorts and LBs
-					eps: util.LbEndpoints{
-						V4IPs: []string{"10.0.0.1"}, // only one ep on node-a
+					clusterEndpoints: lbEndpoints{
+						V4IPs: []string{"10.0.0.1"},
 						Port:  8080,
+					},
+					nodeEndpoints: map[string]lbEndpoints{
+						nodeA: {
+							V4IPs: []string{"10.0.0.1"}, // only one ep on node-a
+							Port:  8080,
+						},
 					},
 				},
 				{
@@ -1656,9 +2296,15 @@ func Test_buildPerNodeLBs(t *testing.T) {
 					externalTrafficLocal: true,
 					internalTrafficLocal: false, // ITP is applicable only to clusterIPs
 					hasNodePort:          true,
-					eps: util.LbEndpoints{
-						V4IPs: []string{"10.0.0.1"}, // only one ep on node-a
+					clusterEndpoints: lbEndpoints{
+						V4IPs: []string{"10.0.0.1"},
 						Port:  8080,
+					},
+					nodeEndpoints: map[string]lbEndpoints{
+						nodeA: {
+							V4IPs: []string{"10.0.0.1"}, // only one ep on node-a
+							Port:  8080,
+						},
 					},
 				},
 			},
@@ -1686,6 +2332,10 @@ func Test_buildPerNodeLBs(t *testing.T) {
 							Source:  ovnlb.Addr{"10.0.0.1", 34345},
 							Targets: []ovnlb.Addr{{"169.254.169.2", 8080}}, // special skip_snat=true LB for ETP=local; used in SGW mode
 						},
+						{
+							Source:  ovnlb.Addr{IP: "10.0.0.111", Port: 34345},
+							Targets: []ovnlb.Addr{{IP: "169.254.169.2", Port: 8080}},
+						},
 					},
 				},
 				{
@@ -1703,8 +2353,16 @@ func Test_buildPerNodeLBs(t *testing.T) {
 							Targets: []ovnlb.Addr{{"10.0.0.1", 8080}},   // filter out eps only on node-a for nodePorts
 						},
 						{
-							Source:  ovnlb.Addr{"10.0.0.1", 34345},
-							Targets: []ovnlb.Addr{{"10.0.0.1", 8080}}, // don't filter out eps for nodePorts on switches when ETP=local
+							Source:  ovnlb.Addr{IP: "10.0.0.1", Port: 34345},
+							Targets: []ovnlb.Addr{{IP: "10.0.0.1", Port: 8080}},
+						},
+						{
+							Source:  ovnlb.Addr{IP: "169.254.169.3", Port: 34345},
+							Targets: []ovnlb.Addr{{IP: "10.0.0.1", Port: 8080}},
+						},
+						{
+							Source:  ovnlb.Addr{IP: "10.0.0.111", Port: 34345},
+							Targets: []ovnlb.Addr{{IP: "10.0.0.1", Port: 8080}}, // don't filter out eps for nodePorts on switches when ETP=local
 						},
 					},
 				},
@@ -1769,6 +2427,10 @@ func Test_buildPerNodeLBs(t *testing.T) {
 							Source:  ovnlb.Addr{"10.0.0.1", 34345},
 							Targets: []ovnlb.Addr{{"169.254.169.2", 8080}}, // special skip_snat=true LB for ETP=local; used in SGW mode
 						},
+						{
+							Source:  ovnlb.Addr{IP: "10.0.0.111", Port: 34345},
+							Targets: []ovnlb.Addr{{IP: "169.254.169.2", Port: 8080}},
+						},
 					},
 				},
 				{
@@ -1786,8 +2448,16 @@ func Test_buildPerNodeLBs(t *testing.T) {
 							Targets: []ovnlb.Addr{{"10.0.0.1", 8080}},   // filter out eps only on node-a for nodePorts
 						},
 						{
-							Source:  ovnlb.Addr{"10.0.0.1", 34345},
-							Targets: []ovnlb.Addr{{"10.0.0.1", 8080}}, // don't filter out eps for nodePorts on switches when ETP=local
+							Source:  ovnlb.Addr{IP: "10.0.0.1", Port: 34345},
+							Targets: []ovnlb.Addr{{IP: "10.0.0.1", Port: 8080}},
+						},
+						{
+							Source:  ovnlb.Addr{IP: "169.254.169.3", Port: 34345},
+							Targets: []ovnlb.Addr{{IP: "10.0.0.1", Port: 8080}},
+						},
+						{
+							Source:  ovnlb.Addr{IP: "10.0.0.111", Port: 34345},
+							Targets: []ovnlb.Addr{{IP: "10.0.0.1", Port: 8080}}, // don't filter out eps for nodePorts on switches when ETP=local
 						},
 					},
 				},
@@ -1829,8 +2499,538 @@ func Test_buildPerNodeLBs(t *testing.T) {
 				},
 			},
 		},
+		// tests for endpoint selection with ExternalTrafficPolicy=local
+		{
+			name:    "LB service with NodePort, standard pods on different nodes, ExternalTrafficPolicy=local, both endpoints are ready",
+			service: defaultService,
+			configs: []lbConfig{
+				{
+					vips:                 []string{"node"},
+					protocol:             v1.ProtocolTCP,
+					inport:               5, // nodePort
+					hasNodePort:          true,
+					externalTrafficLocal: true,
+					clusterEndpoints: lbEndpoints{
+						V4IPs: []string{"10.128.0.2", "10.128.1.2"},
+						Port:  8080,
+					},
+					nodeEndpoints: map[string]lbEndpoints{
+						nodeA: {
+							V4IPs: []string{"10.128.0.2"},
+							Port:  8080,
+						},
+						nodeB: {
+							V4IPs: []string{"10.128.1.2"},
+							Port:  8080,
+						},
+					},
+				},
+				{
+					vips:                 []string{"4.2.2.2", "5.5.5.5"}, // externalIP + LB IP
+					protocol:             v1.ProtocolTCP,
+					inport:               80,
+					hasNodePort:          false,
+					externalTrafficLocal: true,
+					clusterEndpoints: lbEndpoints{
+						V4IPs: []string{"10.128.0.2", "10.128.1.2"},
+						Port:  8080,
+					},
+					nodeEndpoints: map[string]lbEndpoints{
+						nodeA: {
+							V4IPs: []string{"10.128.0.2"},
+							Port:  8080,
+						},
+						nodeB: {
+							V4IPs: []string{"10.128.1.2"},
+							Port:  8080,
+						},
+					},
+				},
+			},
+			expectedShared: []ovnlb.LB{
+				{
+					Name:        "Service_testns/foo_TCP_node_local_router_node-a",
+					Protocol:    "TCP",
+					ExternalIDs: defaultExternalIDs,
+					Opts:        ovnlb.LBOpts{SkipSNAT: true},
+
+					Rules: []ovnlb.LBRule{
+						{
+							Source:  ovnlb.Addr{IP: "10.0.0.1", Port: 5},
+							Targets: []ovnlb.Addr{{IP: "10.128.0.2", Port: 8080}}, // local endpoint (ready)
+						},
+						{
+							Source:  ovnlb.Addr{IP: "10.0.0.111", Port: 5},
+							Targets: []ovnlb.Addr{{IP: "10.128.0.2", Port: 8080}}, // local endpoint (ready)
+						},
+						{
+							Source:  ovnlb.Addr{IP: "4.2.2.2", Port: 80},
+							Targets: []ovnlb.Addr{{IP: "10.128.0.2", Port: 8080}}, // local endpoint (ready)
+						},
+						{
+							Source:  ovnlb.Addr{IP: "5.5.5.5", Port: 80},
+							Targets: []ovnlb.Addr{{IP: "10.128.0.2", Port: 8080}}, // local endpoint (ready)
+						},
+					},
+					Routers: []string{"gr-node-a"},
+				},
+				{
+					Name:        "Service_testns/foo_TCP_node_switch_node-a",
+					Protocol:    "TCP",
+					ExternalIDs: defaultExternalIDs,
+					Rules: []ovnlb.LBRule{
+						{
+							Source:  ovnlb.Addr{IP: "169.254.169.3", Port: 5},
+							Targets: []ovnlb.Addr{{IP: "10.128.0.2", Port: 8080}},
+						},
+						{
+							Source:  ovnlb.Addr{IP: "10.0.0.1", Port: 5},
+							Targets: []ovnlb.Addr{{IP: "10.128.0.2", Port: 8080}, {IP: "10.128.1.2", Port: 8080}},
+						},
+						{
+							Source:  ovnlb.Addr{IP: "169.254.169.3", Port: 5},
+							Targets: []ovnlb.Addr{{IP: "10.128.0.2", Port: 8080}},
+						},
+						{
+							Source:  ovnlb.Addr{IP: "10.0.0.111", Port: 5},
+							Targets: []ovnlb.Addr{{IP: "10.128.0.2", Port: 8080}, {IP: "10.128.1.2", Port: 8080}},
+						},
+						{
+							Source:  ovnlb.Addr{IP: "4.2.2.2", Port: 80},
+							Targets: []ovnlb.Addr{{IP: "10.128.0.2", Port: 8080}, {IP: "10.128.1.2", Port: 8080}},
+						},
+						{
+							Source:  ovnlb.Addr{IP: "5.5.5.5", Port: 80},
+							Targets: []ovnlb.Addr{{IP: "10.128.0.2", Port: 8080}, {IP: "10.128.1.2", Port: 8080}},
+						},
+					},
+					Switches: []string{"switch-node-a"},
+				},
+				{
+					Name:        "Service_testns/foo_TCP_node_local_router_node-b",
+					Protocol:    "TCP",
+					ExternalIDs: defaultExternalIDs,
+					Opts:        ovnlb.LBOpts{SkipSNAT: true},
+					Rules: []ovnlb.LBRule{
+						{
+							Source:  ovnlb.Addr{IP: "10.0.0.2", Port: 5},
+							Targets: []ovnlb.Addr{{IP: "10.128.1.2", Port: 8080}}, // local endpoint (ready)
+						},
+						{
+							Source:  ovnlb.Addr{IP: "4.2.2.2", Port: 80},
+							Targets: []ovnlb.Addr{{IP: "10.128.1.2", Port: 8080}}, // local endpoint (ready)
+						},
+						{
+							Source:  ovnlb.Addr{IP: "5.5.5.5", Port: 80},
+							Targets: []ovnlb.Addr{{IP: "10.128.1.2", Port: 8080}}, // local endpoint (ready)
+						},
+					},
+					Routers: []string{"gr-node-b"},
+				},
+				{
+					Name:        "Service_testns/foo_TCP_node_switch_node-b",
+					Protocol:    "TCP",
+					ExternalIDs: defaultExternalIDs,
+					Rules: []ovnlb.LBRule{
+						{
+							Source:  ovnlb.Addr{IP: "169.254.169.3", Port: 5},
+							Targets: []ovnlb.Addr{{IP: "10.128.1.2", Port: 8080}},
+						},
+						{
+							Source:  ovnlb.Addr{IP: "10.0.0.2", Port: 5},
+							Targets: []ovnlb.Addr{{IP: "10.128.0.2", Port: 8080}, {IP: "10.128.1.2", Port: 8080}},
+						},
+						{
+							Source:  ovnlb.Addr{IP: "4.2.2.2", Port: 80},
+							Targets: []ovnlb.Addr{{IP: "10.128.0.2", Port: 8080}, {IP: "10.128.1.2", Port: 8080}},
+						},
+						{
+							Source:  ovnlb.Addr{IP: "5.5.5.5", Port: 80},
+							Targets: []ovnlb.Addr{{IP: "10.128.0.2", Port: 8080}, {IP: "10.128.1.2", Port: 8080}},
+						},
+					},
+					Switches: []string{"switch-node-b"},
+				},
+			},
+		},
+		{
+			name:    "LB service with NodePort, standard pods on different nodes, ExternalTrafficPolicy=local, one endpoint is ready, the other one is terminating and serving",
+			service: defaultService,
+			configs: []lbConfig{
+				{
+					vips:                 []string{"node"},
+					protocol:             v1.ProtocolTCP,
+					inport:               5, // nodePort
+					hasNodePort:          true,
+					externalTrafficLocal: true,
+					clusterEndpoints: lbEndpoints{
+						V4IPs: []string{"10.128.0.2"},
+						Port:  8080,
+					},
+					nodeEndpoints: map[string]lbEndpoints{
+						nodeA: {V4IPs: []string{"10.128.0.2"}, Port: 8080},
+						nodeB: {V4IPs: []string{"10.128.1.2"}, Port: 8080},
+					},
+				},
+				{
+					vips:                 []string{"4.2.2.2", "5.5.5.5"}, // externalIP + LB IP
+					protocol:             v1.ProtocolTCP,
+					inport:               80,
+					hasNodePort:          false,
+					externalTrafficLocal: true,
+					clusterEndpoints: lbEndpoints{
+						V4IPs: []string{"10.128.0.2"},
+						Port:  8080,
+					},
+					nodeEndpoints: map[string]lbEndpoints{
+						nodeA: {V4IPs: []string{"10.128.0.2"}, Port: 8080},
+						nodeB: {V4IPs: []string{"10.128.1.2"}, Port: 8080},
+					},
+				},
+			},
+			expectedShared: []ovnlb.LB{
+				{
+					Name:        "Service_testns/foo_TCP_node_local_router_node-a",
+					Protocol:    "TCP",
+					ExternalIDs: defaultExternalIDs,
+					Opts:        ovnlb.LBOpts{SkipSNAT: true},
+
+					Rules: []ovnlb.LBRule{
+						{
+							Source:  ovnlb.Addr{IP: "10.0.0.1", Port: 5},
+							Targets: []ovnlb.Addr{{IP: "10.128.0.2", Port: 8080}}, // local endpoint
+						},
+						{
+							Source:  ovnlb.Addr{IP: "10.0.0.111", Port: 5},
+							Targets: []ovnlb.Addr{{IP: "10.128.0.2", Port: 8080}}, // local endpoint
+						},
+						{
+							Source:  ovnlb.Addr{IP: "4.2.2.2", Port: 80},
+							Targets: []ovnlb.Addr{{IP: "10.128.0.2", Port: 8080}}, // local endpoint
+						},
+						{
+							Source:  ovnlb.Addr{IP: "5.5.5.5", Port: 80},
+							Targets: []ovnlb.Addr{{IP: "10.128.0.2", Port: 8080}}, // local endpoint
+						},
+					},
+					Routers: []string{"gr-node-a"},
+				},
+				{
+					Name:        "Service_testns/foo_TCP_node_switch_node-a",
+					Protocol:    "TCP",
+					ExternalIDs: defaultExternalIDs,
+					Rules: []ovnlb.LBRule{
+						{
+							Source:  ovnlb.Addr{IP: "169.254.169.3", Port: 5},
+							Targets: []ovnlb.Addr{{IP: "10.128.0.2", Port: 8080}},
+						},
+						{
+							Source:  ovnlb.Addr{IP: "10.0.0.1", Port: 5},
+							Targets: []ovnlb.Addr{{IP: "10.128.0.2", Port: 8080}}, // prefer endpoint on node1 since it's ready
+						},
+						{
+							Source:  ovnlb.Addr{IP: "169.254.169.3", Port: 5},
+							Targets: []ovnlb.Addr{{IP: "10.128.0.2", Port: 8080}},
+						},
+						{
+							Source:  ovnlb.Addr{IP: "10.0.0.111", Port: 5},
+							Targets: []ovnlb.Addr{{IP: "10.128.0.2", Port: 8080}}, // prefer endpoint on node1 since it's ready
+						},
+						{
+							Source:  ovnlb.Addr{IP: "4.2.2.2", Port: 80},
+							Targets: []ovnlb.Addr{{IP: "10.128.0.2", Port: 8080}}, // prefer endpoint on node1 since it's ready
+						},
+						{
+							Source:  ovnlb.Addr{IP: "5.5.5.5", Port: 80},
+							Targets: []ovnlb.Addr{{IP: "10.128.0.2", Port: 8080}}, // prefer endpoint on node1 since it's ready
+						},
+					},
+					Switches: []string{"switch-node-a"},
+				},
+				{
+					Name:        "Service_testns/foo_TCP_node_local_router_node-b",
+					Protocol:    "TCP",
+					ExternalIDs: defaultExternalIDs,
+					Opts:        ovnlb.LBOpts{SkipSNAT: true},
+					Rules: []ovnlb.LBRule{
+						{
+							Source:  ovnlb.Addr{IP: "10.0.0.2", Port: 5},
+							Targets: []ovnlb.Addr{{IP: "10.128.1.2", Port: 8080}}, // local endpoint (fallback to terminating and serving)
+						},
+						{
+							Source:  ovnlb.Addr{IP: "4.2.2.2", Port: 80},
+							Targets: []ovnlb.Addr{{IP: "10.128.1.2", Port: 8080}}, // local endpoint (fallback to terminating and serving)
+						},
+						{
+							Source:  ovnlb.Addr{IP: "5.5.5.5", Port: 80},
+							Targets: []ovnlb.Addr{{IP: "10.128.1.2", Port: 8080}}, // local endpoint (fallback to terminating and serving)
+						},
+					},
+					Routers: []string{"gr-node-b"},
+				},
+				{
+					Name:        "Service_testns/foo_TCP_node_switch_node-b",
+					Protocol:    "TCP",
+					ExternalIDs: defaultExternalIDs,
+					Rules: []ovnlb.LBRule{
+						{
+							Source:  ovnlb.Addr{IP: "169.254.169.3", Port: 5},
+							Targets: []ovnlb.Addr{{IP: "10.128.1.2", Port: 8080}},
+						},
+						{
+							Source:  ovnlb.Addr{IP: "10.0.0.2", Port: 5},
+							Targets: []ovnlb.Addr{{IP: "10.128.0.2", Port: 8080}}, // prefer endpoint on node1 since it's ready
+						},
+						{
+							Source:  ovnlb.Addr{IP: "4.2.2.2", Port: 80},
+							Targets: []ovnlb.Addr{{IP: "10.128.0.2", Port: 8080}}, // prefer endpoint on node1 since it's ready
+						},
+						{
+							Source:  ovnlb.Addr{IP: "5.5.5.5", Port: 80},
+							Targets: []ovnlb.Addr{{IP: "10.128.0.2", Port: 8080}}, // prefer endpoint on node1 since it's ready
+						},
+					},
+					Switches: []string{"switch-node-b"},
+				},
+			},
+		},
 	}
 
+	// needs separate configuration variables for a V6 cluster
+	tcV6 := []struct {
+		name           string
+		service        *v1.Service
+		configs        []lbConfig
+		expectedShared []ovnlb.LB
+		expectedLocal  []ovnlb.LB
+	}{
+		// exactly the same as the v4 test under the same name
+		{
+			name:    "ipv6, nodeport service, standard pod",
+			service: defaultService,
+			configs: []lbConfig{
+				{
+					vips:     []string{"node"},
+					protocol: v1.ProtocolTCP,
+					inport:   80,
+					clusterEndpoints: lbEndpoints{
+						V6IPs: []string{"fe00:0:0:0:1::2"},
+						Port:  8080,
+					},
+					nodeEndpoints: map[string]lbEndpoints{
+						nodeA: {V6IPs: []string{"fe00:0:0:0:1::2"}, Port: 8080},
+					},
+				},
+			},
+			expectedShared: []ovnlb.LB{
+				{
+					Name:        "Service_testns/foo_TCP_node_router+switch_node-a",
+					ExternalIDs: defaultExternalIDs,
+					Routers:     []string{"gr-node-a"},
+					Switches:    []string{"switch-node-a"},
+					Protocol:    "TCP",
+					Rules: []ovnlb.LBRule{
+						{
+							Source:  ovnlb.Addr{IP: "fd00::1", Port: 80},
+							Targets: []ovnlb.Addr{{IP: "fe00:0:0:0:1::2", Port: 8080}},
+						},
+						{
+							Source:  ovnlb.Addr{IP: "fd00::111", Port: 80},
+							Targets: []ovnlb.Addr{{IP: "fe00:0:0:0:1::2", Port: 8080}},
+						},
+					},
+				},
+				{
+					Name:        "Service_testns/foo_TCP_node_router+switch_node-b",
+					ExternalIDs: defaultExternalIDs,
+					Routers:     []string{"gr-node-b"},
+					Switches:    []string{"switch-node-b"},
+					Protocol:    "TCP",
+					Rules: []ovnlb.LBRule{
+						{
+							Source:  ovnlb.Addr{IP: "fd00::2", Port: 80},
+							Targets: []ovnlb.Addr{{IP: "fe00:0:0:0:1::2", Port: 8080}},
+						},
+					},
+				},
+			},
+			expectedLocal: []ovnlb.LB{
+				{
+					Name:        "Service_testns/foo_TCP_node_router+switch_node-a",
+					ExternalIDs: defaultExternalIDs,
+					Routers:     []string{"gr-node-a"},
+					Switches:    []string{"switch-node-a"},
+					Protocol:    "TCP",
+					Rules: []ovnlb.LBRule{
+						{
+							Source:  ovnlb.Addr{IP: "fd00::1", Port: 80},
+							Targets: []ovnlb.Addr{{IP: "fe00:0:0:0:1::2", Port: 8080}},
+						},
+						{
+							Source:  ovnlb.Addr{IP: "fd00::111", Port: 80},
+							Targets: []ovnlb.Addr{{IP: "fe00:0:0:0:1::2", Port: 8080}},
+						},
+					},
+				},
+				{
+					Name:        "Service_testns/foo_TCP_node_router+switch_node-b",
+					ExternalIDs: defaultExternalIDs,
+					Routers:     []string{"gr-node-b"},
+					Switches:    []string{"switch-node-b"},
+					Protocol:    "TCP",
+					Rules: []ovnlb.LBRule{
+						{
+							Source:  ovnlb.Addr{IP: "fd00::2", Port: 80},
+							Targets: []ovnlb.Addr{{IP: "fe00:0:0:0:1::2", Port: 8080}},
+						},
+					},
+				},
+			},
+		},
+		{
+			// exactly the same as last test case for IPv4 but IPv6
+			name:    "IPv6, LB service with NodePort, standard pods on different nodes, ExternalTrafficPolicy=local, one endpoint is ready, the other one is terminating and serving",
+			service: defaultService,
+			configs: []lbConfig{
+				{
+					vips:                 []string{"node"},
+					protocol:             v1.ProtocolTCP,
+					inport:               5, // nodePort
+					hasNodePort:          true,
+					externalTrafficLocal: true,
+					clusterEndpoints: lbEndpoints{
+						V6IPs: []string{"fe00:0:0:0:1::2"},
+						Port:  8080,
+					},
+					nodeEndpoints: map[string]lbEndpoints{
+						nodeA: {V6IPs: []string{"fe00:0:0:0:1::2"}, Port: 8080},
+						nodeB: {V6IPs: []string{"fe00:0:0:0:2::2"}, Port: 8080},
+					},
+				},
+				{
+					vips:                 []string{"cafe::2", "abcd::5"}, // externalIP + LB IP
+					protocol:             v1.ProtocolTCP,
+					inport:               80,
+					hasNodePort:          false,
+					externalTrafficLocal: true,
+					clusterEndpoints: lbEndpoints{
+						V6IPs: []string{"fe00:0:0:0:1::2"},
+						Port:  8080,
+					},
+					nodeEndpoints: map[string]lbEndpoints{
+						nodeA: {V6IPs: []string{"fe00:0:0:0:1::2"}, Port: 8080},
+						nodeB: {V6IPs: []string{"fe00:0:0:0:2::2"}, Port: 8080},
+					},
+				},
+			},
+			expectedShared: []ovnlb.LB{
+				{
+					Name:        "Service_testns/foo_TCP_node_local_router_node-a",
+					Protocol:    "TCP",
+					ExternalIDs: defaultExternalIDs,
+					Opts:        ovnlb.LBOpts{SkipSNAT: true},
+
+					Rules: []ovnlb.LBRule{
+						{
+							Source:  ovnlb.Addr{IP: "fd00::1", Port: 5},
+							Targets: []ovnlb.Addr{{IP: "fe00:0:0:0:1::2", Port: 8080}}, // local endpoint
+						},
+						{
+							Source:  ovnlb.Addr{IP: "fd00::111", Port: 5},
+							Targets: []ovnlb.Addr{{IP: "fe00:0:0:0:1::2", Port: 8080}}, // local endpoint
+						},
+						{
+							Source:  ovnlb.Addr{IP: "cafe::2", Port: 80},
+							Targets: []ovnlb.Addr{{IP: "fe00:0:0:0:1::2", Port: 8080}}, // local endpoint
+						},
+						{
+							Source:  ovnlb.Addr{IP: "abcd::5", Port: 80},
+							Targets: []ovnlb.Addr{{IP: "fe00:0:0:0:1::2", Port: 8080}}, // local endpoint
+						},
+					},
+					Routers: []string{"gr-node-a"},
+				},
+				{
+					Name:        "Service_testns/foo_TCP_node_switch_node-a",
+					Protocol:    "TCP",
+					ExternalIDs: defaultExternalIDs,
+					Rules: []ovnlb.LBRule{
+						{
+							Source:  ovnlb.Addr{IP: "fd69::3", Port: 5},
+							Targets: []ovnlb.Addr{{IP: "fe00:0:0:0:1::2", Port: 8080}},
+						},
+						{
+							Source:  ovnlb.Addr{IP: "fd00::1", Port: 5},
+							Targets: []ovnlb.Addr{{IP: "fe00:0:0:0:1::2", Port: 8080}}, // prefer endpoint on node1 since it's ready
+						},
+						{
+							Source:  ovnlb.Addr{IP: "fd69::3", Port: 5},
+							Targets: []ovnlb.Addr{{IP: "fe00:0:0:0:1::2", Port: 8080}},
+						},
+						{
+							Source:  ovnlb.Addr{IP: "fd00::111", Port: 5},
+							Targets: []ovnlb.Addr{{IP: "fe00:0:0:0:1::2", Port: 8080}}, // prefer endpoint on node1 since it's ready
+						},
+						{
+							Source:  ovnlb.Addr{IP: "cafe::2", Port: 80},
+							Targets: []ovnlb.Addr{{IP: "fe00:0:0:0:1::2", Port: 8080}}, // prefer endpoint on node1 since it's ready
+						},
+						{
+							Source:  ovnlb.Addr{IP: "abcd::5", Port: 80},
+							Targets: []ovnlb.Addr{{IP: "fe00:0:0:0:1::2", Port: 8080}}, // prefer endpoint on node1 since it's ready
+						},
+					},
+					Switches: []string{"switch-node-a"},
+				},
+				{
+					Name:        "Service_testns/foo_TCP_node_local_router_node-b",
+					Protocol:    "TCP",
+					ExternalIDs: defaultExternalIDs,
+					Opts:        ovnlb.LBOpts{SkipSNAT: true},
+					Rules: []ovnlb.LBRule{
+						{
+							Source:  ovnlb.Addr{IP: "fd00::2", Port: 5},
+							Targets: []ovnlb.Addr{{IP: "fe00:0:0:0:2::2", Port: 8080}}, // local endpoint (fallback to terminating and serving)
+						},
+						{
+							Source:  ovnlb.Addr{IP: "cafe::2", Port: 80},
+							Targets: []ovnlb.Addr{{IP: "fe00:0:0:0:2::2", Port: 8080}}, // local endpoint (fallback to terminating and serving)
+						},
+						{
+							Source:  ovnlb.Addr{IP: "abcd::5", Port: 80},
+							Targets: []ovnlb.Addr{{IP: "fe00:0:0:0:2::2", Port: 8080}}, // local endpoint (fallback to terminating and serving)
+						},
+					},
+					Routers: []string{"gr-node-b"},
+				},
+				{
+					Name:        "Service_testns/foo_TCP_node_switch_node-b",
+					Protocol:    "TCP",
+					ExternalIDs: defaultExternalIDs,
+					Rules: []ovnlb.LBRule{
+						{
+							Source:  ovnlb.Addr{IP: "fd69::3", Port: 5},
+							Targets: []ovnlb.Addr{{IP: "fe00:0:0:0:2::2", Port: 8080}},
+						},
+						{
+							Source:  ovnlb.Addr{IP: "fd00::2", Port: 5},
+							Targets: []ovnlb.Addr{{IP: "fe00:0:0:0:1::2", Port: 8080}}, // prefer endpoint on node1 since it's ready
+						},
+						{
+							Source:  ovnlb.Addr{IP: "cafe::2", Port: 80},
+							Targets: []ovnlb.Addr{{IP: "fe00:0:0:0:1::2", Port: 8080}}, // prefer endpoint on node1 since it's ready
+						},
+						{
+							Source:  ovnlb.Addr{IP: "abcd::5", Port: 80},
+							Targets: []ovnlb.Addr{{IP: "fe00:0:0:0:1::2", Port: 8080}}, // prefer endpoint on node1 since it's ready
+						},
+					},
+					Switches: []string{"switch-node-b"},
+				},
+			},
+		},
+	}
+	// v4
 	for i, tt := range tc {
 		t.Run(fmt.Sprintf("%d_%s", i, tt.name), func(t *testing.T) {
 
@@ -1848,22 +3048,933 @@ func Test_buildPerNodeLBs(t *testing.T) {
 
 		})
 	}
+
+	// v6
+	globalconfig.Kubernetes.ServiceCIDRs = []*net.IPNet{svcCIDRv6}
+	for i, tt := range tcV6 {
+		t.Run(fmt.Sprintf("%d_%s", i, tt.name), func(t *testing.T) {
+
+			if tt.expectedShared != nil {
+				globalconfig.Gateway.Mode = globalconfig.GatewayModeShared
+				actual := buildPerNodeLBs(tt.service, tt.configs, defaultNodesV6)
+				assert.Equal(t, tt.expectedShared, actual, "shared gateway mode not as expected")
+			}
+
+			if tt.expectedLocal != nil {
+				globalconfig.Gateway.Mode = globalconfig.GatewayModeLocal
+				actual := buildPerNodeLBs(tt.service, tt.configs, defaultNodesV6)
+				assert.Equal(t, tt.expectedLocal, actual, "local gateway mode not as expected")
+			}
+
+		})
+	}
+
 }
 
-// OCP hack begin
-func Test_buildPerNodeLBs_OCPHackForDNS(t *testing.T) {
-	oldClusterSubnet := globalconfig.Default.ClusterSubnets
-	oldGwMode := globalconfig.Gateway.Mode
-	defer func() {
-		globalconfig.Gateway.Mode = oldGwMode
-		globalconfig.Default.ClusterSubnets = oldClusterSubnet
-	}()
-	_, cidr4, _ := net.ParseCIDR("10.128.0.0/16")
-	_, cidr6, _ := net.ParseCIDR("fe00::/64")
-	globalconfig.Default.ClusterSubnets = []globalconfig.CIDRNetworkEntry{{cidr4, 26}, {cidr6, 26}}
+func Test_getEndpointsForService(t *testing.T) {
+	type args struct {
+		slices []*discovery.EndpointSlice
+		svc    *v1.Service
+		nodes  sets.String
+	}
 
-	name := "dns-default"
-	namespace := "openshift-dns"
+	tests := []struct {
+		name                 string
+		args                 args
+		wantClusterEndpoints map[string]lbEndpoints
+		wantNodeEndpoints    map[string]map[string]lbEndpoints
+	}{
+		{
+			name: "empty slices",
+			args: args{
+				slices: []*discovery.EndpointSlice{},
+				svc:    getSampleServiceWithOnePort(httpPortName, httpPortValue, tcpv1),
+			},
+			wantClusterEndpoints: map[string]lbEndpoints{},            // no cluster-wide endpoints
+			wantNodeEndpoints:    map[string]map[string]lbEndpoints{}, // no local endpoints
+		},
+		{
+			name: "slice with one local endpoint",
+			args: args{
+				slices: []*discovery.EndpointSlice{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab23",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     utilpointer.String("tcp-example"),
+								Protocol: &tcpv1,
+								Port:     utilpointer.Int32(80),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv4,
+						Endpoints:   kube_test.MakeReadyEndpointList(nodeA, "10.0.0.2"),
+					},
+				},
+				svc:   getSampleServiceWithOnePort("tcp-example", 80, tcpv1),
+				nodes: sets.NewString(nodeA), // one-node zone
+			},
+			wantClusterEndpoints: map[string]lbEndpoints{
+				getServicePortKey(tcpv1, "tcp-example"): {V4IPs: []string{"10.0.0.2"}, Port: 80}}, // one cluster-wide endpoint
+			wantNodeEndpoints: map[string]map[string]lbEndpoints{}, // no need for local endpoints, service is not ETP or ITP local
+		},
+		{
+			name: "slice with one local endpoint, ETP=local",
+			args: args{
+				slices: []*discovery.EndpointSlice{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab23",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     utilpointer.String("tcp-example"),
+								Protocol: &tcpv1,
+								Port:     utilpointer.Int32(80),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv4,
+						Endpoints:   kube_test.MakeReadyEndpointList(nodeA, "10.0.0.2"),
+					},
+				},
+				svc:   getSampleServiceWithOnePortAndETPLocal("tcp-example", 80, tcpv1),
+				nodes: sets.NewString(nodeA), // one-node zone
+			},
+			wantClusterEndpoints: map[string]lbEndpoints{
+				getServicePortKey(tcpv1, "tcp-example"): {V4IPs: []string{"10.0.0.2"}, Port: 80}}, // one cluster-wide endpoint
+			wantNodeEndpoints: map[string]map[string]lbEndpoints{
+				getServicePortKey(tcpv1, "tcp-example"): {nodeA: lbEndpoints{V4IPs: []string{"10.0.0.2"}, Port: 80}}}, // ETP=local, one local endpoint
+		},
+		{
+			name: "slice with one non-local endpoint, ETP=local",
+			args: args{
+				slices: []*discovery.EndpointSlice{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab23",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     utilpointer.String("tcp-example"),
+								Protocol: &tcpv1,
+								Port:     utilpointer.Int32(80),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv4,
+						Endpoints:   kube_test.MakeReadyEndpointList(nodeB, "10.0.0.2"),
+					},
+				},
+				svc:   getSampleServiceWithOnePortAndETPLocal("tcp-example", 80, tcpv1),
+				nodes: sets.NewString(nodeA), // one-node zone
+			},
+			wantClusterEndpoints: map[string]lbEndpoints{
+				getServicePortKey(tcpv1, "tcp-example"): {V4IPs: []string{"10.0.0.2"}, Port: 80}}, // one cluster-wide endpoint
+			wantNodeEndpoints: map[string]map[string]lbEndpoints{}, // ETP=local but no local endpoint
+		},
+		{
+			name: "slice of address type FQDN",
+			args: args{
+				slices: []*discovery.EndpointSlice{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab23",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     utilpointer.String("tcp-example"),
+								Protocol: &tcpv1,
+								Port:     utilpointer.Int32(80),
+							},
+						},
+						AddressType: discovery.AddressTypeFQDN,
+						Endpoints:   kube_test.MakeReadyEndpointList(nodeA, "example.com"),
+					},
+				},
+				svc:   getSampleServiceWithOnePort("tcp-example", 80, tcpv1),
+				nodes: sets.NewString(nodeA), // one-node zone
+			},
+			wantClusterEndpoints: map[string]lbEndpoints{},            // no endpoints
+			wantNodeEndpoints:    map[string]map[string]lbEndpoints{}, // no local endpoint
+		},
+		{
+			name: "slice with one endpoint, OVN zone with two nodes, ETP=local",
+			args: args{
+				slices: []*discovery.EndpointSlice{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab23",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     utilpointer.String("tcp-example"),
+								Protocol: &tcpv1,
+								Port:     utilpointer.Int32(80),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv4,
+						Endpoints:   kube_test.MakeReadyEndpointList(nodeB, "10.0.0.2"),
+					},
+				},
+				svc:   getSampleServiceWithOnePortAndETPLocal("tcp-example", 80, tcpv1),
+				nodes: sets.NewString(nodeA, nodeB), // one-node zone
+			},
+			wantClusterEndpoints: map[string]lbEndpoints{
+				getServicePortKey(tcpv1, "tcp-example"): {V4IPs: []string{"10.0.0.2"}, Port: 80}}, // one cluster-wide endpoint
+			wantNodeEndpoints: map[string]map[string]lbEndpoints{
+				getServicePortKey(tcpv1, "tcp-example"): {nodeB: lbEndpoints{V4IPs: []string{"10.0.0.2"}, Port: 80}}}, // endpoint on nodeB
+		},
+		{
+			name: "slice with different port name than the service",
+			args: args{
+				slices: []*discovery.EndpointSlice{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab23",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     utilpointer.String("tcp-example-wrong"),
+								Protocol: &tcp,
+								Port:     utilpointer.Int32(8080),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv4,
+						Endpoints:   kube_test.MakeReadyEndpointList(nodeA, "10.0.0.2"),
+					},
+				},
+				svc:   getSampleServiceWithOnePort("tcp-example", 80, tcpv1),
+				nodes: sets.NewString(nodeA), // one-node zone
+			},
+			wantClusterEndpoints: map[string]lbEndpoints{},            // no cluster-wide endpoints
+			wantNodeEndpoints:    map[string]map[string]lbEndpoints{}, // no local endpoints
+		},
+		{
+			name: "slice and service without a port name, ETP=local",
+			args: args{
+				slices: []*discovery.EndpointSlice{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab23",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Protocol: &tcpv1,
+								Port:     utilpointer.Int32(8080),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv4,
+						Endpoints:   kube_test.MakeReadyEndpointList(nodeA, "10.0.0.2"),
+					},
+				},
+				svc:   getSampleServiceWithOnePortAndETPLocal("", 80, tcpv1), // port with no name
+				nodes: sets.NewString(nodeA),                                 // one-node zone
+
+			},
+			wantClusterEndpoints: map[string]lbEndpoints{
+				getServicePortKey(tcpv1, ""): {V4IPs: []string{"10.0.0.2"}, Port: 8080}}, // one cluster-wide endpoint
+			wantNodeEndpoints: map[string]map[string]lbEndpoints{
+				getServicePortKey(tcpv1, ""): {nodeA: lbEndpoints{V4IPs: []string{"10.0.0.2"}, Port: 8080}}}, // one local endpoint
+		},
+		{
+			name: "slice with an IPv6 endpoint",
+			args: args{
+				slices: []*discovery.EndpointSlice{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab23",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     utilpointer.String("tcp-example"),
+								Protocol: &tcp,
+								Port:     utilpointer.Int32(80),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv6,
+						Endpoints:   kube_test.MakeReadyEndpointList(nodeA, "2001:db2::2"),
+					},
+				},
+				svc:   getSampleServiceWithOnePort("tcp-example", 80, tcpv1),
+				nodes: sets.NewString(nodeA), // one-node zone
+			},
+			wantClusterEndpoints: map[string]lbEndpoints{
+				getServicePortKey(tcpv1, "tcp-example"): {V6IPs: []string{"2001:db2::2"}, Port: 80}}, // one cluster-wide endpoint
+			wantNodeEndpoints: map[string]map[string]lbEndpoints{}, //  local endpoints not filled in, since service is not ETP or ITP local
+		},
+		{
+			name: "a slice with an IPv4 endpoint and a slice with an IPv6 endpoint (dualstack cluster), ETP=local",
+			args: args{
+				slices: []*discovery.EndpointSlice{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab23",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     utilpointer.String("tcp-example"),
+								Protocol: &tcp,
+								Port:     utilpointer.Int32(80),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv4,
+						Endpoints:   kube_test.MakeReadyEndpointList(nodeA, "10.0.0.2"),
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab24",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     utilpointer.String("tcp-example"),
+								Protocol: &tcp,
+								Port:     utilpointer.Int32(80),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv6,
+						Endpoints:   kube_test.MakeReadyEndpointList(nodeA, "2001:db2::2"),
+					},
+				},
+				svc:   getSampleServiceWithOnePortAndETPLocal("tcp-example", 80, tcpv1),
+				nodes: sets.NewString(nodeA), // one-node zone
+			},
+			wantClusterEndpoints: map[string]lbEndpoints{
+				getServicePortKey(tcpv1, "tcp-example"): {V4IPs: []string{"10.0.0.2"}, V6IPs: []string{"2001:db2::2"}, Port: 80}},
+			wantNodeEndpoints: map[string]map[string]lbEndpoints{
+				getServicePortKey(tcpv1, "tcp-example"): {nodeA: lbEndpoints{V4IPs: []string{"10.0.0.2"}, V6IPs: []string{"2001:db2::2"}, Port: 80}}},
+		},
+		{
+			name: "one slice with a duplicate address in the same endpoint",
+			args: args{
+				slices: []*discovery.EndpointSlice{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab23",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     utilpointer.String("tcp-example"),
+								Protocol: &tcp,
+								Port:     utilpointer.Int32(80),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv4,
+						Endpoints:   kube_test.MakeReadyEndpointList(nodeA, "10.0.0.2", "10.0.0.2"),
+					},
+				},
+				svc:   getSampleServiceWithOnePort("tcp-example", 80, tcpv1),
+				nodes: sets.NewString(nodeA), // one-node zone
+			},
+			wantClusterEndpoints: map[string]lbEndpoints{
+				getServicePortKey(tcpv1, "tcp-example"): {V4IPs: []string{"10.0.0.2"}, Port: 80}},
+			wantNodeEndpoints: map[string]map[string]lbEndpoints{}, // local endpoints not filled in, since service is not ETP or ITP local
+		},
+		{
+			name: "one slice with a duplicate address across two endpoints",
+			args: args{
+				slices: []*discovery.EndpointSlice{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab23",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     utilpointer.String("tcp-example"),
+								Protocol: &tcp,
+								Port:     utilpointer.Int32(80),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv4,
+						Endpoints:   []discovery.Endpoint{kube_test.MakeReadyEndpoint(nodeA, "10.0.0.2"), kube_test.MakeReadyEndpoint(nodeA, "10.0.0.2")},
+					},
+				},
+				svc:   getSampleServiceWithOnePort("tcp-example", 80, tcpv1),
+				nodes: sets.NewString(nodeA), // one-node zone
+			},
+			wantClusterEndpoints: map[string]lbEndpoints{
+				getServicePortKey(tcpv1, "tcp-example"): {V4IPs: []string{"10.0.0.2"}, Port: 80}},
+			wantNodeEndpoints: map[string]map[string]lbEndpoints{}, // local endpoints not filled in, since service is not ETP or ITP local
+		},
+		{
+			name: "multiples slices with a duplicate address, with both address being ready",
+			args: args{
+				slices: []*discovery.EndpointSlice{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab23",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     utilpointer.String("tcp-example"),
+								Protocol: &tcp,
+								Port:     utilpointer.Int32(80),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv4,
+						Endpoints:   kube_test.MakeReadyEndpointList(nodeA, "10.0.0.2", "10.1.1.2"),
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab24",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     utilpointer.String("tcp-example"),
+								Protocol: &tcp,
+								Port:     utilpointer.Int32(80),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv4,
+						Endpoints:   kube_test.MakeReadyEndpointList(nodeA, "10.0.0.2", "10.2.2.2"),
+					},
+				},
+				svc:   getSampleServiceWithOnePort("tcp-example", 80, tcpv1),
+				nodes: sets.NewString(nodeA), // one-node zone
+			},
+			wantClusterEndpoints: map[string]lbEndpoints{
+				getServicePortKey(tcpv1, "tcp-example"): {V4IPs: []string{"10.0.0.2", "10.1.1.2", "10.2.2.2"}, Port: 80}},
+			wantNodeEndpoints: map[string]map[string]lbEndpoints{}, // local endpoints not filled in, since service is not ETP or ITP local
+		},
+		{
+			name: "multiples slices with different ports, ETP=local",
+			args: args{
+				slices: []*discovery.EndpointSlice{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab23",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     utilpointer.String("tcp-example"),
+								Protocol: &tcp,
+								Port:     utilpointer.Int32(80),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv4,
+						Endpoints:   kube_test.MakeReadyEndpointList(nodeA, "10.0.0.2", "10.1.1.2"),
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab24",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     utilpointer.String("other-port"),
+								Protocol: &tcp,
+								Port:     utilpointer.Int32(8080),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv4,
+						Endpoints:   kube_test.MakeReadyEndpointList(nodeA, "10.0.0.3", "10.2.2.3"),
+					},
+				},
+				svc:   getSampleServiceWithTwoPortsAndETPLocal("tcp-example", "other-port", 80, 8080, tcpv1, tcpv1),
+				nodes: sets.NewString(nodeA), // one-node zone
+			},
+			wantClusterEndpoints: map[string]lbEndpoints{
+				getServicePortKey(tcpv1, "tcp-example"): {V4IPs: []string{"10.0.0.2", "10.1.1.2"}, Port: 80},
+				getServicePortKey(tcpv1, "other-port"):  {V4IPs: []string{"10.0.0.3", "10.2.2.3"}, Port: 8080}},
+			wantNodeEndpoints: map[string]map[string]lbEndpoints{
+				getServicePortKey(tcpv1, "tcp-example"): {nodeA: lbEndpoints{V4IPs: []string{"10.0.0.2", "10.1.1.2"}, Port: 80}},
+				getServicePortKey(tcpv1, "other-port"):  {nodeA: lbEndpoints{V4IPs: []string{"10.0.0.3", "10.2.2.3"}, Port: 8080}}},
+		},
+		{
+			name: "multiples slices with different ports, OVN zone with two nodes, ETP=local",
+			args: args{
+				slices: []*discovery.EndpointSlice{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab23",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     utilpointer.String("tcp-example"),
+								Protocol: &tcp,
+								Port:     utilpointer.Int32(80),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv4,
+						Endpoints:   kube_test.MakeReadyEndpointList(nodeA, "10.0.0.2", "10.1.1.2"),
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab24",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     utilpointer.String("other-port"),
+								Protocol: &tcp,
+								Port:     utilpointer.Int32(8080),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv4,
+						Endpoints:   kube_test.MakeReadyEndpointList(nodeB, "10.0.0.3", "10.2.2.3"),
+					},
+				},
+				svc:   getSampleServiceWithTwoPortsAndETPLocal("tcp-example", "other-port", 80, 8080, tcpv1, tcpv1),
+				nodes: sets.NewString(nodeA, nodeB), // zone with two nodes
+			},
+			wantClusterEndpoints: map[string]lbEndpoints{
+				getServicePortKey(tcpv1, "tcp-example"): {V4IPs: []string{"10.0.0.2", "10.1.1.2"}, Port: 80},
+				getServicePortKey(tcpv1, "other-port"):  {V4IPs: []string{"10.0.0.3", "10.2.2.3"}, Port: 8080}},
+			wantNodeEndpoints: map[string]map[string]lbEndpoints{
+				getServicePortKey(tcpv1, "tcp-example"): {nodeA: lbEndpoints{V4IPs: []string{"10.0.0.2", "10.1.1.2"}, Port: 80}},
+				getServicePortKey(tcpv1, "other-port"):  {nodeB: lbEndpoints{V4IPs: []string{"10.0.0.3", "10.2.2.3"}, Port: 8080}}},
+		},
+		{
+			name: "slice with a mix of ready and terminating (serving and non-serving) endpoints",
+			args: args{
+				slices: []*discovery.EndpointSlice{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab23",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     utilpointer.String("tcp-example"),
+								Protocol: &tcp,
+								Port:     utilpointer.Int32(80),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv6,
+						Endpoints: []discovery.Endpoint{
+							kube_test.MakeReadyEndpoint(nodeA, "2001:db2::2"),
+							kube_test.MakeReadyEndpoint(nodeA, "2001:db2::3"),
+							kube_test.MakeTerminatingServingEndpoint(nodeA, "2001:db2::4"),
+							kube_test.MakeTerminatingServingEndpoint(nodeA, "2001:db2::5"),
+							kube_test.MakeTerminatingNonServingEndpoint(nodeA, "2001:db2::6"), // ignored
+						},
+					},
+				},
+				svc:   getSampleServiceWithOnePort("tcp-example", 80, tcpv1),
+				nodes: sets.NewString(nodeA), // one-node zone
+
+			},
+			wantClusterEndpoints: map[string]lbEndpoints{
+				getServicePortKey(tcpv1, "tcp-example"): {V6IPs: []string{"2001:db2::2", "2001:db2::3"}, Port: 80}},
+			wantNodeEndpoints: map[string]map[string]lbEndpoints{}, // local endpoints not filled in, since service is not ETP or ITP local
+		},
+		{
+			name: "slice with a mix of terminating (serving and non-serving) endpoints and no ready endpoints",
+			args: args{
+				slices: []*discovery.EndpointSlice{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab23",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     utilpointer.String("tcp-example"),
+								Protocol: &tcp,
+								Port:     utilpointer.Int32(80),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv6,
+						Endpoints: []discovery.Endpoint{
+							kube_test.MakeTerminatingServingEndpoint(nodeA, "2001:db2::4"),
+							kube_test.MakeTerminatingServingEndpoint(nodeA, "2001:db2::5"),
+							kube_test.MakeTerminatingNonServingEndpoint(nodeA, "2001:db2::6"),
+							kube_test.MakeTerminatingNonServingEndpoint(nodeA, "2001:db2::7"),
+						},
+					},
+				},
+				svc:   getSampleServiceWithOnePort("tcp-example", 80, tcpv1),
+				nodes: sets.NewString(nodeA), // one-node zone
+			},
+			wantClusterEndpoints: map[string]lbEndpoints{
+				getServicePortKey(tcpv1, "tcp-example"): {V6IPs: []string{"2001:db2::4", "2001:db2::5"}, Port: 80}},
+			wantNodeEndpoints: map[string]map[string]lbEndpoints{}, // local endpoints not filled in, since service is not ETP or ITP local
+		},
+		{
+			name: "slice with only terminating non-serving endpoints",
+			args: args{
+				slices: []*discovery.EndpointSlice{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab23",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     utilpointer.String("tcp-example"),
+								Protocol: &tcp,
+								Port:     utilpointer.Int32(80),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv6,
+						Endpoints: []discovery.Endpoint{
+							kube_test.MakeTerminatingNonServingEndpoint(nodeA, "2001:db2::6"),
+							kube_test.MakeTerminatingNonServingEndpoint(nodeA, "2001:db2::7"),
+						},
+					},
+				},
+				svc:   getSampleServiceWithOnePort("tcp-example", 80, tcpv1),
+				nodes: sets.NewString(nodeA), // one-node zone
+			},
+			wantClusterEndpoints: map[string]lbEndpoints{},            // no cluster-wide endpoints
+			wantNodeEndpoints:    map[string]map[string]lbEndpoints{}, // local endpoints not filled in, since service is not ETP or ITP local
+
+		},
+		{
+			name: "multiple slices with a mix of terminating (serving and non-serving) endpoints and no ready endpoints",
+			args: args{
+				slices: []*discovery.EndpointSlice{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab23",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     utilpointer.String("tcp-example"),
+								Protocol: &tcp,
+								Port:     utilpointer.Int32(80),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv6,
+						Endpoints: []discovery.Endpoint{
+							kube_test.MakeTerminatingNonServingEndpoint(nodeA, "2001:db2::2"), // ignored
+							kube_test.MakeTerminatingServingEndpoint(nodeA, "2001:db2::3"),
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab24",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     utilpointer.String("tcp-example"),
+								Protocol: &tcp,
+								Port:     utilpointer.Int32(80),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv6,
+						Endpoints: []discovery.Endpoint{
+							kube_test.MakeTerminatingServingEndpoint(nodeA, "2001:db2::4"),
+							kube_test.MakeTerminatingNonServingEndpoint(nodeA, "2001:db2::5"), // ignored
+						},
+					},
+				},
+				svc:   getSampleServiceWithOnePort("tcp-example", 80, tcpv1),
+				nodes: sets.NewString(nodeA), // one-node zone
+			},
+			wantClusterEndpoints: map[string]lbEndpoints{
+				getServicePortKey(tcpv1, "tcp-example"): {V6IPs: []string{"2001:db2::3", "2001:db2::4"}, Port: 80}},
+			wantNodeEndpoints: map[string]map[string]lbEndpoints{}, // local endpoints not filled in, since service is not ETP or ITP local
+		},
+		{
+			name: "multiple slices with only terminating non-serving endpoints",
+			args: args{
+				slices: []*discovery.EndpointSlice{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab23",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     utilpointer.String("tcp-example"),
+								Protocol: &tcp,
+								Port:     utilpointer.Int32(80),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv6,
+						Endpoints: []discovery.Endpoint{
+							kube_test.MakeTerminatingNonServingEndpoint(nodeA, "2001:db2::2"),
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab24",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     utilpointer.String("tcp-example"),
+								Protocol: &tcp,
+								Port:     utilpointer.Int32(80),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv6,
+						Endpoints: []discovery.Endpoint{
+							kube_test.MakeTerminatingNonServingEndpoint(nodeA, "2001:db2::5"),
+						},
+					},
+				},
+				svc:   getSampleServiceWithOnePort("tcp-example", 80, tcpv1),
+				nodes: sets.NewString(nodeA), // one-node zone
+			},
+			wantClusterEndpoints: map[string]lbEndpoints{},            // no cluster-wide endpoints
+			wantNodeEndpoints:    map[string]map[string]lbEndpoints{}, // no local endpoints
+
+		},
+		{
+			name: "multiple slices with a mix of IPv4 and IPv6 ready and terminating (serving and non-serving) endpoints (dualstack cluster)",
+			args: args{
+				slices: []*discovery.EndpointSlice{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab23",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     utilpointer.String("tcp-example"),
+								Protocol: &tcp,
+								Port:     utilpointer.Int32(80),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv4,
+						Endpoints: []discovery.Endpoint{
+							kube_test.MakeReadyEndpoint(nodeA, "10.0.0.2"),
+							kube_test.MakeTerminatingServingEndpoint(nodeA, "10.0.0.3"),
+							kube_test.MakeTerminatingNonServingEndpoint(nodeA, "10.0.0.4"), // ignored
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab24",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     utilpointer.String("tcp-example"),
+								Protocol: &tcp,
+								Port:     utilpointer.Int32(80),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv6,
+						Endpoints: []discovery.Endpoint{
+							kube_test.MakeReadyEndpoint(nodeA, "2001:db2::2"),
+							kube_test.MakeTerminatingServingEndpoint(nodeA, "2001:db2::3"),
+							kube_test.MakeTerminatingNonServingEndpoint(nodeA, "2001:db2::4"), // ignored
+						},
+					},
+				},
+				svc:   getSampleServiceWithOnePort("tcp-example", 80, tcpv1),
+				nodes: sets.NewString(nodeA), // one-node zone
+			},
+			wantClusterEndpoints: map[string]lbEndpoints{
+				getServicePortKey(tcpv1, "tcp-example"): {V4IPs: []string{"10.0.0.2"}, V6IPs: []string{"2001:db2::2"}, Port: 80}},
+			wantNodeEndpoints: map[string]map[string]lbEndpoints{}, // local endpoints not filled in, since service is not ETP or ITP local
+		},
+		{
+			name: "multiple slices with a mix of IPv4 and IPv6 terminating (serving and non-serving) endpoints and no ready endpoints (dualstack cluster)",
+			args: args{
+				slices: []*discovery.EndpointSlice{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab23",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     utilpointer.String("tcp-example"),
+								Protocol: &tcp,
+								Port:     utilpointer.Int32(80),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv4,
+						Endpoints: []discovery.Endpoint{
+							kube_test.MakeTerminatingServingEndpoint(nodeA, "10.0.0.3"),
+							kube_test.MakeTerminatingNonServingEndpoint(nodeA, "10.0.0.4"),
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab24",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     utilpointer.String("tcp-example"),
+								Protocol: &tcp,
+								Port:     utilpointer.Int32(80),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv6,
+						Endpoints: []discovery.Endpoint{
+							kube_test.MakeTerminatingServingEndpoint(nodeA, "2001:db2::3"),
+							kube_test.MakeTerminatingNonServingEndpoint(nodeA, "2001:db2::4"),
+						},
+					},
+				},
+				svc:   getSampleServiceWithOnePort("tcp-example", 80, tcpv1),
+				nodes: sets.NewString(nodeA), // one-node zone
+			},
+			wantClusterEndpoints: map[string]lbEndpoints{
+				getServicePortKey(tcpv1, "tcp-example"): {V4IPs: []string{"10.0.0.3"}, V6IPs: []string{"2001:db2::3"}, Port: 80}},
+			wantNodeEndpoints: map[string]map[string]lbEndpoints{}, // local endpoints not filled in, since service is not ETP or ITP local
+		},
+		{
+			name: "multiple slices with a mix of IPv4 and IPv6 terminating non-serving endpoints (dualstack cluster)",
+			args: args{
+				slices: []*discovery.EndpointSlice{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab23",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     utilpointer.String("tcp-example"),
+								Protocol: &tcp,
+								Port:     utilpointer.Int32(80),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv4,
+						Endpoints: []discovery.Endpoint{
+							kube_test.MakeTerminatingNonServingEndpoint(nodeA, "10.0.0.4"), // ignored
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab24",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     utilpointer.String("tcp-example"),
+								Protocol: &tcp,
+								Port:     utilpointer.Int32(80),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv6,
+						Endpoints: []discovery.Endpoint{
+							kube_test.MakeTerminatingNonServingEndpoint(nodeA, "2001:db2::4"), // ignored
+						},
+					},
+				},
+				svc:   getSampleServiceWithOnePort("tcp-example", 80, tcpv1),
+				nodes: sets.NewString(nodeA), // one-node zone
+
+			},
+			wantClusterEndpoints: map[string]lbEndpoints{},            // no endpoints
+			wantNodeEndpoints:    map[string]map[string]lbEndpoints{}, // no endpoints
+		},
+		{
+			name: "multiple slices with a mix of IPv4 and IPv6 ready and terminating (serving and non-serving) endpoints (dualstack cluster) and service.PublishNotReadyAddresses=true",
+			args: args{
+				slices: []*discovery.EndpointSlice{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab23",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     utilpointer.String("tcp-example"),
+								Protocol: &tcp,
+								Port:     utilpointer.Int32(80),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv4,
+						Endpoints: []discovery.Endpoint{
+							kube_test.MakeReadyEndpoint(nodeA, "10.0.0.2"),                 // included
+							kube_test.MakeTerminatingServingEndpoint(nodeA, "10.0.0.3"),    // included
+							kube_test.MakeTerminatingNonServingEndpoint(nodeA, "10.0.0.4"), // included
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab24",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     utilpointer.String("tcp-example"),
+								Protocol: &tcp,
+								Port:     utilpointer.Int32(80),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv6,
+						Endpoints: []discovery.Endpoint{
+							kube_test.MakeReadyEndpoint(nodeA, "2001:db2::2"),                 // included
+							kube_test.MakeTerminatingServingEndpoint(nodeA, "2001:db2::3"),    // included
+							kube_test.MakeTerminatingNonServingEndpoint(nodeA, "2001:db2::4"), // included
+						},
+					},
+				},
+				svc:   getSampleServiceWithOnePortAndPublishNotReadyAddresses("tcp-example", 80, tcpv1), // <-- publishNotReadyAddresses=true
+				nodes: sets.NewString(nodeA),                                                            // one-node zone
+			},
+			wantClusterEndpoints: map[string]lbEndpoints{
+				getServicePortKey(tcpv1, "tcp-example"): {
+					V4IPs: []string{"10.0.0.2", "10.0.0.3", "10.0.0.4"},
+					V6IPs: []string{"2001:db2::2", "2001:db2::3", "2001:db2::4"}, Port: 80}},
+
+			wantNodeEndpoints: map[string]map[string]lbEndpoints{}, // local endpoints not filled in, since service is not ETP or ITP local
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			portToClusterEndpoints, portToNodeToEndpoints := getEndpointsForService(tt.args.slices, tt.args.svc, tt.args.nodes)
+			assert.Equal(t, tt.wantClusterEndpoints, portToClusterEndpoints)
+			assert.Equal(t, tt.wantNodeEndpoints, portToNodeToEndpoints)
+
+		})
+	}
+
+}
+
+func Test_makeNodeSwitchTargetIPs(t *testing.T) {
+	// OCP HACK BEGIN
+	name := "foo"
+	namespace := "testns"
 
 	defaultService := &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
@@ -1872,389 +3983,154 @@ func Test_buildPerNodeLBs_OCPHackForDNS(t *testing.T) {
 		},
 	}
 
-	defaultNodes := []nodeInfo{
-		{
-			name:              "node-a",
-			nodeIPs:           []string{"10.0.0.1"},
-			gatewayRouterName: "gr-node-a",
-			switchName:        "switch-node-a",
-			podSubnets:        []net.IPNet{{IP: net.ParseIP("10.128.0.0"), Mask: net.CIDRMask(24, 32)}},
-		},
-		{
-			name:              "node-b",
-			nodeIPs:           []string{"10.0.0.2"},
-			gatewayRouterName: "gr-node-b",
-			switchName:        "switch-node-b",
-			podSubnets:        []net.IPNet{{IP: net.ParseIP("10.128.1.0"), Mask: net.CIDRMask(24, 32)}},
-		},
+	addFallbackAnnotationToService := func(s *v1.Service) *v1.Service {
+		s.Annotations = map[string]string{localWithFallbackAnnotation: ""}
+		return s
 	}
-
-	defaultExternalIDs := map[string]string{
-		"k8s.ovn.org/kind":  "Service",
-		"k8s.ovn.org/owner": fmt.Sprintf("%s/%s", namespace, name),
-	}
-
-	//defaultRouters := []string{"gr-node-a", "gr-node-b"}
-	//defaultSwitches := []string{"switch-node-a", "switch-node-b"}
+	// OCP HACK END
 
 	tc := []struct {
-		name     string
-		service  *v1.Service
-		configs  []lbConfig
-		expected []ovnlb.LB
+		name                string
+		service             *v1.Service
+		config              *lbConfig
+		node                string
+		expectedTargetIPsV4 []string
+		expectedTargetIPsV6 []string
+		expectedV4Changed   bool
+		expectedV6Changed   bool
 	}{
 		{
-			name:    "clusterIP service, standard pods",
+			name:    "cluster ip service", //ETP=cluster by default on all services
 			service: defaultService,
-			configs: []lbConfig{
-				{
-					vips:     []string{"192.168.1.1"},
-					protocol: v1.ProtocolTCP,
-					inport:   80,
-					eps: util.LbEndpoints{
-						V4IPs: []string{"10.128.0.2", "10.128.1.2"},
+			config: &lbConfig{
+				vips:     []string{"1.2.3.4", "fe10::1"},
+				protocol: v1.ProtocolTCP,
+				inport:   80,
+				clusterEndpoints: lbEndpoints{
+					V4IPs: []string{"192.168.0.1"},
+					V6IPs: []string{"fe00:0:0:0:1::2"},
+					Port:  8080,
+				},
+				nodeEndpoints: map[string]lbEndpoints{
+					nodeA: {
+						V4IPs: []string{"192.168.0.1"},
+						V6IPs: []string{"fe00:0:0:0:1::2"},
 						Port:  8080,
 					},
 				},
 			},
-			expected: []ovnlb.LB{
-				{
-					Name:        "Service_openshift-dns/dns-default_TCP_node_router_node-a_merged",
-					ExternalIDs: defaultExternalIDs,
-					Routers:     []string{"gr-node-a", "gr-node-b"},
-					Protocol:    "TCP",
-					Rules: []ovnlb.LBRule{
-						{
-							Source:  ovnlb.Addr{"192.168.1.1", 80},
-							Targets: []ovnlb.Addr{{"10.128.0.2", 8080}, {"10.128.1.2", 8080}},
-						},
-					},
-				},
-				{
-					Name:        "Service_openshift-dns/dns-default_TCP_node_switch_node-a",
-					ExternalIDs: defaultExternalIDs,
-					Switches:    []string{"switch-node-a"},
-					Protocol:    "TCP",
-					Rules: []ovnlb.LBRule{
-						{
-							Source:  ovnlb.Addr{"192.168.1.1", 80},
-							Targets: []ovnlb.Addr{{"10.128.0.2", 8080}},
-						},
-					},
-				},
-				{
-					Name:        "Service_openshift-dns/dns-default_TCP_node_switch_node-b",
-					ExternalIDs: defaultExternalIDs,
-					Switches:    []string{"switch-node-b"},
-					Protocol:    "TCP",
-					Rules: []ovnlb.LBRule{
-						{
-							Source:  ovnlb.Addr{"192.168.1.1", 80},
-							Targets: []ovnlb.Addr{{"10.128.1.2", 8080}},
-						},
-					},
-				},
-			},
+			node:                nodeA,
+			expectedTargetIPsV4: []string{"192.168.0.1"},
+			expectedTargetIPsV6: []string{"fe00:0:0:0:1::2"},
+			expectedV4Changed:   false,
+			expectedV6Changed:   false,
 		},
-	}
+		{
+			name:    "LB service with ETP=local, endpoint count changes",
+			service: getSampleServiceWithOnePortAndETPLocal("tcp-example", 80, tcpv1),
+			config: &lbConfig{
+				vips:     []string{"1.2.3.4", "fe10::1"},
+				protocol: v1.ProtocolTCP,
+				inport:   80,
+				clusterEndpoints: lbEndpoints{
+					V4IPs: []string{"192.168.0.1", "192.168.1.1"},
+					V6IPs: []string{"fe00:0:0:0:1::2", "fe00:0:0:0:2::2"},
 
+					Port: 8080,
+				},
+				nodeEndpoints: map[string]lbEndpoints{
+					nodeA: {
+						V4IPs: []string{"192.168.0.1"},
+						V6IPs: []string{"fe00:0:0:0:1::2"},
+						Port:  8080,
+					},
+				},
+				externalTrafficLocal: true,
+			},
+			node:                nodeA,
+			expectedTargetIPsV4: []string{"192.168.0.1"}, // only the endpoint on nodeA is kept
+			expectedTargetIPsV6: []string{"fe00:0:0:0:1::2"},
+			expectedV4Changed:   true,
+			expectedV6Changed:   true,
+		},
+		{
+			name:    "LB service with ETP=local, endpoint count is the same",
+			service: getSampleServiceWithOnePortAndETPLocal("tcp-example", 80, tcpv1),
+			config: &lbConfig{
+				vips:     []string{"1.2.3.4", "fe10::1"},
+				protocol: v1.ProtocolTCP,
+				inport:   80,
+				clusterEndpoints: lbEndpoints{
+					V4IPs: []string{"192.168.0.1"},
+					V6IPs: []string{"fe00:0:0:0:1::2"},
+
+					Port: 8080,
+				},
+				nodeEndpoints: map[string]lbEndpoints{
+					nodeA: {
+						V4IPs: []string{"192.168.0.1"},
+						V6IPs: []string{"fe00:0:0:0:1::2"},
+						Port:  8080,
+					},
+				},
+				externalTrafficLocal: true,
+			},
+			node:                nodeA,
+			expectedTargetIPsV4: []string{"192.168.0.1"},
+			expectedTargetIPsV6: []string{"fe00:0:0:0:1::2"},
+			expectedV4Changed:   false,
+		},
+		{
+			name:    "LB service with ETP=local, no local endpoints left",
+			service: getSampleServiceWithOnePortAndETPLocal("tcp-example", 80, tcpv1),
+			config: &lbConfig{
+				vips:     []string{"1.2.3.4", "fe10::1"},
+				protocol: v1.ProtocolTCP,
+				inport:   80,
+				clusterEndpoints: lbEndpoints{
+					V4IPs: []string{"192.168.1.1"},     // on nodeB
+					V6IPs: []string{"fe00:0:0:0:2::2"}, // on nodeB
+					Port:  8080,
+				},
+				// nothing on nodeA
+				externalTrafficLocal: true,
+			},
+			node:                nodeA,
+			expectedTargetIPsV4: []string{},
+			expectedTargetIPsV6: []string{}, // no local endpoints
+			expectedV4Changed:   true,
+			expectedV6Changed:   true,
+		},
+		// OCP HACK BEGIN
+		{
+			name:    "LB service with ETP=local, no local endpoints left, localWithFallback annotation",
+			service: addFallbackAnnotationToService(getSampleServiceWithOnePortAndETPLocal("tcp-example", 80, tcpv1)),
+			config: &lbConfig{
+				vips:     []string{"1.2.3.4", "fe10::1"},
+				protocol: v1.ProtocolTCP,
+				inport:   80,
+				clusterEndpoints: lbEndpoints{
+					V4IPs: []string{"192.168.1.1"},     // on nodeB
+					V6IPs: []string{"fe00:0:0:0:2::2"}, // on nodeB
+					Port:  8080,
+				},
+				// nothing on nodeA
+				externalTrafficLocal: true,
+			},
+			node:                nodeA,
+			expectedTargetIPsV4: []string{"192.168.1.1"},     // fallback to cluster endpoints
+			expectedTargetIPsV6: []string{"fe00:0:0:0:2::2"}, // fallback to cluster endpoints
+			expectedV4Changed:   false,
+			expectedV6Changed:   false,
+		},
+		// OCP HACK END
+	}
 	for i, tt := range tc {
 		t.Run(fmt.Sprintf("%d_%s", i, tt.name), func(t *testing.T) {
+			actualTargetIPsV4, actualTargetIPsV6 := makeNodeSwitchTargetIPs(tt.service, tt.node, tt.config)
+			assert.Equal(t, tt.expectedTargetIPsV4, actualTargetIPsV4)
+			assert.Equal(t, tt.expectedTargetIPsV6, actualTargetIPsV6)
 
-			globalconfig.Gateway.Mode = globalconfig.GatewayModeShared
-			actual := buildPerNodeLBs(tt.service, tt.configs, defaultNodes)
-			assert.Equal(t, tt.expected, actual, "shared gateway mode not as expected")
-
-			globalconfig.Gateway.Mode = globalconfig.GatewayModeLocal
-			actual = buildPerNodeLBs(tt.service, tt.configs, defaultNodes)
-			assert.Equal(t, tt.expected, actual, "local gateway mode not as expected")
-		})
-	}
-}
-
-// OCP hack end
-
-// OCP hack begin
-func Test_buildPerNodeLBs_OCPHackForLocalWithFallback(t *testing.T) {
-	oldClusterSubnet := globalconfig.Default.ClusterSubnets
-	oldGwMode := globalconfig.Gateway.Mode
-	defer func() {
-		globalconfig.Gateway.Mode = oldGwMode
-		globalconfig.Default.ClusterSubnets = oldClusterSubnet
-	}()
-	_, cidr4, _ := net.ParseCIDR("10.128.0.0/16")
-	globalconfig.Default.ClusterSubnets = []globalconfig.CIDRNetworkEntry{{cidr4, 26}}
-
-	name := "router-default"
-	namespace := "openshift-ingress"
-	inport := int32(80)
-	outport := int32(8080)
-
-	defaultService := &v1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        name,
-			Namespace:   namespace,
-			Annotations: map[string]string{localWithFallbackAnnotation: ""}, // code checks for this annotation
-		},
-		Spec: v1.ServiceSpec{
-			Type:                  v1.ServiceTypeLoadBalancer,
-			ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeLocal,
-			// add ingress IP
-			ClusterIP:  "192.168.1.1",
-			ClusterIPs: []string{"192.168.1.1"},
-			Ports: []v1.ServicePort{ // don't consider https for simplicity
-				{
-					Name:       "http",
-					Port:       80,
-					Protocol:   v1.ProtocolTCP,
-					TargetPort: intstr.FromInt(80),
-					NodePort:   5,
-				},
-			},
-		},
-		Status: v1.ServiceStatus{
-			LoadBalancer: v1.LoadBalancerStatus{
-				Ingress: []v1.LoadBalancerIngress{{
-					IP: "5.5.5.5",
-				}},
-			},
-		},
-	}
-
-	defaultNodes := []nodeInfo{
-		{
-			name:              "node-a",
-			nodeIPs:           []string{"10.0.0.1"},
-			gatewayRouterName: "gr-node-a",
-			switchName:        "switch-node-a",
-			podSubnets:        []net.IPNet{{IP: net.ParseIP("10.128.0.0"), Mask: net.CIDRMask(24, 32)}},
-		},
-		{
-			name:              "node-b",
-			nodeIPs:           []string{"10.0.0.2"},
-			gatewayRouterName: "gr-node-b",
-			switchName:        "switch-node-b",
-			podSubnets:        []net.IPNet{{IP: net.ParseIP("10.128.1.0"), Mask: net.CIDRMask(24, 32)}},
-		},
-	}
-
-	defaultExternalIDs := map[string]string{
-		"k8s.ovn.org/kind":  "Service",
-		"k8s.ovn.org/owner": fmt.Sprintf("%s/%s", namespace, name),
-	}
-
-	defaultOpts := ovnlb.LBOpts{}
-	noSNATOpts := ovnlb.LBOpts{SkipSNAT: true}
-
-	tc := []struct {
-		name     string
-		service  *v1.Service
-		configs  []lbConfig
-		expected []ovnlb.LB
-	}{
-		{
-			name:    "Load Balancer service with ETP local and local-with-fallback annotation, ovn-networked endpoints, all endpoints are up: no fallback",
-			service: defaultService,
-			configs: []lbConfig{
-				{
-					vips:                 []string{"node"}, //  placeholder for node IP
-					protocol:             v1.ProtocolTCP,
-					inport:               5, // node port
-					externalTrafficLocal: true,
-					hasNodePort:          true,
-					eps: util.LbEndpoints{
-						V4IPs: []string{"10.128.0.2", "10.128.1.2"},
-						V6IPs: []string{},
-						Port:  outport,
-					},
-				},
-				{
-					vips:                 []string{"5.5.5.5"}, // external VIP
-					protocol:             v1.ProtocolTCP,
-					inport:               inport,
-					externalTrafficLocal: true,
-					eps: util.LbEndpoints{
-						V4IPs: []string{"10.128.0.2", "10.128.1.2"},
-						V6IPs: []string{},
-						Port:  outport,
-					},
-				},
-			},
-			expected: []ovnlb.LB{
-				{
-					Name:        "Service_openshift-ingress/router-default_TCP_node_local_router_node-a",
-					Protocol:    "TCP",
-					ExternalIDs: defaultExternalIDs,
-					Opts:        noSNATOpts,
-					Routers:     []string{"gr-node-a"},
-					Rules: []ovnlb.LBRule{
-						{
-							Source:  ovnlb.Addr{IP: "10.0.0.1", Port: 5},
-							Targets: []ovnlb.Addr{{IP: "10.128.0.2", Port: 8080}}},
-						{
-							Source:  ovnlb.Addr{IP: "5.5.5.5", Port: 80},
-							Targets: []ovnlb.Addr{{IP: "10.128.0.2", Port: 8080}}}},
-				},
-				{
-					Name:        "Service_openshift-ingress/router-default_TCP_node_switch_node-a",
-					Protocol:    "TCP",
-					ExternalIDs: defaultExternalIDs,
-					Opts:        defaultOpts,
-					Switches:    []string{"switch-node-a"},
-					Rules: []ovnlb.LBRule{
-						{
-							Source:  ovnlb.Addr{IP: "169.254.169.3", Port: 5},
-							Targets: []ovnlb.Addr{{IP: "10.128.0.2", Port: 8080}}},
-						{
-							Source:  ovnlb.Addr{IP: "10.0.0.1", Port: 5},
-							Targets: []ovnlb.Addr{{IP: "10.128.0.2", Port: 8080}, {IP: "10.128.1.2", Port: 8080}}},
-						{
-							Source:  ovnlb.Addr{IP: "5.5.5.5", Port: 80},
-							Targets: []ovnlb.Addr{{IP: "10.128.0.2", Port: 8080}, {IP: "10.128.1.2", Port: 8080}}}},
-				},
-				{
-					Name:        "Service_openshift-ingress/router-default_TCP_node_local_router_node-b",
-					Protocol:    "TCP",
-					ExternalIDs: defaultExternalIDs,
-					Opts:        noSNATOpts,
-					Routers:     []string{"gr-node-b"},
-					Rules: []ovnlb.LBRule{
-						{
-							Source:  ovnlb.Addr{IP: "10.0.0.2", Port: 5},
-							Targets: []ovnlb.Addr{{IP: "10.128.1.2", Port: 8080}}},
-						{
-							Source:  ovnlb.Addr{IP: "5.5.5.5", Port: 80},
-							Targets: []ovnlb.Addr{{IP: "10.128.1.2", Port: 8080}}}},
-				},
-				{
-					Name:        "Service_openshift-ingress/router-default_TCP_node_switch_node-b",
-					Protocol:    "TCP",
-					ExternalIDs: defaultExternalIDs,
-					Opts:        defaultOpts,
-					Rules: []ovnlb.LBRule{
-						{
-							Source:  ovnlb.Addr{IP: "169.254.169.3", Port: 5},
-							Targets: []ovnlb.Addr{{IP: "10.128.1.2", Port: 8080}}},
-						{
-							Source:  ovnlb.Addr{IP: "10.0.0.2", Port: 5},
-							Targets: []ovnlb.Addr{{IP: "10.128.0.2", Port: 8080}, {IP: "10.128.1.2", Port: 8080}}},
-						{
-							Source:  ovnlb.Addr{IP: "5.5.5.5", Port: 80},
-							Targets: []ovnlb.Addr{{IP: "10.128.0.2", Port: 8080}, {IP: "10.128.1.2", Port: 8080}}}},
-					Switches: []string{"switch-node-b"},
-				},
-			},
-		},
-		{
-			name:    "Load Balancer service with ETP local and local-with-fallback annotation, ovn-networked endpoints, endpoint on node-a is down: fallback to ETP Cluster",
-			service: defaultService,
-			configs: []lbConfig{
-				{
-					vips:                 []string{"node"}, //  placeholder for node IP
-					protocol:             v1.ProtocolTCP,
-					inport:               5, // node port
-					externalTrafficLocal: true,
-					hasNodePort:          true,
-					eps: util.LbEndpoints{
-						V4IPs: []string{"10.128.1.2"}, // only endpoint on node-b is running
-						V6IPs: []string{},
-						Port:  outport,
-					},
-				},
-				{
-					vips:                 []string{"5.5.5.5"}, // external VIP
-					protocol:             v1.ProtocolTCP,
-					inport:               inport,
-					externalTrafficLocal: true,
-					eps: util.LbEndpoints{
-						V4IPs: []string{"10.128.1.2"},
-						V6IPs: []string{},
-						Port:  outport,
-					},
-				},
-			},
-			expected: []ovnlb.LB{
-				{
-					Name:        "Service_openshift-ingress/router-default_TCP_node_router_node-a", // fallback, because no local endpoints left
-					Protocol:    "TCP",
-					ExternalIDs: defaultExternalIDs,
-					Opts:        defaultOpts,
-					Routers:     []string{"gr-node-a"},
-					Rules: []ovnlb.LBRule{
-						{
-							Source:  ovnlb.Addr{IP: "10.0.0.1", Port: 5},
-							Targets: []ovnlb.Addr{{IP: "10.128.1.2", Port: 8080}}, // forwarding to endpoint on node-b, as if ETP=Cluster
-						},
-						{
-							Source:  ovnlb.Addr{IP: "5.5.5.5", Port: 80},
-							Targets: []ovnlb.Addr{{IP: "10.128.1.2", Port: 8080}}, // forwarding to endpoint on node-b, as if ETP=Cluster
-						},
-					},
-				},
-				{
-					Name:        "Service_openshift-ingress/router-default_TCP_node_switch_node-a",
-					Protocol:    "TCP",
-					ExternalIDs: defaultExternalIDs,
-					Opts:        defaultOpts,
-					Switches:    []string{"switch-node-a"},
-					Rules: []ovnlb.LBRule{
-						{
-							Source:  ovnlb.Addr{IP: "169.254.169.3", Port: 5},
-							Targets: []ovnlb.Addr{{IP: "10.128.1.2", Port: 8080}}},
-						{
-							Source:  ovnlb.Addr{IP: "10.0.0.1", Port: 5},
-							Targets: []ovnlb.Addr{{IP: "10.128.1.2", Port: 8080}}},
-						{
-							Source:  ovnlb.Addr{IP: "5.5.5.5", Port: 80},
-							Targets: []ovnlb.Addr{{IP: "10.128.1.2", Port: 8080}}}},
-				},
-
-				{
-					Name:        "Service_openshift-ingress/router-default_TCP_node_local_router_node-b",
-					Protocol:    "TCP",
-					ExternalIDs: defaultExternalIDs,
-					Opts:        noSNATOpts,
-					Rules: []ovnlb.LBRule{
-						{
-							Source:  ovnlb.Addr{IP: "10.0.0.2", Port: 5},
-							Targets: []ovnlb.Addr{{IP: "10.128.1.2", Port: 8080}}}, // endpoint is on node-b, so eTP=local is respected
-						{
-							Source:  ovnlb.Addr{IP: "5.5.5.5", Port: 80},
-							Targets: []ovnlb.Addr{{IP: "10.128.1.2", Port: 8080}}}}, // endpoint is on node-b, so eTP=local is respected
-					Switches: []string(nil), Routers: []string{"gr-node-b"},
-				},
-				{
-					Name:        "Service_openshift-ingress/router-default_TCP_node_switch_node-b",
-					UUID:        "",
-					Protocol:    "TCP",
-					ExternalIDs: defaultExternalIDs,
-					Opts:        defaultOpts,
-					Rules: []ovnlb.LBRule{
-						{
-							Source:  ovnlb.Addr{IP: "169.254.169.3", Port: 5},
-							Targets: []ovnlb.Addr{{IP: "10.128.1.2", Port: 8080}}},
-						{
-							Source:  ovnlb.Addr{IP: "10.0.0.2", Port: 5},
-							Targets: []ovnlb.Addr{{IP: "10.128.1.2", Port: 8080}}},
-						{
-							Source:  ovnlb.Addr{IP: "5.5.5.5", Port: 80},
-							Targets: []ovnlb.Addr{{IP: "10.128.1.2", Port: 8080}}}},
-					Switches: []string{"switch-node-b"},
-				},
-			},
-		},
-	}
-
-	for i, tt := range tc {
-		t.Run(fmt.Sprintf("%d_%s", i, tt.name), func(t *testing.T) {
-
-			globalconfig.Gateway.Mode = globalconfig.GatewayModeShared
-			actual := buildPerNodeLBs(tt.service, tt.configs, defaultNodes)
-			assert.Equal(t, tt.expected, actual, "shared gateway mode not as expected")
-
-			globalconfig.Gateway.Mode = globalconfig.GatewayModeLocal
-			actual = buildPerNodeLBs(tt.service, tt.configs, defaultNodes)
-			assert.Equal(t, tt.expected, actual, "local gateway mode not as expected")
 		})
 	}
 }

--- a/go-controller/pkg/ovn/controller/services/node_tracker.go
+++ b/go-controller/pkg/ovn/controller/services/node_tracker.go
@@ -43,28 +43,6 @@ type nodeInfo struct {
 	switchName string
 }
 
-// returns a list of all ip blocks "assigned" to this node
-// includes node IPs, still as a mask-1 net
-func (ni *nodeInfo) nodeSubnets() []net.IPNet {
-	out := append([]net.IPNet{}, ni.podSubnets...)
-	for _, ipStr := range ni.nodeIPs {
-		ip := net.ParseIP(ipStr)
-		if ipv4 := ip.To4(); ipv4 != nil {
-			out = append(out, net.IPNet{
-				IP:   ip,
-				Mask: net.CIDRMask(32, 32),
-			})
-		} else {
-			out = append(out, net.IPNet{
-				IP:   ip,
-				Mask: net.CIDRMask(128, 128),
-			})
-		}
-	}
-
-	return out
-}
-
 func newNodeTracker(nodeInformer coreinformers.NodeInformer) *nodeTracker {
 	nt := &nodeTracker{
 		nodes: map[string]nodeInfo{},

--- a/go-controller/pkg/ovn/controller/services/services_controller.go
+++ b/go-controller/pkg/ovn/controller/services/services_controller.go
@@ -297,7 +297,7 @@ func (c *Controller) syncService(key string) error {
 	}
 
 	// Build the abstract LB configs for this service
-	perNodeConfigs, clusterConfigs := buildServiceLBConfigs(service, endpointSlices)
+	perNodeConfigs, clusterConfigs := buildServiceLBConfigs(service, endpointSlices, c.nodeTracker.allNodes())
 	klog.V(5).Infof("Built service %s LB cluster-wide configs %#v", key, clusterConfigs)
 	klog.V(5).Infof("Built service %s LB per-node configs %#v", key, perNodeConfigs)
 

--- a/go-controller/pkg/ovn/controller/services/services_controller_test.go
+++ b/go-controller/pkg/ovn/controller/services/services_controller_test.go
@@ -31,6 +31,9 @@ import (
 var alwaysReady = func() bool { return true }
 var FakeGRs = "GR_1 GR_2"
 
+var outport int32 = int32(3456)
+var tcp v1.Protocol = v1.ProtocolTCP
+
 type serviceController struct {
 	*Controller
 	serviceStore       cache.Store
@@ -97,13 +100,11 @@ func TestSyncServices(t *testing.T) {
 	_, cidr4, _ := net.ParseCIDR("10.128.0.0/16")
 	_, cidr6, _ := net.ParseCIDR("fe00::/64")
 	globalconfig.Default.ClusterSubnets = []globalconfig.CIDRNetworkEntry{{cidr4, 26}, {cidr6, 26}}
-
-	outport := int32(3456)
-	tcp := v1.ProtocolTCP
-
+	var (
+		nodeA = "node-a"
+		nodeB = "node-b"
+	)
 	const (
-		nodeA           = "node-a"
-		nodeB           = "node-b"
 		nodeAEndpointIP = "10.128.0.2"
 		nodeBEndpointIP = "10.128.1.2"
 		nodeAHostIP     = "10.0.0.1"
@@ -334,6 +335,7 @@ func TestSyncServices(t *testing.T) {
 							Ready: utilpointer.BoolPtr(true),
 						},
 						Addresses: []string{"10.128.0.2", "10.128.1.2"},
+						NodeName:  &nodeA,
 					},
 				},
 			},
@@ -416,6 +418,7 @@ func TestSyncServices(t *testing.T) {
 							Ready: utilpointer.BoolPtr(true),
 						},
 						Addresses: []string{"10.128.0.2", "10.128.1.2"},
+						NodeName:  &nodeA,
 					},
 				},
 			},

--- a/go-controller/pkg/testing/kube.go
+++ b/go-controller/pkg/testing/kube.go
@@ -1,0 +1,51 @@
+package testing
+
+import (
+	discovery "k8s.io/api/discovery/v1"
+	utilpointer "k8s.io/utils/pointer"
+)
+
+// USED ONLY FOR TESTING
+
+// makeReadyEndpointList returns a list of only one endpoint that carries the input addresses.
+func MakeReadyEndpointList(node string, addresses ...string) []discovery.Endpoint {
+	return []discovery.Endpoint{
+		MakeReadyEndpoint(node, addresses...),
+	}
+}
+
+func MakeReadyEndpoint(node string, addresses ...string) discovery.Endpoint {
+	return discovery.Endpoint{
+		Conditions: discovery.EndpointConditions{
+			Ready:       utilpointer.Bool(true),
+			Serving:     utilpointer.Bool(true),
+			Terminating: utilpointer.Bool(false),
+		},
+		Addresses: addresses,
+		NodeName:  &node,
+	}
+}
+
+func MakeTerminatingServingEndpoint(node string, addresses ...string) discovery.Endpoint {
+	return discovery.Endpoint{
+		Conditions: discovery.EndpointConditions{
+			Ready:       utilpointer.Bool(false),
+			Serving:     utilpointer.Bool(true),
+			Terminating: utilpointer.Bool(true),
+		},
+		Addresses: addresses,
+		NodeName:  &node,
+	}
+}
+
+func MakeTerminatingNonServingEndpoint(node string, addresses ...string) discovery.Endpoint {
+	return discovery.Endpoint{
+		Conditions: discovery.EndpointConditions{
+			Ready:       utilpointer.Bool(false),
+			Serving:     utilpointer.Bool(false),
+			Terminating: utilpointer.Bool(true),
+		},
+		Addresses: addresses,
+		NodeName:  &node,
+	}
+}

--- a/go-controller/pkg/util/kube.go
+++ b/go-controller/pkg/util/kube.go
@@ -2,14 +2,17 @@ package util
 
 import (
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
 
 	kapi "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -323,8 +326,8 @@ type LbEndpoints struct {
 	Port  int32
 }
 
-// GetLbEndpoints returns the IPv4 and IPv6 addresses of valid endpoints as slices inside a struct
-func GetLbEndpoints(slices []*discovery.EndpointSlice, svcPort kapi.ServicePort, includeTerminating bool) LbEndpoints {
+// GetLbEndpoints returns the IPv4 and IPv6 addresses of eligible endpoints as slices inside a struct
+func GetLbEndpoints(slices []*discovery.EndpointSlice, svcPort kapi.ServicePort, service *v1.Service) LbEndpoints {
 	v4ips := sets.NewString()
 	v6ips := sets.NewString()
 
@@ -355,12 +358,7 @@ func GetLbEndpoints(slices []*discovery.EndpointSlice, svcPort kapi.ServicePort,
 			}
 
 			out.Port = *port.Port
-			for _, endpoint := range slice.Endpoints {
-				// Skip endpoint if it's not valid
-				if !IsEndpointValid(endpoint, includeTerminating) {
-					klog.V(4).Infof("Slice endpoint not valid")
-					continue
-				}
+			ForEachEligibleEndpoint(slice, service, func(endpoint discovery.Endpoint, shortcut *bool) {
 				for _, ip := range endpoint.Addresses {
 					klog.V(4).Infof("Adding slice %s endpoint: %v, port: %d", slice.Name, endpoint.Addresses, *port.Port)
 					ipStr := utilnet.ParseIPSloppy(ip).String()
@@ -373,7 +371,7 @@ func GetLbEndpoints(slices []*discovery.EndpointSlice, svcPort kapi.ServicePort,
 						klog.V(5).Infof("Skipping FQDN slice %s/%s", slice.Namespace, slice.Name)
 					}
 				}
-			}
+			})
 		}
 	}
 
@@ -409,4 +407,150 @@ func ExternalIDsForObject(obj K8sObject) map[string]string {
 		types.OvnK8sPrefix + "/owner": nsn.String(),
 		types.OvnK8sPrefix + "/kind":  gk.String(),
 	}
+}
+
+// IsEndpointReady takes as input an endpoint from an endpoint slice and returns true if the endpoint is
+// to be considered ready. Considering as ready an endpoint with Conditions.Ready==nil
+// as per doc: "In most cases consumers should interpret this unknown state as ready"
+// https://github.com/kubernetes/api/blob/0478a3e95231398d8b380dc2a1905972be8ae1d5/discovery/v1/types.go#L129-L131
+func IsEndpointReady(endpoint discovery.Endpoint) bool {
+	return endpoint.Conditions.Ready == nil || *endpoint.Conditions.Ready
+}
+
+// IsEndpointServing takes as input an endpoint from an endpoint slice and returns true if the endpoint is
+// to be considered serving. Falling back to IsEndpointReady when Serving field is nil, as per doc:
+// "If nil, consumers should defer to the ready condition.
+// https://github.com/kubernetes/api/blob/0478a3e95231398d8b380dc2a1905972be8ae1d5/discovery/v1/types.go#L138-L139
+func IsEndpointServing(endpoint discovery.Endpoint) bool {
+	if endpoint.Conditions.Serving != nil {
+		return *endpoint.Conditions.Serving
+	} else {
+		return IsEndpointReady(endpoint)
+	}
+}
+
+// IsEndpointEligible takes as input an endpoint from an endpoint slice and a boolean that indicates whether to include
+// all terminating endpoints, as per the PublishNotReadyAddresses feature in kubernetes service spec. It always returns true
+// if includeTerminating is true and falls back to IsEndpointServing otherwise.
+func IsEndpointEligible(endpoint discovery.Endpoint, includeTerminating bool) bool {
+	return includeTerminating || IsEndpointServing(endpoint)
+}
+
+// NoHostSubnet() compares the no-hostsubnet-nodes flag with node labels to see if the node is managing its
+// own network.
+func NoHostSubnet(node *v1.Node) bool {
+	if config.Kubernetes.NoHostSubnetNodes == nil {
+		return false
+	}
+
+	nodeSelector, _ := metav1.LabelSelectorAsSelector(config.Kubernetes.NoHostSubnetNodes)
+	return nodeSelector.Matches(labels.Set(node.Labels))
+}
+
+// ForEachEligibleEndpoint iterates through each eligible endpoint in the given endpointslice and applies the input function fn to it.
+// An endpoint is eligible if it is serving or if its corresponding service has Spec.PublishNotReadyAddresses set.
+// PublishNotReadyAddresses tells endpoint consumers to disregard any indications of ready/not-ready and is generally used
+// together with headless services so that DNS records of all endpoints (ready or not) are always published.
+// Function fn takes a bool pointer "shortcut" that, when set to true inside fn, ends the iteration; this is useful when fn
+// checks for a condition on the endpoints and we want to return as soon as the condition is satisfied.
+func ForEachEligibleEndpoint(endpointSlice *discovery.EndpointSlice, service *kapi.Service, fn func(ep discovery.Endpoint, shortcut *bool)) {
+	includeTerminating := service != nil && service.Spec.PublishNotReadyAddresses
+	var shortcut bool
+	for _, endpoint := range endpointSlice.Endpoints {
+		if IsEndpointEligible(endpoint, includeTerminating) {
+			fn(endpoint, &shortcut)
+			if shortcut {
+				// shortcircuit the whole iteration
+				return
+			}
+		}
+	}
+}
+
+// GetEndpointAddresses returns a list of IP addresses of all eligible endpoints in the given endpoint slices.
+func GetEndpointAddressesWithCondition(endpointSlices []*discovery.EndpointSlice, service *kapi.Service, fn func(discovery.Endpoint) bool) sets.String {
+	endpointsAddress := sets.NewString()
+	for _, endpointSlice := range endpointSlices {
+		ForEachEligibleEndpoint(endpointSlice, service, func(endpoint discovery.Endpoint, shortcut *bool) {
+			includeEndpoint := fn == nil || fn(endpoint)
+			if !includeEndpoint {
+				return
+			}
+			for _, ip := range endpoint.Addresses {
+				endpointsAddress.Insert(utilnet.ParseIPSloppy(ip).String())
+			}
+		})
+	}
+	return endpointsAddress
+}
+
+// GetEndpointAddresses returns a list of IP addresses of all eligible endpoints in the given endpoint slice.
+func GetEndpointAddresses(endpointSlices []*discovery.EndpointSlice, service *kapi.Service) sets.String {
+	return GetEndpointAddressesWithCondition(endpointSlices, service, nil)
+}
+
+// GetLocalEndpointAddresses returns a list of endpoints that are local to the specified node
+func GetLocalEndpointAddresses(endpointSlices []*discovery.EndpointSlice, service *kapi.Service, nodeName string) sets.String {
+	return GetEndpointAddressesWithCondition(endpointSlices, service, func(endpoint discovery.Endpoint) bool {
+		return endpoint.NodeName != nil && *endpoint.NodeName == nodeName
+	})
+}
+
+// HasLocalHostNetworkEndpoints returns true if any of the nodeAddresses appear in given the set of
+// localEndpointAddresses. This is useful to check whether any of the provided local endpoints are host-networked.
+func HasLocalHostNetworkEndpoints(localEndpointAddresses sets.String, nodeAddresses []net.IP) bool {
+	if len(localEndpointAddresses) == 0 || len(nodeAddresses) == 0 {
+		return false
+	}
+	nodeAddressesSet := sets.NewString()
+	for _, ip := range nodeAddresses {
+		nodeAddressesSet.Insert(ip.String())
+	}
+	return len(localEndpointAddresses.Intersection(nodeAddressesSet)) != 0
+}
+
+// DoesEndpointSliceContainEndpoint returns true if the endpointslice
+// contains an endpoint with the given IP/Port/Protocol and this endpoint is considered eligible
+func DoesEndpointSliceContainEndpoint(endpointSlice *discovery.EndpointSlice,
+	epIP string, epPort int32, protocol kapi.Protocol, service *kapi.Service) bool {
+	var res bool
+	for _, port := range endpointSlice.Ports {
+		ForEachEligibleEndpoint(endpointSlice, service, func(endpoint discovery.Endpoint, shortcut *bool) {
+			for _, ip := range endpoint.Addresses {
+				if utilnet.ParseIPSloppy(ip).String() == epIP && *port.Port == epPort && *port.Protocol == protocol {
+					if shortcut != nil {
+						*shortcut = true
+					}
+					res = true
+					return
+				}
+			}
+		})
+	}
+	return res
+}
+
+// ServiceNamespacedNameFromEndpointSlice returns the namespaced name of the service
+// that corresponds to the given endpointSlice
+func ServiceNamespacedNameFromEndpointSlice(endpointSlice *discovery.EndpointSlice) (k8stypes.NamespacedName, error) {
+	var serviceNamespacedName k8stypes.NamespacedName
+	svcName := endpointSlice.Labels[discovery.LabelServiceName]
+	if svcName == "" {
+		// should not happen, since the informer already filters out endpoint slices with an empty service label
+		return serviceNamespacedName,
+			fmt.Errorf("endpointslice %s/%s: empty value for label %s",
+				endpointSlice.Namespace, endpointSlice.Name, discovery.LabelServiceName)
+	}
+	return k8stypes.NamespacedName{Namespace: endpointSlice.Namespace, Name: svcName}, nil
+}
+
+// isHostEndpoint determines if the given endpoint ip belongs to a host networked pod
+func IsHostEndpoint(endpointIPstr string) bool {
+	endpointIP := net.ParseIP(endpointIPstr)
+	for _, clusterNet := range config.Default.ClusterSubnets {
+		if clusterNet.CIDR.Contains(endpointIP) {
+			return false
+		}
+	}
+	return true
 }

--- a/go-controller/pkg/util/kube.go
+++ b/go-controller/pkg/util/kube.go
@@ -320,86 +320,6 @@ func UseEndpointSlices(kubeClient kubernetes.Interface) bool {
 	return false
 }
 
-type LbEndpoints struct {
-	V4IPs []string
-	V6IPs []string
-	Port  int32
-}
-
-// GetLbEndpoints returns the IPv4 and IPv6 addresses of eligible endpoints from a
-// provided list of endpoint slices, for a given service and service port.
-func GetLbEndpoints(slices []*discovery.EndpointSlice, svcPort kapi.ServicePort, service *v1.Service) LbEndpoints {
-	var validSlices []*discovery.EndpointSlice
-	v4IPs := sets.NewString()
-	v6IPs := sets.NewString()
-	out := LbEndpoints{}
-
-	// return an empty object so the caller doesn't have to check for nil and can use it as an iterator
-	if len(slices) == 0 {
-		return out
-	}
-
-	for _, slice := range slices {
-		klog.V(4).Infof("Getting endpoints for slice %s/%s", slice.Namespace, slice.Name)
-
-		for _, slicePort := range slice.Ports {
-			// If Service port name is set, it must match the name field in the endpoint
-			// If Service port name is not set, we just use the endpoint port
-			if svcPort.Name != "" && svcPort.Name != *slicePort.Name {
-				klog.V(5).Infof("Slice %s with different Port name, requested: %s received: %s",
-					slice.Name, svcPort.Name, *slicePort.Name)
-				continue
-			}
-
-			// Skip ports that don't match the protocol
-			if *slicePort.Protocol != svcPort.Protocol {
-				klog.V(5).Infof("Slice %s with different Port protocol, requested: %s received: %s",
-					slice.Name, svcPort.Protocol, *slicePort.Protocol)
-				continue
-			}
-
-			out.Port = *slicePort.Port
-
-			if slice.AddressType == discovery.AddressTypeFQDN {
-				klog.V(5).Infof("Skipping FQDN slice %s/%s", slice.Namespace, slice.Name)
-			} else { // endpoints are here either IPv4 or IPv6
-				validSlices = append(validSlices, slice)
-			}
-		}
-	}
-
-	serviceStr := ""
-	if service != nil {
-		serviceStr = fmt.Sprintf(" for service %s/%s", service.Namespace, service.Name)
-	}
-	// separate IPv4 from IPv6 addresses for eligible endpoints
-	for _, endpoint := range getEligibleEndpoints(validSlices, service) {
-		for _, ip := range endpoint.Addresses {
-			if utilnet.IsIPv4String(ip) {
-				klog.V(5).Infof("Adding endpoint IPv4 address %s port %d%s",
-					ip, out.Port, serviceStr)
-				v4IPs.Insert(utilnet.ParseIPSloppy(ip).String())
-
-			} else if utilnet.IsIPv6String(ip) {
-				klog.V(5).Infof("Adding endpoint IPv6 address %s port %d%s",
-					ip, out.Port, serviceStr)
-				v6IPs.Insert(utilnet.ParseIPSloppy(ip).String())
-
-			} else {
-				klog.V(5).Infof("Skipping unrecognized address %s port %d%s",
-					ip, out.Port, serviceStr)
-			}
-		}
-	}
-
-	out.V4IPs = v4IPs.List()
-	out.V6IPs = v6IPs.List()
-	klog.V(5).Infof("LB Endpoints for %s/%s are: %v / %v on port: %d",
-		slices[0].Namespace, slices[0].Labels[discovery.LabelServiceName],
-		out.V4IPs, out.V6IPs, out.Port)
-	return out
-}
-
 type K8sObject interface {
 	metav1.Object
 	k8sruntime.Object
@@ -474,64 +394,54 @@ func NoHostSubnet(node *v1.Node) bool {
 // are always published.
 // Note that condFn, when specified, is used by utility functions to filter out non-local endpoints.
 // It's important to run it /before/ the eligible endpoint selection, since the order impacts the output.
-func getSelectedEligibleEndpoints(endpointSlices []*discovery.EndpointSlice, service *kapi.Service, condFn func(ep discovery.Endpoint) bool) []discovery.Endpoint {
+func getSelectedEligibleEndpoints(endpoints []discovery.Endpoint, service *kapi.Service, condFn func(ep discovery.Endpoint) bool) []discovery.Endpoint {
 	var readySelectedEndpoints []discovery.Endpoint
 	var servingTerminatingSelectedEndpoints []discovery.Endpoint
 	var eligibleEndpoints []discovery.Endpoint
 
 	includeAllEndpoints := service != nil && service.Spec.PublishNotReadyAddresses
 
-	for _, slice := range endpointSlices {
-		for _, endpoint := range slice.Endpoints {
-			// Apply precondition on endpoints, if provided
-			if condFn == nil || condFn(endpoint) {
-				// Assign to the ready or the serving&terminating slice for a later decision
-				if includeAllEndpoints || IsEndpointReady(endpoint) {
-					readySelectedEndpoints = append(readySelectedEndpoints, endpoint)
-				} else if IsEndpointServing(endpoint) && IsEndpointTerminating(endpoint) {
-					servingTerminatingSelectedEndpoints = append(servingTerminatingSelectedEndpoints, endpoint)
-				}
+	for _, endpoint := range endpoints {
+		// Apply precondition on endpoints, if provided
+		if condFn == nil || condFn(endpoint) {
+			// Assign to the ready or the serving&terminating slice for a later decision
+			if includeAllEndpoints || IsEndpointReady(endpoint) {
+				readySelectedEndpoints = append(readySelectedEndpoints, endpoint)
+			} else if IsEndpointServing(endpoint) && IsEndpointTerminating(endpoint) {
+				servingTerminatingSelectedEndpoints = append(servingTerminatingSelectedEndpoints, endpoint)
 			}
 		}
 	}
-	serviceStr := ""
-	if service != nil {
-		serviceStr = fmt.Sprintf(" (service %s/%s)", service.Namespace, service.Name)
-	}
-	klog.V(5).Infof("Endpoint selection%s: found %d ready endpoints", serviceStr, len(readySelectedEndpoints))
-
 	// Select eligible endpoints based on readiness
 	eligibleEndpoints = readySelectedEndpoints
 	// Fallback to serving terminating endpoints (ready=false, serving=true, terminating=true) only if none are ready
 	if len(readySelectedEndpoints) == 0 {
 		eligibleEndpoints = servingTerminatingSelectedEndpoints
-		klog.V(5).Infof("Endpoint selection%s: fallback to %d serving & terminating endpoints",
-			serviceStr, len(servingTerminatingSelectedEndpoints))
 	}
 
 	return eligibleEndpoints
 }
 
-func getLocalEligibleEndpoints(endpointSlices []*discovery.EndpointSlice, service *kapi.Service, nodeName string) []discovery.Endpoint {
-	return getSelectedEligibleEndpoints(endpointSlices, service, func(endpoint discovery.Endpoint) bool {
+func getLocalEligibleEndpoints(endpoints []discovery.Endpoint, service *kapi.Service, nodeName string) []discovery.Endpoint {
+	return getSelectedEligibleEndpoints(endpoints, service, func(endpoint discovery.Endpoint) bool {
 		return endpoint.NodeName != nil && *endpoint.NodeName == nodeName
 	})
 }
 
-func getEligibleEndpoints(endpointSlices []*discovery.EndpointSlice, service *kapi.Service) []discovery.Endpoint {
-	return getSelectedEligibleEndpoints(endpointSlices, service, nil)
+func getEligibleEndpoints(endpoints []discovery.Endpoint, service *kapi.Service) []discovery.Endpoint {
+	return getSelectedEligibleEndpoints(endpoints, service, nil)
 }
 
-// getEligibleEndpointAddresses takes a list of endpointSlices, a service and, optionally, a nodeName
+// getEligibleEndpointAddresses takes a list of endpoints, a service and, optionally, a nodeName
 // and applies the endpoint selection logic. It returns the IP addresses of eligible endpoints.
-func getEligibleEndpointAddresses(endpointSlices []*discovery.EndpointSlice, service *kapi.Service, nodeName string) sets.String {
+func getEligibleEndpointAddresses(endpoints []discovery.Endpoint, service *kapi.Service, nodeName string) []string {
 	endpointsAddresses := sets.NewString()
 	var eligibleEndpoints []discovery.Endpoint
 
 	if nodeName != "" {
-		eligibleEndpoints = getLocalEligibleEndpoints(endpointSlices, service, nodeName)
+		eligibleEndpoints = getLocalEligibleEndpoints(endpoints, service, nodeName)
 	} else {
-		eligibleEndpoints = getEligibleEndpoints(endpointSlices, service)
+		eligibleEndpoints = getEligibleEndpoints(endpoints, service)
 	}
 	for _, endpoint := range eligibleEndpoints {
 		for _, ip := range endpoint.Addresses {
@@ -539,25 +449,31 @@ func getEligibleEndpointAddresses(endpointSlices []*discovery.EndpointSlice, ser
 		}
 	}
 
-	return endpointsAddresses
+	return endpointsAddresses.List()
 }
 
-// GetEligibleEndpointAddresses returns a list of IP addresses of all eligible endpoints from the given endpoint slices.
-func GetEligibleEndpointAddresses(endpointSlices []*discovery.EndpointSlice, service *kapi.Service) sets.String {
-	return getEligibleEndpointAddresses(endpointSlices, service, "")
+func GetEligibleEndpointAddresses(endpoints []discovery.Endpoint, service *kapi.Service) []string {
+	return getEligibleEndpointAddresses(endpoints, service, "")
 }
 
-// GetLocalEligibleEndpointAddresses returns a list of IP address of endpoints that are local to the specified node
+// GetEligibleEndpointAddressesFromSlices returns a list of IP addresses of all eligible endpoints from the given endpoint slices.
+func GetEligibleEndpointAddressesFromSlices(endpointSlices []*discovery.EndpointSlice, service *kapi.Service) []string {
+	return getEligibleEndpointAddresses(getEndpointsFromEndpointSlices(endpointSlices), service, "")
+}
+
+// GetLocalEligibleEndpointAddressesFromSlices returns a set of IP addresses of endpoints that are local to the specified node
 // and are eligible.
-func GetLocalEligibleEndpointAddresses(endpointSlices []*discovery.EndpointSlice, service *kapi.Service, nodeName string) sets.String {
-	return getEligibleEndpointAddresses(endpointSlices, service, nodeName)
+func GetLocalEligibleEndpointAddressesFromSlices(endpointSlices []*discovery.EndpointSlice, service *kapi.Service, nodeName string) sets.String {
+	endpoints := getEligibleEndpointAddresses(getEndpointsFromEndpointSlices(endpointSlices), service, nodeName)
+	return sets.NewString(endpoints...)
 }
 
 // DoesEndpointSliceContainEndpoint returns true if the endpointslice
 // contains an endpoint with the given IP, port and Protocol and if this endpoint is considered eligible.
 func DoesEndpointSliceContainEligibleEndpoint(endpointSlice *discovery.EndpointSlice,
 	epIP string, epPort int32, protocol kapi.Protocol, service *kapi.Service) bool {
-	for _, ep := range getEligibleEndpoints([]*discovery.EndpointSlice{endpointSlice}, service) {
+	endpoints := getEndpointsFromEndpointSlices([]*discovery.EndpointSlice{endpointSlice})
+	for _, ep := range getEligibleEndpoints(endpoints, service) {
 		for _, ip := range ep.Addresses {
 			for _, port := range endpointSlice.Ports {
 				if utilnet.ParseIPSloppy(ip).String() == epIP && *port.Port == epPort && *port.Protocol == protocol {
@@ -605,4 +521,12 @@ func IsHostEndpoint(endpointIPstr string) bool {
 		}
 	}
 	return true
+}
+
+func getEndpointsFromEndpointSlices(endpointSlices []*discovery.EndpointSlice) []discovery.Endpoint {
+	endpoints := []discovery.Endpoint{}
+	for _, slice := range endpointSlices {
+		endpoints = append(endpoints, slice.Endpoints...)
+	}
+	return endpoints
 }

--- a/go-controller/pkg/util/kube.go
+++ b/go-controller/pkg/util/kube.go
@@ -326,12 +326,14 @@ type LbEndpoints struct {
 	Port  int32
 }
 
-// GetLbEndpoints returns the IPv4 and IPv6 addresses of eligible endpoints as slices inside a struct
+// GetLbEndpoints returns the IPv4 and IPv6 addresses of eligible endpoints from a
+// provided list of endpoint slices, for a given service and service port.
 func GetLbEndpoints(slices []*discovery.EndpointSlice, svcPort kapi.ServicePort, service *v1.Service) LbEndpoints {
-	v4ips := sets.NewString()
-	v6ips := sets.NewString()
-
+	var validSlices []*discovery.EndpointSlice
+	v4IPs := sets.NewString()
+	v6IPs := sets.NewString()
 	out := LbEndpoints{}
+
 	// return an empty object so the caller doesn't have to check for nil and can use it as an iterator
 	if len(slices) == 0 {
 		return out
@@ -340,44 +342,59 @@ func GetLbEndpoints(slices []*discovery.EndpointSlice, svcPort kapi.ServicePort,
 	for _, slice := range slices {
 		klog.V(4).Infof("Getting endpoints for slice %s/%s", slice.Namespace, slice.Name)
 
-		// build the list of valid endpoints in the slice
-		for _, port := range slice.Ports {
+		for _, slicePort := range slice.Ports {
 			// If Service port name is set, it must match the name field in the endpoint
 			// If Service port name is not set, we just use the endpoint port
-			if svcPort.Name != "" && svcPort.Name != *port.Name {
+			if svcPort.Name != "" && svcPort.Name != *slicePort.Name {
 				klog.V(5).Infof("Slice %s with different Port name, requested: %s received: %s",
-					slice.Name, svcPort.Name, *port.Name)
+					slice.Name, svcPort.Name, *slicePort.Name)
 				continue
 			}
 
 			// Skip ports that don't match the protocol
-			if *port.Protocol != svcPort.Protocol {
+			if *slicePort.Protocol != svcPort.Protocol {
 				klog.V(5).Infof("Slice %s with different Port protocol, requested: %s received: %s",
-					slice.Name, svcPort.Protocol, *port.Protocol)
+					slice.Name, svcPort.Protocol, *slicePort.Protocol)
 				continue
 			}
 
-			out.Port = *port.Port
-			ForEachEligibleEndpoint(slice, service, func(endpoint discovery.Endpoint, shortcut *bool) {
-				for _, ip := range endpoint.Addresses {
-					klog.V(4).Infof("Adding slice %s endpoint: %v, port: %d", slice.Name, endpoint.Addresses, *port.Port)
-					ipStr := utilnet.ParseIPSloppy(ip).String()
-					switch slice.AddressType {
-					case discovery.AddressTypeIPv4:
-						v4ips.Insert(ipStr)
-					case discovery.AddressTypeIPv6:
-						v6ips.Insert(ipStr)
-					default:
-						klog.V(5).Infof("Skipping FQDN slice %s/%s", slice.Namespace, slice.Name)
-					}
-				}
-			})
+			out.Port = *slicePort.Port
+
+			if slice.AddressType == discovery.AddressTypeFQDN {
+				klog.V(5).Infof("Skipping FQDN slice %s/%s", slice.Namespace, slice.Name)
+			} else { // endpoints are here either IPv4 or IPv6
+				validSlices = append(validSlices, slice)
+			}
 		}
 	}
 
-	out.V4IPs = v4ips.List()
-	out.V6IPs = v6ips.List()
-	klog.V(4).Infof("LB Endpoints for %s/%s are: %v / %v on port: %d",
+	serviceStr := ""
+	if service != nil {
+		serviceStr = fmt.Sprintf(" for service %s/%s", service.Namespace, service.Name)
+	}
+	// separate IPv4 from IPv6 addresses for eligible endpoints
+	for _, endpoint := range getEligibleEndpoints(validSlices, service) {
+		for _, ip := range endpoint.Addresses {
+			if utilnet.IsIPv4String(ip) {
+				klog.V(5).Infof("Adding endpoint IPv4 address %s port %d%s",
+					ip, out.Port, serviceStr)
+				v4IPs.Insert(utilnet.ParseIPSloppy(ip).String())
+
+			} else if utilnet.IsIPv6String(ip) {
+				klog.V(5).Infof("Adding endpoint IPv6 address %s port %d%s",
+					ip, out.Port, serviceStr)
+				v6IPs.Insert(utilnet.ParseIPSloppy(ip).String())
+
+			} else {
+				klog.V(5).Infof("Skipping unrecognized address %s port %d%s",
+					ip, out.Port, serviceStr)
+			}
+		}
+	}
+
+	out.V4IPs = v4IPs.List()
+	out.V6IPs = v6IPs.List()
+	klog.V(5).Infof("LB Endpoints for %s/%s are: %v / %v on port: %d",
 		slices[0].Namespace, slices[0].Labels[discovery.LabelServiceName],
 		out.V4IPs, out.V6IPs, out.Port)
 	return out
@@ -429,11 +446,8 @@ func IsEndpointServing(endpoint discovery.Endpoint) bool {
 	}
 }
 
-// IsEndpointEligible takes as input an endpoint from an endpoint slice and a boolean that indicates whether to include
-// all terminating endpoints, as per the PublishNotReadyAddresses feature in kubernetes service spec. It always returns true
-// if includeTerminating is true and falls back to IsEndpointServing otherwise.
-func IsEndpointEligible(endpoint discovery.Endpoint, includeTerminating bool) bool {
-	return includeTerminating || IsEndpointServing(endpoint)
+func IsEndpointTerminating(endpoint discovery.Endpoint) bool {
+	return endpoint.Conditions.Terminating != nil && *endpoint.Conditions.Terminating
 }
 
 // NoHostSubnet() compares the no-hostsubnet-nodes flag with node labels to see if the node is managing its
@@ -447,53 +461,112 @@ func NoHostSubnet(node *v1.Node) bool {
 	return nodeSelector.Matches(labels.Set(node.Labels))
 }
 
-// ForEachEligibleEndpoint iterates through each eligible endpoint in the given endpointslice and applies the input function fn to it.
-// An endpoint is eligible if it is serving or if its corresponding service has Spec.PublishNotReadyAddresses set.
-// PublishNotReadyAddresses tells endpoint consumers to disregard any indications of ready/not-ready and is generally used
-// together with headless services so that DNS records of all endpoints (ready or not) are always published.
-// Function fn takes a bool pointer "shortcut" that, when set to true inside fn, ends the iteration; this is useful when fn
-// checks for a condition on the endpoints and we want to return as soon as the condition is satisfied.
-func ForEachEligibleEndpoint(endpointSlice *discovery.EndpointSlice, service *kapi.Service, fn func(ep discovery.Endpoint, shortcut *bool)) {
-	includeTerminating := service != nil && service.Spec.PublishNotReadyAddresses
-	var shortcut bool
-	for _, endpoint := range endpointSlice.Endpoints {
-		if IsEndpointEligible(endpoint, includeTerminating) {
-			fn(endpoint, &shortcut)
-			if shortcut {
-				// shortcircuit the whole iteration
-				return
+// getSelectedEligibleEndpoints does the following:
+// (1) filters the given endpoints with the provided condition function condFn;
+// (2) further selects eligible endpoints based on readiness.
+// Eligible endpoints are ready endpoints; if there are none, eligible endpoints are serving & terminating
+// endpoints, as defined in KEP-1669
+// (https://github.com/kubernetes/enhancements/blob/master/keps/sig-network/1669-proxy-terminating-endpoints/README.md).
+// The service corresponding to the given endpoints needs to provided as an input argument
+// because if Spec.PublishNotReadyAddresses is set, then all provided endpoints must always be returned.
+// PublishNotReadyAddresses tells endpoint consumers to disregard any indications of ready/not-ready and
+// is generally used together with headless services so that DNS records of all endpoints (ready or not)
+// are always published.
+// Note that condFn, when specified, is used by utility functions to filter out non-local endpoints.
+// It's important to run it /before/ the eligible endpoint selection, since the order impacts the output.
+func getSelectedEligibleEndpoints(endpointSlices []*discovery.EndpointSlice, service *kapi.Service, condFn func(ep discovery.Endpoint) bool) []discovery.Endpoint {
+	var readySelectedEndpoints []discovery.Endpoint
+	var servingTerminatingSelectedEndpoints []discovery.Endpoint
+	var eligibleEndpoints []discovery.Endpoint
+
+	includeAllEndpoints := service != nil && service.Spec.PublishNotReadyAddresses
+
+	for _, slice := range endpointSlices {
+		for _, endpoint := range slice.Endpoints {
+			// Apply precondition on endpoints, if provided
+			if condFn == nil || condFn(endpoint) {
+				// Assign to the ready or the serving&terminating slice for a later decision
+				if includeAllEndpoints || IsEndpointReady(endpoint) {
+					readySelectedEndpoints = append(readySelectedEndpoints, endpoint)
+				} else if IsEndpointServing(endpoint) && IsEndpointTerminating(endpoint) {
+					servingTerminatingSelectedEndpoints = append(servingTerminatingSelectedEndpoints, endpoint)
+				}
 			}
 		}
 	}
-}
-
-// GetEndpointAddresses returns a list of IP addresses of all eligible endpoints in the given endpoint slices.
-func GetEndpointAddressesWithCondition(endpointSlices []*discovery.EndpointSlice, service *kapi.Service, fn func(discovery.Endpoint) bool) sets.String {
-	endpointsAddress := sets.NewString()
-	for _, endpointSlice := range endpointSlices {
-		ForEachEligibleEndpoint(endpointSlice, service, func(endpoint discovery.Endpoint, shortcut *bool) {
-			includeEndpoint := fn == nil || fn(endpoint)
-			if !includeEndpoint {
-				return
-			}
-			for _, ip := range endpoint.Addresses {
-				endpointsAddress.Insert(utilnet.ParseIPSloppy(ip).String())
-			}
-		})
+	serviceStr := ""
+	if service != nil {
+		serviceStr = fmt.Sprintf(" (service %s/%s)", service.Namespace, service.Name)
 	}
-	return endpointsAddress
+	klog.V(5).Infof("Endpoint selection%s: found %d ready endpoints", serviceStr, len(readySelectedEndpoints))
+
+	// Select eligible endpoints based on readiness
+	eligibleEndpoints = readySelectedEndpoints
+	// Fallback to serving terminating endpoints (ready=false, serving=true, terminating=true) only if none are ready
+	if len(readySelectedEndpoints) == 0 {
+		eligibleEndpoints = servingTerminatingSelectedEndpoints
+		klog.V(5).Infof("Endpoint selection%s: fallback to %d serving & terminating endpoints",
+			serviceStr, len(servingTerminatingSelectedEndpoints))
+	}
+
+	return eligibleEndpoints
 }
 
-// GetEndpointAddresses returns a list of IP addresses of all eligible endpoints in the given endpoint slice.
-func GetEndpointAddresses(endpointSlices []*discovery.EndpointSlice, service *kapi.Service) sets.String {
-	return GetEndpointAddressesWithCondition(endpointSlices, service, nil)
-}
-
-// GetLocalEndpointAddresses returns a list of endpoints that are local to the specified node
-func GetLocalEndpointAddresses(endpointSlices []*discovery.EndpointSlice, service *kapi.Service, nodeName string) sets.String {
-	return GetEndpointAddressesWithCondition(endpointSlices, service, func(endpoint discovery.Endpoint) bool {
+func getLocalEligibleEndpoints(endpointSlices []*discovery.EndpointSlice, service *kapi.Service, nodeName string) []discovery.Endpoint {
+	return getSelectedEligibleEndpoints(endpointSlices, service, func(endpoint discovery.Endpoint) bool {
 		return endpoint.NodeName != nil && *endpoint.NodeName == nodeName
 	})
+}
+
+func getEligibleEndpoints(endpointSlices []*discovery.EndpointSlice, service *kapi.Service) []discovery.Endpoint {
+	return getSelectedEligibleEndpoints(endpointSlices, service, nil)
+}
+
+// getEligibleEndpointAddresses takes a list of endpointSlices, a service and, optionally, a nodeName
+// and applies the endpoint selection logic. It returns the IP addresses of eligible endpoints.
+func getEligibleEndpointAddresses(endpointSlices []*discovery.EndpointSlice, service *kapi.Service, nodeName string) sets.String {
+	endpointsAddresses := sets.NewString()
+	var eligibleEndpoints []discovery.Endpoint
+
+	if nodeName != "" {
+		eligibleEndpoints = getLocalEligibleEndpoints(endpointSlices, service, nodeName)
+	} else {
+		eligibleEndpoints = getEligibleEndpoints(endpointSlices, service)
+	}
+	for _, endpoint := range eligibleEndpoints {
+		for _, ip := range endpoint.Addresses {
+			endpointsAddresses.Insert(utilnet.ParseIPSloppy(ip).String())
+		}
+	}
+
+	return endpointsAddresses
+}
+
+// GetEligibleEndpointAddresses returns a list of IP addresses of all eligible endpoints from the given endpoint slices.
+func GetEligibleEndpointAddresses(endpointSlices []*discovery.EndpointSlice, service *kapi.Service) sets.String {
+	return getEligibleEndpointAddresses(endpointSlices, service, "")
+}
+
+// GetLocalEligibleEndpointAddresses returns a list of IP address of endpoints that are local to the specified node
+// and are eligible.
+func GetLocalEligibleEndpointAddresses(endpointSlices []*discovery.EndpointSlice, service *kapi.Service, nodeName string) sets.String {
+	return getEligibleEndpointAddresses(endpointSlices, service, nodeName)
+}
+
+// DoesEndpointSliceContainEndpoint returns true if the endpointslice
+// contains an endpoint with the given IP, port and Protocol and if this endpoint is considered eligible.
+func DoesEndpointSliceContainEligibleEndpoint(endpointSlice *discovery.EndpointSlice,
+	epIP string, epPort int32, protocol kapi.Protocol, service *kapi.Service) bool {
+	for _, ep := range getEligibleEndpoints([]*discovery.EndpointSlice{endpointSlice}, service) {
+		for _, ip := range ep.Addresses {
+			for _, port := range endpointSlice.Ports {
+				if utilnet.ParseIPSloppy(ip).String() == epIP && *port.Port == epPort && *port.Protocol == protocol {
+					return true
+				}
+			}
+		}
+	}
+	return false
 }
 
 // HasLocalHostNetworkEndpoints returns true if any of the nodeAddresses appear in given the set of
@@ -507,27 +580,6 @@ func HasLocalHostNetworkEndpoints(localEndpointAddresses sets.String, nodeAddres
 		nodeAddressesSet.Insert(ip.String())
 	}
 	return len(localEndpointAddresses.Intersection(nodeAddressesSet)) != 0
-}
-
-// DoesEndpointSliceContainEndpoint returns true if the endpointslice
-// contains an endpoint with the given IP/Port/Protocol and this endpoint is considered eligible
-func DoesEndpointSliceContainEndpoint(endpointSlice *discovery.EndpointSlice,
-	epIP string, epPort int32, protocol kapi.Protocol, service *kapi.Service) bool {
-	var res bool
-	for _, port := range endpointSlice.Ports {
-		ForEachEligibleEndpoint(endpointSlice, service, func(endpoint discovery.Endpoint, shortcut *bool) {
-			for _, ip := range endpoint.Addresses {
-				if utilnet.ParseIPSloppy(ip).String() == epIP && *port.Port == epPort && *port.Protocol == protocol {
-					if shortcut != nil {
-						*shortcut = true
-					}
-					res = true
-					return
-				}
-			}
-		})
-	}
-	return res
 }
 
 // ServiceNamespacedNameFromEndpointSlice returns the namespaced name of the service

--- a/go-controller/pkg/util/kube_test.go
+++ b/go-controller/pkg/util/kube_test.go
@@ -423,6 +423,7 @@ func Test_getLbEndpoints(t *testing.T) {
 	type args struct {
 		slices  []*discovery.EndpointSlice
 		svcPort v1.ServicePort
+		service *v1.Service
 	}
 	tests := []struct {
 		name string
@@ -438,11 +439,12 @@ func Test_getLbEndpoints(t *testing.T) {
 					TargetPort: intstr.FromInt(80),
 					Protocol:   v1.ProtocolTCP,
 				},
+				service: getSampleService(false),
 			},
 			want: LbEndpoints{},
 		},
 		{
-			name: "slices with endpoints",
+			name: "slice with one endpoint",
 			args: args{
 				slices: []*discovery.EndpointSlice{
 					{
@@ -474,11 +476,12 @@ func Test_getLbEndpoints(t *testing.T) {
 					TargetPort: intstr.FromInt(80),
 					Protocol:   v1.ProtocolTCP,
 				},
+				service: getSampleService(false),
 			},
 			want: LbEndpoints{[]string{"10.0.0.2"}, []string{}, 80},
 		},
 		{
-			name: "slices with different port name",
+			name: "slice with different port name than the service",
 			args: args{
 				slices: []*discovery.EndpointSlice{
 					{
@@ -510,11 +513,12 @@ func Test_getLbEndpoints(t *testing.T) {
 					TargetPort: intstr.FromInt(80),
 					Protocol:   v1.ProtocolTCP,
 				},
+				service: getSampleService(false),
 			},
 			want: LbEndpoints{[]string{}, []string{}, 0},
 		},
 		{
-			name: "slices and service without port name",
+			name: "slice and service without a port name",
 			args: args{
 				slices: []*discovery.EndpointSlice{
 					{
@@ -544,11 +548,12 @@ func Test_getLbEndpoints(t *testing.T) {
 					TargetPort: intstr.FromInt(80),
 					Protocol:   v1.ProtocolTCP,
 				},
+				service: getSampleService(false),
 			},
 			want: LbEndpoints{[]string{"10.0.0.2"}, []string{}, 8080},
 		},
 		{
-			name: "slices with different IP family",
+			name: "slice with an IPv6 endpoint",
 			args: args{
 				slices: []*discovery.EndpointSlice{
 					{
@@ -580,11 +585,72 @@ func Test_getLbEndpoints(t *testing.T) {
 					TargetPort: intstr.FromInt(80),
 					Protocol:   v1.ProtocolTCP,
 				},
+				service: getSampleService(false),
 			},
 			want: LbEndpoints{[]string{}, []string{"2001:db2::2"}, 80},
 		},
 		{
-			name: "multiples slices with duplicate endpoints",
+			name: "a slice with an IPv4 endpoint and a slice with an IPv6 endpoint (dualstack cluster)",
+			args: args{
+				slices: []*discovery.EndpointSlice{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab23",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     utilpointer.StringPtr("tcp-example"),
+								Protocol: protoPtr(v1.ProtocolTCP),
+								Port:     utilpointer.Int32Ptr(int32(80)),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv4,
+						Endpoints: []discovery.Endpoint{
+							{
+								Conditions: discovery.EndpointConditions{
+									Ready: utilpointer.Bool(true),
+								},
+								Addresses: []string{"10.0.0.2"},
+							},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab24",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     utilpointer.StringPtr("tcp-example"),
+								Protocol: protoPtr(v1.ProtocolTCP),
+								Port:     utilpointer.Int32Ptr(int32(80)),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv6,
+						Endpoints: []discovery.Endpoint{
+							{
+								Conditions: discovery.EndpointConditions{
+									Ready: utilpointer.Bool(true),
+								},
+								Addresses: []string{"2001:db2::2"},
+							},
+						},
+					},
+				},
+				svcPort: v1.ServicePort{
+					Name:       "tcp-example",
+					TargetPort: intstr.FromInt(80),
+					Protocol:   v1.ProtocolTCP,
+				},
+				service: getSampleService(false),
+			},
+			want: LbEndpoints{[]string{"10.0.0.2"}, []string{"2001:db2::2"}, 80},
+		},
+		{
+			name: "multiples slices with a duplicate endpoint",
 			args: args{
 				slices: []*discovery.EndpointSlice{
 					{
@@ -612,6 +678,43 @@ func Test_getLbEndpoints(t *testing.T) {
 					},
 					{
 						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab24",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     utilpointer.StringPtr("tcp-example"),
+								Protocol: protoPtr(v1.ProtocolTCP),
+								Port:     utilpointer.Int32Ptr(int32(80)),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv4,
+						Endpoints: []discovery.Endpoint{
+							{
+								Conditions: discovery.EndpointConditions{
+									Ready: utilpointer.Bool(true),
+								},
+								Addresses: []string{"10.0.0.2", "10.2.2.2"},
+							},
+						},
+					},
+				},
+				svcPort: v1.ServicePort{
+					Name:       "tcp-example",
+					TargetPort: intstr.FromInt(80),
+					Protocol:   v1.ProtocolTCP,
+				},
+				service: getSampleService(false),
+			},
+			want: LbEndpoints{[]string{"10.0.0.2", "10.1.1.2", "10.2.2.2"}, []string{}, 80},
+		},
+		{
+			name: "multiples slices with different ports",
+			args: args{
+				slices: []*discovery.EndpointSlice{
+					{
+						ObjectMeta: metav1.ObjectMeta{
 							Name:      "svc-ab23",
 							Namespace: "ns",
 							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
@@ -627,9 +730,32 @@ func Test_getLbEndpoints(t *testing.T) {
 						Endpoints: []discovery.Endpoint{
 							{
 								Conditions: discovery.EndpointConditions{
-									Ready: utilpointer.BoolPtr(true),
+									Ready: utilpointer.Bool(true),
 								},
-								Addresses: []string{"10.0.0.2", "10.2.2.2"},
+								Addresses: []string{"10.0.0.2", "10.1.1.2"},
+							},
+						},
+					},
+					{ // this slice should be ignored, we're considering only one service port per execution
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab24",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     utilpointer.StringPtr("other-port"),
+								Protocol: protoPtr(v1.ProtocolTCP),
+								Port:     utilpointer.Int32Ptr(int32(8080)),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv4,
+						Endpoints: []discovery.Endpoint{
+							{
+								Conditions: discovery.EndpointConditions{
+									Ready: utilpointer.Bool(true),
+								},
+								Addresses: []string{"10.0.0.3", "10.2.2.3"},
 							},
 						},
 					},
@@ -639,11 +765,12 @@ func Test_getLbEndpoints(t *testing.T) {
 					TargetPort: intstr.FromInt(80),
 					Protocol:   v1.ProtocolTCP,
 				},
+				service: getSampleService(false),
 			},
-			want: LbEndpoints{[]string{"10.0.0.2", "10.1.1.2", "10.2.2.2"}, []string{}, 80},
+			want: LbEndpoints{[]string{"10.0.0.2", "10.1.1.2"}, []string{}, 80},
 		},
 		{
-			name: "slices with non-ready but serving endpoints",
+			name: "slice with a mix of ready and terminating (serving and non-serving) endpoints",
 			args: args{
 				slices: []*discovery.EndpointSlice{
 					{
@@ -663,10 +790,43 @@ func Test_getLbEndpoints(t *testing.T) {
 						Endpoints: []discovery.Endpoint{
 							{
 								Conditions: discovery.EndpointConditions{
-									Ready:   utilpointer.BoolPtr(false),
-									Serving: utilpointer.BoolPtr(true),
+									Ready:       utilpointer.Bool(true),
+									Serving:     utilpointer.Bool(true),
+									Terminating: utilpointer.Bool(false),
 								},
 								Addresses: []string{"2001:db2::2"},
+							},
+							{
+								Conditions: discovery.EndpointConditions{
+									Ready:       utilpointer.Bool(true),
+									Serving:     utilpointer.Bool(true),
+									Terminating: utilpointer.Bool(false),
+								},
+								Addresses: []string{"2001:db2::3"},
+							},
+							{
+								Conditions: discovery.EndpointConditions{ // ignored
+									Ready:       utilpointer.Bool(false),
+									Serving:     utilpointer.Bool(true),
+									Terminating: utilpointer.Bool(true),
+								},
+								Addresses: []string{"2001:db2::4"},
+							},
+							{
+								Conditions: discovery.EndpointConditions{ // ignored
+									Ready:       utilpointer.Bool(false),
+									Serving:     utilpointer.Bool(true),
+									Terminating: utilpointer.Bool(true),
+								},
+								Addresses: []string{"2001:db2::5"},
+							},
+							{
+								Conditions: discovery.EndpointConditions{ // ignored
+									Ready:       utilpointer.Bool(false),
+									Serving:     utilpointer.Bool(false),
+									Terminating: utilpointer.Bool(true),
+								},
+								Addresses: []string{"2001:db2::6"},
 							},
 						},
 					},
@@ -676,11 +836,12 @@ func Test_getLbEndpoints(t *testing.T) {
 					TargetPort: intstr.FromInt(80),
 					Protocol:   v1.ProtocolTCP,
 				},
+				service: getSampleService(false),
 			},
-			want: LbEndpoints{[]string{}, []string{"2001:db2::2"}, 80},
+			want: LbEndpoints{[]string{}, []string{"2001:db2::2", "2001:db2::3"}, 80},
 		},
 		{
-			name: "slices with non-ready non-serving endpoints",
+			name: "slice with a mix of terminating (serving and non-serving) endpoints and no ready endpoints",
 			args: args{
 				slices: []*discovery.EndpointSlice{
 					{
@@ -700,10 +861,35 @@ func Test_getLbEndpoints(t *testing.T) {
 						Endpoints: []discovery.Endpoint{
 							{
 								Conditions: discovery.EndpointConditions{
-									Ready:   utilpointer.BoolPtr(false),
-									Serving: utilpointer.BoolPtr(false),
+									Ready:       utilpointer.Bool(false),
+									Serving:     utilpointer.Bool(true),
+									Terminating: utilpointer.Bool(true),
 								},
-								Addresses: []string{"2001:db2::2"},
+								Addresses: []string{"2001:db2::4"},
+							},
+							{
+								Conditions: discovery.EndpointConditions{
+									Ready:       utilpointer.Bool(false),
+									Serving:     utilpointer.Bool(true),
+									Terminating: utilpointer.Bool(true),
+								},
+								Addresses: []string{"2001:db2::5"},
+							},
+							{
+								Conditions: discovery.EndpointConditions{ // ignored
+									Ready:       utilpointer.Bool(false),
+									Serving:     utilpointer.Bool(false),
+									Terminating: utilpointer.Bool(true),
+								},
+								Addresses: []string{"2001:db2::6"},
+							},
+							{
+								Conditions: discovery.EndpointConditions{ // ignored
+									Ready:       utilpointer.Bool(false),
+									Serving:     utilpointer.Bool(false),
+									Terminating: utilpointer.Bool(true),
+								},
+								Addresses: []string{"2001:db2::7"},
 							},
 						},
 					},
@@ -713,13 +899,541 @@ func Test_getLbEndpoints(t *testing.T) {
 					TargetPort: intstr.FromInt(80),
 					Protocol:   v1.ProtocolTCP,
 				},
+				service: getSampleService(false),
+			},
+			want: LbEndpoints{[]string{}, []string{"2001:db2::4", "2001:db2::5"}, 80},
+		},
+		{
+			name: "slice with only terminating non-serving endpoints",
+			args: args{
+				slices: []*discovery.EndpointSlice{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab23",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     utilpointer.StringPtr("tcp-example"),
+								Protocol: protoPtr(v1.ProtocolTCP),
+								Port:     utilpointer.Int32Ptr(int32(80)),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv6,
+						Endpoints: []discovery.Endpoint{
+							{
+								Conditions: discovery.EndpointConditions{ // ignored
+									Ready:       utilpointer.Bool(false),
+									Serving:     utilpointer.Bool(false),
+									Terminating: utilpointer.Bool(true),
+								},
+								Addresses: []string{"2001:db2::6"},
+							},
+							{
+								Conditions: discovery.EndpointConditions{ // ignored
+									Ready:       utilpointer.Bool(false),
+									Serving:     utilpointer.Bool(false),
+									Terminating: utilpointer.Bool(true),
+								},
+								Addresses: []string{"2001:db2::7"},
+							},
+						},
+					},
+				},
+				svcPort: v1.ServicePort{
+					Name:       "tcp-example",
+					TargetPort: intstr.FromInt(80),
+					Protocol:   v1.ProtocolTCP,
+				},
+				service: getSampleService(false),
 			},
 			want: LbEndpoints{[]string{}, []string{}, 80},
+		},
+		{
+			name: "multiple slices with a mix terminating (serving and non-serving) endpoints and no ready endpoints",
+			args: args{
+				slices: []*discovery.EndpointSlice{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab23",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     utilpointer.StringPtr("tcp-example"),
+								Protocol: protoPtr(v1.ProtocolTCP),
+								Port:     utilpointer.Int32Ptr(int32(80)),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv6,
+						Endpoints: []discovery.Endpoint{
+							{
+								Conditions: discovery.EndpointConditions{ // ignored
+									Ready:       utilpointer.Bool(false),
+									Serving:     utilpointer.Bool(false),
+									Terminating: utilpointer.Bool(true),
+								},
+								Addresses: []string{"2001:db2::2"},
+							},
+							{
+								Conditions: discovery.EndpointConditions{
+									Ready:       utilpointer.Bool(false),
+									Serving:     utilpointer.Bool(true),
+									Terminating: utilpointer.Bool(true),
+								},
+								Addresses: []string{"2001:db2::3"},
+							},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab24",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     utilpointer.StringPtr("tcp-example"),
+								Protocol: protoPtr(v1.ProtocolTCP),
+								Port:     utilpointer.Int32Ptr(int32(80)),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv6,
+						Endpoints: []discovery.Endpoint{
+							{
+								Conditions: discovery.EndpointConditions{
+									Ready:       utilpointer.Bool(false),
+									Serving:     utilpointer.Bool(true),
+									Terminating: utilpointer.Bool(true),
+								},
+								Addresses: []string{"2001:db2::4"},
+							},
+							{
+								Conditions: discovery.EndpointConditions{ // ignored
+									Ready:       utilpointer.Bool(false),
+									Serving:     utilpointer.Bool(false),
+									Terminating: utilpointer.Bool(true),
+								},
+								Addresses: []string{"2001:db2::5"},
+							},
+						},
+					},
+				},
+				svcPort: v1.ServicePort{
+					Name:       "tcp-example",
+					TargetPort: intstr.FromInt(80),
+					Protocol:   v1.ProtocolTCP,
+				},
+				service: getSampleService(false),
+			},
+			want: LbEndpoints{[]string{}, []string{"2001:db2::3", "2001:db2::4"}, 80},
+		},
+		{
+			name: "multiple slices with only terminating non-serving endpoints",
+			args: args{
+				slices: []*discovery.EndpointSlice{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab23",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     utilpointer.StringPtr("tcp-example"),
+								Protocol: protoPtr(v1.ProtocolTCP),
+								Port:     utilpointer.Int32Ptr(int32(80)),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv6,
+						Endpoints: []discovery.Endpoint{
+							{
+								Conditions: discovery.EndpointConditions{ // ignored
+									Ready:       utilpointer.Bool(false),
+									Serving:     utilpointer.Bool(false),
+									Terminating: utilpointer.Bool(true),
+								},
+								Addresses: []string{"2001:db2::2"},
+							},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab24",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     utilpointer.StringPtr("tcp-example"),
+								Protocol: protoPtr(v1.ProtocolTCP),
+								Port:     utilpointer.Int32Ptr(int32(80)),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv6,
+						Endpoints: []discovery.Endpoint{
+							{
+								Conditions: discovery.EndpointConditions{ // ignored
+									Ready:       utilpointer.Bool(false),
+									Serving:     utilpointer.Bool(false),
+									Terminating: utilpointer.Bool(true),
+								},
+								Addresses: []string{"2001:db2::5"},
+							},
+						},
+					},
+				},
+				svcPort: v1.ServicePort{
+					Name:       "tcp-example",
+					TargetPort: intstr.FromInt(80),
+					Protocol:   v1.ProtocolTCP,
+				},
+				service: getSampleService(false),
+			},
+			want: LbEndpoints{[]string{}, []string{}, 80},
+		},
+		{
+			name: "multiple slices with a mix of IPv4 and IPv6 ready and terminating (serving and non-serving) endpoints (dualstack cluster)",
+			args: args{
+				slices: []*discovery.EndpointSlice{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab23",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     utilpointer.StringPtr("tcp-example"),
+								Protocol: protoPtr(v1.ProtocolTCP),
+								Port:     utilpointer.Int32Ptr(int32(80)),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv4,
+						Endpoints: []discovery.Endpoint{
+							{
+								Conditions: discovery.EndpointConditions{
+									Ready:       utilpointer.Bool(true),
+									Serving:     utilpointer.Bool(true),
+									Terminating: utilpointer.Bool(false),
+								},
+								Addresses: []string{"10.0.0.2"},
+							},
+							{
+								Conditions: discovery.EndpointConditions{ // ignored
+									Ready:       utilpointer.Bool(false),
+									Serving:     utilpointer.Bool(true),
+									Terminating: utilpointer.Bool(true),
+								},
+								Addresses: []string{"10.0.0.3"},
+							},
+							{
+								Conditions: discovery.EndpointConditions{ // ignored
+									Ready:       utilpointer.Bool(false),
+									Serving:     utilpointer.Bool(false),
+									Terminating: utilpointer.Bool(true),
+								},
+								Addresses: []string{"10.0.0.4"},
+							},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab24",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     utilpointer.StringPtr("tcp-example"),
+								Protocol: protoPtr(v1.ProtocolTCP),
+								Port:     utilpointer.Int32Ptr(int32(80)),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv6,
+						Endpoints: []discovery.Endpoint{
+							{
+								Conditions: discovery.EndpointConditions{
+									Ready:       utilpointer.Bool(true),
+									Serving:     utilpointer.Bool(true),
+									Terminating: utilpointer.Bool(false),
+								},
+								Addresses: []string{"2001:db2::2"},
+							},
+							{
+								Conditions: discovery.EndpointConditions{ // ignored
+									Ready:       utilpointer.Bool(false),
+									Serving:     utilpointer.Bool(true),
+									Terminating: utilpointer.Bool(true),
+								},
+								Addresses: []string{"2001:db2::3"},
+							},
+							{
+								Conditions: discovery.EndpointConditions{ // ignored
+									Ready:       utilpointer.Bool(false),
+									Serving:     utilpointer.Bool(false),
+									Terminating: utilpointer.Bool(true),
+								},
+								Addresses: []string{"2001:db2::4"},
+							},
+						},
+					},
+				},
+				svcPort: v1.ServicePort{
+					Name:       "tcp-example",
+					TargetPort: intstr.FromInt(80),
+					Protocol:   v1.ProtocolTCP,
+				},
+				service: getSampleService(false),
+			},
+			want: LbEndpoints{[]string{"10.0.0.2"}, []string{"2001:db2::2"}, 80},
+		},
+		{
+			name: "multiple slices with a mix of IPv4 and IPv6 terminating (serving and non-serving) endpoints and no ready endpoints (dualstack cluster)",
+			args: args{
+				slices: []*discovery.EndpointSlice{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab23",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     utilpointer.StringPtr("tcp-example"),
+								Protocol: protoPtr(v1.ProtocolTCP),
+								Port:     utilpointer.Int32Ptr(int32(80)),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv4,
+						Endpoints: []discovery.Endpoint{
+							{
+								Conditions: discovery.EndpointConditions{
+									Ready:       utilpointer.Bool(false),
+									Serving:     utilpointer.Bool(true),
+									Terminating: utilpointer.Bool(true),
+								},
+								Addresses: []string{"10.0.0.3"},
+							},
+							{
+								Conditions: discovery.EndpointConditions{ // ignored
+									Ready:       utilpointer.Bool(false),
+									Serving:     utilpointer.Bool(false),
+									Terminating: utilpointer.Bool(true),
+								},
+								Addresses: []string{"10.0.0.4"},
+							},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab24",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     utilpointer.StringPtr("tcp-example"),
+								Protocol: protoPtr(v1.ProtocolTCP),
+								Port:     utilpointer.Int32Ptr(int32(80)),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv6,
+						Endpoints: []discovery.Endpoint{
+							{
+								Conditions: discovery.EndpointConditions{
+									Ready:       utilpointer.Bool(false),
+									Serving:     utilpointer.Bool(true),
+									Terminating: utilpointer.Bool(true),
+								},
+								Addresses: []string{"2001:db2::3"},
+							},
+							{
+								Conditions: discovery.EndpointConditions{ // ignored
+									Ready:       utilpointer.Bool(false),
+									Serving:     utilpointer.Bool(false),
+									Terminating: utilpointer.Bool(true),
+								},
+								Addresses: []string{"2001:db2::4"},
+							},
+						},
+					},
+				},
+				svcPort: v1.ServicePort{
+					Name:       "tcp-example",
+					TargetPort: intstr.FromInt(80),
+					Protocol:   v1.ProtocolTCP,
+				},
+				service: getSampleService(false),
+			},
+			want: LbEndpoints{[]string{"10.0.0.3"}, []string{"2001:db2::3"}, 80},
+		},
+		{
+			name: "multiple slices with a mix of IPv4 and IPv6 terminating non-serving endpoints (dualstack cluster)",
+			args: args{
+				slices: []*discovery.EndpointSlice{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab23",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     utilpointer.StringPtr("tcp-example"),
+								Protocol: protoPtr(v1.ProtocolTCP),
+								Port:     utilpointer.Int32Ptr(int32(80)),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv4,
+						Endpoints: []discovery.Endpoint{
+							{
+								Conditions: discovery.EndpointConditions{ // ignored
+									Ready:       utilpointer.Bool(false),
+									Serving:     utilpointer.Bool(false),
+									Terminating: utilpointer.Bool(true),
+								},
+								Addresses: []string{"10.0.0.4"},
+							},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab24",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     utilpointer.StringPtr("tcp-example"),
+								Protocol: protoPtr(v1.ProtocolTCP),
+								Port:     utilpointer.Int32Ptr(int32(80)),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv6,
+						Endpoints: []discovery.Endpoint{
+							{
+								Conditions: discovery.EndpointConditions{ // ignored
+									Ready:       utilpointer.Bool(false),
+									Serving:     utilpointer.Bool(false),
+									Terminating: utilpointer.Bool(true),
+								},
+								Addresses: []string{"2001:db2::4"},
+							},
+						},
+					},
+				},
+				svcPort: v1.ServicePort{
+					Name:       "tcp-example",
+					TargetPort: intstr.FromInt(80),
+					Protocol:   v1.ProtocolTCP,
+				},
+				service: getSampleService(false),
+			},
+			want: LbEndpoints{[]string{}, []string{}, 80},
+		},
+		{
+			name: "multiple slices with a mix of IPv4 and IPv6 ready and terminating (serving and non-serving) endpoints (dualstack cluster) and service.PublishNotReadyAddresses=true",
+			args: args{
+				slices: []*discovery.EndpointSlice{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab23",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     utilpointer.StringPtr("tcp-example"),
+								Protocol: protoPtr(v1.ProtocolTCP),
+								Port:     utilpointer.Int32Ptr(int32(80)),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv4,
+						Endpoints: []discovery.Endpoint{
+							{
+								Conditions: discovery.EndpointConditions{ // included
+									Ready:       utilpointer.Bool(true),
+									Serving:     utilpointer.Bool(true),
+									Terminating: utilpointer.Bool(false),
+								},
+								Addresses: []string{"10.0.0.2"},
+							},
+							{
+								Conditions: discovery.EndpointConditions{ // included
+									Ready:       utilpointer.Bool(false),
+									Serving:     utilpointer.Bool(true),
+									Terminating: utilpointer.Bool(true),
+								},
+								Addresses: []string{"10.0.0.3"},
+							},
+							{
+								Conditions: discovery.EndpointConditions{ // included
+									Ready:       utilpointer.Bool(false),
+									Serving:     utilpointer.Bool(false),
+									Terminating: utilpointer.Bool(true),
+								},
+								Addresses: []string{"10.0.0.4"},
+							},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab24",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     utilpointer.StringPtr("tcp-example"),
+								Protocol: protoPtr(v1.ProtocolTCP),
+								Port:     utilpointer.Int32Ptr(int32(80)),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv6,
+						Endpoints: []discovery.Endpoint{
+							{
+								Conditions: discovery.EndpointConditions{ // included
+									Ready:       utilpointer.Bool(true),
+									Serving:     utilpointer.Bool(true),
+									Terminating: utilpointer.Bool(false),
+								},
+								Addresses: []string{"2001:db2::2"},
+							},
+							{
+								Conditions: discovery.EndpointConditions{ // included
+									Ready:       utilpointer.Bool(false),
+									Serving:     utilpointer.Bool(true),
+									Terminating: utilpointer.Bool(true),
+								},
+								Addresses: []string{"2001:db2::3"},
+							},
+							{
+								Conditions: discovery.EndpointConditions{ // included
+									Ready:       utilpointer.Bool(false),
+									Serving:     utilpointer.Bool(false),
+									Terminating: utilpointer.Bool(true),
+								},
+								Addresses: []string{"2001:db2::4"},
+							},
+						},
+					},
+				},
+				svcPort: v1.ServicePort{
+					Name:       "tcp-example",
+					TargetPort: intstr.FromInt(80),
+					Protocol:   v1.ProtocolTCP,
+				},
+				service: getSampleService(true), // <-- publishNotReadyAddresses=true
+			},
+			want: LbEndpoints{[]string{"10.0.0.2", "10.0.0.3", "10.0.0.4"}, []string{"2001:db2::2", "2001:db2::3", "2001:db2::4"}, 80},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := GetLbEndpoints(tt.args.slices, tt.args.svcPort, nil)
+			got := GetLbEndpoints(tt.args.slices, tt.args.svcPort, tt.args.service)
 			assert.Equal(t, tt.want, got)
 		})
 	}
@@ -791,6 +1505,7 @@ func TestExternalIDsForObject(t *testing.T) {
 
 var (
 	testNode   string      = "testNode"
+	otherNode              = "otherNode"
 	ep1Address string      = "10.244.0.3"
 	ep2Address string      = "10.244.0.4"
 	ep3Address string      = "10.244.1.3"
@@ -818,8 +1533,16 @@ func getSampleService(publishNotReadyAddresses bool) *v1.Service {
 	}
 }
 
+func getSampleEndpointSliceOnAnotherNode(service *kapi.Service) *discovery.EndpointSlice {
+	endpointSlice := getSampleEndpointSlice(service)
+	for i := range endpointSlice.Endpoints {
+		endpointSlice.Endpoints[i].NodeName = &otherNode
+	}
+	return endpointSlice
+}
+
 // returns an endpoint slice with three endpoints, two of which belong to the expected local node
-// and one belongs to "other-node"
+// and one belongs to "otherNode"
 func getSampleEndpointSlice(service *kapi.Service) *discovery.EndpointSlice {
 
 	epPortHttps := discovery.EndpointPort{
@@ -842,10 +1565,9 @@ func getSampleEndpointSlice(service *kapi.Service) *discovery.EndpointSlice {
 		Addresses: []string{ep2Address},
 		NodeName:  &testNode,
 	}
-	otherNodeName := "other-node"
 	nonLocalEndpoint := discovery.Endpoint{
 		Addresses: []string{ep3Address},
-		NodeName:  &otherNodeName,
+		NodeName:  &otherNode,
 	}
 
 	return &discovery.EndpointSlice{
@@ -906,7 +1628,57 @@ func setEndpointsToAMixOfStatusConditions(endpointSlice *discovery.EndpointSlice
 	return endpointSlice
 }
 
-func TestGetEndpointAddresses(t *testing.T) {
+func setNodeEndpointsToReady(endpointSlice *discovery.EndpointSlice, nodeName string) *discovery.EndpointSlice {
+	for i := range endpointSlice.Endpoints {
+		if *endpointSlice.Endpoints[i].NodeName == nodeName {
+			setEndpointToReady(&endpointSlice.Endpoints[i])
+		}
+	}
+	return endpointSlice
+}
+func setNodeEndpointsToTerminatingAndServing(endpointSlice *discovery.EndpointSlice, nodeName string) *discovery.EndpointSlice {
+	for i := range endpointSlice.Endpoints {
+		if *endpointSlice.Endpoints[i].NodeName == nodeName {
+			setEndpointToTerminatingAndServing(&endpointSlice.Endpoints[i])
+		}
+	}
+	return endpointSlice
+}
+
+func setNodeEndpointsToTerminatingAndNotServing(endpointSlice *discovery.EndpointSlice, nodeName string) *discovery.EndpointSlice {
+	for i := range endpointSlice.Endpoints {
+		if *endpointSlice.Endpoints[i].NodeName == testNode {
+			setEndpointToTerminatingAndNotServing(&endpointSlice.Endpoints[i])
+		}
+	}
+	return endpointSlice
+}
+
+func setLocalEndpointsToReady(endpointSlice *discovery.EndpointSlice) *discovery.EndpointSlice {
+	return setNodeEndpointsToReady(endpointSlice, testNode)
+}
+
+func setLocalEndpointsToTerminatingAndServing(endpointSlice *discovery.EndpointSlice) *discovery.EndpointSlice {
+	return setNodeEndpointsToTerminatingAndServing(endpointSlice, testNode)
+}
+
+func setLocalEndpointsToTerminatingAndNotServing(endpointSlice *discovery.EndpointSlice) *discovery.EndpointSlice {
+	return setNodeEndpointsToTerminatingAndNotServing(endpointSlice, testNode)
+}
+
+func setRemoteEndpointsToReady(endpointSlice *discovery.EndpointSlice) *discovery.EndpointSlice {
+	return setNodeEndpointsToReady(endpointSlice, otherNode)
+}
+
+func setRemoteEndpointsToTerminatingAndServing(endpointSlice *discovery.EndpointSlice) *discovery.EndpointSlice {
+	return setNodeEndpointsToTerminatingAndServing(endpointSlice, otherNode)
+}
+
+func setRemoteEndpointsToTerminatingAndNotServing(endpointSlice *discovery.EndpointSlice) *discovery.EndpointSlice {
+	return setNodeEndpointsToTerminatingAndNotServing(endpointSlice, otherNode)
+}
+
+func TestGetEligibleEndpointAddresses(t *testing.T) {
 	service := getSampleService(false)
 	var tests = []struct {
 		name          string
@@ -921,7 +1693,7 @@ func TestGetEndpointAddresses(t *testing.T) {
 		{
 			"Tests an endpointslice with all non-ready, serving, terminating endpoints",
 			setAllEndpointsToTerminatingAndServing(getSampleEndpointSlice(service)),
-			sets.NewString(ep1Address, ep2Address, ep3Address),
+			sets.NewString(ep1Address, ep2Address, ep3Address), // with no ready endpoints, we fallback to terminating serving endpoints
 		},
 		{
 			"Tests an endpointslice with all non-ready, non-serving, terminating endpoints",
@@ -931,13 +1703,13 @@ func TestGetEndpointAddresses(t *testing.T) {
 		{
 			"Tests an endpointslice with endpoints showing a mix of status conditions",
 			setEndpointsToAMixOfStatusConditions(getSampleEndpointSlice(service)),
-			sets.NewString(ep1Address, ep2Address),
+			sets.NewString(ep1Address), // only the ready endpoint is included
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			answer := GetEndpointAddresses([]*discovery.EndpointSlice{tt.endpointSlice}, service)
+			answer := GetEligibleEndpointAddresses([]*discovery.EndpointSlice{tt.endpointSlice}, service)
 			if !reflect.DeepEqual(answer, tt.want) {
 				t.Errorf("got %v, want %v", answer, tt.want)
 			}
@@ -983,7 +1755,7 @@ func TestHasLocalHostNetworkEndpoints(t *testing.T) {
 	}
 }
 
-func TestGetLocalEndpointAddresses(t *testing.T) {
+func TestGetLocalEligibleEndpointAddresses(t *testing.T) {
 	service := getSampleService(false)
 	var tests = []struct {
 		name          string
@@ -991,30 +1763,60 @@ func TestGetLocalEndpointAddresses(t *testing.T) {
 		want          sets.String
 	}{
 		{
-			"Tests an endpointslice with all ready endpoints",
+			"Tests an endpointslice with all ready endpoints, one of which is on a different node",
 			setAllEndpointsToReady(getSampleEndpointSlice(service)),
 			sets.NewString(ep1Address, ep2Address),
 		},
 		{
-			"Tests an endpointslice with all non-ready, serving, terminating endpoints",
-			setAllEndpointsToTerminatingAndServing(getSampleEndpointSlice(service)),
-			sets.NewString(ep1Address, ep2Address),
+			"Tests an endpointslice with all ready endpoints, all of which are on a different node",
+			setAllEndpointsToReady(getSampleEndpointSliceOnAnotherNode(service)),
+			sets.NewString(),
 		},
 		{
-			"Tests an endpointslice with all non-ready, non-serving, terminating endpoints",
+			"Tests an endpointslice with all non-ready, serving, terminating endpoints, one of which is on a different node",
+			setAllEndpointsToTerminatingAndServing(getSampleEndpointSlice(service)),
+			sets.NewString(ep1Address, ep2Address), // with no ready endpoints, we fallback to terminating serving endpoints
+		},
+		{
+			"Tests an endpointslice with all non-ready, serving, terminating endpoints, all of which are on a different node",
+			setAllEndpointsToTerminatingAndServing(getSampleEndpointSliceOnAnotherNode(service)),
+			sets.NewString(),
+		},
+		{
+			"Tests an endpointslice with all non-ready, non-serving, terminating endpoints, one of which is on a different node",
 			setAllEndpointsToTerminatingAndNotServing(getSampleEndpointSlice(service)),
 			sets.NewString(),
 		},
 		{
-			"Tests an endpointslice with endpoints showing a mix of status conditions",
+			"Tests an endpointslice with all non-ready, non-serving, terminating endpoints, all of which are on a different node",
+			setAllEndpointsToTerminatingAndNotServing(getSampleEndpointSliceOnAnotherNode(service)),
+			sets.NewString(),
+		},
+		{
+			"Tests an endpointslice with endpoints showing a mix of status conditions, one of which is on a different node",
 			setEndpointsToAMixOfStatusConditions(getSampleEndpointSlice(service)),
-			sets.NewString(ep1Address, ep2Address),
+			sets.NewString(ep1Address), // only the ready endpoint is included
+		},
+		{
+			"Tests an endpointslice with endpoints showing a mix of status conditions, all of which are on a different node",
+			setEndpointsToAMixOfStatusConditions(getSampleEndpointSliceOnAnotherNode(service)),
+			sets.NewString(),
+		},
+		{
+			"Tests an endpointslice where all local endpoints are serving and terminating and a remote endpoint is ready",
+			setLocalEndpointsToTerminatingAndServing(setRemoteEndpointsToReady(getSampleEndpointSlice(service))),
+			sets.NewString(ep1Address, ep2Address), // fallback to serving&terminating should apply
+		},
+		{
+			"Tests an endpointslice where all local endpoints are terminating and not serving and a remote endpoint is ready",
+			setLocalEndpointsToTerminatingAndNotServing(setRemoteEndpointsToReady(getSampleEndpointSlice(service))),
+			sets.NewString(),
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			answer := GetLocalEndpointAddresses([]*discovery.EndpointSlice{tt.endpointSlice}, service, testNode)
+			answer := GetLocalEligibleEndpointAddresses([]*discovery.EndpointSlice{tt.endpointSlice}, service, testNode)
 			if !reflect.DeepEqual(answer, tt.want) {
 				t.Errorf("got %v, want %v", answer, tt.want)
 			}
@@ -1022,7 +1824,7 @@ func TestGetLocalEndpointAddresses(t *testing.T) {
 	}
 }
 
-func TestDoesEndpointSliceContainEndpoint(t *testing.T) {
+func TestDoesEndpointSliceContainEligibleEndpoint(t *testing.T) {
 	service := getSampleService(false)
 	var tests = []struct {
 		name          string
@@ -1067,7 +1869,7 @@ func TestDoesEndpointSliceContainEndpoint(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			answer := DoesEndpointSliceContainEndpoint(tt.endpointSlice, tt.epIP, tt.epPort, tt.protocol, service)
+			answer := DoesEndpointSliceContainEligibleEndpoint(tt.endpointSlice, tt.epIP, tt.epPort, tt.protocol, service)
 			if !reflect.DeepEqual(answer, tt.want) {
 				t.Errorf("got %v, want %v", answer, tt.want)
 			}

--- a/go-controller/pkg/util/kube_test.go
+++ b/go-controller/pkg/util/kube_test.go
@@ -8,16 +8,22 @@ import (
 	"testing"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	kube_test "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
+
 	"github.com/stretchr/testify/assert"
 	kapi "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/sets"
 	clientsetfake "k8s.io/client-go/kubernetes/fake"
 	utilpointer "k8s.io/utils/pointer"
+)
+
+var (
+	nodeA = "node-a"
+	nodeB = "node-b"
 )
 
 // Go Daddy Class 2 CA
@@ -419,1026 +425,6 @@ func makeNodeWithAddresses(name, internal, external string) *v1.Node {
 	return node
 }
 
-func Test_getLbEndpoints(t *testing.T) {
-	type args struct {
-		slices  []*discovery.EndpointSlice
-		svcPort v1.ServicePort
-		service *v1.Service
-	}
-	tests := []struct {
-		name string
-		args args
-		want LbEndpoints
-	}{
-		{
-			name: "empty slices",
-			args: args{
-				slices: []*discovery.EndpointSlice{},
-				svcPort: v1.ServicePort{
-					Name:       "tcp-example",
-					TargetPort: intstr.FromInt(80),
-					Protocol:   v1.ProtocolTCP,
-				},
-				service: getSampleService(false),
-			},
-			want: LbEndpoints{},
-		},
-		{
-			name: "slice with one endpoint",
-			args: args{
-				slices: []*discovery.EndpointSlice{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc-ab23",
-							Namespace: "ns",
-							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
-						},
-						Ports: []discovery.EndpointPort{
-							{
-								Name:     utilpointer.StringPtr("tcp-example"),
-								Protocol: protoPtr(v1.ProtocolTCP),
-								Port:     utilpointer.Int32Ptr(int32(80)),
-							},
-						},
-						AddressType: discovery.AddressTypeIPv4,
-						Endpoints: []discovery.Endpoint{
-							{
-								Conditions: discovery.EndpointConditions{
-									Ready: utilpointer.BoolPtr(true),
-								},
-								Addresses: []string{"10.0.0.2"},
-							},
-						},
-					},
-				},
-				svcPort: v1.ServicePort{
-					Name:       "tcp-example",
-					TargetPort: intstr.FromInt(80),
-					Protocol:   v1.ProtocolTCP,
-				},
-				service: getSampleService(false),
-			},
-			want: LbEndpoints{[]string{"10.0.0.2"}, []string{}, 80},
-		},
-		{
-			name: "slice with different port name than the service",
-			args: args{
-				slices: []*discovery.EndpointSlice{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc-ab23",
-							Namespace: "ns",
-							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
-						},
-						Ports: []discovery.EndpointPort{
-							{
-								Name:     utilpointer.StringPtr("tcp-example-wrong"),
-								Protocol: protoPtr(v1.ProtocolTCP),
-								Port:     utilpointer.Int32Ptr(int32(8080)),
-							},
-						},
-						AddressType: discovery.AddressTypeIPv4,
-						Endpoints: []discovery.Endpoint{
-							{
-								Conditions: discovery.EndpointConditions{
-									Ready: utilpointer.BoolPtr(true),
-								},
-								Addresses: []string{"10.0.0.2"},
-							},
-						},
-					},
-				},
-				svcPort: v1.ServicePort{
-					Name:       "tcp-example",
-					TargetPort: intstr.FromInt(80),
-					Protocol:   v1.ProtocolTCP,
-				},
-				service: getSampleService(false),
-			},
-			want: LbEndpoints{[]string{}, []string{}, 0},
-		},
-		{
-			name: "slice and service without a port name",
-			args: args{
-				slices: []*discovery.EndpointSlice{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc-ab23",
-							Namespace: "ns",
-							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
-						},
-						Ports: []discovery.EndpointPort{
-							{
-								Protocol: protoPtr(v1.ProtocolTCP),
-								Port:     utilpointer.Int32Ptr(int32(8080)),
-							},
-						},
-						AddressType: discovery.AddressTypeIPv4,
-						Endpoints: []discovery.Endpoint{
-							{
-								Conditions: discovery.EndpointConditions{
-									Ready: utilpointer.BoolPtr(true),
-								},
-								Addresses: []string{"10.0.0.2"},
-							},
-						},
-					},
-				},
-				svcPort: v1.ServicePort{
-					TargetPort: intstr.FromInt(80),
-					Protocol:   v1.ProtocolTCP,
-				},
-				service: getSampleService(false),
-			},
-			want: LbEndpoints{[]string{"10.0.0.2"}, []string{}, 8080},
-		},
-		{
-			name: "slice with an IPv6 endpoint",
-			args: args{
-				slices: []*discovery.EndpointSlice{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc-ab23",
-							Namespace: "ns",
-							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
-						},
-						Ports: []discovery.EndpointPort{
-							{
-								Name:     utilpointer.StringPtr("tcp-example"),
-								Protocol: protoPtr(v1.ProtocolTCP),
-								Port:     utilpointer.Int32Ptr(int32(80)),
-							},
-						},
-						AddressType: discovery.AddressTypeIPv6,
-						Endpoints: []discovery.Endpoint{
-							{
-								Conditions: discovery.EndpointConditions{
-									Ready: utilpointer.BoolPtr(true),
-								},
-								Addresses: []string{"2001:db2::2"},
-							},
-						},
-					},
-				},
-				svcPort: v1.ServicePort{
-					Name:       "tcp-example",
-					TargetPort: intstr.FromInt(80),
-					Protocol:   v1.ProtocolTCP,
-				},
-				service: getSampleService(false),
-			},
-			want: LbEndpoints{[]string{}, []string{"2001:db2::2"}, 80},
-		},
-		{
-			name: "a slice with an IPv4 endpoint and a slice with an IPv6 endpoint (dualstack cluster)",
-			args: args{
-				slices: []*discovery.EndpointSlice{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc-ab23",
-							Namespace: "ns",
-							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
-						},
-						Ports: []discovery.EndpointPort{
-							{
-								Name:     utilpointer.StringPtr("tcp-example"),
-								Protocol: protoPtr(v1.ProtocolTCP),
-								Port:     utilpointer.Int32Ptr(int32(80)),
-							},
-						},
-						AddressType: discovery.AddressTypeIPv4,
-						Endpoints: []discovery.Endpoint{
-							{
-								Conditions: discovery.EndpointConditions{
-									Ready: utilpointer.Bool(true),
-								},
-								Addresses: []string{"10.0.0.2"},
-							},
-						},
-					},
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc-ab24",
-							Namespace: "ns",
-							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
-						},
-						Ports: []discovery.EndpointPort{
-							{
-								Name:     utilpointer.StringPtr("tcp-example"),
-								Protocol: protoPtr(v1.ProtocolTCP),
-								Port:     utilpointer.Int32Ptr(int32(80)),
-							},
-						},
-						AddressType: discovery.AddressTypeIPv6,
-						Endpoints: []discovery.Endpoint{
-							{
-								Conditions: discovery.EndpointConditions{
-									Ready: utilpointer.Bool(true),
-								},
-								Addresses: []string{"2001:db2::2"},
-							},
-						},
-					},
-				},
-				svcPort: v1.ServicePort{
-					Name:       "tcp-example",
-					TargetPort: intstr.FromInt(80),
-					Protocol:   v1.ProtocolTCP,
-				},
-				service: getSampleService(false),
-			},
-			want: LbEndpoints{[]string{"10.0.0.2"}, []string{"2001:db2::2"}, 80},
-		},
-		{
-			name: "multiples slices with a duplicate endpoint",
-			args: args{
-				slices: []*discovery.EndpointSlice{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc-ab23",
-							Namespace: "ns",
-							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
-						},
-						Ports: []discovery.EndpointPort{
-							{
-								Name:     utilpointer.StringPtr("tcp-example"),
-								Protocol: protoPtr(v1.ProtocolTCP),
-								Port:     utilpointer.Int32Ptr(int32(80)),
-							},
-						},
-						AddressType: discovery.AddressTypeIPv4,
-						Endpoints: []discovery.Endpoint{
-							{
-								Conditions: discovery.EndpointConditions{
-									Ready: utilpointer.BoolPtr(true),
-								},
-								Addresses: []string{"10.0.0.2", "10.1.1.2"},
-							},
-						},
-					},
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc-ab24",
-							Namespace: "ns",
-							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
-						},
-						Ports: []discovery.EndpointPort{
-							{
-								Name:     utilpointer.StringPtr("tcp-example"),
-								Protocol: protoPtr(v1.ProtocolTCP),
-								Port:     utilpointer.Int32Ptr(int32(80)),
-							},
-						},
-						AddressType: discovery.AddressTypeIPv4,
-						Endpoints: []discovery.Endpoint{
-							{
-								Conditions: discovery.EndpointConditions{
-									Ready: utilpointer.Bool(true),
-								},
-								Addresses: []string{"10.0.0.2", "10.2.2.2"},
-							},
-						},
-					},
-				},
-				svcPort: v1.ServicePort{
-					Name:       "tcp-example",
-					TargetPort: intstr.FromInt(80),
-					Protocol:   v1.ProtocolTCP,
-				},
-				service: getSampleService(false),
-			},
-			want: LbEndpoints{[]string{"10.0.0.2", "10.1.1.2", "10.2.2.2"}, []string{}, 80},
-		},
-		{
-			name: "multiples slices with different ports",
-			args: args{
-				slices: []*discovery.EndpointSlice{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc-ab23",
-							Namespace: "ns",
-							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
-						},
-						Ports: []discovery.EndpointPort{
-							{
-								Name:     utilpointer.StringPtr("tcp-example"),
-								Protocol: protoPtr(v1.ProtocolTCP),
-								Port:     utilpointer.Int32Ptr(int32(80)),
-							},
-						},
-						AddressType: discovery.AddressTypeIPv4,
-						Endpoints: []discovery.Endpoint{
-							{
-								Conditions: discovery.EndpointConditions{
-									Ready: utilpointer.Bool(true),
-								},
-								Addresses: []string{"10.0.0.2", "10.1.1.2"},
-							},
-						},
-					},
-					{ // this slice should be ignored, we're considering only one service port per execution
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc-ab24",
-							Namespace: "ns",
-							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
-						},
-						Ports: []discovery.EndpointPort{
-							{
-								Name:     utilpointer.StringPtr("other-port"),
-								Protocol: protoPtr(v1.ProtocolTCP),
-								Port:     utilpointer.Int32Ptr(int32(8080)),
-							},
-						},
-						AddressType: discovery.AddressTypeIPv4,
-						Endpoints: []discovery.Endpoint{
-							{
-								Conditions: discovery.EndpointConditions{
-									Ready: utilpointer.Bool(true),
-								},
-								Addresses: []string{"10.0.0.3", "10.2.2.3"},
-							},
-						},
-					},
-				},
-				svcPort: v1.ServicePort{
-					Name:       "tcp-example",
-					TargetPort: intstr.FromInt(80),
-					Protocol:   v1.ProtocolTCP,
-				},
-				service: getSampleService(false),
-			},
-			want: LbEndpoints{[]string{"10.0.0.2", "10.1.1.2"}, []string{}, 80},
-		},
-		{
-			name: "slice with a mix of ready and terminating (serving and non-serving) endpoints",
-			args: args{
-				slices: []*discovery.EndpointSlice{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc-ab23",
-							Namespace: "ns",
-							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
-						},
-						Ports: []discovery.EndpointPort{
-							{
-								Name:     utilpointer.StringPtr("tcp-example"),
-								Protocol: protoPtr(v1.ProtocolTCP),
-								Port:     utilpointer.Int32Ptr(int32(80)),
-							},
-						},
-						AddressType: discovery.AddressTypeIPv6,
-						Endpoints: []discovery.Endpoint{
-							{
-								Conditions: discovery.EndpointConditions{
-									Ready:       utilpointer.Bool(true),
-									Serving:     utilpointer.Bool(true),
-									Terminating: utilpointer.Bool(false),
-								},
-								Addresses: []string{"2001:db2::2"},
-							},
-							{
-								Conditions: discovery.EndpointConditions{
-									Ready:       utilpointer.Bool(true),
-									Serving:     utilpointer.Bool(true),
-									Terminating: utilpointer.Bool(false),
-								},
-								Addresses: []string{"2001:db2::3"},
-							},
-							{
-								Conditions: discovery.EndpointConditions{ // ignored
-									Ready:       utilpointer.Bool(false),
-									Serving:     utilpointer.Bool(true),
-									Terminating: utilpointer.Bool(true),
-								},
-								Addresses: []string{"2001:db2::4"},
-							},
-							{
-								Conditions: discovery.EndpointConditions{ // ignored
-									Ready:       utilpointer.Bool(false),
-									Serving:     utilpointer.Bool(true),
-									Terminating: utilpointer.Bool(true),
-								},
-								Addresses: []string{"2001:db2::5"},
-							},
-							{
-								Conditions: discovery.EndpointConditions{ // ignored
-									Ready:       utilpointer.Bool(false),
-									Serving:     utilpointer.Bool(false),
-									Terminating: utilpointer.Bool(true),
-								},
-								Addresses: []string{"2001:db2::6"},
-							},
-						},
-					},
-				},
-				svcPort: v1.ServicePort{
-					Name:       "tcp-example",
-					TargetPort: intstr.FromInt(80),
-					Protocol:   v1.ProtocolTCP,
-				},
-				service: getSampleService(false),
-			},
-			want: LbEndpoints{[]string{}, []string{"2001:db2::2", "2001:db2::3"}, 80},
-		},
-		{
-			name: "slice with a mix of terminating (serving and non-serving) endpoints and no ready endpoints",
-			args: args{
-				slices: []*discovery.EndpointSlice{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc-ab23",
-							Namespace: "ns",
-							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
-						},
-						Ports: []discovery.EndpointPort{
-							{
-								Name:     utilpointer.StringPtr("tcp-example"),
-								Protocol: protoPtr(v1.ProtocolTCP),
-								Port:     utilpointer.Int32Ptr(int32(80)),
-							},
-						},
-						AddressType: discovery.AddressTypeIPv6,
-						Endpoints: []discovery.Endpoint{
-							{
-								Conditions: discovery.EndpointConditions{
-									Ready:       utilpointer.Bool(false),
-									Serving:     utilpointer.Bool(true),
-									Terminating: utilpointer.Bool(true),
-								},
-								Addresses: []string{"2001:db2::4"},
-							},
-							{
-								Conditions: discovery.EndpointConditions{
-									Ready:       utilpointer.Bool(false),
-									Serving:     utilpointer.Bool(true),
-									Terminating: utilpointer.Bool(true),
-								},
-								Addresses: []string{"2001:db2::5"},
-							},
-							{
-								Conditions: discovery.EndpointConditions{ // ignored
-									Ready:       utilpointer.Bool(false),
-									Serving:     utilpointer.Bool(false),
-									Terminating: utilpointer.Bool(true),
-								},
-								Addresses: []string{"2001:db2::6"},
-							},
-							{
-								Conditions: discovery.EndpointConditions{ // ignored
-									Ready:       utilpointer.Bool(false),
-									Serving:     utilpointer.Bool(false),
-									Terminating: utilpointer.Bool(true),
-								},
-								Addresses: []string{"2001:db2::7"},
-							},
-						},
-					},
-				},
-				svcPort: v1.ServicePort{
-					Name:       "tcp-example",
-					TargetPort: intstr.FromInt(80),
-					Protocol:   v1.ProtocolTCP,
-				},
-				service: getSampleService(false),
-			},
-			want: LbEndpoints{[]string{}, []string{"2001:db2::4", "2001:db2::5"}, 80},
-		},
-		{
-			name: "slice with only terminating non-serving endpoints",
-			args: args{
-				slices: []*discovery.EndpointSlice{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc-ab23",
-							Namespace: "ns",
-							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
-						},
-						Ports: []discovery.EndpointPort{
-							{
-								Name:     utilpointer.StringPtr("tcp-example"),
-								Protocol: protoPtr(v1.ProtocolTCP),
-								Port:     utilpointer.Int32Ptr(int32(80)),
-							},
-						},
-						AddressType: discovery.AddressTypeIPv6,
-						Endpoints: []discovery.Endpoint{
-							{
-								Conditions: discovery.EndpointConditions{ // ignored
-									Ready:       utilpointer.Bool(false),
-									Serving:     utilpointer.Bool(false),
-									Terminating: utilpointer.Bool(true),
-								},
-								Addresses: []string{"2001:db2::6"},
-							},
-							{
-								Conditions: discovery.EndpointConditions{ // ignored
-									Ready:       utilpointer.Bool(false),
-									Serving:     utilpointer.Bool(false),
-									Terminating: utilpointer.Bool(true),
-								},
-								Addresses: []string{"2001:db2::7"},
-							},
-						},
-					},
-				},
-				svcPort: v1.ServicePort{
-					Name:       "tcp-example",
-					TargetPort: intstr.FromInt(80),
-					Protocol:   v1.ProtocolTCP,
-				},
-				service: getSampleService(false),
-			},
-			want: LbEndpoints{[]string{}, []string{}, 80},
-		},
-		{
-			name: "multiple slices with a mix terminating (serving and non-serving) endpoints and no ready endpoints",
-			args: args{
-				slices: []*discovery.EndpointSlice{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc-ab23",
-							Namespace: "ns",
-							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
-						},
-						Ports: []discovery.EndpointPort{
-							{
-								Name:     utilpointer.StringPtr("tcp-example"),
-								Protocol: protoPtr(v1.ProtocolTCP),
-								Port:     utilpointer.Int32Ptr(int32(80)),
-							},
-						},
-						AddressType: discovery.AddressTypeIPv6,
-						Endpoints: []discovery.Endpoint{
-							{
-								Conditions: discovery.EndpointConditions{ // ignored
-									Ready:       utilpointer.Bool(false),
-									Serving:     utilpointer.Bool(false),
-									Terminating: utilpointer.Bool(true),
-								},
-								Addresses: []string{"2001:db2::2"},
-							},
-							{
-								Conditions: discovery.EndpointConditions{
-									Ready:       utilpointer.Bool(false),
-									Serving:     utilpointer.Bool(true),
-									Terminating: utilpointer.Bool(true),
-								},
-								Addresses: []string{"2001:db2::3"},
-							},
-						},
-					},
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc-ab24",
-							Namespace: "ns",
-							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
-						},
-						Ports: []discovery.EndpointPort{
-							{
-								Name:     utilpointer.StringPtr("tcp-example"),
-								Protocol: protoPtr(v1.ProtocolTCP),
-								Port:     utilpointer.Int32Ptr(int32(80)),
-							},
-						},
-						AddressType: discovery.AddressTypeIPv6,
-						Endpoints: []discovery.Endpoint{
-							{
-								Conditions: discovery.EndpointConditions{
-									Ready:       utilpointer.Bool(false),
-									Serving:     utilpointer.Bool(true),
-									Terminating: utilpointer.Bool(true),
-								},
-								Addresses: []string{"2001:db2::4"},
-							},
-							{
-								Conditions: discovery.EndpointConditions{ // ignored
-									Ready:       utilpointer.Bool(false),
-									Serving:     utilpointer.Bool(false),
-									Terminating: utilpointer.Bool(true),
-								},
-								Addresses: []string{"2001:db2::5"},
-							},
-						},
-					},
-				},
-				svcPort: v1.ServicePort{
-					Name:       "tcp-example",
-					TargetPort: intstr.FromInt(80),
-					Protocol:   v1.ProtocolTCP,
-				},
-				service: getSampleService(false),
-			},
-			want: LbEndpoints{[]string{}, []string{"2001:db2::3", "2001:db2::4"}, 80},
-		},
-		{
-			name: "multiple slices with only terminating non-serving endpoints",
-			args: args{
-				slices: []*discovery.EndpointSlice{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc-ab23",
-							Namespace: "ns",
-							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
-						},
-						Ports: []discovery.EndpointPort{
-							{
-								Name:     utilpointer.StringPtr("tcp-example"),
-								Protocol: protoPtr(v1.ProtocolTCP),
-								Port:     utilpointer.Int32Ptr(int32(80)),
-							},
-						},
-						AddressType: discovery.AddressTypeIPv6,
-						Endpoints: []discovery.Endpoint{
-							{
-								Conditions: discovery.EndpointConditions{ // ignored
-									Ready:       utilpointer.Bool(false),
-									Serving:     utilpointer.Bool(false),
-									Terminating: utilpointer.Bool(true),
-								},
-								Addresses: []string{"2001:db2::2"},
-							},
-						},
-					},
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc-ab24",
-							Namespace: "ns",
-							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
-						},
-						Ports: []discovery.EndpointPort{
-							{
-								Name:     utilpointer.StringPtr("tcp-example"),
-								Protocol: protoPtr(v1.ProtocolTCP),
-								Port:     utilpointer.Int32Ptr(int32(80)),
-							},
-						},
-						AddressType: discovery.AddressTypeIPv6,
-						Endpoints: []discovery.Endpoint{
-							{
-								Conditions: discovery.EndpointConditions{ // ignored
-									Ready:       utilpointer.Bool(false),
-									Serving:     utilpointer.Bool(false),
-									Terminating: utilpointer.Bool(true),
-								},
-								Addresses: []string{"2001:db2::5"},
-							},
-						},
-					},
-				},
-				svcPort: v1.ServicePort{
-					Name:       "tcp-example",
-					TargetPort: intstr.FromInt(80),
-					Protocol:   v1.ProtocolTCP,
-				},
-				service: getSampleService(false),
-			},
-			want: LbEndpoints{[]string{}, []string{}, 80},
-		},
-		{
-			name: "multiple slices with a mix of IPv4 and IPv6 ready and terminating (serving and non-serving) endpoints (dualstack cluster)",
-			args: args{
-				slices: []*discovery.EndpointSlice{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc-ab23",
-							Namespace: "ns",
-							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
-						},
-						Ports: []discovery.EndpointPort{
-							{
-								Name:     utilpointer.StringPtr("tcp-example"),
-								Protocol: protoPtr(v1.ProtocolTCP),
-								Port:     utilpointer.Int32Ptr(int32(80)),
-							},
-						},
-						AddressType: discovery.AddressTypeIPv4,
-						Endpoints: []discovery.Endpoint{
-							{
-								Conditions: discovery.EndpointConditions{
-									Ready:       utilpointer.Bool(true),
-									Serving:     utilpointer.Bool(true),
-									Terminating: utilpointer.Bool(false),
-								},
-								Addresses: []string{"10.0.0.2"},
-							},
-							{
-								Conditions: discovery.EndpointConditions{ // ignored
-									Ready:       utilpointer.Bool(false),
-									Serving:     utilpointer.Bool(true),
-									Terminating: utilpointer.Bool(true),
-								},
-								Addresses: []string{"10.0.0.3"},
-							},
-							{
-								Conditions: discovery.EndpointConditions{ // ignored
-									Ready:       utilpointer.Bool(false),
-									Serving:     utilpointer.Bool(false),
-									Terminating: utilpointer.Bool(true),
-								},
-								Addresses: []string{"10.0.0.4"},
-							},
-						},
-					},
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc-ab24",
-							Namespace: "ns",
-							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
-						},
-						Ports: []discovery.EndpointPort{
-							{
-								Name:     utilpointer.StringPtr("tcp-example"),
-								Protocol: protoPtr(v1.ProtocolTCP),
-								Port:     utilpointer.Int32Ptr(int32(80)),
-							},
-						},
-						AddressType: discovery.AddressTypeIPv6,
-						Endpoints: []discovery.Endpoint{
-							{
-								Conditions: discovery.EndpointConditions{
-									Ready:       utilpointer.Bool(true),
-									Serving:     utilpointer.Bool(true),
-									Terminating: utilpointer.Bool(false),
-								},
-								Addresses: []string{"2001:db2::2"},
-							},
-							{
-								Conditions: discovery.EndpointConditions{ // ignored
-									Ready:       utilpointer.Bool(false),
-									Serving:     utilpointer.Bool(true),
-									Terminating: utilpointer.Bool(true),
-								},
-								Addresses: []string{"2001:db2::3"},
-							},
-							{
-								Conditions: discovery.EndpointConditions{ // ignored
-									Ready:       utilpointer.Bool(false),
-									Serving:     utilpointer.Bool(false),
-									Terminating: utilpointer.Bool(true),
-								},
-								Addresses: []string{"2001:db2::4"},
-							},
-						},
-					},
-				},
-				svcPort: v1.ServicePort{
-					Name:       "tcp-example",
-					TargetPort: intstr.FromInt(80),
-					Protocol:   v1.ProtocolTCP,
-				},
-				service: getSampleService(false),
-			},
-			want: LbEndpoints{[]string{"10.0.0.2"}, []string{"2001:db2::2"}, 80},
-		},
-		{
-			name: "multiple slices with a mix of IPv4 and IPv6 terminating (serving and non-serving) endpoints and no ready endpoints (dualstack cluster)",
-			args: args{
-				slices: []*discovery.EndpointSlice{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc-ab23",
-							Namespace: "ns",
-							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
-						},
-						Ports: []discovery.EndpointPort{
-							{
-								Name:     utilpointer.StringPtr("tcp-example"),
-								Protocol: protoPtr(v1.ProtocolTCP),
-								Port:     utilpointer.Int32Ptr(int32(80)),
-							},
-						},
-						AddressType: discovery.AddressTypeIPv4,
-						Endpoints: []discovery.Endpoint{
-							{
-								Conditions: discovery.EndpointConditions{
-									Ready:       utilpointer.Bool(false),
-									Serving:     utilpointer.Bool(true),
-									Terminating: utilpointer.Bool(true),
-								},
-								Addresses: []string{"10.0.0.3"},
-							},
-							{
-								Conditions: discovery.EndpointConditions{ // ignored
-									Ready:       utilpointer.Bool(false),
-									Serving:     utilpointer.Bool(false),
-									Terminating: utilpointer.Bool(true),
-								},
-								Addresses: []string{"10.0.0.4"},
-							},
-						},
-					},
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc-ab24",
-							Namespace: "ns",
-							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
-						},
-						Ports: []discovery.EndpointPort{
-							{
-								Name:     utilpointer.StringPtr("tcp-example"),
-								Protocol: protoPtr(v1.ProtocolTCP),
-								Port:     utilpointer.Int32Ptr(int32(80)),
-							},
-						},
-						AddressType: discovery.AddressTypeIPv6,
-						Endpoints: []discovery.Endpoint{
-							{
-								Conditions: discovery.EndpointConditions{
-									Ready:       utilpointer.Bool(false),
-									Serving:     utilpointer.Bool(true),
-									Terminating: utilpointer.Bool(true),
-								},
-								Addresses: []string{"2001:db2::3"},
-							},
-							{
-								Conditions: discovery.EndpointConditions{ // ignored
-									Ready:       utilpointer.Bool(false),
-									Serving:     utilpointer.Bool(false),
-									Terminating: utilpointer.Bool(true),
-								},
-								Addresses: []string{"2001:db2::4"},
-							},
-						},
-					},
-				},
-				svcPort: v1.ServicePort{
-					Name:       "tcp-example",
-					TargetPort: intstr.FromInt(80),
-					Protocol:   v1.ProtocolTCP,
-				},
-				service: getSampleService(false),
-			},
-			want: LbEndpoints{[]string{"10.0.0.3"}, []string{"2001:db2::3"}, 80},
-		},
-		{
-			name: "multiple slices with a mix of IPv4 and IPv6 terminating non-serving endpoints (dualstack cluster)",
-			args: args{
-				slices: []*discovery.EndpointSlice{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc-ab23",
-							Namespace: "ns",
-							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
-						},
-						Ports: []discovery.EndpointPort{
-							{
-								Name:     utilpointer.StringPtr("tcp-example"),
-								Protocol: protoPtr(v1.ProtocolTCP),
-								Port:     utilpointer.Int32Ptr(int32(80)),
-							},
-						},
-						AddressType: discovery.AddressTypeIPv4,
-						Endpoints: []discovery.Endpoint{
-							{
-								Conditions: discovery.EndpointConditions{ // ignored
-									Ready:       utilpointer.Bool(false),
-									Serving:     utilpointer.Bool(false),
-									Terminating: utilpointer.Bool(true),
-								},
-								Addresses: []string{"10.0.0.4"},
-							},
-						},
-					},
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc-ab24",
-							Namespace: "ns",
-							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
-						},
-						Ports: []discovery.EndpointPort{
-							{
-								Name:     utilpointer.StringPtr("tcp-example"),
-								Protocol: protoPtr(v1.ProtocolTCP),
-								Port:     utilpointer.Int32Ptr(int32(80)),
-							},
-						},
-						AddressType: discovery.AddressTypeIPv6,
-						Endpoints: []discovery.Endpoint{
-							{
-								Conditions: discovery.EndpointConditions{ // ignored
-									Ready:       utilpointer.Bool(false),
-									Serving:     utilpointer.Bool(false),
-									Terminating: utilpointer.Bool(true),
-								},
-								Addresses: []string{"2001:db2::4"},
-							},
-						},
-					},
-				},
-				svcPort: v1.ServicePort{
-					Name:       "tcp-example",
-					TargetPort: intstr.FromInt(80),
-					Protocol:   v1.ProtocolTCP,
-				},
-				service: getSampleService(false),
-			},
-			want: LbEndpoints{[]string{}, []string{}, 80},
-		},
-		{
-			name: "multiple slices with a mix of IPv4 and IPv6 ready and terminating (serving and non-serving) endpoints (dualstack cluster) and service.PublishNotReadyAddresses=true",
-			args: args{
-				slices: []*discovery.EndpointSlice{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc-ab23",
-							Namespace: "ns",
-							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
-						},
-						Ports: []discovery.EndpointPort{
-							{
-								Name:     utilpointer.StringPtr("tcp-example"),
-								Protocol: protoPtr(v1.ProtocolTCP),
-								Port:     utilpointer.Int32Ptr(int32(80)),
-							},
-						},
-						AddressType: discovery.AddressTypeIPv4,
-						Endpoints: []discovery.Endpoint{
-							{
-								Conditions: discovery.EndpointConditions{ // included
-									Ready:       utilpointer.Bool(true),
-									Serving:     utilpointer.Bool(true),
-									Terminating: utilpointer.Bool(false),
-								},
-								Addresses: []string{"10.0.0.2"},
-							},
-							{
-								Conditions: discovery.EndpointConditions{ // included
-									Ready:       utilpointer.Bool(false),
-									Serving:     utilpointer.Bool(true),
-									Terminating: utilpointer.Bool(true),
-								},
-								Addresses: []string{"10.0.0.3"},
-							},
-							{
-								Conditions: discovery.EndpointConditions{ // included
-									Ready:       utilpointer.Bool(false),
-									Serving:     utilpointer.Bool(false),
-									Terminating: utilpointer.Bool(true),
-								},
-								Addresses: []string{"10.0.0.4"},
-							},
-						},
-					},
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc-ab24",
-							Namespace: "ns",
-							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
-						},
-						Ports: []discovery.EndpointPort{
-							{
-								Name:     utilpointer.StringPtr("tcp-example"),
-								Protocol: protoPtr(v1.ProtocolTCP),
-								Port:     utilpointer.Int32Ptr(int32(80)),
-							},
-						},
-						AddressType: discovery.AddressTypeIPv6,
-						Endpoints: []discovery.Endpoint{
-							{
-								Conditions: discovery.EndpointConditions{ // included
-									Ready:       utilpointer.Bool(true),
-									Serving:     utilpointer.Bool(true),
-									Terminating: utilpointer.Bool(false),
-								},
-								Addresses: []string{"2001:db2::2"},
-							},
-							{
-								Conditions: discovery.EndpointConditions{ // included
-									Ready:       utilpointer.Bool(false),
-									Serving:     utilpointer.Bool(true),
-									Terminating: utilpointer.Bool(true),
-								},
-								Addresses: []string{"2001:db2::3"},
-							},
-							{
-								Conditions: discovery.EndpointConditions{ // included
-									Ready:       utilpointer.Bool(false),
-									Serving:     utilpointer.Bool(false),
-									Terminating: utilpointer.Bool(true),
-								},
-								Addresses: []string{"2001:db2::4"},
-							},
-						},
-					},
-				},
-				svcPort: v1.ServicePort{
-					Name:       "tcp-example",
-					TargetPort: intstr.FromInt(80),
-					Protocol:   v1.ProtocolTCP,
-				},
-				service: getSampleService(true), // <-- publishNotReadyAddresses=true
-			},
-			want: LbEndpoints{[]string{"10.0.0.2", "10.0.0.3", "10.0.0.4"}, []string{"2001:db2::2", "2001:db2::3", "2001:db2::4"}, 80},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := GetLbEndpoints(tt.args.slices, tt.args.svcPort, tt.args.service)
-			assert.Equal(t, tt.want, got)
-		})
-	}
-}
-
 // protoPtr takes a Protocol and returns a pointer to it.
 func protoPtr(proto v1.Protocol) *v1.Protocol {
 	return &proto
@@ -1512,6 +498,8 @@ var (
 	tcpv1      v1.Protocol = v1.ProtocolTCP
 	udpv1      v1.Protocol = v1.ProtocolUDP
 
+	httpPortName    string = "http"
+	httpPortValue   int32  = int32(80)
 	httpsPortName   string = "https"
 	httpsPortValue  int32  = int32(443)
 	customPortName  string = "customApp"
@@ -1531,14 +519,6 @@ func getSampleService(publishNotReadyAddresses bool) *v1.Service {
 			PublishNotReadyAddresses: publishNotReadyAddresses,
 		},
 	}
-}
-
-func getSampleEndpointSliceOnAnotherNode(service *kapi.Service) *discovery.EndpointSlice {
-	endpointSlice := getSampleEndpointSlice(service)
-	for i := range endpointSlice.Endpoints {
-		endpointSlice.Endpoints[i].NodeName = &otherNode
-	}
-	return endpointSlice
 }
 
 // returns an endpoint slice with three endpoints, two of which belong to the expected local node
@@ -1583,21 +563,21 @@ func getSampleEndpointSlice(service *kapi.Service) *discovery.EndpointSlice {
 }
 
 func setEndpointToReady(endpoint *discovery.Endpoint) {
-	endpoint.Conditions.Ready = utilpointer.BoolPtr(true)
-	endpoint.Conditions.Serving = utilpointer.BoolPtr(true)
-	endpoint.Conditions.Terminating = utilpointer.BoolPtr(false)
+	endpoint.Conditions.Ready = utilpointer.Bool(true)
+	endpoint.Conditions.Serving = utilpointer.Bool(true)
+	endpoint.Conditions.Terminating = utilpointer.Bool(false)
 }
 
 func setEndpointToTerminatingAndServing(endpoint *discovery.Endpoint) {
-	endpoint.Conditions.Ready = utilpointer.BoolPtr(false)
-	endpoint.Conditions.Serving = utilpointer.BoolPtr(true)
-	endpoint.Conditions.Terminating = utilpointer.BoolPtr(true)
+	endpoint.Conditions.Ready = utilpointer.Bool(false)
+	endpoint.Conditions.Serving = utilpointer.Bool(true)
+	endpoint.Conditions.Terminating = utilpointer.Bool(true)
 }
 
 func setEndpointToTerminatingAndNotServing(endpoint *discovery.Endpoint) {
-	endpoint.Conditions.Ready = utilpointer.BoolPtr(false)
-	endpoint.Conditions.Serving = utilpointer.BoolPtr(false)
-	endpoint.Conditions.Terminating = utilpointer.BoolPtr(true)
+	endpoint.Conditions.Ready = utilpointer.Bool(false)
+	endpoint.Conditions.Serving = utilpointer.Bool(false)
+	endpoint.Conditions.Terminating = utilpointer.Bool(true)
 }
 
 func setAllEndpointsToTerminatingAndServing(endpointSlice *discovery.EndpointSlice) *discovery.EndpointSlice {
@@ -1628,88 +608,38 @@ func setEndpointsToAMixOfStatusConditions(endpointSlice *discovery.EndpointSlice
 	return endpointSlice
 }
 
-func setNodeEndpointsToReady(endpointSlice *discovery.EndpointSlice, nodeName string) *discovery.EndpointSlice {
-	for i := range endpointSlice.Endpoints {
-		if *endpointSlice.Endpoints[i].NodeName == nodeName {
-			setEndpointToReady(&endpointSlice.Endpoints[i])
-		}
-	}
-	return endpointSlice
-}
-func setNodeEndpointsToTerminatingAndServing(endpointSlice *discovery.EndpointSlice, nodeName string) *discovery.EndpointSlice {
-	for i := range endpointSlice.Endpoints {
-		if *endpointSlice.Endpoints[i].NodeName == nodeName {
-			setEndpointToTerminatingAndServing(&endpointSlice.Endpoints[i])
-		}
-	}
-	return endpointSlice
-}
-
-func setNodeEndpointsToTerminatingAndNotServing(endpointSlice *discovery.EndpointSlice, nodeName string) *discovery.EndpointSlice {
-	for i := range endpointSlice.Endpoints {
-		if *endpointSlice.Endpoints[i].NodeName == testNode {
-			setEndpointToTerminatingAndNotServing(&endpointSlice.Endpoints[i])
-		}
-	}
-	return endpointSlice
-}
-
-func setLocalEndpointsToReady(endpointSlice *discovery.EndpointSlice) *discovery.EndpointSlice {
-	return setNodeEndpointsToReady(endpointSlice, testNode)
-}
-
-func setLocalEndpointsToTerminatingAndServing(endpointSlice *discovery.EndpointSlice) *discovery.EndpointSlice {
-	return setNodeEndpointsToTerminatingAndServing(endpointSlice, testNode)
-}
-
-func setLocalEndpointsToTerminatingAndNotServing(endpointSlice *discovery.EndpointSlice) *discovery.EndpointSlice {
-	return setNodeEndpointsToTerminatingAndNotServing(endpointSlice, testNode)
-}
-
-func setRemoteEndpointsToReady(endpointSlice *discovery.EndpointSlice) *discovery.EndpointSlice {
-	return setNodeEndpointsToReady(endpointSlice, otherNode)
-}
-
-func setRemoteEndpointsToTerminatingAndServing(endpointSlice *discovery.EndpointSlice) *discovery.EndpointSlice {
-	return setNodeEndpointsToTerminatingAndServing(endpointSlice, otherNode)
-}
-
-func setRemoteEndpointsToTerminatingAndNotServing(endpointSlice *discovery.EndpointSlice) *discovery.EndpointSlice {
-	return setNodeEndpointsToTerminatingAndNotServing(endpointSlice, otherNode)
-}
-
-func TestGetEligibleEndpointAddresses(t *testing.T) {
+func TestGetEligibleEndpointAddressesFromSlices(t *testing.T) {
 	service := getSampleService(false)
 	var tests = []struct {
 		name          string
 		endpointSlice *discovery.EndpointSlice
-		want          sets.String
+		want          []string
 	}{
 		{
 			"Tests an endpointslice with all ready endpoints",
 			setAllEndpointsToReady(getSampleEndpointSlice(service)),
-			sets.NewString(ep1Address, ep2Address, ep3Address),
+			[]string{ep1Address, ep2Address, ep3Address},
 		},
 		{
 			"Tests an endpointslice with all non-ready, serving, terminating endpoints",
 			setAllEndpointsToTerminatingAndServing(getSampleEndpointSlice(service)),
-			sets.NewString(ep1Address, ep2Address, ep3Address), // with no ready endpoints, we fallback to terminating serving endpoints
+			[]string{ep1Address, ep2Address, ep3Address}, // with no ready endpoints, we fallback to terminating serving endpoints
 		},
 		{
 			"Tests an endpointslice with all non-ready, non-serving, terminating endpoints",
 			setAllEndpointsToTerminatingAndNotServing(getSampleEndpointSlice(service)),
-			sets.NewString(),
+			[]string{},
 		},
 		{
 			"Tests an endpointslice with endpoints showing a mix of status conditions",
 			setEndpointsToAMixOfStatusConditions(getSampleEndpointSlice(service)),
-			sets.NewString(ep1Address), // only the ready endpoint is included
+			[]string{ep1Address}, // only the ready endpoint is included
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			answer := GetEligibleEndpointAddresses([]*discovery.EndpointSlice{tt.endpointSlice}, service)
+			answer := GetEligibleEndpointAddressesFromSlices([]*discovery.EndpointSlice{tt.endpointSlice}, service)
 			if !reflect.DeepEqual(answer, tt.want) {
 				t.Errorf("got %v, want %v", answer, tt.want)
 			}
@@ -1755,68 +685,159 @@ func TestHasLocalHostNetworkEndpoints(t *testing.T) {
 	}
 }
 
-func TestGetLocalEligibleEndpointAddresses(t *testing.T) {
+func TestGetEligibleEndpointAddresses(t *testing.T) {
 	service := getSampleService(false)
 	var tests = []struct {
-		name          string
-		endpointSlice *discovery.EndpointSlice
-		want          sets.String
+		name      string
+		endpoints []discovery.Endpoint
+		node      string
+		want      []string
 	}{
 		{
-			"Tests an endpointslice with all ready endpoints, one of which is on a different node",
-			setAllEndpointsToReady(getSampleEndpointSlice(service)),
-			sets.NewString(ep1Address, ep2Address),
+			"Get all eligible endpoints from an endpointslice with all ready endpoints, one of which is on a different node",
+			[]discovery.Endpoint{
+				kube_test.MakeReadyEndpoint(testNode, ep1Address),
+				kube_test.MakeReadyEndpoint(testNode, ep2Address),
+				kube_test.MakeReadyEndpoint(otherNode, ep3Address),
+			},
+			"", // get all endpoints
+			[]string{ep1Address, ep2Address, ep3Address},
 		},
 		{
-			"Tests an endpointslice with all ready endpoints, all of which are on a different node",
-			setAllEndpointsToReady(getSampleEndpointSliceOnAnotherNode(service)),
-			sets.NewString(),
+			"Get all eligible local endpoints from an endpointslice with all ready endpoints, one of which is on a different node",
+			[]discovery.Endpoint{
+				kube_test.MakeReadyEndpoint(testNode, ep1Address),
+				kube_test.MakeReadyEndpoint(testNode, ep2Address),
+				kube_test.MakeReadyEndpoint(otherNode, ep3Address),
+			},
+			testNode,
+			[]string{ep1Address, ep2Address},
 		},
 		{
-			"Tests an endpointslice with all non-ready, serving, terminating endpoints, one of which is on a different node",
-			setAllEndpointsToTerminatingAndServing(getSampleEndpointSlice(service)),
-			sets.NewString(ep1Address, ep2Address), // with no ready endpoints, we fallback to terminating serving endpoints
+			"Get all eligible local endpoints from an endpointslice with all ready endpoints, all of which are on another node",
+			[]discovery.Endpoint{
+				kube_test.MakeReadyEndpoint(otherNode, ep1Address),
+				kube_test.MakeReadyEndpoint(otherNode, ep2Address),
+				kube_test.MakeReadyEndpoint(otherNode, ep3Address),
+			},
+			testNode,
+			[]string{},
 		},
 		{
-			"Tests an endpointslice with all non-ready, serving, terminating endpoints, all of which are on a different node",
-			setAllEndpointsToTerminatingAndServing(getSampleEndpointSliceOnAnotherNode(service)),
-			sets.NewString(),
+			"Get all eligible endpoints from an endpointslice with all non-ready, serving, terminating endpoints, one of which is on a different node",
+			[]discovery.Endpoint{
+				kube_test.MakeTerminatingServingEndpoint(testNode, ep1Address),
+				kube_test.MakeTerminatingServingEndpoint(testNode, ep2Address),
+				kube_test.MakeTerminatingServingEndpoint(otherNode, ep3Address),
+			},
+			"",
+			[]string{ep1Address, ep2Address, ep3Address}, // with no ready endpoints, we fallback to terminating serving endpoints
 		},
 		{
-			"Tests an endpointslice with all non-ready, non-serving, terminating endpoints, one of which is on a different node",
-			setAllEndpointsToTerminatingAndNotServing(getSampleEndpointSlice(service)),
-			sets.NewString(),
+			"Get all eligible local endpoints from an endpointslice with all non-ready, serving, terminating endpoints, one of which is on a different node",
+			[]discovery.Endpoint{
+				kube_test.MakeTerminatingServingEndpoint(testNode, ep1Address),
+				kube_test.MakeTerminatingServingEndpoint(testNode, ep2Address),
+				kube_test.MakeTerminatingServingEndpoint(otherNode, ep3Address),
+			},
+			testNode,
+			[]string{ep1Address, ep2Address}, // with no ready endpoints, we fallback to terminating serving endpoints
 		},
 		{
-			"Tests an endpointslice with all non-ready, non-serving, terminating endpoints, all of which are on a different node",
-			setAllEndpointsToTerminatingAndNotServing(getSampleEndpointSliceOnAnotherNode(service)),
-			sets.NewString(),
+			"Get all eligible local endpoints from an endpointslice with all non-ready, serving, terminating endpoints, all of which are on a different node",
+			[]discovery.Endpoint{
+				kube_test.MakeTerminatingServingEndpoint(otherNode, ep1Address),
+				kube_test.MakeTerminatingServingEndpoint(otherNode, ep2Address),
+				kube_test.MakeTerminatingServingEndpoint(otherNode, ep3Address),
+			},
+			testNode,
+			[]string{},
 		},
 		{
-			"Tests an endpointslice with endpoints showing a mix of status conditions, one of which is on a different node",
-			setEndpointsToAMixOfStatusConditions(getSampleEndpointSlice(service)),
-			sets.NewString(ep1Address), // only the ready endpoint is included
+			"Get all eligible endpoints from an endpointslice with all non-ready, non-serving, terminating endpoints, one of which is on a different node",
+			[]discovery.Endpoint{
+				kube_test.MakeTerminatingNonServingEndpoint(testNode, ep1Address),
+				kube_test.MakeTerminatingNonServingEndpoint(testNode, ep2Address),
+				kube_test.MakeTerminatingNonServingEndpoint(otherNode, ep3Address),
+			},
+			"",
+			[]string{},
 		},
 		{
-			"Tests an endpointslice with endpoints showing a mix of status conditions, all of which are on a different node",
-			setEndpointsToAMixOfStatusConditions(getSampleEndpointSliceOnAnotherNode(service)),
-			sets.NewString(),
+			"Get all eligible local endpoints from an endpointslice with all non-ready, non-serving, terminating endpoints, one of which is on a different node",
+			[]discovery.Endpoint{
+				kube_test.MakeTerminatingNonServingEndpoint(testNode, ep1Address),
+				kube_test.MakeTerminatingNonServingEndpoint(testNode, ep2Address),
+				kube_test.MakeTerminatingNonServingEndpoint(otherNode, ep3Address),
+			},
+			testNode,
+			[]string{},
 		},
 		{
-			"Tests an endpointslice where all local endpoints are serving and terminating and a remote endpoint is ready",
-			setLocalEndpointsToTerminatingAndServing(setRemoteEndpointsToReady(getSampleEndpointSlice(service))),
-			sets.NewString(ep1Address, ep2Address), // fallback to serving&terminating should apply
+			"Get all eligible local endpoints from an endpointslice with endpoints showing a mix of status conditions, one of which is on a different node",
+			[]discovery.Endpoint{
+				kube_test.MakeReadyEndpoint(testNode, ep1Address),
+				kube_test.MakeTerminatingServingEndpoint(testNode, ep2Address),
+				kube_test.MakeTerminatingNonServingEndpoint(otherNode, ep3Address),
+			},
+			testNode,
+			[]string{ep1Address}, // only the ready endpoint is included
 		},
 		{
-			"Tests an endpointslice where all local endpoints are terminating and not serving and a remote endpoint is ready",
-			setLocalEndpointsToTerminatingAndNotServing(setRemoteEndpointsToReady(getSampleEndpointSlice(service))),
-			sets.NewString(),
+			"Get all eligible local endpoints from an endpointslice with endpoints showing a mix of status conditions, all of which are on a different node",
+			[]discovery.Endpoint{
+				kube_test.MakeReadyEndpoint(otherNode, ep1Address),
+				kube_test.MakeTerminatingServingEndpoint(otherNode, ep2Address),
+				kube_test.MakeTerminatingNonServingEndpoint(otherNode, ep3Address),
+			},
+			testNode,
+			[]string{},
+		},
+		{
+			"Get all eligible endpoints from an endpointslice where all local endpoints are serving and terminating and a remote endpoint is ready",
+			[]discovery.Endpoint{
+				kube_test.MakeTerminatingServingEndpoint(testNode, ep1Address),
+				kube_test.MakeTerminatingServingEndpoint(testNode, ep2Address),
+				kube_test.MakeReadyEndpoint(otherNode, ep3Address),
+			},
+			"",
+			[]string{ep3Address}, // fallback to serving&terminating should apply
+		},
+		{
+			"Get all eligible local endpoints from an endpointslice where all local endpoints are serving and terminating and a remote endpoint is ready",
+			[]discovery.Endpoint{
+				kube_test.MakeTerminatingServingEndpoint(testNode, ep1Address),
+				kube_test.MakeTerminatingServingEndpoint(testNode, ep2Address),
+				kube_test.MakeReadyEndpoint(otherNode, ep3Address),
+			},
+			testNode,
+			[]string{ep1Address, ep2Address}, // fallback to serving&terminating should apply
+		},
+		{
+			"Get all eligible endpoints from an endpointslice where all local endpoints are terminating and not serving and a remote endpoint is ready",
+			[]discovery.Endpoint{
+				kube_test.MakeTerminatingNonServingEndpoint(testNode, ep1Address),
+				kube_test.MakeTerminatingNonServingEndpoint(testNode, ep2Address),
+				kube_test.MakeReadyEndpoint(otherNode, ep3Address),
+			},
+			"",
+			[]string{ep3Address},
+		},
+		{
+			"Get all eligible local endpoints from an endpointslice where all local endpoints are terminating and not serving and a remote endpoint is ready",
+			[]discovery.Endpoint{
+				kube_test.MakeTerminatingNonServingEndpoint(testNode, ep1Address),
+				kube_test.MakeTerminatingNonServingEndpoint(testNode, ep2Address),
+				kube_test.MakeReadyEndpoint(otherNode, ep3Address),
+			},
+			testNode,
+			[]string{},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			answer := GetLocalEligibleEndpointAddresses([]*discovery.EndpointSlice{tt.endpointSlice}, service, testNode)
+			answer := getEligibleEndpointAddresses(tt.endpoints, service, tt.node)
 			if !reflect.DeepEqual(answer, tt.want) {
 				t.Errorf("got %v, want %v", answer, tt.want)
 			}

--- a/go-controller/pkg/util/kube_test.go
+++ b/go-controller/pkg/util/kube_test.go
@@ -3,14 +3,19 @@ package util
 import (
 	"context"
 	"fmt"
+	"net"
+	"reflect"
 	"testing"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/stretchr/testify/assert"
+	kapi "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/sets"
 	clientsetfake "k8s.io/client-go/kubernetes/fake"
 	utilpointer "k8s.io/utils/pointer"
 )
@@ -714,7 +719,7 @@ func Test_getLbEndpoints(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := GetLbEndpoints(tt.args.slices, tt.args.svcPort, false)
+			got := GetLbEndpoints(tt.args.slices, tt.args.svcPort, nil)
 			assert.Equal(t, tt.want, got)
 		})
 	}
@@ -782,4 +787,290 @@ func TestExternalIDsForObject(t *testing.T) {
 			"k8s.ovn.org/kind":  "Service",
 			"k8s.ovn.org/owner": "ns/svc-ab23",
 		})
+}
+
+var (
+	testNode   string      = "testNode"
+	ep1Address string      = "10.244.0.3"
+	ep2Address string      = "10.244.0.4"
+	ep3Address string      = "10.244.1.3"
+	tcpv1      v1.Protocol = v1.ProtocolTCP
+	udpv1      v1.Protocol = v1.ProtocolUDP
+
+	httpsPortName   string = "https"
+	httpsPortValue  int32  = int32(443)
+	customPortName  string = "customApp"
+	customPortValue int32  = int32(10600)
+)
+
+func getSampleService(publishNotReadyAddresses bool) *v1.Service {
+	name := "service-test"
+	namespace := "test"
+	return &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:       k8stypes.UID(namespace),
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: v1.ServiceSpec{
+			PublishNotReadyAddresses: publishNotReadyAddresses,
+		},
+	}
+}
+
+// returns an endpoint slice with three endpoints, two of which belong to the expected local node
+// and one belongs to "other-node"
+func getSampleEndpointSlice(service *kapi.Service) *discovery.EndpointSlice {
+
+	epPortHttps := discovery.EndpointPort{
+		Name:     &httpsPortName,
+		Port:     &httpsPortValue,
+		Protocol: &tcpv1,
+	}
+
+	epPortCustom := discovery.EndpointPort{
+		Name:     &customPortName,
+		Port:     &customPortValue,
+		Protocol: &udpv1,
+	}
+
+	ep1 := discovery.Endpoint{
+		Addresses: []string{ep1Address},
+		NodeName:  &testNode,
+	}
+	ep2 := discovery.Endpoint{
+		Addresses: []string{ep2Address},
+		NodeName:  &testNode,
+	}
+	otherNodeName := "other-node"
+	nonLocalEndpoint := discovery.Endpoint{
+		Addresses: []string{ep3Address},
+		NodeName:  &otherNodeName,
+	}
+
+	return &discovery.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      service.Name + "ab23",
+			Namespace: service.Namespace,
+			Labels:    map[string]string{discovery.LabelServiceName: service.Name},
+		},
+		Ports:       []discovery.EndpointPort{epPortHttps, epPortCustom},
+		AddressType: discovery.AddressTypeIPv4,
+		Endpoints:   []discovery.Endpoint{ep1, ep2, nonLocalEndpoint},
+	}
+}
+
+func setEndpointToReady(endpoint *discovery.Endpoint) {
+	endpoint.Conditions.Ready = utilpointer.BoolPtr(true)
+	endpoint.Conditions.Serving = utilpointer.BoolPtr(true)
+	endpoint.Conditions.Terminating = utilpointer.BoolPtr(false)
+}
+
+func setEndpointToTerminatingAndServing(endpoint *discovery.Endpoint) {
+	endpoint.Conditions.Ready = utilpointer.BoolPtr(false)
+	endpoint.Conditions.Serving = utilpointer.BoolPtr(true)
+	endpoint.Conditions.Terminating = utilpointer.BoolPtr(true)
+}
+
+func setEndpointToTerminatingAndNotServing(endpoint *discovery.Endpoint) {
+	endpoint.Conditions.Ready = utilpointer.BoolPtr(false)
+	endpoint.Conditions.Serving = utilpointer.BoolPtr(false)
+	endpoint.Conditions.Terminating = utilpointer.BoolPtr(true)
+}
+
+func setAllEndpointsToTerminatingAndServing(endpointSlice *discovery.EndpointSlice) *discovery.EndpointSlice {
+	for i := range endpointSlice.Endpoints {
+		setEndpointToTerminatingAndServing(&endpointSlice.Endpoints[i])
+	}
+	return endpointSlice
+}
+
+func setAllEndpointsToTerminatingAndNotServing(endpointSlice *discovery.EndpointSlice) *discovery.EndpointSlice {
+	for i := range endpointSlice.Endpoints {
+		setEndpointToTerminatingAndNotServing(&endpointSlice.Endpoints[i])
+	}
+	return endpointSlice
+}
+
+func setAllEndpointsToReady(endpointSlice *discovery.EndpointSlice) *discovery.EndpointSlice {
+	for i := range endpointSlice.Endpoints {
+		setEndpointToReady(&endpointSlice.Endpoints[i])
+	}
+	return endpointSlice
+}
+
+func setEndpointsToAMixOfStatusConditions(endpointSlice *discovery.EndpointSlice) *discovery.EndpointSlice {
+	setEndpointToReady(&endpointSlice.Endpoints[0])
+	setEndpointToTerminatingAndServing(&endpointSlice.Endpoints[1])
+	setEndpointToTerminatingAndNotServing(&endpointSlice.Endpoints[2])
+	return endpointSlice
+}
+
+func TestGetEndpointAddresses(t *testing.T) {
+	service := getSampleService(false)
+	var tests = []struct {
+		name          string
+		endpointSlice *discovery.EndpointSlice
+		want          sets.String
+	}{
+		{
+			"Tests an endpointslice with all ready endpoints",
+			setAllEndpointsToReady(getSampleEndpointSlice(service)),
+			sets.NewString(ep1Address, ep2Address, ep3Address),
+		},
+		{
+			"Tests an endpointslice with all non-ready, serving, terminating endpoints",
+			setAllEndpointsToTerminatingAndServing(getSampleEndpointSlice(service)),
+			sets.NewString(ep1Address, ep2Address, ep3Address),
+		},
+		{
+			"Tests an endpointslice with all non-ready, non-serving, terminating endpoints",
+			setAllEndpointsToTerminatingAndNotServing(getSampleEndpointSlice(service)),
+			sets.NewString(),
+		},
+		{
+			"Tests an endpointslice with endpoints showing a mix of status conditions",
+			setEndpointsToAMixOfStatusConditions(getSampleEndpointSlice(service)),
+			sets.NewString(ep1Address, ep2Address),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			answer := GetEndpointAddresses([]*discovery.EndpointSlice{tt.endpointSlice}, service)
+			if !reflect.DeepEqual(answer, tt.want) {
+				t.Errorf("got %v, want %v", answer, tt.want)
+			}
+		})
+	}
+}
+
+func TestHasLocalHostNetworkEndpoints(t *testing.T) {
+	ep1IP := net.ParseIP(ep1Address)
+	if ep1IP == nil {
+		t.Errorf("error parsing ep1 address %s", ep1Address)
+	}
+	nodeAddresses := []net.IP{ep1IP}
+	var tests = []struct {
+		name           string
+		localEndpoints sets.String
+		want           bool
+	}{
+		{
+			"Tests with local endpoints that include the node address",
+			sets.NewString(ep1Address, ep2Address),
+			true,
+		},
+		{
+			"Tests against a different local endpoint than the node address",
+			sets.NewString(ep2Address),
+			false,
+		},
+		{
+			"Tests against no local endpoints",
+			sets.NewString(),
+			false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			answer := HasLocalHostNetworkEndpoints(tt.localEndpoints, nodeAddresses)
+			if !reflect.DeepEqual(answer, tt.want) {
+				t.Errorf("got %v, want %v", answer, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetLocalEndpointAddresses(t *testing.T) {
+	service := getSampleService(false)
+	var tests = []struct {
+		name          string
+		endpointSlice *discovery.EndpointSlice
+		want          sets.String
+	}{
+		{
+			"Tests an endpointslice with all ready endpoints",
+			setAllEndpointsToReady(getSampleEndpointSlice(service)),
+			sets.NewString(ep1Address, ep2Address),
+		},
+		{
+			"Tests an endpointslice with all non-ready, serving, terminating endpoints",
+			setAllEndpointsToTerminatingAndServing(getSampleEndpointSlice(service)),
+			sets.NewString(ep1Address, ep2Address),
+		},
+		{
+			"Tests an endpointslice with all non-ready, non-serving, terminating endpoints",
+			setAllEndpointsToTerminatingAndNotServing(getSampleEndpointSlice(service)),
+			sets.NewString(),
+		},
+		{
+			"Tests an endpointslice with endpoints showing a mix of status conditions",
+			setEndpointsToAMixOfStatusConditions(getSampleEndpointSlice(service)),
+			sets.NewString(ep1Address, ep2Address),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			answer := GetLocalEndpointAddresses([]*discovery.EndpointSlice{tt.endpointSlice}, service, testNode)
+			if !reflect.DeepEqual(answer, tt.want) {
+				t.Errorf("got %v, want %v", answer, tt.want)
+			}
+		})
+	}
+}
+
+func TestDoesEndpointSliceContainEndpoint(t *testing.T) {
+	service := getSampleService(false)
+	var tests = []struct {
+		name          string
+		endpointSlice *discovery.EndpointSlice
+		epIP          string
+		epPort        int32
+		protocol      v1.Protocol
+		want          bool
+	}{
+		{
+			"Tests an endpointslice with all ready endpoints",
+			setAllEndpointsToReady(getSampleEndpointSlice(service)),
+			ep1Address, httpsPortValue, tcpv1,
+			true,
+		},
+		{
+			"Tests an endpointslice with all ready endpoints and a port that is not included",
+			setAllEndpointsToReady(getSampleEndpointSlice(service)),
+			ep1Address, int32(444), tcpv1,
+			false,
+		},
+
+		{
+			"Tests an endpointslice with all non-ready, serving, terminating endpoints",
+			setAllEndpointsToTerminatingAndServing(getSampleEndpointSlice(service)),
+			ep1Address, customPortValue, udpv1,
+			true,
+		},
+		{
+			"Tests an endpointslice with all non-ready, non-serving, terminating endpoints",
+			setAllEndpointsToTerminatingAndNotServing(getSampleEndpointSlice(service)),
+			ep1Address, customPortValue, udpv1,
+			false,
+		},
+		{
+			"Tests an endpointslice with endpoints showing a mix of status conditions",
+			setEndpointsToAMixOfStatusConditions(getSampleEndpointSlice(service)),
+			ep1Address, customPortValue, udpv1,
+			true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			answer := DoesEndpointSliceContainEndpoint(tt.endpointSlice, tt.epIP, tt.epPort, tt.protocol, service)
+			if !reflect.DeepEqual(answer, tt.want) {
+				t.Errorf("got %v, want %v", answer, tt.want)
+			}
+		})
+	}
 }

--- a/go-controller/pkg/util/util.go
+++ b/go-controller/pkg/util/util.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/urfave/cli/v2"
 
-	discovery "k8s.io/api/discovery/v1"
 	"k8s.io/klog/v2"
 	utilnet "k8s.io/utils/net"
 )
@@ -327,31 +326,4 @@ func UpdateNodeSwitchExcludeIPs(nbClient libovsdbclient.Client, nodeName string,
 	}
 
 	return nil
-}
-
-// IsEndpointReady takes as input an endpoint from an endpoint slice and returns true if the endpoint is
-// to be considered ready. Considering as ready an endpoint with Conditions.Ready==nil
-// as per doc: "In most cases consumers should interpret this unknown state as ready"
-// https://github.com/kubernetes/api/blob/0478a3e95231398d8b380dc2a1905972be8ae1d5/discovery/v1/types.go#L129-L131
-func IsEndpointReady(endpoint discovery.Endpoint) bool {
-	return endpoint.Conditions.Ready == nil || *endpoint.Conditions.Ready
-}
-
-// IsEndpointServing takes as input an endpoint from an endpoint slice and returns true if the endpoint is
-// to be considered serving. Falling back to IsEndpointReady when Serving field is nil, as per doc:
-// "If nil, consumers should defer to the ready condition.
-// https://github.com/kubernetes/api/blob/0478a3e95231398d8b380dc2a1905972be8ae1d5/discovery/v1/types.go#L138-L139
-func IsEndpointServing(endpoint discovery.Endpoint) bool {
-	if endpoint.Conditions.Serving != nil {
-		return *endpoint.Conditions.Serving
-	} else {
-		return IsEndpointReady(endpoint)
-	}
-}
-
-// IsEndpointValid takes as input an endpoint from an endpoint slice and a boolean that indicates whether to include
-// all terminating endpoints, as per the PublishNotReadyAddresses feature in kubernetes service spec. It always returns true
-// if includeTerminating is true and falls back to IsEndpointServing otherwise.
-func IsEndpointValid(endpoint discovery.Endpoint, includeTerminating bool) bool {
-	return includeTerminating || IsEndpointServing(endpoint)
 }


### PR DESCRIPTION
Differences from 4.13 backport (https://github.com/openshift/ovn-kubernetes/pull/2130):

#### [commit 0] Check the "Serving" field for endpoints
Backporting the whole https://github.com/openshift/ovn-kubernetes/commit/f6ef43368cc79b85bf0de535ff3b79a5856ab481#diff-d3aa58d9b58a0a09264f072df46ab01d0501eb508c4656411ae2dc1ac68fb3c4, which had only been partially backported to 4.12 with https://github.com/openshift/ovn-kubernetes/commit/aceef010daf0697fe81dba91a39ed0fdb6563dea#diff-d3aa58d9b58a0a09264f072df46ab01d0501eb508c4656411ae2dc1ac68fb3c4, due to https://github.com/openshift/ovn-kubernetes/commit/80dc930e4bc44256a017849762bf6c5f949209fb not being in 4.12 at the time of the backport. This mainly meant that GetLocalEndpointAddresses, modified by my commit in 4.13,  wasn't in go-controller/pkg/node/gateway_shared_intf.go at the time and had to be excluded from the backport. I'm introducing it now, since my other changes are based on it.
  
#### [commit 1] Consider serving endpoints in hasLocalHostNetworkEndpoints
- no conflict

#### [commit 2] Cleanup of endpoint handling functions
- go-controller/pkg/node/gateway_shared_intf.go :  
    - small conflict due to sets library: sets.List(localEndpoints) in 4.13 becomes localEndPoints.List() in 4.12
- go-controller/pkg/util/util.go:
   - IsReadyEndpoint and similar moved to util.go, just like in 4.13 and later versions

#### [commit 3] Full implementation of KEP-1669 ProxyTerminatingEndpoints 
- go-controller/pkg/node/gateway_shared_intf.go, go-controller/pkg/util/kube.go    
  + adapted code to older sets library

#### [commit 4] Fix endpoint selection for externalTrafficPolicy=local
- several conflicts mainly due to lack of LB templates: for instance,  the two extra output variables (v4Changed, v6Changed bool) in makeNodeSwitchTargetIPs and makeNodeRouterTargetIPs, needed by LB templates, are removed.
- in go-controller/pkg/ovn/controller/services/services_controller.go, we don't need the input variables related to LB templates when calling buildServiceLBConfigs (c.useLBGroups, c.useTemplates)
- added go-controller/pkg/ovn/controller/services/load_balancer_ocphack_test.go
    - for consistency, unit tests on downstream hacks that were on load_balancer_test.go, are now on a separate file like in all later releases.
