### PR TITLE
OCPBUGS-38270: Dockerfile: Bump OVS to 3.4.0-1

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -15,7 +15,7 @@ RUN dnf install -y --nodocs \
 ARG ovsver=3.4.0-1.el9fdp
 ARG ovnver=24.03.2-19.el9fdp
 # NOTE: Ensure that the versions of OVS and OVN are overriden for OKD in each of the subsequent layers.
-ARG ovsver_okd=3.3.0-2.el9s
+ARG ovsver_okd=3.4.0-0.8.el9s
 ARG ovnver_okd=24.03.1-5.el9s
 
 RUN INSTALL_PKGS="iptables nftables" && \

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -12,7 +12,7 @@ RUN dnf install -y --nodocs \
 	selinux-policy procps-ng && \
 	dnf clean all
 
-ARG ovsver=3.3.0-2.el9fdp
+ARG ovsver=3.4.0-1.el9fdp
 ARG ovnver=24.03.2-19.el9fdp
 # NOTE: Ensure that the versions of OVS and OVN are overriden for OKD in each of the subsequent layers.
 ARG ovsver_okd=3.3.0-2.el9s


### PR DESCRIPTION
The new OVS version is used by the OVN observability.
RHCOS counterpart: https://issues.redhat.com//browse/OCPBUGS-37875
previous bump: https://github.com/openshift/ovn-kubernetes/pull/2142