### PR TITLE
OCPBUGS-36554: Handle IP fragments in SGW mode

### DIFF
--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -89,6 +89,7 @@ fi
 # OVN_DISABLE_FORWARDING - disable forwarding on OVNK controlled interfaces
 # OVN_ENABLE_MULTI_EXTERNAL_GATEWAY - enable multi external gateway for ovn-kubernetes
 # OVN_ENABLE_OVNKUBE_IDENTITY - enable per node certificate ovn-kubernetes
+# OVN_KUBERNETES_CONNTRACK_ZONE - Conntrack zone number used for openflow rules (default 64000)
 
 # The argument to the command is the operation to be performed
 # ovn-master ovn-controller ovn-node display display_env ovn_debug
@@ -273,6 +274,8 @@ ovnkube_config_duration_enable=${OVNKUBE_CONFIG_DURATION_ENABLE:-false}
 ovnkube_metrics_scale_enable=${OVNKUBE_METRICS_SCALE_ENABLE:-false}
 # OVN_ENCAP_IP - encap IP to be used for OVN traffic on the node
 ovn_encap_ip=${OVN_ENCAP_IP:-}
+# OVN_KUBERNETES_CONNTRACK_ZONE - conntrack zone number used for openflow rules (default 64000)
+ovn_conntrack_zone=${OVN_KUBERNETES_CONNTRACK_ZONE:-64000}
 
 ovn_ex_gw_network_interface=${OVN_EX_GW_NETWORK_INTERFACE:-}
 # OVNKUBE_COMPACT_MODE_ENABLE indicate if ovnkube run master and node in one process
@@ -582,6 +585,7 @@ display_env() {
   echo OVN_DAEMONSET_VERSION ${ovn_daemonset_version}
   echo OVNKUBE_NODE_MODE ${ovnkube_node_mode}
   echo OVN_ENCAP_IP ${ovn_encap_ip}
+  echo OVN_KUBERNETES_CONNTRACK_ZONE ${ovn_conntrack_zone}
   echo ovnkube.sh version ${ovnkube_version}
   echo OVN_HOST_NETWORK_NAMESPACE ${ovn_host_network_namespace}
 }
@@ -2354,6 +2358,12 @@ ovn-node() {
   fi
   echo "ovnkube_node_certs_flags=${ovnkube_node_certs_flags}"
 
+  ovn_conntrack_zone_flag=
+  if [[ ${ovn_conntrack_zone} != "" ]]; then
+     ovn_conntrack_zone_flag="--conntrack-zone=${ovn_conntrack_zone}"
+  fi
+  echo "ovn_conntrack_zone_flag=${ovn_conntrack_zone_flag}"
+
   echo "=============== ovn-node   --init-node"
   /usr/bin/ovnkube --init-node ${K8S_NODE} \
         ${anp_enabled_flag} \
@@ -2379,6 +2389,7 @@ ovn-node() {
         ${ovn_dbs} \
         ${ovn_encap_ip_flag} \
         ${ovn_encap_port_flag} \
+        ${ovn_conntrack_zone_flag} \
         ${ovnkube_enable_interconnect_flag} \
         ${ovnkube_enable_multi_external_gateway_flag} \
         ${ovnkube_metrics_tls_opts} \

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -215,6 +215,12 @@ type DefaultConfig struct {
 	// that are initiated from the pods so that the reverse connections go back to the pods.
 	// This represents the conntrack zone used for the conntrack flow rules.
 	ConntrackZone int `gcfg:"conntrack-zone"`
+	// HostMasqConntrackZone is an unexposed config with the value of ConntrackZone+1
+	HostMasqConntrackZone int
+	// OVNMasqConntrackZone is an unexposed config with the value of ConntrackZone+2
+	OVNMasqConntrackZone int
+	// HostNodePortCTZone is an unexposed config with the value of ConntrackZone+3
+	HostNodePortConntrackZone int
 	// EncapType value defines the encapsulation protocol to use to transmit packets between
 	// hypervisors. By default the value is 'geneve'
 	EncapType string `gcfg:"encap-type"`
@@ -2046,6 +2052,9 @@ func completeDefaultConfig(allSubnets *configSubnets) error {
 		allSubnets.append(configSubnetCluster, subnet.CIDR)
 	}
 
+	Default.HostMasqConntrackZone = Default.ConntrackZone + 1
+	Default.OVNMasqConntrackZone = Default.ConntrackZone + 2
+	Default.HostNodePortConntrackZone = Default.ConntrackZone + 3
 	return nil
 }
 

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -221,6 +221,8 @@ type DefaultConfig struct {
 	OVNMasqConntrackZone int
 	// HostNodePortCTZone is an unexposed config with the value of ConntrackZone+3
 	HostNodePortConntrackZone int
+	// ReassemblyConntrackZone is an unexposed config with the value of ConntrackZone+4
+	ReassemblyConntrackZone int
 	// EncapType value defines the encapsulation protocol to use to transmit packets between
 	// hypervisors. By default the value is 'geneve'
 	EncapType string `gcfg:"encap-type"`
@@ -2055,6 +2057,7 @@ func completeDefaultConfig(allSubnets *configSubnets) error {
 	Default.HostMasqConntrackZone = Default.ConntrackZone + 1
 	Default.OVNMasqConntrackZone = Default.ConntrackZone + 2
 	Default.HostNodePortConntrackZone = Default.ConntrackZone + 3
+	Default.ReassemblyConntrackZone = Default.ConntrackZone + 4
 	return nil
 }
 

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -1295,6 +1295,13 @@ func flowsForDefaultBridge(bridge *bridgeConfiguration, extraIPs []net.IP) ([]st
 				"actions=drop", defaultOpenFlowCookie, ofPortPatch, protoPrefix, protoPrefix, svcCIDR))
 	}
 
+	// table 0, add IP fragment reassembly flows, only needed in SGW mode with
+	// physical interface attached to bridge
+	if config.Gateway.Mode == config.GatewayModeShared && ofPortPhys != "" {
+		reassemblyFlows := generateIPFragmentReassemblyFlow(ofPortPhys)
+		dftFlows = append(dftFlows, reassemblyFlows...)
+	}
+
 	var actions string
 	if config.Gateway.Mode != config.GatewayModeLocal || config.Gateway.DisablePacketMTUCheck {
 		actions = fmt.Sprintf("output:%s", ofPortPatch)
@@ -2124,4 +2131,34 @@ func addHostMACBindings(bridgeName string) error {
 		}
 	}
 	return nil
+}
+
+// generateIPFragmentReassemblyFlow adds flows in table 0 that send packets to a
+// specific conntrack zone for reassembly with the same priority as node port
+// flows that match on L4 fields. After reassembly packets are reinjected to
+// table 0 again. This requires a conntrack immplementation that reassembles
+// fragments. This reqreuiment is met for the kernel datapath with the netfilter
+// module loaded. This reqreuiment is not met for the userspace datapath.
+func generateIPFragmentReassemblyFlow(ofPortPhys string) []string {
+	flows := make([]string, 0, 2)
+	if config.IPv4Mode {
+		flows = append(flows,
+			fmt.Sprintf("cookie=%s, priority=110, table=0, in_port=%s, ip, nw_frag=yes, actions=ct(table=0,zone=%d)",
+				defaultOpenFlowCookie,
+				ofPortPhys,
+				config.Default.ReassemblyConntrackZone,
+			),
+		)
+	}
+	if config.IPv6Mode {
+		flows = append(flows,
+			fmt.Sprintf("cookie=%s, priority=110, table=0, in_port=%s, ipv6, nw_frag=yes, actions=ct(table=0,zone=%d)",
+				defaultOpenFlowCookie,
+				ofPortPhys,
+				config.Default.ReassemblyConntrackZone,
+			),
+		)
+	}
+
+	return flows
 }

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -55,11 +55,13 @@ const (
 	ovnKubeNodeSNATMark = "0x3f0"
 )
 
