### PR TITLE
OCPBUGS-24386: [release-4.16] EgressService: Fix ETP=Local ingress reply for LGW

### DIFF
--- a/go-controller/pkg/node/controllers/egressservice/egressservice_node.go
+++ b/go-controller/pkg/node/controllers/egressservice/egressservice_node.go
@@ -67,12 +67,14 @@ type Controller struct {
 }
 
 type svcState struct {
-	v4LB   string           // IPv4 ingress of the service
-	v4Eps  sets.Set[string] // v4 endpoints that have an SNAT rule configured
-	v6LB   string           // IPv6 ingress of the service
-	v6Eps  sets.Set[string] // v6 endpoints that have an SNAT rule configured
-	net    string           // net corresponding to the spec.Network
-	netEps sets.Set[string] // All endpoints that have an ip rule configured
+	v4LB        string           // IPv4 ingress of the service
+	v4Eps       sets.Set[string] // v4 endpoints that have an SNAT rule configured
+	v6LB        string           // IPv6 ingress of the service
+	v6Eps       sets.Set[string] // v6 endpoints that have an SNAT rule configured
+	net         string           // net corresponding to the spec.Network
+	netEps      sets.Set[string] // All endpoints that have an ip rule configured
+	v4NodePorts sets.Set[int32]  // All v4 nodeports that have an ip rule configured, relevant when ETP=Local
+	v6NodePorts sets.Set[int32]  // All v6 nodeports that have an ip rule configured, relevant when ETP=Local
 
 	stale bool
 }
