### PR TITLE
[release-4.16] OCPBUGS-38705: Delete EgressIP LRP stale nexthops when node is not found

### DIFF
--- a/go-controller/pkg/libovsdb/ops/router.go
+++ b/go-controller/pkg/libovsdb/ops/router.go
@@ -420,7 +420,9 @@ func CreateOrAddNextHopsToLogicalRouterPolicyWithPredicateOps(nbClient libovsdbc
 	return m.CreateOrUpdateOps(ops, opModels...)
 }
 
-func deleteNextHopsFromLogicalRouterPolicyOps(nbClient libovsdbclient.Client, ops []libovsdb.Operation, routerName string, lrps []*nbdb.LogicalRouterPolicy, nextHops ...string) ([]libovsdb.Operation, error) {
+// DeleteNextHopsFromLogicalRouterPolicyOps removes the Nexthops from the
+// provided logical router policies.
+func DeleteNextHopsFromLogicalRouterPolicyOps(nbClient libovsdbclient.Client, ops []libovsdb.Operation, routerName string, lrps []*nbdb.LogicalRouterPolicy, nextHops ...string) ([]libovsdb.Operation, error) {
 	nextHopSet := sets.NewString(nextHops...)
 	opModels := []operationModel{}
 	router := &nbdb.LogicalRouter{
@@ -481,7 +483,7 @@ func DeleteNextHopsFromLogicalRouterPolicies(nbClient libovsdbclient.Client, rou
 			return err
 		}
 
-		ops, err = deleteNextHopsFromLogicalRouterPolicyOps(nbClient, ops, routerName, []*nbdb.LogicalRouterPolicy{lrp}, nextHops...)
+		ops, err = DeleteNextHopsFromLogicalRouterPolicyOps(nbClient, ops, routerName, []*nbdb.LogicalRouterPolicy{lrp}, nextHops...)
 		if err != nil {
 			return err
 		}
@@ -502,7 +504,7 @@ func DeleteNextHopFromLogicalRouterPoliciesWithPredicateOps(nbClient libovsdbcli
 		return nil, err
 	}
 
-	return deleteNextHopsFromLogicalRouterPolicyOps(nbClient, ops, routerName, lrps, nextHop)
+	return DeleteNextHopsFromLogicalRouterPolicyOps(nbClient, ops, routerName, lrps, nextHop)
 }
 
 // DeleteNextHopFromLogicalRouterPoliciesWithPredicate looks up a logical router
@@ -522,6 +524,22 @@ func DeleteNextHopFromLogicalRouterPoliciesWithPredicate(nbClient libovsdbclient
 // DeleteLogicalRouterPolicies deletes the logical router policies and removes
 // them from the provided logical router
 func DeleteLogicalRouterPolicies(nbClient libovsdbclient.Client, routerName string, lrps ...*nbdb.LogicalRouterPolicy) error {
+	opModels := getDeleteOpModelsForLogicalRouterPolicies(routerName, lrps...)
+
+	m := newModelClient(nbClient)
+	return m.Delete(opModels...)
+}
+
+// DeleteLogicalRouterPoliciesOps builds and returns corresponding delete operations for Logical Router
+// Policies from the provided logical router.
+func DeleteLogicalRouterPoliciesOps(nbClient libovsdbclient.Client, ops []libovsdb.Operation, routerName string, lrps ...*nbdb.LogicalRouterPolicy) ([]libovsdb.Operation, error) {
+	opModels := getDeleteOpModelsForLogicalRouterPolicies(routerName, lrps...)
+
+	m := newModelClient(nbClient)
+	return m.DeleteOps(ops, opModels...)
+}
+
+func getDeleteOpModelsForLogicalRouterPolicies(routerName string, lrps ...*nbdb.LogicalRouterPolicy) []operationModel {
 	router := &nbdb.LogicalRouter{
 		Name:     routerName,
 		Policies: make([]string, 0, len(lrps)),
@@ -544,10 +562,8 @@ func DeleteLogicalRouterPolicies(nbClient libovsdbclient.Client, routerName stri
 		ErrNotFound:      true,
 		BulkOp:           false,
 	}
-	opModels = append(opModels, opModel)
 
-	m := newModelClient(nbClient)
-	return m.Delete(opModels...)
+	return append(opModels, opModel)
 }
 
 // LOGICAL ROUTER STATIC ROUTES

--- a/go-controller/pkg/ovn/egressip.go
+++ b/go-controller/pkg/ovn/egressip.go
@@ -13,6 +13,7 @@ import (
 
 	libovsdbclient "github.com/ovn-org/libovsdb/client"
 	"github.com/ovn-org/libovsdb/ovsdb"
+	libovsdb "github.com/ovn-org/libovsdb/ovsdb"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	egressipv1 "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressip/v1"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
@@ -1872,23 +1873,11 @@ func (e *egressIPZoneController) deleteReroutePolicyOps(ops []ovsdb.Operation, p
 // This function should be called with a lock on e.nodeZoneState.status.Node
 func (e *egressIPZoneController) deleteEgressIPStatusSetup(name string, status egressipv1.EgressIPStatusItem) ([]net.IP, error) {
 	var err error
-	isLocalZoneEgressNode, loadedEgressNode := e.nodeZoneState.Load(status.Node)
-
 	var ops []ovsdb.Operation
-	var nextHopIP string
-	eNode, err := e.watchFactory.GetNode(status.Node)
-	if err == nil {
-		eIPIP := net.ParseIP(status.EgressIP)
-		if eIPConfig, err := util.GetNodeEIPConfig(eNode); err != nil {
-			klog.Warningf("Failed to get Egress IP config from node annotation %s: %v", status.Node, err)
-		} else {
-			isOVNNetwork := util.IsOVNNetwork(eIPConfig, eIPIP)
-			nextHopIP, err = e.getNextHop(status.Node, status.EgressIP, name, isLocalZoneEgressNode, isOVNNetwork)
-			if err != nil {
-				return nil, fmt.Errorf("failed to delete egress IP %s (%s) because unable to determine next hop: %v",
-					name, status.EgressIP, err)
-			}
-		}
+	nextHopIP, err := e.attemptToGetNextHopIP(name, status)
+	if err != nil {
+		return nil, fmt.Errorf("failed to delete egress IP %s (%s) because unable to determine next hop: %v",
+			name, status.EgressIP, err)
 	}
 
 	if nextHopIP != "" {
@@ -1907,11 +1896,11 @@ func (e *egressIPZoneController) deleteEgressIPStatusSetup(name string, status e
 			return nil, fmt.Errorf("error removing nexthop IP %s from egress ip %s policies on router %s: %v",
 				nextHopIP, name, types.OVNClusterRouter, err)
 		}
-	} else {
-		//FIXME: (mk) just nuke everything to do with this 'name'
-		klog.Errorf("Unable to get next hop IP and therefore there could be stale logical route policies for Egress IP %s", status.EgressIP)
+	} else if ops, err = e.ensureOnlyValidNextHops(name, ops); err != nil {
+		return nil, err
 	}
 
+	isLocalZoneEgressNode, loadedEgressNode := e.nodeZoneState.Load(status.Node)
 	var nats []*nbdb.NAT
 	if loadedEgressNode && isLocalZoneEgressNode {
 		routerName := util.GetGatewayRouterFromNode(status.Node)
@@ -1940,6 +1929,92 @@ func (e *egressIPZoneController) deleteEgressIPStatusSetup(name string, status e
 	}
 
 	return podIPs, nil
+}
+
+func (e *egressIPZoneController) ensureOnlyValidNextHops(name string, ops []libovsdb.Operation) ([]libovsdb.Operation, error) {
+	// When no nextHopIP is found, This may happen when node object is already deleted.
+	// So compare validNextHopIPs associated with current eIP.Status and Nexthops present
+	// in the LogicalRouterPolicy, then delete nexthop(s) from LogicalRouterPolicy if
+	// it doesn't match with nexthops derived from eIP.Status.
+	policyPred := func(item *nbdb.LogicalRouterPolicy) bool {
+		return item.Priority == types.EgressIPReroutePriority && item.ExternalIDs["name"] == name
+	}
+	eIP, err := e.watchFactory.GetEgressIP(name)
+	if err != nil && !apierrors.IsNotFound(err) {
+		return ops, fmt.Errorf("error retrieving EgressIP %s object for updating logical router policy nexthops, err: %w", name, err)
+	} else if err != nil && apierrors.IsNotFound(err) {
+		// EgressIP object is not found, so delete LRP associated with it.
+		ops, err = libovsdbops.DeleteLogicalRouterPolicyWithPredicateOps(e.nbClient, ops, types.OVNClusterRouter, policyPred)
+		if err != nil {
+			return ops, fmt.Errorf("error creating ops to remove logical router policy for EgressIP %s from router %s: %v",
+				name, types.OVNClusterRouter, err)
+		}
+	} else {
+		validNextHopIPs := make(sets.Set[string])
+		for _, validStatus := range eIP.Status.Items {
+			nextHopIP, err := e.attemptToGetNextHopIP(name, validStatus)
+			if err != nil {
+				return ops, fmt.Errorf("failed to delete EgressIP %s (%s) because unable to determine next hop: %v",
+					name, validStatus.EgressIP, err)
+			}
+			validNextHopIPs.Insert(nextHopIP)
+		}
+
+		reRoutePolicies, err := libovsdbops.FindLogicalRouterPoliciesWithPredicate(e.nbClient, policyPred)
+		if err != nil {
+			return ops, fmt.Errorf("error finding logical router policy for EgressIP %s: %v", name, err)
+		}
+		if len(validNextHopIPs) == 0 {
+			ops, err = libovsdbops.DeleteLogicalRouterPoliciesOps(e.nbClient, ops, types.OVNClusterRouter, reRoutePolicies...)
+			if err != nil {
+				return ops, fmt.Errorf("error creating ops to remove logical router policy for EgressIP %s from router %s: %v",
+					name, types.OVNClusterRouter, err)
+			}
+			return ops, nil
+		}
+		for _, policy := range reRoutePolicies {
+			for _, nextHop := range policy.Nexthops {
+				if validNextHopIPs.Has(nextHop) {
+					continue
+				}
+				ops, err = libovsdbops.DeleteNextHopsFromLogicalRouterPolicyOps(e.nbClient, ops, types.OVNClusterRouter, []*nbdb.LogicalRouterPolicy{policy}, nextHop)
+				if err != nil {
+					return ops, fmt.Errorf("error creating ops to remove stale next hop IP %s from logical router policy for EgressIP %s from router %s: %v",
+						nextHop, name, types.OVNClusterRouter, err)
+				}
+			}
+		}
+	}
+	return ops, nil
+}
+
+// attemptToGetNextHopIP this function attempts to retrieve nexthops associated with logical router policy for the given
+// EgressIP's status. It ensures the following conditions are met.
+// 1) When node is not found, then it must return empty nexthop without an error.
+// 2) When EgressIP belongs to OVN network and node is local, then it must return node's gateway router IP address.
+// 3) When EgressIP belongs to non OVN network and node is local, then it must return node's management port IP address.
+// 4) When EgressIP belongs to remote node in interconnect zone, then it return node's transit switch IP address.
+func (e *egressIPZoneController) attemptToGetNextHopIP(name string, status egressipv1.EgressIPStatusItem) (string, error) {
+	isLocalZoneEgressNode, _ := e.nodeZoneState.Load(status.Node)
+	eNode, err := e.watchFactory.GetNode(status.Node)
+	if err != nil && !apierrors.IsNotFound(err) {
+		return "", fmt.Errorf("unable to get node for Egress IP %s: %v", status.EgressIP, err)
+	} else if err != nil {
+		klog.Errorf("Node is not found for Egress IP %s", status.EgressIP)
+		return "", nil
+	}
+	var nextHopIP string
+	eIPIP := net.ParseIP(status.EgressIP)
+	if eIPConfig, err := util.GetNodeEIPConfig(eNode); err != nil {
+		klog.Warningf("Failed to get Egress IP config from node annotation %s: %v", status.Node, err)
+	} else {
+		isOVNNetwork := util.IsOVNNetwork(eIPConfig, eIPIP)
+		nextHopIP, err = e.getNextHop(status.Node, status.EgressIP, name, isLocalZoneEgressNode, isOVNNetwork)
+		if err != nil {
+			return "", err
+		}
+	}
+	return nextHopIP, nil
 }
 
 func (oc *DefaultNetworkController) addPodIPsToAddressSet(addrSetIPs []net.IP) error {

--- a/go-controller/pkg/ovn/egressip_test.go
+++ b/go-controller/pkg/ovn/egressip_test.go
@@ -10994,16 +10994,22 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 			app.Action = func(ctx *cli.Context) error {
 				config.IPv4Mode = true
 				config.IPv6Mode = true
-				egressIP := "192.168.126.101"
+				egressIP1 := "192.168.126.101"
+				egressIP2 := "192.168.126.102"
 				node1IPv4 := "192.168.126.12"
-				node1IPv4Net := "192.168.126.0/24"
 				node1IPv4CIDR := node1IPv4 + "/24"
 				node1IPv6 := "::feff:c0a8:8e0c"
 				node1IPv6CIDR := node1IPv6 + "/64"
 				node2IPv4 := "192.168.126.51"
-				node2IPv4Net := "192.168.126.0/24"
 				node2IPv4CIDR := node2IPv4 + "/24"
+				node3IPv4 := "192.168.126.61"
+				node3IPv4CIDR := node3IPv4 + "/24"
 
+				// TODO: had to place pod on node3 instead of node1, otherwise when node1 is deleted, nexthop in LRP (line no 11561) for the pod
+				// doesn't get updated with newly added node node2 (100.64.0.3).
+				// This https://github.com/openshift/ovn-kubernetes/blob/release-4.16/go-controller/pkg/ovn/egressip.go#L1522 doesn't hit.
+				egressPod1 := *newPodWithLabels(eipNamespace, podName, node3Name, podV4IP, egressPodLabel)
+				egressNamespace := newNamespace(eipNamespace)
 				annotations := map[string]string{
 					"k8s.ovn.org/node-primary-ifaddr": fmt.Sprintf("{\"ipv4\": \"%s\", \"ipv6\": \"%s\"}", node1IPv4CIDR, node1IPv6CIDR),
 					"k8s.ovn.org/node-subnets":        fmt.Sprintf("{\"default\":[\"%s\", \"%s\"]}", v4Node1Subnet, v6Node1Subnet),
@@ -11019,11 +11025,25 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 					util.OVNNodeHostCIDRs:             fmt.Sprintf("[\"%s\"]", node2IPv4CIDR),
 				}
 				node2 := getNodeObj(node2Name, annotations, labels)
+				annotations = map[string]string{
+					"k8s.ovn.org/node-primary-ifaddr": fmt.Sprintf("{\"ipv4\": \"%s\", \"ipv6\": \"%s\"}", node3IPv4CIDR, ""),
+					"k8s.ovn.org/node-subnets":        fmt.Sprintf("{\"default\":\"%s\"}", v4Node1Subnet),
+					util.OVNNodeHostCIDRs:             fmt.Sprintf("[\"%s\"]", node3IPv4CIDR),
+				}
+				node3 := getNodeObj(node3Name, annotations, labels)
 
 				eIP := egressipv1.EgressIP{
 					ObjectMeta: newEgressIPMeta(egressIPName),
 					Spec: egressipv1.EgressIPSpec{
-						EgressIPs: []string{egressIP},
+						EgressIPs: []string{egressIP1, egressIP2},
+						PodSelector: metav1.LabelSelector{
+							MatchLabels: egressPodLabel,
+						},
+						NamespaceSelector: metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"name": egressNamespace.Name,
+							},
+						},
 					},
 					Status: egressipv1.EgressIPStatus{
 						Items: []egressipv1.EgressIPStatusItem{},
@@ -11036,6 +11056,10 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 				node2Switch := &nbdb.LogicalSwitch{
 					UUID: node2.Name + "-UUID",
 					Name: node2.Name,
+				}
+				node3Switch := &nbdb.LogicalSwitch{
+					UUID: node3.Name + "-UUID",
+					Name: node3.Name,
 				}
 				fakeOvn.startWithDBSetup(
 					libovsdbtest.TestSetup{
@@ -11050,6 +11074,11 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 								Name:     types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2.Name,
 								Networks: []string{node2LogicalRouterIfAddrV4},
 							},
+							&nbdb.LogicalRouterPort{
+								UUID:     types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node3.Name + "-UUID",
+								Name:     types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node3.Name,
+								Networks: []string{node3LogicalRouterIfAddrV4},
+							},
 							&nbdb.LogicalRouter{
 								Name: types.OVNClusterRouter,
 								UUID: types.OVNClusterRouter + "-UUID",
@@ -11063,6 +11092,11 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 								Name:  types.GWRouterPrefix + node2.Name,
 								UUID:  types.GWRouterPrefix + node2.Name + "-UUID",
 								Ports: []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2.Name + "-UUID"},
+							},
+							&nbdb.LogicalRouter{
+								Name:  types.GWRouterPrefix + node3.Name,
+								UUID:  types.GWRouterPrefix + node3.Name + "-UUID",
+								Ports: []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node3.Name + "-UUID"},
 							},
 							&nbdb.LogicalSwitchPort{
 								UUID: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node1Name + "-UUID",
@@ -11084,6 +11118,16 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 									"exclude-lb-vips-from-garp": "true",
 								},
 							},
+							&nbdb.LogicalSwitchPort{
+								UUID: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node3Name + "-UUID",
+								Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node3Name,
+								Type: "router",
+								Options: map[string]string{
+									"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node3Name,
+									"nat-addresses":             "router",
+									"exclude-lb-vips-from-garp": "true",
+								},
+							},
 							&nbdb.LogicalSwitch{
 								UUID:  types.ExternalSwitchPrefix + node1Name + "-UUID",
 								Name:  types.ExternalSwitchPrefix + node1Name,
@@ -11094,16 +11138,32 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 								Name:  types.ExternalSwitchPrefix + node2Name,
 								Ports: []string{types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node2Name + "-UUID"},
 							},
+							&nbdb.LogicalSwitch{
+								UUID:  types.ExternalSwitchPrefix + node3Name + "-UUID",
+								Name:  types.ExternalSwitchPrefix + node3Name,
+								Ports: []string{types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node3Name + "-UUID"},
+							},
 							node1Switch,
 							node2Switch,
+							node3Switch,
 						},
 					},
 					&egressipv1.EgressIPList{
 						Items: []egressipv1.EgressIP{eIP},
 					},
 					&v1.NodeList{
-						Items: []v1.Node{node1},
+						Items: []v1.Node{node1, node3},
+					},
+					&v1.NamespaceList{
+						Items: []v1.Namespace{*egressNamespace},
+					},
+					&v1.PodList{
+						Items: []v1.Pod{egressPod1},
 					})
+
+				i, n, _ := net.ParseCIDR(podV4IP + "/23")
+				n.IP = i
+				fakeOvn.controller.logicalPortCache.add(&egressPod1, "", types.DefaultNetworkName, "", nil, []*net.IPNet{n})
 
 				err := fakeOvn.controller.WatchEgressIPNamespaces()
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -11115,12 +11175,13 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				nodeIPsASdbIDs := getEgressIPAddrSetDbIDs(NodeIPAddrSetName, DefaultNetworkControllerName)
-				fakeOvn.asf.EventuallyExpectAddressSetWithAddresses(nodeIPsASdbIDs, []string{node1IPv4, node1IPv6})
+				fakeOvn.asf.EventuallyExpectAddressSetWithAddresses(nodeIPsASdbIDs, []string{node1IPv4, node1IPv6, node3IPv4})
 
 				egressSvcPodsV4, egressSvcPodsV6 := addressset.GetHashNamesForAS(egresssvc.GetEgressServiceAddrSetDbIDs(DefaultNetworkControllerName))
 				egressipPodsV4, egressipPodsV6 := addressset.GetHashNamesForAS(getEgressIPAddrSetDbIDs(EgressIPServedPodsAddrSetName, DefaultNetworkControllerName))
 				nodeIPsV4, nodeIPsV6 := addressset.GetHashNamesForAS(nodeIPsASdbIDs)
 				node1Switch.QOSRules = []string{"egressip-QoS-UUID", "egressip-QoSv6-UUID"}
+				node3Switch.QOSRules = []string{"egressip-QoS-UUID", "egressip-QoSv6-UUID"}
 				expectedDatabaseState := []libovsdbtest.TestData{
 					&nbdb.LogicalRouterPolicy{
 						Priority: types.DefaultNoRereoutePriority,
@@ -11149,6 +11210,11 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						Name:     types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2.Name,
 						Networks: []string{node2LogicalRouterIfAddrV4},
 					},
+					&nbdb.LogicalRouterPort{
+						UUID:     types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node3.Name + "-UUID",
+						Name:     types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node3.Name,
+						Networks: []string{node3LogicalRouterIfAddrV4},
+					},
 					&nbdb.LogicalRouterPolicy{
 						Priority: types.DefaultNoRereoutePriority,
 						Match:    "ip4.src == 10.128.0.0/14 && ip4.dst == 10.128.0.0/14",
@@ -11177,6 +11243,11 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						UUID:  types.GWRouterPrefix + node2.Name + "-UUID",
 						Ports: []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2.Name + "-UUID"},
 					},
+					&nbdb.LogicalRouter{
+						Name:  types.GWRouterPrefix + node3.Name,
+						UUID:  types.GWRouterPrefix + node3.Name + "-UUID",
+						Ports: []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node3.Name + "-UUID"},
+					},
 					&nbdb.LogicalSwitchPort{
 						UUID: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node1Name + "-UUID",
 						Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node1Name,
@@ -11197,6 +11268,16 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 							"exclude-lb-vips-from-garp": "true",
 						},
 					},
+					&nbdb.LogicalSwitchPort{
+						UUID: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node3Name + "-UUID",
+						Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node3Name,
+						Type: "router",
+						Options: map[string]string{
+							"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node3Name,
+							"nat-addresses":             "router",
+							"exclude-lb-vips-from-garp": "true",
+						},
+					},
 					&nbdb.LogicalSwitch{
 						UUID:  types.ExternalSwitchPrefix + node1Name + "-UUID",
 						Name:  types.ExternalSwitchPrefix + node1Name,
@@ -11207,21 +11288,43 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						Name:  types.ExternalSwitchPrefix + node2Name,
 						Ports: []string{types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node2Name + "-UUID"},
 					},
+					&nbdb.LogicalSwitch{
+						UUID:  types.ExternalSwitchPrefix + node3Name + "-UUID",
+						Name:  types.ExternalSwitchPrefix + node3Name,
+						Ports: []string{types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node3Name + "-UUID"},
+					},
 					node1Switch,
 					node2Switch,
+					node3Switch,
 					getDefaultQoSRule(false),
 					getDefaultQoSRule(true),
 				}
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
-				fakeOvn.patchEgressIPObj(node1Name, egressIPName, egressIP, node1IPv4Net)
-				gomega.Eventually(getEgressIPStatusLen(egressIPName)).Should(gomega.Equal(1))
+
+				status := []egressipv1.EgressIPStatusItem{
+					{
+						Node:     node1Name,
+						EgressIP: egressIP1,
+					},
+					{
+						Node:     node3Name,
+						EgressIP: egressIP2,
+					},
+				}
+				err = fakeOvn.controller.patchReplaceEgressIPStatus(egressIPName, status)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Eventually(getEgressIPStatusLen(egressIPName)).Should(gomega.Equal(2))
+				gomega.Eventually(getEgressIPReassignmentCount).Should(gomega.Equal(0))
+
 				egressIPs, nodes := getEgressIPStatus(egressIPName)
 				gomega.Expect(nodes[0]).To(gomega.Equal(node1.Name))
-				gomega.Expect(egressIPs[0]).To(gomega.Equal(egressIP))
+				gomega.Expect(nodes[1]).To(gomega.Equal(node3.Name))
 
 				_, err = fakeOvn.fakeClient.KubeClient.CoreV1().Nodes().Create(context.TODO(), &node2, metav1.CreateOptions{})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				node2Switch.QOSRules = []string{"egressip-QoS-UUID", "egressip-QoSv6-UUID"}
+				expectedNatLogicalPort1 := "k8s-node1"
+				expectedNatLogicalPort3 := "k8s-node3"
 				expectedDatabaseState = []libovsdbtest.TestData{
 					&nbdb.LogicalRouterPolicy{
 						Priority: types.DefaultNoRereoutePriority,
@@ -11250,7 +11353,11 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						Name:     types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2.Name,
 						Networks: []string{node2LogicalRouterIfAddrV4},
 					},
-
+					&nbdb.LogicalRouterPort{
+						UUID:     types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node3.Name + "-UUID",
+						Name:     types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node3.Name,
+						Networks: []string{node3LogicalRouterIfAddrV4},
+					},
 					&nbdb.LogicalRouterPolicy{
 						Priority: types.DefaultNoRereoutePriority,
 						Match:    "ip4.src == 10.128.0.0/14 && ip4.dst == 10.128.0.0/14",
@@ -11263,21 +11370,64 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						Action:   nbdb.LogicalRouterPolicyActionAllow,
 						UUID:     "no-reroute-service-UUID",
 					},
+					&nbdb.LogicalRouterPolicy{
+						Priority: types.EgressIPReroutePriority,
+						Match:    fmt.Sprintf("ip4.src == %s", egressPod1.Status.PodIP),
+						Action:   nbdb.LogicalRouterPolicyActionReroute,
+						Nexthops: []string{"100.64.0.2", "100.64.0.4"},
+						ExternalIDs: map[string]string{
+							"name": eIP.Name,
+						},
+						UUID: "reroute-UUID1",
+					},
+					&nbdb.NAT{
+						UUID:       "egressip-nat-UUID1",
+						LogicalIP:  podV4IP,
+						ExternalIP: egressIPs[0],
+						ExternalIDs: map[string]string{
+							"name": egressIPName,
+						},
+						Type:        nbdb.NATTypeSNAT,
+						LogicalPort: &expectedNatLogicalPort1,
+						Options: map[string]string{
+							"stateless": "false",
+						},
+					},
+					&nbdb.NAT{
+						UUID:       "egressip-nat-UUID2",
+						LogicalIP:  podV4IP,
+						ExternalIP: egressIPs[1],
+						ExternalIDs: map[string]string{
+							"name": egressIPName,
+						},
+						Type:        nbdb.NATTypeSNAT,
+						LogicalPort: &expectedNatLogicalPort3,
+						Options: map[string]string{
+							"stateless": "false",
+						},
+					},
 					&nbdb.LogicalRouter{
 						Name: types.OVNClusterRouter,
 						UUID: types.OVNClusterRouter + "-UUID",
 						Policies: []string{"no-reroute-UUID", "no-reroute-service-UUID", "default-no-reroute-node-UUID",
-							"default-v6-no-reroute-node-UUID", "egressip-no-reroute-reply-traffic"},
+							"default-v6-no-reroute-node-UUID", "egressip-no-reroute-reply-traffic", "reroute-UUID1"},
 					},
 					&nbdb.LogicalRouter{
 						Name:  types.GWRouterPrefix + node1.Name,
 						UUID:  types.GWRouterPrefix + node1.Name + "-UUID",
 						Ports: []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node1.Name + "-UUID"},
+						Nat:   []string{"egressip-nat-UUID1"},
 					},
 					&nbdb.LogicalRouter{
 						Name:  types.GWRouterPrefix + node2.Name,
 						UUID:  types.GWRouterPrefix + node2.Name + "-UUID",
 						Ports: []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2.Name + "-UUID"},
+					},
+					&nbdb.LogicalRouter{
+						Name:  types.GWRouterPrefix + node3.Name,
+						UUID:  types.GWRouterPrefix + node3.Name + "-UUID",
+						Ports: []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node3.Name + "-UUID"},
+						Nat:   []string{"egressip-nat-UUID2"},
 					},
 					&nbdb.LogicalSwitchPort{
 						UUID: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node1Name + "-UUID",
@@ -11299,6 +11449,16 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 							"exclude-lb-vips-from-garp": "true",
 						},
 					},
