### PR TITLE
[release-4.15] OCPBUGS-35902: Bump ovn to 23.09.4-16

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -13,7 +13,7 @@ RUN dnf install -y --nodocs \
 	dnf clean all
 
 ARG ovsver=3.1.0-88.el9fdp
-ARG ovnver=23.09.0-139.el9fdp
+ARG ovnver=23.09.4-16.el9fdp
 
 RUN INSTALL_PKGS="iptables" && \
 	ovsver_short=$(echo "$ovsver" | cut -d'.' -f1,2) && \


### PR DESCRIPTION
Includes the fix https://issues.redhat.com/browse/FDP-509
Bumped in 4.16 by https://github.com/openshift/ovn-kubernetes/pull/2209