### PR TITLE
OCPBUGS-25889: [release-4.12] OVN bump to 23.06.1-112

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -13,7 +13,7 @@ RUN yum install -y  \
 	yum clean all
 
 ARG ovsver=2.17.0-62.el8fdp
-ARG ovnver=23.06.1-39.el8fdp
+ARG ovnver=23.06.1-112.el8fdp
 
 RUN \
     yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False "openvswitch2.17 = $ovsver" "python3-openvswitch2.17 = $ovsver" && \


### PR DESCRIPTION
Bumped OVN within Dockerfile.base to a version that contains the fix required in the bug and is available via brew.
The fix is included in 23.06.1-110: https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2944959

OVN fix:
```
"northd: Don't skip the unSNAT stage for traffic towards VIPs."
upstream commit: a4dbe60d7bf1b7aa7698bfbd25be018492fd25d7
```