### PR TITLE
OCPBUGS-45339: Dockerfile: Update OVN to the 24.03.2-32.el9fdp minor release.

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -13,7 +13,7 @@ RUN dnf install -y --nodocs \
 	dnf clean all
 
 ARG ovsver=3.4.0-1.el9fdp
-ARG ovnver=24.03.2-19.el9fdp
+ARG ovnver=24.03.2-32.el9fdp
 # NOTE: Ensure that the versions of OVS and OVN are overriden for OKD in each of the subsequent layers.
 ARG ovsver_okd=3.4.0-0.8.el9s
 ARG ovnver_okd=24.03.1-5.el9s


### PR DESCRIPTION
It is the most recent release of 24.03 with all the latest bug fixes.   See the jira for more details.