### PR TITLE
OCPBUGS-36608: [release-4.16] ovspinning: Set affinity of each thread

### DIFF
--- a/go-controller/pkg/node/ovspinning/testdata/fake_thread_process.go
+++ b/go-controller/pkg/node/ovspinning/testdata/fake_thread_process.go
@@ -1,0 +1,16 @@
+//go:build testing_ovspinning
+// +build testing_ovspinning
+
+package main
+
+// This file is meant to be used in unit tests to validate the behavior of the ovspinnging package.
+// The purpose is to simulate a process with multiple threads, like the ovs-vswitchd daemon and Go programs
+// spawns a pool of thread by default
+
+import (
+	"time"
+)
+
+func main() {
+	time.Sleep(100 * time.Second)
+}


### PR DESCRIPTION
OVS CPU pinning ensures the CPU consumed by the processes `ovsdb-server` and `ovs-vswitchd` are the same as the OVNkube container. `ovs-vswitchd` process has threads and calling `SchedSetaffinity()` on the main PID only is does not guarantee that the already spawned threads inherit that affinity. The following is an example of such a situation:

```
sh-4.4# taskset -apc $(pgrep ovs-vswitchd)
pid 4059's current affinity list: 0-2,6,9,15-66,69,70,73,79-127
pid 4335's current affinity list: 0-2,32,33,64-66,96,97
pid 2715051's current affinity list: 0-2,5,6,15-66,69,70,73,79-127
pid 2715052's current affinity list: 0-2,5,6,15-66,69,70,73,79-127
pid 2715053's current affinity list: 0-2,5,6,15-66,69,70,73,79-127
...
```

This changes makes the CPU align routine loop over all the threads of the given PID and invoke `SchedSetaffinity` on all of them.

To test these changes, a simple `sleep 10` process is not enough, as it doesn't spawn any thread. A go version of the sleep is therefore provided for testing purpose, in the form of a simple `main`.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

#### What this PR does and why is it needed
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

#### How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->

#### Details to documentation updates
<!--
Did you include good docs that explain to our end users/developers/contributors
how your code works?
-->


#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: TBD
-->
```release-note

```

backport of: 
- https://github.com/ovn-org/ovn-kubernetes/pull/4470

cc @MarSik 