### PR TITLE
[release-4.16] OCPBUGS-41551: Add subnet overlap check for transit switch subnet

### DIFF
--- a/go-controller/pkg/clustermanager/clustermanager_test.go
+++ b/go-controller/pkg/clustermanager/clustermanager_test.go
@@ -1175,7 +1175,7 @@ var _ = ginkgo.Describe("Cluster Manager", func() {
 	ginkgo.Context("Transit switch port IP allocations", func() {
 		ginkgo.It("Interconnect enabled", func() {
 			config.ClusterManager.V4TransitSwitchSubnet = "100.89.0.0/16"
-			config.ClusterManager.V6TransitSwitchSubnet = "fd98::/64"
+			config.ClusterManager.V6TransitSwitchSubnet = "fd99::/64"
 			app.Action = func(ctx *cli.Context) error {
 				nodes := []v1.Node{
 					{

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -2046,18 +2046,19 @@ func buildClusterManagerConfig(ctx *cli.Context, cli, file *config) error {
 
 // completeClusterManagerConfig completes the ClusterManager config by parsing raw values
 // into their final form.
-func completeClusterManagerConfig() error {
+func completeClusterManagerConfig(allSubnets *configSubnets) error {
 	// Validate v4 and v6 transit switch subnets
-	v4IP, _, err := net.ParseCIDR(ClusterManager.V4TransitSwitchSubnet)
+	v4IP, v4TransitCIDR, err := net.ParseCIDR(ClusterManager.V4TransitSwitchSubnet)
 	if err != nil || utilnet.IsIPv6(v4IP) {
 		return fmt.Errorf("invalid transit switch v4 subnet specified, subnet: %s: error: %v", ClusterManager.V4TransitSwitchSubnet, err)
 	}
 
-	v6IP, _, err := net.ParseCIDR(ClusterManager.V6TransitSwitchSubnet)
+	v6IP, v6TransitCIDR, err := net.ParseCIDR(ClusterManager.V6TransitSwitchSubnet)
 	if err != nil || !utilnet.IsIPv6(v6IP) {
 		return fmt.Errorf("invalid transit switch v6 subnet specified, subnet: %s: error: %v", ClusterManager.V6TransitSwitchSubnet, err)
 	}
-
+	allSubnets.append(configSubnetTransit, v4TransitCIDR)
+	allSubnets.append(configSubnetTransit, v6TransitCIDR)
 	return nil
 }
 
@@ -2337,7 +2338,7 @@ func completeConfig() error {
 		return err
 	}
 
-	if err := completeClusterManagerConfig(); err != nil {
+	if err := completeClusterManagerConfig(allSubnets); err != nil {
 		return err
 	}
 

--- a/go-controller/pkg/config/config_test.go
+++ b/go-controller/pkg/config/config_test.go
@@ -1223,12 +1223,12 @@ enable-pprof=true
 		cliArgs := []string{
 			app.Name,
 			"-cluster-manager-v4-transit-switch-subnet=100.89.0.0/16",
-			"-cluster-manager-v6-transit-switch-subnet=fd98::/64",
+			"-cluster-manager-v6-transit-switch-subnet=fd99::/64",
 		}
 		err := app.Run(cliArgs)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		gomega.Expect(ClusterManager.V4TransitSwitchSubnet).To(gomega.Equal("100.89.0.0/16"))
-		gomega.Expect(ClusterManager.V6TransitSwitchSubnet).To(gomega.Equal("fd98::/64"))
+		gomega.Expect(ClusterManager.V6TransitSwitchSubnet).To(gomega.Equal("fd99::/64"))
 	})
 	It("overrides config file and defaults with CLI options (multi-master)", func() {
 		kubeconfigFile, _, err := createTempFile("kubeconfig")

--- a/go-controller/pkg/config/utils.go
+++ b/go-controller/pkg/config/utils.go
@@ -166,6 +166,7 @@ const (
 	configSubnetService    configSubnetType = "service subnet"
 	configSubnetHybrid     configSubnetType = "hybrid overlay subnet"
 	configSubnetMasquerade configSubnetType = "masquerade subnet"
+	configSubnetTransit    configSubnetType = "transit switch subnet"
 )
 
 type configSubnet struct {
@@ -191,7 +192,7 @@ func newConfigSubnets() *configSubnets {
 // append adds a single subnet to cs
 func (cs *configSubnets) append(subnetType configSubnetType, subnet *net.IPNet) {
 	cs.subnets = append(cs.subnets, configSubnet{subnetType: subnetType, subnet: subnet})
-	if subnetType != configSubnetJoin && subnetType != configSubnetMasquerade {
+	if subnetType != configSubnetJoin && subnetType != configSubnetMasquerade && subnetType != configSubnetTransit {
 		if utilnet.IsIPv6CIDR(subnet) {
 			cs.v6[subnetType] = true
 		} else {


### PR DESCRIPTION
This PR is to emit error and terminate ovnkube startup if transit switch subnet is being used as either join switch or masquerade subnet.

Signed-off-by: Arnab Ghosh <arnabghosh89@gmail.com>
(cherry picked from commit 46d35e6ce0f5c4a36906f050d11e99b72e390077)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

#### What this PR does and why is it needed
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

#### How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->

#### Details to documentation updates
<!--
Did you include good docs that explain to our end users/developers/contributors
how your code works?
-->


#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: TBD
-->
```release-note

```
