### PR TITLE
Dockerfile.base: Bump OVN to ovn24.09-24.09.0-beta.23.el9fdp.

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-9-release-golang-1.22-openshift-4.17
+  tag: rhel-9-release-golang-1.22-openshift-4.18

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # The standard name for this image is ovn-kube
 
 # Build RHEL-9 binaries
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.17 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.18 AS builder
 
 WORKDIR /go/src/github.com/openshift/ovn-kubernetes
 COPY . .
@@ -13,7 +13,7 @@ RUN cd go-controller; CGO_ENABLED=1 make
 RUN cd go-controller; CGO_ENABLED=0 make windows
 
 # Build RHEL-8 binaries (for upgrades from 4.12 and earlier)
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.22-openshift-4.17 AS rhel8
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.22-openshift-4.18 AS rhel8
 WORKDIR /go/src/github.com/openshift/ovn-kubernetes
 COPY . .
 RUN cd go-controller; CGO_ENABLED=1 make
@@ -26,7 +26,7 @@ RUN cd go-controller; CGO_ENABLED=1 make
 # - creating directories required by ovn-kubernetes
 # - git commit number
 # - ovnkube.sh script
-FROM registry.ci.openshift.org/ocp/4.17:ovn-kubernetes-base
+FROM registry.ci.openshift.org/ocp/4.18:ovn-kubernetes-base
 
 USER root
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,9 @@ USER root
 
 ENV PYTHONDONTWRITEBYTECODE yes
 
+RUN dnf install openshift-clients jq -y
+RUN oc image info -o json registry.ci.openshift.org/ocp/4.18:ovn-kubernetes-base | jq .config.config.Labels
+
 # more-pkgs file is updated in Dockerfile.base
 # more-pkgs file contains the following ovs/ovn packages to be installed in this Dockerfile
 # - openvswitch-devel

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ RUN INSTALL_PKGS=" \
 	openshift-clients \
 	" && \
 	dnf install -y --nodocs $INSTALL_PKGS && \
-	eval "dnf install -y --nodocs $(cat /more-pkgs)" && \
+	eval "dnf install -y --nodocs --nobest $(cat /more-pkgs)" && \
 	dnf clean all && rm -rf /var/cache/*
 
 COPY --from=builder /go/src/github.com/openshift/ovn-kubernetes/go-controller/_output/go/bin/ovnkube /usr/bin/

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -5,7 +5,7 @@
 # The standard name for this image is ovn-kubernetes-base
 
 # build base image shared by both OpenShift and MicroShift
-FROM registry.ci.openshift.org/ocp/4.17:base-rhel9
+FROM registry.ci.openshift.org/ocp/4.18:base-rhel9
 
 # install selinux-policy first to avoid a race
 RUN dnf install -y --nodocs \

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -13,7 +13,7 @@ RUN dnf install -y --nodocs \
 	dnf clean all
 
 ARG ovsver=3.3.0-2.el9fdp
-ARG ovnver=24.03.2-19.el9fdp
+ARG ovnver=24.09.0-beta.23.el9fdp
 # NOTE: Ensure that the versions of OVS and OVN are overriden for OKD in each of the subsequent layers.
 ARG ovsver_okd=3.3.0-2.el9s
 ARG ovnver_okd=24.03.1-5.el9s

--- a/Dockerfile.microshift
+++ b/Dockerfile.microshift
@@ -12,7 +12,7 @@
 # openvswitch-devel, openvswitch-ipsec, libpcap, iproute etc
 # ovn-kube-util, hybrid-overlay-node.exe, ovndbchecker and ovnkube-trace
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.17 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.18 AS builder
 
 WORKDIR /go/src/github.com/openshift/ovn-kubernetes
 COPY . .
@@ -20,7 +20,7 @@ COPY . .
 # build the binaries
 RUN cd go-controller; CGO_ENABLED=0 make
 
-FROM registry.ci.openshift.org/ocp/4.17:ovn-kubernetes-base
+FROM registry.ci.openshift.org/ocp/4.18:ovn-kubernetes-base
 
 USER root
 


### PR DESCRIPTION
This is a pre-release version of the upcoming OVN v24.09.0 release. It's expected the actual release won't be very different from this version.

Relevant OVN features/performance improvements:
- NATs can now be given an arbitrary match condition and priority. This allows for conditional NATs to be configured.
- Added support to define boundaries (min and max values) for selected ct zones.
- Add support for ACL sampling through the new Sample_Collector and Sample tables.  Sampling is supported for both traffic that creates new connections and for traffic that is part of an existing connection.
- Added a new column in the southbound database "flow_desc" to provide human readable context to flows.
- Added two new experimental logical router port options, "routing-protocol-redirect" and "routing-protocols", that allow redirection of routing protocol traffic received by a router port to a different logical switch port.
