### PR TITLE
[Release 4.14] OCPBUGS-43487: NP-1091: Backport SDN live migration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,6 +57,7 @@ COPY --from=builder /go/src/github.com/openshift/ovn-kubernetes/go-controller/_o
 COPY --from=builder /go/src/github.com/openshift/ovn-kubernetes/go-controller/_output/go/bin/windows/hybrid-overlay-node.exe /root/windows/
 COPY --from=builder /go/src/github.com/openshift/ovn-kubernetes/go-controller/_output/go/bin/ovndbchecker /usr/bin/
 COPY --from=builder /go/src/github.com/openshift/ovn-kubernetes/go-controller/_output/go/bin/ovnkube-trace /usr/bin/
+COPY --from=builder /go/src/github.com/openshift/ovn-kubernetes/go-controller/_output/go/bin/hybrid-overlay-node /usr/bin/
 
 # Copy RHEL-8 and RHEL-9 shim binaries where the CNO's ovnkube-node container startup script can find them
 RUN mkdir -p /usr/libexec/cni/rhel9

--- a/go-controller/hybrid-overlay/pkg/controller/node.go
+++ b/go-controller/hybrid-overlay/pkg/controller/node.go
@@ -60,7 +60,8 @@ func nodeChanged(old, new interface{}) bool {
 	newCidr, newNodeIP, newDrMAC, _ := getNodeDetails(newNode)
 
 	return !reflect.DeepEqual(oldCidr, newCidr) || !reflect.DeepEqual(oldNodeIP, newNodeIP) || !reflect.DeepEqual(oldDrMAC, newDrMAC) ||
-		!reflect.DeepEqual(newNode.Annotations[hotypes.HybridOverlayDRIP], oldNode.Annotations[hotypes.HybridOverlayDRIP])
+		!reflect.DeepEqual(newNode.Annotations[hotypes.HybridOverlayDRIP], oldNode.Annotations[hotypes.HybridOverlayDRIP]) ||
+		util.NoHostSubnet(oldNode) != util.NoHostSubnet(newNode)
 }
 
 // podChanged returns true if any relevant pod attributes changed

