### PR TITLE
[release-4.15] OCPBUGS-43605: Add SDN node subnet gateway IP to host-network address_set

### DIFF
--- a/go-controller/pkg/ovn/base_network_controller.go
+++ b/go-controller/pkg/ovn/base_network_controller.go
@@ -3,6 +3,7 @@ package ovn
 import (
 	"fmt"
 	"net"
+	"os"
 	"sync"
 	"time"
 
@@ -37,6 +38,8 @@ import (
 	utilnet "k8s.io/utils/net"
 )
 
+const migrationEnvVar = "NODE_CNI"
+
 // CommonNetworkControllerInfo structure is place holder for all fields shared among controllers.
 type CommonNetworkControllerInfo struct {
 	client       clientset.Interface
@@ -65,6 +68,9 @@ type CommonNetworkControllerInfo struct {
 
 	// Northbound database zone name to which this Controller is connected to - aka local zone
 	zone string
+
+	// is running in SDN live migration mode
+	inMigrationMode bool
 }
 
 // BaseNetworkController structure holds per-network fields and network specific configuration
@@ -171,6 +177,7 @@ func NewCommonNetworkControllerInfo(client clientset.Interface, kube *kube.KubeO
 	if err != nil {
 		return nil, fmt.Errorf("error getting NB zone name : err - %w", err)
 	}
+	_, inMigration := os.LookupEnv(migrationEnvVar)
 	return &CommonNetworkControllerInfo{
 		client:             client,
 		kube:               kube,
@@ -183,6 +190,7 @@ func NewCommonNetworkControllerInfo(client clientset.Interface, kube *kube.KubeO
 		multicastSupport:   multicastSupport,
 		svcTemplateSupport: svcTemplateSupport,
 		zone:               zone,
+		inMigrationMode:    inMigration,
 	}, nil
 }
 

--- a/go-controller/pkg/ovn/default_network_controller.go
+++ b/go-controller/pkg/ovn/default_network_controller.go
@@ -860,9 +860,12 @@ func (h *defaultNetworkControllerEventHandler) UpdateResource(oldObj, newObj int
 		if config.HybridOverlay.Enabled {
 			if util.NoHostSubnet(newNode) && !util.NoHostSubnet(oldNode) {
 				klog.Infof("Node %s has been updated to be a remote/unmanaged hybrid overlay node", newNode.Name)
+				// need to reset the host network address set, as the address is different in ovn and sdn.
+				h.oc.syncHostNetAddrSetFailed.Store(newNode.Name, true)
 				return h.oc.addUpdateHoNodeEvent(newNode)
 			} else if !util.NoHostSubnet(newNode) && util.NoHostSubnet(oldNode) {
 				klog.Infof("Node %s has been updated to be an ovn-kubernetes managed node", newNode.Name)
+				h.oc.syncHostNetAddrSetFailed.Store(newNode.Name, true)
 				if err := h.oc.deleteHoNodeEvent(newNode); err != nil {
 					return err
 				}

--- a/go-controller/pkg/ovn/namespace.go
+++ b/go-controller/pkg/ovn/namespace.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/ovn-org/libovsdb/ovsdb"
+	hotypes "github.com/ovn-org/ovn-kubernetes/go-controller/hybrid-overlay/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	libovsdbops "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdb/ops"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
@@ -328,18 +329,43 @@ func (oc *DefaultNetworkController) getAllHostNamespaceAddresses() []net.IP {
 	} else {
 		ips = make([]net.IP, 0, len(existingNodes))
 		for _, node := range existingNodes {
+			var hostNetworkIPs []net.IP
 			if config.HybridOverlay.Enabled && util.NoHostSubnet(node) {
-				// skip hybrid overlay nodes
-				continue
-			}
-			hostNetworkIPs, err := oc.getHostNamespaceAddressesForNode(node)
-			if err != nil {
-				klog.Errorf("Error parsing annotation for node %s: %v", node.Name, err)
+				if oc.inMigrationMode {
+					hostNetworkIPs, err = oc.getHostNamespaceAddressesForHoNode(node)
+					if err != nil {
+						klog.Errorf("Error parsing annotation for node %s: %v", node.Name, err)
+					}
+				} else {
+					continue
+				}
+			} else {
+				hostNetworkIPs, err = oc.getHostNamespaceAddressesForNode(node)
+				if err != nil {
+					klog.Errorf("Error parsing annotation for node %s: %v", node.Name, err)
+				}
 			}
 			ips = append(ips, hostNetworkIPs...)
 		}
 	}
 	return ips
+}
+
+func (oc *DefaultNetworkController) getHostNamespaceAddressesForHoNode(node *kapi.Node) ([]net.IP, error) {
+	var ips []net.IP
+	// during SDN live migration, add the SDN node GW IP to the host network address set.
+	hoSubnet, ok := node.Annotations[hotypes.HybridOverlayNodeSubnet]
+	if !ok {
+		// skip hybrid overlay nodes without per-node subnet
+		return nil, nil
+	}
+	_, subnet, err := net.ParseCIDR(hoSubnet)
+	if err != nil {
+		klog.Errorf("Error parsing hybrid overlay subnet %s for node %s: %v", hoSubnet, node.Name, err)
+	}
+	gwIP := util.GetNodeGatewayIfAddr(subnet)
+	ips = append(ips, gwIP.IP)
+	return ips, nil
 }
 
 // getHostNamespaceAddressesForNode retrives management port and gateway router LRP


### PR DESCRIPTION
During live SDN migration, host-to-pod traffic originating from SDN nodes will use the first IP address of the hybrid overlay node subnet. These IPs are being added to ensure proper functionality of host network policies.

This manual backport resolved the conflict that the method`DeleteAddresses` of `AddressSet` doesn't exist in 4.15, by replacing it with `DeleteIPs`.