@@ -225,6 +227,9 @@ func (c *Controller) repair() error {
 	// all the current cluster ips to valid egress services keys
 	cipsToSvcKey := map[string]string{}
 
+	// all the current node ports of ETP=Local services to valid egress services keys
+	nodePortsToSvcKey := map[int32]string{}
+
 	services, err := c.serviceLister.List(labels.Everything())
 	if err != nil {
 		return err
@@ -291,19 +296,31 @@ func (c *Controller) repair() error {
 			cipsToSvcKey[cip] = key
 		}
 
+		// We care about node ports only when the return traffic involves the MASQUERADE IPs.
+		if svc.Spec.ExternalTrafficPolicy == corev1.ServiceExternalTrafficPolicyLocal {
+			for _, p := range svc.Spec.Ports {
+				if p.NodePort == 0 {
+					continue
+				}
+				nodePortsToSvcKey[p.NodePort] = key
+			}
+		}
+
 		c.services[key] = &svcState{
-			v4LB:   v4LB,
-			v4Eps:  sets.New[string](),
-			v6LB:   v6LB,
-			v6Eps:  sets.New[string](),
-			net:    es.Spec.Network,
-			netEps: sets.New[string](),
-			stale:  false,
+			v4LB:        v4LB,
+			v4Eps:       sets.New[string](),
+			v6LB:        v6LB,
+			v6Eps:       sets.New[string](),
+			net:         es.Spec.Network,
+			netEps:      sets.New[string](),
+			v4NodePorts: sets.New[int32](),
+			v6NodePorts: sets.New[int32](),
+			stale:       false,
 		}
 	}
 
 	errorList := []error{}
-	err = c.repairIPRules(v4EndpointsToSvcKey, v6EndpointsToSvcKey, cipsToSvcKey)
+	err = c.repairIPRules(v4EndpointsToSvcKey, v6EndpointsToSvcKey, cipsToSvcKey, nodePortsToSvcKey)
 	if err != nil {
 		errorList = append(errorList, err)
 	}
@@ -320,10 +337,11 @@ func (c *Controller) repair() error {
 // Valid ip rules in this context are those that belong to an existing EgressService, their
 // src points to either an existing ep or cip of the service and the routing table matches the
 // Network field of the service.
-func (c *Controller) repairIPRules(v4EpsToServices, v6EpsToServices, cipsToServices map[string]string) error {
+func (c *Controller) repairIPRules(v4EpsToServices, v6EpsToServices, cipsToServices map[string]string, nodePortsToServices map[int32]string) error {
 	type IPRule struct {
 		Priority int32  `json:"priority"`
 		Src      string `json:"src"`
+		SrcPort  int32  `json:"sport"`
 		Table    string `json:"table"`
 	}
 
@@ -334,8 +352,6 @@ func (c *Controller) repairIPRules(v4EpsToServices, v6EpsToServices, cipsToServi
 		}
 
 		allIPRules := []IPRule{}
-		ipRulesToDelete := []IPRule{}
-
 		stdout, stderr, err := util.RunIP(family, "--json", "rule", "show")
 		if err != nil {
 			return fmt.Errorf("could not list %s rules - stdout: %s, stderr: %s, err: %v", family, stdout, stderr, err)
@@ -346,12 +362,24 @@ func (c *Controller) repairIPRules(v4EpsToServices, v6EpsToServices, cipsToServi
 			return err
 		}
 
+		currEpsIPRules := []IPRule{}
+		currNodePortIPRules := []IPRule{}
 		for _, rule := range allIPRules {
 			if rule.Priority != IPRulePriority {
 				// the priority isn't the fixed one for the controller
 				continue
 			}
 
+			if rule.SrcPort != 0 { // we configure source port only for ETP=Local NodePorts
+				currNodePortIPRules = append(currNodePortIPRules, rule)
+				continue
+			}
+
+			currEpsIPRules = append(currEpsIPRules, rule)
+		}
+
+		ipRulesToDelete := []IPRule{}
+		for _, rule := range currEpsIPRules {
 			svcKey, found := epsToSvcKey[rule.Src]
 			if !found {
 				svcKey, found = cipsToServices[rule.Src]
@@ -379,9 +407,50 @@ func (c *Controller) repairIPRules(v4EpsToServices, v6EpsToServices, cipsToServi
 			state.netEps.Insert(rule.Src)
 		}
 
+		nodePortIPRulesToDelete := []IPRule{}
+		for _, rule := range currNodePortIPRules {
+			svcKey, found := nodePortsToServices[rule.SrcPort]
+			if !found {
+				nodePortIPRulesToDelete = append(nodePortIPRulesToDelete, rule)
+				continue
+			}
+			srcIsV4Masquerade := rule.Src == config.Gateway.MasqueradeIPs.V4HostETPLocalMasqueradeIP.String()
+			srcIsV6Masquerade := rule.Src == config.Gateway.MasqueradeIPs.V6HostETPLocalMasqueradeIP.String()
+			if !srcIsV4Masquerade && !srcIsV6Masquerade {
+				nodePortIPRulesToDelete = append(nodePortIPRulesToDelete, rule)
+				continue
+			}
+
+			state := c.services[svcKey]
+			if state == nil {
+				// the rule belongs to a service that is no longer valid
+				nodePortIPRulesToDelete = append(nodePortIPRulesToDelete, rule)
+				continue
+			}
+
+			if state.net != rule.Table {
+				// the rule points to the wrong routing table
+				nodePortIPRulesToDelete = append(nodePortIPRulesToDelete, rule)
+				continue
+			}
+
+			if srcIsV4Masquerade {
+				state.v4NodePorts.Insert(rule.SrcPort)
+				continue
+			}
+			state.v6NodePorts.Insert(rule.SrcPort)
+		}
+
 		errorList := []error{}
 		for _, rule := range ipRulesToDelete {
 			err := deleteIPRule(family, rule.Priority, rule.Src, rule.Table)
+			if err != nil {
+				errorList = append(errorList, err)
+			}
+		}
+
+		for _, rule := range nodePortIPRulesToDelete {
+			err := deleteNodePortIPRule(family, rule.Priority, rule.Src, rule.SrcPort, rule.Table)
 			if err != nil {
 				errorList = append(errorList, err)
 			}
@@ -709,10 +778,12 @@ func (c *Controller) syncEgressService(key string) error {
 
 	if cachedState == nil {
 		cachedState = &svcState{
-			v4Eps:  sets.New[string](),
-			v6Eps:  sets.New[string](),
-			netEps: sets.New[string](),
-			stale:  false,
+			v4Eps:       sets.New[string](),
+			v6Eps:       sets.New[string](),
+			netEps:      sets.New[string](),
+			v4NodePorts: sets.New[int32](),
+			v6NodePorts: sets.New[int32](),
+			stale:       false,
 		}
 		c.services[key] = cachedState
 	}
@@ -820,6 +891,72 @@ func (c *Controller) syncEgressService(key string) error {
 		cachedState.netEps.Delete(ip)
 	}
 
+	// Now we create the ip rules for the MASQUERADE+NodePort.
+	// This is needed only when ETP=Local, and its purpose is to ensure
+	// that reply for ingress traffic uses the correct network.
+
+	v4NodePortIPRulesToAdd := sets.New[int32]()
+	v6NodePortIPRulesToAdd := sets.New[int32]()
+	v4NodePortIPRulesToDelete := cachedState.v4NodePorts
+	v6NodePortIPRulesToDelete := cachedState.v6NodePorts
+	if svc.Spec.ExternalTrafficPolicy == corev1.ServiceExternalTrafficPolicyLocal {
+		allNodePorts := sets.New[int32]()
+		for _, p := range svc.Spec.Ports {
+			allNodePorts.Insert(p.NodePort)
+		}
+
+		hasV4Ingress, hasV6Ingress := false, false
+		for _, ip := range svc.Status.LoadBalancer.Ingress {
+			if utilnet.IsIPv4String(ip.IP) {
+				hasV4Ingress = true
+				continue
+			}
+			hasV6Ingress = true
+		}
+
+		if hasV4Ingress {
+			v4NodePortIPRulesToAdd = allNodePorts.Difference(cachedState.v4NodePorts)
+			v4NodePortIPRulesToDelete = cachedState.v4NodePorts.Difference(allNodePorts)
+		}
+
+		if hasV6Ingress {
+			v6NodePortIPRulesToAdd = allNodePorts.Difference(cachedState.v6NodePorts)
+			v6NodePortIPRulesToDelete = cachedState.v6NodePorts.Difference(allNodePorts)
+		}
+	}
+
+	for port := range v4NodePortIPRulesToAdd {
+		err := createNodePortIPRule("-4", IPRulePriority, config.Gateway.MasqueradeIPs.V4HostETPLocalMasqueradeIP.String(), port, cachedState.net)
+		if err != nil {
+			return err
+		}
+		cachedState.v4NodePorts.Insert(port)
+	}
+
+	for port := range v4NodePortIPRulesToDelete {
+		err := deleteNodePortIPRule("-4", IPRulePriority, config.Gateway.MasqueradeIPs.V4HostETPLocalMasqueradeIP.String(), port, cachedState.net)
+		if err != nil {
+			return err
+		}
+		cachedState.v4NodePorts.Delete(port)
+	}
+
+	for port := range v6NodePortIPRulesToAdd {
+		err := createNodePortIPRule("-6", IPRulePriority, config.Gateway.MasqueradeIPs.V6HostETPLocalMasqueradeIP.String(), port, cachedState.net)
+		if err != nil {
+			return err
+		}
+		cachedState.v6NodePorts.Insert(port)
+	}
+
+	for port := range v6NodePortIPRulesToDelete {
+		err := deleteNodePortIPRule("-6", IPRulePriority, config.Gateway.MasqueradeIPs.V6HostETPLocalMasqueradeIP.String(), port, cachedState.net)
+		if err != nil {
+			return err
+		}
+		cachedState.v6NodePorts.Delete(port)
+	}
+
 	return nil
 }
 
@@ -889,7 +1026,7 @@ func (c *Controller) clearServiceSNATRules(key string, state *svcState) error {
 	return nil
 }
 
-// Clears all of the FWMark rules of the service.
+// Clears all of the ip rules of the service.
 func (c *Controller) clearServiceIPRules(state *svcState) error {
 	errorList := []error{}
 	for ip := range state.netEps {
@@ -905,6 +1042,23 @@ func (c *Controller) clearServiceIPRules(state *svcState) error {
 		}
 
 		state.netEps.Delete(ip)
+	}
+
+	for port := range state.v4NodePorts {
+		err := deleteNodePortIPRule("-4", IPRulePriority, config.Gateway.MasqueradeIPs.V4HostETPLocalMasqueradeIP.String(), port, state.net)
+		if err != nil {
+			errorList = append(errorList, err)
+			continue
+		}
+		state.v4NodePorts.Delete(port)
+	}
+	for port := range state.v6NodePorts {
+		err := deleteNodePortIPRule("-6", IPRulePriority, config.Gateway.MasqueradeIPs.V6HostETPLocalMasqueradeIP.String(), port, state.net)
+		if err != nil {
+			errorList = append(errorList, err)
+			continue
+		}
+		state.v6NodePorts.Delete(port)
 	}
 
 	return errors.NewAggregate(errorList)
@@ -948,12 +1102,36 @@ func createIPRule(family string, priority int32, src, table string) error {
 	return nil
 }
 
+// Create ip rule with the given fields.
+func createNodePortIPRule(family string, priority int32, src string, srcPort int32, table string) error {
+	prio := fmt.Sprintf("%d", priority)
+	sPort := fmt.Sprintf("%d", srcPort)
+	stdout, stderr, err := util.RunIP(family, "rule", "add", "prio", prio, "from", src, "sport", sPort, "table", table)
+	if err != nil && !strings.Contains(stderr, "File exists") {
+		return fmt.Errorf("could not add rule for src %s sport %s table %s - stdout: %s, stderr: %s, err: %v", src, sPort, table, stdout, stderr, err)
+	}
+
+	return nil
+}
+
 // Delete ip rule with the given fields.
 func deleteIPRule(family string, priority int32, src, table string) error {
 	prio := fmt.Sprintf("%d", priority)
 	stdout, stderr, err := util.RunIP(family, "rule", "del", "prio", prio, "from", src, "table", table)
 	if err != nil && !strings.Contains(stderr, "No such file or directory") {
 		return fmt.Errorf("could not delete rule for src %s table %s - stdout: %s, stderr: %s, err: %v", src, table, stdout, stderr, err)
+	}
+
+	return nil
+}
+
+// Delete ip rule with the given fields.
+func deleteNodePortIPRule(family string, priority int32, src string, srcPort int32, table string) error {
+	prio := fmt.Sprintf("%d", priority)
+	sPort := fmt.Sprintf("%d", srcPort)
+	stdout, stderr, err := util.RunIP(family, "rule", "del", "prio", prio, "from", src, "sport", sPort, "table", table)
+	if err != nil && !strings.Contains(stderr, "No such file or directory") {
+		return fmt.Errorf("could not delete rule for src %s sport %s table %s - stdout: %s, stderr: %s, err: %v", src, sPort, table, stdout, stderr, err)
 	}
 
 	return nil

--- a/go-controller/pkg/node/egress_service_test.go
+++ b/go-controller/pkg/node/egress_service_test.go
@@ -2,6 +2,7 @@ package node
 
 import (
 	"context"
+	"fmt"
 	"net"
 
 	. "github.com/onsi/ginkgo"
@@ -66,7 +67,9 @@ var _ = Describe("Egress Service Operations", func() {
 					Cmd: "ip -4 --json rule show",
 					Output: "[{\"priority\":5000,\"src\":\"10.128.0.3\",\"table\":\"wrongTable\"},{\"priority\":5000,\"src\":\"goneEp\",\"table\":\"mynetwork\"}," +
 						"{\"priority\":5000,\"src\":\"10.128.0.3\",\"table\":\"mynetwork\"},{\"priority\":5000,\"src\":\"10.129.0.2\",\"table\":\"mynetwork\"}," +
-						"{\"priority\":5000,\"src\":\"10.128.0.33\",\"table\":\"mynetwork\"},{\"priority\":5000,\"src\":\"10.129.0.3\",\"table\":\"mynetwork\"}]",
+						"{\"priority\":5000,\"src\":\"10.128.0.33\",\"table\":\"mynetwork2\"},{\"priority\":5000,\"src\":\"10.129.0.3\",\"table\":\"mynetwork2\"}," +
+						fmt.Sprintf("{\"priority\":5000,\"src\":\"%s\",\"sport\":31111,\"table\":\"mynetwork\"},", config.Gateway.MasqueradeIPs.V4HostETPLocalMasqueradeIP) +
+						fmt.Sprintf("{\"priority\":5000,\"src\":\"%s\",\"sport\":30300,\"table\":\"mynetwork2\"}]", config.Gateway.MasqueradeIPs.V4HostETPLocalMasqueradeIP),
 					Err: nil,
 				})
 				fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
@@ -75,6 +78,10 @@ var _ = Describe("Egress Service Operations", func() {
 				})
 				fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
 					Cmd: "ip -4 rule del prio 5000 from goneEp table mynetwork",
+					Err: nil,
+				})
+				fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
+					Cmd: fmt.Sprintf("ip -4 rule del prio 5000 from %s sport 31111 table mynetwork", config.Gateway.MasqueradeIPs.V4HostETPLocalMasqueradeIP),
 					Err: nil,
 				})
 
@@ -207,7 +214,7 @@ var _ = Describe("Egress Service Operations", func() {
 						Namespace: "namespace1",
 					},
 					Spec: egressserviceapi.EgressServiceSpec{
-						Network: "mynetwork",
+						Network: "mynetwork2",
 					},
 					Status: egressserviceapi.EgressServiceStatus{
 						Host: "ALL",
@@ -216,7 +223,7 @@ var _ = Describe("Egress Service Operations", func() {
 				service2 := *newService("service2", "namespace1", "10.129.0.3",
 					[]v1.ServicePort{
 						{
-							NodePort: int32(31111),
+							NodePort: int32(30300),
 							Protocol: v1.ProtocolTCP,
 							Port:     int32(8080),
 						},
@@ -230,7 +237,7 @@ var _ = Describe("Egress Service Operations", func() {
 							}},
 						},
 					},
-					false, false,
+					true, false,
 				)
 
 				ep3 := discovery.Endpoint{
@@ -435,11 +442,35 @@ var _ = Describe("Egress Service Operations", func() {
 					Err: nil,
 				})
 				fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
+					Cmd: "ip -4 rule add prio 5000 from 10.129.0.10 table mynetwork",
+					Err: nil,
+				})
+				fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
+					Cmd: "ip -4 rule add prio 5000 from 10.128.0.11 table mynetwork",
+					Err: nil,
+				})
+				fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
+					Cmd: fmt.Sprintf("ip -4 rule add prio 5000 from %s sport 30300 table mynetwork", config.Gateway.MasqueradeIPs.V4HostETPLocalMasqueradeIP),
+					Err: nil,
+				})
+				fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
 					Cmd: "ip -4 rule del prio 5000 from 10.129.0.2 table mynetwork",
 					Err: nil,
 				})
 				fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
 					Cmd: "ip -4 rule del prio 5000 from 10.128.0.3 table mynetwork",
+					Err: nil,
+				})
+				fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
+					Cmd: "ip -4 rule del prio 5000 from 10.129.0.10 table mynetwork",
+					Err: nil,
+				})
+				fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
+					Cmd: "ip -4 rule del prio 5000 from 10.128.0.11 table mynetwork",
+					Err: nil,
+				})
+				fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
+					Cmd: fmt.Sprintf("ip -4 rule del prio 5000 from %s sport 30300 table mynetwork", config.Gateway.MasqueradeIPs.V4HostETPLocalMasqueradeIP),
 					Err: nil,
 				})
 				epPortName := "https"
