### PR TITLE
OCPBUGS-42952: pin libreswan to the known working version 4.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN INSTALL_PKGS=" \
 	libpcap iproute iproute-tc strace \
 	containernetworking-plugins \
 	tcpdump iputils \
-	libreswan \
+	libreswan-4.5-1.el9 \
 	ethtool conntrack-tools \
 	openshift-clients \
 	" && \


### PR DESCRIPTION
Until the libreswan issue is fixed in RHEL:
https://issues.redhat.com/browse/RHEL-61461

This is 4.14 only fix 

Several reasons we don't do it in 4.15 and beyond:

1. libreswan is installed on the host via rhcos extension, it was suggested to use layered coreos image instead of pinning the extension
2. libreswan-4.5 doesn't solve the bug on 4.15: https://issues.redhat.com/browse/OCPBUGS-41823
3. It is considered risky by coreos team to update the default rhcos image as libreswan-4.5 is quite old 