### PR TITLE
[release-4.15] OCPBUGS-45097: pin libreswan to 4.6-3.el9_0.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN INSTALL_PKGS=" \
 	openssl firewalld-filesystem \
 	libpcap iproute iproute-tc strace \
 	tcpdump iputils \
-	libreswan \
+	libreswan-4.6-3.el9_0.3 \
 	ethtool conntrack-tools \
 	openshift-clients \
 	" && \


### PR DESCRIPTION
For a crash fix and CVE backports in libreswan