### PR TITLE
OCPBUGS-49840: Bump OVN to 24.09.2-14 for FDP-1131

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -13,11 +13,12 @@ RUN dnf --setopt=retries=2 --setopt=timeout=2 install -y --nodocs \
 	dnf clean all
 
 ARG ovsver=3.4.0-18.el9fdp
-ARG ovnver=24.09.1-10.el9fdp
+ARG ovnver=24.09.2-14.el9fdp
 # NOTE: Ensure that the versions of OVS and OVN are overriden for OKD in each of the subsequent layers.
 # Centos and RHEL releases for ovn are built out of sync, so please make sure to bump for OKD with
 # the corresponding Centos version when updating the OCP version.
 ARG ovsver_okd=3.4.0-12.el9s
+# We are not bumping the OVN version for OKD since the FDP release is not done yet.
 ARG ovnver_okd=24.09.1-10.el9s
 
 RUN INSTALL_PKGS="iptables nftables" && \


### PR DESCRIPTION
Bump ovn to 24.09.2-14 to bring in a critical fix for ARP binding expiration ([FDP-1131](https://issues.redhat.com//browse/FDP-1131)).