### PR TITLE
[release-4.18] OCPBUGS-37193: fixes overzealous deletion of SNAT in egressIP

### DIFF
--- a/go-controller/pkg/ovn/pods_test.go
+++ b/go-controller/pkg/ovn/pods_test.go
@@ -53,6 +53,29 @@ func newPodMeta(namespace, name string, additionalLabels map[string]string) meta
 	}
 }
 
+func newPodWithLabelsAllIPFamilies(namespace, name, node string, podIPs []string, additionalLabels map[string]string) *v1.Pod {
+	podIPList := []v1.PodIP{}
+	for _, podIP := range podIPs {
+		podIPList = append(podIPList, v1.PodIP{IP: podIP})
+	}
+	return &v1.Pod{
+		ObjectMeta: newPodMeta(namespace, name, additionalLabels),
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name:  "containerName",
+					Image: "containerImage",
+				},
+			},
+			NodeName: node,
+		},
+		Status: v1.PodStatus{
+			Phase:  v1.PodRunning,
+			PodIP:  podIPList[0].IP,
+			PodIPs: podIPList,
+		},
+	}
+}
 func newPodWithLabels(namespace, name, node, podIP string, additionalLabels map[string]string) *v1.Pod {
 	podIPs := []v1.PodIP{}
 	if podIP != "" {


### PR DESCRIPTION
currently when creating egressIP in a dualstack cluster regardless of if the egressip is ipv4 or ipv6 when disable-snat-multiple-gws is set the code removes both ipv4 and ipv6 snats from the database. This means that the pod will not be able to communicate with the cluster correctly becuase the Gateway Router is missing an SNAT and the traffic will be dropped.

Additionally the testing looks a little different from the others because we do not correctly setup dualstack clusters when running unit tests

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My code requires changes to the documentation
- [x] if so, I have updated the documentation as required
- [x] My code requires tests
- [x] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
