### PR TITLE
DNM/TEST: Enrich CNI request pod UID error with the mismatched UIDs

### DIFF
--- a/go-controller/pkg/cni/cni.go
+++ b/go-controller/pkg/cni/cni.go
@@ -101,7 +101,8 @@ func (pr *PodRequest) checkOrUpdatePodUID(pod *kapi.Pod) error {
 		pr.PodUID = string(pod.UID)
 	} else if string(pod.UID) != pr.PodUID {
 		// Exit early if the pod was deleted and recreated already
-		return fmt.Errorf("pod deleted before sandbox %v operation began", pr.Command)
+		return fmt.Errorf("pod deleted before sandbox %v operation began. Request Pod UID %s is different from "+
+			"the Pod UID (%s) retrieved from the informer/API", pr.Command, pr.PodUID, pod.UID)
 	}
 	return nil
 }


### PR DESCRIPTION
I am trying to debug an issue where this error occurs and I dont easily know what pod UIDs that were compared.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
