### PR TITLE
OKD-227: bump ovn version to 24.09.0-41 for OKD

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -15,8 +15,10 @@ RUN dnf install -y --nodocs \
 ARG ovsver=3.4.0-1.el9fdp
 ARG ovnver=24.09.0-beta.31.el9fdp
 # NOTE: Ensure that the versions of OVS and OVN are overriden for OKD in each of the subsequent layers.
-ARG ovsver_okd=3.4.0-0.8.el9s
-ARG ovnver_okd=24.03.1-5.el9s
+# Centos and RHEL releases for ovn are built out of sync, so please make sure to bump for OKD with
+# the corresponding Centos version when updating the OCP version.
+ARG ovsver_okd=3.4.0-12.el9s
+ARG ovnver_okd=24.09.0-41.el9s
 
 RUN INSTALL_PKGS="iptables nftables" && \
     source /etc/os-release && \


### PR DESCRIPTION
This fixes the database schema mismatch causing ovnkube-node pods to crash.