### PR TITLE
TRT-1637: Revert #2142 "OCPBUGS-32985,OCPBUGS-32925: Dockerfile: Bump OVS to 3.3.0-2"

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -12,7 +12,7 @@ RUN dnf install -y --nodocs \
 	selinux-policy procps-ng && \
 	dnf clean all
 
-ARG ovsver=3.3.0-2.el9fdp
+ARG ovsver=3.1.0-73.el9fdp
 ARG ovnver=24.03.1-36.el9fdp
 
 RUN INSTALL_PKGS="iptables nftables" && \


### PR DESCRIPTION

Reverts #2142 ; tracked by [TRT-1637](https://issues.redhat.com//browse/TRT-1637)

Per [OpenShift policy](https://github.com/openshift/enhancements/blob/master/enhancements/release/improving-ci-signal.md#quick-revert), we are reverting this breaking change to get CI and/or nightly payloads flowing again.

Test revert only, we don't know if this is our issue yet, but some metal jobs now are losing apiserver during install.

To unrevert this, revert this PR, and layer an additional separate commit on top that addresses the problem. Before merging the unrevert, please run these jobs on the PR and check the result of these jobs to confirm the fix has corrected the problem:

```
/payload-job periodic-ci-openshift-release-master-nightly-4.16-e2e-metal-ipi-ovn-ipv6
```

CC: @igsilya

<div align="right">
PR created by <a href="https://github.com/stbenjam/revertomatic">Revertomatic<sup>:tm:</sup></a>
</div>
