### PR TITLE
OCPBUGS-33218: [release-4.13] OVN bump to 23.06.1-112

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -13,7 +13,7 @@ RUN dnf install -y --nodocs \
 	dnf clean all
 
 ARG ovsver=3.1.0-32.el9fdp
-ARG ovnver=23.06.1-82.el9fdp
+ARG ovnver=23.06.1-112.el9fdp
 
 RUN INSTALL_PKGS="iptables" && \
 	dnf install -y --nodocs $INSTALL_PKGS && \

--- a/dist/images/Dockerfile.fedora
+++ b/dist/images/Dockerfile.fedora
@@ -15,7 +15,7 @@ USER root
 
 ENV PYTHONDONTWRITEBYTECODE yes
 
-ARG ovnver=ovn-23.03.0-16.fc37
+ARG ovnver=ovn-23.06.0-0.fc37
 # Automatically populated when using docker buildx
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM

--- a/test/e2e/service.go
+++ b/test/e2e/service.go
@@ -27,6 +27,7 @@ import (
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	e2erc "k8s.io/kubernetes/test/e2e/framework/rc"
 	e2eservice "k8s.io/kubernetes/test/e2e/framework/service"
+	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 	testutils "k8s.io/kubernetes/test/utils"
 )
 
@@ -58,6 +59,36 @@ var _ = ginkgo.Describe("Services", func() {
 
 	udpPort := int32(rand.Intn(1000) + 10000)
 	udpPortS := fmt.Sprintf("%d", udpPort)
+
+	ginkgo.It("Allow connection to an external IP using a source port that is equal to a node port", func() {
+		const (
+			nodePort    = 31990
+			connTimeout = "2"
+			dstIPv4     = "1.1.1.1"
+			dstPort     = "80"
+		)
+		if IsIPv6Cluster(f.ClientSet) {
+			e2eskipper.Skipf("Test requires IPv4 or IPv4 primary dualstack cluster")
+		}
+		ginkgo.By("create node port service")
+		jig := e2eservice.NewTestJig(cs, f.Namespace.Name, serviceName)
+		_, err := jig.CreateTCPService(context.TODO(), func(svc *v1.Service) {
+			svc.Spec.Type = v1.ServiceTypeNodePort
+			svc.Spec.Ports[0].NodePort = nodePort
+		})
+		framework.ExpectNoError(err, "failed to create TCP node port service")
+		ginkgo.By("create pod selected by node port service")
+		serverPod := e2epod.NewAgnhostPod(f.Namespace.Name, "svc-backend", nil, nil, nil)
+		serverPod.Labels = jig.Labels
+		e2epod.NewPodClient(f).CreateSync(context.TODO(), serverPod)
+		ginkgo.By("create pod which will connect externally")
+		clientPod := e2epod.NewAgnhostPod(f.Namespace.Name, "client-for-external", nil, nil, nil)
+		e2epod.NewPodClient(f).CreateSync(context.TODO(), clientPod)
+		ginkgo.By("connect externally pinning the source port to equal the node port")
+		_, err = e2ekubectl.RunKubectl(clientPod.Namespace, "exec", clientPod.Name, "--", "nc",
+			"-p", strconv.Itoa(nodePort), "-z", "-w", connTimeout, dstIPv4, dstPort)
+		framework.ExpectNoError(err, "expected connection to succeed using source port identical to node port")
+	})
 
 	ginkgo.It("Creates a host-network service, and ensures that host-network pods can connect to it", func() {
 		namespace := f.Namespace.Name


### PR DESCRIPTION
Bumped fedora to the closest version available.
Bumped OVN within `Dockerfile.base` to a version that contains the fix required in the bug and is available via brew.
The fix is included in `23.06.1-110`: https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2944959