-var (
-	HostMasqCTZone     = config.Default.ConntrackZone + 1 //64001
-	OVNMasqCTZone      = HostMasqCTZone + 1               //64002
-	HostNodePortCTZone = config.Default.ConntrackZone + 3 //64003
-)
+var HostMasqCTZone, OVNMasqCTZone, HostNodePortCTZone, HostXDPCTZone int
+
+func initCTZones() {
+	HostMasqCTZone = util.GetConntrackZone() + 1
+	OVNMasqCTZone = util.GetConntrackZone() + 2
+	HostNodePortCTZone = util.GetConntrackZone() + 3
+}
 
 // nodePortWatcherIptables manages iptables rules for shared gateway
 // to ensure that services using NodePorts are accessible.
@@ -1748,6 +1750,8 @@ func newSharedGateway(nodeName string, subnets []*net.IPNet, gwNextHops []net.IP
 	watchFactory factory.NodeWatchFactory, routeManager *routemanager.Controller) (*gateway, error) {
 	klog.Info("Creating new shared gateway")
 	gw := &gateway{}
+	klog.Info("Initializing the ovn-kubernetes conntrack zones")
+	initCTZones()
 
 	gwBridge, exGwBridge, err := gatewayInitInternal(
 		nodeName, gwIntf, egressGWIntf, gwNextHops, gwIPs, nodeAnnotator)

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -55,14 +55,6 @@ const (
 	ovnKubeNodeSNATMark = "0x3f0"
 )
 
-var HostMasqCTZone, OVNMasqCTZone, HostNodePortCTZone, HostXDPCTZone int
-
-func initCTZones() {
-	HostMasqCTZone = util.GetConntrackZone() + 1
-	OVNMasqCTZone = util.GetConntrackZone() + 2
-	HostNodePortCTZone = util.GetConntrackZone() + 3
-}
-
 // nodePortWatcherIptables manages iptables rules for shared gateway
 // to ensure that services using NodePorts are accessible.
 type nodePortWatcherIptables struct {
@@ -183,11 +175,11 @@ func (npw *nodePortWatcher) updateServiceFlowCache(service *kapi.Service, add, h
 					if strings.Contains(flowProtocol, "6") {
 						nodeportFlows = append(nodeportFlows,
 							fmt.Sprintf("cookie=%s, priority=110, in_port=%s, %s, tp_dst=%d, actions=ct(commit,zone=%d,nat(dst=[%s]:%s),table=6)",
-								cookie, npw.ofportPhys, flowProtocol, svcPort.NodePort, HostNodePortCTZone, npw.gatewayIPv6, svcPort.TargetPort.String()))
+								cookie, npw.ofportPhys, flowProtocol, svcPort.NodePort, config.Default.HostNodePortConntrackZone, npw.gatewayIPv6, svcPort.TargetPort.String()))
 					} else {
 						nodeportFlows = append(nodeportFlows,
 							fmt.Sprintf("cookie=%s, priority=110, in_port=%s, %s, tp_dst=%d, actions=ct(commit,zone=%d,nat(dst=%s:%s),table=6)",
-								cookie, npw.ofportPhys, flowProtocol, svcPort.NodePort, HostNodePortCTZone, npw.gatewayIPv4, svcPort.TargetPort.String()))
+								cookie, npw.ofportPhys, flowProtocol, svcPort.NodePort, config.Default.HostNodePortConntrackZone, npw.gatewayIPv4, svcPort.TargetPort.String()))
 					}
 					nodeportFlows = append(nodeportFlows,
 						// table 6, Sends the packet to the host. Note that the constant etp svc cookie is used since this flow would be
@@ -196,7 +188,7 @@ func (npw *nodePortWatcher) updateServiceFlowCache(service *kapi.Service, add, h
 							etpSvcOpenFlowCookie),
 						// table 0, Matches on return traffic, i.e traffic coming from the host networked pod's port, and unDNATs
 						fmt.Sprintf("cookie=%s, priority=110, in_port=LOCAL, %s, tp_src=%s, actions=ct(zone=%d nat,table=7)",
-							cookie, flowProtocol, svcPort.TargetPort.String(), HostNodePortCTZone),
+							cookie, flowProtocol, svcPort.TargetPort.String(), config.Default.HostNodePortConntrackZone),
 						// table 7, Sends the packet back out eth0 to the external client. Note that the constant etp svc
 						// cookie is used since this would be same for all such services.
 						fmt.Sprintf("cookie=%s, priority=110, table=7, "+
@@ -333,11 +325,11 @@ func (npw *nodePortWatcher) createLbAndExternalSvcFlows(service *kapi.Service, s
 			if strings.Contains(flowProtocol, "6") {
 				externalIPFlows = append(externalIPFlows,
 					fmt.Sprintf("cookie=%s, priority=110, in_port=%s, %s, %s=%s, tp_dst=%d, actions=ct(commit,zone=%d,nat(dst=[%s]:%s),table=6)",
-						cookie, npw.ofportPhys, flowProtocol, nwDst, externalIPOrLBIngressIP, svcPort.Port, HostNodePortCTZone, npw.gatewayIPv6, svcPort.TargetPort.String()))
+						cookie, npw.ofportPhys, flowProtocol, nwDst, externalIPOrLBIngressIP, svcPort.Port, config.Default.HostNodePortConntrackZone, npw.gatewayIPv6, svcPort.TargetPort.String()))
 			} else {
 				externalIPFlows = append(externalIPFlows,
 					fmt.Sprintf("cookie=%s, priority=110, in_port=%s, %s, %s=%s, tp_dst=%d, actions=ct(commit,zone=%d,nat(dst=%s:%s),table=6)",
-						cookie, npw.ofportPhys, flowProtocol, nwDst, externalIPOrLBIngressIP, svcPort.Port, HostNodePortCTZone, npw.gatewayIPv4, svcPort.TargetPort.String()))
+						cookie, npw.ofportPhys, flowProtocol, nwDst, externalIPOrLBIngressIP, svcPort.Port, config.Default.HostNodePortConntrackZone, npw.gatewayIPv4, svcPort.TargetPort.String()))
 			}
 			externalIPFlows = append(externalIPFlows,
 				// table 6, Sends the packet to Host. Note that the constant etp svc cookie is used since this flow would be
@@ -346,7 +338,7 @@ func (npw *nodePortWatcher) createLbAndExternalSvcFlows(service *kapi.Service, s
 					etpSvcOpenFlowCookie),
 				// table 0, Matches on return traffic, i.e traffic coming from the host networked pod's port, and unDNATs
 				fmt.Sprintf("cookie=%s, priority=110, in_port=LOCAL, %s, tp_src=%s, actions=ct(commit,zone=%d nat,table=7)",
-					cookie, flowProtocol, svcPort.TargetPort.String(), HostNodePortCTZone),
+					cookie, flowProtocol, svcPort.TargetPort.String(), config.Default.HostNodePortConntrackZone),
 				// table 7, Sends the reply packet back out eth0 to the external client. Note that the constant etp svc
 				// cookie is used since this would be same for all such services.
 				fmt.Sprintf("cookie=%s, priority=110, table=7, actions=output:%s",
@@ -1180,7 +1172,7 @@ func flowsForDefaultBridge(bridge *bridgeConfiguration, extraIPs []net.IP) ([]st
 			fmt.Sprintf("cookie=%s, priority=500, in_port=%s, ip, ip_dst=%s, ip_src=%s,"+
 				"actions=ct(commit,zone=%d,nat(dst=%s),table=4)",
 				defaultOpenFlowCookie, ofPortPatch, config.Gateway.MasqueradeIPs.V4HostMasqueradeIP.String(), physicalIP.IP,
-				HostMasqCTZone, physicalIP.IP))
+				config.Default.HostMasqConntrackZone, physicalIP.IP))
 
 		// table 0, hairpin from OVN destined to local host (but an additional node IP), send to table 4
 		for _, ip := range extraIPs {
@@ -1201,14 +1193,14 @@ func flowsForDefaultBridge(bridge *bridgeConfiguration, extraIPs []net.IP) ([]st
 				fmt.Sprintf("cookie=%s, priority=500, in_port=%s, ip, ip_dst=%s, ip_src=%s,"+
 					"actions=ct(commit,zone=%d,table=4)",
 					defaultOpenFlowCookie, ofPortPatch, ip.String(), physicalIP.IP,
-					HostMasqCTZone))
+					config.Default.HostMasqConntrackZone))
 		}
 
 		// table 0, Reply SVC traffic from Host -> OVN, unSNAT and goto table 5
 		dftFlows = append(dftFlows,
 			fmt.Sprintf("cookie=%s, priority=500, in_port=%s, ip, ip_dst=%s,"+
 				"actions=ct(zone=%d,nat,table=5)",
-				defaultOpenFlowCookie, ofPortHost, config.Gateway.MasqueradeIPs.V4OVNMasqueradeIP.String(), OVNMasqCTZone))
+				defaultOpenFlowCookie, ofPortHost, config.Gateway.MasqueradeIPs.V4OVNMasqueradeIP.String(), config.Default.OVNMasqConntrackZone))
 	}
 	if config.IPv6Mode {
 		if ofPortPhys != "" {
@@ -1238,7 +1230,7 @@ func flowsForDefaultBridge(bridge *bridgeConfiguration, extraIPs []net.IP) ([]st
 			fmt.Sprintf("cookie=%s, priority=500, in_port=%s, ipv6, ipv6_dst=%s, ipv6_src=%s,"+
 				"actions=ct(commit,zone=%d,nat(dst=%s),table=4)",
 				defaultOpenFlowCookie, ofPortPatch, config.Gateway.MasqueradeIPs.V6HostMasqueradeIP.String(), physicalIP.IP,
-				HostMasqCTZone, physicalIP.IP))
+				config.Default.HostMasqConntrackZone, physicalIP.IP))
 
 		// table 0, hairpin from OVN destined to local host (but an additional node IP), send to table 4
 		for _, ip := range extraIPs {
@@ -1259,14 +1251,14 @@ func flowsForDefaultBridge(bridge *bridgeConfiguration, extraIPs []net.IP) ([]st
 				fmt.Sprintf("cookie=%s, priority=500, in_port=%s, ipv6, ipv6_dst=%s, ipv6_src=%s,"+
 					"actions=ct(commit,zone=%d,table=4)",
 					defaultOpenFlowCookie, ofPortPatch, ip.String(), physicalIP.IP,
-					HostMasqCTZone))
+					config.Default.HostMasqConntrackZone))
 		}
 
 		// table 0, Reply SVC traffic from Host -> OVN, unSNAT and goto table 5
 		dftFlows = append(dftFlows,
 			fmt.Sprintf("cookie=%s, priority=500, in_port=%s, ipv6, ipv6_dst=%s,"+
 				"actions=ct(zone=%d,nat,table=5)",
-				defaultOpenFlowCookie, ofPortHost, config.Gateway.MasqueradeIPs.V6OVNMasqueradeIP.String(), OVNMasqCTZone))
+				defaultOpenFlowCookie, ofPortHost, config.Gateway.MasqueradeIPs.V6OVNMasqueradeIP.String(), config.Default.OVNMasqConntrackZone))
 	}
 
 	var protoPrefix string