+					&nbdb.LogicalSwitchPort{
+						UUID: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node3Name + "-UUID",
+						Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node3Name,
+						Type: "router",
+						Options: map[string]string{
+							"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node3Name,
+							"nat-addresses":             "router",
+							"exclude-lb-vips-from-garp": "true",
+						},
+					},
 					&nbdb.LogicalSwitch{
 						UUID:  types.ExternalSwitchPrefix + node1Name + "-UUID",
 						Name:  types.ExternalSwitchPrefix + node1Name,
@@ -11309,35 +11469,46 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						Name:  types.ExternalSwitchPrefix + node2Name,
 						Ports: []string{types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node2Name + "-UUID"},
 					},
+					&nbdb.LogicalSwitch{
+						UUID:  types.ExternalSwitchPrefix + node3Name + "-UUID",
+						Name:  types.ExternalSwitchPrefix + node3Name,
+						Ports: []string{types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node3Name + "-UUID"},
+					},
 					node1Switch,
 					node2Switch,
+					node3Switch,
 					getDefaultQoSRule(false),
 					getDefaultQoSRule(true),
 				}
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 
-				gomega.Eventually(getEgressIPStatusLen(egressIPName)).Should(gomega.Equal(1))
-				egressIPs, nodes = getEgressIPStatus(egressIPName)
+				gomega.Eventually(getEgressIPStatusLen(egressIPName)).Should(gomega.Equal(2))
+				_, nodes = getEgressIPStatus(egressIPName)
 				gomega.Expect(nodes[0]).To(gomega.Equal(node1.Name))
