### PR TITLE
OCPBUGS-47506: Let OVN-northd bind remote ports

### DIFF
--- a/go-controller/pkg/ovn/base_network_controller_secondary.go
+++ b/go-controller/pkg/ovn/base_network_controller_secondary.go
@@ -356,16 +356,6 @@ func (bsnc *BaseSecondaryNetworkController) addLogicalPortToNetworkForNAD(pod *k
 		_ = bsnc.logicalPortCache.add(pod, switchName, nadName, lsp.UUID, podAnnotation.MAC, podAnnotation.IPs)
 	}
 
-	// we need to create the binding ourselves for the remote ports we create on
-	// layer2 topologies with interconnect
-	isRemotePort := !isLocalPod && bsnc.isLayer2Interconnect()
-	if isRemotePort {
-		err := bsnc.zoneICHandler.BindTransitRemotePort(pod.Spec.NodeName, lsp.Name)
-		if err != nil {
-			return fmt.Errorf("failed to bind remote transit port: %w", err)
-		}
-	}
-
 	if isLocalPod {
 		bsnc.podRecorder.AddLSP(pod.UID, bsnc.NetInfo)
 		if newlyCreated {


### PR DESCRIPTION
Presently for each remote node, ovnkube after creating the remote port in the OVN Northbound db transit switch, binds the port to the remote chassis in the Southbound database.  In order to do this, we have to wait for the remote logical ports (for each of the remote zone nodes) to appear in the OVN Southbound database. This can lead to race conditions.  Instead ask ovn-northd to bind to the remote chassis.  OVN after this commit [1] already supports this.  We just need to set the requested-chassis option in the logical port.

[1] - https://github.com/ovn-org/ovn/commit/170d3e5f19f0fcd760db068cda29fc1b7f1d7ef5

Jira: https://issues.redhat.com/browse/OCPBUGS-42616

Signed-off-by: Numan Siddique <numans@ovn.org>
(cherry picked from commit e4f360cc82c4202175b8667398a4dcc7334aafd9)

