### PR TITLE
[release-4.17] OCPBUGS-42931: Add static route to the hairpin masquerade IPs to pod

### DIFF
--- a/go-controller/pkg/allocator/pod/pod_annotation_test.go
+++ b/go-controller/pkg/allocator/pod/pod_annotation_test.go
@@ -219,6 +219,13 @@ func Test_allocatePodAnnotationWithRollback(t *testing.T) {
 				Gateways: []net.IP{ovntest.MustParseIP("192.168.0.1").To4()},
 				Routes: []util.PodRoute{
 					{
+						Dest: &net.IPNet{
+							IP:   ovntest.MustParseIP("169.254.169.5"),
+							Mask: net.CIDRMask(32, 32),
+						},
+						NextHop: ovntest.MustParseIP("192.168.0.1").To4(),
+					},
+					{
 						Dest:    ovntest.MustParseIPNet("100.64.0.0/16"),
 						NextHop: ovntest.MustParseIP("192.168.0.1").To4(),
 					},
@@ -302,6 +309,13 @@ func Test_allocatePodAnnotationWithRollback(t *testing.T) {
 				Gateways: []net.IP{ovntest.MustParseIP("192.168.0.1").To4()},
 				Routes: []util.PodRoute{
 					{
+						Dest: &net.IPNet{
+							IP:   ovntest.MustParseIP("169.254.169.5"),
+							Mask: net.CIDRMask(32, 32),
+						},
+						NextHop: ovntest.MustParseIP("192.168.0.1").To4(),
+					},
+					{
 						Dest:    ovntest.MustParseIPNet("100.64.0.0/16"),
 						NextHop: ovntest.MustParseIP("192.168.0.1").To4(),
 					},
@@ -333,6 +347,13 @@ func Test_allocatePodAnnotationWithRollback(t *testing.T) {
 				Gateways: []net.IP{ovntest.MustParseIP("192.168.0.1").To4()},
 				Routes: []util.PodRoute{
 					{
+						Dest: &net.IPNet{
+							IP:   ovntest.MustParseIP("169.254.169.5"),
+							Mask: net.CIDRMask(32, 32),
+						},
+						NextHop: ovntest.MustParseIP("192.168.0.1").To4(),
+					},
+					{
 						Dest:    ovntest.MustParseIPNet("100.64.0.0/16"),
 						NextHop: ovntest.MustParseIP("192.168.0.1").To4(),
 					},
@@ -362,6 +383,13 @@ func Test_allocatePodAnnotationWithRollback(t *testing.T) {
 				MAC:      util.IPAddrToHWAddr(ovntest.MustParseIPNets("192.168.0.3/24")[0].IP),
 				Gateways: []net.IP{ovntest.MustParseIP("192.168.0.1").To4()},
 				Routes: []util.PodRoute{
+					{
+						Dest: &net.IPNet{
+							IP:   ovntest.MustParseIP("169.254.169.5"),
+							Mask: net.CIDRMask(32, 32),
+						},
+						NextHop: ovntest.MustParseIP("192.168.0.1").To4(),
+					},
 					{
 						Dest:    ovntest.MustParseIPNet("100.64.0.0/16"),
 						NextHop: ovntest.MustParseIP("192.168.0.1").To4(),
@@ -420,6 +448,13 @@ func Test_allocatePodAnnotationWithRollback(t *testing.T) {
 				MAC:      requestedMACParsed,
 				Gateways: []net.IP{ovntest.MustParseIP("192.168.0.1").To4()},
 				Routes: []util.PodRoute{
+					{
+						Dest: &net.IPNet{
+							IP:   ovntest.MustParseIP("169.254.169.5"),
+							Mask: net.CIDRMask(32, 32),
+						},
+						NextHop: ovntest.MustParseIP("192.168.0.1").To4(),
+					},
 					{
 						Dest:    ovntest.MustParseIPNet("100.64.0.0/16"),
 						NextHop: ovntest.MustParseIP("192.168.0.1").To4(),

--- a/go-controller/pkg/ovn/pods_test.go
+++ b/go-controller/pkg/ovn/pods_test.go
@@ -250,6 +250,13 @@ func newTPod(nodeName, nodeSubnet, nodeMgtIP, nodeGWIP, podName, podIPs, podMAC,
 				routeSources = append(routeSources, sc)
 			}
 		}
+		hairpinMasqueradeIP := config.Gateway.MasqueradeIPs.V4OVNServiceHairpinMasqueradeIP.String()
+		mask := 32
+		if isIPv6 {
+			hairpinMasqueradeIP = config.Gateway.MasqueradeIPs.V6OVNServiceHairpinMasqueradeIP.String()
+			mask = 128
+		}
+		routeSources = append(routeSources, ovntest.MustParseIPNet(fmt.Sprintf("%s/%d", hairpinMasqueradeIP, mask)))
 		joinNet := config.Gateway.V4JoinSubnet
 		if isIPv6 {
 			joinNet = config.Gateway.V6JoinSubnet

--- a/go-controller/pkg/util/pod_annotation.go
+++ b/go-controller/pkg/util/pod_annotation.go
@@ -467,6 +467,20 @@ func serviceCIDRToRoute(isIPv6 bool, gatewayIP net.IP) []PodRoute {
 	return podRoutes
 }
 
+func hairpinMasqueradeIPToRoute(isIPv6 bool, gatewayIP net.IP) PodRoute {
+	ip := config.Gateway.MasqueradeIPs.V4OVNServiceHairpinMasqueradeIP
+	if isIPv6 {
+		ip = config.Gateway.MasqueradeIPs.V6OVNServiceHairpinMasqueradeIP
+	}
+	return PodRoute{
+		Dest: &net.IPNet{
+			IP:   ip,
+			Mask: GetIPFullMask(ip),
+		},
+		NextHop: gatewayIP,
+	}
+}
+
 // addRoutesGatewayIP updates the provided pod annotation for the provided pod
 // with the gateways derived from the allocated IPs
 func AddRoutesGatewayIP(
@@ -581,7 +595,8 @@ func AddRoutesGatewayIP(
 		if podAnnotation.Role == types.NetworkRolePrimary {
 			// Ensure default service network traffic always goes to OVN
 			podAnnotation.Routes = append(podAnnotation.Routes, serviceCIDRToRoute(isIPv6, gatewayIPnet.IP)...)
-
+			// Ensure service hairpin masquerade traffic always goes to OVN
+			podAnnotation.Routes = append(podAnnotation.Routes, hairpinMasqueradeIPToRoute(isIPv6, gatewayIPnet.IP))
 			otherDefaultRoute := otherDefaultRouteV4
 			if isIPv6 {
 				otherDefaultRoute = otherDefaultRouteV6


### PR DESCRIPTION
When users attach pod to a secondary network and override the default route pod. It will cause the assymetric routing for service haripin traffic.

We add static routes to ensure the traffic to the hairpin masquerade IP always goes to OVN.

(This is a clean cherry-pick of 6cdf7ecdff5ea9017c09ca8b35acc3de944a6eff)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

#### What this PR does and why is it needed
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

#### How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->

#### Details to documentation updates
<!--
Did you include good docs that explain to our end users/developers/contributors
how your code works?
-->


#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: TBD
-->
```release-note

```
