### PR TITLE
Revert "SDN-4930: Bump OVN to ovn24.09-24.09.0-beta.31.el9fdp"

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -13,7 +13,7 @@ RUN dnf install -y --nodocs \
 	dnf clean all
 
 ARG ovsver=3.4.0-1.el9fdp
-ARG ovnver=24.09.0-beta.31.el9fdp
+ARG ovnver=24.03.2-19.el9fdp
 # NOTE: Ensure that the versions of OVS and OVN are overriden for OKD in each of the subsequent layers.
 ARG ovsver_okd=3.4.0-0.8.el9s
 ARG ovnver_okd=24.03.1-5.el9s


### PR DESCRIPTION
Reverts openshift/ovn-kubernetes#2297; tracked by [TRT-1819](https://issues.redhat.com/browse/TRT-1819)

TRT suspects this PR as being a possible cause of a recent payload regression. We are floating this revert to perform additional testing.

Holding pending confirmation:
/hold
