### PR TITLE
OCPBUGS-37362: Fix registering northd metrics on appropriate nodes

### DIFF
--- a/dist/templates/ovnkube-db.yaml.j2
+++ b/dist/templates/ovnkube-db.yaml.j2
@@ -48,11 +48,11 @@ spec:
   template:
     metadata:
       labels:
-        ovn-db-pod: "true"
         name: ovnkube-db
         component: network
         type: infra
         kubernetes.io/os: "linux"
+        ovn-db-pod: "true"
     spec:
       priorityClassName: "system-cluster-critical"
       # Requires fairly broad permissions - ability to read all services and network functions as well

--- a/dist/templates/ovnkube-single-node-zone.yaml.j2
+++ b/dist/templates/ovnkube-single-node-zone.yaml.j2
@@ -25,6 +25,7 @@ spec:
         component: network
         type: infra
         kubernetes.io/os: "linux"
+        ovn-db-pod: "true"
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:

--- a/dist/templates/ovnkube-zone-controller.yaml.j2
+++ b/dist/templates/ovnkube-zone-controller.yaml.j2
@@ -25,6 +25,7 @@ spec:
         component: network
         type: infra
         kubernetes.io/os: "linux"
+        ovn-db-pod: "true"
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:

--- a/go-controller/pkg/metrics/ovn_northd.go
+++ b/go-controller/pkg/metrics/ovn_northd.go
@@ -92,7 +92,7 @@ var ovnNorthdStopwatchShowMetricsMap = map[string]*stopwatchMetricDetails{
 
 func RegisterOvnNorthdMetrics(clientset kubernetes.Interface, k8sNodeName string, stopChan <-chan struct{}) {
 	err := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 300*time.Second, true, func(ctx context.Context) (bool, error) {
-		return checkPodRunsOnGivenNode(clientset, []string{"app=ovnkube-master", "name=ovnkube-master"}, k8sNodeName, true)
+		return checkPodRunsOnGivenNode(clientset, []string{"ovn-db-pod=true"}, k8sNodeName, true)
 	})
 	if err != nil {
 		klog.Infof("Not registering OVN North Metrics because OVNKube Master Pod was not found running on this "+

--- a/helm/ovn-kubernetes/charts/ovnkube-db-raft/templates/statefulset.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-db-raft/templates/statefulset.yaml
@@ -21,11 +21,11 @@ spec:
   template:
     metadata:
       labels:
-        ovn-db-pod: "true"
         name: ovnkube-db
         component: network
         type: infra
         kubernetes.io/os: "linux"
+        ovn-db-pod: "true"
     spec:
       priorityClassName: "system-cluster-critical"
       terminationGracePeriodSeconds: 30

--- a/helm/ovn-kubernetes/charts/ovnkube-db/templates/deployment.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-db/templates/deployment.yaml
@@ -26,11 +26,11 @@ spec:
   template:
     metadata:
       labels:
-        ovn-db-pod: "true"
         name: ovnkube-db
         component: network
         type: infra
         kubernetes.io/os: "linux"
+        ovn-db-pod: "true"
     spec:
       priorityClassName: "system-cluster-critical"
       # Requires fairly broad permissions - ability to read all services and network functions as well

--- a/helm/ovn-kubernetes/charts/ovnkube-single-node-zone/templates/ovnkube-single-node-zone.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-single-node-zone/templates/ovnkube-single-node-zone.yaml
@@ -24,6 +24,7 @@ spec:
         component: network
         type: infra
         kubernetes.io/os: "linux"
+        ovn-db-pod: "true"
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:

--- a/helm/ovn-kubernetes/charts/ovnkube-zone-controller/templates/ovnkube-zone-controller.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-zone-controller/templates/ovnkube-zone-controller.yaml
@@ -24,6 +24,7 @@ spec:
         component: network
         type: infra
         kubernetes.io/os: "linux"
+        ovn-db-pod: "true"
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:


### PR DESCRIPTION
With IC, we are not registering northd metrics since there is no ovnkube-master pod. To fix, use `ovn-db-pod=true` label instead since in all our deployment models northd has been collocated with the DBs.

Signed-off-by: Jaime Caamaño Ruiz <jcaamano@redhat.com>
(cherry picked from commit d8c924f33cbaa5a5a8c507c8b759c0209da88496)

no conflicts.
