### PR TITLE
OCPBUGS-37541: Fix per-pod MCS/metadata blocking

### DIFF
--- a/go-controller/pkg/cni/OCP_HACKS.go
+++ b/go-controller/pkg/cni/OCP_HACKS.go
@@ -30,7 +30,7 @@ func doNFTablesRules(platformType string) error {
 	tx.Add(&knftables.Rule{
 		Chain: "block",
 		Rule: knftables.Concat(
-			"tcp dport { 22623, 22624 } tcp flags syn",
+			"tcp dport { 22623, 22624 } tcp flags syn / fin,syn,rst,ack",
 			"reject",
 		),
 	})


### PR DESCRIPTION
The conversion from former iptables rule to nftables rule failed to include further matching criteria [1][2].

TCP SYN-ACK packets from Pod in response to client-side initiating TCP connections on source ports :22623 and :22624 are being rejected.

[1] Commit 90696a9
[2] https://github.com/openshift/ovn-kubernetes/pull/1946/