@@ -1286,14 +1278,14 @@ func flowsForDefaultBridge(bridge *bridgeConfiguration, extraIPs []net.IP) ([]st
 		dftFlows = append(dftFlows,
 			fmt.Sprintf("cookie=%s, priority=500, in_port=%s, %s, %s_dst=%s,"+
 				"actions=ct(commit,zone=%d,nat(src=%s),table=2)",
-				defaultOpenFlowCookie, ofPortHost, protoPrefix, protoPrefix, svcCIDR, HostMasqCTZone, masqIP))
+				defaultOpenFlowCookie, ofPortHost, protoPrefix, protoPrefix, svcCIDR, config.Default.HostMasqConntrackZone, masqIP))
 
 		// table 0, Reply hairpin traffic to host, coming from OVN, unSNAT
 		dftFlows = append(dftFlows,
 			fmt.Sprintf("cookie=%s, priority=500, in_port=%s, %s, %s_src=%s, %s_dst=%s,"+
 				"actions=ct(zone=%d,nat,table=3)",
 				defaultOpenFlowCookie, ofPortPatch, protoPrefix, protoPrefix, svcCIDR,
-				protoPrefix, masqIP, HostMasqCTZone))
+				protoPrefix, masqIP, config.Default.HostMasqConntrackZone))
 
 		// table 0, Reply traffic coming from OVN to outside, drop it if the DNAT wasn't done either
 		// at the GR load balancer or switch load balancer. It means the correct port wasn't provided.
