### PR TITLE
OCPBUGS-45314: pin libreswan to 4.6-3.el9_0.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN INSTALL_PKGS=" \
 	openssl firewalld-filesystem \
 	libpcap iproute iproute-tc strace \
 	tcpdump iputils \
-	libreswan \
+	libreswan-4.6-3.el9_0.3 \
 	ethtool conntrack-tools \
 	openshift-clients \
 	" && \


### PR DESCRIPTION
For a crash fix and CVE backports in libreswan

NOTE: This is a temporary fix until the RHEL fix lands because we have time constrants and this will be reverted in the future on all the pinning PRs