### PR TITLE
OKD-40: Add ovnver_okd and ovsver_okd to Dockerfile.base

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -14,17 +14,19 @@ RUN dnf install -y --nodocs \
 
 ARG ovsver=3.3.0-2.el9fdp
 ARG ovnver=24.03.1-36.el9fdp
+# NOTE: Ensure that the versions of OVS and OVN are overriden for OKD in each of the subsequent layers.
+ARG ovsver_okd=3.3.0-2.el9s
+ARG ovnver_okd=24.03.1-5.el9s
 
 RUN INSTALL_PKGS="iptables nftables" && \
+    source /etc/os-release && \
+    [ "${ID}" == "centos" ] && ovsver=$ovsver_okd && ovnver=$ovnver_okd; \
 	ovsver_short=$(echo "$ovsver" | cut -d'.' -f1,2) && \
 	ovnver_short=$(echo "$ovnver" | cut -d'.' -f1,2) && \
 	dnf install -y --nodocs $INSTALL_PKGS && \
 	dnf install -y --nodocs "openvswitch$ovsver_short = $ovsver" "python3-openvswitch$ovsver_short = $ovsver" && \
 	dnf install -y --nodocs "ovn$ovnver_short = $ovnver" "ovn$ovnver_short-central = $ovnver" "ovn$ovnver_short-host = $ovnver" && \
-	dnf clean all && rm -rf /var/cache/*
-
-RUN ovsver_short=$(echo "$ovsver" | cut -d'.' -f1,2) && \
-	ovnver_short=$(echo "$ovnver" | cut -d'.' -f1,2) && \
+	dnf clean all && rm -rf /var/cache/* && \
 	sed 's/%/"/g' <<<"%openvswitch$ovsver_short-devel = $ovsver% %openvswitch$ovsver_short-ipsec = $ovsver% %ovn$ovnver_short-vtep = $ovnver%" > /more-pkgs
 
 RUN mkdir -p /var/run/openvswitch && \


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**

The current process involving a reconciliation of the openshift/release from ART does not allow overwriting the build arguments in the OKD variant Prow Config for ovn-kubernetes. This commit adds two additional build-args with default values for OKD and let the RUN layer decide on whether to use them as ovn and ovs versions to consider for installation.


**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

To simplify (avoid redundant shell code), this PR also proposes to flatten the second RUN layer into the first.

**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->

- [OCP] ci/prow/images should succeed => 
- [OKD] ci/prow/okd-scos-images should succeed => https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_ovn-kubernetes/2161/pull-ci-openshift-ovn-kubernetes-master-okd-scos-images/1788571045293199360