@@ -1386,26 +1378,26 @@ func flowsForDefaultBridge(bridge *bridgeConfiguration, extraIPs []net.IP) ([]st
 		dftFlows = append(dftFlows,
 			fmt.Sprintf("cookie=%s, table=4,ip,"+
 				"actions=ct(commit,zone=%d,nat(src=%s),table=3)",
-				defaultOpenFlowCookie, OVNMasqCTZone, config.Gateway.MasqueradeIPs.V4OVNMasqueradeIP.String()))
+				defaultOpenFlowCookie, config.Default.OVNMasqConntrackZone, config.Gateway.MasqueradeIPs.V4OVNMasqueradeIP.String()))
 	}
 	if config.IPv6Mode {
 		dftFlows = append(dftFlows,
 			fmt.Sprintf("cookie=%s, table=4,ipv6, "+
 				"actions=ct(commit,zone=%d,nat(src=%s),table=3)",
-				defaultOpenFlowCookie, OVNMasqCTZone, config.Gateway.MasqueradeIPs.V6OVNMasqueradeIP.String()))
+				defaultOpenFlowCookie, config.Default.OVNMasqConntrackZone, config.Gateway.MasqueradeIPs.V6OVNMasqueradeIP.String()))
 	}
 	// table 5, Host Reply traffic to hairpinned svc, need to unDNAT, send to table 2
 	if config.IPv4Mode {
 		dftFlows = append(dftFlows,
 			fmt.Sprintf("cookie=%s, table=5, ip, "+
 				"actions=ct(commit,zone=%d,nat,table=2)",
-				defaultOpenFlowCookie, HostMasqCTZone))
+				defaultOpenFlowCookie, config.Default.HostMasqConntrackZone))
 	}
 	if config.IPv6Mode {
 		dftFlows = append(dftFlows,
 			fmt.Sprintf("cookie=%s, table=5, ipv6, "+
 				"actions=ct(commit,zone=%d,nat,table=2)",
-				defaultOpenFlowCookie, HostMasqCTZone))
+				defaultOpenFlowCookie, config.Default.HostMasqConntrackZone))
 	}
 	return dftFlows, nil
 }
