### PR TITLE
[release-4.12] OCPBUGS-32990: Bump OVS

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -12,7 +12,7 @@ RUN yum install -y  \
 	selinux-policy && \
 	yum clean all
 
-ARG ovsver=2.17.0-62.el8fdp
+ARG ovsver=2.17.0-148.el8fdp
 ARG ovnver=23.06.1-112.el8fdp
 
 RUN \


### PR DESCRIPTION
Bumping ovn to 23.06.1-112.el8fdp brings in fixes for 
CVE-2024-2182

Bumping ovs to 2.17.0-148.el8fdp brings in fixes for 
CVE-2022-4337
CVE-2022-4338
CVE-2023-1668
CVE-2023-3966
CVE-2023-5366


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->