-				gomega.Expect(egressIPs[0]).To(gomega.Equal(egressIP))
+				gomega.Expect(nodes[1]).To(gomega.Equal(node3.Name))
 
 				err = fakeOvn.fakeClient.KubeClient.CoreV1().Nodes().Delete(context.TODO(), node1.Name, *metav1.NewDeleteOptions(0))
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				fakeOvn.patchEgressIPObj(node2Name, egressIPName, egressIP, node2IPv4Net)
-				gomega.Eventually(getEgressIPStatusLen(egressIPName)).Should(gomega.Equal(1))
-
-				getNewNode := func() string {
-					_, nodes = getEgressIPStatus(egressIPName)
-					if len(nodes) > 0 {
-						return nodes[0]
-					}
-					return ""
+				status = []egressipv1.EgressIPStatusItem{
+					{
+						Node:     node2Name,
+						EgressIP: egressIP1,
+					},
+					{
+						Node:     node3Name,
+						EgressIP: egressIP2,
+					},
 				}
+				err = fakeOvn.controller.patchReplaceEgressIPStatus(egressIPName, status)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Eventually(getEgressIPStatusLen(egressIPName)).Should(gomega.Equal(2))
+				gomega.Eventually(getEgressIPReassignmentCount).Should(gomega.Equal(0))
 
-				gomega.Eventually(getNewNode).Should(gomega.Equal(node2.Name))
-				egressIPs, _ = getEgressIPStatus(egressIPName)
-				gomega.Expect(egressIPs[0]).To(gomega.Equal(egressIP))
+				egressIPs, nodes = getEgressIPStatus(egressIPName)
+				gomega.Expect(nodes[0]).To(gomega.Equal(node2.Name))
+				gomega.Expect(nodes[1]).To(gomega.Equal(node3.Name))
 
+				expectedNatLogicalPort2 := "k8s-node2"
 				expectedDatabaseState = []libovsdbtest.TestData{
 					&nbdb.LogicalRouterPolicy{
 						Priority: types.DefaultNoRereoutePriority,
@@ -11366,6 +11537,11 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						Name:     types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2.Name,
 						Networks: []string{node2LogicalRouterIfAddrV4},
 					},
+					&nbdb.LogicalRouterPort{
+						UUID:     types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node3.Name + "-UUID",
+						Name:     types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node3.Name,
+						Networks: []string{node3LogicalRouterIfAddrV4},
+					},
 					&nbdb.LogicalRouterPolicy{
 						Priority: types.DefaultNoRereoutePriority,
 						Match:    "ip4.src == 10.128.0.0/14 && ip4.dst == 10.128.0.0/14",
@@ -11378,11 +11554,47 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						Action:   nbdb.LogicalRouterPolicyActionAllow,
 						UUID:     "no-reroute-service-UUID",
 					},
+					&nbdb.LogicalRouterPolicy{
+						Priority: types.EgressIPReroutePriority,
+						Match:    fmt.Sprintf("ip4.src == %s", egressPod1.Status.PodIP),
+						Action:   nbdb.LogicalRouterPolicyActionReroute,
+						Nexthops: []string{"100.64.0.3", "100.64.0.4"},
+						ExternalIDs: map[string]string{
+							"name": eIP.Name,
+						},
+						UUID: "reroute-UUID1",
+					},
+					&nbdb.NAT{
+						UUID:       "egressip-nat-UUID1",
+						LogicalIP:  podV4IP,
+						ExternalIP: egressIPs[0],
+						ExternalIDs: map[string]string{
+							"name": egressIPName,
+						},
+						Type:        nbdb.NATTypeSNAT,
+						LogicalPort: &expectedNatLogicalPort2,
+						Options: map[string]string{
+							"stateless": "false",
+						},
+					},
+					&nbdb.NAT{
+						UUID:       "egressip-nat-UUID2",
+						LogicalIP:  podV4IP,
+						ExternalIP: egressIPs[1],
+						ExternalIDs: map[string]string{
+							"name": egressIPName,
+						},
+						Type:        nbdb.NATTypeSNAT,
+						LogicalPort: &expectedNatLogicalPort3,
+						Options: map[string]string{
+							"stateless": "false",
+						},
+					},
 					&nbdb.LogicalRouter{
 						Name: types.OVNClusterRouter,
 						UUID: types.OVNClusterRouter + "-UUID",
 						Policies: []string{"no-reroute-UUID", "no-reroute-service-UUID", "default-no-reroute-node-UUID",
-							"default-v6-no-reroute-node-UUID", "egressip-no-reroute-reply-traffic"},
+							"default-v6-no-reroute-node-UUID", "egressip-no-reroute-reply-traffic", "reroute-UUID1"},
 					},
 					&nbdb.LogicalRouter{
 						Name:  types.GWRouterPrefix + node1.Name,
@@ -11393,6 +11605,13 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						Name:  types.GWRouterPrefix + node2.Name,
 						UUID:  types.GWRouterPrefix + node2.Name + "-UUID",
 						Ports: []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2.Name + "-UUID"},
+						Nat:   []string{"egressip-nat-UUID1"},
+					},
+					&nbdb.LogicalRouter{
+						Name:  types.GWRouterPrefix + node3.Name,
+						UUID:  types.GWRouterPrefix + node3.Name + "-UUID",
+						Ports: []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node3.Name + "-UUID"},
+						Nat:   []string{"egressip-nat-UUID2"},
 					},
 					&nbdb.LogicalSwitchPort{
 						UUID: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node1Name + "-UUID",
@@ -11414,6 +11633,16 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 							"exclude-lb-vips-from-garp": "true",
 						},
 					},
