### PR TITLE
[WIP] [DNM] Perf improvement: egress ip/qos reroute rules

### DIFF
--- a/go-controller/pkg/networkmanager/api.go
+++ b/go-controller/pkg/networkmanager/api.go
@@ -3,7 +3,6 @@ package networkmanager
 import (
 	"context"
 	"errors"
-
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 	"k8s.io/client-go/tools/record"
@@ -61,6 +60,7 @@ func NewForCluster(
 		wf,
 		ovnClient,
 		recorder,
+		1,
 	)
 }
 
@@ -78,6 +78,7 @@ func NewForZone(
 		wf,
 		nil,
 		nil,
+		15,
 	)
 }
 
@@ -95,6 +96,7 @@ func NewForNode(
 		wf,
 		nil,
 		nil,
+		15,
 	)
 }
 
@@ -109,8 +111,9 @@ func new(
 	wf watchFactory,
 	ovnClient *util.OVNClusterManagerClientset,
 	recorder record.EventRecorder,
+	threadiness int,
 ) (Controller, error) {
-	return newController(name, zone, node, cm, wf, ovnClient, recorder)
+	return newController(name, zone, node, cm, wf, ovnClient, recorder, threadiness)
 }
 
 // ControllerManager manages controllers. Needs to be provided in order to build