@@ -1462,15 +1454,15 @@ func commonFlows(subnets []*net.IPNet, bridge *bridgeConfiguration) ([]string, e
 			dftFlows = append(dftFlows,
 				fmt.Sprintf("cookie=%s, priority=175, in_port=%s, tcp, nw_src=%s, "+
 					"actions=ct(table=4,zone=%d)",
-					defaultOpenFlowCookie, ofPortPatch, physicalIP.IP, HostMasqCTZone))
+					defaultOpenFlowCookie, ofPortPatch, physicalIP.IP, config.Default.HostMasqConntrackZone))
 			dftFlows = append(dftFlows,
 				fmt.Sprintf("cookie=%s, priority=175, in_port=%s, udp, nw_src=%s, "+
 					"actions=ct(table=4,zone=%d)",
-					defaultOpenFlowCookie, ofPortPatch, physicalIP.IP, HostMasqCTZone))
+					defaultOpenFlowCookie, ofPortPatch, physicalIP.IP, config.Default.HostMasqConntrackZone))
 			dftFlows = append(dftFlows,
 				fmt.Sprintf("cookie=%s, priority=175, in_port=%s, sctp, nw_src=%s, "+
 					"actions=ct(table=4,zone=%d)",
-					defaultOpenFlowCookie, ofPortPatch, physicalIP.IP, HostMasqCTZone))
+					defaultOpenFlowCookie, ofPortPatch, physicalIP.IP, config.Default.HostMasqConntrackZone))
 			// We send BFD traffic coming from OVN to outside directly using a higher priority flow
 			if ofPortPhys != "" {
 				dftFlows = append(dftFlows,
@@ -1523,15 +1515,15 @@ func commonFlows(subnets []*net.IPNet, bridge *bridgeConfiguration) ([]string, e
 			dftFlows = append(dftFlows,
 				fmt.Sprintf("cookie=%s, priority=175, in_port=%s, tcp6, ipv6_src=%s, "+
 					"actions=ct(table=4,zone=%d)",
-					defaultOpenFlowCookie, ofPortPatch, physicalIP.IP, HostMasqCTZone))
+					defaultOpenFlowCookie, ofPortPatch, physicalIP.IP, config.Default.HostMasqConntrackZone))
 			dftFlows = append(dftFlows,
 				fmt.Sprintf("cookie=%s, priority=175, in_port=%s, udp6, ipv6_src=%s, "+
 					"actions=ct(table=4,zone=%d)",
-					defaultOpenFlowCookie, ofPortPatch, physicalIP.IP, HostMasqCTZone))
+					defaultOpenFlowCookie, ofPortPatch, physicalIP.IP, config.Default.HostMasqConntrackZone))
 			dftFlows = append(dftFlows,
 				fmt.Sprintf("cookie=%s, priority=175, in_port=%s, sctp6, ipv6_src=%s, "+
 					"actions=ct(table=4,zone=%d)",
-					defaultOpenFlowCookie, ofPortPatch, physicalIP.IP, HostMasqCTZone))
+					defaultOpenFlowCookie, ofPortPatch, physicalIP.IP, config.Default.HostMasqConntrackZone))
 			if ofPortPhys != "" {
 				// We send BFD traffic coming from OVN to outside directly using a higher priority flow
 				dftFlows = append(dftFlows,
@@ -1750,8 +1742,6 @@ func newSharedGateway(nodeName string, subnets []*net.IPNet, gwNextHops []net.IP
 	watchFactory factory.NodeWatchFactory, routeManager *routemanager.Controller) (*gateway, error) {
 	klog.Info("Creating new shared gateway")
 	gw := &gateway{}
-	klog.Info("Initializing the ovn-kubernetes conntrack zones")
-	initCTZones()
 
 	gwBridge, exGwBridge, err := gatewayInitInternal(
 		nodeName, gwIntf, egressGWIntf, gwNextHops, gwIPs, nodeAnnotator)

--- a/go-controller/pkg/util/kube.go
+++ b/go-controller/pkg/util/kube.go
@@ -811,3 +811,7 @@ func getEndpointsFromEndpointSlices(endpointSlices []*discovery.EndpointSlice) [
 	}
 	return endpoints
 }
+
+func GetConntrackZone() int {
+	return config.Default.ConntrackZone
+}

--- a/test/e2e/service.go
+++ b/test/e2e/service.go
@@ -544,7 +544,7 @@ var _ = ginkgo.Describe("Services", func() {
 			gomega.Expect(pods.Items).To(gomega.HaveLen(1))
 			clientPod := &pods.Items[0]
 			cmd := fmt.Sprintf(`ip addr del %s dev lo || true`, extraCIDR)
-			_, err = framework.RunHostCmdWithRetries(clientPod.Namespace, clientPod.Name, cmd, framework.Poll, 30*time.Second)
+			_, _ = framework.RunHostCmdWithRetries(clientPod.Namespace, clientPod.Name, cmd, framework.Poll, 30*time.Second)
 		}
 
 		ginkgo.By("Starting a UDP server listening on the additional IP")
@@ -635,7 +635,11 @@ var _ = ginkgo.Describe("Services", func() {
 		framework.ExpectNoError(err)
 	})
 
-	ginkgo.It("of type NodePort should listen on each host addresses", func() {
+	ginkgo.Context("of type NodePort", func() {
+		var nodes *v1.NodeList
+		var err error
+		nodeIPs := make(map[string]map[int]string)
+
 		const (
 			endpointHTTPPort    = 80
 			endpointUDPPort     = 90
@@ -644,130 +648,163 @@ var _ = ginkgo.Describe("Services", func() {
 			clientContainerName = "npclient"
 		)
 
-		endPoints := make([]*v1.Pod, 0)
-		endpointsSelector := map[string]string{"servicebackend": "true"}
-		nodesHostnames := sets.NewString()
-
-		nodes, err := e2enode.GetBoundedReadySchedulableNodes(f.ClientSet, 3)
-		framework.ExpectNoError(err)
-
-		if len(nodes.Items) < 3 {
-			framework.Failf(
-				"Test requires >= 3 Ready nodes, but there are only %v nodes",
-				len(nodes.Items))
-		}
-
-		ginkgo.By("Creating the endpoints pod, one for each worker")
-		for _, node := range nodes.Items {
-			args := []string{
-				"netexec",
-				fmt.Sprintf("--http-port=%d", endpointHTTPPort),
-				fmt.Sprintf("--udp-port=%d", endpointUDPPort),
+		ginkgo.AfterEach(func() {
+			ginkgo.By("Cleaning up external container")
+			deleteClusterExternalContainer(clientContainerName)
+			ginkgo.By("Deleting additional IP addresses from nodes")
+			for nodeName, ipFamilies := range nodeIPs {
+				for _, ip := range ipFamilies {
+					_, err := runCommand(containerRuntime, "exec", nodeName, "ip", "addr", "delete",
+						fmt.Sprintf("%s/32", ip), "dev", "breth0")
+					if err != nil && !strings.Contains(err.Error(),
+						"RTNETLINK answers: Cannot assign requested address") {
+						framework.Failf("failed to remove ip address %s from node %s, err: %q", ip, nodeName, err)
+					}
+				}
 			}
-			pod, err := createPod(f, node.Name+"-ep", node.Name, f.Namespace.Name, []string{},
-				endpointsSelector, func(p *v1.Pod) {
-					p.Spec.Containers[0].Args = args
-				})
+		})
+
+		ginkgo.It("should listen on each host addresses", func() {
+			endPoints := make([]*v1.Pod, 0)
+			endpointsSelector := map[string]string{"servicebackend": "true"}
+			nodesHostnames := sets.NewString()
+
+			nodes, err = e2enode.GetBoundedReadySchedulableNodes(f.ClientSet, 3)
 			framework.ExpectNoError(err)
 
-			endPoints = append(endPoints, pod)
-			nodesHostnames.Insert(pod.Name)
-		}
-
-		ginkgo.By("Creating an external container to send the traffic from")
-		createClusterExternalContainer(clientContainerName, agnhostImage,
-			[]string{"--network", "kind", "-P"},
-			[]string{"netexec", "--http-port=80"})
-
-		// If `kindexgw` exists, connect client container to it
-		runCommand(containerRuntime, "network", "connect", "kindexgw", clientContainerName)
-
-		ginkgo.By("Adding ip addresses to each node")
-		// add new secondary IP from node subnet to all nodes, if the cluster is v6 add an ipv6 address
-		toCurlAddresses := sets.NewString()
-		for i, node := range nodes.Items {
-
-			addrAnnotation, ok := node.Annotations["k8s.ovn.org/host-cidrs"]
-			gomega.Expect(ok).To(gomega.BeTrue())
-
-			var addrs []string
-			err := json.Unmarshal([]byte(addrAnnotation), &addrs)
-			framework.ExpectNoError(err, "failed to parse node[%s] host-address annotation[%s]", node.Name, addrAnnotation)
-			for i, addr := range addrs {
-				addrSplit := strings.Split(addr, "/")
-				gomega.Expect(addrSplit).Should(gomega.HaveLen(2))
-				addrs[i] = addrSplit[0]
-			}
-			toCurlAddresses.Insert(addrs...)
-
-			var newIP string
-			if utilnet.IsIPv6String(e2enode.GetAddresses(&node, v1.NodeInternalIP)[0]) {
-				newIP = "fc00:f853:ccd:e794::" + strconv.Itoa(i)
-			} else {
-				newIP = "172.18.1." + strconv.Itoa(i+1)
-			}
-			// manually add the a secondary IP to each node
-			_, err = runCommand(containerRuntime, "exec", node.Name, "ip", "addr", "add", newIP, "dev", "breth0")
-			if err != nil {
-				framework.Failf("failed to add new Addresses to node %s: %v", node.Name, err)
+			if len(nodes.Items) < 3 {
+				framework.Failf(
+					"Test requires >= 3 Ready nodes, but there are only %v nodes",
+					len(nodes.Items))
 			}
 
-			nodeName := node.Name
-			defer func() {
-				runCommand(containerRuntime, "exec", nodeName, "ip", "addr", "delete", newIP+"/32", "dev", "breth0")
-				framework.ExpectNoError(err, "failed to remove ip address %s from node %s", newIP, nodeName)
-			}()
-
-			toCurlAddresses.Insert(newIP)
-		}
-
-		defer deleteClusterExternalContainer(clientContainerName)
-
-		isIPv6Cluster := IsIPv6Cluster(f.ClientSet)
-
-		ginkgo.By("Creating NodePort services")
-
-		etpLocalServiceName := "etp-local-svc"
-		etpLocalSvc := nodePortServiceSpecFrom(etpLocalServiceName, v1.IPFamilyPolicyPreferDualStack, endpointHTTPPort, endpointUDPPort, clusterHTTPPort, clusterUDPPort, endpointsSelector, v1.ServiceExternalTrafficPolicyTypeLocal)
-		etpLocalSvc, err = f.ClientSet.CoreV1().Services(f.Namespace.Name).Create(context.Background(), etpLocalSvc, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
-
-		etpClusterServiceName := "etp-cluster-svc"
-		etpClusterSvc := nodePortServiceSpecFrom(etpClusterServiceName, v1.IPFamilyPolicyPreferDualStack, endpointHTTPPort, endpointUDPPort, clusterHTTPPort, clusterUDPPort, endpointsSelector, v1.ServiceExternalTrafficPolicyTypeCluster)
-		etpClusterSvc, err = f.ClientSet.CoreV1().Services(f.Namespace.Name).Create(context.Background(), etpClusterSvc, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
-
-		ginkgo.By("Waiting for the endpoints to pop up")
-
-		err = framework.WaitForServiceEndpointsNum(f.ClientSet, f.Namespace.Name, etpLocalServiceName, len(endPoints), time.Second, wait.ForeverTestTimeout)
-		framework.ExpectNoError(err, "failed to validate endpoints for service %s in namespace: %s", etpLocalServiceName, f.Namespace.Name)
-
-		err = framework.WaitForServiceEndpointsNum(f.ClientSet, f.Namespace.Name, etpClusterServiceName, len(endPoints), time.Second, wait.ForeverTestTimeout)
-		framework.ExpectNoError(err, "failed to validate endpoints for service %s in namespace: %s", etpClusterServiceName, f.Namespace.Name)
-
-		for _, serviceSpec := range []*v1.Service{etpLocalSvc, etpClusterSvc} {
-			tcpNodePort, udpNodePort := nodePortsFromService(serviceSpec)
-
-			for _, protocol := range []string{"http", "udp"} {
-				toCurlPort := int32(tcpNodePort)
-				if protocol == "udp" {
-					toCurlPort = int32(udpNodePort)
+			ginkgo.By("Creating the endpoints pod, one for each worker")
+			for _, node := range nodes.Items {
+				args := []string{
+					"netexec",
+					fmt.Sprintf("--http-port=%d", endpointHTTPPort),
+					fmt.Sprintf("--udp-port=%d", endpointUDPPort),
 				}
+				pod, err := createPod(f, node.Name+"-ep", node.Name, f.Namespace.Name, []string{},
+					endpointsSelector, func(p *v1.Pod) {
+						p.Spec.Containers[0].Args = args
+					})
+				framework.ExpectNoError(err)
 
-				for _, address := range toCurlAddresses.List() {
-					if !isIPv6Cluster && utilnet.IsIPv6String(address) {
-						continue
+				endPoints = append(endPoints, pod)
+				nodesHostnames.Insert(pod.Name)
+			}
+
+			ginkgo.By("Creating an external container to send the traffic from")
+			createClusterExternalContainer(clientContainerName, agnhostImage,
+				[]string{"--network", "kind", "-P"},
+				[]string{"netexec", "--http-port=80"})
+
+			// If `kindexgw` exists, connect client container to it
+			runCommand(containerRuntime, "network", "connect", "kindexgw", clientContainerName)
+
+			ginkgo.By("Selecting additional IP addresses for each node")
+			// add new secondary IP from node subnet to all nodes, if the cluster is v6 add an ipv6 address
+			toCurlAddresses := sets.NewString()
+			for i, node := range nodes.Items {
+
+				addrAnnotation, ok := node.Annotations["k8s.ovn.org/host-cidrs"]
+				gomega.Expect(ok).To(gomega.BeTrue())
+
+				var addrs []string
+				err := json.Unmarshal([]byte(addrAnnotation), &addrs)
+				framework.ExpectNoError(err, "failed to parse node[%s] host-address annotation[%s]", node.Name,
+					addrAnnotation)
+				for i, addr := range addrs {
+					addrSplit := strings.Split(addr, "/")
+					gomega.Expect(addrSplit).Should(gomega.HaveLen(2))
+					addrs[i] = addrSplit[0]
+				}
+				toCurlAddresses.Insert(addrs...)
+
+				// Calculate and store for AfterEach new target IP addresses.
+				var newIP string
+				if nodeIPs[node.Name] == nil {
+					nodeIPs[node.Name] = make(map[int]string)
+				}
+				if utilnet.IsIPv6String(e2enode.GetAddresses(&node, v1.NodeInternalIP)[0]) {
+					newIP = "fc00:f853:ccd:e794::" + strconv.Itoa(i)
+					nodeIPs[node.Name][6] = newIP
+				} else {
+					newIP = "172.18.1." + strconv.Itoa(i+1)
+					nodeIPs[node.Name][4] = newIP
+				}
+			}
+
+			ginkgo.By("Adding additional IP addresses to each node")
+			for nodeName, ipFamilies := range nodeIPs {
+				for _, ip := range ipFamilies {
+					// manually add the a secondary IP to each node
+					_, err = runCommand(containerRuntime, "exec", nodeName, "ip", "addr", "add", ip, "dev", "breth0")
+					if err != nil {
+						framework.Failf("failed to add new IP address %s to node %s: %v", ip, nodeName, err)
+					}
+					toCurlAddresses.Insert(ip)
+				}
+			}
+
+			isIPv6Cluster := IsIPv6Cluster(f.ClientSet)
+
+			ginkgo.By("Creating NodePort services")
+
+			etpLocalServiceName := "etp-local-svc"
+			etpLocalSvc := nodePortServiceSpecFrom(etpLocalServiceName, v1.IPFamilyPolicyPreferDualStack,
+				endpointHTTPPort, endpointUDPPort, clusterHTTPPort, clusterUDPPort, endpointsSelector,
+				v1.ServiceExternalTrafficPolicyTypeLocal)
+			etpLocalSvc, err = f.ClientSet.CoreV1().Services(f.Namespace.Name).Create(context.Background(), etpLocalSvc,
+				metav1.CreateOptions{})
+			framework.ExpectNoError(err)
+
+			etpClusterServiceName := "etp-cluster-svc"
+			etpClusterSvc := nodePortServiceSpecFrom(etpClusterServiceName, v1.IPFamilyPolicyPreferDualStack,
+				endpointHTTPPort, endpointUDPPort, clusterHTTPPort, clusterUDPPort, endpointsSelector,
+				v1.ServiceExternalTrafficPolicyTypeCluster)
+			etpClusterSvc, err = f.ClientSet.CoreV1().Services(f.Namespace.Name).Create(context.Background(),
+				etpClusterSvc, metav1.CreateOptions{})
+			framework.ExpectNoError(err)
+
+			ginkgo.By("Waiting for the endpoints to pop up")
+
+			err = framework.WaitForServiceEndpointsNum(f.ClientSet, f.Namespace.Name,
+				etpLocalServiceName, len(endPoints), time.Second, wait.ForeverTestTimeout)
+			framework.ExpectNoError(err, "failed to validate endpoints for service %s in namespace: %s",
+				etpLocalServiceName, f.Namespace.Name)
+
+			err = framework.WaitForServiceEndpointsNum(f.ClientSet, f.Namespace.Name,
+				etpClusterServiceName, len(endPoints), time.Second, wait.ForeverTestTimeout)
+			framework.ExpectNoError(err, "failed to validate endpoints for service %s in namespace: %s",
+				etpClusterServiceName, f.Namespace.Name)
+
+			for _, serviceSpec := range []*v1.Service{etpLocalSvc, etpClusterSvc} {
+				tcpNodePort, udpNodePort := nodePortsFromService(serviceSpec)
+
+				for _, protocol := range []string{"http", "udp"} {
+					toCurlPort := int32(tcpNodePort)
+					if protocol == "udp" {
+						toCurlPort = int32(udpNodePort)
 					}
 
-					ginkgo.By("Hitting service " + serviceSpec.Name + " on " + address + " via " + protocol)
-					gomega.Eventually(func() bool {
-						epHostname := pokeEndpoint("", clientContainerName, protocol, address, toCurlPort, "hostname")
-						// Expect to receive a valid hostname
-						return nodesHostnames.Has(epHostname)
-					}, "20s", "1s").Should(gomega.BeTrue())
+					for _, address := range toCurlAddresses.List() {
+						if !isIPv6Cluster && utilnet.IsIPv6String(address) {
+							continue
+						}
+
+						ginkgo.By("Hitting service " + serviceSpec.Name + " on " + address + " via " + protocol)
+						gomega.Eventually(func() bool {
+							epHostname := pokeEndpoint("", clientContainerName, protocol, address, toCurlPort,
+								"hostname")
+							// Expect to receive a valid hostname
+							return nodesHostnames.Has(epHostname)
+						}, "20s", "1s").Should(gomega.BeTrue())
+					}
 				}
 			}
-		}
+		})
 	})
 })
 

--- a/test/e2e/service.go
+++ b/test/e2e/service.go
@@ -805,6 +805,165 @@ var _ = ginkgo.Describe("Services", func() {
 				}
 			}
 		})
+
+		// This tests specific flows required to handle IP fragments towards
+		// node port services to avoid forwarding via host in SGW mode. On one
+		// side, it is undesireable due to performance considerations. On the
+		// other side, it could be problematic if some fragmented packets within
+		// a stream are forwarded via host while other non fragmented packets of
+		// that same stream are forwarded directly to OVN, as the NATing in both
+		// scenarios is different such that OVN could interpret them as
+		// different streams and replace what it thinks to be a conflicting port
+		// with a different one, breaking the stream for the involved peers.
+		ginkgo.It("should handle IP fragments", func() {
+			ginkgo.By("Selecting a schedulable node")
+			nodes, err = e2enode.GetBoundedReadySchedulableNodes(f.ClientSet, 1)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(len(nodes.Items)).To(gomega.BeNumerically(">", 0))
+			nodeName := nodes.Items[0].Name
+			serverNodeIPv4, serverNodeIPv6 := getContainerAddressesForNetwork(nodeName, primaryNetworkName)
+
+			ginkgo.By("Creating the backend pod")
+			args := []string{
+				"netexec",
+				fmt.Sprintf("--http-port=%d", endpointHTTPPort),
+				fmt.Sprintf("--udp-port=%d", endpointUDPPort),
+			}
+			endpointsSelector := map[string]string{"servicebackend": "true"}
+
+			serverPodName := nodeName + "-ep"
+			var serverContainerName string
+			_, err := createPod(f, serverPodName, nodeName, f.Namespace.Name, []string{}, endpointsSelector,
+				func(p *v1.Pod) {
+					p.Spec.Containers[0].Args = args
+					serverContainerName = p.Spec.Containers[0].Name
+				},
+			)
+			framework.ExpectNoError(err)
+
+			ginkgo.By("Creating NodePort service")
+			serviceName := "service"
+			service := nodePortServiceSpecFrom(
+				serviceName,
+				v1.IPFamilyPolicyPreferDualStack,
+				endpointHTTPPort,
+				endpointUDPPort,
+				clusterHTTPPort,
+				clusterUDPPort,
+				endpointsSelector,
+				v1.ServiceExternalTrafficPolicyTypeCluster,
+			)
+			service, err = f.ClientSet.CoreV1().Services(f.Namespace.Name).Create(context.Background(), service, metav1.CreateOptions{})
+			framework.ExpectNoError(err)
+
+			ginkgo.By("Waiting for the endpoints to pop up")
+			err = framework.WaitForServiceEndpointsNum(
+				f.ClientSet,
+				f.Namespace.Name,
+				serviceName,
+				1,
+				time.Second,
+				wait.ForeverTestTimeout,
+			)
+			framework.ExpectNoError(err)
+
+			ginkgo.By("Creating an external client")
+			clientIPv4, clientIPv6 := createClusterExternalContainer(
+				clientContainerName,
+				agnhostImage,
+				[]string{"--privileged", "--network", "kind"},
+				[]string{"pause"},
+			)
+
+			clientIP := clientIPv4
+			serverNodeIP := serverNodeIPv4
+			ipContainerCmd := "ip"
+			if IsIPv6Cluster(f.ClientSet) {
+				clientIP = clientIPv6
+				serverNodeIP = serverNodeIPv6
+				ipContainerCmd = "ip -6"
+			}
+
+			const pmtu = "1300"
+			payloads := map[string]string{
+				"non-fragmented": "1220",
+				"fragmented":     "1320",
+			}
+
+			// We set a route MTU towards the server node emulating that PMTUD
+			// has already happened resulting in a plausible low PMTU.
+			// For UDP the system wide default IP_PMTUDISC_WANT will
+			// result in fragmentation for packets bigger than the PMTU.
+			// Note that fragmentation could also happen if a client chooses to
+			// not use PMTUD with IP_PMTUDISC_DONT both for TCP or UDP but the
+			// test setup required to achieve fragmentation without emulating
+			// PMTUD is more complex so we stick to UDP.
+			ginkgo.By("Lowering PMTU towards the server")
+			ipContainerCmd += " route add " + serverNodeIP + " dev eth0 src " + clientIP + " mtu " + pmtu
+			cmd := []string{
+				containerRuntime,
+				"exec",
+				clientContainerName,
+				"/bin/sh",
+				"-c",
+				ipContainerCmd,
+			}
+			framework.Logf("Running %v", cmd)
+			_, err = runCommand(cmd...)
+			framework.ExpectNoError(err, "lowering MTU in the external kind container failed: %v", err)
+
+			var udpPort int32
+			for _, port := range service.Spec.Ports {
+				if port.Protocol == v1.ProtocolUDP {
+					udpPort = port.NodePort
+				}
+			}
+			gomega.Expect(udpPort).NotTo(gomega.Equal(0))
+
+			// To check that forwarding did not happen via host, we send a
+			// non-fragmented packet first and then a fragmented one on the same
+			// source port. If the server sees the same source port it means
+			// that both packets were forwarded the same. This is because when
+			// forwarding via OVN, GR SNATs from the node IP to the join subnet,
+			// whereas forwarding via host, GR SNATs from the masquerade IP to
+			// the join subnet. Thus, OVN sees both as different streams and
+			// ends up replacing the source port to avoid the collision.
+			sourcePortRegex := `to UDP client .*:(?P<Port>\d{1,5})`
+			var sourcePort string
+			for _, payload := range []string{"non-fragmented", "fragmented"} {
+				ginkgo.By(fmt.Sprintf("Sending a %s UDP payload to the service node port", payload))
+				payload := fmt.Sprintf("%0"+payloads[payload]+"d", 1)
+				containerCmd := fmt.Sprintf("echo 'echo %s' | nc -w2 -u %s %d", payload, serverNodeIP, udpPort)
+				if sourcePort != "" {
+					containerCmd = fmt.Sprintf("echo 'echo %s' | nc -w2 -u -p %s %s %d", payload, sourcePort, serverNodeIP, udpPort)
+				}
+				cmd = []string{
+					containerRuntime,
+					"exec",
+					clientContainerName,
+					"/bin/sh",
+					"-c",
+					containerCmd,
+				}
+				framework.Logf("Running %v", cmd)
+				stdout, err := runCommand(cmd...)
+				framework.ExpectNoError(err, "sending echo request failed: %v", err)
+
+				ginkgo.By("Checking that the service received the request and replied")
+				framework.Logf("Server replied with %s", stdout)
+				gomega.Expect(stdout).To(gomega.Equal(payload), "server did not reply with the requested payload")
+
+				ginkgo.By("Checking that the request was done on the intended source port")
+				matches, err := CaptureContainerOutput(context.TODO(), f.ClientSet, f.Namespace.Name, serverPodName, serverContainerName, sourcePortRegex)
+				framework.ExpectNoError(err)
+				gomega.Expect(matches).To(gomega.HaveKey("Port"))
+				gomega.Expect(matches["Port"]).ToNot(gomega.BeEmpty())
+				if sourcePort != "" {
+					gomega.Expect(matches).To(gomega.HaveKeyWithValue("Port", sourcePort), "request did not use the intended source port")
+				}
+				sourcePort = matches["Port"]
+			}
+		})
 	})
 })
 


### PR DESCRIPTION
Backport to 4.14 of e6f139e 3fe4301 b7ba318 from 4.15 #2215

Also cherry-picked related (but non feature) commits from 4.15 for reduced conflict resolution: 7f1d28f
 
Conflicts:
* ovnkube.sh (trivial)
* util.go (changes on the e2e APIs)
* service.go: this one was in a bad state and did not even compile in HEAD, so added a CARRY commit to fix compilation errors. Then it had trivial conflicts and also changes due to different e2e APIs. No guarantees it actually works as it obviously didn't before. It does compile.

