### PR TITLE
[release-4.15] OCPBUGS-44708: Add hybird overlay pod IPs to the namespace address_set

### DIFF
--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -125,10 +125,10 @@ func (oc *DefaultNetworkController) ensurePod(oldPod, pod *kapi.Pod, addPort boo
 		return nil
 	}
 
-	// skip the pods on no host subnet nodes
+	// Add podIPs on no host subnet Nodes to the namespace address_set
 	switchName := pod.Spec.NodeName
 	if oc.lsManager.IsNonHostSubnetSwitch(switchName) {
-		return nil
+		return oc.ensureRemotePodIP(oldPod, pod, addPort)
 	}
 
 	if oc.isPodScheduledinLocalZone(pod) {
@@ -184,11 +184,7 @@ func (oc *DefaultNetworkController) ensureLocalZonePod(oldPod, pod *kapi.Pod, ad
 	return nil
 }
 
-// ensureRemoteZonePod tries to set up remote zone pod bits required to interconnect it.
-//   - Adds the remote pod ips to the pod namespace address set for network policy and egress gw
-//
-// It returns nil on success and error on failure; failure indicates the pod set up should be retried later.
-func (oc *DefaultNetworkController) ensureRemoteZonePod(oldPod, pod *kapi.Pod, addPort bool) error {
+func (oc *DefaultNetworkController) ensureRemotePodIP(oldPod, pod *kapi.Pod, addPort bool) error {
 	if (addPort || (oldPod != nil && len(pod.Status.PodIPs) != len(oldPod.Status.PodIPs))) && !util.PodWantsHostNetwork(pod) {
 		podIfAddrs, err := util.GetPodCIDRsWithFullMask(pod, oc.NetInfo)
 		if err != nil {
@@ -199,6 +195,17 @@ func (oc *DefaultNetworkController) ensureRemoteZonePod(oldPod, pod *kapi.Pod, a
 		if err := oc.addRemotePodToNamespace(pod.Namespace, podIfAddrs); err != nil {
 			return fmt.Errorf("failed to add remote pod %s/%s to namespace: %w", pod.Namespace, pod.Name, err)
 		}
+	}
+	return nil
+}
+
+// ensureRemoteZonePod tries to set up remote zone pod bits required to interconnect it.
+//   - Adds the remote pod ips to the pod namespace address set for network policy and egress gw
+//
+// It returns nil on success and error on failure; failure indicates the pod set up should be retried later.
+func (oc *DefaultNetworkController) ensureRemoteZonePod(oldPod, pod *kapi.Pod, addPort bool) error {
+	if err := oc.ensureRemotePodIP(oldPod, pod, addPort); err != nil {
+		return err
 	}
 
 	//FIXME: Update comments & reduce code duplication.

--- a/go-controller/pkg/ovn/pods_test.go
+++ b/go-controller/pkg/ovn/pods_test.go
@@ -2501,5 +2501,56 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 			err := app.Run([]string{app.Name})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		})
+
+		ginkgo.It("should correctly handle a pod running on a no host subnet node", func() {
+			app.Action = func(ctx *cli.Context) error {
+				testNs := "namespace1"
+				testPodIP := "10.128.1.3"
+				namespaceT := *newNamespace(testNs)
+				myPod := newPod(testNs, "myPod", node2Name, testPodIP)
+				myPod.Status.Phase = v1.PodRunning
+				initialDB = libovsdbtest.TestSetup{
+					NBData: []libovsdbtest.TestData{},
+				}
+				fakeOvn.startWithDBSetup(initialDB,
+					&v1.NamespaceList{
+						Items: []v1.Namespace{
+							namespaceT,
+						},
+					},
+					&v1.NodeList{
+						Items: []v1.Node{
+							// Add a hybrid overlay node
+							{
+								ObjectMeta: metav1.ObjectMeta{
+									Name: nodeName,
+								},
+								Status: v1.NodeStatus{
+									Conditions: []v1.NodeCondition{
+										{
+											Type:   v1.NodeReady,
+											Status: v1.ConditionTrue,
+										},
+									},
+								},
+							},
+						},
+					},
+					&v1.PodList{
+						Items: []v1.Pod{*myPod},
+					},
+				)
+				fakeOvn.controller.lsManager.AddOrUpdateSwitch(myPod.Spec.NodeName, nil)
+				err := fakeOvn.controller.WatchPods()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				// check that the pod IP is added to the namespace AS
+				fakeOvn.asf.ExpectAddressSetWithIPs(testNs, []string{testPodIP})
+
+				return nil
+			}
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
 	})
 })


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/openshift/ovn-kubernetes/pull/2352

Fix the function name mismatch in pods_test.go. Replace `ExpectAddressSetWithAddresses` with `ExpectAddressSetWithIPs`.