### PR TITLE
OCPBUGS-35835: [release-4.16] bump OVN to ovn24.03-24.03.2-19.el9fdp 

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -13,7 +13,7 @@ RUN dnf install -y --nodocs \
 	dnf clean all
 
 ARG ovsver=3.3.0-2.el9fdp
-ARG ovnver=24.03.1-36.el9fdp
+ARG ovnver=24.03.2-19.el9fdp
 # NOTE: Ensure that the versions of OVS and OVN are overriden for OKD in each of the subsequent layers.
 ARG ovsver_okd=3.3.0-2.el9s
 ARG ovnver_okd=24.03.1-5.el9s


### PR DESCRIPTION
This version of OVN reverts some multicast commits that introduced a regression.
https://issues.redhat.com/browse/FDP-656