--- a/go-controller/pkg/networkmanager/nad_controller.go
+++ b/go-controller/pkg/networkmanager/nad_controller.go
@@ -84,13 +84,14 @@ func newController(
 	wf watchFactory,
 	ovnClient *util.OVNClusterManagerClientset,
 	recorder record.EventRecorder,
+	threadiness int,
 ) (*nadController, error) {
 	c := &nadController{
 		name:              fmt.Sprintf("[%s NAD controller]", name),
 		recorder:          recorder,
 		nadLister:         wf.NADInformer().Lister(),
 		nodeLister:        wf.NodeCoreInformer().Lister(),
-		networkController: newNetworkController(name, zone, node, cm, wf),
+		networkController: newNetworkController(name, zone, node, cm, wf, threadiness),
 		nads:              map[string]string{},
 		primaryNADs:       map[string]string{},
 	}

--- a/go-controller/pkg/networkmanager/nad_controller_test.go
+++ b/go-controller/pkg/networkmanager/nad_controller_test.go
@@ -487,7 +487,7 @@ func TestNADController(t *testing.T) {
 			nadController := &nadController{
 				nads:               map[string]string{},
 				primaryNADs:        map[string]string{},
-				networkController:  newNetworkController("", "", "", tcm, nil),
+				networkController:  newNetworkController("", "", "", tcm, nil, 1),
 				networkIDAllocator: id.NewIDAllocator("NetworkIDs", MaxNetworks),
 				nadClient:          fakeClient.NetworkAttchDefClient,
 				namespaceLister:    &fakeNamespaceLister{},

--- a/go-controller/pkg/networkmanager/network_controller.go
+++ b/go-controller/pkg/networkmanager/network_controller.go
@@ -42,6 +42,7 @@ func newNetworkController(name, zone, node string, cm ControllerManager, wf watc
 		RateLimiter: workqueue.DefaultTypedControllerRateLimiter[string](),
 		Reconcile:   nc.syncNetwork,
 		Threadiness: threadiness,
+		MaxAttempts: controller.InfiniteAttempts,
 	}
 	nc.networkReconciler = controller.NewReconciler(
 		nc.name,

--- a/go-controller/pkg/networkmanager/network_controller.go
+++ b/go-controller/pkg/networkmanager/network_controller.go
@@ -26,7 +26,7 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 )
 
-func newNetworkController(name, zone, node string, cm ControllerManager, wf watchFactory) *networkController {
+func newNetworkController(name, zone, node string, cm ControllerManager, wf watchFactory, threadiness int) *networkController {
 	nc := &networkController{
 		name:               fmt.Sprintf("[%s network controller]", name),
 		node:               node,
@@ -41,7 +41,7 @@ func newNetworkController(name, zone, node string, cm ControllerManager, wf watc
 	networkConfig := &controller.ReconcilerConfig{
 		RateLimiter: workqueue.DefaultTypedControllerRateLimiter[string](),
 		Reconcile:   nc.syncNetwork,
-		Threadiness: 1,
+		Threadiness: threadiness,
 	}
 	nc.networkReconciler = controller.NewReconciler(
 		nc.name,

--- a/go-controller/pkg/networkmanager/network_controller_test.go
+++ b/go-controller/pkg/networkmanager/network_controller_test.go
@@ -180,7 +180,7 @@ func TestSetAdvertisements(t *testing.T) {
 					ReconcilableNetInfo: &util.DefaultNetInfo{},
 				},
 			}
-			nm := newNetworkController("", testZoneName, testNodeName, tcm, wf)
+			nm := newNetworkController("", testZoneName, testNodeName, tcm, wf, 1)
 
 			namespace, name, err := cache.SplitMetaNamespaceKey(testNADName)
 			g.Expect(err).ToNot(gomega.HaveOccurred())

--- a/go-controller/pkg/ovn/default_network_controller.go
+++ b/go-controller/pkg/ovn/default_network_controller.go
@@ -131,6 +131,7 @@ type DefaultNetworkController struct {
 	hybridOverlayFailed         sync.Map
 	syncZoneICFailed            sync.Map
 	syncHostNetAddrSetFailed    sync.Map
+	syncRerouteFailed           sync.Map
 
 	// variable to determine if all pods present on the node during startup have been processed
 	// updated atomically
@@ -843,14 +844,20 @@ func (h *defaultNetworkControllerEventHandler) AddResource(obj interface{}, from
 				_, hoSync := h.oc.hybridOverlayFailed.Load(node.Name)
 				_, zoneICSync := h.oc.syncZoneICFailed.Load(node.Name)
 				nodeParams = &nodeSyncs{
-					nodeSync,
-					clusterRtrSync,
-					mgmtSync,
-					gwSync,
-					hoSync,
-					zoneICSync}
+					syncNode:              nodeSync,
+					syncClusterRouterPort: clusterRtrSync,
+					syncMgmtPort:          mgmtSync,
+					syncGw:                gwSync,
+					syncHo:                hoSync,
+					syncZoneIC:            zoneICSync}
 			} else {
-				nodeParams = &nodeSyncs{true, true, true, true, config.HybridOverlay.Enabled, config.OVNKubernetesFeature.EnableInterconnect}
+				nodeParams = &nodeSyncs{
+					syncNode:              true,
+					syncClusterRouterPort: true,
+					syncMgmtPort:          true,
+					syncGw:                true,
+					syncHo:                config.HybridOverlay.Enabled,
+					syncZoneIC:            config.OVNKubernetesFeature.EnableInterconnect}
 			}
 
 			if err = h.oc.addUpdateLocalNodeEvent(node, nodeParams); err != nil {
@@ -898,17 +905,27 @@ func (h *defaultNetworkControllerEventHandler) AddResource(obj interface{}, from
 		h.oc.eIPC.nodeZoneState.LockKey(node.Name)
 		h.oc.eIPC.nodeZoneState.Store(node.Name, h.oc.isLocalZoneNode(node))
 		h.oc.eIPC.nodeZoneState.UnlockKey(node.Name)
-		// add the 103 qos rule to new node's switch
-		// NOTE: We don't need to remove this on node delete since entire node switch will get cleaned up
-		if h.oc.isLocalZoneNode(node) {
-			if err := h.oc.eIPC.ensureDefaultNoRerouteQoSRules(node.Name); err != nil {
+
+		shouldSyncReroute := true
+		if fromRetryLoop {
+			_, shouldSyncReroute = h.oc.syncRerouteFailed.Load(node.Name)
+		}
+
+		if shouldSyncReroute {
+			// add the 103 qos rule to new node's switch
+			// NOTE: We don't need to remove this on node delete since entire node switch will get cleaned up
+			if h.oc.isLocalZoneNode(node) {
+				if err := h.oc.eIPC.ensureDefaultNoRerouteQoSRules(node.Name); err != nil {
+					h.oc.syncRerouteFailed.Store(node.Name, true)
+					return err
+				}
+			}
+			// add the nodeIP to the default LRP (102 priority) destination address-set
+			err := h.oc.eIPC.ensureDefaultNoRerouteNodePolicies()
+			if err != nil {
+				h.oc.syncRerouteFailed.Store(node.Name, true)
 				return err
 			}
-		}
-		// add the nodeIP to the default LRP (102 priority) destination address-set
-		err := h.oc.eIPC.ensureDefaultNoRerouteNodePolicies()
-		if err != nil {
-			return err
 		}
 		// Add routing specific to Egress IP NOTE: GARP configuration that
 		// Egress IP depends on is added from the gateway reconciliation logic
@@ -1001,17 +1018,24 @@ func (h *defaultNetworkControllerEventHandler) UpdateResource(oldObj, newObj int
 				_, syncZoneIC := h.oc.syncZoneICFailed.Load(newNode.Name)
 				syncZoneIC = syncZoneIC || zoneClusterChanged || primaryAddrChanged(oldNode, newNode)
 				nodeSyncsParam = &nodeSyncs{
-					nodeSync,
-					clusterRtrSync,
-					mgmtSync,
-					gwSync,
-					hoSync,
-					syncZoneIC}
+					syncNode:              nodeSync,
+					syncClusterRouterPort: clusterRtrSync,
+					syncMgmtPort:          mgmtSync,
+					syncGw:                gwSync,
+					syncHo:                hoSync,
+					syncZoneIC:            syncZoneIC,
+				}
 			} else {
 				klog.Infof("Node %s moved from the remote zone %s to local zone %s.",
 					newNode.Name, util.GetNodeZone(oldNode), util.GetNodeZone(newNode))
 				// The node is now a local zone node.  Trigger a full node sync.
-				nodeSyncsParam = &nodeSyncs{true, true, true, true, true, config.OVNKubernetesFeature.EnableInterconnect}
+				nodeSyncsParam = &nodeSyncs{
+					syncNode:              true,
+					syncClusterRouterPort: true,
+					syncMgmtPort:          true,
+					syncGw:                true,
+					syncHo:                true,
+					syncZoneIC:            config.OVNKubernetesFeature.EnableInterconnect}
 			}
 
 			if err := h.oc.addUpdateLocalNodeEvent(newNode, nodeSyncsParam); err != nil {
@@ -1066,24 +1090,24 @@ func (h *defaultNetworkControllerEventHandler) UpdateResource(oldObj, newObj int
 		h.oc.eIPC.nodeZoneState.LockKey(newNode.Name)
 		h.oc.eIPC.nodeZoneState.Store(newNode.Name, h.oc.isLocalZoneNode(newNode))
 		h.oc.eIPC.nodeZoneState.UnlockKey(newNode.Name)
-		// try to add the 103 qos rule to new node's switch if it doesn't exist
-		// The reason we call this from update is because in case the add node event
-		// did not succeed and we got an update node event which overrides the add event
-		// and removes the add event from retry cache, we'd need to ensure the qos rule exists
-		// NOTE: We don't need to remove this on node delete since entire node switch will get cleaned up
-		if h.oc.isLocalZoneNode(newNode) {
+
+		_, failed := h.oc.syncRerouteFailed.Load(newNode.Name)
+
+		// node moved from remote -> local or previously failed reroute config
+		if (!h.oc.isLocalZoneNode(oldNode) || failed) && h.oc.isLocalZoneNode(newNode) {
 			if err := h.oc.eIPC.ensureDefaultNoRerouteQoSRules(newNode.Name); err != nil {
 				return err
 			}
 		}
-		// update the nodeIP in the defalt-reRoute (102 priority) destination address-set
-		if util.NodeHostCIDRsAnnotationChanged(oldNode, newNode) {
+		// update the nodeIP in the default-reRoute (102 priority) destination address-set
+		if failed || util.NodeHostCIDRsAnnotationChanged(oldNode, newNode) {
 			klog.Infof("Egress IP detected IP address change for node %s. Updating no re-route policies", newNode.Name)
 			err := h.oc.eIPC.ensureDefaultNoRerouteNodePolicies()
 			if err != nil {
 				return err
 			}
 		}
+		h.oc.syncRerouteFailed.Delete(newNode.Name)
 		return h.oc.eIPC.addEgressNode(newNode)
 
 	case factory.NamespaceType:

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -468,6 +468,7 @@ type nodeSyncs struct {
 	syncGw                bool
 	syncHo                bool
 	syncZoneIC            bool
+	syncReroute           bool
 }
 
 func (oc *DefaultNetworkController) addUpdateLocalNodeEvent(node *kapi.Node, nSyncs *nodeSyncs) error {
@@ -540,7 +541,7 @@ func (oc *DefaultNetworkController) addUpdateLocalNodeEvent(node *kapi.Node, nSy
 			}
 		}
 
-		// If we succcessfully discovered the host subnets then add the management port.
+		// If we successfully discovered the host subnets then add the management port.
 		if hostSubnets != nil {
 			if err = oc.syncNodeManagementPortDefault(node, oc.GetNetworkScopedSwitchName(node.Name), hostSubnets); err != nil {
 				errs = append(errs, err)


### PR DESCRIPTION
These things were constantly being executed on every node update. Bring them inline with what we do for other node syncs, keep a cache of what needs to be sync'ed. The impact of this was especially bad for UDN.

testing https://github.com/ovn-kubernetes/ovn-kubernetes/pull/5046