### PR TITLE
[release-4.17] OCPBUGS-50519: kubevirt, localnet: Reduce live migration downtime

### DIFF
--- a/go-controller/pkg/kubevirt/pod.go
+++ b/go-controller/pkg/kubevirt/pod.go
@@ -355,7 +355,9 @@ func IsPodOwnedByVirtualMachine(pod *corev1.Pod) bool {
 
 // IsPodAllowedForMigration determines whether a given pod is eligible for live migration
 func IsPodAllowedForMigration(pod *corev1.Pod, netInfo util.NetInfo) bool {
-	return IsPodOwnedByVirtualMachine(pod) && netInfo.TopologyType() == ovntypes.Layer2Topology
+	return IsPodOwnedByVirtualMachine(pod) &&
+		(netInfo.TopologyType() == ovntypes.Layer2Topology ||
+			netInfo.TopologyType() == ovntypes.LocalnetTopology)
 }
 
 func isTargetPodReady(targetPod *corev1.Pod) bool {

--- a/go-controller/pkg/kubevirt/pod.go
+++ b/go-controller/pkg/kubevirt/pod.go
@@ -353,6 +353,11 @@ func IsPodOwnedByVirtualMachine(pod *corev1.Pod) bool {
 	return ExtractVMNameFromPod(pod) != nil
 }
 
+// IsPodAllowedForMigration determines whether a given pod is eligible for live migration
+func IsPodAllowedForMigration(pod *corev1.Pod, netInfo util.NetInfo) bool {
+	return IsPodOwnedByVirtualMachine(pod) && netInfo.TopologyType() == ovntypes.Layer2Topology
+}
+
 func isTargetPodReady(targetPod *corev1.Pod) bool {
 	if targetPod == nil {
 		return false
@@ -406,6 +411,11 @@ type LiveMigrationStatus struct {
 	SourcePod *corev1.Pod        // SourcePod is the original pod.
 	TargetPod *corev1.Pod        // TargetPod is the destination pod.
 	State     LiveMigrationState // State is the current state of the live migration.
+}
+
+// IsTargetDomainReady returns true if the target domain in the live migration process is ready.
+func (lm LiveMigrationStatus) IsTargetDomainReady() bool {
+	return lm.State == LiveMigrationTargetDomainReady
 }
 
 // DiscoverLiveMigrationStatus determines the status of a live migration for a given pod.

--- a/go-controller/pkg/kubevirt/pod.go
+++ b/go-controller/pkg/kubevirt/pod.go
@@ -3,6 +3,8 @@ package kubevirt
 import (
 	"fmt"
 	"net"
+	"sort"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -12,6 +14,7 @@ import (
 	kubevirtv1 "kubevirt.io/api/core/v1"
 
 	libovsdbclient "github.com/ovn-org/libovsdb/client"
+
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
 	libovsdbops "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdb/ops"
@@ -342,4 +345,127 @@ func ZoneContainsPodSubnetOrUntracked(watchFactory *factory.WatchFactory, lsMana
 	// we can just use one of the IPs to check if it belongs to a subnet assigned
 	// to a node
 	return hostSubnets, !util.IsContainedInAnyCIDR(annotation.IPs[0], hostSubnets...), nil
+}
+
+// IsPodOwnedByVirtualMachine returns true if the pod is own by a
+// kubevirt virtual machine, false otherwise.
+func IsPodOwnedByVirtualMachine(pod *corev1.Pod) bool {
+	return ExtractVMNameFromPod(pod) != nil
+}
+
+func isTargetPodReady(targetPod *corev1.Pod) bool {
+	if targetPod == nil {
+		return false
+	}
+
+	// This annotation only appears on live migration scenarios, and it signals
+	// that target VM pod is ready to receive traffic, so we can route
+	// traffic to it.
+	targetReadyTimestamp := targetPod.Annotations[kubevirtv1.MigrationTargetReadyTimestamp]
+
+	// VM is ready to receive traffic
+	return targetReadyTimestamp != ""
+}
+
+func filterNotComplete(vmPods []*corev1.Pod) []*corev1.Pod {
+	var notCompletePods []*corev1.Pod
+	for _, vmPod := range vmPods {
+		if !util.PodCompleted(vmPod) {
+			notCompletePods = append(notCompletePods, vmPod)
+		}
+	}
+
+	return notCompletePods
+}
+
+func tooManyPodsError(livingPods []*corev1.Pod) error {
+	var podNames = make([]string, len(livingPods))
+	for i := range livingPods {
+		podNames[i] = livingPods[i].Namespace + "/" + livingPods[i].Name
+	}
+	return fmt.Errorf("unexpected live migration state at pods: %s", strings.Join(podNames, ","))
+}
+
+// LiveMigrationState represents the various states of a live migration process.
+type LiveMigrationState string
+
+const (
+	// LiveMigrationInProgress indicates that a live migration is currently ongoing.
+	LiveMigrationInProgress LiveMigrationState = "InProgress"
+
+	// LiveMigrationTargetDomainReady indicates that the target domain is ready to take over.
+	LiveMigrationTargetDomainReady LiveMigrationState = "TargetDomainReady"
+
+	// LiveMigrationFailed indicates that the live migration process has failed.
+	LiveMigrationFailed LiveMigrationState = "Failed"
+)
+
+// LiveMigrationStatus provides details about the current status of a live migration.
+// It includes information about the source and target pods as well as the migration state.
+type LiveMigrationStatus struct {
+	SourcePod *corev1.Pod        // SourcePod is the original pod.
+	TargetPod *corev1.Pod        // TargetPod is the destination pod.
+	State     LiveMigrationState // State is the current state of the live migration.
+}
+
+// DiscoverLiveMigrationStatus determines the status of a live migration for a given pod.
+// It analyzes the state of pods associated with a VirtualMachine (VM) to identify whether
+// a live migration is in progress, the target domain is ready, or the migration has failed.
+//
+// Note: The function assumes that the pod is part of a VirtualMachine resource managed
+// by KubeVirt.
+func DiscoverLiveMigrationStatus(client *factory.WatchFactory, pod *corev1.Pod) (*LiveMigrationStatus, error) {
+	vmKey := ExtractVMNameFromPod(pod)
+	if vmKey == nil {
+		return nil, nil
+	}
+
+	vmPods, err := client.GetPodsBySelector(pod.Namespace, metav1.LabelSelector{MatchLabels: map[string]string{kubevirtv1.VirtualMachineNameLabel: vmKey.Name}})
+	if err != nil {
+		return nil, err
+	}
+
+	// no migration
+	if len(vmPods) < 2 {
+		return nil, nil
+	}
+
+	// Sort vmPods by creation time
+	sort.Slice(vmPods, func(i, j int) bool {
+		return vmPods[j].CreationTimestamp.After(vmPods[i].CreationTimestamp.Time)
+	})
+
+	targetPod := vmPods[len(vmPods)-1]
+	livingPods := filterNotComplete(vmPods)
+	if util.PodCompleted(targetPod) {
+		// if target pod failed, then there should be only one living source pod.
+		if len(livingPods) != 1 {
+			return nil, fmt.Errorf("unexpected live migration state: should have a single living pod")
+		}
+		return &LiveMigrationStatus{
+			SourcePod: livingPods[0],
+			TargetPod: targetPod,
+			State:     LiveMigrationFailed,
+		}, nil
+	}
+
+	// no active migration
+	if len(livingPods) < 2 {
+		return nil, nil
+	}
+
+	if len(livingPods) > 2 {
+		return nil, tooManyPodsError(livingPods)
+	}
+
+	status := LiveMigrationStatus{
+		SourcePod: livingPods[0],
+		TargetPod: livingPods[1],
+		State:     LiveMigrationInProgress,
+	}
+
+	if isTargetPodReady(status.TargetPod) {
+		status.State = LiveMigrationTargetDomainReady
+	}
+	return &status, nil
 }

--- a/go-controller/pkg/kubevirt/pod_test.go
+++ b/go-controller/pkg/kubevirt/pod_test.go
@@ -1,0 +1,213 @@
+package kubevirt
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/rand"
+	kubevirtv1 "kubevirt.io/api/core/v1"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+)
+
+const vmName = "test-vm"
+
+var _ = Describe("Kubevirt Pod", func() {
+	const (
+		t0 = time.Duration(0)
+		t1 = time.Duration(1)
+		t2 = time.Duration(2)
+		t3 = time.Duration(3)
+		t4 = time.Duration(4)
+	)
+	runningKvSourcePod := runningKubevirtPod(t0)
+	successfullyMigratedKvSourcePod := completedKubevirtPod(t1)
+
+	failedMigrationKvTargetPod := failedKubevirtPod(t2)
+	successfulMigrationKvTargetPod := runningKubevirtPod(t3)
+	anotherFailedMigrationKvTargetPod := failedKubevirtPod(t4)
+	duringMigrationKvTargetPod := runningKubevirtPod(t4)
+	yetAnotherDuringMigrationKvTargetPod := runningKubevirtPod(t4)
+	readyMigrationKvTargetPod := domainReadyKubevirtPod(t4)
+
+	type testParams struct {
+		pods                    []corev1.Pod
+		expectedError           error
+		expectedMigrationStatus *LiveMigrationStatus
+	}
+	DescribeTable("DiscoverLiveMigrationStatus", func(params testParams) {
+		Expect(config.PrepareTestConfig()).To(Succeed())
+		config.OVNKubernetesFeature.EnableNetworkSegmentation = true
+		config.OVNKubernetesFeature.EnableMultiNetwork = true
+		config.OVNKubernetesFeature.EnableInterconnect = true
+
+		fakeClient := util.GetOVNClientset().GetOVNKubeControllerClientset()
+		wf, err := factory.NewOVNKubeControllerWatchFactory(fakeClient)
+		Expect(err).ToNot(HaveOccurred())
+
+		for _, pod := range params.pods {
+			_, err := fakeClient.KubeClient.CoreV1().Pods(pod.Namespace).Create(context.Background(), &pod, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+		}
+
+		Expect(wf.Start()).To(Succeed())
+		defer wf.Shutdown()
+
+		currentPod := params.pods[0]
+		migrationStatus, err := DiscoverLiveMigrationStatus(wf, &currentPod)
+		if params.expectedError == nil {
+			Expect(err).To(BeNil())
+		} else {
+			Expect(err).To(MatchError(ContainSubstring(params.expectedError.Error())))
+		}
+
+		if params.expectedMigrationStatus == nil {
+			Expect(migrationStatus).To(BeNil())
+		} else {
+			Expect(migrationStatus.State).To(Equal(params.expectedMigrationStatus.State))
+			Expect(migrationStatus.SourcePod.Name).To(Equal(params.expectedMigrationStatus.SourcePod.Name))
+			Expect(migrationStatus.TargetPod.Name).To(Equal(params.expectedMigrationStatus.TargetPod.Name))
+		}
+	},
+		Entry("returns nil when pod is not kubevirt related",
+			testParams{
+				pods: []corev1.Pod{nonKubevirtPod()},
+			},
+		),
+		Entry("returns nil when migration was not performed",
+			testParams{
+				pods: []corev1.Pod{runningKvSourcePod},
+			},
+		),
+		Entry("returns nil when there is no active migration",
+			testParams{
+				pods: []corev1.Pod{successfullyMigratedKvSourcePod, successfulMigrationKvTargetPod},
+			},
+		),
+		Entry("returns nil when there is no active migration (multiple migrations)",
+			testParams{
+				pods: []corev1.Pod{successfullyMigratedKvSourcePod, failedMigrationKvTargetPod, successfulMigrationKvTargetPod},
+			},
+		),
+		Entry("returns Migration in progress status when 2 pods are running, target pod is not yet ready",
+			testParams{
+				pods: []corev1.Pod{runningKvSourcePod, duringMigrationKvTargetPod},
+				expectedMigrationStatus: &LiveMigrationStatus{
+					SourcePod: &runningKvSourcePod,
+					TargetPod: &duringMigrationKvTargetPod,
+					State:     LiveMigrationInProgress,
+				},
+			},
+		),
+		Entry("returns Migration Failed status when latest target pod failed",
+			testParams{
+				pods: []corev1.Pod{runningKvSourcePod, failedMigrationKvTargetPod},
+				expectedMigrationStatus: &LiveMigrationStatus{
+					SourcePod: &runningKvSourcePod,
+					TargetPod: &failedMigrationKvTargetPod,
+					State:     LiveMigrationFailed,
+				},
+			},
+		),
+		Entry("returns Migration Failed status when latest target pod failed (multiple migrations)",
+			testParams{
+				pods: []corev1.Pod{runningKvSourcePod, failedMigrationKvTargetPod, anotherFailedMigrationKvTargetPod},
+				expectedMigrationStatus: &LiveMigrationStatus{
+					SourcePod: &runningKvSourcePod,
+					TargetPod: &anotherFailedMigrationKvTargetPod,
+					State:     LiveMigrationFailed,
+				},
+			},
+		),
+		Entry("returns Migration Ready status when latest target pod is ready",
+			testParams{
+				pods: []corev1.Pod{runningKvSourcePod, readyMigrationKvTargetPod},
+				expectedMigrationStatus: &LiveMigrationStatus{
+					SourcePod: &runningKvSourcePod,
+					TargetPod: &readyMigrationKvTargetPod,
+					State:     LiveMigrationTargetDomainReady,
+				},
+			},
+		),
+		Entry("returns Migration Ready status when latest target pod is ready (multiple migrations)",
+			testParams{
+				pods: []corev1.Pod{runningKvSourcePod, failedMigrationKvTargetPod, readyMigrationKvTargetPod},
+				expectedMigrationStatus: &LiveMigrationStatus{
+					SourcePod: &runningKvSourcePod,
+					TargetPod: &readyMigrationKvTargetPod,
+					State:     LiveMigrationTargetDomainReady,
+				},
+			},
+		),
+		Entry("returns err when kubevirt VM has several living pods and target pod failed",
+			testParams{
+				pods:          []corev1.Pod{runningKvSourcePod, successfulMigrationKvTargetPod, anotherFailedMigrationKvTargetPod},
+				expectedError: fmt.Errorf("unexpected live migration state: should have a single living pod"),
+			},
+		),
+		Entry("returns err when kubevirt VM has several living pods",
+			testParams{
+				pods:          []corev1.Pod{runningKvSourcePod, duringMigrationKvTargetPod, yetAnotherDuringMigrationKvTargetPod},
+				expectedError: fmt.Errorf("unexpected live migration state at pods"),
+			},
+		),
+	)
+})
+
+func completedKubevirtPod(creationOffset time.Duration) corev1.Pod {
+	return newKubevirtPod(corev1.PodSucceeded, nil, creationOffset)
+}
+
+func failedKubevirtPod(creationOffset time.Duration) corev1.Pod {
+	return newKubevirtPod(corev1.PodFailed, nil, creationOffset)
+}
+
+func runningKubevirtPod(creationOffset time.Duration) corev1.Pod {
+	return newKubevirtPod(corev1.PodRunning, nil, creationOffset)
+}
+
+func domainReadyKubevirtPod(creationOffset time.Duration) corev1.Pod {
+	return newKubevirtPod(corev1.PodRunning, map[string]string{kubevirtv1.MigrationTargetReadyTimestamp: "some-timestamp"}, creationOffset)
+}
+
+func nonKubevirtPod() corev1.Pod {
+	return corev1.Pod{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Pod",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "some-pod",
+			Namespace: corev1.NamespaceDefault,
+		},
+		Spec: corev1.PodSpec{},
+	}
+}
+func newKubevirtPod(phase corev1.PodPhase, annotations map[string]string, creationOffset time.Duration) corev1.Pod {
+	return corev1.Pod{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Pod",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "virt-launcher-" + vmName + rand.String(5),
+			Namespace:         corev1.NamespaceDefault,
+			Annotations:       annotations,
+			Labels:            map[string]string{kubevirtv1.VirtualMachineNameLabel: vmName},
+			CreationTimestamp: metav1.Time{Time: time.Now().Add(creationOffset)},
+		},
+		Spec: corev1.PodSpec{},
+		Status: corev1.PodStatus{
+			Phase: phase,
+		},
+	}
+}

--- a/go-controller/pkg/libovsdb/ops/model.go
+++ b/go-controller/pkg/libovsdb/ops/model.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ovn-org/libovsdb/client"
 	"github.com/ovn-org/libovsdb/model"
 	"github.com/ovn-org/libovsdb/ovsdb"
+
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/sbdb"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
@@ -454,6 +455,64 @@ func buildFailOnDuplicateOps(c client.Client, m model.Model) ([]ovsdb.Operation,
 		Value:    value,
 	}
 	return c.WhereAny(m, cond).Wait(ovsdb.WaitConditionNotEqual, &timeout, m, field)
+}
+
+// ModelUpdateField enumeration represents fields that can be updated on the supported models
+type ModelUpdateField int
+
+const (
+	LogicalSwitchPortAddresses ModelUpdateField = iota
+	LogicalSwitchPortType
+	LogicalSwitchPortTagRequest
+	LogicalSwitchPortOptions
+	LogicalSwitchPortPortSecurity
+	LogicalSwitchPortEnabled
+
+	PortGroupACLs
+	PortGroupPorts
+	PortGroupExternalIDs
+)
+
+// getFieldsToUpdate gets a model and a list of ModelUpdateField and returns a list of their related interface{} fields.
+func getFieldsToUpdate(model model.Model, fieldNames []ModelUpdateField) []interface{} {
+	var fields []interface{}
+	switch t := model.(type) {
+	case *nbdb.LogicalSwitchPort:
+		for _, field := range fieldNames {
+			switch field {
+			case LogicalSwitchPortAddresses:
+				fields = append(fields, &t.Addresses)
+			case LogicalSwitchPortType:
+				fields = append(fields, &t.Type)
+			case LogicalSwitchPortTagRequest:
+				fields = append(fields, &t.TagRequest)
+			case LogicalSwitchPortOptions:
+				fields = append(fields, &t.Options)
+			case LogicalSwitchPortPortSecurity:
+				fields = append(fields, &t.PortSecurity)
+			case LogicalSwitchPortEnabled:
+				fields = append(fields, &t.Enabled)
+			default:
+				panic(fmt.Sprintf("getFieldsToUpdate: unknown or unsupported field %q for LogicalSwitchPort", field))
+			}
+		}
+	case *nbdb.PortGroup:
+		for _, field := range fieldNames {
+			switch field {
+			case PortGroupACLs:
+				fields = append(fields, &t.ACLs)
+			case PortGroupPorts:
+				fields = append(fields, &t.Ports)
+			case PortGroupExternalIDs:
+				fields = append(fields, &t.ExternalIDs)
+			default:
+				panic(fmt.Sprintf("getFieldsToUpdate: unknown or unsupported field %q for PortGroup", field))
+			}
+		}
+	default:
+		panic(fmt.Sprintf("getFieldsToUpdate: unknown model type %T", t))
+	}
+	return fields
 }
 
 // getAllUpdatableFields returns a list of all of the columns/fields that can be updated for a model

--- a/go-controller/pkg/libovsdb/ops/switch.go
+++ b/go-controller/pkg/libovsdb/ops/switch.go
@@ -286,28 +286,42 @@ func GetLogicalSwitchPort(nbClient libovsdbclient.Client, lsp *nbdb.LogicalSwitc
 	return found[0], nil
 }
 
-func createOrUpdateLogicalSwitchPortsOps(nbClient libovsdbclient.Client, ops []libovsdb.Operation, sw *nbdb.LogicalSwitch, createSwitch bool, lsps ...*nbdb.LogicalSwitchPort) ([]libovsdb.Operation, error) {
+func createOrUpdateLogicalSwitchPortOpModelWithCustomFields(sw *nbdb.LogicalSwitch, lsp *nbdb.LogicalSwitchPort, createLSP bool, customFields []ModelUpdateField) operationModel {
+	var fieldInterfaces []interface{}
+	if len(customFields) != 0 {
+		fieldInterfaces = getFieldsToUpdate(lsp, customFields)
+	} else {
+		fieldInterfaces = getAllUpdatableFields(lsp)
+	}
+	return operationModel{
+		Model:          lsp,
+		OnModelUpdates: fieldInterfaces,
+		DoAfter: func() {
+			// lsp.UUID should be set here
+			sw.Ports = append(sw.Ports, lsp.UUID)
+		},
+		ErrNotFound: !createLSP,
+		BulkOp:      false,
+	}
+}
+
+func createOrUpdateLogicalSwitchPortsOps(nbClient libovsdbclient.Client, ops []libovsdb.Operation, sw *nbdb.LogicalSwitch, createSwitch, createLSP bool, customFields []ModelUpdateField, lsps ...*nbdb.LogicalSwitchPort) ([]libovsdb.Operation, error) {
 	originalPorts := sw.Ports
 	sw.Ports = make([]string, 0, len(lsps))
 	opModels := make([]operationModel, 0, len(lsps)+1)
-	for i := range lsps {
-		lsp := lsps[i]
-		opModel := operationModel{
-			Model:          lsp,
-			OnModelUpdates: getAllUpdatableFields(lsp),
-			DoAfter:        func() { sw.Ports = append(sw.Ports, lsp.UUID) },
-			ErrNotFound:    false,
-			BulkOp:         false,
-		}
+
+	for _, lsp := range lsps {
+		opModel := createOrUpdateLogicalSwitchPortOpModelWithCustomFields(sw, lsp, createLSP, customFields)
 		opModels = append(opModels, opModel)
 	}
-	opModel := operationModel{
+
+	opModelSwitch := operationModel{
 		Model:            sw,
 		OnModelMutations: []interface{}{&sw.Ports},
 		ErrNotFound:      !createSwitch,
 		BulkOp:           false,
 	}
-	opModels = append(opModels, opModel)
+	opModels = append(opModels, opModelSwitch)
 
 	m := newModelClient(nbClient)
 	ops, err := m.CreateOrUpdateOps(ops, opModels...)
@@ -316,7 +330,7 @@ func createOrUpdateLogicalSwitchPortsOps(nbClient libovsdbclient.Client, ops []l
 }
 
 func createOrUpdateLogicalSwitchPorts(nbClient libovsdbclient.Client, sw *nbdb.LogicalSwitch, createSwitch bool, lsps ...*nbdb.LogicalSwitchPort) error {
-	ops, err := createOrUpdateLogicalSwitchPortsOps(nbClient, nil, sw, createSwitch, lsps...)
+	ops, err := createOrUpdateLogicalSwitchPortsOps(nbClient, nil, sw, createSwitch, true, nil, lsps...)
 	if err != nil {
 		return err
 	}
@@ -325,11 +339,18 @@ func createOrUpdateLogicalSwitchPorts(nbClient libovsdbclient.Client, sw *nbdb.L
 	return err
 }
 
-// CreateOrUpdateLogicalSwitchPortsOnSwitchOps creates or updates the provided
+// CreateOrUpdateLogicalSwitchPortsOnSwitchWithCustomFieldsOps creates or updates the provided
 // logical switch ports, adds them to the provided logical switch and returns
 // the corresponding ops
-func CreateOrUpdateLogicalSwitchPortsOnSwitchOps(nbClient libovsdbclient.Client, ops []libovsdb.Operation, sw *nbdb.LogicalSwitch, lsps ...*nbdb.LogicalSwitchPort) ([]libovsdb.Operation, error) {
-	return createOrUpdateLogicalSwitchPortsOps(nbClient, ops, sw, false, lsps...)
+func CreateOrUpdateLogicalSwitchPortsOnSwitchWithCustomFieldsOps(nbClient libovsdbclient.Client, ops []libovsdb.Operation, sw *nbdb.LogicalSwitch, customFields []ModelUpdateField, lsps ...*nbdb.LogicalSwitchPort) ([]libovsdb.Operation, error) {
+	return createOrUpdateLogicalSwitchPortsOps(nbClient, ops, sw, false, true, customFields, lsps...)
+}
+
+// UpdateLogicalSwitchPortsOnSwitchWithCustomFieldsOps updates the provided
+// logical switch ports, adds them to the provided logical switch and returns
+// the corresponding ops
+func UpdateLogicalSwitchPortsOnSwitchWithCustomFieldsOps(nbClient libovsdbclient.Client, ops []libovsdb.Operation, sw *nbdb.LogicalSwitch, customFields []ModelUpdateField, lsps ...*nbdb.LogicalSwitchPort) ([]libovsdb.Operation, error) {
+	return createOrUpdateLogicalSwitchPortsOps(nbClient, ops, sw, false, false, customFields, lsps...)
 }
 
 // CreateOrUpdateLogicalSwitchPortsOnSwitch creates or updates the provided

--- a/go-controller/pkg/ovn/base_network_controller_pods.go
+++ b/go-controller/pkg/ovn/base_network_controller_pods.go
@@ -558,15 +558,25 @@ func (bnc *BaseNetworkController) addLogicalPortToNetwork(pod *kapi.Pod, nadName
 		return nil, nil, nil, false, err
 	}
 
-	// set addresses on the port
-	// LSP addresses in OVN are a single space-separated value
+	lsp.Enabled = enable
+	if lsp.Enabled != nil {
+		customFields = append(customFields, libovsdbops.LogicalSwitchPortEnabled)
+	}
+
 	addresses = []string{podAnnotation.MAC.String()}
 	for _, podIfAddr := range podAnnotation.IPs {
 		addresses[0] = addresses[0] + " " + podIfAddr.IP.String()
 	}
 
-	lsp.Addresses = addresses
-	customFields = append(customFields, libovsdbops.LogicalSwitchPortAddresses)
+	// Skip address configuration if LSP is disabled since it will install
+	// l2 look up flows that harms some topologies
+	if lsp.Enabled == nil || *lsp.Enabled {
+		// set addresses on the port
+		// LSP addresses in OVN are a single space-separated value
+
+		lsp.Addresses = addresses
+		customFields = append(customFields, libovsdbops.LogicalSwitchPortAddresses)
+	}
 
 	// add external ids
 	lsp.ExternalIDs = map[string]string{"namespace": pod.Namespace, "pod": "true"}
@@ -593,11 +603,6 @@ func (bnc *BaseNetworkController) addLogicalPortToNetwork(pod *kapi.Pod, nadName
 	}
 	if len(lsp.Options) != 0 {
 		customFields = append(customFields, libovsdbops.LogicalSwitchPortOptions)
-	}
-
-	lsp.Enabled = enable
-	if lsp.Enabled != nil {
-		customFields = append(customFields, libovsdbops.LogicalSwitchPortEnabled)
 	}
 	ops, err = libovsdbops.CreateOrUpdateLogicalSwitchPortsOnSwitchWithCustomFieldsOps(bnc.nbClient, nil, ls, customFields, lsp)
 	if err != nil {

--- a/go-controller/pkg/ovn/base_network_controller_pods.go
+++ b/go-controller/pkg/ovn/base_network_controller_pods.go
@@ -511,6 +511,8 @@ func (bnc *BaseNetworkController) addLogicalPortToNetwork(pod *kapi.Pod, nadName
 		}
 	}
 
+	var customFields []libovsdbops.ModelUpdateField
+
 	lsp.Options = make(map[string]string)
 	// Unique identifier to distinguish interfaces for recreated pods, also set by ovnkube-node
 	// ovn-controller will claim the OVS interface only if external_ids:iface-id
@@ -564,6 +566,7 @@ func (bnc *BaseNetworkController) addLogicalPortToNetwork(pod *kapi.Pod, nadName
 	}
 
 	lsp.Addresses = addresses
+	customFields = append(customFields, libovsdbops.LogicalSwitchPortAddresses)
 
 	// add external ids
 	lsp.ExternalIDs = map[string]string{"namespace": pod.Namespace, "pod": "true"}
@@ -575,6 +578,7 @@ func (bnc *BaseNetworkController) addLogicalPortToNetwork(pod *kapi.Pod, nadName
 
 	// CNI depends on the flows from port security, delay setting it until end
 	lsp.PortSecurity = addresses
+	customFields = append(customFields, libovsdbops.LogicalSwitchPortPortSecurity)
 
 	// On layer2 topology with interconnect, we need to add specific port config
 	if bnc.isLayer2Interconnect() {
@@ -583,9 +587,15 @@ func (bnc *BaseNetworkController) addLogicalPortToNetwork(pod *kapi.Pod, nadName
 		if err != nil {
 			return nil, nil, nil, false, err
 		}
+		if isRemotePort {
+			customFields = append(customFields, libovsdbops.LogicalSwitchPortType)
+		}
+	}
+	if len(lsp.Options) != 0 {
+		customFields = append(customFields, libovsdbops.LogicalSwitchPortOptions)
 	}
 
-	ops, err = libovsdbops.CreateOrUpdateLogicalSwitchPortsOnSwitchOps(bnc.nbClient, nil, ls, lsp)
+	ops, err = libovsdbops.CreateOrUpdateLogicalSwitchPortsOnSwitchWithCustomFieldsOps(bnc.nbClient, nil, ls, customFields, lsp)
 	if err != nil {
 		return nil, nil, nil, false,
 			fmt.Errorf("error creating logical switch port %+v on switch %+v: %+v", *lsp, *ls, err)

--- a/go-controller/pkg/ovn/base_network_controller_pods.go
+++ b/go-controller/pkg/ovn/base_network_controller_pods.go
@@ -444,7 +444,7 @@ func (bnc *BaseNetworkController) ensurePodAnnotation(pod *kapi.Pod, nadName str
 }
 
 func (bnc *BaseNetworkController) addLogicalPortToNetwork(pod *kapi.Pod, nadName string,
-	network *nadapi.NetworkSelectionElement) (ops []ovsdb.Operation,
+	network *nadapi.NetworkSelectionElement, enable *bool) (ops []ovsdb.Operation,
 	lsp *nbdb.LogicalSwitchPort, podAnnotation *util.PodAnnotation, newlyCreatedPort bool, err error) {
 	var ls *nbdb.LogicalSwitch
 
@@ -595,6 +595,10 @@ func (bnc *BaseNetworkController) addLogicalPortToNetwork(pod *kapi.Pod, nadName
 		customFields = append(customFields, libovsdbops.LogicalSwitchPortOptions)
 	}
 
+	lsp.Enabled = enable
+	if lsp.Enabled != nil {
+		customFields = append(customFields, libovsdbops.LogicalSwitchPortEnabled)
+	}
 	ops, err = libovsdbops.CreateOrUpdateLogicalSwitchPortsOnSwitchWithCustomFieldsOps(bnc.nbClient, nil, ls, customFields, lsp)
 	if err != nil {
 		return nil, nil, nil, false,

--- a/go-controller/pkg/ovn/base_network_controller_secondary.go
+++ b/go-controller/pkg/ovn/base_network_controller_secondary.go
@@ -349,7 +349,9 @@ func (bsnc *BaseSecondaryNetworkController) addLogicalPortToNetworkForNAD(pod *k
 	}
 
 	if shouldHandleLiveMigration &&
-		kubevirtLiveMigrationStatus.IsTargetDomainReady() {
+		kubevirtLiveMigrationStatus.IsTargetDomainReady() &&
+		// At localnet there is no source pod remote LSP so it should be skipped
+		(bsnc.TopologyType() != types.LocalnetTopology || bsnc.isPodScheduledinLocalZone(kubevirtLiveMigrationStatus.SourcePod)) {
 		ops, err = bsnc.disableLiveMigrationSourceLSPOps(kubevirtLiveMigrationStatus, nadName, ops)
 		if err != nil {
 			return fmt.Errorf("failed to create LSP ops for source pod during Live-migration status: %w", err)

--- a/go-controller/pkg/ovn/base_network_controller_secondary.go
+++ b/go-controller/pkg/ovn/base_network_controller_secondary.go
@@ -457,6 +457,11 @@ func (bsnc *BaseSecondaryNetworkController) removePodForSecondaryNetwork(pod *ka
 			return err
 		}
 
+		if kubevirt.IsPodAllowedForMigration(pod, bsnc.NetInfo) {
+			if err = bsnc.enableSourceLSPFailedLiveMigration(pod, nadName); err != nil {
+				return err
+			}
+		}
 		bsnc.logicalPortCache.remove(pod, nadName)
 		pInfo, err := bsnc.deletePodLogicalPort(pod, portInfoMap[nadName], nadName)
 		if err != nil {
@@ -763,4 +768,27 @@ func (bsnc *BaseSecondaryNetworkController) disableLiveMigrationSourceLSPOps(
 	// closing the sourcePod lsp to ensure traffic goes to the now ready targetPod.
 	ops, _, err := bsnc.setPodLogicalSwitchPortEnabledField(kubevirtLiveMigrationStatus.SourcePod, nadName, ops, false)
 	return ops, err
+}
+
+func (bsnc *BaseSecondaryNetworkController) enableSourceLSPFailedLiveMigration(pod *kapi.Pod, nadName string) error {
+	kubevirtLiveMigrationStatus, err := kubevirt.DiscoverLiveMigrationStatus(bsnc.watchFactory, pod)
+	if err != nil {
+		return fmt.Errorf("failed to discover Live-migration status after pod termination: %w", err)
+	}
+	if kubevirtLiveMigrationStatus == nil ||
+		pod.Name != kubevirtLiveMigrationStatus.TargetPod.Name ||
+		kubevirtLiveMigrationStatus.State != kubevirt.LiveMigrationFailed {
+		return nil
+	}
+	// make sure sourcePod lsp is enabled if migration failed after DomainReady was set.
+	ops, sourcePodLsp, err := bsnc.setPodLogicalSwitchPortEnabledField(kubevirtLiveMigrationStatus.SourcePod, nadName, nil, true)
+	if err != nil {
+		return fmt.Errorf("failed to set source Pod lsp to enabled after migration failed: %w", err)
+	}
+	_, err = libovsdbops.TransactAndCheckAndSetUUIDs(bsnc.nbClient, sourcePodLsp, ops)
+	if err != nil {
+		return fmt.Errorf("failed transacting operations %+v: %w", ops, err)
+	}
+
+	return nil
 }

--- a/go-controller/pkg/ovn/base_network_controller_secondary.go
+++ b/go-controller/pkg/ovn/base_network_controller_secondary.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ovn-org/libovsdb/ovsdb"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kubevirt"
 	libovsdbops "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdb/ops"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/metrics"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
@@ -226,12 +227,28 @@ func (bsnc *BaseSecondaryNetworkController) ensurePodForSecondaryNetwork(pod *ka
 		return nil
 	}
 
-	if util.PodWantsHostNetwork(pod) && !addPort {
+	if util.PodWantsHostNetwork(pod) {
+		return nil
+	}
+
+	var kubevirtLiveMigrationStatus *kubevirt.LiveMigrationStatus
+	var err error
+
+	if kubevirt.IsPodAllowedForMigration(pod, bsnc.NetInfo) {
+		kubevirtLiveMigrationStatus, err = kubevirt.DiscoverLiveMigrationStatus(bsnc.watchFactory, pod)
+		if err != nil {
+			return fmt.Errorf("failed to discover Live-migration status: %w", err)
+		}
+	}
+	updatePort := kubevirtLiveMigrationStatus != nil && pod.Name == kubevirtLiveMigrationStatus.TargetPod.Name
+
+	if !addPort && !updatePort {
 		return nil
 	}
 
 	// If a node does not have an assigned hostsubnet don't wait for the logical switch to appear
-	switchName, err := bsnc.getExpectedSwitchName(pod)
+	var switchName string
+	switchName, err = bsnc.getExpectedSwitchName(pod)
 	if err != nil {
 		return err
 	}
@@ -265,7 +282,7 @@ func (bsnc *BaseSecondaryNetworkController) ensurePodForSecondaryNetwork(pod *ka
 
 	var errs []error
 	for nadName, network := range networkMap {
-		if err = bsnc.addLogicalPortToNetworkForNAD(pod, nadName, switchName, network); err != nil {
+		if err = bsnc.addLogicalPortToNetworkForNAD(pod, nadName, switchName, network, kubevirtLiveMigrationStatus); err != nil {
 			errs = append(errs, fmt.Errorf("failed to add logical port of Pod %s/%s for NAD %s: %w", pod.Namespace, pod.Name, nadName, err))
 		}
 	}
@@ -276,7 +293,7 @@ func (bsnc *BaseSecondaryNetworkController) ensurePodForSecondaryNetwork(pod *ka
 }
 
 func (bsnc *BaseSecondaryNetworkController) addLogicalPortToNetworkForNAD(pod *kapi.Pod, nadName, switchName string,
-	network *nadapi.NetworkSelectionElement) error {
+	network *nadapi.NetworkSelectionElement, kubevirtLiveMigrationStatus *kubevirt.LiveMigrationStatus) error {
 	var libovsdbExecuteTime time.Duration
 
 	start := time.Now()
@@ -291,6 +308,15 @@ func (bsnc *BaseSecondaryNetworkController) addLogicalPortToNetworkForNAD(pod *k
 	var lsp *nbdb.LogicalSwitchPort
 	var newlyCreated bool
 
+	var lspEnabled *bool
+	// actions on the pods' LSP are only triggerred from the target pod
+	shouldHandleLiveMigration := kubevirtLiveMigrationStatus != nil && pod.Name == kubevirtLiveMigrationStatus.TargetPod.Name
+	if shouldHandleLiveMigration {
+		// LSP should be altered inside addLogicalPortToNetwork() before ops are generated because one cannot append
+		// multiple ops regarding the same object in the same transact, so passing enabled parameter.
+		lspEnabled = ptr.To(kubevirtLiveMigrationStatus.IsTargetDomainReady())
+	}
+
 	// we need to create a logical port for all local pods
 	// we also need to create a remote logical port for remote pods on layer2
 	// topologies with interconnect
@@ -298,7 +324,7 @@ func (bsnc *BaseSecondaryNetworkController) addLogicalPortToNetworkForNAD(pod *k
 	requiresLogicalPort := isLocalPod || bsnc.isLayer2Interconnect()
 
 	if requiresLogicalPort {
-		ops, lsp, podAnnotation, newlyCreated, err = bsnc.addLogicalPortToNetwork(pod, nadName, network)
+		ops, lsp, podAnnotation, newlyCreated, err = bsnc.addLogicalPortToNetwork(pod, nadName, network, lspEnabled)
 		if err != nil {
 			return err
 		}
@@ -320,6 +346,14 @@ func (bsnc *BaseSecondaryNetworkController) addLogicalPortToNetworkForNAD(pod *k
 			return err
 		}
 		bsnc.logicalPortCache.remove(pod, nadName)
+	}
+
+	if shouldHandleLiveMigration &&
+		kubevirtLiveMigrationStatus.IsTargetDomainReady() {
+		ops, err = bsnc.disableLiveMigrationSourceLSPOps(kubevirtLiveMigrationStatus, nadName, ops)
+		if err != nil {
+			return fmt.Errorf("failed to create LSP ops for source pod during Live-migration status: %w", err)
+		}
 	}
 
 	if podAnnotation == nil {
@@ -705,4 +739,28 @@ func (oc *BaseSecondaryNetworkController) getNetworkID() (int, error) {
 		}
 	}
 	return *oc.networkID, nil
+}
+
+func (bsnc *BaseSecondaryNetworkController) setPodLogicalSwitchPortEnabledField(
+	pod *kapi.Pod, nadName string, ops []ovsdb.Operation, enabled bool) ([]ovsdb.Operation, *nbdb.LogicalSwitchPort, error) {
+	lsp := &nbdb.LogicalSwitchPort{Name: bsnc.GetLogicalPortName(pod, nadName)}
+	lsp.Enabled = ptr.To(enabled)
+	switchName, err := bsnc.getExpectedSwitchName(pod)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to fetch switch name for pod %s: %w", pod.Name, err)
+	}
+	customFields := []libovsdbops.ModelUpdateField{libovsdbops.LogicalSwitchPortEnabled}
+	ops, err = libovsdbops.UpdateLogicalSwitchPortsOnSwitchWithCustomFieldsOps(bsnc.nbClient, ops, &nbdb.LogicalSwitch{Name: switchName}, customFields, lsp)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed updating logical switch port %+v on switch %s: %w", *lsp, switchName, err)
+	}
+	return ops, lsp, nil
+}
+
+func (bsnc *BaseSecondaryNetworkController) disableLiveMigrationSourceLSPOps(
+	kubevirtLiveMigrationStatus *kubevirt.LiveMigrationStatus,
+	nadName string, ops []ovsdb.Operation) ([]ovsdb.Operation, error) {
+	// closing the sourcePod lsp to ensure traffic goes to the now ready targetPod.
+	ops, _, err := bsnc.setPodLogicalSwitchPortEnabledField(kubevirtLiveMigrationStatus.SourcePod, nadName, ops, false)
+	return ops, err
 }

--- a/go-controller/pkg/ovn/multihoming_test.go
+++ b/go-controller/pkg/ovn/multihoming_test.go
@@ -115,6 +115,8 @@ func (em *secondaryNetworkExpectationMachine) expectedLogicalSwitchesAndPorts() 
 		nodeslsps := make(map[string][]string)
 		acls := make(map[string][]string)
 		var switchName string
+		switchNodeMap := make(map[string]*nbdb.LogicalSwitch)
+		alreadyAddedManagementElements := make(map[string]struct{})
 		for _, pod := range em.pods {
 			podInfo, ok := pod.secondaryPodInfos[ocInfo.bnc.GetNetworkName()]
 			if !ok {
@@ -149,6 +151,7 @@ func (em *secondaryNetworkExpectationMachine) expectedLogicalSwitchesAndPorts() 
 					lsp.Options["requested-tnl-key"] = "1" // hardcode this for now.
 				}
 				data = append(data, lsp)
+
 				switch ocInfo.bnc.TopologyType() {
 				case ovntypes.Layer3Topology:
 					switchName = ocInfo.bnc.GetNetworkScopedName(pod.nodeName)
@@ -159,7 +162,8 @@ func (em *secondaryNetworkExpectationMachine) expectedLogicalSwitchesAndPorts() 
 					data = append(data, newExpectedSwitchToRouterPort(switchToRouterPortUUID, switchToRouterPortName, pod, ocInfo.bnc, nad))
 					nodeslsps[switchName] = append(nodeslsps[switchName], switchToRouterPortUUID)
 
-					if em.gatewayConfig != nil {
+					if _, alreadyAdded := alreadyAddedManagementElements[pod.nodeName]; !alreadyAdded &&
+						em.gatewayConfig != nil {
 						mgmtPortName := managementPortName(switchName)
 						mgmtPortUUID := mgmtPortName + "-UUID"
 						mgmtPort := expectedManagementPort(mgmtPortName, managementIP.String())
@@ -176,7 +180,8 @@ func (em *secondaryNetworkExpectationMachine) expectedLogicalSwitchesAndPorts() 
 					switchName = ocInfo.bnc.GetNetworkScopedName(ovntypes.OVNLayer2Switch)
 					managementIP := managementPortIP(subnet.CIDR)
 
-					if em.gatewayConfig != nil {
+					if _, alreadyAdded := alreadyAddedManagementElements[pod.nodeName]; !alreadyAdded &&
+						em.gatewayConfig != nil {
 						// there are multiple mgmt ports in the cluster, thus the ports must be scoped with the node name
 						mgmtPortName := managementPortName(ocInfo.bnc.GetNetworkScopedName(nodeName))
 						mgmtPortUUID := mgmtPortName + "-UUID"
@@ -232,15 +237,17 @@ func (em *secondaryNetworkExpectationMachine) expectedLogicalSwitchesAndPorts() 
 				otherConfig = nil
 			}
 
-			data = append(data, &nbdb.LogicalSwitch{
+			switchNodeMap[switchName] = &nbdb.LogicalSwitch{
 				UUID:        switchName + "-UUID",
 				Name:        switchName,
 				Ports:       nodeslsps[switchName],
 				ExternalIDs: map[string]string{ovntypes.NetworkExternalID: ocInfo.bnc.GetNetworkName()},
 				OtherConfig: otherConfig,
 				ACLs:        acls[switchName],
-			})
-			if em.gatewayConfig != nil {
+			}
+
+			if _, alreadyAdded := alreadyAddedManagementElements[pod.nodeName]; !alreadyAdded &&
+				em.gatewayConfig != nil {
 				if ocInfo.bnc.TopologyType() == ovntypes.Layer3Topology {
 					data = append(data, expectedGWEntities(pod.nodeName, ocInfo.bnc, *em.gatewayConfig)...)
 					data = append(data, expectedLayer3EgressEntities(ocInfo.bnc, *em.gatewayConfig)...)
@@ -248,7 +255,8 @@ func (em *secondaryNetworkExpectationMachine) expectedLogicalSwitchesAndPorts() 
 					data = append(data, expectedLayer2EgressEntities(ocInfo.bnc, *em.gatewayConfig, pod.nodeName)...)
 				}
 			}
-			if em.isInterconnectCluster && ocInfo.bnc.TopologyType() == ovntypes.Layer3Topology {
+			if _, alreadyAdded := alreadyAddedManagementElements[pod.nodeName]; !alreadyAdded &&
+				em.isInterconnectCluster && ocInfo.bnc.TopologyType() == ovntypes.Layer3Topology {
 				transitSwitchName := ocInfo.bnc.GetNetworkName() + "_transit_switch"
 				data = append(data, &nbdb.LogicalSwitch{
 					UUID: transitSwitchName + "-UUID",
@@ -262,9 +270,13 @@ func (em *secondaryNetworkExpectationMachine) expectedLogicalSwitchesAndPorts() 
 					},
 				})
 			}
+			alreadyAddedManagementElements[pod.nodeName] = struct{}{}
 		}
-
+		for _, logicalSwitch := range switchNodeMap {
+			data = append(data, logicalSwitch)
+		}
 	}
+
 	return data
 }
 

--- a/go-controller/pkg/ovn/multihoming_test.go
+++ b/go-controller/pkg/ovn/multihoming_test.go
@@ -151,6 +151,9 @@ func (em *secondaryNetworkExpectationMachine) expectedLogicalSwitchesAndPortsWit
 				lsp := newExpectedSwitchPort(lspUUID, portName, podAddr, pod, ocInfo.bnc, nad)
 				if expectedPodLspEnabled != nil {
 					lsp.Enabled = expectedPodLspEnabled[pod.podName]
+					if lsp.Enabled != nil && !*lsp.Enabled {
+						lsp.Addresses = nil
+					}
 				}
 
 				if pod.noIfaceIdVer {
@@ -400,15 +403,34 @@ func enableICFeatureConfig() *config.OVNKubernetesFeatureConfig {
 	return featConfig
 }
 
-func icClusterTestConfiguration() testConfiguration {
-	return testConfiguration{
+func enableNonICFeatureConfig() *config.OVNKubernetesFeatureConfig {
+	featConfig := minimalFeatureConfig()
+	featConfig.EnableInterconnect = false
+	featConfig.EnablePersistentIPs = true
+	return featConfig
+}
+
+type testConfigOpt = func(*testConfiguration)
+
+func icClusterTestConfiguration(opts ...testConfigOpt) testConfiguration {
+	config := testConfiguration{
 		configToOverride:   enableICFeatureConfig(),
 		expectationOptions: []option{withInterconnectCluster()},
 	}
+	for _, opt := range opts {
+		opt(&config)
+	}
+	return config
 }
 
-func nonICClusterTestConfiguration() testConfiguration {
-	return testConfiguration{}
+func nonICClusterTestConfiguration(opts ...testConfigOpt) testConfiguration {
+	config := testConfiguration{
+		configToOverride: enableNonICFeatureConfig(),
+	}
+	for _, opt := range opts {
+		opt(&config)
+	}
+	return config
 }
 
 func newMultiHomedKubevirtPod(vmName string, liveMigrationInfo liveMigrationPodInfo, testPod testPod, multiHomingConfigs ...secondaryNetInfo) *v1.Pod {
@@ -425,6 +447,9 @@ func newMultiHomedKubevirtPod(vmName string, liveMigrationInfo liveMigrationPodI
 func newMultiHomedPod(testPod testPod, multiHomingConfigs ...secondaryNetInfo) *v1.Pod {
 	pod := newPod(testPod.namespace, testPod.podName, testPod.nodeName, testPod.podIP)
 	var secondaryNetworks []nadapi.NetworkSelectionElement
+	if len(pod.Annotations) == 0 {
+		pod.Annotations = map[string]string{}
+	}
 	for _, multiHomingConf := range multiHomingConfigs {
 		nadNamePair := strings.Split(multiHomingConf.nadName, "/")
 		ns := pod.Namespace
@@ -434,13 +459,14 @@ func newMultiHomedPod(testPod testPod, multiHomingConfigs ...secondaryNetInfo) *
 			attachmentName = nadNamePair[1]
 		}
 		nse := nadapi.NetworkSelectionElement{
-			Name:      attachmentName,
-			Namespace: ns,
+			Name:               attachmentName,
+			Namespace:          ns,
+			IPAMClaimReference: multiHomingConf.ipamClaimReference,
 		}
 		secondaryNetworks = append(secondaryNetworks, nse)
 	}
 	serializedNetworkSelectionElements, _ := json.Marshal(secondaryNetworks)
-	pod.Annotations = map[string]string{nadapi.NetworkAttachmentAnnot: string(serializedNetworkSelectionElements)}
+	pod.Annotations[nadapi.NetworkAttachmentAnnot] = string(serializedNetworkSelectionElements)
 	if config.OVNKubernetesFeature.EnableInterconnect {
 		dummyOVNNetAnnotations := dummyOVNPodNetworkAnnotations(testPod.secondaryPodInfos, multiHomingConfigs)
 		if dummyOVNNetAnnotations != "{}" {

--- a/go-controller/pkg/ovn/multihoming_test.go
+++ b/go-controller/pkg/ovn/multihoming_test.go
@@ -396,9 +396,6 @@ func newMultiHomedPod(namespace, name, node, podIP string, multiHomingConfigs ..
 	pod := newPod(namespace, name, node, podIP)
 	var secondaryNetworks []nadapi.NetworkSelectionElement
 	for _, multiHomingConf := range multiHomingConfigs {
-		if multiHomingConf.isPrimary {
-			continue // these will be automatically plugged in
-		}
 		nadNamePair := strings.Split(multiHomingConf.nadName, "/")
 		ns := pod.Namespace
 		attachmentName := multiHomingConf.nadName
@@ -445,9 +442,6 @@ func dummyOVNPodNetworkAnnotations(multiHomingConfigs []secondaryNetInfo) string
 
 func dummyOVNPodNetworkAnnotationForNetwork(netConfig secondaryNetInfo, tunnelID int) podAnnotation {
 	role := ovntypes.NetworkRoleSecondary
-	if netConfig.isPrimary {
-		role = ovntypes.NetworkRolePrimary
-	}
 	var (
 		gateways []string
 		ips      []string

--- a/go-controller/pkg/ovn/ovn_test.go
+++ b/go-controller/pkg/ovn/ovn_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/onsi/ginkgo"
 
+	ipamclaimsapi "github.com/k8snetworkplumbingwg/ipamclaims/pkg/crd/ipamclaims/v1alpha1"
 	fakeipamclaimclient "github.com/k8snetworkplumbingwg/ipamclaims/pkg/crd/ipamclaims/v1alpha1/apis/clientset/versioned/fake"
 	mnpapi "github.com/k8snetworkplumbingwg/multi-networkpolicy/pkg/apis/k8s.cni.cncf.io/v1beta1"
 	mnpfake "github.com/k8snetworkplumbingwg/multi-networkpolicy/pkg/client/clientset/versioned/fake"
@@ -119,6 +120,7 @@ func (o *FakeOVN) start(objects ...runtime.Object) {
 	egressServiceObjects := []runtime.Object{}
 	apbExternalRouteObjects := []runtime.Object{}
 	anpObjects := []runtime.Object{}
+	ipamClaimObjects := []runtime.Object{}
 	v1Objects := []runtime.Object{}
 	nads := []nettypes.NetworkAttachmentDefinition{}
 	nadClient := fakenadclient.NewSimpleClientset()
@@ -150,6 +152,8 @@ func (o *FakeOVN) start(objects ...runtime.Object) {
 			apbExternalRouteObjects = append(apbExternalRouteObjects, object)
 		case *anpapi.AdminNetworkPolicyList:
 			anpObjects = append(anpObjects, object)
+		case *ipamclaimsapi.IPAMClaimList:
+			ipamClaimObjects = append(ipamClaimObjects, object)
 		default:
 			v1Objects = append(v1Objects, object)
 		}
@@ -164,7 +168,7 @@ func (o *FakeOVN) start(objects ...runtime.Object) {
 		MultiNetworkPolicyClient: mnpfake.NewSimpleClientset(multiNetworkPolicyObjects...),
 		EgressServiceClient:      egressservicefake.NewSimpleClientset(egressServiceObjects...),
 		AdminPolicyRouteClient:   adminpolicybasedroutefake.NewSimpleClientset(apbExternalRouteObjects...),
-		IPAMClaimsClient:         fakeipamclaimclient.NewSimpleClientset(),
+		IPAMClaimsClient:         fakeipamclaimclient.NewSimpleClientset(ipamClaimObjects...),
 		NetworkAttchDefClient:    nadClient,
 		UserDefinedNetworkClient: udnclientfake.NewSimpleClientset(),
 	}
@@ -307,6 +311,7 @@ func NewOvnController(ovnClient *util.OVNMasterClientset, wf *factory.WatchFacto
 			EgressServiceClient:  ovnClient.EgressServiceClient,
 			APBRouteClient:       ovnClient.AdminPolicyRouteClient,
 			EgressQoSClient:      ovnClient.EgressQoSClient,
+			IPAMClaimsClient:     ovnClient.IPAMClaimsClient,
 		},
 		wf,
 		recorder,
@@ -422,6 +427,7 @@ func (o *FakeOVN) NewSecondaryNetworkController(netattachdef *nettypes.NetworkAt
 				Kube:                 kube.Kube{KClient: o.fakeClient.KubeClient},
 				EIPClient:            o.fakeClient.EgressIPClient,
 				EgressFirewallClient: o.fakeClient.EgressFirewallClient,
+				IPAMClaimsClient:     o.fakeClient.IPAMClaimsClient,
 			},
 			o.watcher,
 			o.fakeRecorder,

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -243,7 +243,7 @@ func (oc *DefaultNetworkController) addLogicalPort(pod *kapi.Pod) (err error) {
 	}()
 
 	nadName := ovntypes.DefaultNetworkName
-	ops, lsp, podAnnotation, newlyCreatedPort, err = oc.addLogicalPortToNetwork(pod, nadName, network)
+	ops, lsp, podAnnotation, newlyCreatedPort, err = oc.addLogicalPortToNetwork(pod, nadName, network, nil)
 	if err != nil {
 		return err
 	}

--- a/go-controller/pkg/ovn/secondary_layer2_network_controller_test.go
+++ b/go-controller/pkg/ovn/secondary_layer2_network_controller_test.go
@@ -83,7 +83,7 @@ var _ = Describe("OVN Multi-Homed pod operations for layer2 network", func() {
 					&v1.NodeList{Items: []v1.Node{*testNode}},
 					&v1.PodList{
 						Items: []v1.Pod{
-							*newMultiHomedPod(podInfo.namespace, podInfo.podName, podInfo.nodeName, podInfo.podIP, netInfo),
+							*newMultiHomedPod(podInfo, netInfo),
 						},
 					},
 					&nadapi.NetworkAttachmentDefinitionList{

--- a/go-controller/pkg/ovn/secondary_layer2_network_controller_test.go
+++ b/go-controller/pkg/ovn/secondary_layer2_network_controller_test.go
@@ -189,12 +189,17 @@ var _ = Describe("OVN Multi-Homed pod operations for layer2 network", func() {
 				By("asserting the OVN entities provisioned in the NBDB are the expected ones after migration")
 				expectedPodLspEnabled := map[string]*bool{}
 				expectedPodLspEnabled[sourcePodInfo.podName] = migrationInfo.sourcePodInfo.expectedLspEnabled
-				expectedPodLspEnabled[targetPodInfo.podName] = migrationInfo.targetPodInfo.expectedLspEnabled
+
+				testPods := []testPod{sourcePodInfo}
+				if !util.PodCompleted(targetKvPod) {
+					testPods = append(testPods, targetPodInfo)
+					expectedPodLspEnabled[targetPodInfo.podName] = migrationInfo.targetPodInfo.expectedLspEnabled
+				}
 				Eventually(fakeOvn.nbClient).Should(
 					libovsdbtest.HaveData(
 						newSecondaryNetworkExpectationMachine(
 							fakeOvn,
-							[]testPod{sourcePodInfo, targetPodInfo},
+							testPods,
 							expectationOptions...,
 						).expectedLogicalSwitchesAndPortsWithLspEnabled(expectedPodLspEnabled)...))
 				return nil
@@ -225,6 +230,12 @@ var _ = Describe("OVN Multi-Homed pod operations for layer2 network", func() {
 			dummySecondaryLayer2UserDefinedNetwork("100.200.0.0/16"),
 			icClusterTestConfiguration(),
 			readyMigrationInfo(),
+		),
+
+		table.Entry("on a layer2 topology with user defined secondary network and an IC cluster, when target pod failed",
+			dummySecondaryLayer2UserDefinedNetwork("100.200.0.0/16"),
+			icClusterTestConfiguration(),
+			failedMigrationInfo(),
 		),
 	)
 })
@@ -472,6 +483,22 @@ func readyMigrationInfo() *liveMigrationInfo {
 			creationTimestamp:  metav1.NewTime(time.Now()),
 			annotation:         map[string]string{kubevirtv1.MigrationTargetReadyTimestamp: "some-timestamp"},
 			expectedLspEnabled: lspEnableExplicitlyTrue,
+		},
+	}
+}
+
+func failedMigrationInfo() *liveMigrationInfo {
+	const vmName = "my-vm"
+	return &liveMigrationInfo{
+		vmName: vmName,
+		sourcePodInfo: liveMigrationPodInfo{
+			podPhase:           v1.PodRunning,
+			creationTimestamp:  metav1.NewTime(time.Now().Add(-time.Hour)),
+			expectedLspEnabled: lspEnableExplicitlyTrue,
+		},
+		targetPodInfo: liveMigrationPodInfo{
+			podPhase:          v1.PodFailed,
+			creationTimestamp: metav1.NewTime(time.Now()),
 		},
 	}
 }

--- a/go-controller/pkg/ovn/secondary_layer2_network_controller_test.go
+++ b/go-controller/pkg/ovn/secondary_layer2_network_controller_test.go
@@ -12,10 +12,12 @@ import (
 
 	"github.com/urfave/cli/v2"
 
+	ipamclaimsapi "github.com/k8snetworkplumbingwg/ipamclaims/pkg/crd/ipamclaims/v1alpha1"
+	nadapi "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	nadapi "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/ptr"
 
 	kubevirtv1 "kubevirt.io/api/core/v1"
@@ -79,7 +81,7 @@ var _ = Describe("OVN Multi-Homed pod operations for layer2 network", func() {
 		"reconciles a new",
 		func(netInfo secondaryNetInfo, testConfig testConfiguration) {
 			const podIdx = 0
-			podInfo := dummyL2TestPod(ns, netInfo, podIdx)
+			podInfo := dummyL2TestPod(ns, netInfo, podIdx, podIdx)
 			if testConfig.configToOverride != nil {
 				config.OVNKubernetesFeature = *testConfig.configToOverride
 			}
@@ -130,11 +132,25 @@ var _ = Describe("OVN Multi-Homed pod operations for layer2 network", func() {
 	table.DescribeTable(
 		"reconciles a new kubevirt-related pod during its live-migration phases",
 		func(netInfo secondaryNetInfo, testConfig testConfiguration, migrationInfo *liveMigrationInfo) {
+			ipamClaim := ipamclaimsapi.IPAMClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: ns,
+					Name:      netInfo.netName + "-" + migrationInfo.vmName,
+				},
+				Spec: ipamclaimsapi.IPAMClaimSpec{
+					Network:   netInfo.netName,
+					Interface: "net1",
+				},
+			}
+			netInfo.allowPersistentIPs = true
+			netInfo.ipamClaimReference = ipamClaim.Name
+
 			const (
-				sourcePodInfoIdx = 0
-				targetPodInfoIdx = 1
+				sourcePodInfoIdx    = 0
+				targetPodInfoIdx    = 1
+				secondaryNetworkIdx = 0
 			)
-			sourcePodInfo := dummyL2TestPod(ns, netInfo, sourcePodInfoIdx)
+			sourcePodInfo := dummyL2TestPod(ns, netInfo, sourcePodInfoIdx, secondaryNetworkIdx)
 			if testConfig.configToOverride != nil {
 				config.OVNKubernetesFeature = *testConfig.configToOverride
 			}
@@ -150,7 +166,9 @@ var _ = Describe("OVN Multi-Homed pod operations for layer2 network", func() {
 				testNode, err := newNodeWithSecondaryNets(nodeName, nodeIPv4CIDR, netInfo)
 				Expect(err).NotTo(HaveOccurred())
 
-				Expect(setupFakeOvnForLayer2Topology(fakeOvn, initialDB, netInfo, testNode, sourcePodInfo, sourcePod)).To(Succeed())
+				Expect(setupFakeOvnForLayer2Topology(fakeOvn, initialDB, netInfo, testNode, sourcePodInfo, sourcePod,
+					&ipamclaimsapi.IPAMClaimList{Items: []ipamclaimsapi.IPAMClaim{ipamClaim}}),
+				).To(Succeed())
 
 				// for layer2 on interconnect, it is the cluster manager that
 				// allocates the OVN annotation; on unit tests, this just
@@ -176,7 +194,7 @@ var _ = Describe("OVN Multi-Homed pod operations for layer2 network", func() {
 							expectationOptions...,
 						).expectedLogicalSwitchesAndPorts()...))
 
-				targetPodInfo := dummyL2TestPod(ns, netInfo, targetPodInfoIdx)
+				targetPodInfo := dummyL2TestPod(ns, netInfo, targetPodInfoIdx, secondaryNetworkIdx)
 				targetKvPod := newMultiHomedKubevirtPod(
 					migrationInfo.vmName,
 					migrationInfo.targetPodInfo,
@@ -258,7 +276,7 @@ func dummySecondaryLayer2UserDefinedNetwork(subnets string) secondaryNetInfo {
 	}
 }
 
-func dummyL2TestPod(nsName string, info secondaryNetInfo, podIdx int) testPod {
+func dummyL2TestPod(nsName string, info secondaryNetInfo, podIdx, secondaryNetIdx int) testPod {
 	const nodeSubnet = "10.128.1.0/24"
 	pod := newTPod(nodeName, nodeSubnet, "10.128.1.2", "10.128.1.1", fmt.Sprintf("%s-%d", podName, podIdx), fmt.Sprintf("10.128.1.%d", podIdx+3), fmt.Sprintf("0a:58:0a:80:01:%0.2d", podIdx+3), nsName)
 	pod.addNetwork(
@@ -267,8 +285,8 @@ func dummyL2TestPod(nsName string, info secondaryNetInfo, podIdx int) testPod {
 		info.subnets,
 		"",
 		"",
-		fmt.Sprintf("100.200.0.%d/16", podIdx+1),
-		fmt.Sprintf("0a:58:64:c8:00:%0.2d", podIdx+1),
+		fmt.Sprintf("100.200.0.%d/16", secondaryNetIdx+1),
+		fmt.Sprintf("0a:58:64:c8:00:%0.2d", secondaryNetIdx+1),
 		"secondary",
 		0,
 		[]util.PodRoute{},
@@ -379,7 +397,7 @@ func nodeIP() *net.IPNet {
 	}
 }
 
-func setupFakeOvnForLayer2Topology(fakeOvn *FakeOVN, initialDB libovsdbtest.TestSetup, netInfo secondaryNetInfo, testNode *v1.Node, podInfo testPod, pod *v1.Pod) error {
+func setupFakeOvnForLayer2Topology(fakeOvn *FakeOVN, initialDB libovsdbtest.TestSetup, netInfo secondaryNetInfo, testNode *v1.Node, podInfo testPod, pod *corev1.Pod, extraObjects ...runtime.Object) error {
 	By(fmt.Sprintf("creating a network attachment definition for network: %s", netInfo.netName))
 	nad, err := newNetworkAttachmentDefinition(
 		ns,
@@ -394,8 +412,7 @@ func setupFakeOvnForLayer2Topology(fakeOvn *FakeOVN, initialDB libovsdbtest.Test
 		return err
 	}
 
-	fakeOvn.startWithDBSetup(
-		initialDB,
+	objects := []runtime.Object{
 		&v1.NamespaceList{
 			Items: []v1.Namespace{
 				*newNamespace(ns),
@@ -410,7 +427,11 @@ func setupFakeOvnForLayer2Topology(fakeOvn *FakeOVN, initialDB libovsdbtest.Test
 		&nadapi.NetworkAttachmentDefinitionList{
 			Items: []nadapi.NetworkAttachmentDefinition{*nad},
 		},
-	)
+	}
+
+	objects = append(objects, extraObjects...)
+
+	fakeOvn.startWithDBSetup(initialDB, objects...)
 	podInfo.populateLogicalSwitchCache(fakeOvn)
 
 	// on IC, the test itself spits out the pod with the

--- a/go-controller/pkg/ovn/secondary_layer2_network_controller_test.go
+++ b/go-controller/pkg/ovn/secondary_layer2_network_controller_test.go
@@ -16,6 +16,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	nadapi "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+	"k8s.io/utils/ptr"
+
+	kubevirtv1 "kubevirt.io/api/core/v1"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
@@ -23,6 +26,27 @@ import (
 	ovntypes "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 )
+
+type lspEnableValue *bool
+
+var (
+	lspEnableNotSpecified    lspEnableValue = nil
+	lspEnableExplicitlyTrue  lspEnableValue = ptr.To(true)
+	lspEnableExplicitlyFalse lspEnableValue = ptr.To(false)
+)
+
+type liveMigrationPodInfo struct {
+	podPhase           v1.PodPhase
+	annotation         map[string]string
+	creationTimestamp  metav1.Time
+	expectedLspEnabled lspEnableValue
+}
+
+type liveMigrationInfo struct {
+	vmName        string
+	sourcePodInfo liveMigrationPodInfo
+	targetPodInfo liveMigrationPodInfo
+}
 
 var _ = Describe("OVN Multi-Homed pod operations for layer2 network", func() {
 	var (
@@ -102,7 +126,117 @@ var _ = Describe("OVN Multi-Homed pod operations for layer2 network", func() {
 			nonICClusterTestConfiguration(),
 		),
 	)
+
+	table.DescribeTable(
+		"reconciles a new kubevirt-related pod during its live-migration phases",
+		func(netInfo secondaryNetInfo, testConfig testConfiguration, migrationInfo *liveMigrationInfo) {
+			const (
+				sourcePodInfoIdx = 0
+				targetPodInfoIdx = 1
+			)
+			sourcePodInfo := dummyL2TestPod(ns, netInfo, sourcePodInfoIdx)
+			if testConfig.configToOverride != nil {
+				config.OVNKubernetesFeature = *testConfig.configToOverride
+			}
+			app.Action = func(ctx *cli.Context) error {
+				sourcePod := newMultiHomedKubevirtPod(
+					migrationInfo.vmName,
+					migrationInfo.sourcePodInfo,
+					sourcePodInfo,
+					netInfo)
+
+				const nodeIPv4CIDR = "192.168.126.202/24"
+				By(fmt.Sprintf("Creating a node named %q, with IP: %s", nodeName, nodeIPv4CIDR))
+				testNode, err := newNodeWithSecondaryNets(nodeName, nodeIPv4CIDR, netInfo)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(setupFakeOvnForLayer2Topology(fakeOvn, initialDB, netInfo, testNode, sourcePodInfo, sourcePod)).To(Succeed())
+
+				// for layer2 on interconnect, it is the cluster manager that
+				// allocates the OVN annotation; on unit tests, this just
+				// doesn't happen, and we create the pod with these annotations
+				// set. Hence, no point checking they're the expected ones.
+				// TODO: align the mocked annotations with the production code
+				//   - currently missing setting the routes.
+				if !config.OVNKubernetesFeature.EnableInterconnect {
+					By("asserting the pod OVN pod networks annotation are the expected ones")
+					// check that after start networks annotations and nbdb will be updated
+					Eventually(func() string {
+						return getPodAnnotations(fakeOvn.fakeClient.KubeClient, sourcePodInfo.namespace, sourcePodInfo.podName)
+					}).WithTimeout(2 * time.Second).Should(MatchJSON(sourcePodInfo.getAnnotationsJson()))
+				}
+
+				expectationOptions := testConfig.expectationOptions
+				By("asserting the OVN entities provisioned in the NBDB are the expected ones before migration started")
+				Eventually(fakeOvn.nbClient).Should(
+					libovsdbtest.HaveData(
+						newSecondaryNetworkExpectationMachine(
+							fakeOvn,
+							[]testPod{sourcePodInfo},
+							expectationOptions...,
+						).expectedLogicalSwitchesAndPorts()...))
+
+				targetPodInfo := dummyL2TestPod(ns, netInfo, targetPodInfoIdx)
+				targetKvPod := newMultiHomedKubevirtPod(
+					migrationInfo.vmName,
+					migrationInfo.targetPodInfo,
+					targetPodInfo,
+					netInfo)
+
+				_, err = fakeOvn.fakeClient.KubeClient.CoreV1().Pods(targetKvPod.Namespace).Create(context.Background(), targetKvPod, metav1.CreateOptions{})
+				Expect(err).NotTo(HaveOccurred())
+
+				By("asserting the OVN entities provisioned in the NBDB are the expected ones after migration")
+				expectedPodLspEnabled := map[string]*bool{}
+				expectedPodLspEnabled[sourcePodInfo.podName] = migrationInfo.sourcePodInfo.expectedLspEnabled
+				expectedPodLspEnabled[targetPodInfo.podName] = migrationInfo.targetPodInfo.expectedLspEnabled
+				Eventually(fakeOvn.nbClient).Should(
+					libovsdbtest.HaveData(
+						newSecondaryNetworkExpectationMachine(
+							fakeOvn,
+							[]testPod{sourcePodInfo, targetPodInfo},
+							expectationOptions...,
+						).expectedLogicalSwitchesAndPortsWithLspEnabled(expectedPodLspEnabled)...))
+				return nil
+			}
+
+			Expect(app.Run([]string{app.Name})).To(Succeed())
+		},
+
+		table.Entry("on a layer2 topology with user defined secondary network, when target pod is not yet ready",
+			dummySecondaryLayer2UserDefinedNetwork("100.200.0.0/16"),
+			nonICClusterTestConfiguration(),
+			notReadyMigrationInfo(),
+		),
+
+		table.Entry("on a layer2 topology with user defined secondary network, when target pod is ready",
+			dummySecondaryLayer2UserDefinedNetwork("100.200.0.0/16"),
+			nonICClusterTestConfiguration(),
+			readyMigrationInfo(),
+		),
+
+		table.Entry("on a layer2 topology with user defined secondary network and an IC cluster, when target pod is not yet ready",
+			dummySecondaryLayer2UserDefinedNetwork("100.200.0.0/16"),
+			icClusterTestConfiguration(),
+			notReadyMigrationInfo(),
+		),
+
+		table.Entry("on a layer2 topology with user defined secondary network and an IC cluster, when target pod is ready",
+			dummySecondaryLayer2UserDefinedNetwork("100.200.0.0/16"),
+			icClusterTestConfiguration(),
+			readyMigrationInfo(),
+		),
+	)
 })
+
+func dummyLocalnetWithSecondaryUserDefinedNetwork(subnets string) secondaryNetInfo {
+	return secondaryNetInfo{
+		netName:  secondaryNetworkName,
+		nadName:  namespacedName(ns, nadName),
+		topology: ovntypes.LocalnetTopology,
+		subnets:  subnets,
+	}
+}
 
 func dummySecondaryLayer2UserDefinedNetwork(subnets string) secondaryNetInfo {
 	return secondaryNetInfo{
@@ -305,4 +439,39 @@ func setupFakeOvnForLayer2Topology(fakeOvn *FakeOVN, initialDB libovsdbtest.Test
 		return err
 	}
 	return nil
+}
+
+func notReadyMigrationInfo() *liveMigrationInfo {
+	const vmName = "my-vm"
+	return &liveMigrationInfo{
+		vmName: vmName,
+		sourcePodInfo: liveMigrationPodInfo{
+			podPhase:           v1.PodRunning,
+			creationTimestamp:  metav1.NewTime(time.Now().Add(-time.Hour)),
+			expectedLspEnabled: lspEnableNotSpecified,
+		},
+		targetPodInfo: liveMigrationPodInfo{
+			podPhase:           v1.PodRunning,
+			creationTimestamp:  metav1.NewTime(time.Now()),
+			expectedLspEnabled: lspEnableExplicitlyFalse,
+		},
+	}
+}
+
+func readyMigrationInfo() *liveMigrationInfo {
+	const vmName = "my-vm"
+	return &liveMigrationInfo{
+		vmName: vmName,
+		sourcePodInfo: liveMigrationPodInfo{
+			podPhase:           v1.PodRunning,
+			creationTimestamp:  metav1.NewTime(time.Now().Add(-time.Hour)),
+			expectedLspEnabled: lspEnableExplicitlyFalse,
+		},
+		targetPodInfo: liveMigrationPodInfo{
+			podPhase:           v1.PodRunning,
+			creationTimestamp:  metav1.NewTime(time.Now()),
+			annotation:         map[string]string{kubevirtv1.MigrationTargetReadyTimestamp: "some-timestamp"},
+			expectedLspEnabled: lspEnableExplicitlyTrue,
+		},
+	}
 }

--- a/go-controller/pkg/ovn/secondary_layer2_network_controller_test.go
+++ b/go-controller/pkg/ovn/secondary_layer2_network_controller_test.go
@@ -54,7 +54,8 @@ var _ = Describe("OVN Multi-Homed pod operations for layer2 network", func() {
 	table.DescribeTable(
 		"reconciles a new",
 		func(netInfo secondaryNetInfo, testConfig testConfiguration) {
-			podInfo := dummyL2TestPod(ns, netInfo)
+			const podIdx = 0
+			podInfo := dummyL2TestPod(ns, netInfo, podIdx)
 			if testConfig.configToOverride != nil {
 				config.OVNKubernetesFeature = *testConfig.configToOverride
 			}
@@ -160,17 +161,17 @@ func dummySecondaryLayer2UserDefinedNetwork(subnets string) secondaryNetInfo {
 	}
 }
 
-func dummyL2TestPod(nsName string, info secondaryNetInfo) testPod {
+func dummyL2TestPod(nsName string, info secondaryNetInfo, podIdx int) testPod {
 	const nodeSubnet = "10.128.1.0/24"
-	pod := newTPod(nodeName, nodeSubnet, "10.128.1.2", "10.128.1.1", podName, "10.128.1.3", "0a:58:0a:80:01:03", nsName)
+	pod := newTPod(nodeName, nodeSubnet, "10.128.1.2", "10.128.1.1", fmt.Sprintf("%s-%d", podName, podIdx), fmt.Sprintf("10.128.1.%d", podIdx+3), fmt.Sprintf("0a:58:0a:80:01:%0.2d", podIdx+3), nsName)
 	pod.addNetwork(
 		info.netName,
 		info.nadName,
 		info.subnets,
 		"",
 		"",
-		"100.200.0.1/16",
-		"0a:58:64:c8:00:01",
+		fmt.Sprintf("100.200.0.%d/16", podIdx+1),
+		fmt.Sprintf("0a:58:64:c8:00:%0.2d", podIdx+1),
 		"secondary",
 		0,
 		[]util.PodRoute{},

--- a/go-controller/pkg/ovn/secondary_layer3_network_controller_test.go
+++ b/go-controller/pkg/ovn/secondary_layer3_network_controller_test.go
@@ -141,7 +141,6 @@ var _ = Describe("OVN Multi-Homed pod operations", func() {
 
 				defaultNetExpectations := getDefaultNetExpectedPodsAndSwitches([]testPod{podInfo}, []string{nodeName})
 				expectationOptions := testConfig.expectationOptions
-
 				Eventually(fakeOvn.nbClient).Should(
 					libovsdbtest.HaveData(
 						append(

--- a/go-controller/pkg/ovn/secondary_layer3_network_controller_test.go
+++ b/go-controller/pkg/ovn/secondary_layer3_network_controller_test.go
@@ -109,7 +109,7 @@ var _ = Describe("OVN Multi-Homed pod operations", func() {
 					},
 					&v1.PodList{
 						Items: []v1.Pod{
-							*newMultiHomedPod(podInfo.namespace, podInfo.podName, podInfo.nodeName, podInfo.podIP, netInfo),
+							*newMultiHomedPod(podInfo, netInfo),
 						},
 					},
 					&nadapi.NetworkAttachmentDefinitionList{
@@ -307,6 +307,14 @@ func dummyJoinIP() *net.IPNet {
 		Mask: net.CIDRMask(24, 32),
 	}
 }
+
+func dummyMasqueradeIP() *net.IPNet {
+	return &net.IPNet{
+		IP:   net.ParseIP("169.254.169.13"),
+		Mask: net.CIDRMask(24, 32),
+	}
+}
+
 func dummyMasqueradeSubnet() *net.IPNet {
 	return &net.IPNet{
 		IP:   net.ParseIP("169.254.169.0"),

--- a/go-controller/pkg/ovn/secondary_layer3_network_controller_test.go
+++ b/go-controller/pkg/ovn/secondary_layer3_network_controller_test.go
@@ -29,11 +29,10 @@ import (
 )
 
 type secondaryNetInfo struct {
-	netName   string
-	nadName   string
-	subnets   string
-	topology  string
-	isPrimary bool
+	netName  string
+	nadName  string
+	subnets  string
+	topology string
 }
 
 const (
@@ -95,26 +94,6 @@ var _ = Describe("OVN Multi-Homed pod operations", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(netInfo.setupOVNDependencies(&initialDB)).To(Succeed())
 
-				if netInfo.isPrimary {
-					networkConfig, err := util.NewNetInfo(netInfo.netconf())
-					Expect(err).NotTo(HaveOccurred())
-
-					initialDB.NBData = append(
-						initialDB.NBData,
-						&nbdb.LogicalSwitch{
-							Name:        fmt.Sprintf("%s_join", netInfo.netName),
-							ExternalIDs: standardNonDefaultNetworkExtIDs(networkConfig),
-						},
-						&nbdb.LogicalRouter{
-							Name:        fmt.Sprintf("%s_ovn_cluster_router", netInfo.netName),
-							ExternalIDs: standardNonDefaultNetworkExtIDs(networkConfig),
-						},
-						&nbdb.LogicalRouterPort{
-							Name: fmt.Sprintf("rtos-%s_%s", netInfo.netName, nodeName),
-						},
-					)
-				}
-
 				const nodeIPv4CIDR = "192.168.126.202/24"
 				testNode, err := newNodeWithSecondaryNets(nodeName, nodeIPv4CIDR, netInfo)
 				Expect(err).NotTo(HaveOccurred())
@@ -162,13 +141,7 @@ var _ = Describe("OVN Multi-Homed pod operations", func() {
 
 				defaultNetExpectations := getDefaultNetExpectedPodsAndSwitches([]testPod{podInfo}, []string{nodeName})
 				expectationOptions := testConfig.expectationOptions
-				if netInfo.isPrimary {
-					defaultNetExpectations = emptyDefaultClusterNetworkNodeSwitch(podInfo.nodeName)
-					gwConfig, err := util.ParseNodeL3GatewayAnnotation(testNode)
-					Expect(err).NotTo(HaveOccurred())
-					Expect(gwConfig.NextHops).NotTo(BeEmpty())
-					expectationOptions = append(expectationOptions, withGatewayConfig(gwConfig))
-				}
+
 				Eventually(fakeOvn.nbClient).Should(
 					libovsdbtest.HaveData(
 						append(
@@ -188,172 +161,13 @@ var _ = Describe("OVN Multi-Homed pod operations", func() {
 			dummySecondaryUserDefinedNetwork("192.168.0.0/16"),
 			nonICClusterTestConfiguration(),
 		),
-		table.Entry("pod on a user defined primary network",
-			dummyPrimaryUserDefinedNetwork("192.168.0.0/16"),
-			nonICClusterTestConfiguration(),
-		),
+
 		table.Entry("pod on a user defined secondary network on an interconnect cluster",
 			dummySecondaryUserDefinedNetwork("192.168.0.0/16"),
 			icClusterTestConfiguration(),
 		),
-		table.Entry("pod on a user defined primary network on an interconnect cluster",
-			dummyPrimaryUserDefinedNetwork("192.168.0.0/16"),
-			icClusterTestConfiguration(),
-		),
-	)
-
-	table.DescribeTable(
-		"the gateway is properly cleaned up",
-		func(netInfo secondaryNetInfo, testConfig testConfiguration) {
-			podInfo := dummyTestPod(ns, netInfo)
-			if testConfig.configToOverride != nil {
-				config.OVNKubernetesFeature = *testConfig.configToOverride
-			}
-			app.Action = func(ctx *cli.Context) error {
-				netConf := netInfo.netconf()
-				networkConfig, err := util.NewNetInfo(netConf)
-				Expect(err).NotTo(HaveOccurred())
-
-				nad, err := newNetworkAttachmentDefinition(
-					ns,
-					nadName,
-					*netConf,
-				)
-				Expect(err).NotTo(HaveOccurred())
-
-				const nodeIPv4CIDR = "192.168.126.202/24"
-				testNode, err := newNodeWithSecondaryNets(nodeName, nodeIPv4CIDR, netInfo)
-				Expect(err).NotTo(HaveOccurred())
-
-				defaultNetExpectations := emptyDefaultClusterNetworkNodeSwitch(podInfo.nodeName)
-				gwConfig, err := util.ParseNodeL3GatewayAnnotation(testNode)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(gwConfig.NextHops).NotTo(BeEmpty())
-
-				if netInfo.isPrimary {
-					gwConfig, err := util.ParseNodeL3GatewayAnnotation(testNode)
-					Expect(err).NotTo(HaveOccurred())
-					initialDB.NBData = append(
-						initialDB.NBData,
-						expectedGWEntities(podInfo.nodeName, networkConfig, *gwConfig)...)
-					initialDB.NBData = append(
-						initialDB.NBData,
-						expectedLayer3EgressEntities(networkConfig, *gwConfig)...)
-				}
-
-				fakeOvn.startWithDBSetup(
-					initialDB,
-					&v1.NamespaceList{
-						Items: []v1.Namespace{
-							*newNamespace(ns),
-						},
-					},
-					&v1.NodeList{
-						Items: []v1.Node{*testNode},
-					},
-					&v1.PodList{
-						Items: []v1.Pod{
-							*newMultiHomedPod(podInfo.namespace, podInfo.podName, podInfo.nodeName, podInfo.podIP, netInfo),
-						},
-					},
-					&nadapi.NetworkAttachmentDefinitionList{
-						Items: []nadapi.NetworkAttachmentDefinition{*nad},
-					},
-				)
-
-				Expect(netInfo.setupOVNDependencies(&initialDB)).To(Succeed())
-
-				podInfo.populateLogicalSwitchCache(fakeOvn)
-
-				// pod exists, networks annotations don't
-				pod, err := fakeOvn.fakeClient.KubeClient.CoreV1().Pods(podInfo.namespace).Get(context.Background(), podInfo.podName, metav1.GetOptions{})
-				Expect(err).NotTo(HaveOccurred())
-				_, ok := pod.Annotations[util.OvnPodAnnotationName]
-				Expect(ok).To(BeFalse())
-
-				Expect(fakeOvn.controller.WatchNamespaces()).To(Succeed())
-				Expect(fakeOvn.controller.WatchPods()).To(Succeed())
-				secondaryNetController, ok := fakeOvn.secondaryControllers[secondaryNetworkName]
-				Expect(ok).To(BeTrue())
-
-				secondaryNetController.bnc.ovnClusterLRPToJoinIfAddrs = dummyJoinIPs()
-				podInfo.populateSecondaryNetworkLogicalSwitchCache(fakeOvn, secondaryNetController)
-				Expect(secondaryNetController.bnc.WatchNodes()).To(Succeed())
-				Expect(secondaryNetController.bnc.WatchPods()).To(Succeed())
-
-				Expect(fakeOvn.fakeClient.KubeClient.CoreV1().Pods(pod.Namespace).Delete(context.Background(), pod.Name, metav1.DeleteOptions{})).To(Succeed())
-				Expect(fakeOvn.fakeClient.NetworkAttchDefClient.K8sCniCncfIoV1().NetworkAttachmentDefinitions(nad.Namespace).Delete(context.Background(), nad.Name, metav1.DeleteOptions{})).To(Succeed())
-
-				// we must access the layer3 controller to be able to issue its cleanup function (to remove the GW related stuff).
-				Expect(
-					newSecondaryLayer3NetworkController(
-						&secondaryNetController.bnc.CommonNetworkControllerInfo,
-						networkConfig,
-						nodeName,
-					).Cleanup()).To(Succeed())
-				Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(defaultNetExpectations))
-
-				return nil
-			}
-			Expect(app.Run([]string{app.Name})).To(Succeed())
-		},
-		table.Entry("pod on a user defined primary network",
-			dummyPrimaryUserDefinedNetwork("192.168.0.0/16"),
-			nonICClusterTestConfiguration(),
-		),
-		table.Entry("pod on a user defined primary network on an interconnect cluster",
-			dummyPrimaryUserDefinedNetwork("192.168.0.0/16"),
-			icClusterTestConfiguration(),
-		),
 	)
 })
-
-func newPodWithPrimaryUDN(
-	nodeName, nodeSubnet, nodeMgtIP, nodeGWIP, podName, podIPs, podMAC, namespace string,
-	primaryUDNConfig secondaryNetInfo,
-) testPod {
-	pod := newTPod(nodeName, nodeSubnet, nodeMgtIP, "", podName, podIPs, podMAC, namespace)
-	if primaryUDNConfig.isPrimary {
-		pod.networkRole = "infrastructure-locked"
-		pod.routes = append(
-			pod.routes,
-			util.PodRoute{
-				Dest:    testing.MustParseIPNet("10.128.0.0/14"),
-				NextHop: testing.MustParseIP("10.128.1.1"),
-			},
-			util.PodRoute{
-				Dest:    testing.MustParseIPNet("100.64.0.0/16"),
-				NextHop: testing.MustParseIP("10.128.1.1"),
-			},
-		)
-	}
-	pod.addNetwork(
-		primaryUDNConfig.netName,
-		primaryUDNConfig.nadName,
-		primaryUDNConfig.subnets,
-		"",
-		nodeGWIP,
-		"192.168.0.3/16",
-		"0a:58:c0:a8:00:03",
-		"primary",
-		0,
-		[]util.PodRoute{
-			{
-				Dest:    testing.MustParseIPNet("192.168.0.0/16"),
-				NextHop: testing.MustParseIP("192.168.0.1"),
-			},
-			{
-				Dest:    testing.MustParseIPNet("172.16.1.0/24"),
-				NextHop: testing.MustParseIP("192.168.0.1"),
-			},
-			{
-				Dest:    testing.MustParseIPNet("100.65.0.0/16"),
-				NextHop: testing.MustParseIP("192.168.0.1"),
-			},
-		},
-	)
-	return pod
-}
 
 func namespacedName(ns, name string) string { return fmt.Sprintf("%s/%s", ns, name) }
 
@@ -392,9 +206,7 @@ func (sni *secondaryNetInfo) netconf() *ovncnitypes.NetConf {
 	const plugin = "ovn-k8s-cni-overlay"
 
 	role := ovntypes.NetworkRoleSecondary
-	if sni.isPrimary {
-		role = ovntypes.NetworkRolePrimary
-	}
+
 	return &ovncnitypes.NetConf{
 		NetConf: cnitypes.NetConf{
 			Name: sni.netName,
@@ -409,19 +221,6 @@ func (sni *secondaryNetInfo) netconf() *ovncnitypes.NetConf {
 
 func dummyTestPod(nsName string, info secondaryNetInfo) testPod {
 	const nodeSubnet = "10.128.1.0/24"
-	if info.isPrimary {
-		return newPodWithPrimaryUDN(
-			nodeName,
-			nodeSubnet,
-			"10.128.1.2",
-			"192.168.0.1",
-			"myPod",
-			"10.128.1.3",
-			"0a:58:0a:80:01:03",
-			nsName,
-			info,
-		)
-	}
 	pod := newTPod(nodeName, nodeSubnet, "10.128.1.2", "10.128.1.1", podName, "10.128.1.3", "0a:58:0a:80:01:03", nsName)
 	pod.addNetwork(
 		info.netName,
@@ -450,12 +249,6 @@ func dummySecondaryUserDefinedNetwork(subnets string) secondaryNetInfo {
 		topology: ovntypes.Layer3Topology,
 		subnets:  subnets,
 	}
-}
-
-func dummyPrimaryUserDefinedNetwork(subnets string) secondaryNetInfo {
-	secondaryNet := dummySecondaryUserDefinedNetwork(subnets)
-	secondaryNet.isPrimary = true
-	return secondaryNet
 }
 
 func (sni *secondaryNetInfo) String() string {

--- a/go-controller/pkg/ovn/secondary_layer3_network_controller_test.go
+++ b/go-controller/pkg/ovn/secondary_layer3_network_controller_test.go
@@ -29,10 +29,12 @@ import (
 )
 
 type secondaryNetInfo struct {
-	netName  string
-	nadName  string
-	subnets  string
-	topology string
+	netName            string
+	nadName            string
+	subnets            string
+	topology           string
+	allowPersistentIPs bool
+	ipamClaimReference string
 }
 
 const (
@@ -211,10 +213,11 @@ func (sni *secondaryNetInfo) netconf() *ovncnitypes.NetConf {
 			Name: sni.netName,
 			Type: plugin,
 		},
-		Topology: sni.topology,
-		NADName:  sni.nadName,
-		Subnets:  sni.subnets,
-		Role:     role,
+		Topology:           sni.topology,
+		NADName:            sni.nadName,
+		Subnets:            sni.subnets,
+		Role:               role,
+		AllowPersistentIPs: sni.allowPersistentIPs,
 	}
 }
 

--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/clarketm/json v1.17.1 // indirect
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/containernetworking/cni v1.1.2 // indirect
+	github.com/containernetworking/plugins v1.2.0 // indirect
 	github.com/coreos/go-iptables v0.6.0 // indirect
 	github.com/coreos/go-json v0.0.0-20230131223807-18775e0fb4fb // indirect
 	github.com/coreos/go-semver v0.3.1 // indirect
@@ -165,7 +166,6 @@ require (
 )
 
 require (
-	github.com/containernetworking/plugins v1.2.0
 	github.com/coreos/butane v0.18.0
 	github.com/docker/docker v25.0.6+incompatible
 	github.com/google/goexpect v0.0.0-20210430020637-ab937bf7fd6f

--- a/test/e2e/images/crictl.go
+++ b/test/e2e/images/crictl.go
@@ -1,0 +1,32 @@
+package images
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+type minimalCrictlImage struct {
+	ID          string   `json:"id"`
+	RepoDigests []string `json:"repoDigests"`
+}
+
+type minimalCrictlImages struct {
+	Images []minimalCrictlImage `json:"images"`
+}
+
+func ImageIDByImageURL(desiredImage, jsonData string) (string, error) {
+	var imagesData minimalCrictlImages
+	if err := json.Unmarshal([]byte(jsonData), &imagesData); err != nil {
+		return "", fmt.Errorf("failed to parse crictl JSON: %w", err)
+	}
+
+	for _, img := range imagesData.Images {
+		for _, repoDigest := range img.RepoDigests {
+			if strings.Contains(repoDigest, desiredImage) {
+				return img.ID, nil
+			}
+		}
+	}
+	return "", nil
+}

--- a/test/e2e/kubevirt.go
+++ b/test/e2e/kubevirt.go
@@ -1365,10 +1365,12 @@ chpasswd: { expire: False }`
 				By("setting up the localnet underlay")
 				nodes := ovsPods(clientSet)
 				Expect(nodes).NotTo(BeEmpty())
-				defer func() {
-					By("tearing down the localnet underlay")
-					Expect(teardownUnderlay(nodes)).To(Succeed())
-				}()
+				DeferCleanup(func() {
+					if e2eframework.TestContext.DeleteNamespace && (e2eframework.TestContext.DeleteNamespaceOnFailure || !CurrentSpecReport().Failed()) {
+						By("tearing down the localnet underlay")
+						Expect(teardownUnderlay(nodes)).To(Succeed())
+					}
+				})
 
 				const secondaryInterfaceName = "eth1"
 				Expect(setupUnderlay(nodes, secondaryInterfaceName, netConfig)).To(Succeed())

--- a/test/e2e/kubevirt.go
+++ b/test/e2e/kubevirt.go
@@ -15,6 +15,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/ovn-org/ovn-kubernetes/test/e2e/diagnostics"
+	"github.com/ovn-org/ovn-kubernetes/test/e2e/images"
 	"github.com/ovn-org/ovn-kubernetes/test/e2e/kubevirt"
 
 	corev1 "k8s.io/api/core/v1"
@@ -75,15 +76,16 @@ func newControllerRuntimeClient() (crclient.Client, error) {
 
 var _ = Describe("Kubevirt Virtual Machines", func() {
 	var (
-		fr                 = wrappedTestFramework("kv-live-migration")
-		d                  = diagnostics.New(fr)
-		crClient           crclient.Client
-		namespace          string
-		tcpServerPort      = int32(9900)
-		wg                 sync.WaitGroup
-		selectedNodes      = []corev1.Node{}
-		httpServerTestPods = []*corev1.Pod{}
-		clientSet          kubernetes.Interface
+		fr                  = wrappedTestFramework("kv-live-migration")
+		d                   = diagnostics.New(fr)
+		crClient            crclient.Client
+		namespace           string
+		tcpServerPort       = int32(9900)
+		wg                  sync.WaitGroup
+		selectedNodes       = []corev1.Node{}
+		httpServerTestPods  = []*corev1.Pod{}
+		iperfServerTestPods = []*corev1.Pod{}
+		clientSet           kubernetes.Interface
 		// Systemd resolvd prevent resolving kube api service by fqdn, so
 		// we replace it here with NetworkManager
 		labelNode = func(nodeName, label string) error {
@@ -106,8 +108,8 @@ var _ = Describe("Kubevirt Virtual Machines", func() {
 		isDualStack = func() bool {
 			GinkgoHelper()
 			nodeList, err := fr.ClientSet.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
-			Expect(err).ToNot(HaveOccurred())
-			Expect(nodeList.Items).ToNot(BeEmpty())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(nodeList.Items).NotTo(BeEmpty())
 			hasIPv4Address, hasIPv6Address := false, false
 			for _, addr := range nodeList.Items[0].Status.Addresses {
 				if addr.Type == corev1.NodeInternalIP {
@@ -274,6 +276,7 @@ var _ = Describe("Kubevirt Virtual Machines", func() {
 
 		checkEastWestTraffic = func(vmi *kubevirtv1.VirtualMachineInstance, podIPsByName map[string][]string, stage string) {
 			GinkgoHelper()
+			Expect(podIPsByName).NotTo(BeEmpty())
 			polling := 15 * time.Second
 			timeout := time.Minute
 			for podName, podIPs := range podIPsByName {
@@ -282,6 +285,26 @@ var _ = Describe("Kubevirt Virtual Machines", func() {
 					Eventually(func() error {
 						var err error
 						output, err = kubevirt.RunCommand(vmi, fmt.Sprintf("curl http://%s", net.JoinHostPort(podIP, "8000")), polling)
+						return err
+					}).
+						WithPolling(polling).
+						WithTimeout(timeout).
+						Should(Succeed(), func() string { return stage + ": " + podName + ": " + output })
+				}
+			}
+		}
+
+		checkEastWestIperfTraffic = func(vmi *kubevirtv1.VirtualMachineInstance, podIPsByName map[string][]string, stage string) {
+			GinkgoHelper()
+			Expect(podIPsByName).NotTo(BeEmpty())
+			polling := 15 * time.Second
+			timeout := time.Minute
+			for podName, podIPs := range podIPsByName {
+				for _, podIP := range podIPs {
+					output := ""
+					Eventually(func() error {
+						var err error
+						output, err = kubevirt.RunCommand(vmi, fmt.Sprintf("iperf3 -t 1 -c %s", podIP), polling)
 						return err
 					}).
 						WithPolling(polling).
@@ -301,28 +324,22 @@ var _ = Describe("Kubevirt Virtual Machines", func() {
 			return ips
 		}
 
-		checkPodHasIPsAtNetwork = func(netName string, expectedNumberOfAddresses int) func(Gomega, *corev1.Pod) {
-			return func(g Gomega, pod *corev1.Pod) {
-				GinkgoHelper()
-				netStatus, err := podNetworkStatus(pod, func(status nadapi.NetworkStatus) bool {
-					return status.Name == netName
-				})
-				g.Expect(err).ToNot(HaveOccurred())
-				g.Expect(netStatus).To(HaveLen(1))
-				g.Expect(netStatus[0].IPs).To(HaveLen(expectedNumberOfAddresses))
-			}
-		}
-
-		httpServerTestPodsMultusNetworkIPs = func(netName string) map[string][]string {
+		podsMultusNetworkIPs = func(pods []*corev1.Pod, networkStatusPredicate func(nadapi.NetworkStatus) bool) map[string][]string {
 			GinkgoHelper()
 			ips := map[string][]string{}
-			for _, pod := range httpServerTestPods {
-				netStatus, err := podNetworkStatus(pod, func(status nadapi.NetworkStatus) bool {
-					return status.Name == netName
-				})
-				Expect(err).NotTo(HaveOccurred())
-				Expect(netStatus).To(HaveLen(1))
-				ips[pod.Name] = append(ips[pod.Name], netStatus[0].IPs...)
+			for _, pod := range pods {
+				var networkStatuses []nadapi.NetworkStatus
+				Eventually(func() ([]nadapi.NetworkStatus, error) {
+					var err error
+					networkStatuses, err = podNetworkStatus(pod, networkStatusPredicate)
+					return networkStatuses, err
+				}).
+					WithTimeout(5 * time.Second).
+					WithPolling(200 * time.Millisecond).
+					Should(HaveLen(1))
+				for _, ip := range networkStatuses[0].IPs {
+					ips[pod.Name] = append(ips[pod.Name], ip)
+				}
 			}
 			return ips
 		}
@@ -337,7 +354,7 @@ var _ = Describe("Kubevirt Virtual Machines", func() {
 				},
 			}
 			err := crClient.Get(context.TODO(), crclient.ObjectKeyFromObject(vmi), vmi)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 			polling := 15 * time.Second
 			timeout := time.Minute
 			step := by(vmName, stage+": Check tcp connection is not broken")
@@ -367,7 +384,7 @@ var _ = Describe("Kubevirt Virtual Machines", func() {
 			/*
 				step := by(vmName, stage+": Create deny all network policy")
 				policy, err := createDenyAllPolicy(vmName)
-				Expect(err).ToNot(HaveOccurred(), step)
+				Expect(err).NotTo(HaveOccurred(), step)
 
 				step = by(vmName, stage+": Check connectivity block after create deny all network policy")
 				Eventually(func() error { return sendEchos(endpoints) }).
@@ -427,26 +444,26 @@ var _ = Describe("Kubevirt Virtual Machines", func() {
 				},
 			}
 			err := crClient.Get(context.TODO(), crclient.ObjectKeyFromObject(vmi), vmi)
-			Expect(err).ToNot(HaveOccurred(), "should success retrieving vmi")
+			Expect(err).NotTo(HaveOccurred(), "should success retrieving vmi")
 			currentNode := vmi.Status.NodeName
 
 			Eventually(func() *kubevirtv1.VirtualMachineInstanceMigrationState {
 				err := crClient.Get(context.TODO(), crclient.ObjectKeyFromObject(vmi), vmi)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
 				return vmi.Status.MigrationState
 			}).WithPolling(time.Second).WithTimeout(10*time.Minute).ShouldNot(BeNil(), "should have a MigrationState")
 			Eventually(func() string {
 				err := crClient.Get(context.TODO(), crclient.ObjectKeyFromObject(vmi), vmi)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
 				return vmi.Status.MigrationState.TargetNode
 			}).WithPolling(time.Second).WithTimeout(10*time.Minute).ShouldNot(Equal(currentNode), "should refresh MigrationState")
 			Eventually(func() bool {
 				err := crClient.Get(context.TODO(), crclient.ObjectKeyFromObject(vmi), vmi)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
 				return vmi.Status.MigrationState.Completed
 			}).WithPolling(time.Second).WithTimeout(20*time.Minute).Should(BeTrue(), "should complete migration")
 			err = crClient.Get(context.TODO(), crclient.ObjectKeyFromObject(vmi), vmi)
-			Expect(err).ToNot(HaveOccurred(), "should success retrieving vmi after migration")
+			Expect(err).NotTo(HaveOccurred(), "should success retrieving vmi after migration")
 			Expect(vmi.Status.MigrationState.Failed).To(BeFalse(), func() string {
 				vmiJSON, err := json.Marshal(vmi)
 				if err != nil {
@@ -497,7 +514,7 @@ var _ = Describe("Kubevirt Virtual Machines", func() {
 				},
 			}
 			err := crClient.Get(context.TODO(), crclient.ObjectKeyFromObject(vmi), vmi)
-			Expect(err).ToNot(HaveOccurred(), "should success retrieving vmi")
+			Expect(err).NotTo(HaveOccurred(), "should success retrieving vmi")
 
 			Eventually(func() (kubevirtv1.VirtualMachineInstanceMigrationPhase, error) {
 				migrations, err := vmiMigrations(crClient)
@@ -618,10 +635,10 @@ var _ = Describe("Kubevirt Virtual Machines", func() {
 				WithTimeout(5*time.Minute).
 				Should(HaveLen(1), step)
 			addresses, err := addressByFamily(ipv4, vmi)()
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 			if isDualStack() {
 				output, err := kubevirt.RunCommand(vmi, `echo '{"interfaces":[{"name":"enp1s0","type":"ethernet","state":"up","ipv4":{"enabled":true,"dhcp":true},"ipv6":{"enabled":true,"dhcp":true,"autoconf":false}}],"routes":{"config":[{"destination":"::/0","next-hop-interface":"enp1s0","next-hop-address":"fe80::1"}]}}' |nmstatectl apply`, 5*time.Second)
-				Expect(err).ToNot(HaveOccurred(), output)
+				Expect(err).NotTo(HaveOccurred(), output)
 				step = by(vmi.Name, "Wait for virtual machine to receive IPv6 address from DHCP")
 				Eventually(addressByFamily(ipv6, vmi)).
 					WithPolling(time.Second).
@@ -631,7 +648,7 @@ var _ = Describe("Kubevirt Virtual Machines", func() {
 						return step + " -> journal nmstate: " + output
 					})
 				ipv6Addresses, err := addressByFamily(ipv6, vmi)()
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
 				addresses = append(addresses, ipv6Addresses...)
 			}
 			return addresses
@@ -646,29 +663,17 @@ var _ = Describe("Kubevirt Virtual Machines", func() {
 				Should(HaveLen(expectedNumberOfAddresses), step)
 
 			addresses, err := addressesFromStatus(vmi)()
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 			return addresses
 		}
 
-		fcosVMI = func(idx int, labels map[string]string, annotations map[string]string, nodeSelector map[string]string, networkSource kubevirtv1.NetworkSource, butane string) (*kubevirtv1.VirtualMachineInstance, error) {
-			workingDirectory, err := os.Getwd()
-			if err != nil {
-				return nil, err
-			}
-			ignition, _, err := butaneconfig.TranslateBytes([]byte(butane), butanecommon.TranslateBytesOptions{
-				TranslateOptions: butanecommon.TranslateOptions{
-					FilesDir: workingDirectory,
-				},
-			})
-			if err != nil {
-				return nil, fmt.Errorf("failed translating butane: %w", err)
-			}
+		generateVMI = func(labels map[string]string, annotations map[string]string, nodeSelector map[string]string, networkSource kubevirtv1.NetworkSource, cloudInitVolumeSource kubevirtv1.VolumeSource, image string) *kubevirtv1.VirtualMachineInstance {
 			return &kubevirtv1.VirtualMachineInstance{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace:   namespace,
-					Name:        fmt.Sprintf("worker%d", idx),
-					Annotations: annotations,
-					Labels:      labels,
+					Namespace:    namespace,
+					GenerateName: "worker-",
+					Annotations:  annotations,
+					Labels:       labels,
 				},
 				Spec: kubevirtv1.VirtualMachineInstanceSpec{
 					NodeSelector: nodeSelector,
@@ -720,46 +725,79 @@ var _ = Describe("Kubevirt Virtual Machines", func() {
 							Name: "containerdisk",
 							VolumeSource: kubevirtv1.VolumeSource{
 								ContainerDisk: &kubevirtv1.ContainerDiskSource{
-									Image: "quay.io/kubevirtci/fedora-coreos-kubevirt:v20230905-be4fa50",
+									Image: image,
 								},
 							},
 						},
 						{
-							Name: "cloudinitdisk",
-							VolumeSource: kubevirtv1.VolumeSource{
-								CloudInitConfigDrive: &kubevirtv1.CloudInitConfigDriveSource{
-									UserData: string(ignition),
-								},
-							},
+							Name:         "cloudinitdisk",
+							VolumeSource: cloudInitVolumeSource,
 						},
 					},
 				},
-			}, nil
-		}
-		fcosVM = func(idx int, labels map[string]string, annotations map[string]string, nodeSelector map[string]string, networkSource kubevirtv1.NetworkSource, butane string) (*kubevirtv1.VirtualMachine, error) {
-			vmi, err := fcosVMI(idx, labels, annotations, nodeSelector, networkSource, butane)
-			if err != nil {
-				return nil, err
 			}
+		}
+
+		generateVM = func(vmi *kubevirtv1.VirtualMachineInstance) *kubevirtv1.VirtualMachine {
 			return &kubevirtv1.VirtualMachine{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: namespace,
-					Name:      fmt.Sprintf("worker%d", idx),
+					Namespace:    namespace,
+					GenerateName: vmi.GenerateName,
 				},
 				Spec: kubevirtv1.VirtualMachineSpec{
 					Running: pointer.Bool(true),
 					Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
-							Annotations: annotations,
-							Labels:      labels,
+							Annotations: vmi.Annotations,
+							Labels:      vmi.Labels,
 						},
 						Spec: vmi.Spec,
 					},
 				},
-			}, nil
+			}
 		}
 
-		composeDefaultNetworkLiveMigratableVM = func(idx int, labels map[string]string, butane string) (*kubevirtv1.VirtualMachine, error) {
+		fcosVMI = func(labels map[string]string, annotations map[string]string, nodeSelector map[string]string, networkSource kubevirtv1.NetworkSource, butane string) (*kubevirtv1.VirtualMachineInstance, error) {
+			workingDirectory, err := os.Getwd()
+			if err != nil {
+				return nil, err
+			}
+			ignition, _, err := butaneconfig.TranslateBytes([]byte(butane), butanecommon.TranslateBytesOptions{
+				TranslateOptions: butanecommon.TranslateOptions{
+					FilesDir: workingDirectory,
+				},
+			})
+			cloudInitVolumeSource := kubevirtv1.VolumeSource{
+				CloudInitConfigDrive: &kubevirtv1.CloudInitConfigDriveSource{
+					UserData: string(ignition),
+				},
+			}
+			return generateVMI(labels, annotations, nodeSelector, networkSource, cloudInitVolumeSource, kubevirt.FedoraCoreOSContainerDiskImage), nil
+		}
+
+		fcosVM = func(labels map[string]string, annotations map[string]string, nodeSelector map[string]string, networkSource kubevirtv1.NetworkSource, butane string) (*kubevirtv1.VirtualMachine, error) {
+			vmi, err := fcosVMI(labels, annotations, nodeSelector, networkSource, butane)
+			if err != nil {
+				return nil, err
+			}
+			return generateVM(vmi), nil
+		}
+
+		fedoraWithTestToolingVMI = func(labels map[string]string, annotations map[string]string, nodeSelector map[string]string, networkSource kubevirtv1.NetworkSource, userData, networkData string) *kubevirtv1.VirtualMachineInstance {
+			cloudInitVolumeSource := kubevirtv1.VolumeSource{
+				CloudInitNoCloud: &kubevirtv1.CloudInitNoCloudSource{
+					UserData:    userData,
+					NetworkData: networkData,
+				},
+			}
+			return generateVMI(labels, annotations, nodeSelector, networkSource, cloudInitVolumeSource, kubevirt.FedoraContainerDiskImage)
+		}
+
+		fedoraWithTestToolingVM = func(labels map[string]string, annotations map[string]string, nodeSelector map[string]string, networkSource kubevirtv1.NetworkSource, userData, networkData string) *kubevirtv1.VirtualMachine {
+			return generateVM(fedoraWithTestToolingVMI(labels, annotations, nodeSelector, networkSource, userData, networkData))
+		}
+
+		composeDefaultNetworkLiveMigratableVM = func(labels map[string]string, butane string) (*kubevirtv1.VirtualMachine, error) {
 			annotations := map[string]string{
 				"kubevirt.io/allow-pod-bridge-network-live-migration": "",
 			}
@@ -769,7 +807,7 @@ var _ = Describe("Kubevirt Virtual Machines", func() {
 			networkSource := kubevirtv1.NetworkSource{
 				Pod: &kubevirtv1.PodNetwork{},
 			}
-			return fcosVM(idx, labels, annotations, nodeSelector, networkSource, butane)
+			return fcosVM(labels, annotations, nodeSelector, networkSource, butane)
 		}
 
 		composeDefaultNetworkLiveMigratableVMs = func(numberOfVMs int, labels map[string]string) ([]*kubevirtv1.VirtualMachine, error) {
@@ -817,7 +855,7 @@ passwd:
 
 			vms := []*kubevirtv1.VirtualMachine{}
 			for i := 1; i <= numberOfVMs; i++ {
-				vm, err := composeDefaultNetworkLiveMigratableVM(i, labels, butane)
+				vm, err := composeDefaultNetworkLiveMigratableVM(labels, butane)
 				if err != nil {
 					return nil, err
 				}
@@ -843,17 +881,17 @@ passwd:
 				},
 			}
 			err := crClient.Get(context.TODO(), crclient.ObjectKeyFromObject(vmi), vmi)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 			Expect(kubevirt.LoginToFedora(vmi, "core", "fedora")).To(Succeed(), step)
 
 			waitVirtualMachineAddresses(vmi)
 
 			step = by(vm.Name, "Expose tcpServer as a service")
 			svc, err := fr.ClientSet.CoreV1().Services(namespace).Create(context.TODO(), composeService("tcpserver", vm.Name, tcpServerPort), metav1.CreateOptions{})
-			Expect(err).ToNot(HaveOccurred(), step)
+			Expect(err).NotTo(HaveOccurred(), step)
 			defer func() {
 				output, err := kubevirt.RunCommand(vmi, "podman logs tcpserver", 10*time.Second)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
 				fmt.Printf("%s tcpserver logs: %s", vmi.Name, output)
 			}()
 
@@ -896,7 +934,7 @@ passwd:
 		}
 
 		checkPodHasIPAtStatus = func(g Gomega, pod *corev1.Pod) {
-			g.Expect(pod.Status.PodIP).ToNot(BeEmpty(), "pod %s has no valid IP address yet", pod.Name)
+			g.Expect(pod.Status.PodIP).NotTo(BeEmpty(), "pod %s has no valid IP address yet", pod.Name)
 		}
 
 		createHTTPServerPods = func(annotations map[string]string) []*corev1.Pod {
@@ -913,12 +951,29 @@ passwd:
 			return pods
 		}
 
+		createIperfServerPods = func(nodes []corev1.Node, netConfig networkAttachmentConfig) ([]*corev1.Pod, error) {
+			annotations := map[string]string{}
+			annotations["k8s.v1.cni.cncf.io/networks"] = fmt.Sprintf(`[{"name": %q}]`, netConfig.name)
+			var pods []*corev1.Pod
+			for _, node := range nodes {
+				pod, err := createPod(fr, "testpod-"+node.Name, node.Name, namespace, []string{"iperf3", "-s"}, map[string]string{}, func(pod *corev1.Pod) {
+					pod.Annotations = annotations
+					pod.Spec.Containers[0].Image = iperf3Image
+				})
+				if err != nil {
+					return nil, err
+				}
+				pods = append(pods, pod)
+			}
+			return pods, nil
+		}
+
 		waitForPodsCondition = func(pods []*corev1.Pod, conditionFn func(g Gomega, pod *corev1.Pod)) {
 			for _, pod := range pods {
 				Eventually(func(g Gomega) {
 					var err error
 					pod, err = fr.ClientSet.CoreV1().Pods(fr.Namespace.Name).Get(context.TODO(), pod.Name, metav1.GetOptions{})
-					g.Expect(err).ToNot(HaveOccurred())
+					g.Expect(err).NotTo(HaveOccurred())
 					conditionFn(g, pod)
 				}).
 					WithTimeout(time.Minute).
@@ -931,7 +986,7 @@ passwd:
 			for i, pod := range pods {
 				var err error
 				pod, err = fr.ClientSet.CoreV1().Pods(fr.Namespace.Name).Get(context.TODO(), pod.Name, metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
 				pods[i] = pod
 			}
 			return pods
@@ -943,6 +998,47 @@ passwd:
 			waitForPodsCondition(httpServerTestPods, conditionFn)
 			httpServerTestPods = updatePods(httpServerTestPods)
 		}
+
+		removeImagesInNode = func(node, imageURL string) error {
+			By("Removing unused images in node " + node)
+			output, err := runCommand(containerRuntime, "exec", node,
+				"crictl", "images", "-o", "json")
+			if err != nil {
+				return err
+			}
+
+			// Remove tag if exists.
+			taglessImageURL := strings.Split(imageURL, ":")[0]
+			imageID, err := images.ImageIDByImageURL(taglessImageURL, output)
+			if err != nil {
+				return err
+			}
+			if imageID != "" {
+				_, err = runCommand(containerRuntime, "exec", node,
+					"crictl", "rmi", imageID)
+				if err != nil {
+					return err
+				}
+				_, err = runCommand(containerRuntime, "exec", node,
+					"crictl", "rmi", "--prune")
+				if err != nil {
+					return err
+				}
+			}
+			return nil
+		}
+
+		removeImagesInNodes = func(imageURL string) error {
+			nodesList, err := fr.ClientSet.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			for nodeIdx, _ := range nodesList.Items {
+				err = removeImagesInNode(nodesList.Items[nodeIdx].Name, imageURL)
+				if err != nil {
+					return err
+				}
+			}
+			return nil
+		}
 	)
 	BeforeEach(func() {
 		namespace = fr.Namespace.Name
@@ -951,14 +1047,14 @@ passwd:
 
 		var err error
 		crClient, err = newControllerRuntimeClient()
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred())
 	})
 
-	Context("with default pod network", func() {
+	Context("with default pod network", Ordered, func() {
 
 		BeforeEach(func() {
 			workerNodeList, err := fr.ClientSet.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{LabelSelector: labels.FormatLabels(map[string]string{"node-role.kubernetes.io/worker": ""})})
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 			nodesByOVNZone := map[string][]corev1.Node{}
 			for _, workerNode := range workerNodeList.Items {
 				ovnZone, ok := workerNode.Labels["k8s.ovn.org/zone-name"]
@@ -1010,6 +1106,10 @@ passwd:
 			}
 		})
 
+		AfterAll(func() {
+			Expect(removeImagesInNodes(kubevirt.FedoraCoreOSContainerDiskImage)).To(Succeed())
+		})
+
 		DescribeTable("when live migration", func(td liveMigrationTestData) {
 			if td.mode == kubevirtv1.MigrationPostCopy && os.Getenv("GITHUB_ACTIONS") == "true" {
 				Skip("Post copy live migration not working at github actions")
@@ -1018,7 +1118,7 @@ passwd:
 				err error
 			)
 
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 
 			d.ConntrackDumpingDaemonSet()
 			d.OVSFlowsDumpingDaemonSet("breth0")
@@ -1042,7 +1142,7 @@ passwd:
 			}
 			if td.mode == kubevirtv1.MigrationPostCopy {
 				err = crClient.Create(context.TODO(), forcePostCopyMigrationPolicy)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
 				defer func() {
 					Expect(crClient.Delete(context.TODO(), forcePostCopyMigrationPolicy)).To(Succeed())
 				}()
@@ -1053,7 +1153,7 @@ passwd:
 				vmLabels = forcePostCopyMigrationPolicy.Spec.Selectors.VirtualMachineInstanceSelector
 			}
 			vms, err := composeDefaultNetworkLiveMigratableVMs(td.numberOfVMs, vmLabels)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 
 			for _, vm := range vms {
 				By(fmt.Sprintf("Create virtual machine %s", vm.Name))
@@ -1070,24 +1170,27 @@ passwd:
 				}).WithPolling(time.Second).WithTimeout(time.Minute).Should(Succeed())
 			}
 
-			if td.shouldExpectFailure {
-				By("annotating the VMI with `fail fast`")
-				vmKey := types.NamespacedName{Namespace: namespace, Name: "worker1"}
-				var vmi kubevirtv1.VirtualMachineInstance
-				Eventually(func() error {
-					return crClient.Get(context.TODO(), vmKey, &vmi)
-				}).WithPolling(time.Second).WithTimeout(time.Minute).Should(Succeed())
+			for _, vm := range vms {
+				By(fmt.Sprintf("Create virtual machine %s", vm.Name))
+				if td.shouldExpectFailure {
+					By("annotating the VMI with `fail fast`")
+					vmKey := types.NamespacedName{Namespace: namespace, Name: vm.Name}
+					var vmi kubevirtv1.VirtualMachineInstance
+					Eventually(func() error {
+						return crClient.Get(context.TODO(), vmKey, &vmi)
+					}).WithPolling(time.Second).WithTimeout(time.Minute).Should(Succeed())
 
-				vmi.ObjectMeta.Annotations[kubevirtv1.FuncTestLauncherFailFastAnnotation] = "true"
+					vmi.ObjectMeta.Annotations[kubevirtv1.FuncTestLauncherFailFastAnnotation] = "true"
 
-				Expect(crClient.Update(context.TODO(), &vmi)).To(Succeed())
+					Expect(crClient.Update(context.TODO(), &vmi)).To(Succeed())
+				}
 			}
 
 			for _, vm := range vms {
 				By(fmt.Sprintf("Waiting for readiness at virtual machine %s", vm.Name))
 				Eventually(func() bool {
 					err = crClient.Get(context.Background(), crclient.ObjectKeyFromObject(vm), vm)
-					Expect(err).ToNot(HaveOccurred())
+					Expect(err).NotTo(HaveOccurred())
 					return vm.Status.Ready
 				}).WithPolling(time.Second).WithTimeout(5 * time.Minute).Should(BeTrue())
 			}
@@ -1112,7 +1215,10 @@ passwd:
 			}),
 		)
 	})
-	Context("with secondary network and persistent ips configured", func() {
+	Context("with secondary network and persistent ips configured", Ordered, func() {
+		AfterAll(func() {
+			Expect(removeImagesInNodes(kubevirt.FedoraContainerDiskImage)).To(Succeed())
+		})
 		type testCommand struct {
 			description string
 			cmd         func()
@@ -1122,18 +1228,17 @@ passwd:
 			cmd         func() string
 		}
 		var (
-			nad              *nadv1.NetworkAttachmentDefinition
-			vm               *kubevirtv1.VirtualMachine
-			vmi              *kubevirtv1.VirtualMachineInstance
-			cidrIPv4         = "10.128.0.0/24"
-			cidrIPv6         = "2010:100:200::0/60"
-			expectedAddreses []string
-			restart          = testCommand{
+			nad      *nadv1.NetworkAttachmentDefinition
+			vm       *kubevirtv1.VirtualMachine
+			vmi      *kubevirtv1.VirtualMachineInstance
+			cidrIPv4 = "10.128.0.0/24"
+			cidrIPv6 = "2010:100:200::0/60"
+			restart  = testCommand{
 				description: "restart",
 				cmd: func() {
 					By("Restarting vm")
 					output, err := exec.Command("virtctl", "restart", "-n", namespace, vmi.Name).CombinedOutput()
-					Expect(err).ToNot(HaveOccurred(), output)
+					Expect(err).NotTo(HaveOccurred(), output)
 
 					By("Wait some time to vmi conditions to catch up after restart")
 					time.Sleep(3 * time.Second)
@@ -1148,24 +1253,23 @@ passwd:
 					checkLiveMigrationSucceeded(vmi.Name, kubevirtv1.MigrationPreCopy)
 				},
 			}
-			butane = `
-variant: fcos
-version: 1.4.0
-passwd:
-  users:
-  - name: core
-    password_hash: $y$j9T$b7RFf2LW7MUOiF4RyLHKA0$T.Ap/uzmg8zrTcUNXyXvBvT26UgkC6zZUVg3UKXeEp5
-`
+			networkData = `version: 2
+ethernets:
+  eth0:
+    dhcp4: true
+    dhcp6: true
+    ipv6-address-generation: eui64`
+			userData = `#cloud-config
+password: fedora
+chpasswd: { expire: False }`
 			virtualMachine = resourceCommand{
 				description: "VirtualMachine",
 				cmd: func() string {
-					var err error
-					vm, err = fcosVM(1, nil /*labels*/, nil /*annotations*/, nil /*nodeSelector*/, kubevirtv1.NetworkSource{
+					vm = fedoraWithTestToolingVM(nil /*labels*/, nil /*annotations*/, nil /*nodeSelector*/, kubevirtv1.NetworkSource{
 						Multus: &kubevirtv1.MultusNetwork{
 							NetworkName: nad.Name,
 						},
-					}, butane)
-					Expect(err).ToNot(HaveOccurred())
+					}, userData, networkData)
 					createVirtualMachine(vm)
 					return vm.Name
 				},
@@ -1174,31 +1278,14 @@ passwd:
 			virtualMachineInstance = resourceCommand{
 				description: "VirtualMachineInstance",
 				cmd: func() string {
-					var err error
-					vmi, err = fcosVMI(1, nil /*labels*/, nil /*annotations*/, nil /*nodeSelector*/, kubevirtv1.NetworkSource{
+					vmi = fedoraWithTestToolingVMI(nil /*labels*/, nil /*annotations*/, nil /*nodeSelector*/, kubevirtv1.NetworkSource{
 						Multus: &kubevirtv1.MultusNetwork{
 							NetworkName: nad.Name,
 						},
-					}, butane)
-					Expect(err).ToNot(HaveOccurred())
+					}, userData, networkData)
 					createVirtualMachineInstance(vmi)
 					return vmi.Name
 				},
-			}
-			filterOutIPv6 = func(ips map[string][]string) map[string][]string {
-				filteredOutIPs := map[string][]string{}
-				for podName, podIPs := range ips {
-					for _, podIP := range podIPs {
-						if !utilnet.IsIPv6String(podIP) {
-							_, ok := filteredOutIPs[podName]
-							if !ok {
-								filteredOutIPs[podName] = []string{}
-							}
-							filteredOutIPs[podName] = append(filteredOutIPs[podName], podIP)
-						}
-					}
-				}
-				return filteredOutIPs
 			}
 		)
 		type testData struct {
@@ -1234,12 +1321,12 @@ passwd:
 			nad = generateNAD(netConfig)
 			Expect(crClient.Create(context.Background(), nad)).To(Succeed())
 			workerNodeList, err := fr.ClientSet.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{LabelSelector: labels.FormatLabels(map[string]string{"node-role.kubernetes.io/worker": ""})})
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 			selectedNodes = workerNodeList.Items
-			networkName := fmt.Sprintf("%s/%s", nad.Namespace, nad.Name)
-			prepareHTTPServerPods(map[string]string{
-				"k8s.v1.cni.cncf.io/networks": fmt.Sprintf(`[{"name": %q}]`, nad.Name),
-			}, checkPodHasIPsAtNetwork(networkName, 2 /*expectedNumberOfAddresses*/))
+			Expect(selectedNodes).NotTo(BeEmpty())
+
+			iperfServerTestPods, err = createIperfServerPods(selectedNodes, netConfig)
+			Expect(err).NotTo(HaveOccurred())
 
 			vmiName := td.resource.cmd()
 			vmi = &kubevirtv1.VirtualMachineInstance{
@@ -1248,32 +1335,54 @@ passwd:
 					Name:      vmiName,
 				},
 			}
+
 			waitVirtualMachineInstanceReadiness(vmi)
 			Expect(crClient.Get(context.TODO(), crclient.ObjectKeyFromObject(vmi), vmi)).To(Succeed())
 
 			step := by(vmi.Name, "Login to virtual machine for the first time")
-			Expect(kubevirt.LoginToFedora(vmi, "core", "fedora")).To(Succeed(), step)
-			expectedAddreses = virtualMachineAddressesFromStatus(vmi, 2 /*two addresses, dual stack*/)
+			Eventually(func() error {
+				return kubevirt.LoginToFedora(vmi, "fedora", "fedora")
+			}).
+				WithTimeout(5*time.Second).
+				WithPolling(time.Second).
+				Should(Succeed(), step)
+
+			step = by(vmi.Name, "Wait for addresses at the virtual machine")
+
+			// expect 2 addresses on dual-stack deployments; 1 on single-stack
+			expectedNumberOfAddresses := len(strings.Split(netConfig.cidr, ","))
+			expectedAddreses := virtualMachineAddressesFromStatus(vmi, expectedNumberOfAddresses)
+			expectedAddresesAtGuest := expectedAddreses
+			testPodsIPs := podsMultusNetworkIPs(iperfServerTestPods, podNetworkStatusByNetConfigPredicate(netConfig))
+
+			Eventually(kubevirt.RetrieveAllGlobalAddressesFromGuest).
+				WithArguments(vmi).
+				WithTimeout(5*time.Second).
+				WithPolling(time.Second).
+				Should(ConsistOf(expectedAddresesAtGuest), step)
 
 			step = by(vmi.Name, fmt.Sprintf("Check east/west traffic before %s %s", td.resource.description, td.test.description))
-			testPodsIPs := httpServerTestPodsMultusNetworkIPs(networkName)
 
-			// kubevirt secondary IPAM do not support IPv6, so guest is not
-			// going to have an ipv6 address at the interface
-			testPodsIPs = filterOutIPv6(testPodsIPs)
-
-			checkEastWestTraffic(vmi, testPodsIPs, step)
+			checkEastWestIperfTraffic(vmi, testPodsIPs, step)
 
 			by(vmi.Name, fmt.Sprintf("Running %s for %s", td.test.description, td.resource.description))
 			td.test.cmd()
 
-			step = by(vm.Name, fmt.Sprintf("Login to virtual machine after %s %s", td.resource.description, td.test.description))
-			Expect(kubevirt.LoginToFedora(vmi, "core", "fedora")).To(Succeed(), step)
-			obtainedAddresses := virtualMachineAddressesFromStatus(vmi, 2 /*two addresses, dual stack*/)
+			step = by(vmi.Name, fmt.Sprintf("Login to virtual machine after %s %s", td.resource.description, td.test.description))
+			Expect(kubevirt.LoginToFedora(vmi, "fedora", "fedora")).To(Succeed(), step)
+			var obtainedAddresses []string
+
+			obtainedAddresses = virtualMachineAddressesFromStatus(vmi, expectedNumberOfAddresses)
+
 			Expect(obtainedAddresses).To(Equal(expectedAddreses))
+			Eventually(kubevirt.RetrieveAllGlobalAddressesFromGuest).
+				WithArguments(vmi).
+				WithTimeout(5*time.Second).
+				WithPolling(time.Second).
+				Should(ConsistOf(expectedAddresesAtGuest), step)
 
 			step = by(vmi.Name, fmt.Sprintf("Check east/west traffic after %s %s", td.resource.description, td.test.description))
-			checkEastWestTraffic(vmi, testPodsIPs, step)
+			checkEastWestIperfTraffic(vmi, testPodsIPs, step)
 		},
 			func(td testData) string {
 				return fmt.Sprintf("after %s of %s with %s", td.test.description, td.resource.description, td.topology)

--- a/test/e2e/kubevirt.go
+++ b/test/e2e/kubevirt.go
@@ -703,7 +703,7 @@ var _ = Describe("Kubevirt Virtual Machines", func() {
 					Domain: kubevirtv1.DomainSpec{
 						Resources: kubevirtv1.ResourceRequirements{
 							Requests: corev1.ResourceList{
-								corev1.ResourceMemory: resource.MustParse("512Mi"),
+								corev1.ResourceMemory: resource.MustParse("1024Mi"),
 							},
 						},
 						Devices: kubevirtv1.Devices{

--- a/test/e2e/kubevirt.go
+++ b/test/e2e/kubevirt.go
@@ -1462,7 +1462,7 @@ chpasswd: { expire: False }`
 				test:     restart,
 				topology: "layer2",
 			}),
-			XEntry(nil, Label("TODO", "SDN-5490"), testData{
+			Entry(nil, testData{
 				resource: virtualMachine,
 				test:     liveMigrate,
 				topology: "localnet",
@@ -1472,7 +1472,7 @@ chpasswd: { expire: False }`
 				test:     liveMigrate,
 				topology: "layer2",
 			}),
-			XEntry(nil, Label("TODO", "SDN-5490"), testData{
+			Entry(nil, testData{
 				resource: virtualMachineInstance,
 				test:     liveMigrate,
 				topology: "localnet",
@@ -1486,6 +1486,11 @@ chpasswd: { expire: False }`
 				resource: virtualMachineInstance,
 				test:     liveMigrateFailed,
 				topology: "layer2",
+			}),
+			Entry(nil, testData{
+				resource: virtualMachineInstance,
+				test:     liveMigrateFailed,
+				topology: "localnet",
 			}),
 		)
 	})

--- a/test/e2e/kubevirt.go
+++ b/test/e2e/kubevirt.go
@@ -294,22 +294,45 @@ var _ = Describe("Kubevirt Virtual Machines", func() {
 			}
 		}
 
+		startEastWestIperfTraffic = func(vmi *kubevirtv1.VirtualMachineInstance, serverPodIPsByName map[string][]string, stage string) error {
+			GinkgoHelper()
+			Expect(serverPodIPsByName).NotTo(BeEmpty())
+			polling := 15 * time.Second
+			for podName, serverPodIPs := range serverPodIPsByName {
+				for _, serverPodIP := range serverPodIPs {
+					output, err := kubevirt.RunCommand(vmi, fmt.Sprintf("iperf3 -t 0 -c %[2]s --logfile /tmp/%[1]s_%[2]s_iperf3.log &", podName, serverPodIP), polling)
+					if err != nil {
+						return fmt.Errorf("%s: %w", output, err)
+					}
+				}
+			}
+			return nil
+		}
+
 		checkEastWestIperfTraffic = func(vmi *kubevirtv1.VirtualMachineInstance, podIPsByName map[string][]string, stage string) {
 			GinkgoHelper()
-			Expect(podIPsByName).NotTo(BeEmpty())
-			polling := 15 * time.Second
-			timeout := time.Minute
 			for podName, podIPs := range podIPsByName {
 				for _, podIP := range podIPs {
-					output := ""
-					Eventually(func() error {
-						var err error
-						output, err = kubevirt.RunCommand(vmi, fmt.Sprintf("iperf3 -t 1 -c %s", podIP), polling)
-						return err
+					// Check the last line eventually show traffic flowing
+					Eventually(func() (string, error) {
+						iperfLog, err := kubevirt.RunCommand(vmi, fmt.Sprintf("cat /tmp/%s_%s_iperf3.log", podName, podIP), 2*time.Second)
+						if err != nil {
+							return "", err
+						}
+						iperfLogLines := strings.Split(iperfLog, "\n")
+						if len(iperfLogLines) == 0 {
+							return "", nil
+						}
+						return iperfLogLines[len(iperfLogLines)-1], nil
 					}).
-						WithPolling(polling).
-						WithTimeout(timeout).
-						Should(Succeed(), func() string { return stage + ": " + podName + ": " + output })
+						WithPolling(time.Second).
+						WithTimeout(3 * time.Minute).
+						Should(
+							SatisfyAll(
+								ContainSubstring(" sec "),
+								Not(ContainSubstring("0.00 Bytes  0.00 bits/sec")),
+							),
+						)
 				}
 			}
 		}
@@ -951,14 +974,29 @@ passwd:
 			return pods
 		}
 
+		iperfServerScript = `
+dnf install -y psmisc procps
+iface=$(ifconfig  |grep flags |grep -v "eth0\|lo" | sed "s/: .*//")
+ipv4=$(ifconfig $iface | grep "inet "|awk '{print $2}'| sed "s#/.*##")
+ipv6=$(ifconfig $iface | grep inet6 |grep -v fe80 |awk '{print $2}'| sed "s#/.*##")
+if [ "$ipv4" != "" ]; then
+	iperf3 -s -D --bind $ipv4 --logfile /tmp/test_${ipv4}_iperf3.log
+fi
+if [ "$ipv6" != "" ]; then
+	iperf3 -s -D --bind $ipv6 --logfile /tmp/test_${ipv6}_iperf3.log
+fi
+sleep infinity
+`
 		createIperfServerPods = func(nodes []corev1.Node, netConfig networkAttachmentConfig) ([]*corev1.Pod, error) {
 			annotations := map[string]string{}
 			annotations["k8s.v1.cni.cncf.io/networks"] = fmt.Sprintf(`[{"name": %q}]`, netConfig.name)
 			var pods []*corev1.Pod
 			for _, node := range nodes {
-				pod, err := createPod(fr, "testpod-"+node.Name, node.Name, namespace, []string{"iperf3", "-s"}, map[string]string{}, func(pod *corev1.Pod) {
+				pod, err := createPod(fr, "testpod-"+node.Name, node.Name, namespace, []string{"bash", "-c"}, map[string]string{}, func(pod *corev1.Pod) {
 					pod.Annotations = annotations
 					pod.Spec.Containers[0].Image = iperf3Image
+					pod.Spec.Containers[0].Args = []string{iperfServerScript}
+
 				})
 				if err != nil {
 					return nil, err
@@ -1355,6 +1393,10 @@ chpasswd: { expire: False }`
 			expectedAddresesAtGuest := expectedAddreses
 			testPodsIPs := podsMultusNetworkIPs(iperfServerTestPods, podNetworkStatusByNetConfigPredicate(netConfig))
 
+			step = by(vmi.Name, "Expose VM iperf server as a service")
+			svc, err := fr.ClientSet.CoreV1().Services(namespace).Create(context.TODO(), composeService("iperf3-vm-server", vm.Name, 5201), metav1.CreateOptions{})
+			Expect(svc.Spec.Ports[0].NodePort).NotTo(Equal(0), step)
+
 			Eventually(kubevirt.RetrieveAllGlobalAddressesFromGuest).
 				WithArguments(vmi).
 				WithTimeout(5*time.Second).
@@ -1362,7 +1404,7 @@ chpasswd: { expire: False }`
 				Should(ConsistOf(expectedAddresesAtGuest), step)
 
 			step = by(vmi.Name, fmt.Sprintf("Check east/west traffic before %s %s", td.resource.description, td.test.description))
-
+			Expect(startEastWestIperfTraffic(vmi, testPodsIPs, step)).To(Succeed(), step)
 			checkEastWestIperfTraffic(vmi, testPodsIPs, step)
 
 			by(vmi.Name, fmt.Sprintf("Running %s for %s", td.test.description, td.resource.description))
@@ -1382,6 +1424,10 @@ chpasswd: { expire: False }`
 				Should(ConsistOf(expectedAddresesAtGuest), step)
 
 			step = by(vmi.Name, fmt.Sprintf("Check east/west traffic after %s %s", td.resource.description, td.test.description))
+			if td.test.description == restart.description {
+				// At restart we need re-connect
+				Expect(startEastWestIperfTraffic(vmi, testPodsIPs, step)).To(Succeed(), step)
+			}
 			checkEastWestIperfTraffic(vmi, testPodsIPs, step)
 		},
 			func(td testData) string {
@@ -1397,7 +1443,7 @@ chpasswd: { expire: False }`
 				test:     restart,
 				topology: "layer2",
 			}),
-			Entry(nil, testData{
+			XEntry(nil, Label("TODO", "SDN-5490"), testData{
 				resource: virtualMachine,
 				test:     liveMigrate,
 				topology: "localnet",
@@ -1407,7 +1453,7 @@ chpasswd: { expire: False }`
 				test:     liveMigrate,
 				topology: "layer2",
 			}),
-			Entry(nil, testData{
+			XEntry(nil, Label("TODO", "SDN-5490"), testData{
 				resource: virtualMachineInstance,
 				test:     liveMigrate,
 				topology: "localnet",

--- a/test/e2e/kubevirt/ip.go
+++ b/test/e2e/kubevirt/ip.go
@@ -1,0 +1,41 @@
+package kubevirt
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	v1 "kubevirt.io/api/core/v1"
+)
+
+func RetrieveAllGlobalAddressesFromGuest(vmi *v1.VirtualMachineInstance) ([]string, error) {
+	ifaces := []struct {
+		Name      string `json:"ifname"`
+		Addresses []struct {
+			Family string `json:"family"`
+			Scope  string `json:"scope"`
+			Local  string `json:"local"`
+		} `json:"addr_info"`
+	}{}
+
+	output, err := RunCommand(vmi, "ip -j a show", 2*time.Second)
+	if err != nil {
+		return nil, fmt.Errorf("failed retrieving adresses with ip command: %s: %w", output, err)
+	}
+	if err := json.Unmarshal([]byte(output), &ifaces); err != nil {
+		return nil, fmt.Errorf("failed unmarshaling ip command addresses: %s: %w", output, err)
+	}
+	addresses := []string{}
+	for _, iface := range ifaces {
+		if iface.Name == "lo" {
+			continue
+		}
+		for _, address := range iface.Addresses {
+			if address.Scope != "global" {
+				continue
+			}
+			addresses = append(addresses, address.Local)
+		}
+	}
+	return addresses, nil
+}

--- a/test/e2e/kubevirt/ip.go
+++ b/test/e2e/kubevirt/ip.go
@@ -12,9 +12,10 @@ func RetrieveAllGlobalAddressesFromGuest(vmi *v1.VirtualMachineInstance) ([]stri
 	ifaces := []struct {
 		Name      string `json:"ifname"`
 		Addresses []struct {
-			Family string `json:"family"`
-			Scope  string `json:"scope"`
-			Local  string `json:"local"`
+			Family    string `json:"family"`
+			Scope     string `json:"scope"`
+			Local     string `json:"local"`
+			PrefixLen uint   `json:"prefixlen"`
 		} `json:"addr_info"`
 	}{}
 
@@ -31,7 +32,8 @@ func RetrieveAllGlobalAddressesFromGuest(vmi *v1.VirtualMachineInstance) ([]stri
 			continue
 		}
 		for _, address := range iface.Addresses {
-			if address.Scope != "global" {
+			// Skip non DHCPv6 address
+			if address.Family == "inet6" && address.PrefixLen != 128 {
 				continue
 			}
 			addresses = append(addresses, address.Local)

--- a/test/e2e/kubevirt/types.go
+++ b/test/e2e/kubevirt/types.go
@@ -1,0 +1,6 @@
+package kubevirt
+
+const (
+	FedoraCoreOSContainerDiskImage = "quay.io/kubevirtci/fedora-coreos-kubevirt:v20230905-be4fa50"
+	FedoraContainerDiskImage       = "quay.io/kubevirtci/fedora-with-test-tooling:v20241128-4d4c8fe"
+)

--- a/test/e2e/multihoming_utils.go
+++ b/test/e2e/multihoming_utils.go
@@ -167,6 +167,16 @@ func podNetworkStatus(pod *v1.Pod, predicates ...func(nadapi.NetworkStatus) bool
 	return netStatusMeetingPredicates, nil
 }
 
+func podNetworkStatusByNetConfigPredicate(netConfig networkAttachmentConfig) func(nadapi.NetworkStatus) bool {
+	return func(networkStatus nadapi.NetworkStatus) bool {
+		if netConfig.role == "primary" {
+			return networkStatus.Default
+		} else {
+			return networkStatus.Name == netConfig.namespace+"/"+netConfig.name
+		}
+	}
+}
+
 func namespacedName(namespace, name string) string {
 	return fmt.Sprintf("%s/%s", namespace, name)
 }


### PR DESCRIPTION
## 📑 Description
Currently all pods have the LSP.Enabled option set to nil (which later
translates to &true) by default.

During live-migration of kubevirt pods, in order to prevent unneeded
packet loss the lsp.Enabled of the migration pods (source and target)
need to be as follows:

until target pod is domain ready: source pod lsp is enabled, target
pod lsp is disabled.
when target pod is domain-ready: source pod lsp is disabled, target
pod lsp is enabled.
This switch significantly reduces the migration downtime to <0.5s (see details below).

This PR also handles the scenario of a failed migration, where the lsp
of the source pod needs to be re-enabled.

Apart from playing with lsp Enabled field for localnet is also needed to remove Addresses field to be sure that OVN is removing the L2 lookup table so traffic is steering to the localnet LSP.

This PR is a manual cherry-pick of 3 PRs:
- https://github.com/ovn-kubernetes/ovn-kubernetes/pull/4774
- https://github.com/ovn-kubernetes/ovn-kubernetes/pull/4834
- https://github.com/ovn-kubernetes/ovn-kubernetes/pull/4917

*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
