### PR TITLE
[release-4.14] OCPBUGS-44793: Delete EgressIP LRP stale nexthops when node is not found 

### DIFF
--- a/go-controller/pkg/libovsdb/ops/router.go
+++ b/go-controller/pkg/libovsdb/ops/router.go
@@ -408,7 +408,9 @@ func CreateOrAddNextHopsToLogicalRouterPolicyWithPredicateOps(nbClient libovsdbc
 	return m.CreateOrUpdateOps(ops, opModels...)
 }
 
-func deleteNextHopsFromLogicalRouterPolicyOps(nbClient libovsdbclient.Client, ops []libovsdb.Operation, routerName string, lrps []*nbdb.LogicalRouterPolicy, nextHops ...string) ([]libovsdb.Operation, error) {
+// DeleteNextHopsFromLogicalRouterPolicyOps removes the Nexthops from the
+// provided logical router policies.
+func DeleteNextHopsFromLogicalRouterPolicyOps(nbClient libovsdbclient.Client, ops []libovsdb.Operation, routerName string, lrps []*nbdb.LogicalRouterPolicy, nextHops ...string) ([]libovsdb.Operation, error) {
 	nextHopSet := sets.NewString(nextHops...)
 	opModels := []operationModel{}
 	router := &nbdb.LogicalRouter{
@@ -469,7 +471,7 @@ func DeleteNextHopsFromLogicalRouterPolicies(nbClient libovsdbclient.Client, rou
 			return err
 		}
 
-		ops, err = deleteNextHopsFromLogicalRouterPolicyOps(nbClient, ops, routerName, []*nbdb.LogicalRouterPolicy{lrp}, nextHops...)
+		ops, err = DeleteNextHopsFromLogicalRouterPolicyOps(nbClient, ops, routerName, []*nbdb.LogicalRouterPolicy{lrp}, nextHops...)
 		if err != nil {
 			return err
 		}
@@ -490,7 +492,7 @@ func DeleteNextHopFromLogicalRouterPoliciesWithPredicateOps(nbClient libovsdbcli
 		return nil, err
 	}
 
-	return deleteNextHopsFromLogicalRouterPolicyOps(nbClient, ops, routerName, lrps, nextHop)
+	return DeleteNextHopsFromLogicalRouterPolicyOps(nbClient, ops, routerName, lrps, nextHop)
 }
 
 // DeleteNextHopFromLogicalRouterPoliciesWithPredicate looks up a logical router
@@ -510,6 +512,22 @@ func DeleteNextHopFromLogicalRouterPoliciesWithPredicate(nbClient libovsdbclient
 // DeleteLogicalRouterPolicies deletes the logical router policies and removes
 // them from the provided logical router
 func DeleteLogicalRouterPolicies(nbClient libovsdbclient.Client, routerName string, lrps ...*nbdb.LogicalRouterPolicy) error {
+	opModels := getDeleteOpModelsForLogicalRouterPolicies(routerName, lrps...)
+
+	m := newModelClient(nbClient)
+	return m.Delete(opModels...)
+}
+
+// DeleteLogicalRouterPoliciesOps builds and returns corresponding delete operations for Logical Router
+// Policies from the provided logical router.
+func DeleteLogicalRouterPoliciesOps(nbClient libovsdbclient.Client, ops []libovsdb.Operation, routerName string, lrps ...*nbdb.LogicalRouterPolicy) ([]libovsdb.Operation, error) {
+	opModels := getDeleteOpModelsForLogicalRouterPolicies(routerName, lrps...)
+
+	m := newModelClient(nbClient)
+	return m.DeleteOps(ops, opModels...)
+}
+
+func getDeleteOpModelsForLogicalRouterPolicies(routerName string, lrps ...*nbdb.LogicalRouterPolicy) []operationModel {
 	router := &nbdb.LogicalRouter{
 		Name:     routerName,
 		Policies: make([]string, 0, len(lrps)),
@@ -532,10 +550,8 @@ func DeleteLogicalRouterPolicies(nbClient libovsdbclient.Client, routerName stri
 		ErrNotFound:      true,
 		BulkOp:           false,
 	}
-	opModels = append(opModels, opModel)
 
-	m := newModelClient(nbClient)
-	return m.Delete(opModels...)
+	return append(opModels, opModel)
 }
 
 // LOGICAL ROUTER STATIC ROUTES

--- a/go-controller/pkg/ovn/egressip_test.go
+++ b/go-controller/pkg/ovn/egressip_test.go
@@ -9701,15 +9701,19 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 			app.Action = func(ctx *cli.Context) error {
 				config.IPv4Mode = true
 				config.IPv6Mode = true
-				egressIP := "192.168.126.101"
+				egressIP1 := "192.168.126.101"
+				egressIP2 := "192.168.126.102"
 				node1IPv4 := "192.168.126.12"
-				node1IPv4Net := "192.168.126.0/24"
 				node1IPv4CIDR := node1IPv4 + "/24"
 				node1IPv6 := "::feff:c0a8:8e0c"
 				node1IPv6CIDR := node1IPv6 + "/64"
 				node2IPv4 := "192.168.126.51"
-				node2IPv4Net := "192.168.126.0/24"
 				node2IPv4CIDR := node2IPv4 + "/24"
+				node3IPv4 := "192.168.126.61"
+				node3IPv4CIDR := node3IPv4 + "/24"
+
+				egressPod1 := *newPodWithLabels(namespace, podName, node3Name, podV4IP, egressPodLabel)
+				egressNamespace := newNamespace(namespace)
 
 				annotations := map[string]string{
 					"k8s.ovn.org/node-primary-ifaddr": fmt.Sprintf("{\"ipv4\": \"%s\", \"ipv6\": \"%s\"}", node1IPv4CIDR, node1IPv6CIDR),
@@ -9726,11 +9730,25 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 					util.OVNNodeHostCIDRs:             fmt.Sprintf("[\"%s\"]", node2IPv4CIDR),
 				}
 				node2 := getNodeObj(node2Name, annotations, labels)
+				annotations = map[string]string{
+					"k8s.ovn.org/node-primary-ifaddr": fmt.Sprintf("{\"ipv4\": \"%s\", \"ipv6\": \"%s\"}", node3IPv4CIDR, ""),
+					"k8s.ovn.org/node-subnets":        fmt.Sprintf("{\"default\":\"%s\"}", v4Node1Subnet),
+					util.OVNNodeHostCIDRs:             fmt.Sprintf("[\"%s\"]", node3IPv4CIDR),
+				}
+				node3 := getNodeObj(node3Name, annotations, labels)
 
 				eIP := egressipv1.EgressIP{
 					ObjectMeta: newEgressIPMeta(egressIPName),
 					Spec: egressipv1.EgressIPSpec{
-						EgressIPs: []string{egressIP},
+						EgressIPs: []string{egressIP1, egressIP2},
+						PodSelector: metav1.LabelSelector{
+							MatchLabels: egressPodLabel,
+						},
+						NamespaceSelector: metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"name": egressNamespace.Name,
+							},
+						},
 					},
 					Status: egressipv1.EgressIPStatus{
 						Items: []egressipv1.EgressIPStatusItem{},
@@ -9750,6 +9768,11 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 								Name:     ovntypes.GWRouterToJoinSwitchPrefix + ovntypes.GWRouterPrefix + node2.Name,
 								Networks: []string{node2LogicalRouterIfAddrV4},
 							},
+							&nbdb.LogicalRouterPort{
+								UUID:     ovntypes.GWRouterToJoinSwitchPrefix + ovntypes.GWRouterPrefix + node3.Name + "-UUID",
+								Name:     ovntypes.GWRouterToJoinSwitchPrefix + ovntypes.GWRouterPrefix + node3.Name,
+								Networks: []string{node3LogicalRouterIfAddrV4},
+							},
 							&nbdb.LogicalRouter{
 								Name: ovntypes.OVNClusterRouter,
 								UUID: ovntypes.OVNClusterRouter + "-UUID",
@@ -9761,6 +9784,10 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 							&nbdb.LogicalRouter{
 								Name: ovntypes.GWRouterPrefix + node2.Name,
 								UUID: ovntypes.GWRouterPrefix + node2.Name + "-UUID",
+							},
+							&nbdb.LogicalRouter{
+								Name: ovntypes.GWRouterPrefix + node3.Name,
+								UUID: ovntypes.GWRouterPrefix + node3.Name + "-UUID",
 							},
 							&nbdb.LogicalSwitchPort{
 								UUID: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node1Name + "UUID",
@@ -9782,14 +9809,34 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 									"exclude-lb-vips-from-garp": "true",
 								},
 							},
+							&nbdb.LogicalSwitchPort{
+								UUID: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node3Name + "UUID",
+								Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node3Name,
+								Type: "router",
+								Options: map[string]string{
+									"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node3Name,
+									"nat-addresses":             "router",
+									"exclude-lb-vips-from-garp": "true",
+								},
+							},
 						},
 					},
 					&egressipv1.EgressIPList{
 						Items: []egressipv1.EgressIP{eIP},
 					},
 					&v1.NodeList{
-						Items: []v1.Node{node1},
+						Items: []v1.Node{node1, node3},
+					},
+					&v1.NamespaceList{
+						Items: []v1.Namespace{*egressNamespace},
+					},
+					&v1.PodList{
+						Items: []v1.Pod{egressPod1},
 					})
+
+				i, n, _ := net.ParseCIDR(podV4IP + "/23")
+				n.IP = i
+				fakeOvn.controller.logicalPortCache.add(&egressPod1, "", types.DefaultNetworkName, "", nil, []*net.IPNet{n})
 
 				err := fakeOvn.controller.WatchEgressIPNamespaces()
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -9801,7 +9848,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				nodeIPsASdbIDs := getEgressIPAddrSetDbIDs(NodeIPAddrSetName, DefaultNetworkControllerName)
-				fakeOvn.asf.EventuallyExpectAddressSetWithIPs(nodeIPsASdbIDs, []string{node1IPv4, node1IPv6})
+				fakeOvn.asf.EventuallyExpectAddressSetWithIPs(nodeIPsASdbIDs, []string{node1IPv4, node1IPv6, node3IPv4})
 
 				egressSvcPodsV4, egressSvcPodsV6 := addressset.GetHashNamesForAS(egresssvc.GetEgressServiceAddrSetDbIDs(DefaultNetworkControllerName))
 				egressipPodsV4, egressipPodsV6 := addressset.GetHashNamesForAS(getEgressIPAddrSetDbIDs(EgressIPServedPodsAddrSetName, DefaultNetworkControllerName))
@@ -9834,6 +9881,11 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						Name:     ovntypes.GWRouterToJoinSwitchPrefix + ovntypes.GWRouterPrefix + node2.Name,
 						Networks: []string{node2LogicalRouterIfAddrV4},
 					},