@@ -499,20 +530,68 @@ var _ = Describe("Egress Service Operations", func() {
 					[]discovery.Endpoint{ep1, ep2},
 					[]discovery.EndpointPort{epPort})
 
+				egressService2 := egressserviceapi.EgressService{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "service2",
+						Namespace: "namespace1",
+					},
+					Spec: egressserviceapi.EgressServiceSpec{
+						Network: "mynetwork",
+					},
+					Status: egressserviceapi.EgressServiceStatus{
+						Host: fakeNodeName,
+					},
+				}
+
+				service2 := *newService("service2", "namespace1", "10.129.0.10",
+					[]v1.ServicePort{
+						{
+							NodePort: int32(30300),
+							Protocol: v1.ProtocolTCP,
+							Port:     int32(8080),
+						},
+					},
+					v1.ServiceTypeLoadBalancer,
+					[]string{},
+					v1.ServiceStatus{
+						LoadBalancer: v1.LoadBalancerStatus{
+							Ingress: []v1.LoadBalancerIngress{{
+								IP: "5.5.5.6",
+							}},
+						},
+					},
+					true, false,
+				)
+
+				ep3 := discovery.Endpoint{
+					Addresses: []string{"10.128.0.11"},
+				}
+
+				// endpointSlice.Endpoints is ovn-networked so this will
+				// come under !hasLocalHostNetEp case
+				endpointSlice2 := *newEndpointSlice(
+					"service2",
+					"namespace1",
+					[]discovery.Endpoint{ep3},
+					[]discovery.EndpointPort{epPort})
+
 				fakeOvnNode.start(ctx,
 					&v1.ServiceList{
 						Items: []v1.Service{
 							service,
+							service2,
 						},
 					},
 					&discovery.EndpointSliceList{
 						Items: []discovery.EndpointSlice{
 							endpointSlice,
+							endpointSlice2,
 						},
 					},
 					&egressserviceapi.EgressServiceList{
 						Items: []egressserviceapi.EgressService{
 							egressService,
+							egressService2,
 						},
 					},
 				)