--- a/go-controller/hybrid-overlay/pkg/controller/node_linux.go
+++ b/go-controller/hybrid-overlay/pkg/controller/node_linux.go
@@ -16,6 +16,8 @@ import (
 // This controller is running in ovnkube-node binary. It's responsible for local
 // node configuration and annotation.
 type NodeController struct {
+	kube kube.Interface
+	sync.RWMutex
 	nodeName  string
 	initState hotypes.HybridInitState
 	drMAC     net.HardwareAddr

--- a/go-controller/pkg/clustermanager/node/node_allocator.go
+++ b/go-controller/pkg/clustermanager/node/node_allocator.go
@@ -91,7 +91,8 @@ func (na *NodeAllocator) Init() error {
 }
 
 func (na *NodeAllocator) hasHybridOverlayAllocation() bool {
-	return config.HybridOverlay.Enabled && !na.netInfo.IsSecondary()
+	// When config.HybridOverlay.ClusterSubnets is empty, assume the subnet allocation will be managed by an external component.
+	return config.HybridOverlay.Enabled && !na.netInfo.IsSecondary() && len(config.HybridOverlay.ClusterSubnets) > 0
 }
 
 func (na *NodeAllocator) recordSubnetCount() {

--- a/go-controller/pkg/ovn/controller/services/node_tracker.go
+++ b/go-controller/pkg/ovn/controller/services/node_tracker.go
@@ -112,13 +112,15 @@ func (nt *nodeTracker) Start(nodeInformer coreinformers.NodeInformer) (cache.Res
 			// - the name of the node (very rare) has changed
 			// - the `host-cidrs` annotation changed
 			// - node changes its zone
+			// - node becomes a hybrid overlay node from a ovn node or vice verse
 			// . No need to trigger update for any other field change.
 			if util.NodeSubnetAnnotationChanged(oldObj, newObj) ||
 				util.NodeL3GatewayAnnotationChanged(oldObj, newObj) ||
 				oldObj.Name != newObj.Name ||
 				util.NodeHostCIDRsAnnotationChanged(oldObj, newObj) ||
 				util.NodeZoneAnnotationChanged(oldObj, newObj) ||
-				util.NodeMigratedZoneAnnotationChanged(oldObj, newObj) {
+				util.NodeMigratedZoneAnnotationChanged(oldObj, newObj) ||
+				util.NoHostSubnet(oldObj) != util.NoHostSubnet(newObj) {
 				nt.updateNode(newObj)
 			}
 		},
@@ -202,9 +204,9 @@ func (nt *nodeTracker) removeNode(nodeName string) {
 func (nt *nodeTracker) updateNode(node *v1.Node) {
 	klog.V(2).Infof("Processing possible switch / router updates for node %s", node.Name)
 	hsn, err := util.ParseNodeHostSubnetAnnotation(node, types.DefaultNetworkName)
-	if err != nil || hsn == nil {
+	if err != nil || hsn == nil || util.NoHostSubnet(node) {
 		// usually normal; means the node's gateway hasn't been initialized yet
-		klog.Infof("Node %s has invalid / no HostSubnet annotations (probably waiting on initialization): %v", node.Name, err)
+		klog.Infof("Node %s has invalid / no HostSubnet annotations (probably waiting on initialization), or it's a hybrid overlay node: %v", node.Name, err)
 		nt.removeNode(node.Name)
 		return
 	}

--- a/go-controller/pkg/ovn/default_network_controller.go
+++ b/go-controller/pkg/ovn/default_network_controller.go
@@ -740,6 +740,16 @@ func (h *defaultNetworkControllerEventHandler) AddResource(obj interface{}, from
 			return fmt.Errorf("could not cast %T object to *kapi.Node", obj)
 		}
 		var aggregatedErrors []error
+		if config.HybridOverlay.Enabled {
+			if util.NoHostSubnet(node) {
+				return h.oc.addUpdateHoNodeEvent(node)
+			} else {
+				// clean possible remainings for a node that is used to be a HO node
+				if err := h.oc.deleteHoNodeEvent(node); err != nil {
+					return err
+				}
+			}
+		}
 		if h.oc.isLocalZoneNode(node) {
 			var nodeParams *nodeSyncs
 			if fromRetryLoop {
@@ -868,6 +878,19 @@ func (h *defaultNetworkControllerEventHandler) UpdateResource(oldObj, newObj int
 		if !ok {
 			return fmt.Errorf("could not cast oldObj of type %T to *kapi.Node", oldObj)
 		}
+		var switchToOvnNode bool
+		if config.HybridOverlay.Enabled {
+			if util.NoHostSubnet(newNode) && !util.NoHostSubnet(oldNode) {
+				klog.Infof("Node %s has been updated to be a remote/unmanaged hybrid overlay node", newNode.Name)
+				return h.oc.addUpdateHoNodeEvent(newNode)
+			} else if !util.NoHostSubnet(newNode) && util.NoHostSubnet(oldNode) {
+				klog.Infof("Node %s has been updated to be an ovn-kubernetes managed node", newNode.Name)
+				if err := h.oc.deleteHoNodeEvent(newNode); err != nil {
+					return err
+				}
+				switchToOvnNode = true
+			}
+		}
 
 		// +--------------------+-------------------+-------------------------------------------------+
 		// |    oldNode         |      newNode      |       Action                                    |
@@ -933,7 +956,8 @@ func (h *defaultNetworkControllerEventHandler) UpdateResource(oldObj, newObj int
 
 			// Check if the node moved from local zone to remote zone and if so syncZoneIC should be set to true.
 			// Also check if node subnet changed, so static routes are properly set
-			syncZoneIC = syncZoneIC || h.oc.isLocalZoneNode(oldNode) || nodeSubnetChanged || zoneClusterChanged || primaryAddrChanged(oldNode, newNode)
+			// Also check if the node is used to be a hybrid overlay node
+			syncZoneIC = syncZoneIC || h.oc.isLocalZoneNode(oldNode) || nodeSubnetChanged || zoneClusterChanged || primaryAddrChanged(oldNode, newNode) || switchToOvnNode
 			if syncZoneIC {
 				klog.Infof("Node %s in remote zone %s needs interconnect zone sync up. Zone cluster changed: %v",
 					newNode.Name, util.GetNodeZone(newNode), zoneClusterChanged)

--- a/go-controller/pkg/ovn/hybrid.go
+++ b/go-controller/pkg/ovn/hybrid.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"regexp"
 	"strings"
 	"sync/atomic"
 
@@ -369,7 +370,7 @@ func (oc *DefaultNetworkController) allocateHybridOverlayDRIP(node *kapi.Node) e
 	return nil
 }
 
-func (oc *DefaultNetworkController) removeRoutesToHONodeSubnet(nodeSubnet *net.IPNet) error {
+func (oc *DefaultNetworkController) removeRoutesToHONodeSubnet(nodeName string, nodeSubnet *net.IPNet) error {
 	klog.Infof("Delete hybrid overlay policy and static routes to %s", nodeSubnet.String())
 
 	// Delete policy to HO subnet from the cluster router
@@ -385,7 +386,10 @@ func (oc *DefaultNetworkController) removeRoutesToHONodeSubnet(nodeSubnet *net.I
 		if !ok {
 			return false
 		}
-		if !strings.Contains(name, ovntypes.HybridSubnetPrefix) || strings.Contains(name, ovntypes.HybridOverlayGRSubfix) {
+		// we delete all the static routes with name match 'hybrid-subnet-<ovn-node-name>:<ho-node-name>'
+		pattern := fmt.Sprintf("^%s.+:%s$", ovntypes.HybridSubnetPrefix, nodeName)
+		re, _ := regexp.Compile(pattern)
+		if !re.MatchString(name) {
 			return false
 		}
 		return item.IPPrefix == nodeSubnet.String() && item.Policy == nil

--- a/go-controller/pkg/ovn/hybrid.go
+++ b/go-controller/pkg/ovn/hybrid.go
@@ -1,11 +1,13 @@
 package ovn
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"strings"
 	"sync/atomic"
 
+	libovsdbclient "github.com/ovn-org/libovsdb/client"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/hybrid-overlay/pkg/types"
 	hotypes "github.com/ovn-org/ovn-kubernetes/go-controller/hybrid-overlay/pkg/types"
 	houtil "github.com/ovn-org/ovn-kubernetes/go-controller/hybrid-overlay/pkg/util"
@@ -93,7 +95,7 @@ func (oc *DefaultNetworkController) handleHybridOverlayPort(node *kapi.Node, ann
 	// we need to setup a reroute policy for hybrid overlay subnet
 	// this is so hybrid pod -> service -> hybrid endpoint will reroute to the DR IP
 	if err := oc.setupHybridLRPolicySharedGw(subnets, node.Name, portMAC, drIP); err != nil {
-		return fmt.Errorf("unable to setup Hybrid Subnet Logical Route Policy for node: %s, error: %v",
+		return fmt.Errorf("unable to setup Hybrid Subnet Logical Route Policy for node: %s, error: %w",
 			node.Name, err)
 	}
 
@@ -161,8 +163,10 @@ func (oc *DefaultNetworkController) setupHybridLRPolicySharedGw(nodeSubnets []*n
 				return err
 			}
 			for _, node := range nodes.Items {
-				if subnet, _ := houtil.ParseHybridOverlayHostSubnet(&node); subnet != nil {
-					hybridCIDRs = append(hybridCIDRs, subnet)
+				if util.NoHostSubnet(&node) {
+					if subnet, _ := houtil.ParseHybridOverlayHostSubnet(&node); subnet != nil {
+						hybridCIDRs = append(hybridCIDRs, subnet)
+					}
 				}
 			}
 		}
@@ -189,9 +193,10 @@ func (oc *DefaultNetworkController) setupHybridLRPolicySharedGw(nodeSubnets []*n
 
 			if err := libovsdbops.CreateOrUpdateLogicalRouterPolicyWithPredicate(oc.nbClient, ovntypes.OVNClusterRouter, &logicalRouterPolicy, func(item *nbdb.LogicalRouterPolicy) bool {
 				return item.Priority == logicalRouterPolicy.Priority &&
-					item.ExternalIDs["name"] == logicalRouterPolicy.ExternalIDs["name"]
+					item.ExternalIDs["name"] == logicalRouterPolicy.ExternalIDs["name"] &&
+					item.Match == matchStr
 			}, &logicalRouterPolicy.Nexthops, &logicalRouterPolicy.Match, &logicalRouterPolicy.Action); err != nil {
-				return fmt.Errorf("failed to add policy route '%s' for host %q on %s , error: %v", matchStr, nodeName, ovntypes.OVNClusterRouter, err)
+				return fmt.Errorf("failed to add policy route '%s' for host %q on %s , error: %w", matchStr, nodeName, ovntypes.OVNClusterRouter, err)
 			}
 
 			smb := &nbdb.StaticMACBinding{
@@ -218,7 +223,7 @@ func (oc *DefaultNetworkController) setupHybridLRPolicySharedGw(nodeSubnets []*n
 			grLogicalRouterPolicy := nbdb.LogicalRouterPolicy{
 				Priority: ovntypes.HybridOverlaySubnetPriority,
 				ExternalIDs: map[string]string{
-					"name": ovntypes.HybridSubnetPrefix + nodeName + "-gr",
+					"name": ovntypes.HybridSubnetPrefix + nodeName + ovntypes.HybridOverlayGRSubfix,
 				},
 				Action:   nbdb.LogicalRouterPolicyActionReroute,
 				Nexthops: []string{drIP.String()},
@@ -229,7 +234,7 @@ func (oc *DefaultNetworkController) setupHybridLRPolicySharedGw(nodeSubnets []*n
 				return item.Priority == grLogicalRouterPolicy.Priority &&
 					item.ExternalIDs["name"] == grLogicalRouterPolicy.ExternalIDs["name"]
 			}, &grLogicalRouterPolicy.Nexthops, &grLogicalRouterPolicy.Match, &grLogicalRouterPolicy.Action); err != nil {
-				return fmt.Errorf("failed to add policy route '%s' for host %q on %s , error: %v", matchStr, nodeName, ovntypes.OVNClusterRouter, err)
+				return fmt.Errorf("failed to add policy route '%s' for host %q on %s , error: %w", matchStr, nodeName, ovntypes.OVNClusterRouter, err)
 			}
 			klog.Infof("Created hybrid overlay logical route policies for node %s", nodeName)
 
@@ -249,7 +254,7 @@ func (oc *DefaultNetworkController) setupHybridLRPolicySharedGw(nodeSubnets []*n
 						item.ExternalIDs["name"] == clusterRouterStaticRoutes.ExternalIDs["name"] &&
 						libovsdbops.PolicyEqualPredicate(clusterRouterStaticRoutes.Policy, item.Policy)
 				}, &clusterRouterStaticRoutes.Nexthop); err != nil {
-				return fmt.Errorf("failed to add policy route static '%s %s' for on %s , error: %v",
+				return fmt.Errorf("failed to add policy route static '%s %s' for on %s , error: %w",
 					clusterRouterStaticRoutes.IPPrefix, clusterRouterStaticRoutes.Nexthop,
 					ovntypes.GWRouterPrefix+nodeName, err)
 			}
@@ -268,7 +273,7 @@ func (oc *DefaultNetworkController) setupHybridLRPolicySharedGw(nodeSubnets []*n
 				IPPrefix: hybridCIDR.String(),
 				Nexthop:  drLRPIfAddr.IP.String(),
 				ExternalIDs: map[string]string{
-					"name": ovntypes.HybridSubnetPrefix + nodeName + "-gr",
+					"name": ovntypes.HybridSubnetPrefix + nodeName + ovntypes.HybridOverlayGRSubfix,
 				},
 			}
 			if err := libovsdbops.CreateOrReplaceLogicalRouterStaticRouteWithPredicate(oc.nbClient,
@@ -278,7 +283,7 @@ func (oc *DefaultNetworkController) setupHybridLRPolicySharedGw(nodeSubnets []*n
 						item.ExternalIDs["name"] == nodeGWRouterStaticRoutes.ExternalIDs["name"] &&
 						libovsdbops.PolicyEqualPredicate(nodeGWRouterStaticRoutes.Policy, item.Policy)
 				}, &nodeGWRouterStaticRoutes.Nexthop); err != nil {
-				return fmt.Errorf("failed to add policy route static '%s %s' for on %s , error: %v",
+				return fmt.Errorf("failed to add policy route static '%s %s' for on %s , error: %w",
 					nodeGWRouterStaticRoutes.IPPrefix, nodeGWRouterStaticRoutes.Nexthop,
 					ovntypes.GWRouterPrefix+nodeName, err)
 			}
@@ -293,20 +298,20 @@ func (oc *DefaultNetworkController) removeHybridLRPolicySharedGW(node *kapi.Node
 	name := ovntypes.HybridSubnetPrefix + nodeName
 
 	if err := libovsdbops.DeleteLogicalRouterPoliciesWithPredicate(oc.nbClient, ovntypes.OVNClusterRouter, func(item *nbdb.LogicalRouterPolicy) bool {
-		return item.ExternalIDs["name"] == ovntypes.HybridSubnetPrefix+nodeName || item.ExternalIDs["name"] == ovntypes.HybridSubnetPrefix+nodeName+"-gr"
-	}); err != nil {
-		return fmt.Errorf("failed to delete policy %s from %s, error: %v", name, ovntypes.OVNClusterRouter, err)
+		return item.ExternalIDs["name"] == ovntypes.HybridSubnetPrefix+nodeName || item.ExternalIDs["name"] == ovntypes.HybridSubnetPrefix+nodeName+ovntypes.HybridOverlayGRSubfix
+	}); err != nil && !errors.Is(err, libovsdbclient.ErrNotFound) {
+		return fmt.Errorf("failed to delete policy %s from %s, error: %w", name, ovntypes.OVNClusterRouter, err)
 	}
 
 	if err := libovsdbops.DeleteLogicalRouterStaticRoutesWithPredicate(oc.nbClient, ovntypes.OVNClusterRouter, func(item *nbdb.LogicalRouterStaticRoute) bool {
 		return item.ExternalIDs["name"] == name
-	}); err != nil {
-		return fmt.Errorf("failed to delete static route %s from %s, error: %v", name, ovntypes.OVNClusterRouter, err)
+	}); err != nil && !errors.Is(err, libovsdbclient.ErrNotFound) {
+		return fmt.Errorf("failed to delete static route %s from %s, error: %w", name, ovntypes.OVNClusterRouter, err)
 	}
 	if err := libovsdbops.DeleteLogicalRouterStaticRoutesWithPredicate(oc.nbClient, ovntypes.GWRouterPrefix+nodeName, func(item *nbdb.LogicalRouterStaticRoute) bool {
-		return item.ExternalIDs["name"] == name+"-gr"
-	}); err != nil {
-		return fmt.Errorf("failed to delete static route %s from %s, error: %v", name+"gr", ovntypes.GWRouterPrefix+nodeName, err)
+		return item.ExternalIDs["name"] == name+ovntypes.HybridOverlayGRSubfix
+	}); err != nil && !errors.Is(err, libovsdbclient.ErrNotFound) {
+		return fmt.Errorf("failed to delete static route %s from %s, error: %w", name+"gr", ovntypes.GWRouterPrefix+nodeName, err)
 	}
 
 	if node.Annotations[hotypes.HybridOverlayDRIP] != "" {
@@ -351,5 +356,58 @@ func (oc *DefaultNetworkController) allocateHybridOverlayDRIP(node *kapi.Node) e
 		return fmt.Errorf("cannot set hybrid annotation on node %s: %v", node.Name, err)
 	}
 
+	return nil
+}
+
+func (oc *DefaultNetworkController) removeRoutesToHONodeSubnet(nodeSubnet *net.IPNet) error {
+	klog.Infof("Delete hybrid overlay policy and static routes to %s", nodeSubnet.String())
+
+	// Delete policy to HO subnet from the cluster router
+	if err := libovsdbops.DeleteLogicalRouterPoliciesWithPredicate(oc.nbClient, ovntypes.OVNClusterRouter, func(item *nbdb.LogicalRouterPolicy) bool {
+		return strings.Contains(item.Match, nodeSubnet.String())
+	}); err != nil && !errors.Is(err, libovsdbclient.ErrNotFound) {
+		return fmt.Errorf("failed to delete policy route to %s from %s, error: %w", nodeSubnet, ovntypes.OVNClusterRouter, err)
+	}
+
+	// Delete routes to HO subnet from the cluster router
+	if err := libovsdbops.DeleteLogicalRouterStaticRoutesWithPredicate(oc.nbClient, ovntypes.OVNClusterRouter, func(item *nbdb.LogicalRouterStaticRoute) bool {
+		name, ok := item.ExternalIDs["name"]
+		if !ok {
+			return false
+		}
+		if !strings.Contains(name, ovntypes.HybridSubnetPrefix) || strings.Contains(name, ovntypes.HybridOverlayGRSubfix) {
+			return false
+		}
+		return item.IPPrefix == nodeSubnet.String() && item.Policy == nil
+	}); err != nil && !errors.Is(err, libovsdbclient.ErrNotFound) {
+		return fmt.Errorf("failed to delete static route to %s from %s, error: %w", nodeSubnet, ovntypes.OVNClusterRouter, err)
+	}
+
+	// Delete routes to HO subnet from GRs
+	nodes, err := oc.kube.GetNodes()
+	if err != nil {
+		return err
+	}
+	for _, node := range nodes.Items {
+		// Check existence of Gateway Router before removing the static route from it.
+		if _, err := libovsdbops.GetLogicalRouter(oc.nbClient, &nbdb.LogicalRouter{Name: ovntypes.GWRouterPrefix + node.Name}); err != nil {
+			if err == libovsdbclient.ErrNotFound {
+				continue
+			}
+			return fmt.Errorf("failed to get logical router %s, error: %w", ovntypes.GWRouterPrefix+node.Name, err)
+		}
+		if err := libovsdbops.DeleteLogicalRouterStaticRoutesWithPredicate(oc.nbClient, ovntypes.GWRouterPrefix+node.Name, func(item *nbdb.LogicalRouterStaticRoute) bool {
+			name, ok := item.ExternalIDs["name"]
+			if !ok {
+				return false
+			}
+			if name != ovntypes.HybridSubnetPrefix+node.Name+ovntypes.HybridOverlayGRSubfix {
+				return false
+			}
+			return item.IPPrefix == nodeSubnet.String() && item.Policy == nil
+		}); err != nil && !errors.Is(err, libovsdbclient.ErrNotFound) {
+			return fmt.Errorf("failed to delete static route to %s from %s, error: %w", nodeSubnet, ovntypes.GWRouterPrefix+node.Name, err)
+		}
+	}
 	return nil
 }

--- a/go-controller/pkg/ovn/hybrid_test.go
+++ b/go-controller/pkg/ovn/hybrid_test.go
@@ -1357,7 +1357,7 @@ var _ = ginkgo.Describe("Hybrid SDN Master Operations", func() {
 			gomega.Eventually(func() ([]*nbdb.LogicalRouterStaticRoute, error) {
 				p := func(item *nbdb.LogicalRouterStaticRoute) bool {
 					if item.ExternalIDs["name"] == "hybrid-subnet-node1-gr" ||
-						strings.Contains(item.ExternalIDs["name"], "hybrid-subnet-node1") {
+						item.ExternalIDs["name"] == "hybrid-subnet-node1:node-windows" {
 						return true
 					}
 					return false

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -1062,7 +1062,7 @@ func (oc *DefaultNetworkController) deleteHoNodeEvent(node *kapi.Node) error {
 		if err != nil {
 			return fmt.Errorf("failed to parse hybridOverlay node subnet for node %s: %w", node.Name, err)
 		}
-		err = oc.removeRoutesToHONodeSubnet(nodeSubnet)
+		err = oc.removeRoutesToHONodeSubnet(node.Name, nodeSubnet)
 		if err != nil {
 			return fmt.Errorf("failed to remove hybrid overlay static routes and route policy: %w", err)
 		}

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -78,6 +78,7 @@ const (
 	// ovnNodeGRLRPAddr is the CIDR form representation of Gate Router LRP IP address to join switch (i.e: 100.64.0.5/24)
 	ovnNodeGRLRPAddr     = "k8s.ovn.org/node-gateway-router-lrp-ifaddr"
 	ovnNodePrimaryIfAddr = "k8s.ovn.org/node-primary-ifaddr"
+	ovnNodeSubnets       = "k8s.ovn.org/node-subnets"
 )
 
 func (n tNode) k8sNode(nodeID string) v1.Node {
@@ -1518,11 +1519,12 @@ var _ = ginkgo.Describe("Default network controller operations", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 
-	ginkgo.It("use node retry for a node without a host subnet", func() {
+	ginkgo.It("use node retry for an unmanaged hybrid overlay node node", func() {
 		app.Action = func(ctx *cli.Context) error {
 			_, err := config.InitConfig(ctx, nil, nil)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			// Don't create clusterManager so that the node has not subnets allocated.
+			config.HybridOverlay.Enabled = true
 
 			config.Kubernetes.NoHostSubnetNodes = &metav1.LabelSelector{
 				MatchLabels: nodeNoHostSubnetAnnotation(),
@@ -1531,9 +1533,10 @@ var _ = ginkgo.Describe("Default network controller operations", func() {
 			gomega.Expect(
 				oc.retryNodes.ResourceHandler.AddResource(
 					&testNode, false)).To(
-				gomega.MatchError(
-					"[nodeAdd: error adding node \"node1\": could not find \"k8s.ovn.org/node-subnets\" annotation, error parsing annotation for node node1: could not find \"k8s.ovn.org/node-subnets\" annotation]"))
-			ginkgo.By("annotating the node with no host subnet")
+				gomega.MatchError(gomega.ContainSubstring(
+					"nodeAdd: error adding node \"node1\": could not find \"k8s.ovn.org/node-subnets\" annotation")))
+
+			ginkgo.By("labeling the node to a hybrid overlay node")
 			testNode.Labels = nodeNoHostSubnetAnnotation()
 			_, err = fakeClient.KubeClient.CoreV1().Nodes().Update(context.TODO(), &testNode, metav1.UpdateOptions{})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())

--- a/go-controller/pkg/ovn/namespace.go
+++ b/go-controller/pkg/ovn/namespace.go
@@ -328,6 +328,10 @@ func (oc *DefaultNetworkController) getAllHostNamespaceAddresses() []net.IP {
 	} else {
 		ips = make([]net.IP, 0, len(existingNodes))
 		for _, node := range existingNodes {
+			if config.HybridOverlay.Enabled && util.NoHostSubnet(node) {
+				// skip hybrid overlay nodes
+				continue
+			}
 			hostNetworkIPs, err := oc.getHostNamespaceAddressesForNode(node)
 			if err != nil {
 				klog.Errorf("Error parsing annotation for node %s: %v", node.Name, err)

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -124,6 +124,12 @@ func (oc *DefaultNetworkController) ensurePod(oldPod, pod *kapi.Pod, addPort boo
 		return nil
 	}
 
+	// skip the pods on no host subnet nodes
+	switchName := pod.Spec.NodeName
+	if oc.lsManager.IsNonHostSubnetSwitch(switchName) {
+		return nil
+	}
+
 	if oc.isPodScheduledinLocalZone(pod) {
 		klog.V(5).Infof("Ensuring zone local for Pod %s/%s in node %s", pod.Namespace, pod.Name, pod.Spec.NodeName)
 		return oc.ensureLocalZonePod(oldPod, pod, addPort)
@@ -420,10 +426,6 @@ func shouldUpdateNode(node, oldNode *kapi.Node) (bool, error) {
 
 	if oldNoHostSubnet && newNoHostSubnet {
 		return false, nil
-	} else if oldNoHostSubnet && !newNoHostSubnet {
-		return false, fmt.Errorf("error updating node %s, cannot remove assigned hostsubnet, please delete node and recreate.", node.Name)
-	} else if !oldNoHostSubnet && newNoHostSubnet {
-		return false, fmt.Errorf("error updating node %s, cannot assign a hostsubnet to already created node, please delete node and recreate.", node.Name)
 	}
 
 	return true, nil

--- a/go-controller/pkg/types/const.go
+++ b/go-controller/pkg/types/const.go
@@ -4,9 +4,10 @@ import "time"
 
 const (
 	// Default network name
-	DefaultNetworkName  = "default"
-	K8sPrefix           = "k8s-"
-	HybridOverlayPrefix = "int-"
+	DefaultNetworkName    = "default"
+	K8sPrefix             = "k8s-"
+	HybridOverlayPrefix   = "int-"
+	HybridOverlayGRSubfix = "-gr"
 
 	// K8sMgmtIntfName name to be used as an OVS internal port on the node
 	K8sMgmtIntfName = "ovn-k8s-mp0"


### PR DESCRIPTION
This PR cherry-picked the following commits for master

No conflicts

- 6dd663235 Use more exact name match when deleting static routes to HO nodes.
- 0de2919b7 Add hybrid-overlay-node binary to the container image
- 2d44a24dd Use unique name for hybrid overlay per node router static routes and policies

Resolved conflicts manually
- aeb9817f5 Allow a node switching between OVN node and hybrid overlay node
- `func (n *NodeController) AddNode(node *kapi.Node) error` in `pkg\ovn\default_network_controller.go`
- `pkg/ovn/master.go`
