### PR TITLE
[release-4.16] OCPBUGS-38697: Use more exact name match when deleting static routes to HO nodes.

### DIFF
--- a/go-controller/pkg/ovn/hybrid_test.go
+++ b/go-controller/pkg/ovn/hybrid_test.go
@@ -1362,7 +1362,7 @@ var _ = ginkgo.Describe("Hybrid SDN Master Operations", func() {
 			gomega.Eventually(func() ([]*nbdb.LogicalRouterStaticRoute, error) {
 				p := func(item *nbdb.LogicalRouterStaticRoute) bool {
 					if item.ExternalIDs["name"] == "hybrid-subnet-node1-gr" ||
-						strings.Contains(item.ExternalIDs["name"], "hybrid-subnet-node1") {
+						item.ExternalIDs["name"] == "hybrid-subnet-node1:node-windows" {
 						return true
 					}
 					return false

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -910,7 +910,7 @@ func (oc *DefaultNetworkController) deleteHoNodeEvent(node *kapi.Node) error {
 		if err != nil {
 			return fmt.Errorf("failed to parse hybridOverlay node subnet for node %s: %w", node.Name, err)
 		}
-		err = oc.removeRoutesToHONodeSubnet(nodeSubnet)
+		err = oc.removeRoutesToHONodeSubnet(node.Name, nodeSubnet)
 		if err != nil {
 			return fmt.Errorf("failed to remove hybrid overlay static routes and route policy: %w", err)
 		}


### PR DESCRIPTION
It can help to avoid the unintended match when the '-gr' substring exists in a node name.

This is manual cherrypick of commit 6dd663235dab22377971f2b9e109b7af327fd9fb