+					&nbdb.LogicalSwitchPort{
+						UUID: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node3Name + "-UUID",
+						Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node3Name,
+						Type: "router",
+						Options: map[string]string{
+							"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node3Name,
+							"nat-addresses":             "router",
+							"exclude-lb-vips-from-garp": "true",
+						},
+					},
 					&nbdb.LogicalSwitch{
 						UUID:  types.ExternalSwitchPrefix + node1Name + "-UUID",
 						Name:  types.ExternalSwitchPrefix + node1Name,
@@ -11424,8 +11653,14 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						Name:  types.ExternalSwitchPrefix + node2Name,
 						Ports: []string{types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node2Name + "-UUID"},
 					},
+					&nbdb.LogicalSwitch{
+						UUID:  types.ExternalSwitchPrefix + node3Name + "-UUID",
+						Name:  types.ExternalSwitchPrefix + node3Name,
+						Ports: []string{types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node3Name + "-UUID"},
+					},
 					node1Switch,
 					node2Switch,
+					node3Switch,
 					getDefaultQoSRule(false),
 					getDefaultQoSRule(true),
 				}


### PR DESCRIPTION
Manually cherry-picked. Resolved conflicts:

`go-controller/pkg/ovn/egressip.go` (had to refer to `types.OVNClusterRouter` instead of `e.GetNetworkScopedClusterRouterName()`)
`go-controller/pkg/ovn/egressip_test.go` (had to align the test with 4.17 to get test succeed)

