### PR TITLE
OCPBUGS-38699,OCPBUGS-38704: EgressIP VRF support & ignore localnet patch ports when bootstrapping

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -182,6 +182,13 @@ jobs:
         cache-dependency-path: "**/*.sum"
       id: go
 
+    - name: Install VRF kernel module
+      if: steps.is_pr_image_build_needed.outputs.PR_IMAGE_RESTORED != 'true' && success()
+      run: |
+        set -x
+        sudo apt-get install linux-modules-extra-$(uname -r) -y
+        sudo modprobe vrf
+
     - name: Build and Test - from current pr branch
       if: steps.is_pr_image_build_needed.outputs.PR_IMAGE_RESTORED != 'true' && success()
       run: |
@@ -447,6 +454,12 @@ jobs:
       OVN_DISABLE_FORWARDING: "${{ matrix.forwarding == 'disable-forwarding' }}"
       USE_HELM: "${{ matrix.target == 'control-plane-helm' }}"
     steps:
+
+    - name: Install VRF kernel module
+      run: |
+        set -x
+        sudo apt-get install linux-modules-extra-$(uname -r) -y
+        sudo modprobe vrf
 
     - name: Free up disk space
       run: |

--- a/docs/features/cluster-egress-controls/egress-ip.md
+++ b/docs/features/cluster-egress-controls/egress-ip.md
@@ -130,6 +130,8 @@ And the default route in the correct table `1111`:
 sh-5.2# ip route show table 1111
 default dev dummy
 ```
+Routes associated with the egress interface are copied from the main routing table to the routing table that was created to support EgressIP, as shown above.
+If the interface is enslaved to a VRF device, routes are copied from the VRF interfaces associated routing table.
 
 No NAT is required on the OVN primary network gateway router.
 OVN-Kubernetes (ovnkube-node) takes care of adding a rule to the rule table with src IP of the pod and routed towards a

--- a/go-controller/pkg/node/controllers/egressip/egressip.go
+++ b/go-controller/pkg/node/controllers/egressip/egressip.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net"
 	"net/netip"
+	"reflect"
 	"strings"
 	"sync"
 	"time"
@@ -623,12 +624,28 @@ func generateEIPConfig(link netlink.Link, eIPNet *net.IPNet, isEIPV6 bool) (*eIP
 }
 
 func generateRoutesForLink(link netlink.Link, isV6 bool) ([]netlink.Route, error) {
-	linkRoutes, err := netlink.RouteList(link, util.GetIPFamily(isV6))
+	routeTable := 254 // main table number
+	// check if device is a slave to a VRF device and if so, use VRF devices associated routing table to lookup routes instead of main table
+	if isVRFSlaveDevice(link) {
+		vrfLink, err := util.GetNetLinkOps().LinkByIndex(link.Attrs().MasterIndex)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get VRF link from interface index %d: %w", link.Attrs().MasterIndex, err)
+		}
+		vrf, ok := vrfLink.(*netlink.Vrf)
+		if !ok {
+			actualType := reflect.TypeOf(vrfLink)
+			return nil, fmt.Errorf("expected link %s to be type VRF, instead received type %s", vrfLink.Attrs().Name, actualType)
+		}
+		routeTable = int(vrf.Table)
+	}
+	filterRoute, filterMask := filterRouteByLinkTable(link.Attrs().Index, routeTable)
+	linkRoutes, err := util.GetNetLinkOps().RouteListFiltered(util.GetIPFamily(isV6), filterRoute, filterMask)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get routes for link %s: %v", link.Attrs().Name, err)
 	}
 	linkRoutes = ensureAtLeastOneDefaultRoute(linkRoutes, link.Attrs().Index, isV6)
 	overwriteRoutesTableID(linkRoutes, getRouteTableID(link.Attrs().Index))
+	clearSrcFromRoutes(linkRoutes)
 	return linkRoutes, nil
 }
 
@@ -1324,6 +1341,12 @@ func getRouteTableID(ifIndex int) int {
 	return ifIndex + routingTableIDStart
 }
 
+func clearSrcFromRoutes(routes []netlink.Route) {
+	for i := range routes {
+		routes[i].Src = nil
+	}
+}
+
 func findLinkOnSameNetworkAsIP(ip net.IP, v4, v6 bool) (bool, netlink.Link, error) {
 	found, link, err := findLinkOnSameNetworkAsIPUsingLPM(ip, v4, v6)
 	if err != nil {
@@ -1513,4 +1536,8 @@ func getNodeIPFwMarkIPRule(ipFamily int) netlink.Rule {
 	r.Table = 254 // main
 	r.Family = ipFamily
 	return *r
+}
+
+func isVRFSlaveDevice(link netlink.Link) bool {
+	return link.Attrs().Slave != nil && link.Attrs().Slave.SlaveType() == "vrf"
 }

--- a/go-controller/pkg/node/controllers/egressip/egressip_test.go
+++ b/go-controller/pkg/node/controllers/egressip/egressip_test.go
@@ -229,6 +229,29 @@ func setupFakeTestNode(nodeInitialState nodeConfig) (ns.NetNS, cleanupFn, error)
 	return testNS, cleanupFn, nil
 }
 
+func createVRFAndEnslaveLink(testNS ns.NetNS, linkName, vrfName string, vrfTable uint32) error {
+	vrfLink := &netlink.Vrf{
+		LinkAttrs: netlink.LinkAttrs{Name: vrfName},
+		Table:     vrfTable,
+	}
+	return testNS.Do(func(netNS ns.NetNS) error {
+		if err := netlink.LinkAdd(vrfLink); err != nil {
+			return fmt.Errorf("failed to create VRF link %s and table ID %d: %v", vrfName, vrfTable, err)
+		}
+		if err := netlink.LinkSetUp(vrfLink); err != nil {
+			return fmt.Errorf("failed to set VRF link %s up: %v", vrfName, err)
+		}
+		slaveLink, err := netlink.LinkByName(linkName)
+		if err != nil {
+			return fmt.Errorf("failed to get link %s: %v", linkName, err)
+		}
+		if err = netlink.LinkSetMaster(slaveLink, vrfLink); err != nil {
+			return fmt.Errorf("failed to set link %s master to link %s: %v", linkName, vrfName, err)
+		}
+		return nil
+	})
+}
+
 func initController(namespaces []corev1.Namespace, pods []corev1.Pod, egressIPs []egressipv1.EgressIP, node nodeConfig, v4, v6, createEIPAnnot bool) (*Controller, *egressipfake.Clientset, error) {
 
 	kubeClient := fake.NewSimpleClientset(&corev1.NodeList{Items: []corev1.Node{getNodeObj(node, createEIPAnnot)}},
@@ -353,10 +376,10 @@ func runController(testNS ns.NetNS, c *Controller) (cleanupFn, error) {
 	}
 
 	cleanupFn := func() error {
-		close(stopCh)
 		c.eIPQueue.ShutDown()
 		c.podQueue.ShutDown()
 		c.namespaceQueue.ShutDown()
+		close(stopCh)
 		wg.Wait()
 		return nil
 	}
@@ -697,7 +720,7 @@ var _ = table.DescribeTable("EgressIP selectors",
 			{
 				newEgressIP(egressIP1Name, egressIP1IPV4, node1Name, namespace1Label, egressPodLabel),
 				[]netlink.Route{getDefaultIPv4Route(getLinkIndex(dummyLink1Name)),
-					getDstWithSrcRoute(getLinkIndex(dummyLink1Name), dummy1IPv4CIDRNetwork, dummy1IPv4)},
+					getDstRoute(getLinkIndex(dummyLink1Name), dummy1IPv4CIDRNetwork)},
 				getNetlinkAddr(egressIP1IPV4, egressIPv4Mask),
 				dummyLink1Name,
 				[]testPodConfig{
@@ -772,7 +795,7 @@ var _ = table.DescribeTable("EgressIP selectors",
 			{
 				newEgressIP(egressIP1Name, egressIP1IPV4, node1Name, namespace1Label, egressPodLabel),
 				[]netlink.Route{getDefaultIPv4Route(getLinkIndex(dummyLink1Name)),
-					getDstWithSrcRoute(getLinkIndex(dummyLink1Name), dummy1IPv4CIDRNetwork, dummy1IPv4)},
+					getDstRoute(getLinkIndex(dummyLink1Name), dummy1IPv4CIDRNetwork)},
 				getNetlinkAddr(egressIP1IPV4, egressIPv4Mask),
 				dummyLink1Name,
 				[]testPodConfig{
@@ -836,7 +859,7 @@ var _ = table.DescribeTable("EgressIP selectors",
 			{
 				newEgressIP(egressIP1Name, egressIP1IPV4, node1Name, namespace1Label, egressPodLabel),
 				[]netlink.Route{getDefaultIPv4Route(getLinkIndex(dummyLink1Name)),
-					getDstWithSrcRoute(getLinkIndex(dummyLink1Name), dummy1IPv4CIDRNetwork, dummy1IPv4)},
+					getDstRoute(getLinkIndex(dummyLink1Name), dummy1IPv4CIDRNetwork)},
 				getNetlinkAddr(egressIP1IPV4, egressIPv4Mask),
 				dummyLink1Name,
 				[]testPodConfig{
@@ -902,7 +925,7 @@ var _ = table.DescribeTable("EgressIP selectors",
 			{
 				newEgressIP(egressIP1Name, egressIP1IPV4, node1Name, namespace1Label, egressPodLabel),
 				[]netlink.Route{getDefaultIPv4Route(getLinkIndex(dummyLink1Name)),
-					getDstWithSrcRoute(getLinkIndex(dummyLink1Name), dummy1IPv4CIDRNetwork, dummy1IPv4)},
+					getDstRoute(getLinkIndex(dummyLink1Name), dummy1IPv4CIDRNetwork)},
 				getNetlinkAddr(egressIP1IPV4, egressIPv4Mask),
 				dummyLink1Name,
 				[]testPodConfig{
@@ -921,7 +944,7 @@ var _ = table.DescribeTable("EgressIP selectors",
 			{
 				newEgressIP(egressIP2Name, egressIP2IPV4, node1Name, namespace2Label, egressPodLabel),
 				[]netlink.Route{getDefaultIPv4Route(getLinkIndex(dummyLink2Name)),
-					getDstWithSrcRoute(getLinkIndex(dummyLink2Name), dummy2IPv4CIDRNetwork, dummy2IPv4)},
+					getDstRoute(getLinkIndex(dummyLink2Name), dummy2IPv4CIDRNetwork)},
 				getNetlinkAddr(egressIP2IPV4, egressIPv4Mask),
 				dummyLink2Name,
 				[]testPodConfig{
@@ -1067,6 +1090,51 @@ var _ = ginkgo.Describe("label to annotations migration", func() {
 	ginkgo.AfterEach(func() {
 		defer runtime.UnlockOSThread()
 		gomega.Expect(cleanupFn()).Should(gomega.Succeed())
+	})
+})
+
+var _ = ginkgo.Describe("VRF", func() {
+	ginkgo.It("copies routes from the VRF routing table for a link enslaved by VRF device", func() {
+		defer ginkgo.GinkgoRecover()
+		if os.Getenv("NOROOT") == "TRUE" {
+			ginkgo.Skip("Test requires root privileges")
+		}
+		vrfName := "vrf-dummy"
+		var vrfTable uint32 = 55555
+		ginkgo.By("setup link")
+		nodeConfig := nodeConfig{routes: []netlink.Route{}, linkConfigs: []linkConfig{
+			{dummyLink1Name, []address{{dummy1IPv4CIDR, false}}},
+		}}
+		testNS, cleanupNodeFn, err := setupFakeTestNode(nodeConfig)
+		gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "fake node setup should succeed")
+		ginkgo.By("create VRF and add link")
+		gomega.Expect(createVRFAndEnslaveLink(testNS, dummyLink1Name, vrfName, vrfTable)).Should(gomega.Succeed())
+		ginkgo.By("add route to routing table associated with VRF")
+		vrfRoute := getDstRouteForTable(getLinkIndex(dummyLink1Name), int(vrfTable), dummy3IPv4CIDR)
+		gomega.Expect(testNS.Do(func(netNS ns.NetNS) error {
+			return netlink.RouteAdd(&vrfRoute)
+		})).Should(gomega.Succeed())
+		egressIPList := []egressipv1.EgressIP{*newEgressIP(egressIP1Name, egressIP1IPV4, node1Name, namespace1Label, egressPodLabel)}
+		pods := []corev1.Pod{newPodWithLabels(namespace1, pod1Name, node1Name, pod1IPv4, egressPodLabel)}
+		namespaces := []corev1.Namespace{newNamespaceWithLabels(namespace1, namespace1Label)}
+		ginkgo.By("start controller")
+		c, _, err := initController(namespaces, pods, egressIPList, nodeConfig, true, false, true)
+		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+		cleanupControllerFn, err := runController(testNS, c)
+		ginkgo.By("ensure route previously added is copied to new routing table")
+		eipTable := getRouteTableID(getLinkIndex(dummyLink1Name))
+		gomega.Eventually(func() bool {
+			eipRoutes, err := getRoutesFromTable(testNS, eipTable, netlink.FAMILY_V4)
+			gomega.Expect(err).Should(gomega.Succeed())
+			for _, eipRoute := range eipRoutes {
+				if eipRoute.Dst.String() == vrfRoute.Dst.String() {
+					return true
+				}
+			}
+			return false
+		}).Should(gomega.BeTrue(), "route should be copied to new routing table")
+		gomega.Expect(cleanupControllerFn()).ShouldNot(gomega.HaveOccurred())
+		gomega.Expect(cleanupNodeFn()).ShouldNot(gomega.HaveOccurred())
 	})
 })
 
@@ -1415,7 +1483,7 @@ func getRoutesForLinkFromTable(testNS ns.NetNS, linkName string) ([]netlink.Rout
 		if err != nil {
 			return err
 		}
-		filterRoute, filterMask := filterRouteByTable(link.Attrs().Index, getRouteTableID(link.Attrs().Index))
+		filterRoute, filterMask := filterRouteByLinkTable(link.Attrs().Index, getRouteTableID(link.Attrs().Index))
 		routes, err = netlink.RouteListFiltered(netlink.FAMILY_ALL, filterRoute, filterMask)
 		if err != nil {
 			return err
@@ -1425,12 +1493,25 @@ func getRoutesForLinkFromTable(testNS ns.NetNS, linkName string) ([]netlink.Rout
 	return routes, err
 }
 
-func filterRouteByTable(linkIndex, table int) (*netlink.Route, uint64) {
+func getRoutesFromTable(testNS ns.NetNS, table, family int) ([]netlink.Route, error) {
+	var err error
+	var routes []netlink.Route
+	err = testNS.Do(func(netNS ns.NetNS) error {
+		filterRoute, filterMask := filterRouteByTable(table)
+		routes, err = netlink.RouteListFiltered(family, filterRoute, filterMask)
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+	return routes, err
+}
+
+func filterRouteByTable(table int) (*netlink.Route, uint64) {
 	return &netlink.Route{
-			LinkIndex: linkIndex,
-			Table:     table,
+			Table: table,
 		},
-		netlink.RT_FILTER_OIF | netlink.RT_FILTER_TABLE
+		netlink.RT_FILTER_TABLE
 }
 
 func newEgressIPMeta(name string) metav1.ObjectMeta {
@@ -1549,6 +1630,11 @@ func getDefaultIPv6Route(linkIndex int) netlink.Route {
 }
 
 func getDstRoute(linkIndex int, dst string) netlink.Route {
+	return getDstRouteForTable(linkIndex, getRouteTableID(linkIndex), dst)
+
+}
+
+func getDstRouteForTable(linkIndex, table int, dst string) netlink.Route {
 	_, dstIPNet, err := net.ParseCIDR(dst)
 	if err != nil {
 		panic(err.Error())

--- a/go-controller/pkg/node/default_node_network_controller.go
+++ b/go-controller/pkg/node/default_node_network_controller.go
@@ -701,7 +701,7 @@ func (nc *DefaultNodeNetworkController) Start(ctx context.Context) error {
 	}()
 
 	// Bootstrap flows in OVS if just normal flow is present
-	if err := bootstrapOVSFlows(); err != nil {
+	if err := bootstrapOVSFlows(nc.name); err != nil {
 		return fmt.Errorf("failed to bootstrap OVS flows: %w", err)
 	}
 

--- a/go-controller/pkg/node/linkmanager/link_network_manager.go
+++ b/go-controller/pkg/node/linkmanager/link_network_manager.go
@@ -138,7 +138,13 @@ func (c *Controller) DelAddress(address netlink.Addr) error {
 		return fmt.Errorf("address (%s) is not valid", address.String())
 	}
 	link, err := util.GetNetLinkOps().LinkByIndex(address.LinkIndex)
-	if err != nil && !util.GetNetLinkOps().IsLinkNotFoundError(err) {
+	if err != nil {
+		if util.GetNetLinkOps().IsLinkNotFoundError(err) {
+			c.mu.Lock()
+			c.delLinkFromStoreByIndex(address.LinkIndex)
+			c.mu.Unlock()
+			return nil
+		}
 		return fmt.Errorf("no valid link associated with addresses %s: %v", address.String(), err)
 	}
 	klog.Infof("Link manager: deleting address %s from link %s", address.String(), link.Attrs().Name)
@@ -245,7 +251,26 @@ func (c *Controller) delAddressFromStore(linkName string, address netlink.Addr) 
 			temp = append(temp, addressSaved)
 		}
 	}
-	c.store[linkName] = temp
+	if len(temp) == 0 {
+		delete(c.store, linkName)
+	} else {
+		c.store[linkName] = temp
+	}
+}
+
+func (c *Controller) delLinkFromStoreByIndex(linkToDelIndex int) {
+	var linkNameToDelete string
+	for linkName, addresses := range c.store {
+		if len(addresses) > 0 {
+			if linkToDelIndex == addresses[0].LinkIndex {
+				linkNameToDelete = linkName
+				break
+			}
+		}
+	}
+	if linkNameToDelete != "" {
+		delete(c.store, linkNameToDelete)
+	}
 }
 
 func (c *Controller) isAddressValid(address netlink.Addr) bool {

--- a/go-controller/pkg/node/openflow_manager.go
+++ b/go-controller/pkg/node/openflow_manager.go
@@ -254,7 +254,7 @@ func checkPorts(patchIntf, ofPortPatch, physIntf, ofPortPhys string) error {
 
 // bootstrapOVSFlows handles ensuring basic, required flows are in place. This is done before OpenFlow manager has
 // been created/started, and only done when there is just a NORMAL flow programmed and OVN/OVS is already setup
-func bootstrapOVSFlows() error {
+func bootstrapOVSFlows(nodeName string) error {
 	// see if patch port exists already
 	var portsOutput string
 	var stderr string
@@ -267,8 +267,11 @@ func bootstrapOVSFlows() error {
 
 	var bridge string
 	var patchPort string
-	// patch-br-int-to-<bridge name>_<node>
-	r := regexp.MustCompile("^patch-(.*)_.*?-to-br-int$")
+	// This needs to work with:
+	// - default network: patch-<bridge name>_<node>-to-br-int
+	// but not with:
+	// - secondary network: patch-<bridge name>_<node>-to-br-int
+	r := regexp.MustCompile(fmt.Sprintf("^patch-([^_]*)_%s-to-br-int$", nodeName))
 	for _, line := range strings.Split(portsOutput, "\n") {
 		matches := r.FindStringSubmatch(line)
 		if len(matches) == 2 {

--- a/go-controller/pkg/node/openflow_manager.go
+++ b/go-controller/pkg/node/openflow_manager.go
@@ -265,21 +265,7 @@ func bootstrapOVSFlows(nodeName string) error {
 		return fmt.Errorf("failed to list ports on existing bridge br-int: %s, %w", stderr, err)
 	}
 
-	var bridge string
-	var patchPort string
-	// This needs to work with:
-	// - default network: patch-<bridge name>_<node>-to-br-int
-	// but not with:
-	// - secondary network: patch-<bridge name>_<node>-to-br-int
-	r := regexp.MustCompile(fmt.Sprintf("^patch-([^_]*)_%s-to-br-int$", nodeName))
-	for _, line := range strings.Split(portsOutput, "\n") {
-		matches := r.FindStringSubmatch(line)
-		if len(matches) == 2 {
-			patchPort = matches[0]
-			bridge = matches[1]
-			break
-		}
-	}
+	bridge, patchPort := localnetPortInfo(nodeName, portsOutput)
 
 	if len(bridge) == 0 {
 		// bridge exists but no patch port was found
@@ -341,4 +327,22 @@ func bootstrapOVSFlows(nodeName string) error {
 	}
 
 	return nil
+}
+
+// localnetPortInfo returns the name of the bridge and the patch port name for the default cluster network
+func localnetPortInfo(nodeName string, portsOutput string) (string, string) {
+	// This needs to work with:
+	// - default network: patch-<bridge name>_<node>-to-br-int
+	// but not with:
+	// - user defined primary network: patch-<bridge name>_<network-name>_<node>-to-br-int
+	// - user defined secondary localnet network: patch-<bridge name>_<network-name>_ovn_localnet_port-to-br-int
+	// TODO: going forward, maybe it would preferable to just read the bridge name from the config.
+	r := regexp.MustCompile(fmt.Sprintf("^patch-([^_]*)_%s-to-br-int$", nodeName))
+	for _, line := range strings.Split(portsOutput, "\n") {
+		matches := r.FindStringSubmatch(line)
+		if len(matches) == 2 {
+			return matches[1], matches[0]
+		}
+	}
+	return "", ""
 }

--- a/go-controller/pkg/node/openflow_manager_test.go
+++ b/go-controller/pkg/node/openflow_manager_test.go
@@ -1,0 +1,79 @@
+package node
+
+import "testing"
+
+func TestOpenFlowManagerDefaultNetOVSBridgeFinder(t *testing.T) {
+	const nodeName = "multi-homing-worker-0.maiqueb.org"
+
+	testCases := []struct {
+		name                  string
+		desc                  string
+		inputPortInfo         string
+		expectedBridgeName    string
+		expectedPatchPortName string
+	}{
+		{
+			name:                  "empty input ports",
+			inputPortInfo:         "",
+			expectedBridgeName:    "",
+			expectedPatchPortName: "",
+		},
+		{
+			name:                  "input ports without patch ports",
+			inputPortInfo:         "port1",
+			expectedBridgeName:    "",
+			expectedPatchPortName: "",
+		},
+		{
+			name: "input ports with a patch port",
+			inputPortInfo: `
+port1
+port2
+patch-br-ex_multi-homing-worker-0.maiqueb.org-to-br-int`,
+			expectedBridgeName:    "br-ex",
+			expectedPatchPortName: "patch-br-ex_multi-homing-worker-0.maiqueb.org-to-br-int",
+		},
+		{
+			name: "input ports with a patch port for a localnet network",
+			inputPortInfo: `
+port1
+port2
+patch-vlan2003_ovn_localnet_port-to-br-int`,
+			expectedBridgeName:    "",
+			expectedPatchPortName: "",
+		},
+		{
+			name: "input ports with a patch port for the default network and a localnet",
+			inputPortInfo: `
+port1
+port2
+patch-vlan2003_ovn_localnet_port-to-br-int
+patch-br-ex_multi-homing-worker-0.maiqueb.org-to-br-int`,
+			expectedBridgeName:    "br-ex",
+			expectedPatchPortName: "patch-br-ex_multi-homing-worker-0.maiqueb.org-to-br-int",
+		},
+		{
+			name: "input ports with a patch port for the default network, a localnet, and an extra primary UDN",
+			inputPortInfo: `
+port1
+port2
+patch-vlan2003_ovn_localnet_port-to-br-int
+patch-br-ex_tenant-blue_multi-homing-worker-0.maiqueb.org-to-br-int
+patch-br-ex_multi-homing-worker-0.maiqueb.org-to-br-int`,
+			expectedBridgeName:    "br-ex",
+			expectedPatchPortName: "patch-br-ex_multi-homing-worker-0.maiqueb.org-to-br-int",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			bridgeName, patchPortName := localnetPortInfo(nodeName, tc.inputPortInfo)
+			if bridgeName != tc.expectedBridgeName {
+				t.Errorf("Expected bridge name %q got %q", tc.expectedBridgeName, bridgeName)
+			}
+			if patchPortName != tc.expectedPatchPortName {
+				t.Errorf("Expected patch port name %q got %q", tc.expectedPatchPortName, patchPortName)
+			}
+		})
+	}
+}

--- a/go-controller/pkg/node/routemanager/route_manager.go
+++ b/go-controller/pkg/node/routemanager/route_manager.go
@@ -273,6 +273,7 @@ func (c *Controller) sync() {
 				link, err := util.GetNetLinkOps().LinkByIndex(managedRoute.LinkIndex)
 				if err != nil {
 					klog.Errorf("Route Manager: failed to apply route (%s) because unable to retrieve associated link: %v", managedRoute.String(), err)
+					continue
 				}
 				if err := c.applyRoute(link, managedRoute.Gw, managedRoute.Dst, managedRoute.MTU, managedRoute.Src, managedRoute.Table); err != nil {
 					klog.Errorf("Route Manager: failed to apply route (%s): %v", managedRoute.String(), err)

--- a/go-controller/pkg/node/routemanager/route_manager.go
+++ b/go-controller/pkg/node/routemanager/route_manager.go
@@ -115,6 +115,10 @@ func (c *Controller) delRoute(r netlink.Route) error {
 	klog.Infof("Route Manager: attempting to delete route: %s", r.String())
 	link, err := util.GetNetLinkOps().LinkByIndex(r.LinkIndex)
 	if err != nil {
+		if util.GetNetLinkOps().IsLinkNotFoundError(err) {
+			delete(c.store, r.LinkIndex)
+			return nil
+		}
 		return fmt.Errorf("failed to delete route (%s) because unable to get link: %v", r.String(), err)
 	}
 	if err := c.netlinkDelRoute(link, r.Dst, r.Table); err != nil {
@@ -254,6 +258,7 @@ func (c *Controller) addRouteToStore(r netlink.Route) bool {
 // sync will iterate through all routes seen on a node and ensure any route manager managed routes are applied. Any additional
 // routes for this link are preserved. sync only inspects routes for links which we managed and ignore routes for non-managed links.
 func (c *Controller) sync() {
+	deletedLinkIndexes := make([]int, 0)
 	for linkIndex, managedRoutes := range c.store {
 		for _, managedRoute := range managedRoutes {
 			filterRoute, filterMask := filterRouteByDstAndTable(linkIndex, managedRoute.Dst, managedRoute.Table)
@@ -272,7 +277,11 @@ func (c *Controller) sync() {
 			if !found {
 				link, err := util.GetNetLinkOps().LinkByIndex(managedRoute.LinkIndex)
 				if err != nil {
-					klog.Errorf("Route Manager: failed to apply route (%s) because unable to retrieve associated link: %v", managedRoute.String(), err)
+					if util.GetNetLinkOps().IsLinkNotFoundError(err) {
+						deletedLinkIndexes = append(deletedLinkIndexes, linkIndex)
+					} else {
+						klog.Errorf("Route Manager: failed to apply route (%s) because unable to retrieve associated link: %v", managedRoute.String(), err)
+					}
 					continue
 				}
 				if err := c.applyRoute(link, managedRoute.Gw, managedRoute.Dst, managedRoute.MTU, managedRoute.Src, managedRoute.Table); err != nil {
@@ -280,6 +289,10 @@ func (c *Controller) sync() {
 				}
 			}
 		}
+	}
+	for _, linkIndex := range deletedLinkIndexes {
+		klog.Infof("Route Manager: removing all routes associated with link index %d because link deleted", linkIndex)
+		delete(c.store, linkIndex)
 	}
 }
 


### PR DESCRIPTION
/hold

~During cherry-pick, I needed to adjust d83b3f916cb9a384009afb89dc4a8f70ac87bcc3 to remove the UDN APIs regarding lookup by network for the cluster router name. Also needed to fix conflicts in the OVN EIP test file.~

cc @maiqueb @pperiyasamy @tssurya 