### PR TITLE
[release-4.14] OCPBUGS-45096: pin libreswan to 4.6-3.el9_0.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN INSTALL_PKGS=" \
 	libpcap iproute iproute-tc strace \
 	containernetworking-plugins \
 	tcpdump iputils \
-	libreswan \
+	libreswan-4.6-3.el9_0.3 \
 	ethtool conntrack-tools \
 	openshift-clients \
 	" && \


### PR DESCRIPTION
For a crash fix and CVE backports in libreswan