### PR TITLE
[release-4.13] OCPBUGS-33355,OCPBUGS-24651: EgressIP: Validate cache state when reconciling EgressIP pods and namespaces

### DIFF
--- a/go-controller/pkg/ovn/egressip.go
+++ b/go-controller/pkg/ovn/egressip.go
@@ -2703,7 +2703,8 @@ func (e *egressIPController) deleteEgressIPStatusSetup(name string, status egres
 
 	routerName := util.GetGatewayRouterFromNode(status.Node)
 	natPred := func(nat *nbdb.NAT) bool {
-		return nat.ExternalIDs["name"] == name && nat.ExternalIP == status.EgressIP
+		// We should delete NATs only from the status.Node that was passed into this function
+		return nat.ExternalIDs["name"] == name && nat.ExternalIP == status.EgressIP && nat.LogicalPort != nil && *nat.LogicalPort == types.K8sPrefix+status.Node
 	}
 	nats, err := libovsdbops.FindNATsWithPredicate(e.nbClient, natPred) // save the nats to get the podIPs before that nats get deleted
 	if err != nil {


### PR DESCRIPTION
Note: This change is <4.14 specific because of the EgressIP redesign that happened with IC.

When an egressIP moves from nodeA to nodeB the following happens in `reconcileEgressIP`:
1. Allocate the new node and store it in cache
2. Reassign all matching pods to the new node in nbdb
3. Update the EgressIP status with the new node

There is a chance that `reconcileEgressIPPod`/`reconcileEgressIPNamespace` will run at the same time. If it happens to run before step 3 completes and the informers are updated with the new status there it will use the stale status to configure the nbdb. 
To avoid this issue verify that the cache state matches the current egressIP status.