@@ -529,6 +608,20 @@ var _ = Describe("Egress Service Operations", func() {
 						"OVN-KUBE-EGRESS-SVC": []string{
 							"-m mark --mark 0x3f0 -m comment --comment DoNotSNAT -j RETURN",
 							"-s 10.128.0.3 -m comment --comment namespace1/service1 -j SNAT --to-source 5.5.5.5",
+							"-s 10.128.0.11 -m comment --comment namespace1/service2 -j SNAT --to-source 5.5.5.6",
+						},
+					},
+					"filter": {},
+					"mangle": {},
+				}
+				// The order of the rules is determined by the order the services are processed.
+				// We check if one of the two tables match to not flake on ordering.
+				expectedTables2 := map[string]util.FakeTable{
+					"nat": {
+						"OVN-KUBE-EGRESS-SVC": []string{
+							"-m mark --mark 0x3f0 -m comment --comment DoNotSNAT -j RETURN",
+							"-s 10.128.0.11 -m comment --comment namespace1/service2 -j SNAT --to-source 5.5.5.6",
+							"-s 10.128.0.3 -m comment --comment namespace1/service1 -j SNAT --to-source 5.5.5.5",
 						},
 					},
 					"filter": {},
@@ -536,7 +629,11 @@ var _ = Describe("Egress Service Operations", func() {
 				}
 				f4 := iptV4.(*util.FakeIPTables)
 				Eventually(func() error {
-					return f4.MatchState(expectedTables)
+					err := f4.MatchState(expectedTables)
+					if err == nil {
+						return nil
+					}
+					return f4.MatchState(expectedTables2)
 				}).ShouldNot(HaveOccurred())
 
 				expectedTables = map[string]util.FakeTable{
@@ -548,6 +645,9 @@ var _ = Describe("Egress Service Operations", func() {
 				}
 
 				err = fakeOvnNode.fakeClient.EgressServiceClient.K8sV1().EgressServices("namespace1").Delete(context.TODO(), "service1", metav1.DeleteOptions{})
+				Expect(err).ToNot(HaveOccurred())
+
+				err = fakeOvnNode.fakeClient.EgressServiceClient.K8sV1().EgressServices("namespace1").Delete(context.TODO(), "service2", metav1.DeleteOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
 				Eventually(func() error {
@@ -562,6 +662,228 @@ var _ = Describe("Egress Service Operations", func() {
 		})
 
 		It("manages ip rules for LoadBalancer egress service backed by ovn-k pods with Network and Host=ALL", func() {
+			app.Action = func(ctx *cli.Context) error {
+				fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
+					Cmd:    "ip -4 --json rule show",
+					Output: "[]",
+					Err:    nil,
+				})
+				fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
+					Cmd: "ip -4 rule add prio 5000 from 10.129.0.2 table mynetwork",
+					Err: nil,
+				})
+				fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
+					Cmd: "ip -4 rule add prio 5000 from 10.128.0.3 table mynetwork",
+					Err: nil,
+				})
+				fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
+					Cmd: "ip -4 rule add prio 5000 from 10.129.0.10 table mynetwork",
+					Err: nil,
+				})
+				fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
+					Cmd: "ip -4 rule add prio 5000 from 10.128.0.11 table mynetwork",
+					Err: nil,
+				})
+				fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
+					Cmd: fmt.Sprintf("ip -4 rule add prio 5000 from %s sport 30300 table mynetwork", config.Gateway.MasqueradeIPs.V4HostETPLocalMasqueradeIP),
+					Err: nil,
+				})
+				epPortName := "https"
+				epPortValue := int32(443)
+
+				egressService := egressserviceapi.EgressService{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "service1",
+						Namespace: "namespace1",
+					},
+					Spec: egressserviceapi.EgressServiceSpec{
+						Network: "mynetwork",
+					},
+					Status: egressserviceapi.EgressServiceStatus{
+						Host: "ALL",
+					},
+				}
+
+				service := *newService("service1", "namespace1", "10.129.0.2",
+					[]v1.ServicePort{
+						{
+							NodePort: int32(31111),
+							Protocol: v1.ProtocolTCP,
+							Port:     int32(8080),
+						},
+					},
+					v1.ServiceTypeLoadBalancer,
+					[]string{},
+					v1.ServiceStatus{
+						LoadBalancer: v1.LoadBalancerStatus{
+							Ingress: []v1.LoadBalancerIngress{{
+								IP: "5.5.5.5",
+							}},
+						},
+					},
+					false, false,
+				)
+
+				ep1 := discovery.Endpoint{
+					Addresses: []string{"10.128.0.3"},
+					NodeName:  &fakeNodeName,
+				}
+				epPort := discovery.EndpointPort{
+					Name: &epPortName,
+					Port: &epPortValue,
+				}
+
+				// host-networked endpoint, should not have an ip rule created
+				ep2 := discovery.Endpoint{
+					Addresses: []string{"192.168.18.15"},
+					NodeName:  &fakeNodeName,
+				}
+
+				// ep that does not belong to our node should not have an ip rule created
+				someOtherNode := "someOtherNode"
+				ep3 := discovery.Endpoint{
+					Addresses: []string{"10.128.1.5"},
+					NodeName:  &someOtherNode,
+				}
+				// endpointSlice.Endpoints is ovn-networked so this will
+				// come under !hasLocalHostNetEp case
+				endpointSlice := *newEndpointSlice(
+					"service1",
+					"namespace1",
+					[]discovery.Endpoint{ep1, ep2, ep3},
+					[]discovery.EndpointPort{epPort})
+
+				egressService2 := egressserviceapi.EgressService{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "service2",
+						Namespace: "namespace1",
+					},
+					Spec: egressserviceapi.EgressServiceSpec{
+						Network: "mynetwork",
+					},
+					Status: egressserviceapi.EgressServiceStatus{
+						Host: "ALL",
+					},
+				}
+
+				service2 := *newService("service2", "namespace1", "10.129.0.10",
+					[]v1.ServicePort{
+						{
+							NodePort: int32(30300),
+							Protocol: v1.ProtocolTCP,
+							Port:     int32(8080),
+						},
+					},
+					v1.ServiceTypeLoadBalancer,
+					[]string{},
+					v1.ServiceStatus{
+						LoadBalancer: v1.LoadBalancerStatus{
+							Ingress: []v1.LoadBalancerIngress{{
+								IP: "5.5.5.6",
+							}},
+						},
+					},
+					true, false,
+				)
+
+				ep4 := discovery.Endpoint{
+					Addresses: []string{"10.128.0.11"},
+					NodeName:  &fakeNodeName,
+				}
+
+				endpointSlice2 := *newEndpointSlice(
+					"service2",
+					"namespace1",
+					[]discovery.Endpoint{ep4},
+					[]discovery.EndpointPort{epPort})
+
+				fakeOvnNode.start(ctx,
+					&v1.ServiceList{
+						Items: []v1.Service{
+							service,
+							service2,
+						},
+					},
+					&discovery.EndpointSliceList{
+						Items: []discovery.EndpointSlice{
+							endpointSlice,
+							endpointSlice2,
+						},
+					},
+					&egressserviceapi.EgressServiceList{
+						Items: []egressserviceapi.EgressService{
+							egressService,
+							egressService2,
+						},
+					},
+				)
+
+				wf := fakeOvnNode.watcher.(*factory.WatchFactory)
+				c, err := egressservice.NewController(fakeOvnNode.stopChan, ovnKubeNodeSNATMark, fakeOvnNode.nc.name,
+					wf.EgressServiceInformer(), wf.ServiceInformer(), wf.EndpointSliceInformer())
+				Expect(err).ToNot(HaveOccurred())
+				err = c.Run(fakeOvnNode.wg, 1)
+				Expect(err).ToNot(HaveOccurred())
+
+				expectedTables := map[string]util.FakeTable{
+					"nat": {
+						"OVN-KUBE-EGRESS-SVC": []string{
+							"-m mark --mark 0x3f0 -m comment --comment DoNotSNAT -j RETURN",
+						},
+					},
+					"filter": {},
+					"mangle": {},
+				}
+				f4 := iptV4.(*util.FakeIPTables)
+				Eventually(func() error {
+					return f4.MatchState(expectedTables)
+				}).ShouldNot(HaveOccurred())
+
+				Eventually(func() bool {
+					return fakeOvnNode.fakeExec.CalledMatchesExpected()
+				}).Should(BeTrue())
+
+				fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
+					Cmd: "ip -4 rule del prio 5000 from 10.129.0.2 table mynetwork",
+					Err: nil,
+				})
+				fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
+					Cmd: "ip -4 rule del prio 5000 from 10.128.0.3 table mynetwork",
+					Err: nil,
+				})
+				fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
+					Cmd: "ip -4 rule del prio 5000 from 10.129.0.10 table mynetwork",
+					Err: nil,
+				})
+				fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
+					Cmd: "ip -4 rule del prio 5000 from 10.128.0.11 table mynetwork",
+					Err: nil,
+				})
+				fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
+					Cmd: fmt.Sprintf("ip -4 rule del prio 5000 from %s sport 30300 table mynetwork", config.Gateway.MasqueradeIPs.V4HostETPLocalMasqueradeIP),
+					Err: nil,
+				})
+
+				err = fakeOvnNode.fakeClient.EgressServiceClient.K8sV1().EgressServices("namespace1").Delete(context.TODO(), "service1", metav1.DeleteOptions{})
+				Expect(err).ToNot(HaveOccurred())
+
+				err = fakeOvnNode.fakeClient.EgressServiceClient.K8sV1().EgressServices("namespace1").Delete(context.TODO(), "service2", metav1.DeleteOptions{})
+				Expect(err).ToNot(HaveOccurred())
+
+				Eventually(func() error {
+					return f4.MatchState(expectedTables)
+				}).ShouldNot(HaveOccurred())
+
+				Eventually(func() bool {
+					return fakeOvnNode.fakeExec.CalledMatchesExpected()
+				}).Should(BeTrue())
+				return nil
+			}
+			err := app.Run([]string{app.Name})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("updates network ip rules for LoadBalancer egress service when ETP changes", func() {
 			app.Action = func(ctx *cli.Context) error {
 				fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
 					Cmd:    "ip -4 --json rule show",
@@ -595,7 +917,7 @@ var _ = Describe("Egress Service Operations", func() {
 				service := *newService("service1", "namespace1", "10.129.0.2",
 					[]v1.ServicePort{
 						{
-							NodePort: int32(31111),
+							NodePort: int32(30300),
 							Protocol: v1.ProtocolTCP,
 							Port:     int32(8080),
 						},
@@ -684,6 +1006,43 @@ var _ = Describe("Egress Service Operations", func() {
 					return fakeOvnNode.fakeExec.CalledMatchesExpected()
 				}).Should(BeTrue())
 
+				By("switching to ETP=Local an ip rule should be created for the masquerade IP")
+				fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
+					Cmd: fmt.Sprintf("ip -4 rule add prio 5000 from %s sport 30300 table mynetwork", config.Gateway.MasqueradeIPs.V4HostETPLocalMasqueradeIP),
+					Err: nil,
+				})
+				service.Spec.ExternalTrafficPolicy = v1.ServiceExternalTrafficPolicyLocal
+				service.ResourceVersion = "100"
+				_, err = fakeOvnNode.fakeClient.KubeClient.CoreV1().Services("namespace1").Update(context.TODO(), &service, metav1.UpdateOptions{})
+				Expect(err).ToNot(HaveOccurred())
+
+				Eventually(func() error {
+					return f4.MatchState(expectedTables)
+				}).ShouldNot(HaveOccurred())
+
+				Eventually(func() bool {
+					return fakeOvnNode.fakeExec.CalledMatchesExpected()
+				}).Should(BeTrue())
+
+				By("switching back to ETP=Cluster the masquerade ip rule should be deleted")
+				fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
+					Cmd: fmt.Sprintf("ip -4 rule del prio 5000 from %s sport 30300 table mynetwork", config.Gateway.MasqueradeIPs.V4HostETPLocalMasqueradeIP),
+					Err: nil,
+				})
+				service.Spec.ExternalTrafficPolicy = v1.ServiceExternalTrafficPolicyCluster
+				service.ResourceVersion = "110"
+				_, err = fakeOvnNode.fakeClient.KubeClient.CoreV1().Services("namespace1").Update(context.TODO(), &service, metav1.UpdateOptions{})
+				Expect(err).ToNot(HaveOccurred())
+
+				Eventually(func() error {
+					return f4.MatchState(expectedTables)
+				}).ShouldNot(HaveOccurred())
+
+				Eventually(func() bool {
+					return fakeOvnNode.fakeExec.CalledMatchesExpected()
+				}).Should(BeTrue())
+
+				By("deleting the egress service the ip rules should be deleted")
 				fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
 					Cmd: "ip -4 rule del prio 5000 from 10.129.0.2 table mynetwork",
 					Err: nil,


### PR DESCRIPTION
Almost clean cherry-pick, 4.16 uses:
* `errors.NewAggregate` instead of `utilerrors.Join`
* `f4.MatchState(expectedTables)` instead of `f4.MatchState(expectedTables, nil)`