### PR TITLE
[release-4.17] OCPBUGS-43454: Ignore cluster manager topology not managed errors for localnet with no subnets

### DIFF
--- a/go-controller/pkg/clustermanager/secondary_network_cluster_manager.go
+++ b/go-controller/pkg/clustermanager/secondary_network_cluster_manager.go
@@ -61,7 +61,7 @@ func newSecondaryNetworkClusterManager(ovnClient *util.OVNClusterManagerClientse
 	return sncm, nil
 }
 
-// Start the secondary layer3 controller, handles all events and creates all
+// Start the secondary network controller, handles all events and creates all
 // needed logical entities
 func (sncm *secondaryNetworkClusterManager) Start() error {
 	klog.Infof("Starting secondary network cluster manager")

--- a/go-controller/pkg/network-attach-def-controller/network_manager.go
+++ b/go-controller/pkg/network-attach-def-controller/network_manager.go
@@ -2,6 +2,7 @@ package networkAttachDefController
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -179,7 +180,13 @@ func (nm *networkManagerImpl) syncAll() error {
 	start := time.Now()
 	klog.Infof("%s: syncing all networks", nm.name)
 	for _, networkName := range networkNames {
-		if err := nm.sync(networkName); err != nil {
+		if err := nm.sync(networkName); errors.Is(err, ErrNetworkControllerTopologyNotManaged) {
+			klog.V(5).Infof(
+				"ignoring network %q since %q does not manage it",
+				networkName,
+				nm.name,
+			)
+		} else if err != nil {
 			return fmt.Errorf("failed to sync network %s: %w", networkName, err)
 		}
 	}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->
This PR ignores topology net managed errors on the initial all networks sync of the cluster manager controllers.

Only the `secondaryNetworkClusterManager` - which is created by the cluster controller manager, and executed in the control plane pods - actually returns this type of error.

The original PR (upstream) is: https://github.com/ovn-kubernetes/ovn-kubernetes/pull/4813
The code was merged downstream to openshift/master with: https://github.com/openshift/ovn-kubernetes/pull/2345

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

This was **not** a clean cherry-pick - there were conflicts in all the files.

Conflicts in `go-controller/pkg/clustermanager/secondary_network_cluster_manager.go`:
```sh
++<<<<<<< HEAD
 +// Start the secondary layer3 controller, handles all events and creates all
++=======
+ func (sncm *secondaryNetworkClusterManager) SetNetworkStatusReporter(errorReporter NetworkStatusReporter) {
+       sncm.errorReporter = errorReporter
+ }
+ 
+ // Start the secondary network controller, handles all events and creates all
++>>>>>>> 5827107b4 (cluster manager: the Start method is topology agnostic)
```

Conflicts in `go-controller/pkg/network-attach-def-controller/network_manager.go`:
```sh
@@@ -178,9 -214,15 +179,21 @@@ func (nm *networkManagerImpl) syncAll(
        // as stale.
        start := time.Now()
        klog.Infof("%s: syncing all networks", nm.name)
++<<<<<<< HEAD
 +      for _, networkName := range networkNames {
 +              if err := nm.sync(networkName); err != nil {
 +                      return fmt.Errorf("failed to sync network %s: %w", networkName, err)
++=======
+       for _, network := range validNetworks {
+               if err := nm.sync(network.GetNetworkName()); errors.Is(err, ErrNetworkControllerTopologyNotManaged) {
+                       klog.V(5).Infof(
+                               "ignoring network %q since %q does not manage it",
+                               network.GetNetworkName(),
+                               nm.name,
+                       )
+               } else if err != nil {
+                       return fmt.Errorf("failed to sync network %s: %w", network.GetNetworkName(), err)
++>>>>>>> a5ac6a334 (network manager: ignore topology not managed errors)
```

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
