### PR TITLE
[release-4.12] OCPBUGS-34273,OCPBUGS-34414: Improves service iptables efficiency on start up + ICMP error messages to pass through

### DIFF
--- a/go-controller/go.mod
+++ b/go-controller/go.mod
@@ -112,6 +112,7 @@ require (
 
 replace (
 	github.com/Microsoft/hcsshim => github.com/Microsoft/hcsshim v0.8.20
+	github.com/coreos/go-iptables => github.com/trozet/go-iptables v0.0.0-20240328221912-077e672b3808
 	github.com/gogo/protobuf => github.com/gogo/protobuf v1.3.2
 	github.com/vishvananda/netlink => github.com/jcaamano/netlink v1.1.1-0.20220831114501-3a761ed61db6
 	k8s.io/api => k8s.io/api v0.24.0

--- a/go-controller/go.sum
+++ b/go-controller/go.sum
@@ -223,10 +223,6 @@ github.com/containers/ocicrypt v1.1.1/go.mod h1:Dm55fwWm1YZAjYRaJ94z2mfZikIyIN4B
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
-github.com/coreos/go-iptables v0.4.5/go.mod h1:/mVI274lEDI2ns62jHCDnCyBF9Iwsmekav8Dbxlm1MU=
-github.com/coreos/go-iptables v0.5.0/go.mod h1:/mVI274lEDI2ns62jHCDnCyBF9Iwsmekav8Dbxlm1MU=
-github.com/coreos/go-iptables v0.6.0 h1:is9qnZMPYjLd8LYqmm/qlE+wwEgJIkTYdhV3rfZo4jk=
-github.com/coreos/go-iptables v0.6.0/go.mod h1:Qe8Bv2Xik5FyTXwgIbLAnv2sWSBmvWdFETJConOQ//Q=
 github.com/coreos/go-oidc v2.1.0+incompatible/go.mod h1:CgnwVTmzoESiwO9qyAFEMiHoZ1nMCKZlZ9V6mm3/LKc=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
@@ -742,6 +738,8 @@ github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG
 github.com/tchap/go-patricia v2.2.6+incompatible/go.mod h1:bmLyhP68RS6kStMGxByiQ23RP/odRBOTVjwp2cDyi6I=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
+github.com/trozet/go-iptables v0.0.0-20240328221912-077e672b3808 h1:dhannoFtRVRqYF22YA/M0iUD0IQhB9PmT9XRuynUWxg=
+github.com/trozet/go-iptables v0.0.0-20240328221912-077e672b3808/go.mod h1:Qe8Bv2Xik5FyTXwgIbLAnv2sWSBmvWdFETJConOQ//Q=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/urfave/cli v1.22.2/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=

--- a/go-controller/pkg/node/OCP_HACKS.go
+++ b/go-controller/pkg/node/OCP_HACKS.go
@@ -5,29 +5,30 @@ package node
 
 import (
 	"github.com/coreos/go-iptables/iptables"
+	nodeipt "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/iptables"
 )
 
 // Block MCS Access. https://github.com/openshift/ovn-kubernetes/pull/170
-func generateBlockMCSRules(rules *[]iptRule, protocol iptables.Protocol) {
-	var delRules []iptRule
+func generateBlockMCSRules(rules *[]nodeipt.Rule, protocol iptables.Protocol) {
+	var delRules []nodeipt.Rule
 
 	for _, chain := range []string{"FORWARD", "OUTPUT"} {
 		for _, port := range []string{"22623", "22624"} {
-			*rules = append(*rules, iptRule{
-				table:    "filter",
-				chain:    chain,
-				args:     []string{"-p", "tcp", "-m", "tcp", "--dport", port, "--syn", "-j", "REJECT"},
-				protocol: protocol,
+			*rules = append(*rules, nodeipt.Rule{
+				Table:    "filter",
+				Chain:    chain,
+				Args:     []string{"-p", "tcp", "-m", "tcp", "--dport", port, "--syn", "-j", "REJECT"},
+				Protocol: protocol,
 			})
 			// Delete the old "--syn"-less rules on upgrade
-			delRules = append(delRules, iptRule{
-				table:    "filter",
-				chain:    chain,
-				args:     []string{"-p", "tcp", "-m", "tcp", "--dport", port, "-j", "REJECT"},
-				protocol: protocol,
+			delRules = append(delRules, nodeipt.Rule{
+				Table:    "filter",
+				Chain:    chain,
+				Args:     []string{"-p", "tcp", "-m", "tcp", "--dport", port, "-j", "REJECT"},
+				Protocol: protocol,
 			})
 		}
 	}
 
-	_ = delIptRules(delRules)
+	_ = nodeipt.DelRules(delRules)
 }

--- a/go-controller/pkg/node/gateway.go
+++ b/go-controller/pkg/node/gateway.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"sync"
+	"time"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
@@ -130,6 +131,8 @@ func (g *gateway) DeleteService(svc *kapi.Service) error {
 
 func (g *gateway) SyncServices(objs []interface{}) error {
 	var err error
+	klog.Infof("Starting gateway service sync")
+	start := time.Now()
 	if g.portClaimWatcher != nil {
 		err = g.portClaimWatcher.SyncServices(objs)
 	}
@@ -145,6 +148,7 @@ func (g *gateway) SyncServices(objs []interface{}) error {
 	if err != nil {
 		return fmt.Errorf("gateway sync services failed: %v", err)
 	}
+	klog.Infof("Gateway service sync done. Time taken: %s", time.Since(start))
 	return nil
 }
 

--- a/go-controller/pkg/node/gateway_iptables.go
+++ b/go-controller/pkg/node/gateway_iptables.go
@@ -59,10 +59,12 @@ func insertIptRules(rules []nodeipt.Rule) error {
 	return nodeipt.AddRules(rules, false)
 }
 
-// insertIptRulesFiltered adds the provided rules in an insert fashion with a filter for table/chain
+// restoreIptRulesFiltered restores the provided rules in an insert fashion with a filter for table/chain
 // i.e each rule gets added at the first position in the chain
-func insertIptRulesFiltered(rules []nodeipt.Rule, filter map[string]map[string]bool) error {
-	return nodeipt.AddRulesFiltered(rules, filter)
+// filter is defined as a map of table/chains. Only rules matching this filter will be restored.
+// If no rules match the filter, the chain will still be restored as empty as specified in the filter.
+func restoreIptRulesFiltered(rules []nodeipt.Rule, filter map[string]map[string]struct{}) error {
+	return nodeipt.RestoreRulesFiltered(rules, filter)
 }
 
 func getGatewayInitRules(chain string, proto iptables.Protocol) []nodeipt.Rule {
@@ -434,18 +436,10 @@ func cleanupSharedGatewayIPTChains() {
 func recreateIPTRules(table, chain string, keepIPTRules []nodeipt.Rule) error {
 	var errors []error
 	var err error
-	var ipt util.IPTablesHelper
-	for _, proto := range clusterIPTablesProtocols() {
-		if ipt, err = util.GetIPTablesHelper(proto); err != nil {
-			errors = append(errors, err)
-			continue
-		}
-		if err = ipt.ClearChain(table, chain); err != nil {
-			errors = append(errors, fmt.Errorf("error clearing chain: %s in table: %s, err: %v", chain, table, err))
-		}
-	}
-	filter := map[string]map[string]bool{table: {chain: false}}
-	if err = insertIptRulesFiltered(keepIPTRules, filter); err != nil {
+	klog.Infof("Recreating iptables rules for table: %s, chain: %s", table, chain)
+	// filter is a map of the table/chain to program rules for, as all rules are included in keepIPTRules
+	filter := map[string]map[string]struct{}{table: {chain: {}}}
+	if err = restoreIptRulesFiltered(keepIPTRules, filter); err != nil {
 		errors = append(errors, err)
 	}
 	return apierrors.NewAggregate(errors)

--- a/go-controller/pkg/node/gateway_iptables.go
+++ b/go-controller/pkg/node/gateway_iptables.go
@@ -62,7 +62,7 @@ func insertIptRules(rules []nodeipt.Rule) error {
 // insertIptRulesFiltered adds the provided rules in an insert fashion with a filter for table/chain
 // i.e each rule gets added at the first position in the chain
 func insertIptRulesFiltered(rules []nodeipt.Rule, filter map[string]map[string]bool) error {
-	return nodeipt.AddRulesFiltered(rules, false, filter)
+	return nodeipt.AddRulesFiltered(rules, filter)
 }
 
 func getGatewayInitRules(chain string, proto iptables.Protocol) []nodeipt.Rule {

--- a/go-controller/pkg/node/gateway_iptables.go
+++ b/go-controller/pkg/node/gateway_iptables.go
@@ -209,31 +209,53 @@ func getITPLocalIPTRules(svcPort kapi.ServicePort, clusterIP string, svcHasLocal
 	}
 }
 
-// getNodePortETPLocalIPTRules returns the IPTable REDIRECT or RETURN rules for a service of type nodePort if ETP=local
+// getNodePortETPLocalIPTRule returns the IPTable REDIRECT or RETURN rules for a service of type nodePort if ETP=local
 // `svcPort` corresponds to port details for this service as specified in the service object
 // `targetIP` corresponds to svc.spec.ClusterIP
 // This function returns a RETURN rule in iptableMgmPortChain to prevent SNAT of sourceIP
-func getNodePortETPLocalIPTRules(svcPort kapi.ServicePort, targetIP string) []nodeipt.Rule {
-	return []nodeipt.Rule{
-		{
-			Table: "nat",
-			Chain: iptableMgmPortChain,
-			Args: []string{
-				"-p", string(svcPort.Protocol),
-				"--dport", fmt.Sprintf("%d", svcPort.NodePort),
-				"-j", "RETURN",
-			},
-			Protocol: getIPTablesProtocol(targetIP),
-		},
+func getNodePortETPLocalIPTRule(svcPort kapi.ServicePort, targetIP string) nodeipt.Rule {
+	return getSkipMgmtSNATRule(string(svcPort.Protocol), fmt.Sprintf("%d", svcPort.NodePort), "", getIPTablesProtocol(targetIP))
+}
+
+// getSkipMgmtSNATRule generates the return iptables rule for avoiding SNAT to mgmt port
+func getSkipMgmtSNATRule(protocol, port, destIP string, ipFamily iptables.Protocol) nodeipt.Rule {
+	args := make([]string, 0, 8)
+	args = append(args, "-p", protocol)
+	if len(destIP) > 0 {
+		args = append(args, "-d", destIP)
 	}
+	args = append(args, "--dport", port, "-j", "RETURN")
+	n := nodeipt.Rule{
+		Table:    "nat",
+		Chain:    iptableMgmPortChain,
+		Args:     args,
+		Protocol: ipFamily,
+	}
+	return n
 }
 
 func computeProbability(n, i int) string {
 	return fmt.Sprintf("%0.10f", 1.0/float64(n-i+1))
 }
 
-func generateIPTRulesForLoadBalancersWithoutNodePorts(svcPort kapi.ServicePort, externalIP string, service *kapi.Service, localEndpoints []string) []nodeipt.Rule {
-	var iptRules []nodeipt.Rule
+func generateSkipMgmtForLocalEndpoints(svcPort kapi.ServicePort, externalIP string, localEndpoints []string) []nodeipt.Rule {
+	iptRules := make([]nodeipt.Rule, 0, len(localEndpoints))
+	for _, localEndpoint := range localEndpoints {
+		if len(localEndpoint) == 0 {
+			continue
+		}
+		iptRules = append([]nodeipt.Rule{getSkipMgmtSNATRule(
+			string(svcPort.Protocol),
+			fmt.Sprintf("%v", int32(svcPort.TargetPort.IntValue())),
+			localEndpoint,
+			getIPTablesProtocol(externalIP),
+		)}, iptRules...)
+	}
+	return iptRules
+}
+
+func generateIPTRulesForLoadBalancersWithoutNodePorts(svcPort kapi.ServicePort, externalIP string, localEndpoints []string) []nodeipt.Rule {
+	iptRules := make([]nodeipt.Rule, 0, len(localEndpoints))
 	if len(localEndpoints) == 0 {
 		// either its smart nic mode; etp&itp not implemented, OR
 		// fetching endpointSlices error-ed out prior to reaching here so nothing to do
@@ -254,17 +276,6 @@ func generateIPTRulesForLoadBalancersWithoutNodePorts(svcPort kapi.ServicePort, 
 					"-m", "statistic",
 					"--mode", "random",
 					"--probability", computeProbability(numLocalEndpoints, i+1),
-				},
-				Protocol: getIPTablesProtocol(externalIP),
-			},
-			{
-				Table: "nat",
-				Chain: iptableMgmPortChain,
-				Args: []string{
-					"-p", string(svcPort.Protocol),
-					"-d", ip,
-					"--dport", fmt.Sprintf("%v", int32(svcPort.TargetPort.IntValue())),
-					"-j", "RETURN",
 				},
 				Protocol: getIPTablesProtocol(externalIP),
 			},
@@ -472,7 +483,7 @@ func getGatewayIPTRules(service *kapi.Service, localEndpoints []string, svcHasLo
 					// A DNAT rule to masqueradeIP is added that takes priority over DNAT to clusterIP.
 					rules = append(rules, getNodePortIPTRules(svcPort, clusterIP, svcPort.NodePort, svcHasLocalHostNetEndPnt, svcTypeIsETPLocal)...)
 					// add a skip SNAT rule to OVN-KUBE-SNAT-MGMTPORT to preserve sourceIP for etp=local traffic.
-					rules = append(rules, getNodePortETPLocalIPTRules(svcPort, clusterIP)...)
+					rules = append(rules, getNodePortETPLocalIPTRule(svcPort, clusterIP))
 				}
 				// case2 (see function description for details)
 				rules = append(rules, getNodePortIPTRules(svcPort, clusterIP, svcPort.Port, svcHasLocalHostNetEndPnt, false)...)
@@ -481,6 +492,7 @@ func getGatewayIPTRules(service *kapi.Service, localEndpoints []string, svcHasLo
 
 		externalIPs := util.GetExternalAndLBIPs(service)
 
+		snatRulesCreated := false
 		for _, externalIP := range externalIPs {
 			err := util.ValidatePort(svcPort.Protocol, svcPort.Port)
 			if err != nil {
@@ -493,7 +505,12 @@ func getGatewayIPTRules(service *kapi.Service, localEndpoints []string, svcHasLo
 					// DNAT traffic to masqueradeIP:nodePort instead of clusterIP:Port. We are leveraging the existing rules for NODEPORT
 					// service so no need to add skip SNAT rule to OVN-KUBE-SNAT-MGMTPORT since the corresponding nodePort svc would have one.
 					if !util.ServiceTypeHasNodePort(service) {
-						rules = append(rules, generateIPTRulesForLoadBalancersWithoutNodePorts(svcPort, externalIP, service, localEndpoints)...)
+						rules = append(rules, generateIPTRulesForLoadBalancersWithoutNodePorts(svcPort, externalIP, localEndpoints)...)
+						// These rules are per endpoint and should only be created one time per endpoint and port combination
+						if !snatRulesCreated {
+							rules = append(rules, generateSkipMgmtForLocalEndpoints(svcPort, externalIP, localEndpoints)...)
+							snatRulesCreated = true
+						}
 					} else {
 						rules = append(rules, getExternalIPTRules(svcPort, externalIP, "", svcHasLocalHostNetEndPnt, svcTypeIsETPLocal)...)
 					}

--- a/go-controller/pkg/node/gateway_iptables.go
+++ b/go-controller/pkg/node/gateway_iptables.go
@@ -59,6 +59,12 @@ func insertIptRules(rules []nodeipt.Rule) error {
 	return nodeipt.AddRules(rules, false)
 }
 
+// insertIptRulesFiltered adds the provided rules in an insert fashion with a filter for table/chain
+// i.e each rule gets added at the first position in the chain
+func insertIptRulesFiltered(rules []nodeipt.Rule, filter map[string]map[string]bool) error {
+	return nodeipt.AddRulesFiltered(rules, false, filter)
+}
+
 func getGatewayInitRules(chain string, proto iptables.Protocol) []nodeipt.Rule {
 	iptRules := []nodeipt.Rule{}
 	if chain == iptableESVCChain {
@@ -427,7 +433,8 @@ func recreateIPTRules(table, chain string, keepIPTRules []nodeipt.Rule) error {
 			errors = append(errors, fmt.Errorf("error clearing chain: %s in table: %s, err: %v", chain, table, err))
 		}
 	}
-	if err = insertIptRules(keepIPTRules); err != nil {
+	filter := map[string]map[string]bool{table: {chain: false}}
+	if err = insertIptRulesFiltered(keepIPTRules, filter); err != nil {
 		errors = append(errors, err)
 	}
 	return apierrors.NewAggregate(errors)

--- a/go-controller/pkg/node/gateway_localnet.go
+++ b/go-controller/pkg/node/gateway_localnet.go
@@ -49,19 +49,6 @@ func newLocalGateway(nodeName string, hostSubnets []*net.IPNet, gwNextHops []net
 		return nil, err
 	}
 
-	// OCP HACK -- block MCS ports https://github.com/openshift/ovn-kubernetes/pull/170
-	rules := []nodeipt.Rule{}
-	if config.IPv4Mode {
-		generateBlockMCSRules(&rules, iptables.ProtocolIPv4)
-	}
-	if config.IPv6Mode {
-		generateBlockMCSRules(&rules, iptables.ProtocolIPv6)
-	}
-	if err := insertIptRules(rules); err != nil {
-		return nil, fmt.Errorf("failed to setup MCS-blocking rules: %w", err)
-	}
-	// END OCP HACK
-
 	if exGwBridge != nil {
 		gw.readyFunc = func() (bool, error) {
 			ready, err := gatewayReady(gwBridge.patchPort)
@@ -132,6 +119,19 @@ func newLocalGateway(nodeName string, hostSubnets []*net.IPNet, gwNextHops []net
 			// no service OpenFlows, request to sync flows now.
 			gw.openflowManager.requestFlowSync()
 		}
+
+		// OCP HACK -- block MCS ports https://github.com/openshift/ovn-kubernetes/pull/170
+		rules := []nodeipt.Rule{}
+		if config.IPv4Mode {
+			generateBlockMCSRules(&rules, iptables.ProtocolIPv4)
+		}
+		if config.IPv6Mode {
+			generateBlockMCSRules(&rules, iptables.ProtocolIPv6)
+		}
+		if err := insertIptRules(rules); err != nil {
+			return fmt.Errorf("failed to setup MCS-blocking rules: %w", err)
+		}
+		// END OCP HACK
 
 		if err := addHostMACBindings(gwBridge.bridgeName); err != nil {
 			return fmt.Errorf("failed to add MAC bindings for service routing")

--- a/go-controller/pkg/node/gateway_localnet.go
+++ b/go-controller/pkg/node/gateway_localnet.go
@@ -5,6 +5,7 @@ package node
 
 import (
 	"fmt"
+	nodeipt "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/iptables"
 	"net"
 	"strings"
 
@@ -49,14 +50,14 @@ func newLocalGateway(nodeName string, hostSubnets []*net.IPNet, gwNextHops []net
 	}
 
 	// OCP HACK -- block MCS ports https://github.com/openshift/ovn-kubernetes/pull/170
-	rules := []iptRule{}
+	rules := []nodeipt.Rule{}
 	if config.IPv4Mode {
 		generateBlockMCSRules(&rules, iptables.ProtocolIPv4)
 	}
 	if config.IPv6Mode {
 		generateBlockMCSRules(&rules, iptables.ProtocolIPv6)
 	}
-	if err := addIptRules(rules); err != nil {
+	if err := insertIptRules(rules); err != nil {
 		return nil, fmt.Errorf("failed to setup MCS-blocking rules: %w", err)
 	}
 	// END OCP HACK

--- a/go-controller/pkg/node/gateway_localnet_linux_test.go
+++ b/go-controller/pkg/node/gateway_localnet_linux_test.go
@@ -1707,6 +1707,108 @@ var _ = Describe("Node Operations", func() {
 
 		})
 
+		It("check openflows for LoadBalancer and external ip are correctly added and removed where ETP=local, LGW mode", func() {
+			app.Action = func(ctx *cli.Context) error {
+				externalIP := "1.1.1.1"
+				externalIP2 := "1.1.1.2"
+				config.Gateway.Mode = config.GatewayModeLocal
+				fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
+					Cmd: "ovs-ofctl show ",
+					Err: fmt.Errorf("deliberate error to fall back to output:LOCAL"),
+				})
+				fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
+					Cmd: "ovs-ofctl show ",
+					Err: fmt.Errorf("deliberate error to fall back to output:LOCAL"),
+				})
+				fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
+					Cmd: "ovs-ofctl show ",
+					Err: fmt.Errorf("deliberate error to fall back to output:LOCAL"),
+				})
+				service := *newService("service1", "namespace1", "10.129.0.2",
+					[]v1.ServicePort{
+						{
+							NodePort: int32(31111),
+							Protocol: v1.ProtocolTCP,
+							Port:     int32(8080),
+						},
+					},
+					v1.ServiceTypeLoadBalancer,
+					[]string{externalIP, externalIP2},
+					v1.ServiceStatus{
+						LoadBalancer: v1.LoadBalancerStatus{
+							Ingress: []v1.LoadBalancerIngress{{
+								IP: "5.5.5.5",
+							}},
+						},
+					},
+					true, false,
+				)
+				// endpointSlice.Endpoints is empty and yet this will come under
+				// !hasLocalHostNetEp case
+				endpointSlice := *newEndpointSlice(
+					"service1",
+					"namespace1",
+					[]discovery.Endpoint{},
+					[]discovery.EndpointPort{})
+
+				fakeOvnNode.start(ctx,
+					&v1.ServiceList{
+						Items: []v1.Service{
+							service,
+						},
+					},
+					&endpointSlice,
+				)
+
+				fNPW.watchFactory = fakeOvnNode.watcher
+				Expect(startNodePortWatcher(fNPW, fakeOvnNode.fakeClient, &fakeMgmtPortConfig)).To(Succeed())
+				err := fNPW.AddService(&service)
+				Expect(err).NotTo(HaveOccurred())
+
+				expectedLBIngressFlows := []string{
+					"cookie=0x10c6b89e483ea111, priority=110, in_port=eth0, arp, arp_op=1, arp_tpa=5.5.5.5, actions=output:LOCAL",
+				}
+				expectedLBExternalIPFlows1 := []string{
+					"cookie=0x71765945a31dc2f1, priority=110, in_port=eth0, arp, arp_op=1, arp_tpa=1.1.1.1, actions=output:LOCAL",
+				}
+				expectedLBExternalIPFlows2 := []string{
+					"cookie=0x77df6d2c74c0a658, priority=110, in_port=eth0, arp, arp_op=1, arp_tpa=1.1.1.2, actions=output:LOCAL",
+				}
+
+				Expect(err).NotTo(HaveOccurred())
+				flows := fNPW.ofm.flowCache["NodePort_namespace1_service1_tcp_31111"]
+				Expect(flows).To(BeNil())
+				flows = fNPW.ofm.flowCache["Ingress_namespace1_service1_5.5.5.5_8080"]
+				Expect(flows).To(Equal(expectedLBIngressFlows))
+				flows = fNPW.ofm.flowCache["External_namespace1_service1_1.1.1.1_8080"]
+				Expect(flows).To(Equal(expectedLBExternalIPFlows1))
+				flows = fNPW.ofm.flowCache["External_namespace1_service1_1.1.1.2_8080"]
+				Expect(flows).To(Equal(expectedLBExternalIPFlows2))
+
+				addConntrackMocks(netlinkMock, []ctFilterDesc{
+					{"1.1.1.1", 8080},
+					{"1.1.1.2", 8080},
+					{"5.5.5.5", 8080},
+					{"192.168.18.15", 31111},
+					{"10.129.0.2", 8080},
+				})
+				err = fNPW.DeleteService(&service)
+				Expect(err).NotTo(HaveOccurred())
+				flows = fNPW.ofm.flowCache["NodePort_namespace1_service1_tcp_31111"]
+				Expect(flows).To(BeNil())
+				flows = fNPW.ofm.flowCache["Ingress_namespace1_service1_5.5.5.5_8080"]
+				Expect(flows).To(BeNil())
+				flows = fNPW.ofm.flowCache["External_namespace1_service1_1.1.1.1_8080"]
+				Expect(flows).To(BeNil())
+				flows = fNPW.ofm.flowCache["External_namespace1_service1_1.1.1.2_8080"]
+				Expect(flows).To(BeNil())
+
+				return nil
+			}
+			err := app.Run([]string{app.Name})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
 		It("manages iptables rules with ExternalIP through retry logic", func() {
 			app.Action = func(ctx *cli.Context) error {
 				var nodePortWatcherRetry *retry.RetryFramework

--- a/go-controller/pkg/node/gateway_localnet_linux_test.go
+++ b/go-controller/pkg/node/gateway_localnet_linux_test.go
@@ -632,9 +632,6 @@ var _ = Describe("Node Operations", func() {
 				fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
 					Cmd: "ovs-ofctl show ",
 				})
-				fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
-					Cmd: "ovs-ofctl show ",
-				})
 				service := *newService("service1", "namespace1", "10.129.0.2",
 					[]v1.ServicePort{
 						{
@@ -1316,9 +1313,6 @@ var _ = Describe("Node Operations", func() {
 				fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
 					Cmd: "ovs-ofctl show ",
 				})
-				fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
-					Cmd: "ovs-ofctl show ",
-				})
 
 				service := *newService("service1", "namespace1", clusterIPv4,
 					[]v1.ServicePort{
@@ -1770,7 +1764,6 @@ var _ = Describe("Node Operations", func() {
 				key, err := retry.GetResourceKey(&service)
 				Expect(err).NotTo(HaveOccurred())
 				retry.CheckRetryObjectEventually(key, true, nodePortWatcherRetry)
-
 				// check iptables
 				f4 := iptV4.(*util.FakeIPTables)
 				err = f4.MatchState(expectedTables)

--- a/go-controller/pkg/node/gateway_localnet_linux_test.go
+++ b/go-controller/pkg/node/gateway_localnet_linux_test.go
@@ -287,7 +287,7 @@ var _ = Describe("Node Operations", func() {
 				)
 
 				fakeRules := getExternalIPTRules(service.Spec.Ports[0], externalIP, service.Spec.ClusterIP, false, false)
-				Expect(addIptRules(fakeRules)).To(Succeed())
+				Expect(insertIptRules(fakeRules)).To(Succeed())
 				fakeRules = getExternalIPTRules(
 					v1.ServicePort{
 						Port:     27000,
@@ -299,7 +299,7 @@ var _ = Describe("Node Operations", func() {
 					false,
 					false,
 				)
-				Expect(addIptRules(fakeRules)).To(Succeed())
+				Expect(insertIptRules(fakeRules)).To(Succeed())
 
 				expectedTables := map[string]util.FakeTable{
 					"nat": {

--- a/go-controller/pkg/node/gateway_localnet_linux_test.go
+++ b/go-controller/pkg/node/gateway_localnet_linux_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
+	nodeipt "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/iptables"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/retry"
 	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
@@ -18,6 +19,7 @@ import (
 	"github.com/urfave/cli/v2"
 	"github.com/vishvananda/netlink"
 
+	"github.com/coreos/go-iptables/iptables"
 	kapi "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1"
@@ -215,6 +217,12 @@ func addConntrackMocks(nlMock *mocks.NetLinkOps, filterDescs []ctFilterDesc) {
 	ovntest.ProcessMockFnList(&nlMock.Mock, ctMocks)
 }
 
+/*
+Note: all of the tests described below actually rely on OVNK node controller start up failing. This is
+because no node is actually added when the controller is started, so node start up fails querying kapi for its
+own node. This is either intentional or accidentally convenient as the node port watcher is then replaced with a fake
+one and started again to exercise the tests.
+*/
 var _ = Describe("Node Operations", func() {
 	var (
 		app                *cli.App
@@ -301,11 +309,18 @@ var _ = Describe("Node Operations", func() {
 				)
 				Expect(insertIptRules(fakeRules)).To(Succeed())
 
+				// Inject rules into SNAT MGMT chain that shouldn't exist and should be cleared on a restore, even if the chain has no rules
+				fakeRule := getSkipMgmtSNATRule("TCP", "1337", "8.8.8.8", iptables.ProtocolIPv4)
+				Expect(insertIptRules([]nodeipt.Rule{fakeRule})).To(Succeed())
+
 				expectedTables := map[string]util.FakeTable{
 					"nat": {
 						"OVN-KUBE-EXTERNALIP": []string{
 							fmt.Sprintf("-p UDP -d 10.10.10.10 --dport 27000 -j DNAT --to-destination 172.32.0.12:27000"),
 							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, externalIP, service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
+						},
+						iptableMgmPortChain: []string{
+							fmt.Sprintf("-p TCP -d 8.8.8.8 --dport 1337 -j RETURN"),
 						},
 					},
 					"filter": {},

--- a/go-controller/pkg/node/gateway_localnet_linux_test.go
+++ b/go-controller/pkg/node/gateway_localnet_linux_test.go
@@ -1180,11 +1180,13 @@ var _ = Describe("Node Operations", func() {
 				}
 				expectedLBIngressFlows := []string{
 					"cookie=0x10c6b89e483ea111, priority=110, in_port=eth0, arp, arp_op=1, arp_tpa=5.5.5.5, actions=output:LOCAL",
+					"cookie=0x10c6b89e483ea111, priority=110, in_port=eth0, icmp, nw_dst=5.5.5.5, icmp_type=3, icmp_code=4, actions=output:patch-breth0_ov",
 					"cookie=0x10c6b89e483ea111, priority=110, in_port=eth0, tcp, nw_dst=5.5.5.5, tp_dst=8080, actions=output:patch-breth0_ov",
 					"cookie=0x10c6b89e483ea111, priority=110, in_port=patch-breth0_ov, tcp, nw_src=5.5.5.5, tp_src=8080, actions=output:eth0",
 				}
 				expectedLBExternalIPFlows := []string{
 					"cookie=0x71765945a31dc2f1, priority=110, in_port=eth0, arp, arp_op=1, arp_tpa=1.1.1.1, actions=output:LOCAL",
+					"cookie=0x71765945a31dc2f1, priority=110, in_port=eth0, icmp, nw_dst=1.1.1.1, icmp_type=3, icmp_code=4, actions=output:patch-breth0_ov",
 					"cookie=0x71765945a31dc2f1, priority=110, in_port=eth0, tcp, nw_dst=1.1.1.1, tp_dst=8080, actions=output:patch-breth0_ov",
 					"cookie=0x71765945a31dc2f1, priority=110, in_port=patch-breth0_ov, tcp, nw_src=1.1.1.1, tp_src=8080, actions=output:eth0",
 				}

--- a/go-controller/pkg/node/gateway_localnet_linux_test.go
+++ b/go-controller/pkg/node/gateway_localnet_linux_test.go
@@ -848,6 +848,10 @@ var _ = Describe("Node Operations", func() {
 					Cmd: "ovs-ofctl show ",
 					Err: fmt.Errorf("deliberate error to fall back to output:LOCAL"),
 				})
+				fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
+					Cmd: "ovs-ofctl show ",
+					Err: fmt.Errorf("deliberate error to fall back to output:LOCAL"),
+				})
 				service := *newServiceWithoutNodePortAllocation("service1", "namespace1", "10.129.0.2",
 					[]v1.ServicePort{
 						{

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -271,9 +271,10 @@ func (npw *nodePortWatcher) updateServiceFlowCache(service *kapi.Service, add, h
 func (npw *nodePortWatcher) createLbAndExternalSvcFlows(service *kapi.Service, svcPort *kapi.ServicePort, add bool,
 	hasLocalHostNetworkEp bool, protocol string, actions string, externalIPOrLBIngressIPs []string, ipType string, ofPorts []string) error {
 
-	// each path has per IP generates about 4-5 flows. So we preallocate a slice with capacity = max flows * num IPs
-	externalIPFlows := make([]string, 0, 5*len(externalIPOrLBIngressIPs))
 	for _, externalIPOrLBIngressIP := range externalIPOrLBIngressIPs {
+		// each path has per IP generates about 4-5 flows. So we preallocate a slice with capacity.
+		externalIPFlows := make([]string, 0, 5)
+
 		// CAUTION: when adding new flows where the in_port is ofPortPatch and the out_port is ofPortPhys, ensure
 		// that dl_src is included in match criteria!
 
@@ -295,7 +296,7 @@ func (npw *nodePortWatcher) createLbAndExternalSvcFlows(service *kapi.Service, s
 		// Delete if needed and skip to next protocol
 		if !add {
 			npw.ofm.deleteFlowsByKey(key)
-			return nil
+			continue
 		}
 		// add the ARP bypass flow regardless of service type or gateway modes since its applicable in all scenarios.
 		arpFlow := npw.generateARPBypassFlow(ofPorts, externalIPOrLBIngressIP, cookie)

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -2,6 +2,7 @@ package node
 
 import (
 	"fmt"
+	nodeipt "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/iptables"
 	"hash/fnv"
 	"net"
 	"reflect"
@@ -690,7 +691,7 @@ func (npw *nodePortWatcher) DeleteService(service *kapi.Service) error {
 func (npw *nodePortWatcher) SyncServices(services []interface{}) error {
 	var err error
 	var errors []error
-	keepIPTRules := []iptRule{}
+	keepIPTRules := []nodeipt.Rule{}
 	for _, serviceInterface := range services {
 		name := ktypes.NamespacedName{Namespace: serviceInterface.(*kapi.Service).Namespace, Name: serviceInterface.(*kapi.Service).Name}
 
@@ -1040,7 +1041,7 @@ func (npwipt *nodePortWatcherIptables) DeleteService(service *kapi.Service) erro
 func (npwipt *nodePortWatcherIptables) SyncServices(services []interface{}) error {
 	var err error
 	var errors []error
-	keepIPTRules := []iptRule{}
+	keepIPTRules := []nodeipt.Rule{}
 	for _, serviceInterface := range services {
 		service, ok := serviceInterface.(*kapi.Service)
 		if !ok {
@@ -1654,14 +1655,14 @@ func newSharedGateway(nodeName string, subnets []*net.IPNet, gwNextHops []net.IP
 	}
 
 	// OCP HACK -- block MCS ports
-	rules := []iptRule{}
+	rules := []nodeipt.Rule{}
 	if config.IPv4Mode {
 		generateBlockMCSRules(&rules, iptables.ProtocolIPv4)
 	}
 	if config.IPv6Mode {
 		generateBlockMCSRules(&rules, iptables.ProtocolIPv6)
 	}
-	if err := addIptRules(rules); err != nil {
+	if err := insertIptRules(rules); err != nil {
 		return nil, fmt.Errorf("failed to setup MCS-blocking rules: %w", err)
 	}
 	// END OCP HACK

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -301,6 +301,9 @@ func (npw *nodePortWatcher) createLbAndExternalSvcFlows(service *kapi.Service, s
 			fmt.Sprintf("cookie=%s, priority=110, table=7, actions=output:%s",
 				etpSvcOpenFlowCookie, npw.ofportPhys))
 	} else if config.Gateway.Mode == config.GatewayModeShared {
+		// add the ICMP Fragmentation flow for shared gateway mode.
+		icmpFlow := npw.generateICMPFragmentationFlow(nwDst, externalIPOrLBIngressIP, cookie)
+		externalIPFlows = append(externalIPFlows, icmpFlow)
 		// case2 (see function description for details)
 		externalIPFlows = append(externalIPFlows,
 			// table=0, matches on service traffic towards externalIP or LB ingress and sends it to OVN pipeline
@@ -356,6 +359,23 @@ func (npw *nodePortWatcher) generateArpBypassFlow(protocol string, ipAddr string
 	}
 
 	return arpFlow
+}
+
+func (npw *nodePortWatcher) generateICMPFragmentationFlow(nwDst, ipAddr string, cookie string) string {
+	// we send any ICMP destination unreachable, fragmentation needed to the OVN pipeline too so that
+	// path MTU discovery continues to work.
+	icmpMatch := "icmp"
+	icmpType := 3
+	icmpCode := 4
+	if utilnet.IsIPv6String(ipAddr) {
+		icmpMatch = "icmp6"
+		icmpType = 2
+		icmpCode = 0
+	}
+	icmpFragmentationFlow := fmt.Sprintf("cookie=%s, priority=110, in_port=%s, %s, %s=%s, icmp_type=%d, "+
+		"icmp_code=%d, actions=output:%s",
+		cookie, npw.ofportPhys, icmpMatch, nwDst, ipAddr, icmpType, icmpCode, npw.ofportPatch)
+	return icmpFragmentationFlow
 }
 
 // getAndDeleteServiceInfo returns the serviceConfig for a service and if it exists and then deletes the entry

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -1706,19 +1706,6 @@ func newSharedGateway(nodeName string, subnets []*net.IPNet, gwNextHops []net.IP
 		}
 	}
 
-	// OCP HACK -- block MCS ports
-	rules := []nodeipt.Rule{}
-	if config.IPv4Mode {
-		generateBlockMCSRules(&rules, iptables.ProtocolIPv4)
-	}
-	if config.IPv6Mode {
-		generateBlockMCSRules(&rules, iptables.ProtocolIPv6)
-	}
-	if err := insertIptRules(rules); err != nil {
-		return nil, fmt.Errorf("failed to setup MCS-blocking rules: %w", err)
-	}
-	// END OCP HACK
-
 	gw.initFunc = func() error {
 		// Program cluster.GatewayIntf to let non-pod traffic to go to host
 		// stack
@@ -1777,6 +1764,19 @@ func newSharedGateway(nodeName string, subnets []*net.IPNet, gwNextHops []net.IP
 			// no service OpenFlows, request to sync flows now.
 			gw.openflowManager.requestFlowSync()
 		}
+
+		// OCP HACK -- block MCS ports
+		rules := []nodeipt.Rule{}
+		if config.IPv4Mode {
+			generateBlockMCSRules(&rules, iptables.ProtocolIPv4)
+		}
+		if config.IPv6Mode {
+			generateBlockMCSRules(&rules, iptables.ProtocolIPv6)
+		}
+		if err := insertIptRules(rules); err != nil {
+			return fmt.Errorf("failed to setup MCS-blocking rules: %w", err)
+		}
+		// END OCP HACK
 
 		if err := addHostMACBindings(gwBridge.bridgeName); err != nil {
 			return fmt.Errorf("failed to add MAC bindings for service routing")

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -203,22 +203,50 @@ func (npw *nodePortWatcher) updateServiceFlowCache(service *kapi.Service, add, h
 		// Flows for cloud load balancers on Azure/GCP
 		// Established traffic is handled by default conntrack rules
 		// NodePort/Ingress access in the OVS bridge will only ever come from outside of the host
+		ingParsedIPs := make([]string, 0, len(service.Status.LoadBalancer.Ingress))
 		for _, ing := range service.Status.LoadBalancer.Ingress {
 			if len(ing.IP) > 0 {
-				if err = npw.createLbAndExternalSvcFlows(service, &svcPort, add, hasLocalHostNetworkEp, protocol, actions, utilnet.ParseIPSloppy(ing.IP).String(), "Ingress"); err != nil {
-					errors = append(errors, err)
+				ip := utilnet.ParseIPSloppy(ing.IP)
+				if ip == nil {
+					errors = append(errors, fmt.Errorf("failed to parse Ingress IP: %q", ing.IP))
+				} else {
+					ingParsedIPs = append(ingParsedIPs, ip.String())
 				}
 			}
 		}
+
 		// flows for externalIPs
+		extParsedIPs := make([]string, 0, len(service.Spec.ExternalIPs))
 		for _, externalIP := range service.Spec.ExternalIPs {
-			if err = npw.createLbAndExternalSvcFlows(service, &svcPort, add, hasLocalHostNetworkEp, protocol, actions, utilnet.ParseIPSloppy(externalIP).String(), "External"); err != nil {
-				errors = append(errors, err)
+			ip := utilnet.ParseIPSloppy(externalIP)
+			if ip == nil {
+				errors = append(errors, fmt.Errorf("failed to parse External IP: %q", externalIP))
+			} else {
+				extParsedIPs = append(extParsedIPs, ip.String())
 			}
+		}
+		var ofPorts []string
+		// don't get the ports unless we need to as it is a costly operation
+		if (len(extParsedIPs) > 0 || len(ingParsedIPs) > 0) && add {
+			ofPorts, err = util.GetOpenFlowPorts(npw.gwBridge, false)
+			if err != nil {
+				// in the odd case that getting all ports from the bridge should not work,
+				// simply output to LOCAL (this should work well in the vast majority of cases, anyway)
+				klog.Warningf("Unable to get port list from bridge. Using ovsLocalPort as output only: error: %v",
+					err)
+			}
+		}
+		if err = npw.createLbAndExternalSvcFlows(service, &svcPort, add, hasLocalHostNetworkEp, protocol, actions,
+			ingParsedIPs, "Ingress", ofPorts); err != nil {
+			errors = append(errors, err)
+		}
+
+		if err = npw.createLbAndExternalSvcFlows(service, &svcPort, add, hasLocalHostNetworkEp, protocol, actions,
+			extParsedIPs, "External", ofPorts); err != nil {
+			errors = append(errors, err)
 		}
 	}
 	return apierrors.NewAggregate(errors)
-
 }
 
 // createLbAndExternalSvcFlows handles managing breth0 gateway flows for ingress traffic towards kubernetes services
@@ -240,89 +268,95 @@ func (npw *nodePortWatcher) updateServiceFlowCache(service *kapi.Service, add, h
 // `actions`: "send to patchport"
 // `externalIPOrLBIngressIP` is either externalIP.IP or LB.status.ingress.IP
 // `ipType` is either "External" or "Ingress"
-func (npw *nodePortWatcher) createLbAndExternalSvcFlows(service *kapi.Service, svcPort *kapi.ServicePort, add bool, hasLocalHostNetworkEp bool, protocol string, actions string, externalIPOrLBIngressIP string, ipType string) error {
-	if net.ParseIP(externalIPOrLBIngressIP) == nil {
-		return fmt.Errorf("failed to parse %s IP: %q", ipType, externalIPOrLBIngressIP)
-	}
-	flowProtocol := protocol
-	nwDst := "nw_dst"
-	nwSrc := "nw_src"
-	if utilnet.IsIPv6String(externalIPOrLBIngressIP) {
-		flowProtocol = protocol + "6"
-		nwDst = "ipv6_dst"
-		nwSrc = "ipv6_src"
-	}
-	cookie, err := svcToCookie(service.Namespace, service.Name, externalIPOrLBIngressIP, svcPort.Port)
-	if err != nil {
-		klog.Warningf("Unable to generate cookie for %s svc: %s, %s, %s, %d, error: %v",
-			ipType, service.Namespace, service.Name, externalIPOrLBIngressIP, svcPort.Port, err)
-		cookie = "0"
-	}
-	key := strings.Join([]string{ipType, service.Namespace, service.Name, externalIPOrLBIngressIP, fmt.Sprintf("%d", svcPort.Port)}, "_")
-	// Delete if needed and skip to next protocol
-	if !add {
-		npw.ofm.deleteFlowsByKey(key)
-		return nil
-	}
-	// add the ARP bypass flow regardless of service type or gateway modes since its applicable in all scenarios.
-	arpFlow := npw.generateArpBypassFlow(protocol, externalIPOrLBIngressIP, cookie)
-	externalIPFlows := []string{arpFlow}
-	// This allows external traffic ingress when the svc's ExternalTrafficPolicy is
-	// set to Local, and the backend pod is HostNetworked. We need to add
-	// Flows that will DNAT all external traffic destined for the lb/externalIP service
-	// to the nodeIP / nodeIP:port of the host networked backend.
-	// And then ensure that return traffic is UnDNATed correctly back
-	// to the ingress / external IP
-	isServiceTypeETPLocal := util.ServiceExternalTrafficPolicyLocal(service)
-	if isServiceTypeETPLocal && hasLocalHostNetworkEp {
-		// case1 (see function description for details)
-		klog.V(5).Infof("Adding flows on breth0 for %s Service %s in Namespace: %s since ExternalTrafficPolicy=local", ipType, service.Name, service.Namespace)
-		// table 0, This rule matches on all traffic with dst ip == LoadbalancerIP / externalIP, DNAT's the nodePort to the svc targetPort
-		// If ipv6 make sure to choose the ipv6 node address for rule
-		if strings.Contains(flowProtocol, "6") {
-			externalIPFlows = append(externalIPFlows,
-				fmt.Sprintf("cookie=%s, priority=110, in_port=%s, %s, %s=%s, tp_dst=%d, actions=ct(commit,zone=%d,nat(dst=[%s]:%s),table=6)",
-					cookie, npw.ofportPhys, flowProtocol, nwDst, externalIPOrLBIngressIP, svcPort.Port, HostNodePortCTZone, npw.gatewayIPv6, svcPort.TargetPort.String()))
-		} else {
-			externalIPFlows = append(externalIPFlows,
-				fmt.Sprintf("cookie=%s, priority=110, in_port=%s, %s, %s=%s, tp_dst=%d, actions=ct(commit,zone=%d,nat(dst=%s:%s),table=6)",
-					cookie, npw.ofportPhys, flowProtocol, nwDst, externalIPOrLBIngressIP, svcPort.Port, HostNodePortCTZone, npw.gatewayIPv4, svcPort.TargetPort.String()))
+func (npw *nodePortWatcher) createLbAndExternalSvcFlows(service *kapi.Service, svcPort *kapi.ServicePort, add bool,
+	hasLocalHostNetworkEp bool, protocol string, actions string, externalIPOrLBIngressIPs []string, ipType string, ofPorts []string) error {
+
+	// each path has per IP generates about 4-5 flows. So we preallocate a slice with capacity = max flows * num IPs
+	externalIPFlows := make([]string, 0, 5*len(externalIPOrLBIngressIPs))
+	for _, externalIPOrLBIngressIP := range externalIPOrLBIngressIPs {
+		// CAUTION: when adding new flows where the in_port is ofPortPatch and the out_port is ofPortPhys, ensure
+		// that dl_src is included in match criteria!
+
+		flowProtocol := protocol
+		nwDst := "nw_dst"
+		nwSrc := "nw_src"
+		if utilnet.IsIPv6String(externalIPOrLBIngressIP) {
+			flowProtocol = protocol + "6"
+			nwDst = "ipv6_dst"
+			nwSrc = "ipv6_src"
 		}
-		externalIPFlows = append(externalIPFlows,
-			// table 6, Sends the packet to Host. Note that the constant etp svc cookie is used since this flow would be
-			// same for all such services.
-			fmt.Sprintf("cookie=%s, priority=110, table=6, actions=output:LOCAL",
-				etpSvcOpenFlowCookie),
-			// table 0, Matches on return traffic, i.e traffic coming from the host networked pod's port, and unDNATs
-			fmt.Sprintf("cookie=%s, priority=110, in_port=LOCAL, %s, tp_src=%s, actions=ct(commit,zone=%d nat,table=7)",
-				cookie, flowProtocol, svcPort.TargetPort.String(), HostNodePortCTZone),
-			// table 7, Sends the reply packet back out eth0 to the external client. Note that the constant etp svc
-			// cookie is used since this would be same for all such services.
-			fmt.Sprintf("cookie=%s, priority=110, table=7, actions=output:%s",
-				etpSvcOpenFlowCookie, npw.ofportPhys))
-	} else if config.Gateway.Mode == config.GatewayModeShared {
-		// add the ICMP Fragmentation flow for shared gateway mode.
-		icmpFlow := npw.generateICMPFragmentationFlow(nwDst, externalIPOrLBIngressIP, cookie)
-		externalIPFlows = append(externalIPFlows, icmpFlow)
-		// case2 (see function description for details)
-		externalIPFlows = append(externalIPFlows,
-			// table=0, matches on service traffic towards externalIP or LB ingress and sends it to OVN pipeline
-			fmt.Sprintf("cookie=%s, priority=110, in_port=%s, %s, %s=%s, tp_dst=%d, "+
-				"actions=%s",
-				cookie, npw.ofportPhys, flowProtocol, nwDst, externalIPOrLBIngressIP, svcPort.Port, actions),
-			// table=0, matches on return traffic from service externalIP or LB ingress and sends it out to primary node interface (br-ex)
-			fmt.Sprintf("cookie=%s, priority=110, in_port=%s, %s, %s=%s, tp_src=%d, "+
-				"actions=output:%s",
-				cookie, npw.ofportPatch, flowProtocol, nwSrc, externalIPOrLBIngressIP, svcPort.Port, npw.ofportPhys))
+		cookie, err := svcToCookie(service.Namespace, service.Name, externalIPOrLBIngressIP, svcPort.Port)
+		if err != nil {
+			klog.Warningf("Unable to generate cookie for %s svc: %s, %s, %s, %d, error: %v",
+				ipType, service.Namespace, service.Name, externalIPOrLBIngressIP, svcPort.Port, err)
+			cookie = "0"
+		}
+		key := strings.Join([]string{ipType, service.Namespace, service.Name, externalIPOrLBIngressIP, fmt.Sprintf("%d", svcPort.Port)}, "_")
+		// Delete if needed and skip to next protocol
+		if !add {
+			npw.ofm.deleteFlowsByKey(key)
+			return nil
+		}
+		// add the ARP bypass flow regardless of service type or gateway modes since its applicable in all scenarios.
+		arpFlow := npw.generateARPBypassFlow(ofPorts, externalIPOrLBIngressIP, cookie)
+		externalIPFlows = append(externalIPFlows, arpFlow)
+		// This allows external traffic ingress when the svc's ExternalTrafficPolicy is
+		// set to Local, and the backend pod is HostNetworked. We need to add
+		// Flows that will DNAT all external traffic destined for the lb/externalIP service
+		// to the nodeIP / nodeIP:port of the host networked backend.
+		// And then ensure that return traffic is UnDNATed correctly back
+		// to the ingress / external IP
+		isServiceTypeETPLocal := util.ServiceExternalTrafficPolicyLocal(service)
+		if isServiceTypeETPLocal && hasLocalHostNetworkEp {
+			// case1 (see function description for details)
+			klog.V(5).Infof("Adding flows on breth0 for %s Service %s in Namespace: %s since ExternalTrafficPolicy=local", ipType, service.Name, service.Namespace)
+			// table 0, This rule matches on all traffic with dst ip == LoadbalancerIP / externalIP, DNAT's the nodePort to the svc targetPort
+			// If ipv6 make sure to choose the ipv6 node address for rule
+			if strings.Contains(flowProtocol, "6") {
+				externalIPFlows = append(externalIPFlows,
+					fmt.Sprintf("cookie=%s, priority=110, in_port=%s, %s, %s=%s, tp_dst=%d, actions=ct(commit,zone=%d,nat(dst=[%s]:%s),table=6)",
+						cookie, npw.ofportPhys, flowProtocol, nwDst, externalIPOrLBIngressIP, svcPort.Port, HostNodePortCTZone, npw.gatewayIPv6, svcPort.TargetPort.String()))
+			} else {
+				externalIPFlows = append(externalIPFlows,
+					fmt.Sprintf("cookie=%s, priority=110, in_port=%s, %s, %s=%s, tp_dst=%d, actions=ct(commit,zone=%d,nat(dst=%s:%s),table=6)",
+						cookie, npw.ofportPhys, flowProtocol, nwDst, externalIPOrLBIngressIP, svcPort.Port, HostNodePortCTZone, npw.gatewayIPv4, svcPort.TargetPort.String()))
+			}
+			externalIPFlows = append(externalIPFlows,
+				// table 6, Sends the packet to Host. Note that the constant etp svc cookie is used since this flow would be
+				// same for all such services.
+				fmt.Sprintf("cookie=%s, priority=110, table=6, actions=output:LOCAL",
+					etpSvcOpenFlowCookie),
+				// table 0, Matches on return traffic, i.e traffic coming from the host networked pod's port, and unDNATs
+				fmt.Sprintf("cookie=%s, priority=110, in_port=LOCAL, %s, tp_src=%s, actions=ct(commit,zone=%d nat,table=7)",
+					cookie, flowProtocol, svcPort.TargetPort.String(), HostNodePortCTZone),
+				// table 7, Sends the reply packet back out eth0 to the external client. Note that the constant etp svc
+				// cookie is used since this would be same for all such services.
+				fmt.Sprintf("cookie=%s, priority=110, table=7, actions=output:%s",
+					etpSvcOpenFlowCookie, npw.ofportPhys))
+		} else if config.Gateway.Mode == config.GatewayModeShared {
+			// add the ICMP Fragmentation flow for shared gateway mode.
+			icmpFlow := npw.generateICMPFragmentationFlow(nwDst, externalIPOrLBIngressIP, cookie)
+			externalIPFlows = append(externalIPFlows, icmpFlow)
+			// case2 (see function description for details)
+			externalIPFlows = append(externalIPFlows,
+				// table=0, matches on service traffic towards externalIP or LB ingress and sends it to OVN pipeline
+				fmt.Sprintf("cookie=%s, priority=110, in_port=%s, %s, %s=%s, tp_dst=%d, "+
+					"actions=%s",
+					cookie, npw.ofportPhys, flowProtocol, nwDst, externalIPOrLBIngressIP, svcPort.Port, actions),
+				// table=0, matches on return traffic from service externalIP or LB ingress and sends it out to primary node interface (br-ex)
+				fmt.Sprintf("cookie=%s, priority=110, in_port=%s, %s, %s=%s, tp_src=%d, "+
+					"actions=output:%s",
+					cookie, npw.ofportPatch, flowProtocol, nwSrc, externalIPOrLBIngressIP, svcPort.Port, npw.ofportPhys))
+		}
+		npw.ofm.updateFlowCacheEntry(key, externalIPFlows)
 	}
-	npw.ofm.updateFlowCacheEntry(key, externalIPFlows)
 
 	return nil
 }
 
 // generate ARP/NS bypass flow which will send the ARP/NS request everywhere *but* to OVN
 // OpenFlow will not do hairpin switching, so we can safely add the origin port to the list of ports, too
-func (npw *nodePortWatcher) generateArpBypassFlow(protocol string, ipAddr string, cookie string) string {
+func (npw *nodePortWatcher) generateARPBypassFlow(ofPorts []string, ipAddr string, cookie string) string {
 	addrResDst := "arp_tpa"
 	addrResProto := "arp, arp_op=1"
 	if utilnet.IsIPv6String(ipAddr) {
@@ -332,12 +366,9 @@ func (npw *nodePortWatcher) generateArpBypassFlow(protocol string, ipAddr string
 
 	var arpFlow string
 	var arpPortsFiltered []string
-	arpPorts, err := util.GetOpenFlowPorts(npw.gwBridge, false)
-	if err != nil {
+	if len(ofPorts) == 0 {
 		// in the odd case that getting all ports from the bridge should not work,
 		// simply output to LOCAL (this should work well in the vast majority of cases, anyway)
-		klog.Warningf("Unable to get port list from bridge. Using ovsLocalPort as output only: error: %v",
-			err)
 		arpFlow = fmt.Sprintf("cookie=%s, priority=110, in_port=%s, %s, %s=%s, "+
 			"actions=output:%s",
 			cookie, npw.ofportPhys, addrResProto, addrResDst, ipAddr, ovsLocalPort)
@@ -347,7 +378,7 @@ func (npw *nodePortWatcher) generateArpBypassFlow(protocol string, ipAddr string
 		// Use all ports except for ofPortPhys and the ofportPatch
 		// Filtering ofPortPhys is for consistency / readability only, OpenFlow will not send
 		// out the in_port normally (see man 7 ovs-actions)
-		for _, port := range arpPorts {
+		for _, port := range ofPorts {
 			if port == npw.ofportPatch || port == npw.ofportPhys {
 				continue
 			}

--- a/go-controller/pkg/node/gateway_shared_intf_linux.go
+++ b/go-controller/pkg/node/gateway_shared_intf_linux.go
@@ -5,6 +5,7 @@ package node
 
 import (
 	"fmt"
+	nodeipt "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/iptables"
 	"strings"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
@@ -62,7 +63,7 @@ func deleteLocalNodeAccessBridge() error {
 func addGatewayIptRules(service *kapi.Service, localEndpoints []string, svcHasLocalHostNetEndPnt bool) error {
 	rules := getGatewayIPTRules(service, localEndpoints, svcHasLocalHostNetEndPnt)
 
-	if err := addIptRules(rules); err != nil {
+	if err := insertIptRules(rules); err != nil {
 		return fmt.Errorf("failed to add iptables rules for service %s/%s: %v",
 			service.Namespace, service.Name, err)
 	}
@@ -73,7 +74,7 @@ func addGatewayIptRules(service *kapi.Service, localEndpoints []string, svcHasLo
 func delGatewayIptRules(service *kapi.Service, localEndpoints []string, svcHasLocalHostNetEndPnt bool) error {
 	rules := getGatewayIPTRules(service, localEndpoints, svcHasLocalHostNetEndPnt)
 
-	if err := delIptRules(rules); err != nil {
+	if err := nodeipt.DelRules(rules); err != nil {
 		return fmt.Errorf("failed to delete iptables rules for service %s/%s: %v", service.Namespace, service.Name, err)
 	}
 	return nil
@@ -128,7 +129,7 @@ func updateEgressSVCIptRules(svc *kapi.Service, npw *nodePortWatcher) error {
 
 	// Add rules for endpoints without one.
 	addRules := egressSVCIPTRulesForEndpoints(svc, v4ToAdd, v6ToAdd)
-	if err := addIptRules(addRules); err != nil {
+	if err := insertIptRules(addRules); err != nil {
 		return fmt.Errorf("failed to add iptables rules for service %s/%s during update: %v",
 			svc.Namespace, svc.Name, err)
 	}
@@ -139,7 +140,7 @@ func updateEgressSVCIptRules(svc *kapi.Service, npw *nodePortWatcher) error {
 
 	// Delete rules for endpoints that should not have one.
 	delRules := egressSVCIPTRulesForEndpoints(svc, v4ToDelete, v6ToDelete)
-	if err := delIptRules(delRules); err != nil {
+	if err := nodeipt.DelRules(delRules); err != nil {
 		return fmt.Errorf("failed to delete iptables rules for service %s/%s during update: %v",
 			svc.Namespace, svc.Name, err)
 	}
@@ -169,7 +170,7 @@ func delAllEgressSVCIptRules(svc *kapi.Service, npw *nodePortWatcher) error {
 	}
 
 	delRules := egressSVCIPTRulesForEndpoints(svc, v4ToDelete, v6ToDelete)
-	if err := delIptRules(delRules); err != nil {
+	if err := nodeipt.DelRules(delRules); err != nil {
 		return fmt.Errorf("failed to delete iptables rules for service %s/%s: %v", svc.Namespace, svc.Name, err)
 	}
 

--- a/go-controller/pkg/node/iptables/iptables.go
+++ b/go-controller/pkg/node/iptables/iptables.go
@@ -17,12 +17,79 @@ type Rule struct {
 	Protocol iptables.Protocol
 }
 
+// AddRulesFiltered adds the given rules to iptables.
+// filter is a map[table][chain] of valid tables/chains to use for filtering rules to be added.
+func AddRulesFiltered(rules []Rule, append bool, filter map[string]map[string]bool) error {
+	addErrors := errors.New("")
+	var err error
+	var ipt util.IPTablesHelper
+	var exists bool
+
+	// stores valid table chains and whether they were already created or not
+	// key is ip protocol, table, chain
+	createdChains := map[iptables.Protocol]map[string]map[string]bool{
+		iptables.ProtocolIPv4: make(map[string]map[string]bool),
+		iptables.ProtocolIPv6: make(map[string]map[string]bool),
+	}
+
+	for _, r := range rules {
+		if _, ok := filter[r.Table][r.Chain]; !ok {
+			klog.V(5).Infof("Ignoring processing rule in table: %s, chain: %s with args: \"%s\" for protocol: %v ",
+				r.Table, r.Chain, strings.Join(r.Args, " "), r.Protocol)
+			continue
+		}
+		klog.V(5).Infof("Adding rule in table: %s, chain: %s with args: \"%s\" for protocol: %v ",
+			r.Table, r.Chain, strings.Join(r.Args, " "), r.Protocol)
+		if ipt, err = util.GetIPTablesHelper(r.Protocol); err != nil {
+			addErrors = errors.Wrapf(addErrors,
+				"Failed to add iptables %s/%s rule %q: %v", r.Table, r.Chain, strings.Join(r.Args, " "), err)
+			continue
+		}
+		if _, ok := createdChains[r.Protocol][r.Table][r.Chain]; !ok {
+			klog.Infof("Creating table: %s chain: %s", r.Table, r.Chain)
+			if err = ipt.NewChain(r.Table, r.Chain); err != nil {
+				klog.V(5).Infof("Chain: \"%s\" in table: \"%s\" already exists, skipping creation: %v",
+					r.Chain, r.Table, err)
+			}
+			// we assume an error means it was already created
+			if _, ok := createdChains[r.Protocol][r.Table]; !ok {
+				createdChains[r.Protocol][r.Table] = make(map[string]bool)
+			}
+			createdChains[r.Protocol][r.Table][r.Chain] = true
+		}
+		exists, err = ipt.Exists(r.Table, r.Chain, r.Args...)
+		if !exists && err == nil {
+			if append {
+				err = ipt.Append(r.Table, r.Chain, r.Args...)
+			} else {
+				err = ipt.Insert(r.Table, r.Chain, 1, r.Args...)
+			}
+		}
+		if err != nil {
+			addErrors = errors.Wrapf(addErrors, "failed to add iptables %s/%s rule %q: %v",
+				r.Table, r.Chain, strings.Join(r.Args, " "), err)
+		}
+	}
+	if addErrors.Error() == "" {
+		addErrors = nil
+	}
+	return addErrors
+}
+
 // AddRules adds the given rules to iptables.
 func AddRules(rules []Rule, append bool) error {
 	addErrors := errors.New("")
 	var err error
 	var ipt util.IPTablesHelper
 	var exists bool
+
+	// stores valid chains and whether they were already created or not
+	// key is ip protocol, table, chain
+	createdChains := map[iptables.Protocol]map[string]map[string]bool{
+		iptables.ProtocolIPv4: make(map[string]map[string]bool),
+		iptables.ProtocolIPv6: make(map[string]map[string]bool),
+	}
+
 	for _, r := range rules {
 		klog.V(5).Infof("Adding rule in table: %s, chain: %s with args: \"%s\" for protocol: %v ",
 			r.Table, r.Chain, strings.Join(r.Args, " "), r.Protocol)
@@ -31,9 +98,17 @@ func AddRules(rules []Rule, append bool) error {
 				"Failed to add iptables %s/%s rule %q: %v", r.Table, r.Chain, strings.Join(r.Args, " "), err)
 			continue
 		}
-		if err = ipt.NewChain(r.Table, r.Chain); err != nil {
-			klog.V(5).Infof("Chain: \"%s\" in table: \"%s\" already exists, skipping creation: %v",
-				r.Chain, r.Table, err)
+		if _, ok := createdChains[r.Protocol][r.Table][r.Chain]; !ok {
+			klog.Infof("Creating table: %s chain: %s", r.Table, r.Chain)
+			if err = ipt.NewChain(r.Table, r.Chain); err != nil {
+				klog.V(5).Infof("Chain: \"%s\" in table: \"%s\" already exists, skipping creation: %v",
+					r.Chain, r.Table, err)
+			}
+			// we assume an error means it was already created
+			if _, ok := createdChains[r.Protocol][r.Table]; !ok {
+				createdChains[r.Protocol][r.Table] = make(map[string]bool)
+			}
+			createdChains[r.Protocol][r.Table][r.Chain] = true
 		}
 		exists, err = ipt.Exists(r.Table, r.Chain, r.Args...)
 		if !exists && err == nil {

--- a/go-controller/pkg/node/iptables/iptables.go
+++ b/go-controller/pkg/node/iptables/iptables.go
@@ -1,0 +1,81 @@
+package iptables
+
+import (
+	"strings"
+
+	"github.com/coreos/go-iptables/iptables"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	"github.com/pkg/errors"
+	"k8s.io/klog/v2"
+)
+
+// Rule represents an iptables rule.
+type Rule struct {
+	Table    string
+	Chain    string
+	Args     []string
+	Protocol iptables.Protocol
+}
+
+// AddRules adds the given rules to iptables.
+func AddRules(rules []Rule, append bool) error {
+	addErrors := errors.New("")
+	var err error
+	var ipt util.IPTablesHelper
+	var exists bool
+	for _, r := range rules {
+		klog.V(5).Infof("Adding rule in table: %s, chain: %s with args: \"%s\" for protocol: %v ",
+			r.Table, r.Chain, strings.Join(r.Args, " "), r.Protocol)
+		if ipt, err = util.GetIPTablesHelper(r.Protocol); err != nil {
+			addErrors = errors.Wrapf(addErrors,
+				"Failed to add iptables %s/%s rule %q: %v", r.Table, r.Chain, strings.Join(r.Args, " "), err)
+			continue
+		}
+		if err = ipt.NewChain(r.Table, r.Chain); err != nil {
+			klog.V(5).Infof("Chain: \"%s\" in table: \"%s\" already exists, skipping creation: %v",
+				r.Chain, r.Table, err)
+		}
+		exists, err = ipt.Exists(r.Table, r.Chain, r.Args...)
+		if !exists && err == nil {
+			if append {
+				err = ipt.Append(r.Table, r.Chain, r.Args...)
+			} else {
+				err = ipt.Insert(r.Table, r.Chain, 1, r.Args...)
+			}
+		}
+		if err != nil {
+			addErrors = errors.Wrapf(addErrors, "failed to add iptables %s/%s rule %q: %v",
+				r.Table, r.Chain, strings.Join(r.Args, " "), err)
+		}
+	}
+	if addErrors.Error() == "" {
+		addErrors = nil
+	}
+	return addErrors
+}
+
+func DelRules(rules []Rule) error {
+	delErrors := errors.New("")
+	var err error
+	var ipt util.IPTablesHelper
+	for _, r := range rules {
+		klog.V(5).Infof("Deleting rule in table: %s, chain: %s with args: \"%s\" for protocol: %v ",
+			r.Table, r.Chain, strings.Join(r.Args, " "), r.Protocol)
+		if ipt, err = util.GetIPTablesHelper(r.Protocol); err != nil {
+			delErrors = errors.Wrapf(delErrors,
+				"Failed to delete iptables %s/%s rule %q: %v", r.Table, r.Chain, strings.Join(r.Args, " "), err)
+			continue
+		}
+		if exists, err := ipt.Exists(r.Table, r.Chain, r.Args...); err == nil && exists {
+			err := ipt.Delete(r.Table, r.Chain, r.Args...)
+			if err != nil {
+				delErrors = errors.Wrapf(delErrors, "failed to delete iptables %s/%s rule %q: %v",
+					r.Table, r.Chain, strings.Join(r.Args, " "), err)
+			}
+		}
+	}
+	if delErrors.Error() == "" {
+		delErrors = nil
+	}
+	return delErrors
+}

--- a/go-controller/pkg/node/node.go
+++ b/go-controller/pkg/node/node.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	nodeipt "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/iptables"
 	"io/ioutil"
 	"net"
 	"strconv"
@@ -915,7 +916,7 @@ func upgradeServiceRoute(bridgeName string) error {
 			klog.Errorf("Failed to LocalGatewayNATRules: %v", err)
 		}
 		rules := getLocalGatewayNATRules(types.LocalnetGatewayNextHopPort, IPNet)
-		if err := delIptRules(rules); err != nil {
+		if err := nodeipt.DelRules(rules); err != nil {
 			klog.Errorf("Failed to LocalGatewayNATRules: %v", err)
 		}
 	}

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -15,10 +15,8 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	utilwait "k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/leaderelection"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
-	ref "k8s.io/client-go/tools/reference"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
 	utilnet "k8s.io/utils/net"
@@ -1346,17 +1344,6 @@ func (oc *Controller) addUpdateNodeEvent(node *kapi.Node, nSyncs *nodeSyncs) err
 	}
 
 	return kerrors.NewAggregate(errs)
-}
-
-func (oc *Controller) recordNodeErrorEvent(node *kapi.Node, nodeErr error) {
-	nodeRef, err := ref.GetReference(scheme.Scheme, node)
-	if err != nil {
-		klog.Errorf("Couldn't get a reference to node %s to post an event: %v", node.Name, err)
-		return
-	}
-
-	klog.V(5).Infof("Posting %s event for Node %s: %v", kapi.EventTypeWarning, node.Name, nodeErr)
-	oc.recorder.Eventf(nodeRef, kapi.EventTypeWarning, "ErrorReconcilingNode", nodeErr.Error())
 }
 
 func (oc *Controller) deleteNodeEvent(node *kapi.Node) error {

--- a/go-controller/pkg/util/iptables.go
+++ b/go-controller/pkg/util/iptables.go
@@ -266,6 +266,7 @@ func (f *FakeIPTables) Restore(tableName string, rulesMap map[string][][]string)
 		return err
 	}
 	for chainName, rules := range rulesMap {
+		(*table)[chainName] = []string{}
 		for _, rule := range rules {
 			chain, _ := table.getChain(chainName)
 			(*table)[chainName] = append([]string{strings.Join(rule, " ")}, chain...)

--- a/go-controller/pkg/util/iptables.go
+++ b/go-controller/pkg/util/iptables.go
@@ -33,6 +33,8 @@ type IPTablesHelper interface {
 	Append(string, string, ...string) error
 	// Delete removes rulespec in specified table/chain
 	Delete(string, string, ...string) error
+	// Restore uses iptables-restore to restore rules for multiple chains in a table at once
+	Restore(table string, rulesMap map[string][][]string) error
 }
 
 var helpers = make(map[iptables.Protocol]IPTablesHelper)
@@ -253,6 +255,20 @@ func (f *FakeIPTables) Delete(tableName, chainName string, rulespec ...string) e
 		if r == rule {
 			(*table)[chainName] = append(chain[:i], chain[i+1:]...)
 			break
+		}
+	}
+	return nil
+}
+
+func (f *FakeIPTables) Restore(tableName string, rulesMap map[string][][]string) error {
+	table, err := f.getTable(tableName)
+	if err != nil {
+		return err
+	}
+	for chainName, rules := range rulesMap {
+		for _, rule := range rules {
+			chain, _ := table.getChain(chainName)
+			(*table)[chainName] = append([]string{strings.Join(rule, " ")}, chain...)
 		}
 	}
 	return nil

--- a/go-controller/vendor/modules.txt
+++ b/go-controller/vendor/modules.txt
@@ -84,7 +84,7 @@ github.com/containernetworking/plugins/pkg/ns
 github.com/containernetworking/plugins/pkg/testutils
 github.com/containernetworking/plugins/pkg/utils/buildversion
 github.com/containernetworking/plugins/pkg/utils/sysctl
-# github.com/coreos/go-iptables v0.6.0
+# github.com/coreos/go-iptables v0.6.0 => github.com/trozet/go-iptables v0.0.0-20240328221912-077e672b3808
 ## explicit; go 1.16
 github.com/coreos/go-iptables/iptables
 # github.com/cpuguy83/go-md2man/v2 v2.0.1
@@ -951,6 +951,7 @@ sigs.k8s.io/structured-merge-diff/v4/value
 ## explicit; go 1.12
 sigs.k8s.io/yaml
 # github.com/Microsoft/hcsshim => github.com/Microsoft/hcsshim v0.8.20
+# github.com/coreos/go-iptables => github.com/trozet/go-iptables v0.0.0-20240328221912-077e672b3808
 # github.com/gogo/protobuf => github.com/gogo/protobuf v1.3.2
 # github.com/vishvananda/netlink => github.com/jcaamano/netlink v1.1.1-0.20220831114501-3a761ed61db6
 # k8s.io/api => k8s.io/api v0.24.0


### PR DESCRIPTION
Conflicts and modifications done in the first patch: [CARRY: manual cherry pick of iptables refactor](https://github.com/openshift/ovn-kubernetes/commit/5b6b6e9e038ff06c0e3c3d8bf6cf463753b37bfb)

The rest was pretty clean. I also brought in [Make PMTUD works in shared gateway mode](https://github.com/openshift/ovn-kubernetes/commit/84895aea4cdc980202c54969d01da2a70c219ac3)

in order to make the rest of the cherry-picking clean.

@pperiyasamy fyi ^