### PR TITLE
[WIP] Refactor legacy informer/handler framework

### DIFF
--- a/go-controller/pkg/factory/factory_test.go
+++ b/go-controller/pkg/factory/factory_test.go
@@ -716,6 +716,7 @@ var _ = Describe("Watch Factory Operations", func() {
 					UpdateFunc: func(old, new interface{}) {},
 					DeleteFunc: func(obj interface{}) {},
 				}, nil, wf.GetHandlerPriority(objType))
+			Eventually(h.NumberOfProcessedItems).Should(Equal(2))
 			Expect(int(addCalls)).To(Equal(2))
 			Expect(err).NotTo(HaveOccurred())
 			wf.removeHandler(objType, h)


### PR DESCRIPTION
The legacy event driven informer/handler framework has flaws with performance. The regular "informer" object is not multi-threaded and handles events without a queue. The federated "queued informer" sends events to queues where worker threads pull items off and process them. In either informer version, the processing of objects is paused when a new handler is added to the informer. When a new handler is added, all existing objects in the cluster are processed as ADDs. This is extremely slow with UDN and adding new handlers on the fly as UDNs are created. Additionally, the previous model for queued informer did not actually stop the shared informer from enqueuing objects directly. It only paused the workers, which indirectly would eventually stop the shared informer from enqueuing after the channel buffer (size 10) was full.

To address this, the following has been changed:
 1. Classic informer type object is removed, all legacy informers now use a queued informer. These queued informers only use 1 worker thread.
 2. The queued informer now only enqueues events on initial add. The queue size has been adjusted to 10k to account for buffering initial add objects. Can tweak this later.
 3. Locking has been modified. The informer lock is now used to control event flow into the queues. In order to enqueue events from the informer cache, a read lock must be obtained. When a handler is added the informer lock is temporarily taken, to stop the informer cache so that initial objects can be enqueued. Additionally a new handlerMutex is introduced to control adding/removing handlers on an queued informer object.
 4. Since now all objects are enqueued when a handler is added and all handlers will iterate over these already processed objects, a map has been added to the handler. This processedInitialAdd map allows the handler to determine if it has already processed the object or not. In the case of existing handlers, they will ignore adds for objects they already procesed. For newly added handlers, they will ignore updates and deletes received before they have first added the object.

Signed-off-by: Tim Rozet <trozet@redhat.com>
(cherry picked from commit 27998123011b1eb6cb056e9a307a62c8eea20026)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