+					&nbdb.LogicalRouterPort{
+						UUID:     ovntypes.GWRouterToJoinSwitchPrefix + ovntypes.GWRouterPrefix + node3.Name + "-UUID",
+						Name:     ovntypes.GWRouterToJoinSwitchPrefix + ovntypes.GWRouterPrefix + node3.Name,
+						Networks: []string{node3LogicalRouterIfAddrV4},
+					},
 					&nbdb.LogicalRouterPolicy{
 						Priority: types.DefaultNoRereoutePriority,
 						Match:    "ip4.src == 10.128.0.0/14 && ip4.dst == 10.128.0.0/14",
@@ -9859,6 +9911,10 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						Name: ovntypes.GWRouterPrefix + node2.Name,
 						UUID: ovntypes.GWRouterPrefix + node2.Name + "-UUID",
 					},
+					&nbdb.LogicalRouter{
+						Name: ovntypes.GWRouterPrefix + node3.Name,
+						UUID: ovntypes.GWRouterPrefix + node3.Name + "-UUID",
+					},
 					&nbdb.LogicalSwitchPort{
 						UUID: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node1Name + "UUID",
 						Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node1Name,
@@ -9879,16 +9935,42 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 							"exclude-lb-vips-from-garp": "true",
 						},
 					},
+					&nbdb.LogicalSwitchPort{
+						UUID: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node3Name + "UUID",
+						Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node3Name,
+						Type: "router",
+						Options: map[string]string{
+							"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node3Name,
+							"nat-addresses":             "router",
+							"exclude-lb-vips-from-garp": "true",
+						},
+					},
 				}
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
-				fakeOvn.patchEgressIPObj(node1Name, egressIPName, egressIP, node1IPv4Net)
-				gomega.Eventually(getEgressIPStatusLen(egressIPName)).Should(gomega.Equal(1))
+
+				status := []egressipv1.EgressIPStatusItem{
+					{
+						Node:     node1Name,
+						EgressIP: egressIP1,
+					},
+					{
+						Node:     node3Name,
+						EgressIP: egressIP2,
+					},
+				}
+				err = fakeOvn.controller.patchReplaceEgressIPStatus(egressIPName, status)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Eventually(getEgressIPStatusLen(egressIPName)).Should(gomega.Equal(2))
+				gomega.Eventually(getEgressIPReassignmentCount).Should(gomega.Equal(0))
+
 				egressIPs, nodes := getEgressIPStatus(egressIPName)
 				gomega.Expect(nodes[0]).To(gomega.Equal(node1.Name))
