### PR TITLE
[release-4.16] OCPBUGS-44457: Add static route to the hairpin masquerade IPs to pod

### DIFF
--- a/go-controller/pkg/allocator/pod/pod_annotation_test.go
+++ b/go-controller/pkg/allocator/pod/pod_annotation_test.go
@@ -212,6 +212,13 @@ func Test_allocatePodAnnotationWithRollback(t *testing.T) {
 				Gateways: []net.IP{ovntest.MustParseIP("192.168.0.1").To4()},
 				Routes: []util.PodRoute{
 					{
+						Dest: &net.IPNet{
+							IP:   ovntest.MustParseIP("169.254.169.5"),
+							Mask: net.CIDRMask(32, 32),
+						},
+						NextHop: ovntest.MustParseIP("192.168.0.1").To4(),
+					},
+					{
 						Dest:    ovntest.MustParseIPNet("100.64.0.0/16"),
 						NextHop: ovntest.MustParseIP("192.168.0.1").To4(),
 					},
@@ -293,6 +300,13 @@ func Test_allocatePodAnnotationWithRollback(t *testing.T) {
 				Gateways: []net.IP{ovntest.MustParseIP("192.168.0.1").To4()},
 				Routes: []util.PodRoute{
 					{
+						Dest: &net.IPNet{
+							IP:   ovntest.MustParseIP("169.254.169.5"),
+							Mask: net.CIDRMask(32, 32),
+						},
+						NextHop: ovntest.MustParseIP("192.168.0.1").To4(),
+					},
+					{
 						Dest:    ovntest.MustParseIPNet("100.64.0.0/16"),
 						NextHop: ovntest.MustParseIP("192.168.0.1").To4(),
 					},
@@ -322,6 +336,13 @@ func Test_allocatePodAnnotationWithRollback(t *testing.T) {
 				Gateways: []net.IP{ovntest.MustParseIP("192.168.0.1").To4()},
 				Routes: []util.PodRoute{
 					{
+						Dest: &net.IPNet{
+							IP:   ovntest.MustParseIP("169.254.169.5"),
+							Mask: net.CIDRMask(32, 32),
+						},
+						NextHop: ovntest.MustParseIP("192.168.0.1").To4(),
+					},
+					{
 						Dest:    ovntest.MustParseIPNet("100.64.0.0/16"),
 						NextHop: ovntest.MustParseIP("192.168.0.1").To4(),
 					},
@@ -349,6 +370,13 @@ func Test_allocatePodAnnotationWithRollback(t *testing.T) {
 				MAC:      util.IPAddrToHWAddr(ovntest.MustParseIPNets("192.168.0.3/24")[0].IP),
 				Gateways: []net.IP{ovntest.MustParseIP("192.168.0.1").To4()},
 				Routes: []util.PodRoute{
+					{
+						Dest: &net.IPNet{
+							IP:   ovntest.MustParseIP("169.254.169.5"),
+							Mask: net.CIDRMask(32, 32),
+						},
+						NextHop: ovntest.MustParseIP("192.168.0.1").To4(),
+					},
 					{
 						Dest:    ovntest.MustParseIPNet("100.64.0.0/16"),
 						NextHop: ovntest.MustParseIP("192.168.0.1").To4(),
@@ -405,6 +433,13 @@ func Test_allocatePodAnnotationWithRollback(t *testing.T) {
 				MAC:      requestedMACParsed,
 				Gateways: []net.IP{ovntest.MustParseIP("192.168.0.1").To4()},
 				Routes: []util.PodRoute{
+					{
+						Dest: &net.IPNet{
+							IP:   ovntest.MustParseIP("169.254.169.5"),
+							Mask: net.CIDRMask(32, 32),
+						},
+						NextHop: ovntest.MustParseIP("192.168.0.1").To4(),
+					},
 					{
 						Dest:    ovntest.MustParseIPNet("100.64.0.0/16"),
 						NextHop: ovntest.MustParseIP("192.168.0.1").To4(),

--- a/go-controller/pkg/ovn/pods_test.go
+++ b/go-controller/pkg/ovn/pods_test.go
@@ -246,6 +246,13 @@ func newTPod(nodeName, nodeSubnet, nodeMgtIP, nodeGWIP, podName, podIPs, podMAC,
 				routeSources = append(routeSources, sc)
 			}
 		}
+		hairpinMasqueradeIP := config.Gateway.MasqueradeIPs.V4OVNServiceHairpinMasqueradeIP.String()
+		mask := 32
+		if isIPv6 {
+			hairpinMasqueradeIP = config.Gateway.MasqueradeIPs.V6OVNServiceHairpinMasqueradeIP.String()
+			mask = 128
+		}
+		routeSources = append(routeSources, ovntest.MustParseIPNet(fmt.Sprintf("%s/%d", hairpinMasqueradeIP, mask)))
 		joinNet := config.Gateway.V4JoinSubnet
 		if isIPv6 {
 			joinNet = config.Gateway.V6JoinSubnet


### PR DESCRIPTION
When users attach pod to a secondary network and override the default route pod. It will cause the assymetric routing for service haripin traffic.

We add static routes to ensure the traffic to the hairpin masquerade IP always goes to OVN.

This is a manual cherry-pick of https://github.com/openshift/ovn-kubernetes/pull/2315. Resolve the conflict by removing the condition check for UDN `podAnnotation.Role == types.NetworkRolePrimary`.