-				gomega.Expect(egressIPs[0]).To(gomega.Equal(egressIP))
+				gomega.Expect(nodes[1]).To(gomega.Equal(node3.Name))
 
 				_, err = fakeOvn.fakeClient.KubeClient.CoreV1().Nodes().Create(context.TODO(), &node2, metav1.CreateOptions{})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				expectedNatLogicalPort1 := "k8s-node1"
+				expectedNatLogicalPort3 := "k8s-node3"
 				expectedDatabaseState = []libovsdbtest.TestData{
 					&nbdb.LogicalRouterPolicy{
 						Priority: types.DefaultNoRereoutePriority,
@@ -9916,6 +9998,11 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						Name:     ovntypes.GWRouterToJoinSwitchPrefix + ovntypes.GWRouterPrefix + node2.Name,
 						Networks: []string{node2LogicalRouterIfAddrV4},
 					},
+					&nbdb.LogicalRouterPort{
+						UUID:     ovntypes.GWRouterToJoinSwitchPrefix + ovntypes.GWRouterPrefix + node3.Name + "-UUID",
+						Name:     ovntypes.GWRouterToJoinSwitchPrefix + ovntypes.GWRouterPrefix + node3.Name,
+						Networks: []string{node3LogicalRouterIfAddrV4},
+					},
 
 					&nbdb.LogicalRouterPolicy{
 						Priority: types.DefaultNoRereoutePriority,
@@ -9929,18 +10016,61 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						Action:   nbdb.LogicalRouterPolicyActionAllow,
 						UUID:     "no-reroute-service-UUID",
 					},
+					&nbdb.LogicalRouterPolicy{
+						Priority: types.EgressIPReroutePriority,
+						Match:    fmt.Sprintf("ip4.src == %s", egressPod1.Status.PodIP),
+						Action:   nbdb.LogicalRouterPolicyActionReroute,
+						Nexthops: []string{"100.64.0.2", "100.64.0.4"},
+						ExternalIDs: map[string]string{
+							"name": eIP.Name,
+						},
+						UUID: "reroute-UUID1",
+					},
+					&nbdb.NAT{
+						UUID:       "egressip-nat-UUID1",
+						LogicalIP:  podV4IP,
+						ExternalIP: egressIPs[0],
+						ExternalIDs: map[string]string{
+							"name": egressIPName,
+						},
+						Type:        nbdb.NATTypeSNAT,
+						LogicalPort: &expectedNatLogicalPort1,
+						Options: map[string]string{
+							"stateless": "false",
+						},
+					},
+					&nbdb.NAT{
+						UUID:       "egressip-nat-UUID2",
+						LogicalIP:  podV4IP,
+						ExternalIP: egressIPs[1],
+						ExternalIDs: map[string]string{
+							"name": egressIPName,
+						},
+						Type:        nbdb.NATTypeSNAT,
+						LogicalPort: &expectedNatLogicalPort3,
+						Options: map[string]string{
+							"stateless": "false",
+						},
+					},
 					&nbdb.LogicalRouter{
-						Name:     ovntypes.OVNClusterRouter,
-						UUID:     ovntypes.OVNClusterRouter + "-UUID",
-						Policies: []string{"no-reroute-UUID", "no-reroute-service-UUID", "default-no-reroute-node-UUID", "default-v6-no-reroute-node-UUID"},
+						Name: ovntypes.OVNClusterRouter,
+						UUID: ovntypes.OVNClusterRouter + "-UUID",
+						Policies: []string{"no-reroute-UUID", "no-reroute-service-UUID",
+							"default-no-reroute-node-UUID", "default-v6-no-reroute-node-UUID", "reroute-UUID1"},
 					},
 					&nbdb.LogicalRouter{
 						Name: ovntypes.GWRouterPrefix + node1.Name,
 						UUID: ovntypes.GWRouterPrefix + node1.Name + "-UUID",
+						Nat:  []string{"egressip-nat-UUID1"},
 					},
 					&nbdb.LogicalRouter{
 						Name: ovntypes.GWRouterPrefix + node2.Name,
 						UUID: ovntypes.GWRouterPrefix + node2.Name + "-UUID",
+					},
+					&nbdb.LogicalRouter{
+						Name: ovntypes.GWRouterPrefix + node3.Name,
+						UUID: ovntypes.GWRouterPrefix + node3.Name + "-UUID",
+						Nat:  []string{"egressip-nat-UUID2"},
 					},
 					&nbdb.LogicalSwitchPort{
 						UUID: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node1Name + "UUID",
@@ -9958,6 +10088,16 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						Type: "router",
 						Options: map[string]string{
 							"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node2Name,
+							"nat-addresses":             "router",
+							"exclude-lb-vips-from-garp": "true",
+						},
+					},
+					&nbdb.LogicalSwitchPort{
+						UUID: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node3Name + "UUID",
+						Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node3Name,
+						Type: "router",
+						Options: map[string]string{
+							"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node3Name,
 							"nat-addresses":             "router",
 							"exclude-lb-vips-from-garp": "true",
 						},
@@ -9965,28 +10105,33 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 				}
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 
-				gomega.Eventually(getEgressIPStatusLen(egressIPName)).Should(gomega.Equal(1))
-				egressIPs, nodes = getEgressIPStatus(egressIPName)
+				gomega.Eventually(getEgressIPStatusLen(egressIPName)).Should(gomega.Equal(2))
+				_, nodes = getEgressIPStatus(egressIPName)
 				gomega.Expect(nodes[0]).To(gomega.Equal(node1.Name))
-				gomega.Expect(egressIPs[0]).To(gomega.Equal(egressIP))
+				gomega.Expect(nodes[1]).To(gomega.Equal(node3.Name))
 
 				err = fakeOvn.fakeClient.KubeClient.CoreV1().Nodes().Delete(context.TODO(), node1.Name, *metav1.NewDeleteOptions(0))
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				fakeOvn.patchEgressIPObj(node2Name, egressIPName, egressIP, node2IPv4Net)
-				gomega.Eventually(getEgressIPStatusLen(egressIPName)).Should(gomega.Equal(1))
-
-				getNewNode := func() string {
-					_, nodes = getEgressIPStatus(egressIPName)
-					if len(nodes) > 0 {
-						return nodes[0]
-					}
-					return ""
+				status = []egressipv1.EgressIPStatusItem{
+					{
+						Node:     node2Name,
+						EgressIP: egressIP1,
+					},
+					{
+						Node:     node3Name,
+						EgressIP: egressIP2,
+					},
 				}
+				err = fakeOvn.controller.patchReplaceEgressIPStatus(egressIPName, status)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Eventually(getEgressIPStatusLen(egressIPName)).Should(gomega.Equal(2))
+				gomega.Eventually(getEgressIPReassignmentCount).Should(gomega.Equal(0))
 
-				gomega.Eventually(getNewNode).Should(gomega.Equal(node2.Name))
-				egressIPs, _ = getEgressIPStatus(egressIPName)
-				gomega.Expect(egressIPs[0]).To(gomega.Equal(egressIP))
+				egressIPs, nodes = getEgressIPStatus(egressIPName)
+				gomega.Expect(nodes[0]).To(gomega.Equal(node2.Name))
+				gomega.Expect(nodes[1]).To(gomega.Equal(node3.Name))
 
+				expectedNatLogicalPort2 := "k8s-node2"
 				expectedDatabaseState = []libovsdbtest.TestData{
 					&nbdb.LogicalRouterPolicy{
 						Priority: types.DefaultNoRereoutePriority,
@@ -10014,6 +10159,11 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						Name:     ovntypes.GWRouterToJoinSwitchPrefix + ovntypes.GWRouterPrefix + node2.Name,
 						Networks: []string{node2LogicalRouterIfAddrV4},
 					},
+					&nbdb.LogicalRouterPort{
+						UUID:     ovntypes.GWRouterToJoinSwitchPrefix + ovntypes.GWRouterPrefix + node3.Name + "-UUID",
+						Name:     ovntypes.GWRouterToJoinSwitchPrefix + ovntypes.GWRouterPrefix + node3.Name,
+						Networks: []string{node3LogicalRouterIfAddrV4},
+					},
 					&nbdb.LogicalRouterPolicy{
 						Priority: types.DefaultNoRereoutePriority,
 						Match:    "ip4.src == 10.128.0.0/14 && ip4.dst == 10.128.0.0/14",
@@ -10026,10 +10176,47 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						Action:   nbdb.LogicalRouterPolicyActionAllow,
 						UUID:     "no-reroute-service-UUID",
 					},
+					&nbdb.LogicalRouterPolicy{
+						Priority: types.EgressIPReroutePriority,
+						Match:    fmt.Sprintf("ip4.src == %s", egressPod1.Status.PodIP),
+						Action:   nbdb.LogicalRouterPolicyActionReroute,
+						Nexthops: []string{"100.64.0.3", "100.64.0.4"},
+						ExternalIDs: map[string]string{
+							"name": eIP.Name,
+						},
+						UUID: "reroute-UUID1",
+					},
+					&nbdb.NAT{
+						UUID:       "egressip-nat-UUID1",
+						LogicalIP:  podV4IP,
+						ExternalIP: egressIPs[0],
+						ExternalIDs: map[string]string{
+							"name": egressIPName,
+						},
+						Type:        nbdb.NATTypeSNAT,
+						LogicalPort: &expectedNatLogicalPort2,
+						Options: map[string]string{
+							"stateless": "false",
+						},
+					},
+					&nbdb.NAT{
+						UUID:       "egressip-nat-UUID2",
+						LogicalIP:  podV4IP,
+						ExternalIP: egressIPs[1],
+						ExternalIDs: map[string]string{
+							"name": egressIPName,
+						},
+						Type:        nbdb.NATTypeSNAT,
+						LogicalPort: &expectedNatLogicalPort3,
+						Options: map[string]string{
+							"stateless": "false",
+						},
+					},
 					&nbdb.LogicalRouter{
-						Name:     ovntypes.OVNClusterRouter,
-						UUID:     ovntypes.OVNClusterRouter + "-UUID",
-						Policies: []string{"no-reroute-UUID", "no-reroute-service-UUID", "default-no-reroute-node-UUID", "default-v6-no-reroute-node-UUID"},
+						Name: ovntypes.OVNClusterRouter,
+						UUID: ovntypes.OVNClusterRouter + "-UUID",
+						Policies: []string{"no-reroute-UUID", "no-reroute-service-UUID",
+							"default-no-reroute-node-UUID", "default-v6-no-reroute-node-UUID", "reroute-UUID1"},
 					},
 					&nbdb.LogicalRouter{
 						Name: ovntypes.GWRouterPrefix + node1.Name,
@@ -10038,6 +10225,12 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 					&nbdb.LogicalRouter{
 						Name: ovntypes.GWRouterPrefix + node2.Name,
 						UUID: ovntypes.GWRouterPrefix + node2.Name + "-UUID",
+						Nat:  []string{"egressip-nat-UUID1"},
+					},
+					&nbdb.LogicalRouter{
+						Name: ovntypes.GWRouterPrefix + node3.Name,
+						UUID: ovntypes.GWRouterPrefix + node3.Name + "-UUID",
+						Nat:  []string{"egressip-nat-UUID2"},
 					},
 					&nbdb.LogicalSwitchPort{
 						UUID: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node1Name + "UUID",
@@ -10055,6 +10248,16 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						Type: "router",
 						Options: map[string]string{
 							"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node2Name,
+							"nat-addresses":             "router",
+							"exclude-lb-vips-from-garp": "true",
+						},
+					},
+					&nbdb.LogicalSwitchPort{
+						UUID: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node3Name + "UUID",
+						Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node3Name,
+						Type: "router",
+						Options: map[string]string{
+							"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node3Name,
 							"nat-addresses":             "router",
 							"exclude-lb-vips-from-garp": "true",
 						},


### PR DESCRIPTION
Manual cherry-pick of 4.15 commit d61d75bf5b7d4a7b5de3fb7013eb933b5a8adaad.

No conflicts (avoided auto cherry-pick to avoid another backport bug being created)