### PR TITLE
[release-4.16] OCPBUGS-50595: kubevirt, localnet: Reduce live migration downtime

### DIFF
--- a/go-controller/pkg/kubevirt/pod.go
+++ b/go-controller/pkg/kubevirt/pod.go
@@ -3,6 +3,8 @@ package kubevirt
 import (
 	"fmt"
 	"net"
+	"sort"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -12,6 +14,7 @@ import (
 	kubevirtv1 "kubevirt.io/api/core/v1"
 
 	libovsdbclient "github.com/ovn-org/libovsdb/client"
+
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
 	libovsdbops "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdb/ops"
@@ -315,4 +318,127 @@ func ZoneContainsPodSubnetOrUntracked(watchFactory *factory.WatchFactory, lsMana
 	// we can just use one of the IPs to check if it belongs to a subnet assigned
 	// to a node
 	return hostSubnets, !util.IsContainedInAnyCIDR(annotation.IPs[0], hostSubnets...), nil
+}
+
+// IsPodOwnedByVirtualMachine returns true if the pod is own by a
+// kubevirt virtual machine, false otherwise.
+func IsPodOwnedByVirtualMachine(pod *corev1.Pod) bool {
+	return ExtractVMNameFromPod(pod) != nil
+}
+
+func isTargetPodReady(targetPod *corev1.Pod) bool {
+	if targetPod == nil {
+		return false
+	}
+
+	// This annotation only appears on live migration scenarios, and it signals
+	// that target VM pod is ready to receive traffic, so we can route
+	// traffic to it.
+	targetReadyTimestamp := targetPod.Annotations[kubevirtv1.MigrationTargetReadyTimestamp]
+
+	// VM is ready to receive traffic
+	return targetReadyTimestamp != ""
+}
+
+func filterNotComplete(vmPods []*corev1.Pod) []*corev1.Pod {
+	var notCompletePods []*corev1.Pod
+	for _, vmPod := range vmPods {
+		if !util.PodCompleted(vmPod) {
+			notCompletePods = append(notCompletePods, vmPod)
+		}
+	}
+
+	return notCompletePods
+}
+
+func tooManyPodsError(livingPods []*corev1.Pod) error {
+	var podNames = make([]string, len(livingPods))
+	for i := range livingPods {
+		podNames[i] = livingPods[i].Namespace + "/" + livingPods[i].Name
+	}
+	return fmt.Errorf("unexpected live migration state at pods: %s", strings.Join(podNames, ","))
+}
+
+// LiveMigrationState represents the various states of a live migration process.
+type LiveMigrationState string
+
+const (
+	// LiveMigrationInProgress indicates that a live migration is currently ongoing.
+	LiveMigrationInProgress LiveMigrationState = "InProgress"
+
+	// LiveMigrationTargetDomainReady indicates that the target domain is ready to take over.
+	LiveMigrationTargetDomainReady LiveMigrationState = "TargetDomainReady"
+
+	// LiveMigrationFailed indicates that the live migration process has failed.
+	LiveMigrationFailed LiveMigrationState = "Failed"
+)
+
+// LiveMigrationStatus provides details about the current status of a live migration.
+// It includes information about the source and target pods as well as the migration state.
+type LiveMigrationStatus struct {
+	SourcePod *corev1.Pod        // SourcePod is the original pod.
+	TargetPod *corev1.Pod        // TargetPod is the destination pod.
+	State     LiveMigrationState // State is the current state of the live migration.
+}
+
+// DiscoverLiveMigrationStatus determines the status of a live migration for a given pod.
+// It analyzes the state of pods associated with a VirtualMachine (VM) to identify whether
+// a live migration is in progress, the target domain is ready, or the migration has failed.
+//
+// Note: The function assumes that the pod is part of a VirtualMachine resource managed
+// by KubeVirt.
+func DiscoverLiveMigrationStatus(client *factory.WatchFactory, pod *corev1.Pod) (*LiveMigrationStatus, error) {
+	vmKey := ExtractVMNameFromPod(pod)
+	if vmKey == nil {
+		return nil, nil
+	}
+
+	vmPods, err := client.GetPodsBySelector(pod.Namespace, metav1.LabelSelector{MatchLabels: map[string]string{kubevirtv1.VirtualMachineNameLabel: vmKey.Name}})
+	if err != nil {
+		return nil, err
+	}
+
+	// no migration
+	if len(vmPods) < 2 {
+		return nil, nil
+	}
+
+	// Sort vmPods by creation time
+	sort.Slice(vmPods, func(i, j int) bool {
+		return vmPods[j].CreationTimestamp.After(vmPods[i].CreationTimestamp.Time)
+	})
+
+	targetPod := vmPods[len(vmPods)-1]
+	livingPods := filterNotComplete(vmPods)
+	if util.PodCompleted(targetPod) {
+		// if target pod failed, then there should be only one living source pod.
+		if len(livingPods) != 1 {
+			return nil, fmt.Errorf("unexpected live migration state: should have a single living pod")
+		}
+		return &LiveMigrationStatus{
+			SourcePod: livingPods[0],
+			TargetPod: targetPod,
+			State:     LiveMigrationFailed,
+		}, nil
+	}
+
+	// no active migration
+	if len(livingPods) < 2 {
+		return nil, nil
+	}
+
+	if len(livingPods) > 2 {
+		return nil, tooManyPodsError(livingPods)
+	}
+
+	status := LiveMigrationStatus{
+		SourcePod: livingPods[0],
+		TargetPod: livingPods[1],
+		State:     LiveMigrationInProgress,
+	}
+
+	if isTargetPodReady(status.TargetPod) {
+		status.State = LiveMigrationTargetDomainReady
+	}
+	return &status, nil
 }

--- a/go-controller/pkg/kubevirt/pod.go
+++ b/go-controller/pkg/kubevirt/pod.go
@@ -328,7 +328,9 @@ func IsPodOwnedByVirtualMachine(pod *corev1.Pod) bool {
 
 // IsPodAllowedForMigration determines whether a given pod is eligible for live migration
 func IsPodAllowedForMigration(pod *corev1.Pod, netInfo util.NetInfo) bool {
-	return IsPodOwnedByVirtualMachine(pod) && netInfo.TopologyType() == ovntypes.Layer2Topology
+	return IsPodOwnedByVirtualMachine(pod) &&
+		(netInfo.TopologyType() == ovntypes.Layer2Topology ||
+			netInfo.TopologyType() == ovntypes.LocalnetTopology)
 }
 
 func isTargetPodReady(targetPod *corev1.Pod) bool {

--- a/go-controller/pkg/kubevirt/pod.go
+++ b/go-controller/pkg/kubevirt/pod.go
@@ -326,6 +326,11 @@ func IsPodOwnedByVirtualMachine(pod *corev1.Pod) bool {
 	return ExtractVMNameFromPod(pod) != nil
 }
 
+// IsPodAllowedForMigration determines whether a given pod is eligible for live migration
+func IsPodAllowedForMigration(pod *corev1.Pod, netInfo util.NetInfo) bool {
+	return IsPodOwnedByVirtualMachine(pod) && netInfo.TopologyType() == ovntypes.Layer2Topology
+}
+
 func isTargetPodReady(targetPod *corev1.Pod) bool {
 	if targetPod == nil {
 		return false
@@ -379,6 +384,11 @@ type LiveMigrationStatus struct {
 	SourcePod *corev1.Pod        // SourcePod is the original pod.
 	TargetPod *corev1.Pod        // TargetPod is the destination pod.
 	State     LiveMigrationState // State is the current state of the live migration.
+}
+
+// IsTargetDomainReady returns true if the target domain in the live migration process is ready.
+func (lm LiveMigrationStatus) IsTargetDomainReady() bool {
+	return lm.State == LiveMigrationTargetDomainReady
 }
 
 // DiscoverLiveMigrationStatus determines the status of a live migration for a given pod.

--- a/go-controller/pkg/kubevirt/pod_test.go
+++ b/go-controller/pkg/kubevirt/pod_test.go
@@ -1,0 +1,212 @@
+package kubevirt
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/rand"
+	kubevirtv1 "kubevirt.io/api/core/v1"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+)
+
+const vmName = "test-vm"
+
+var _ = Describe("Kubevirt Pod", func() {
+	const (
+		t0 = time.Duration(0)
+		t1 = time.Duration(1)
+		t2 = time.Duration(2)
+		t3 = time.Duration(3)
+		t4 = time.Duration(4)
+	)
+	runningKvSourcePod := runningKubevirtPod(t0)
+	successfullyMigratedKvSourcePod := completedKubevirtPod(t1)
+
+	failedMigrationKvTargetPod := failedKubevirtPod(t2)
+	successfulMigrationKvTargetPod := runningKubevirtPod(t3)
+	anotherFailedMigrationKvTargetPod := failedKubevirtPod(t4)
+	duringMigrationKvTargetPod := runningKubevirtPod(t4)
+	yetAnotherDuringMigrationKvTargetPod := runningKubevirtPod(t4)
+	readyMigrationKvTargetPod := domainReadyKubevirtPod(t4)
+
+	type testParams struct {
+		pods                    []corev1.Pod
+		expectedError           error
+		expectedMigrationStatus *LiveMigrationStatus
+	}
+	DescribeTable("DiscoverLiveMigrationStatus", func(params testParams) {
+		Expect(config.PrepareTestConfig()).To(Succeed())
+		config.OVNKubernetesFeature.EnableMultiNetwork = true
+		config.OVNKubernetesFeature.EnableInterconnect = true
+
+		fakeClient := util.GetOVNClientset().GetOVNKubeControllerClientset()
+		wf, err := factory.NewOVNKubeControllerWatchFactory(fakeClient)
+		Expect(err).ToNot(HaveOccurred())
+
+		for _, pod := range params.pods {
+			_, err := fakeClient.KubeClient.CoreV1().Pods(pod.Namespace).Create(context.Background(), &pod, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+		}
+
+		Expect(wf.Start()).To(Succeed())
+		defer wf.Shutdown()
+
+		currentPod := params.pods[0]
+		migrationStatus, err := DiscoverLiveMigrationStatus(wf, &currentPod)
+		if params.expectedError == nil {
+			Expect(err).To(BeNil())
+		} else {
+			Expect(err).To(MatchError(ContainSubstring(params.expectedError.Error())))
+		}
+
+		if params.expectedMigrationStatus == nil {
+			Expect(migrationStatus).To(BeNil())
+		} else {
+			Expect(migrationStatus.State).To(Equal(params.expectedMigrationStatus.State))
+			Expect(migrationStatus.SourcePod.Name).To(Equal(params.expectedMigrationStatus.SourcePod.Name))
+			Expect(migrationStatus.TargetPod.Name).To(Equal(params.expectedMigrationStatus.TargetPod.Name))
+		}
+	},
+		Entry("returns nil when pod is not kubevirt related",
+			testParams{
+				pods: []corev1.Pod{nonKubevirtPod()},
+			},
+		),
+		Entry("returns nil when migration was not performed",
+			testParams{
+				pods: []corev1.Pod{runningKvSourcePod},
+			},
+		),
+		Entry("returns nil when there is no active migration",
+			testParams{
+				pods: []corev1.Pod{successfullyMigratedKvSourcePod, successfulMigrationKvTargetPod},
+			},
+		),
+		Entry("returns nil when there is no active migration (multiple migrations)",
+			testParams{
+				pods: []corev1.Pod{successfullyMigratedKvSourcePod, failedMigrationKvTargetPod, successfulMigrationKvTargetPod},
+			},
+		),
+		Entry("returns Migration in progress status when 2 pods are running, target pod is not yet ready",
+			testParams{
+				pods: []corev1.Pod{runningKvSourcePod, duringMigrationKvTargetPod},
+				expectedMigrationStatus: &LiveMigrationStatus{
+					SourcePod: &runningKvSourcePod,
+					TargetPod: &duringMigrationKvTargetPod,
+					State:     LiveMigrationInProgress,
+				},
+			},
+		),
+		Entry("returns Migration Failed status when latest target pod failed",
+			testParams{
+				pods: []corev1.Pod{runningKvSourcePod, failedMigrationKvTargetPod},
+				expectedMigrationStatus: &LiveMigrationStatus{
+					SourcePod: &runningKvSourcePod,
+					TargetPod: &failedMigrationKvTargetPod,
+					State:     LiveMigrationFailed,
+				},
+			},
+		),
+		Entry("returns Migration Failed status when latest target pod failed (multiple migrations)",
+			testParams{
+				pods: []corev1.Pod{runningKvSourcePod, failedMigrationKvTargetPod, anotherFailedMigrationKvTargetPod},
+				expectedMigrationStatus: &LiveMigrationStatus{
+					SourcePod: &runningKvSourcePod,
+					TargetPod: &anotherFailedMigrationKvTargetPod,
+					State:     LiveMigrationFailed,
+				},
+			},
+		),
+		Entry("returns Migration Ready status when latest target pod is ready",
+			testParams{
+				pods: []corev1.Pod{runningKvSourcePod, readyMigrationKvTargetPod},
+				expectedMigrationStatus: &LiveMigrationStatus{
+					SourcePod: &runningKvSourcePod,
+					TargetPod: &readyMigrationKvTargetPod,
+					State:     LiveMigrationTargetDomainReady,
+				},
+			},
+		),
+		Entry("returns Migration Ready status when latest target pod is ready (multiple migrations)",
+			testParams{
+				pods: []corev1.Pod{runningKvSourcePod, failedMigrationKvTargetPod, readyMigrationKvTargetPod},
+				expectedMigrationStatus: &LiveMigrationStatus{
+					SourcePod: &runningKvSourcePod,
+					TargetPod: &readyMigrationKvTargetPod,
+					State:     LiveMigrationTargetDomainReady,
+				},
+			},
+		),
+		Entry("returns err when kubevirt VM has several living pods and target pod failed",
+			testParams{
+				pods:          []corev1.Pod{runningKvSourcePod, successfulMigrationKvTargetPod, anotherFailedMigrationKvTargetPod},
+				expectedError: fmt.Errorf("unexpected live migration state: should have a single living pod"),
+			},
+		),
+		Entry("returns err when kubevirt VM has several living pods",
+			testParams{
+				pods:          []corev1.Pod{runningKvSourcePod, duringMigrationKvTargetPod, yetAnotherDuringMigrationKvTargetPod},
+				expectedError: fmt.Errorf("unexpected live migration state at pods"),
+			},
+		),
+	)
+})
+
+func completedKubevirtPod(creationOffset time.Duration) corev1.Pod {
+	return newKubevirtPod(corev1.PodSucceeded, nil, creationOffset)
+}
+
+func failedKubevirtPod(creationOffset time.Duration) corev1.Pod {
+	return newKubevirtPod(corev1.PodFailed, nil, creationOffset)
+}
+
+func runningKubevirtPod(creationOffset time.Duration) corev1.Pod {
+	return newKubevirtPod(corev1.PodRunning, nil, creationOffset)
+}
+
+func domainReadyKubevirtPod(creationOffset time.Duration) corev1.Pod {
+	return newKubevirtPod(corev1.PodRunning, map[string]string{kubevirtv1.MigrationTargetReadyTimestamp: "some-timestamp"}, creationOffset)
+}
+
+func nonKubevirtPod() corev1.Pod {
+	return corev1.Pod{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Pod",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "some-pod",
+			Namespace: corev1.NamespaceDefault,
+		},
+		Spec: corev1.PodSpec{},
+	}
+}
+func newKubevirtPod(phase corev1.PodPhase, annotations map[string]string, creationOffset time.Duration) corev1.Pod {
+	return corev1.Pod{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Pod",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "virt-launcher-" + vmName + rand.String(5),
+			Namespace:         corev1.NamespaceDefault,
+			Annotations:       annotations,
+			Labels:            map[string]string{kubevirtv1.VirtualMachineNameLabel: vmName},
+			CreationTimestamp: metav1.Time{Time: time.Now().Add(creationOffset)},
+		},
+		Spec: corev1.PodSpec{},
+		Status: corev1.PodStatus{
+			Phase: phase,
+		},
+	}
+}

--- a/go-controller/pkg/libovsdb/ops/model.go
+++ b/go-controller/pkg/libovsdb/ops/model.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ovn-org/libovsdb/client"
 	"github.com/ovn-org/libovsdb/model"
 	"github.com/ovn-org/libovsdb/ovsdb"
+
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/sbdb"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
@@ -454,6 +455,64 @@ func buildFailOnDuplicateOps(c client.Client, m model.Model) ([]ovsdb.Operation,
 		Value:    value,
 	}
 	return c.WhereAny(m, cond).Wait(ovsdb.WaitConditionNotEqual, &timeout, m, field)
+}
+
+// ModelUpdateField enumeration represents fields that can be updated on the supported models
+type ModelUpdateField int
+
+const (
+	LogicalSwitchPortAddresses ModelUpdateField = iota
+	LogicalSwitchPortType
+	LogicalSwitchPortTagRequest
+	LogicalSwitchPortOptions
+	LogicalSwitchPortPortSecurity
+	LogicalSwitchPortEnabled
+
+	PortGroupACLs
+	PortGroupPorts
+	PortGroupExternalIDs
+)
+
+// getFieldsToUpdate gets a model and a list of ModelUpdateField and returns a list of their related interface{} fields.
+func getFieldsToUpdate(model model.Model, fieldNames []ModelUpdateField) []interface{} {
+	var fields []interface{}
+	switch t := model.(type) {
+	case *nbdb.LogicalSwitchPort:
+		for _, field := range fieldNames {
+			switch field {
+			case LogicalSwitchPortAddresses:
+				fields = append(fields, &t.Addresses)
+			case LogicalSwitchPortType:
+				fields = append(fields, &t.Type)
+			case LogicalSwitchPortTagRequest:
+				fields = append(fields, &t.TagRequest)
+			case LogicalSwitchPortOptions:
+				fields = append(fields, &t.Options)
+			case LogicalSwitchPortPortSecurity:
+				fields = append(fields, &t.PortSecurity)
+			case LogicalSwitchPortEnabled:
+				fields = append(fields, &t.Enabled)
+			default:
+				panic(fmt.Sprintf("getFieldsToUpdate: unknown or unsupported field %q for LogicalSwitchPort", field))
+			}
+		}
+	case *nbdb.PortGroup:
+		for _, field := range fieldNames {
+			switch field {
+			case PortGroupACLs:
+				fields = append(fields, &t.ACLs)
+			case PortGroupPorts:
+				fields = append(fields, &t.Ports)
+			case PortGroupExternalIDs:
+				fields = append(fields, &t.ExternalIDs)
+			default:
+				panic(fmt.Sprintf("getFieldsToUpdate: unknown or unsupported field %q for PortGroup", field))
+			}
+		}
+	default:
+		panic(fmt.Sprintf("getFieldsToUpdate: unknown model type %T", t))
+	}
+	return fields
 }
 
 // getAllUpdatableFields returns a list of all of the columns/fields that can be updated for a model

--- a/go-controller/pkg/libovsdb/ops/switch.go
+++ b/go-controller/pkg/libovsdb/ops/switch.go
@@ -286,28 +286,42 @@ func GetLogicalSwitchPort(nbClient libovsdbclient.Client, lsp *nbdb.LogicalSwitc
 	return found[0], nil
 }
 
-func createOrUpdateLogicalSwitchPortsOps(nbClient libovsdbclient.Client, ops []libovsdb.Operation, sw *nbdb.LogicalSwitch, createSwitch bool, lsps ...*nbdb.LogicalSwitchPort) ([]libovsdb.Operation, error) {
+func createOrUpdateLogicalSwitchPortOpModelWithCustomFields(sw *nbdb.LogicalSwitch, lsp *nbdb.LogicalSwitchPort, createLSP bool, customFields []ModelUpdateField) operationModel {
+	var fieldInterfaces []interface{}
+	if len(customFields) != 0 {
+		fieldInterfaces = getFieldsToUpdate(lsp, customFields)
+	} else {
+		fieldInterfaces = getAllUpdatableFields(lsp)
+	}
+	return operationModel{
+		Model:          lsp,
+		OnModelUpdates: fieldInterfaces,
+		DoAfter: func() {
+			// lsp.UUID should be set here
+			sw.Ports = append(sw.Ports, lsp.UUID)
+		},
+		ErrNotFound: !createLSP,
+		BulkOp:      false,
+	}
+}
+
+func createOrUpdateLogicalSwitchPortsOps(nbClient libovsdbclient.Client, ops []libovsdb.Operation, sw *nbdb.LogicalSwitch, createSwitch, createLSP bool, customFields []ModelUpdateField, lsps ...*nbdb.LogicalSwitchPort) ([]libovsdb.Operation, error) {
 	originalPorts := sw.Ports
 	sw.Ports = make([]string, 0, len(lsps))
 	opModels := make([]operationModel, 0, len(lsps)+1)
-	for i := range lsps {
-		lsp := lsps[i]
-		opModel := operationModel{
-			Model:          lsp,
-			OnModelUpdates: getAllUpdatableFields(lsp),
-			DoAfter:        func() { sw.Ports = append(sw.Ports, lsp.UUID) },
-			ErrNotFound:    false,
-			BulkOp:         false,
-		}
+
+	for _, lsp := range lsps {
+		opModel := createOrUpdateLogicalSwitchPortOpModelWithCustomFields(sw, lsp, createLSP, customFields)
 		opModels = append(opModels, opModel)
 	}
-	opModel := operationModel{
+
+	opModelSwitch := operationModel{
 		Model:            sw,
 		OnModelMutations: []interface{}{&sw.Ports},
 		ErrNotFound:      !createSwitch,
 		BulkOp:           false,
 	}
-	opModels = append(opModels, opModel)
+	opModels = append(opModels, opModelSwitch)
 
 	m := newModelClient(nbClient)
 	ops, err := m.CreateOrUpdateOps(ops, opModels...)
@@ -316,7 +330,7 @@ func createOrUpdateLogicalSwitchPortsOps(nbClient libovsdbclient.Client, ops []l
 }
 
 func createOrUpdateLogicalSwitchPorts(nbClient libovsdbclient.Client, sw *nbdb.LogicalSwitch, createSwitch bool, lsps ...*nbdb.LogicalSwitchPort) error {
-	ops, err := createOrUpdateLogicalSwitchPortsOps(nbClient, nil, sw, createSwitch, lsps...)
+	ops, err := createOrUpdateLogicalSwitchPortsOps(nbClient, nil, sw, createSwitch, true, nil, lsps...)
 	if err != nil {
 		return err
 	}
@@ -325,11 +339,18 @@ func createOrUpdateLogicalSwitchPorts(nbClient libovsdbclient.Client, sw *nbdb.L
 	return err
 }
 
-// CreateOrUpdateLogicalSwitchPortsOnSwitchOps creates or updates the provided
+// CreateOrUpdateLogicalSwitchPortsOnSwitchWithCustomFieldsOps creates or updates the provided
 // logical switch ports, adds them to the provided logical switch and returns
 // the corresponding ops
-func CreateOrUpdateLogicalSwitchPortsOnSwitchOps(nbClient libovsdbclient.Client, ops []libovsdb.Operation, sw *nbdb.LogicalSwitch, lsps ...*nbdb.LogicalSwitchPort) ([]libovsdb.Operation, error) {
-	return createOrUpdateLogicalSwitchPortsOps(nbClient, ops, sw, false, lsps...)
+func CreateOrUpdateLogicalSwitchPortsOnSwitchWithCustomFieldsOps(nbClient libovsdbclient.Client, ops []libovsdb.Operation, sw *nbdb.LogicalSwitch, customFields []ModelUpdateField, lsps ...*nbdb.LogicalSwitchPort) ([]libovsdb.Operation, error) {
+	return createOrUpdateLogicalSwitchPortsOps(nbClient, ops, sw, false, true, customFields, lsps...)
+}
+
+// UpdateLogicalSwitchPortsOnSwitchWithCustomFieldsOps updates the provided
+// logical switch ports, adds them to the provided logical switch and returns
+// the corresponding ops
+func UpdateLogicalSwitchPortsOnSwitchWithCustomFieldsOps(nbClient libovsdbclient.Client, ops []libovsdb.Operation, sw *nbdb.LogicalSwitch, customFields []ModelUpdateField, lsps ...*nbdb.LogicalSwitchPort) ([]libovsdb.Operation, error) {
+	return createOrUpdateLogicalSwitchPortsOps(nbClient, ops, sw, false, false, customFields, lsps...)
 }
 
 // CreateOrUpdateLogicalSwitchPortsOnSwitch creates or updates the provided

--- a/go-controller/pkg/ovn/base_network_controller_pods.go
+++ b/go-controller/pkg/ovn/base_network_controller_pods.go
@@ -443,7 +443,7 @@ func (bnc *BaseNetworkController) ensurePodAnnotation(pod *kapi.Pod, nadName str
 }
 
 func (bnc *BaseNetworkController) addLogicalPortToNetwork(pod *kapi.Pod, nadName string,
-	network *nadapi.NetworkSelectionElement) (ops []ovsdb.Operation,
+	network *nadapi.NetworkSelectionElement, enable *bool) (ops []ovsdb.Operation,
 	lsp *nbdb.LogicalSwitchPort, podAnnotation *util.PodAnnotation, newlyCreatedPort bool, err error) {
 	var ls *nbdb.LogicalSwitch
 
@@ -587,6 +587,10 @@ func (bnc *BaseNetworkController) addLogicalPortToNetwork(pod *kapi.Pod, nadName
 		customFields = append(customFields, libovsdbops.LogicalSwitchPortOptions)
 	}
 
+	lsp.Enabled = enable
+	if lsp.Enabled != nil {
+		customFields = append(customFields, libovsdbops.LogicalSwitchPortEnabled)
+	}
 	ops, err = libovsdbops.CreateOrUpdateLogicalSwitchPortsOnSwitchWithCustomFieldsOps(bnc.nbClient, nil, ls, customFields, lsp)
 	if err != nil {
 		return nil, nil, nil, false,

--- a/go-controller/pkg/ovn/base_network_controller_pods.go
+++ b/go-controller/pkg/ovn/base_network_controller_pods.go
@@ -550,15 +550,25 @@ func (bnc *BaseNetworkController) addLogicalPortToNetwork(pod *kapi.Pod, nadName
 		return nil, nil, nil, false, err
 	}
 
-	// set addresses on the port
-	// LSP addresses in OVN are a single space-separated value
+	lsp.Enabled = enable
+	if lsp.Enabled != nil {
+		customFields = append(customFields, libovsdbops.LogicalSwitchPortEnabled)
+	}
+
 	addresses = []string{podAnnotation.MAC.String()}
 	for _, podIfAddr := range podAnnotation.IPs {
 		addresses[0] = addresses[0] + " " + podIfAddr.IP.String()
 	}
 
-	lsp.Addresses = addresses
-	customFields = append(customFields, libovsdbops.LogicalSwitchPortAddresses)
+	// Skip address configuration if LSP is disabled since it will install
+	// l2 look up flows that harms some topologies
+	if lsp.Enabled == nil || *lsp.Enabled {
+		// set addresses on the port
+		// LSP addresses in OVN are a single space-separated value
+
+		lsp.Addresses = addresses
+		customFields = append(customFields, libovsdbops.LogicalSwitchPortAddresses)
+	}
 
 	// add external ids
 	lsp.ExternalIDs = map[string]string{"namespace": pod.Namespace, "pod": "true"}
@@ -585,11 +595,6 @@ func (bnc *BaseNetworkController) addLogicalPortToNetwork(pod *kapi.Pod, nadName
 	}
 	if len(lsp.Options) != 0 {
 		customFields = append(customFields, libovsdbops.LogicalSwitchPortOptions)
-	}
-
-	lsp.Enabled = enable
-	if lsp.Enabled != nil {
-		customFields = append(customFields, libovsdbops.LogicalSwitchPortEnabled)
 	}
 	ops, err = libovsdbops.CreateOrUpdateLogicalSwitchPortsOnSwitchWithCustomFieldsOps(bnc.nbClient, nil, ls, customFields, lsp)
 	if err != nil {

--- a/go-controller/pkg/ovn/base_network_controller_secondary.go
+++ b/go-controller/pkg/ovn/base_network_controller_secondary.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ovn-org/libovsdb/ovsdb"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kubevirt"
 	libovsdbops "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdb/ops"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/metrics"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
@@ -26,6 +27,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
 )
 
 func (bsnc *BaseSecondaryNetworkController) getPortInfoForSecondaryNetwork(pod *kapi.Pod) map[string]*lpInfo {
@@ -225,12 +227,28 @@ func (bsnc *BaseSecondaryNetworkController) ensurePodForSecondaryNetwork(pod *ka
 		return nil
 	}
 
-	if util.PodWantsHostNetwork(pod) && !addPort {
+	if util.PodWantsHostNetwork(pod) {
+		return nil
+	}
+
+	var kubevirtLiveMigrationStatus *kubevirt.LiveMigrationStatus
+	var err error
+
+	if kubevirt.IsPodAllowedForMigration(pod, bsnc.NetInfo) {
+		kubevirtLiveMigrationStatus, err = kubevirt.DiscoverLiveMigrationStatus(bsnc.watchFactory, pod)
+		if err != nil {
+			return fmt.Errorf("failed to discover Live-migration status: %w", err)
+		}
+	}
+	updatePort := kubevirtLiveMigrationStatus != nil && pod.Name == kubevirtLiveMigrationStatus.TargetPod.Name
+
+	if !addPort && !updatePort {
 		return nil
 	}
 
 	// If a node does not have an assigned hostsubnet don't wait for the logical switch to appear
-	switchName, err := bsnc.getExpectedSwitchName(pod)
+	var switchName string
+	switchName, err = bsnc.getExpectedSwitchName(pod)
 	if err != nil {
 		return err
 	}
@@ -258,7 +276,7 @@ func (bsnc *BaseSecondaryNetworkController) ensurePodForSecondaryNetwork(pod *ka
 
 	var errs []error
 	for nadName, network := range networkMap {
-		if err = bsnc.addLogicalPortToNetworkForNAD(pod, nadName, switchName, network); err != nil {
+		if err = bsnc.addLogicalPortToNetworkForNAD(pod, nadName, switchName, network, kubevirtLiveMigrationStatus); err != nil {
 			errs = append(errs, fmt.Errorf("failed to add logical port of Pod %s/%s for NAD %s: %w", pod.Namespace, pod.Name, nadName, err))
 		}
 	}
@@ -269,7 +287,7 @@ func (bsnc *BaseSecondaryNetworkController) ensurePodForSecondaryNetwork(pod *ka
 }
 
 func (bsnc *BaseSecondaryNetworkController) addLogicalPortToNetworkForNAD(pod *kapi.Pod, nadName, switchName string,
-	network *nadapi.NetworkSelectionElement) error {
+	network *nadapi.NetworkSelectionElement, kubevirtLiveMigrationStatus *kubevirt.LiveMigrationStatus) error {
 	var libovsdbExecuteTime time.Duration
 
 	start := time.Now()
@@ -284,6 +302,15 @@ func (bsnc *BaseSecondaryNetworkController) addLogicalPortToNetworkForNAD(pod *k
 	var lsp *nbdb.LogicalSwitchPort
 	var newlyCreated bool
 
+	var lspEnabled *bool
+	// actions on the pods' LSP are only triggerred from the target pod
+	shouldHandleLiveMigration := kubevirtLiveMigrationStatus != nil && pod.Name == kubevirtLiveMigrationStatus.TargetPod.Name
+	if shouldHandleLiveMigration {
+		// LSP should be altered inside addLogicalPortToNetwork() before ops are generated because one cannot append
+		// multiple ops regarding the same object in the same transact, so passing enabled parameter.
+		lspEnabled = ptr.To(kubevirtLiveMigrationStatus.IsTargetDomainReady())
+	}
+
 	// we need to create a logical port for all local pods
 	// we also need to create a remote logical port for remote pods on layer2
 	// topologies with interconnect
@@ -291,7 +318,7 @@ func (bsnc *BaseSecondaryNetworkController) addLogicalPortToNetworkForNAD(pod *k
 	requiresLogicalPort := isLocalPod || bsnc.isLayer2Interconnect()
 
 	if requiresLogicalPort {
-		ops, lsp, podAnnotation, newlyCreated, err = bsnc.addLogicalPortToNetwork(pod, nadName, network)
+		ops, lsp, podAnnotation, newlyCreated, err = bsnc.addLogicalPortToNetwork(pod, nadName, network, lspEnabled)
 		if err != nil {
 			return err
 		}
@@ -313,6 +340,14 @@ func (bsnc *BaseSecondaryNetworkController) addLogicalPortToNetworkForNAD(pod *k
 			return err
 		}
 		bsnc.logicalPortCache.remove(pod, nadName)
+	}
+
+	if shouldHandleLiveMigration &&
+		kubevirtLiveMigrationStatus.IsTargetDomainReady() {
+		ops, err = bsnc.disableLiveMigrationSourceLSPOps(kubevirtLiveMigrationStatus, nadName, ops)
+		if err != nil {
+			return fmt.Errorf("failed to create LSP ops for source pod during Live-migration status: %w", err)
+		}
 	}
 
 	if podAnnotation == nil {
@@ -669,4 +704,28 @@ func (oc *BaseSecondaryNetworkController) allowPersistentIPs() bool {
 		oc.NetInfo.AllowsPersistentIPs() &&
 		util.DoesNetworkRequireIPAM(oc.NetInfo) &&
 		(oc.NetInfo.TopologyType() == types.Layer2Topology || oc.NetInfo.TopologyType() == types.LocalnetTopology)
+}
+
+func (bsnc *BaseSecondaryNetworkController) setPodLogicalSwitchPortEnabledField(
+	pod *kapi.Pod, nadName string, ops []ovsdb.Operation, enabled bool) ([]ovsdb.Operation, *nbdb.LogicalSwitchPort, error) {
+	lsp := &nbdb.LogicalSwitchPort{Name: bsnc.GetLogicalPortName(pod, nadName)}
+	lsp.Enabled = ptr.To(enabled)
+	switchName, err := bsnc.getExpectedSwitchName(pod)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to fetch switch name for pod %s: %w", pod.Name, err)
+	}
+	customFields := []libovsdbops.ModelUpdateField{libovsdbops.LogicalSwitchPortEnabled}
+	ops, err = libovsdbops.UpdateLogicalSwitchPortsOnSwitchWithCustomFieldsOps(bsnc.nbClient, ops, &nbdb.LogicalSwitch{Name: switchName}, customFields, lsp)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed updating logical switch port %+v on switch %s: %w", *lsp, switchName, err)
+	}
+	return ops, lsp, nil
+}
+
+func (bsnc *BaseSecondaryNetworkController) disableLiveMigrationSourceLSPOps(
+	kubevirtLiveMigrationStatus *kubevirt.LiveMigrationStatus,
+	nadName string, ops []ovsdb.Operation) ([]ovsdb.Operation, error) {
+	// closing the sourcePod lsp to ensure traffic goes to the now ready targetPod.
+	ops, _, err := bsnc.setPodLogicalSwitchPortEnabledField(kubevirtLiveMigrationStatus.SourcePod, nadName, ops, false)
+	return ops, err
 }

--- a/go-controller/pkg/ovn/base_network_controller_secondary.go
+++ b/go-controller/pkg/ovn/base_network_controller_secondary.go
@@ -343,7 +343,9 @@ func (bsnc *BaseSecondaryNetworkController) addLogicalPortToNetworkForNAD(pod *k
 	}
 
 	if shouldHandleLiveMigration &&
-		kubevirtLiveMigrationStatus.IsTargetDomainReady() {
+		kubevirtLiveMigrationStatus.IsTargetDomainReady() &&
+		// At localnet there is no source pod remote LSP so it should be skipped
+		(bsnc.TopologyType() != types.LocalnetTopology || bsnc.isPodScheduledinLocalZone(kubevirtLiveMigrationStatus.SourcePod)) {
 		ops, err = bsnc.disableLiveMigrationSourceLSPOps(kubevirtLiveMigrationStatus, nadName, ops)
 		if err != nil {
 			return fmt.Errorf("failed to create LSP ops for source pod during Live-migration status: %w", err)

--- a/go-controller/pkg/ovn/base_network_controller_secondary.go
+++ b/go-controller/pkg/ovn/base_network_controller_secondary.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"reflect"
+	"strings"
 	"time"
 
 	ipamclaimsapi "github.com/k8snetworkplumbingwg/ipamclaims/pkg/crd/ipamclaims/v1alpha1"
@@ -436,7 +437,7 @@ func (bsnc *BaseSecondaryNetworkController) removePodForSecondaryNetwork(pod *ka
 	if portInfoMap == nil {
 		portInfoMap = map[string]*lpInfo{}
 	}
-	for nadName := range podNetworks {
+	for nadName, podAnnotation := range podNetworks {
 		if !bsnc.HasNAD(nadName) {
 			continue
 		}
@@ -447,7 +448,7 @@ func (bsnc *BaseSecondaryNetworkController) removePodForSecondaryNetwork(pod *ka
 		}
 
 		if kubevirt.IsPodAllowedForMigration(pod, bsnc.NetInfo) {
-			if err = bsnc.enableSourceLSPFailedLiveMigration(pod, nadName); err != nil {
+			if err = bsnc.enableSourceLSPFailedLiveMigration(pod, nadName, podAnnotation.MAC, podAnnotation.IPs); err != nil {
 				return err
 			}
 		}
@@ -713,15 +714,34 @@ func (oc *BaseSecondaryNetworkController) allowPersistentIPs() bool {
 		(oc.NetInfo.TopologyType() == types.Layer2Topology || oc.NetInfo.TopologyType() == types.LocalnetTopology)
 }
 
-func (bsnc *BaseSecondaryNetworkController) setPodLogicalSwitchPortEnabledField(
-	pod *kapi.Pod, nadName string, ops []ovsdb.Operation, enabled bool) ([]ovsdb.Operation, *nbdb.LogicalSwitchPort, error) {
+func (bsnc *BaseSecondaryNetworkController) setPodLogicalSwitchPortAddressesAndEnabledField(
+	pod *kapi.Pod, nadName string, mac string, ips []string, enabled bool, ops []ovsdb.Operation) ([]ovsdb.Operation, *nbdb.LogicalSwitchPort, error) {
 	lsp := &nbdb.LogicalSwitchPort{Name: bsnc.GetLogicalPortName(pod, nadName)}
 	lsp.Enabled = ptr.To(enabled)
+	customFields := []libovsdbops.ModelUpdateField{
+		libovsdbops.LogicalSwitchPortEnabled,
+		libovsdbops.LogicalSwitchPortAddresses,
+	}
+	if !enabled {
+		lsp.Addresses = nil
+	} else {
+		if len(mac) == 0 || len(ips) == 0 {
+			return nil, nil, fmt.Errorf("failed to configure addresses for lsp, missing mac and ips for pod %s", pod.Name)
+		}
+
+		// Remove length
+		for i, ip := range ips {
+			ips[i] = strings.Split(ip, "/")[0]
+		}
+
+		lsp.Addresses = []string{
+			strings.Join(append([]string{mac}, ips...), " "),
+		}
+	}
 	switchName, err := bsnc.getExpectedSwitchName(pod)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to fetch switch name for pod %s: %w", pod.Name, err)
 	}
-	customFields := []libovsdbops.ModelUpdateField{libovsdbops.LogicalSwitchPortEnabled}
 	ops, err = libovsdbops.UpdateLogicalSwitchPortsOnSwitchWithCustomFieldsOps(bsnc.nbClient, ops, &nbdb.LogicalSwitch{Name: switchName}, customFields, lsp)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed updating logical switch port %+v on switch %s: %w", *lsp, switchName, err)
@@ -733,11 +753,11 @@ func (bsnc *BaseSecondaryNetworkController) disableLiveMigrationSourceLSPOps(
 	kubevirtLiveMigrationStatus *kubevirt.LiveMigrationStatus,
 	nadName string, ops []ovsdb.Operation) ([]ovsdb.Operation, error) {
 	// closing the sourcePod lsp to ensure traffic goes to the now ready targetPod.
-	ops, _, err := bsnc.setPodLogicalSwitchPortEnabledField(kubevirtLiveMigrationStatus.SourcePod, nadName, ops, false)
+	ops, _, err := bsnc.setPodLogicalSwitchPortAddressesAndEnabledField(kubevirtLiveMigrationStatus.SourcePod, nadName, "", nil, false, ops)
 	return ops, err
 }
 
-func (bsnc *BaseSecondaryNetworkController) enableSourceLSPFailedLiveMigration(pod *kapi.Pod, nadName string) error {
+func (bsnc *BaseSecondaryNetworkController) enableSourceLSPFailedLiveMigration(pod *kapi.Pod, nadName string, mac string, ips []string) error {
 	kubevirtLiveMigrationStatus, err := kubevirt.DiscoverLiveMigrationStatus(bsnc.watchFactory, pod)
 	if err != nil {
 		return fmt.Errorf("failed to discover Live-migration status after pod termination: %w", err)
@@ -748,7 +768,7 @@ func (bsnc *BaseSecondaryNetworkController) enableSourceLSPFailedLiveMigration(p
 		return nil
 	}
 	// make sure sourcePod lsp is enabled if migration failed after DomainReady was set.
-	ops, sourcePodLsp, err := bsnc.setPodLogicalSwitchPortEnabledField(kubevirtLiveMigrationStatus.SourcePod, nadName, nil, true)
+	ops, sourcePodLsp, err := bsnc.setPodLogicalSwitchPortAddressesAndEnabledField(kubevirtLiveMigrationStatus.SourcePod, nadName, mac, ips, true, nil)
 	if err != nil {
 		return fmt.Errorf("failed to set source Pod lsp to enabled after migration failed: %w", err)
 	}

--- a/go-controller/pkg/ovn/base_network_controller_secondary.go
+++ b/go-controller/pkg/ovn/base_network_controller_secondary.go
@@ -444,6 +444,11 @@ func (bsnc *BaseSecondaryNetworkController) removePodForSecondaryNetwork(pod *ka
 			return err
 		}
 
+		if kubevirt.IsPodAllowedForMigration(pod, bsnc.NetInfo) {
+			if err = bsnc.enableSourceLSPFailedLiveMigration(pod, nadName); err != nil {
+				return err
+			}
+		}
 		bsnc.logicalPortCache.remove(pod, nadName)
 		pInfo, err := bsnc.deletePodLogicalPort(pod, portInfoMap[nadName], nadName)
 		if err != nil {
@@ -728,4 +733,27 @@ func (bsnc *BaseSecondaryNetworkController) disableLiveMigrationSourceLSPOps(
 	// closing the sourcePod lsp to ensure traffic goes to the now ready targetPod.
 	ops, _, err := bsnc.setPodLogicalSwitchPortEnabledField(kubevirtLiveMigrationStatus.SourcePod, nadName, ops, false)
 	return ops, err
+}
+
+func (bsnc *BaseSecondaryNetworkController) enableSourceLSPFailedLiveMigration(pod *kapi.Pod, nadName string) error {
+	kubevirtLiveMigrationStatus, err := kubevirt.DiscoverLiveMigrationStatus(bsnc.watchFactory, pod)
+	if err != nil {
+		return fmt.Errorf("failed to discover Live-migration status after pod termination: %w", err)
+	}
+	if kubevirtLiveMigrationStatus == nil ||
+		pod.Name != kubevirtLiveMigrationStatus.TargetPod.Name ||
+		kubevirtLiveMigrationStatus.State != kubevirt.LiveMigrationFailed {
+		return nil
+	}
+	// make sure sourcePod lsp is enabled if migration failed after DomainReady was set.
+	ops, sourcePodLsp, err := bsnc.setPodLogicalSwitchPortEnabledField(kubevirtLiveMigrationStatus.SourcePod, nadName, nil, true)
+	if err != nil {
+		return fmt.Errorf("failed to set source Pod lsp to enabled after migration failed: %w", err)
+	}
+	_, err = libovsdbops.TransactAndCheckAndSetUUIDs(bsnc.nbClient, sourcePodLsp, ops)
+	if err != nil {
+		return fmt.Errorf("failed transacting operations %+v: %w", ops, err)
+	}
+
+	return nil
 }

--- a/go-controller/pkg/ovn/multihoming_test.go
+++ b/go-controller/pkg/ovn/multihoming_test.go
@@ -1,6 +1,22 @@
 package ovn
 
-import "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"strings"
+
+	nadapi "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+
+	v1 "k8s.io/api/core/v1"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
+	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
+	libovsdbtest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
+	ovntypes "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+)
 
 func (p testPod) addNetwork(
 	netName, nadName, nodeSubnet, nodeMgtIP, nodeGWIP, podIP, podMAC, role string,
@@ -13,19 +29,22 @@ func (p testPod) addNetwork(
 			nodeSubnet:  nodeSubnet,
 			nodeMgtIP:   nodeMgtIP,
 			nodeGWIP:    nodeGWIP,
-			role:        role,
 			routes:      routes,
 			allportInfo: map[string]portInfo{},
 		}
 		p.secondaryPodInfos[netName] = podInfo
 	}
+
+	prefixLen, ip := splitPodIPMaskLength(podIP)
+
 	portName := util.GetSecondaryNetworkLogicalPortName(p.namespace, p.podName, nadName)
 	podInfo.allportInfo[nadName] = portInfo{
-		portUUID: portName + "-UUID",
-		podIP:    podIP,
-		podMAC:   podMAC,
-		portName: portName,
-		tunnelID: tunnelID,
+		portUUID:  portName + "-UUID",
+		podIP:     ip,
+		podMAC:    podMAC,
+		portName:  portName,
+		tunnelID:  tunnelID,
+		prefixLen: prefixLen,
 	}
 }
 
@@ -40,4 +59,301 @@ func (p testPod) getNetworkPortInfo(netName, nadName string) *portInfo {
 	}
 
 	return &info
+}
+
+func splitPodIPMaskLength(podIP string) (int, string) {
+	var prefixLen int
+	ip, ipNet, err := net.ParseCIDR(podIP)
+	if err != nil || ipNet == nil {
+		return 0, podIP // falling back to the test's default - e.g. 24 for v4 / 64 for v6
+	}
+	prefixLen, _ = ipNet.Mask.Size()
+	return prefixLen, ip.String()
+}
+
+type option func(machine *secondaryNetworkExpectationMachine)
+
+type secondaryNetworkExpectationMachine struct {
+	fakeOvn               *FakeOVN
+	pods                  []testPod
+	isInterconnectCluster bool
+}
+
+func newSecondaryNetworkExpectationMachine(fakeOvn *FakeOVN, pods []testPod, opts ...option) *secondaryNetworkExpectationMachine {
+	machine := &secondaryNetworkExpectationMachine{
+		fakeOvn: fakeOvn,
+		pods:    pods,
+	}
+
+	for _, opt := range opts {
+		opt(machine)
+	}
+	return machine
+}
+
+func withInterconnectCluster() option {
+	return func(machine *secondaryNetworkExpectationMachine) {
+		machine.isInterconnectCluster = true
+	}
+}
+
+func (em *secondaryNetworkExpectationMachine) expectedLogicalSwitchesAndPorts() []libovsdbtest.TestData {
+	data := []libovsdbtest.TestData{}
+	for _, ocInfo := range em.fakeOvn.secondaryControllers {
+		nodeslsps := make(map[string][]string)
+		acls := make(map[string][]string)
+		var switchName string
+		for _, pod := range em.pods {
+			podInfo, ok := pod.secondaryPodInfos[ocInfo.bnc.GetNetworkName()]
+			if !ok {
+				continue
+			}
+			subnets := podInfo.nodeSubnet
+			var (
+				subnet     *net.IPNet
+				hasSubnets bool
+			)
+			if len(subnets) > 0 {
+				subnet = ovntest.MustParseIPNet(subnets)
+				hasSubnets = true
+			}
+
+			for nad, portInfo := range podInfo.allportInfo {
+				portName := portInfo.portName
+				var lspUUID string
+				if len(portInfo.portUUID) == 0 {
+					lspUUID = portName + "-UUID"
+				} else {
+					lspUUID = portInfo.portUUID
+				}
+				podAddr := fmt.Sprintf("%s %s", portInfo.podMAC, portInfo.podIP)
+				lsp := newExpectedSwitchPort(lspUUID, portName, podAddr, pod, ocInfo.bnc, nad)
+
+				if pod.noIfaceIdVer {
+					delete(lsp.Options, "iface-id-ver")
+				}
+				if ocInfo.bnc.isLayer2Interconnect() {
+					lsp.Options["requested-tnl-key"] = "1" // hardcode this for now.
+				}
+				data = append(data, lsp)
+				switch ocInfo.bnc.TopologyType() {
+				case ovntypes.Layer3Topology:
+					switchName = ocInfo.bnc.GetNetworkScopedName(pod.nodeName)
+
+					switchToRouterPortName := "stor-" + switchName
+					switchToRouterPortUUID := switchToRouterPortName + "-UUID"
+					data = append(data, newExpectedSwitchToRouterPort(switchToRouterPortUUID, switchToRouterPortName, pod, ocInfo.bnc, nad))
+					nodeslsps[switchName] = append(nodeslsps[switchName], switchToRouterPortUUID)
+
+				case ovntypes.Layer2Topology:
+					switchName = ocInfo.bnc.GetNetworkScopedName(ovntypes.OVNLayer2Switch)
+
+				case ovntypes.LocalnetTopology:
+					switchName = ocInfo.bnc.GetNetworkScopedName(ovntypes.OVNLocalnetSwitch)
+				}
+				nodeslsps[switchName] = append(nodeslsps[switchName], lspUUID)
+			}
+
+			var otherConfig map[string]string
+			if hasSubnets {
+				otherConfig = map[string]string{
+					"exclude_ips": managementPortIP(subnet).String(),
+					"subnet":      subnet.String(),
+				}
+			}
+
+			// TODO: once we start the "full" SecondaryLayer2NetworkController (instead of just Base)
+			// we can drop this, and compare all objects created by the controller (right now we're
+			// missing all the meters, and the COPP)
+			if ocInfo.bnc.TopologyType() == ovntypes.Layer2Topology {
+				otherConfig = nil
+			}
+
+			data = append(data, &nbdb.LogicalSwitch{
+				UUID:  switchName + "-UUID",
+				Name:  switchName,
+				Ports: nodeslsps[switchName],
+				ExternalIDs: map[string]string{
+					ovntypes.NetworkExternalID: ocInfo.bnc.GetNetworkName(),
+				},
+				OtherConfig: otherConfig,
+				ACLs:        acls[switchName],
+			})
+
+			if em.isInterconnectCluster && ocInfo.bnc.TopologyType() == ovntypes.Layer3Topology {
+				transitSwitchName := ocInfo.bnc.GetNetworkName() + "_transit_switch"
+				data = append(data, &nbdb.LogicalSwitch{
+					UUID: transitSwitchName + "-UUID",
+					Name: transitSwitchName,
+					OtherConfig: map[string]string{
+						"mcast_querier":            "false",
+						"mcast_flood_unregistered": "true",
+						"interconn-ts":             transitSwitchName,
+						"requested-tnl-key":        "16711685",
+						"mcast_snoop":              "true",
+					},
+				})
+			}
+		}
+
+	}
+	return data
+}
+
+func newExpectedSwitchPort(lspUUID string, portName string, podAddr string, pod testPod, netInfo util.NetInfo, nad string) *nbdb.LogicalSwitchPort {
+	return &nbdb.LogicalSwitchPort{
+		UUID:      lspUUID,
+		Name:      portName,
+		Addresses: []string{podAddr},
+		ExternalIDs: map[string]string{
+			"pod":                       "true",
+			"namespace":                 pod.namespace,
+			ovntypes.NetworkExternalID:  netInfo.GetNetworkName(),
+			ovntypes.NADExternalID:      nad,
+			ovntypes.TopologyExternalID: netInfo.TopologyType(),
+		},
+		Options: map[string]string{
+			"requested-chassis": pod.nodeName,
+			"iface-id-ver":      pod.podName,
+		},
+		PortSecurity: []string{podAddr},
+	}
+}
+
+func newExpectedSwitchToRouterPort(lspUUID string, portName string, pod testPod, netInfo util.NetInfo, nad string) *nbdb.LogicalSwitchPort {
+	lrp := newExpectedSwitchPort(lspUUID, portName, "router", pod, netInfo, nad)
+	lrp.ExternalIDs = nil
+	lrp.Options = map[string]string{
+		"router-port": "rtos-isolatednet_test-node",
+		"arp_proxy":   "0a:58:a9:fe:01:01 169.254.1.1 fe80::1 10.128.0.0/14",
+	}
+	lrp.PortSecurity = nil
+	lrp.Type = "router"
+	return lrp
+}
+
+func managementPortIP(subnet *net.IPNet) net.IP {
+	return util.GetNodeManagementIfAddr(subnet).IP
+}
+
+func minimalFeatureConfig() *config.OVNKubernetesFeatureConfig {
+	return &config.OVNKubernetesFeatureConfig{
+		EnableMultiNetwork: true,
+	}
+}
+
+func enableICFeatureConfig() *config.OVNKubernetesFeatureConfig {
+	featConfig := minimalFeatureConfig()
+	featConfig.EnableInterconnect = true
+	return featConfig
+}
+
+func icClusterTestConfiguration() testConfiguration {
+	return testConfiguration{
+		configToOverride:   enableICFeatureConfig(),
+		expectationOptions: []option{withInterconnectCluster()},
+	}
+}
+
+func nonICClusterTestConfiguration() testConfiguration {
+	return testConfiguration{}
+}
+
+func icClusterWithDisableSNATTestConfiguration() testConfiguration {
+	return testConfiguration{
+		configToOverride:   enableICFeatureConfig(),
+		expectationOptions: []option{withInterconnectCluster()},
+	}
+}
+
+func newMultiHomedPod(testPod testPod, multiHomingConfigs ...secondaryNetInfo) *v1.Pod {
+	pod := newPod(testPod.namespace, testPod.podName, testPod.nodeName, testPod.podIP)
+	var secondaryNetworks []nadapi.NetworkSelectionElement
+	for _, multiHomingConf := range multiHomingConfigs {
+		nadNamePair := strings.Split(multiHomingConf.nadName, "/")
+		ns := pod.Namespace
+		attachmentName := multiHomingConf.nadName
+		if len(nadNamePair) > 1 {
+			ns = nadNamePair[0]
+			attachmentName = nadNamePair[1]
+		}
+		nse := nadapi.NetworkSelectionElement{
+			Name:      attachmentName,
+			Namespace: ns,
+		}
+		secondaryNetworks = append(secondaryNetworks, nse)
+	}
+	serializedNetworkSelectionElements, _ := json.Marshal(secondaryNetworks)
+	pod.Annotations = map[string]string{nadapi.NetworkAttachmentAnnot: string(serializedNetworkSelectionElements)}
+	if config.OVNKubernetesFeature.EnableInterconnect {
+		dummyOVNNetAnnotations := dummyOVNPodNetworkAnnotations(testPod.secondaryPodInfos, multiHomingConfigs)
+		if dummyOVNNetAnnotations != "{}" {
+			pod.Annotations["k8s.ovn.org/pod-networks"] = dummyOVNNetAnnotations
+		}
+	}
+	return pod
+}
+
+func dummyOVNPodNetworkAnnotations(secondaryPodInfos map[string]*secondaryPodInfo, multiHomingConfigs []secondaryNetInfo) string {
+	var ovnPodNetworksAnnotations []byte
+	podAnnotations := map[string]podAnnotation{}
+	for i, netConfig := range multiHomingConfigs {
+		// we need to inject a dummy OVN annotation into the pods for each multihoming config
+		// for layer2 topology since allocating the annotation for this cluster configuration
+		// is performed by cluster manager - which doesn't exist in the unit tests.
+		if netConfig.topology == ovntypes.Layer2Topology {
+			portInfo := secondaryPodInfos[netConfig.netName].allportInfo[netConfig.nadName]
+			podAnnotations[netConfig.nadName] = dummyOVNPodNetworkAnnotationForNetwork(portInfo, netConfig, i+1)
+		}
+	}
+
+	var err error
+	ovnPodNetworksAnnotations, err = json.Marshal(podAnnotations)
+	if err != nil {
+		panic(fmt.Errorf("failed to marshal the pod annotations: %w", err))
+	}
+	return string(ovnPodNetworksAnnotations)
+}
+
+func dummyOVNPodNetworkAnnotationForNetwork(portInfo portInfo, netConfig secondaryNetInfo, tunnelID int) podAnnotation {
+	var gateways []string
+	for _, subnetStr := range strings.Split(netConfig.subnets, ",") {
+		subnet := ovntest.MustParseIPNet(subnetStr)
+		gateways = append(gateways, util.GetNodeGatewayIfAddr(subnet).IP.String())
+	}
+	ip := ovntest.MustParseIP(portInfo.podIP)
+	_, maskSize := util.GetIPFullMask(ip).Size()
+	ipNet := net.IPNet{
+		IP:   ip,
+		Mask: net.CIDRMask(portInfo.prefixLen, maskSize),
+	}
+	return podAnnotation{
+		IPs:      []string{ipNet.String()},
+		MAC:      util.IPAddrToHWAddr(ip).String(),
+		Gateways: gateways,
+		Routes:   nil, // TODO: must add here the expected routes.
+		TunnelID: tunnelID,
+	}
+}
+
+// Internal struct used to marshal PodAnnotation to the pod annotationç
+// Copied from pkg/util/pod_annotation.go
+type podAnnotation struct {
+	IPs      []string   `json:"ip_addresses"`
+	MAC      string     `json:"mac_address"`
+	Gateways []string   `json:"gateway_ips,omitempty"`
+	Routes   []podRoute `json:"routes,omitempty"`
+
+	IP      string `json:"ip_address,omitempty"`
+	Gateway string `json:"gateway_ip,omitempty"`
+
+	TunnelID int    `json:"tunnel_id,omitempty"`
+	Role     string `json:"role,omitempty"`
+}
+
+// Internal struct used to marshal PodRoute to the pod annotation
+// Copied from pkg/util/pod_annotation.go
+type podRoute struct {
+	Dest    string `json:"dest"`
+	NextHop string `json:"nextHop"`
 }

--- a/go-controller/pkg/ovn/multihoming_test.go
+++ b/go-controller/pkg/ovn/multihoming_test.go
@@ -1,0 +1,43 @@
+package ovn
+
+import "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+
+func (p testPod) addNetwork(
+	netName, nadName, nodeSubnet, nodeMgtIP, nodeGWIP, podIP, podMAC, role string,
+	tunnelID int,
+	routes []util.PodRoute,
+) {
+	podInfo, ok := p.secondaryPodInfos[netName]
+	if !ok {
+		podInfo = &secondaryPodInfo{
+			nodeSubnet:  nodeSubnet,
+			nodeMgtIP:   nodeMgtIP,
+			nodeGWIP:    nodeGWIP,
+			role:        role,
+			routes:      routes,
+			allportInfo: map[string]portInfo{},
+		}
+		p.secondaryPodInfos[netName] = podInfo
+	}
+	portName := util.GetSecondaryNetworkLogicalPortName(p.namespace, p.podName, nadName)
+	podInfo.allportInfo[nadName] = portInfo{
+		portUUID: portName + "-UUID",
+		podIP:    podIP,
+		podMAC:   podMAC,
+		portName: portName,
+		tunnelID: tunnelID,
+	}
+}
+
+func (p testPod) getNetworkPortInfo(netName, nadName string) *portInfo {
+	podInfo, ok := p.secondaryPodInfos[netName]
+	if !ok {
+		return nil
+	}
+	info, ok := podInfo.allportInfo[nadName]
+	if !ok {
+		return nil
+	}
+
+	return &info
+}

--- a/go-controller/pkg/ovn/multihoming_test.go
+++ b/go-controller/pkg/ovn/multihoming_test.go
@@ -177,7 +177,8 @@ func (em *secondaryNetworkExpectationMachine) expectedLogicalSwitchesAndPortsWit
 			// TODO: once we start the "full" SecondaryLayer2NetworkController (instead of just Base)
 			// we can drop this, and compare all objects created by the controller (right now we're
 			// missing all the meters, and the COPP)
-			if ocInfo.bnc.TopologyType() == ovntypes.Layer2Topology {
+			if ocInfo.bnc.TopologyType() == ovntypes.Layer2Topology ||
+				ocInfo.bnc.TopologyType() == ovntypes.LocalnetTopology {
 				otherConfig = nil
 			}
 
@@ -320,9 +321,10 @@ func dummyOVNPodNetworkAnnotations(secondaryPodInfos map[string]*secondaryPodInf
 	podAnnotations := map[string]podAnnotation{}
 	for i, netConfig := range multiHomingConfigs {
 		// we need to inject a dummy OVN annotation into the pods for each multihoming config
-		// for layer2 topology since allocating the annotation for this cluster configuration
+		// for layer2 & localnet topology since allocating the annotation for this cluster configuration
 		// is performed by cluster manager - which doesn't exist in the unit tests.
-		if netConfig.topology == ovntypes.Layer2Topology {
+		if netConfig.topology == ovntypes.Layer2Topology ||
+			netConfig.topology == ovntypes.LocalnetTopology {
 			portInfo := secondaryPodInfos[netConfig.netName].allportInfo[netConfig.nadName]
 			podAnnotations[netConfig.nadName] = dummyOVNPodNetworkAnnotationForNetwork(portInfo, netConfig, i+1)
 		}

--- a/go-controller/pkg/ovn/multipolicy_test.go
+++ b/go-controller/pkg/ovn/multipolicy_test.go
@@ -91,40 +91,6 @@ func convertNetPolicyToMultiNetPolicy(policy *knet.NetworkPolicy) *mnpapi.MultiN
 	return &mpolicy
 }
 
-func (p testPod) addNetwork(netName, nadName, nodeSubnet, nodeMgtIP, nodeGWIP, podIP, podMAC string, tunnelID int) {
-	podInfo, ok := p.secondaryPodInfos[netName]
-	if !ok {
-		podInfo = &secondaryPodInfo{
-			nodeSubnet:  nodeSubnet,
-			nodeMgtIP:   nodeMgtIP,
-			nodeGWIP:    nodeGWIP,
-			allportInfo: map[string]portInfo{},
-		}
-		p.secondaryPodInfos[netName] = podInfo
-	}
-	portName := util.GetSecondaryNetworkLogicalPortName(p.namespace, p.podName, nadName)
-	podInfo.allportInfo[nadName] = portInfo{
-		portUUID: portName + "-UUID",
-		podIP:    podIP,
-		podMAC:   podMAC,
-		portName: portName,
-		tunnelID: tunnelID,
-	}
-}
-
-func (p testPod) getNetworkPortInfo(netName, nadName string) *portInfo {
-	podInfo, ok := p.secondaryPodInfos[netName]
-	if !ok {
-		return nil
-	}
-	info, ok := podInfo.allportInfo[nadName]
-	if !ok {
-		return nil
-	}
-
-	return &info
-}
-
 func addPodNetwork(pod *v1.Pod, secondaryPodInfos map[string]*secondaryPodInfo) {
 	nadNames := []string{}
 	for _, podInfo := range secondaryPodInfos {
@@ -481,7 +447,7 @@ var _ = ginkgo.Describe("OVN MultiNetworkPolicy Operations", func() {
 
 				namespace1 := *newNamespace(namespaceName1)
 				nPodTest := getTestPod(namespace1.Name, nodeName)
-				nPodTest.addNetwork(secondaryNetworkName, nadNamespacedName, "", "", "", "10.1.1.1", "0a:58:0a:01:01:01", 1)
+				nPodTest.addNetwork(secondaryNetworkName, nadNamespacedName, "", "", "", "10.1.1.1", "0a:58:0a:01:01:01", "secondary", 1, nil)
 				networkPolicy := getPortNetworkPolicy(netPolicyName1, namespace1.Name, labelName, labelVal, portNum)
 
 				watchNodes := false
@@ -614,7 +580,7 @@ var _ = ginkgo.Describe("OVN MultiNetworkPolicy Operations", func() {
 					ocInfo.asf.EventuallyExpectEmptyAddressSetExist(namespaceName1)
 
 					nPodTest := getTestPod(namespace1.Name, nodeName)
-					nPodTest.addNetwork(secondaryNetworkName, nadNamespacedName, nodeSubnet, "", "", "10.1.1.1", "0a:58:0a:01:01:01", 1)
+					nPodTest.addNetwork(secondaryNetworkName, nadNamespacedName, nodeSubnet, "", "", "10.1.1.1", "0a:58:0a:01:01:01", "secondary", 1, nil)
 					knetPod := newPod(nPodTest.namespace, nPodTest.podName, nPodTest.nodeName, nPodTest.podIP)
 					addPodNetwork(knetPod, nPodTest.secondaryPodInfos)
 					setPodAnnotations(knetPod, nPodTest)

--- a/go-controller/pkg/ovn/ovn_test.go
+++ b/go-controller/pkg/ovn/ovn_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/onsi/ginkgo"
 
+	ipamclaimsapi "github.com/k8snetworkplumbingwg/ipamclaims/pkg/crd/ipamclaims/v1alpha1"
 	fakeipamclaimclient "github.com/k8snetworkplumbingwg/ipamclaims/pkg/crd/ipamclaims/v1alpha1/apis/clientset/versioned/fake"
 	mnpapi "github.com/k8snetworkplumbingwg/multi-networkpolicy/pkg/apis/k8s.cni.cncf.io/v1beta1"
 	mnpfake "github.com/k8snetworkplumbingwg/multi-networkpolicy/pkg/client/clientset/versioned/fake"
@@ -114,6 +115,7 @@ func (o *FakeOVN) start(objects ...runtime.Object) {
 	egressServiceObjects := []runtime.Object{}
 	apbExternalRouteObjects := []runtime.Object{}
 	anpObjects := []runtime.Object{}
+	ipamClaimObjects := []runtime.Object{}
 	v1Objects := []runtime.Object{}
 	nads := []nettypes.NetworkAttachmentDefinition{}
 	for _, object := range objects {
@@ -136,6 +138,8 @@ func (o *FakeOVN) start(objects ...runtime.Object) {
 			apbExternalRouteObjects = append(apbExternalRouteObjects, object)
 		case *anpapi.AdminNetworkPolicyList:
 			anpObjects = append(anpObjects, object)
+		case *ipamclaimsapi.IPAMClaimList:
+			ipamClaimObjects = append(ipamClaimObjects, object)
 		default:
 			v1Objects = append(v1Objects, object)
 		}
@@ -150,7 +154,7 @@ func (o *FakeOVN) start(objects ...runtime.Object) {
 		MultiNetworkPolicyClient: mnpfake.NewSimpleClientset(multiNetworkPolicyObjects...),
 		EgressServiceClient:      egressservicefake.NewSimpleClientset(egressServiceObjects...),
 		AdminPolicyRouteClient:   adminpolicybasedroutefake.NewSimpleClientset(apbExternalRouteObjects...),
-		IPAMClaimsClient:         fakeipamclaimclient.NewSimpleClientset(),
+		IPAMClaimsClient:         fakeipamclaimclient.NewSimpleClientset(ipamClaimObjects...),
 	}
 	o.init(nads)
 }
@@ -291,6 +295,7 @@ func NewOvnController(ovnClient *util.OVNMasterClientset, wf *factory.WatchFacto
 			EgressServiceClient:  ovnClient.EgressServiceClient,
 			APBRouteClient:       ovnClient.AdminPolicyRouteClient,
 			EgressQoSClient:      ovnClient.EgressQoSClient,
+			IPAMClaimsClient:     ovnClient.IPAMClaimsClient,
 		},
 		wf,
 		recorder,
@@ -406,6 +411,7 @@ func (o *FakeOVN) NewSecondaryNetworkController(netattachdef *nettypes.NetworkAt
 				Kube:                 kube.Kube{KClient: o.fakeClient.KubeClient},
 				EIPClient:            o.fakeClient.EgressIPClient,
 				EgressFirewallClient: o.fakeClient.EgressFirewallClient,
+				IPAMClaimsClient:     o.fakeClient.IPAMClaimsClient,
 			},
 			o.watcher,
 			o.fakeRecorder,

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -222,7 +222,7 @@ func (oc *DefaultNetworkController) addLogicalPort(pod *kapi.Pod) (err error) {
 	}()
 
 	nadName := ovntypes.DefaultNetworkName
-	ops, lsp, podAnnotation, newlyCreatedPort, err = oc.addLogicalPortToNetwork(pod, nadName, network)
+	ops, lsp, podAnnotation, newlyCreatedPort, err = oc.addLogicalPortToNetwork(pod, nadName, network, nil)
 	if err != nil {
 		return err
 	}

--- a/go-controller/pkg/ovn/pods_test.go
+++ b/go-controller/pkg/ovn/pods_test.go
@@ -200,7 +200,6 @@ type secondaryPodInfo struct {
 	nodeSubnet  string
 	nodeMgtIP   string
 	nodeGWIP    string
-	role        string
 	routes      []util.PodRoute
 	allportInfo map[string]portInfo
 }

--- a/go-controller/pkg/ovn/pods_test.go
+++ b/go-controller/pkg/ovn/pods_test.go
@@ -206,11 +206,12 @@ type secondaryPodInfo struct {
 }
 
 type portInfo struct {
-	portUUID string
-	podIP    string
-	podMAC   string
-	portName string
-	tunnelID int
+	portUUID  string
+	podIP     string
+	podMAC    string
+	portName  string
+	tunnelID  int
+	prefixLen int
 }
 
 func newTPod(nodeName, nodeSubnet, nodeMgtIP, nodeGWIP, podName, podIPs, podMAC, namespace string) testPod {
@@ -357,6 +358,9 @@ func (p testPod) getAnnotationsJson() string {
 			ipPrefix := 24
 			if ovntest.MustParseIP(p.podIP).To4() == nil {
 				ipPrefix = 64
+			}
+			if portInfo.prefixLen != 0 {
+				ipPrefix = portInfo.prefixLen
 			}
 			ip := fmt.Sprintf("%s/%d", portInfo.podIP, ipPrefix)
 			podAnnotation := podAnnotation{

--- a/go-controller/pkg/ovn/secondary_layer2_network_controller_test.go
+++ b/go-controller/pkg/ovn/secondary_layer2_network_controller_test.go
@@ -240,6 +240,36 @@ var _ = Describe("OVN Multi-Homed pod operations for layer2 network", func() {
 			icClusterTestConfiguration(),
 			failedMigrationInfo(),
 		),
+
+		table.Entry("on a localnet topology with user defined secondary network, when target pod is not yet ready",
+			dummyLocalnetWithSecondaryUserDefinedNetwork("100.200.0.0/16"),
+			nonICClusterTestConfiguration(),
+			notReadyMigrationInfo(),
+		),
+
+		table.Entry("on a localnet topology with user defined secondary network, when target pod is ready",
+			dummyLocalnetWithSecondaryUserDefinedNetwork("100.200.0.0/16"),
+			nonICClusterTestConfiguration(),
+			readyMigrationInfo(),
+		),
+
+		table.Entry("on a localnet topology with user defined secondary network and an IC cluster, when target pod is not yet ready",
+			dummyLocalnetWithSecondaryUserDefinedNetwork("100.200.0.0/16"),
+			icClusterTestConfiguration(),
+			notReadyMigrationInfo(),
+		),
+
+		table.Entry("on a localnet topology with user defined secondary network and an IC cluster, when target pod is ready",
+			dummyLocalnetWithSecondaryUserDefinedNetwork("100.200.0.0/16"),
+			icClusterTestConfiguration(),
+			readyMigrationInfo(),
+		),
+
+		table.Entry("on a localnet topology with user defined secondary network and an IC cluster, when target pod failed",
+			dummyLocalnetWithSecondaryUserDefinedNetwork("100.200.0.0/16"),
+			icClusterTestConfiguration(),
+			failedMigrationInfo(),
+		),
 	)
 })
 

--- a/go-controller/pkg/ovn/secondary_layer2_network_controller_test.go
+++ b/go-controller/pkg/ovn/secondary_layer2_network_controller_test.go
@@ -1,0 +1,182 @@
+package ovn
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+
+	"github.com/urfave/cli/v2"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	nadapi "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	libovsdbtest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
+	ovntypes "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+)
+
+var _ = Describe("OVN Multi-Homed pod operations for layer2 network", func() {
+	var (
+		app       *cli.App
+		fakeOvn   *FakeOVN
+		initialDB libovsdbtest.TestSetup
+	)
+
+	BeforeEach(func() {
+		Expect(config.PrepareTestConfig()).To(Succeed()) // reset defaults
+
+		app = cli.NewApp()
+		app.Name = "test"
+		app.Flags = config.Flags
+
+		fakeOvn = NewFakeOVN(true)
+		initialDB = libovsdbtest.TestSetup{
+			NBData: []libovsdbtest.TestData{},
+		}
+
+		config.OVNKubernetesFeature = *minimalFeatureConfig()
+		config.Gateway.V4MasqueradeSubnet = dummyMasqueradeSubnet().String()
+	})
+
+	AfterEach(func() {
+		fakeOvn.shutdown()
+	})
+
+	table.DescribeTable(
+		"reconciles a new",
+		func(netInfo secondaryNetInfo, testConfig testConfiguration) {
+			const podIdx = 0
+			podInfo := dummyL2TestPod(ns, netInfo, podIdx)
+			if testConfig.configToOverride != nil {
+				config.OVNKubernetesFeature = *testConfig.configToOverride
+			}
+			app.Action = func(ctx *cli.Context) error {
+				By(fmt.Sprintf("creating a network attachment definition for network: %s", netInfo.netName))
+				nad, err := newNetworkAttachmentDefinition(
+					ns,
+					nadName,
+					*netInfo.netconf(),
+				)
+				Expect(err).NotTo(HaveOccurred())
+				By("setting up the OVN DB without any entities in it")
+				Expect(netInfo.setupOVNDependencies(&initialDB)).To(Succeed())
+
+				const nodeIPv4CIDR = "192.168.126.202/24"
+				By(fmt.Sprintf("Creating a node named %q, with IP: %s", nodeName, nodeIPv4CIDR))
+				testNode, err := newNodeWithSecondaryNets(nodeName, nodeIPv4CIDR, netInfo)
+				Expect(err).NotTo(HaveOccurred())
+				fakeOvn.startWithDBSetup(
+					initialDB,
+					&v1.NamespaceList{
+						Items: []v1.Namespace{
+							*newNamespace(ns),
+						},
+					},
+					&v1.NodeList{Items: []v1.Node{*testNode}},
+					&v1.PodList{
+						Items: []v1.Pod{
+							*newMultiHomedPod(podInfo, netInfo),
+						},
+					},
+					&nadapi.NetworkAttachmentDefinitionList{
+						Items: []nadapi.NetworkAttachmentDefinition{*nad},
+					},
+				)
+				podInfo.populateLogicalSwitchCache(fakeOvn)
+
+				// on IC, the test itself spits out the pod with the
+				// annotations set, since on production it would be the
+				// clustermanager to annotate the pod.
+				if !config.OVNKubernetesFeature.EnableInterconnect {
+					By("asserting the pod originally does *not* feature the OVN pod networks annotation")
+					// pod exists, networks annotations don't
+					pod, err := fakeOvn.fakeClient.KubeClient.CoreV1().Pods(podInfo.namespace).Get(context.Background(), podInfo.podName, metav1.GetOptions{})
+					Expect(err).NotTo(HaveOccurred())
+					_, ok := pod.Annotations[util.OvnPodAnnotationName]
+					Expect(ok).To(BeFalse())
+				}
+
+				Expect(fakeOvn.controller.WatchNamespaces()).NotTo(HaveOccurred())
+				Expect(fakeOvn.controller.WatchPods()).NotTo(HaveOccurred())
+				By("asserting the pod (once reconciled) *features* the OVN pod networks annotation")
+				secondaryNetController, ok := fakeOvn.secondaryControllers[secondaryNetworkName]
+				Expect(ok).To(BeTrue())
+
+				podInfo.populateSecondaryNetworkLogicalSwitchCache(fakeOvn, secondaryNetController)
+				Expect(secondaryNetController.bnc.WatchNodes()).To(Succeed())
+				Expect(secondaryNetController.bnc.WatchPods()).To(Succeed())
+
+				// for layer2 on interconnect, it is the cluster manager that
+				// allocates the OVN annotation; on unit tests, this just
+				// doesn't happen, and we create the pod with these annotations
+				// set. Hence, no point checking they're the expected ones.
+				// TODO: align the mocked annotations with the production code
+				//   - currently missing setting the routes.
+				if !config.OVNKubernetesFeature.EnableInterconnect {
+					By("asserting the pod OVN pod networks annotation are the expected ones")
+					// check that after start networks annotations and nbdb will be updated
+					Eventually(func() string {
+						return getPodAnnotations(fakeOvn.fakeClient.KubeClient, podInfo.namespace, podInfo.podName)
+					}).WithTimeout(2 * time.Second).Should(MatchJSON(podInfo.getAnnotationsJson()))
+				}
+
+				expectationOptions := testConfig.expectationOptions
+				By("asserting the OVN entities provisioned in the NBDB are the expected ones")
+				Eventually(fakeOvn.nbClient).Should(
+					libovsdbtest.HaveData(
+						newSecondaryNetworkExpectationMachine(
+							fakeOvn,
+							[]testPod{podInfo},
+							expectationOptions...,
+						).expectedLogicalSwitchesAndPorts()...))
+
+				return nil
+			}
+
+			Expect(app.Run([]string{app.Name})).To(Succeed())
+		},
+		table.Entry("pod on a user defined secondary network",
+			dummySecondaryLayer2UserDefinedNetwork("100.200.0.0/16"),
+			nonICClusterTestConfiguration(),
+		),
+
+		table.Entry("pod on a user defined secondary network on an interconnect cluster",
+			dummySecondaryLayer2UserDefinedNetwork("100.200.0.0/16"),
+			icClusterTestConfiguration(),
+		),
+	)
+})
+
+func dummySecondaryLayer2UserDefinedNetwork(subnets string) secondaryNetInfo {
+	return secondaryNetInfo{
+		netName:  secondaryNetworkName,
+		nadName:  namespacedName(ns, nadName),
+		topology: ovntypes.Layer2Topology,
+		subnets:  subnets,
+	}
+}
+
+func dummyL2TestPod(nsName string, info secondaryNetInfo, podIdx int) testPod {
+	const nodeSubnet = "10.128.1.0/24"
+	pod := newTPod(nodeName, nodeSubnet, "10.128.1.2", "10.128.1.1", fmt.Sprintf("%s-%d", podName, podIdx), fmt.Sprintf("10.128.1.%d", podIdx+3), fmt.Sprintf("0a:58:0a:80:01:%0.2d", podIdx+3), nsName)
+	pod.addNetwork(
+		info.netName,
+		info.nadName,
+		info.subnets,
+		"",
+		"",
+		fmt.Sprintf("100.200.0.%d/16", podIdx+1),
+		fmt.Sprintf("0a:58:64:c8:00:%0.2d", podIdx+1),
+		"secondary",
+		0,
+		[]util.PodRoute{},
+	)
+	return pod
+}

--- a/go-controller/pkg/ovn/secondary_layer2_network_controller_test.go
+++ b/go-controller/pkg/ovn/secondary_layer2_network_controller_test.go
@@ -58,60 +58,13 @@ var _ = Describe("OVN Multi-Homed pod operations for layer2 network", func() {
 				config.OVNKubernetesFeature = *testConfig.configToOverride
 			}
 			app.Action = func(ctx *cli.Context) error {
-				By(fmt.Sprintf("creating a network attachment definition for network: %s", netInfo.netName))
-				nad, err := newNetworkAttachmentDefinition(
-					ns,
-					nadName,
-					*netInfo.netconf(),
-				)
-				Expect(err).NotTo(HaveOccurred())
-				By("setting up the OVN DB without any entities in it")
-				Expect(netInfo.setupOVNDependencies(&initialDB)).To(Succeed())
+				pod := newMultiHomedPod(podInfo, netInfo)
 
 				const nodeIPv4CIDR = "192.168.126.202/24"
 				By(fmt.Sprintf("Creating a node named %q, with IP: %s", nodeName, nodeIPv4CIDR))
 				testNode, err := newNodeWithSecondaryNets(nodeName, nodeIPv4CIDR, netInfo)
 				Expect(err).NotTo(HaveOccurred())
-				fakeOvn.startWithDBSetup(
-					initialDB,
-					&v1.NamespaceList{
-						Items: []v1.Namespace{
-							*newNamespace(ns),
-						},
-					},
-					&v1.NodeList{Items: []v1.Node{*testNode}},
-					&v1.PodList{
-						Items: []v1.Pod{
-							*newMultiHomedPod(podInfo, netInfo),
-						},
-					},
-					&nadapi.NetworkAttachmentDefinitionList{
-						Items: []nadapi.NetworkAttachmentDefinition{*nad},
-					},
-				)
-				podInfo.populateLogicalSwitchCache(fakeOvn)
-
-				// on IC, the test itself spits out the pod with the
-				// annotations set, since on production it would be the
-				// clustermanager to annotate the pod.
-				if !config.OVNKubernetesFeature.EnableInterconnect {
-					By("asserting the pod originally does *not* feature the OVN pod networks annotation")
-					// pod exists, networks annotations don't
-					pod, err := fakeOvn.fakeClient.KubeClient.CoreV1().Pods(podInfo.namespace).Get(context.Background(), podInfo.podName, metav1.GetOptions{})
-					Expect(err).NotTo(HaveOccurred())
-					_, ok := pod.Annotations[util.OvnPodAnnotationName]
-					Expect(ok).To(BeFalse())
-				}
-
-				Expect(fakeOvn.controller.WatchNamespaces()).NotTo(HaveOccurred())
-				Expect(fakeOvn.controller.WatchPods()).NotTo(HaveOccurred())
-				By("asserting the pod (once reconciled) *features* the OVN pod networks annotation")
-				secondaryNetController, ok := fakeOvn.secondaryControllers[secondaryNetworkName]
-				Expect(ok).To(BeTrue())
-
-				podInfo.populateSecondaryNetworkLogicalSwitchCache(fakeOvn, secondaryNetController)
-				Expect(secondaryNetController.bnc.WatchNodes()).To(Succeed())
-				Expect(secondaryNetController.bnc.WatchPods()).To(Succeed())
+				Expect(setupFakeOvnForLayer2Topology(fakeOvn, initialDB, netInfo, testNode, podInfo, pod)).To(Succeed())
 
 				// for layer2 on interconnect, it is the cluster manager that
 				// allocates the OVN annotation; on unit tests, this just
@@ -179,4 +132,75 @@ func dummyL2TestPod(nsName string, info secondaryNetInfo, podIdx int) testPod {
 		[]util.PodRoute{},
 	)
 	return pod
+}
+
+func setupFakeOvnForLayer2Topology(fakeOvn *FakeOVN, initialDB libovsdbtest.TestSetup, netInfo secondaryNetInfo, testNode *v1.Node, podInfo testPod, pod *v1.Pod) error {
+	By(fmt.Sprintf("creating a network attachment definition for network: %s", netInfo.netName))
+	nad, err := newNetworkAttachmentDefinition(
+		ns,
+		nadName,
+		*netInfo.netconf(),
+	)
+	if err != nil {
+		return err
+	}
+	By("setting up the OVN DB without any entities in it")
+	if err = netInfo.setupOVNDependencies(&initialDB); err != nil {
+		return err
+	}
+	fakeOvn.startWithDBSetup(
+		initialDB,
+		&v1.NamespaceList{
+			Items: []v1.Namespace{
+				*newNamespace(ns),
+			},
+		},
+		&v1.NodeList{Items: []v1.Node{*testNode}},
+		&v1.PodList{
+			Items: []v1.Pod{
+				*pod,
+			},
+		},
+		&nadapi.NetworkAttachmentDefinitionList{
+			Items: []nadapi.NetworkAttachmentDefinition{*nad},
+		},
+	)
+	podInfo.populateLogicalSwitchCache(fakeOvn)
+
+	// on IC, the test itself spits out the pod with the
+	// annotations set, since on production it would be the
+	// clustermanager to annotate the pod.
+	if !config.OVNKubernetesFeature.EnableInterconnect {
+		By("asserting the pod originally does *not* feature the OVN pod networks annotation")
+		// pod exists, networks annotations don't
+		pod, err := fakeOvn.fakeClient.KubeClient.CoreV1().Pods(podInfo.namespace).Get(context.Background(), podInfo.podName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		_, ok := pod.Annotations[util.OvnPodAnnotationName]
+		if ok {
+			return fmt.Errorf("pod annotation %s is not expected", util.OvnPodAnnotationName)
+		}
+	}
+
+	if err = fakeOvn.controller.WatchNamespaces(); err != nil {
+		return err
+	}
+	if err = fakeOvn.controller.WatchPods(); err != nil {
+		return err
+	}
+	By("asserting the pod (once reconciled) *features* the OVN pod networks annotation")
+	secondaryNetController, ok := fakeOvn.secondaryControllers[secondaryNetworkName]
+	if ok != true {
+		return fmt.Errorf("secondary network controller %s is expected", secondaryNetworkName)
+	}
+
+	podInfo.populateSecondaryNetworkLogicalSwitchCache(fakeOvn, secondaryNetController)
+	if err = secondaryNetController.bnc.WatchNodes(); err != nil {
+		return err
+	}
+	if err = secondaryNetController.bnc.WatchPods(); err != nil {
+		return err
+	}
+	return err
 }

--- a/go-controller/pkg/ovn/secondary_layer3_network_controller_test.go
+++ b/go-controller/pkg/ovn/secondary_layer3_network_controller_test.go
@@ -29,10 +29,12 @@ import (
 )
 
 type secondaryNetInfo struct {
-	netName  string
-	nadName  string
-	subnets  string
-	topology string
+	netName            string
+	nadName            string
+	subnets            string
+	topology           string
+	allowPersistentIPs bool
+	ipamClaimReference string
 }
 
 const (
@@ -208,9 +210,10 @@ func (sni *secondaryNetInfo) netconf() *ovncnitypes.NetConf {
 			Name: sni.netName,
 			Type: plugin,
 		},
-		Topology: sni.topology,
-		NADName:  sni.nadName,
-		Subnets:  sni.subnets,
+		Topology:           sni.topology,
+		NADName:            sni.nadName,
+		Subnets:            sni.subnets,
+		AllowPersistentIPs: sni.allowPersistentIPs,
 	}
 }
 

--- a/go-controller/pkg/ovn/secondary_layer3_network_controller_test.go
+++ b/go-controller/pkg/ovn/secondary_layer3_network_controller_test.go
@@ -141,7 +141,6 @@ var _ = Describe("OVN Multi-Homed pod operations", func() {
 
 				defaultNetExpectations := getExpectedDataPodsAndSwitches([]testPod{podInfo}, []string{nodeName})
 				expectationOptions := testConfig.expectationOptions
-
 				Eventually(fakeOvn.nbClient).Should(
 					libovsdbtest.HaveData(
 						append(

--- a/go-controller/pkg/ovn/secondary_layer3_network_controller_test.go
+++ b/go-controller/pkg/ovn/secondary_layer3_network_controller_test.go
@@ -1,0 +1,301 @@
+package ovn
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+
+	cnitypes "github.com/containernetworking/cni/pkg/types"
+	"github.com/urfave/cli/v2"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	nadapi "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+
+	ovncnitypes "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/cni/types"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
+	libovsdbtest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
+	ovntypes "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+)
+
+type secondaryNetInfo struct {
+	netName  string
+	nadName  string
+	subnets  string
+	topology string
+}
+
+const (
+	dummyMACAddr         = "02:03:04:05:06:07"
+	nadName              = "blue-net"
+	ns                   = "namespace1"
+	secondaryNetworkName = "isolatednet"
+)
+
+type testConfiguration struct {
+	configToOverride   *config.OVNKubernetesFeatureConfig
+	expectationOptions []option
+}
+
+var _ = Describe("OVN Multi-Homed pod operations", func() {
+	var (
+		app       *cli.App
+		fakeOvn   *FakeOVN
+		initialDB libovsdbtest.TestSetup
+	)
+
+	BeforeEach(func() {
+		Expect(config.PrepareTestConfig()).To(Succeed()) // reset defaults
+
+		app = cli.NewApp()
+		app.Name = "test"
+		app.Flags = config.Flags
+
+		fakeOvn = NewFakeOVN(true)
+		initialDB = libovsdbtest.TestSetup{
+			NBData: []libovsdbtest.TestData{
+				&nbdb.LogicalSwitch{
+					Name: nodeName,
+				},
+			},
+		}
+
+		config.OVNKubernetesFeature = *minimalFeatureConfig()
+		config.Gateway.V4MasqueradeSubnet = dummyMasqueradeSubnet().String()
+	})
+
+	AfterEach(func() {
+		fakeOvn.shutdown()
+	})
+
+	table.DescribeTable(
+		"reconciles a new",
+		func(netInfo secondaryNetInfo, testConfig testConfiguration) {
+			podInfo := dummyTestPod(ns, netInfo)
+			if testConfig.configToOverride != nil {
+				config.OVNKubernetesFeature = *testConfig.configToOverride
+			}
+			app.Action = func(ctx *cli.Context) error {
+				nad, err := newNetworkAttachmentDefinition(
+					ns,
+					nadName,
+					*netInfo.netconf(),
+				)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(netInfo.setupOVNDependencies(&initialDB)).To(Succeed())
+
+				const nodeIPv4CIDR = "192.168.126.202/24"
+				testNode, err := newNodeWithSecondaryNets(nodeName, nodeIPv4CIDR, netInfo)
+				Expect(err).NotTo(HaveOccurred())
+				fakeOvn.startWithDBSetup(
+					initialDB,
+					&v1.NamespaceList{
+						Items: []v1.Namespace{
+							*newNamespace(ns),
+						},
+					},
+					&v1.NodeList{
+						Items: []v1.Node{*testNode},
+					},
+					&v1.PodList{
+						Items: []v1.Pod{
+							*newMultiHomedPod(podInfo, netInfo),
+						},
+					},
+					&nadapi.NetworkAttachmentDefinitionList{
+						Items: []nadapi.NetworkAttachmentDefinition{*nad},
+					},
+				)
+				podInfo.populateLogicalSwitchCache(fakeOvn)
+
+				// pod exists, networks annotations don't
+				pod, err := fakeOvn.fakeClient.KubeClient.CoreV1().Pods(podInfo.namespace).Get(context.Background(), podInfo.podName, metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				_, ok := pod.Annotations[util.OvnPodAnnotationName]
+				Expect(ok).To(BeFalse())
+
+				Expect(fakeOvn.controller.WatchNamespaces()).NotTo(HaveOccurred())
+				Expect(fakeOvn.controller.WatchPods()).NotTo(HaveOccurred())
+				secondaryNetController, ok := fakeOvn.secondaryControllers[secondaryNetworkName]
+				Expect(ok).To(BeTrue())
+
+				//RAMSAMSAM secondaryNetController.bnc.ovnClusterLRPToJoinIfAddrs = dummyJoinIPs()
+				podInfo.populateSecondaryNetworkLogicalSwitchCache(fakeOvn, secondaryNetController)
+				Expect(secondaryNetController.bnc.WatchNodes()).To(Succeed())
+				Expect(secondaryNetController.bnc.WatchPods()).To(Succeed())
+
+				// check that after start networks annotations and nbdb will be updated
+				Eventually(func() string {
+					return getPodAnnotations(fakeOvn.fakeClient.KubeClient, podInfo.namespace, podInfo.podName)
+				}).WithTimeout(2 * time.Second).Should(MatchJSON(podInfo.getAnnotationsJson()))
+
+				defaultNetExpectations := getExpectedDataPodsAndSwitches([]testPod{podInfo}, []string{nodeName})
+				expectationOptions := testConfig.expectationOptions
+
+				Eventually(fakeOvn.nbClient).Should(
+					libovsdbtest.HaveData(
+						append(
+							defaultNetExpectations,
+							newSecondaryNetworkExpectationMachine(
+								fakeOvn,
+								[]testPod{podInfo},
+								expectationOptions...,
+							).expectedLogicalSwitchesAndPorts()...)))
+
+				return nil
+			}
+
+			Expect(app.Run([]string{app.Name})).To(Succeed())
+		},
+		table.Entry("pod on a user defined secondary network",
+			dummySecondaryUserDefinedNetwork("192.168.0.0/16"),
+			nonICClusterTestConfiguration(),
+		),
+
+		table.Entry("pod on a user defined secondary network on an interconnect cluster",
+			dummySecondaryUserDefinedNetwork("192.168.0.0/16"),
+			icClusterTestConfiguration(),
+		),
+	)
+})
+
+func namespacedName(ns, name string) string { return fmt.Sprintf("%s/%s", ns, name) }
+
+func (sni *secondaryNetInfo) setupOVNDependencies(dbData *libovsdbtest.TestSetup) error {
+	netInfo, err := util.NewNetInfo(sni.netconf())
+	if err != nil {
+		return err
+	}
+
+	switch sni.topology {
+	case ovntypes.Layer2Topology:
+		dbData.NBData = append(dbData.NBData, &nbdb.LogicalSwitch{
+			Name:        netInfo.GetNetworkScopedName(ovntypes.OVNLayer2Switch),
+			UUID:        netInfo.GetNetworkScopedName(ovntypes.OVNLayer2Switch) + "_UUID",
+			ExternalIDs: map[string]string{ovntypes.NetworkExternalID: sni.netName},
+		})
+	case ovntypes.Layer3Topology:
+		dbData.NBData = append(dbData.NBData, &nbdb.LogicalSwitch{
+			Name:        netInfo.GetNetworkScopedName(nodeName),
+			UUID:        netInfo.GetNetworkScopedName(nodeName) + "_UUID",
+			ExternalIDs: map[string]string{ovntypes.NetworkExternalID: sni.netName},
+		})
+	case ovntypes.LocalnetTopology:
+		dbData.NBData = append(dbData.NBData, &nbdb.LogicalSwitch{
+			Name:        netInfo.GetNetworkScopedName(ovntypes.OVNLocalnetSwitch),
+			UUID:        netInfo.GetNetworkScopedName(ovntypes.OVNLocalnetSwitch) + "_UUID",
+			ExternalIDs: map[string]string{ovntypes.NetworkExternalID: sni.netName},
+		})
+	default:
+		return fmt.Errorf("missing topology in the network configuration: %v", sni)
+	}
+	return nil
+}
+
+func (sni *secondaryNetInfo) netconf() *ovncnitypes.NetConf {
+	const plugin = "ovn-k8s-cni-overlay"
+	return &ovncnitypes.NetConf{
+		NetConf: cnitypes.NetConf{
+			Name: sni.netName,
+			Type: plugin,
+		},
+		Topology: sni.topology,
+		NADName:  sni.nadName,
+		Subnets:  sni.subnets,
+	}
+}
+
+func dummyTestPod(nsName string, info secondaryNetInfo) testPod {
+	const nodeSubnet = "10.128.1.0/24"
+	pod := newTPod(nodeName, nodeSubnet, "10.128.1.2", "10.128.1.1", podName, "10.128.1.3", "0a:58:0a:80:01:03", nsName)
+	pod.addNetwork(
+		info.netName,
+		info.nadName,
+		info.subnets,
+		"",
+		"",
+		"192.168.0.3/16",
+		"0a:58:c0:a8:00:03",
+		"secondary",
+		0,
+		[]util.PodRoute{
+			{
+				Dest:    testing.MustParseIPNet("192.168.0.0/16"),
+				NextHop: testing.MustParseIP("192.168.0.1"),
+			},
+		},
+	)
+	return pod
+}
+
+func dummySecondaryUserDefinedNetwork(subnets string) secondaryNetInfo {
+	return secondaryNetInfo{
+		netName:  secondaryNetworkName,
+		nadName:  namespacedName(ns, nadName),
+		topology: ovntypes.Layer3Topology,
+		subnets:  subnets,
+	}
+}
+
+func (sni *secondaryNetInfo) String() string {
+	return fmt.Sprintf("%q: %q", sni.netName, sni.subnets)
+}
+
+func newNodeWithSecondaryNets(nodeName string, nodeIPv4CIDR string, netInfos ...secondaryNetInfo) (*v1.Node, error) {
+	var nodeSubnetInfo []string
+	for _, info := range netInfos {
+		nodeSubnetInfo = append(nodeSubnetInfo, info.String())
+	}
+
+	nodeIP, nodeCIDR, err := net.ParseCIDR(nodeIPv4CIDR)
+	if err != nil {
+		return nil, err
+	}
+	nextHopIP := util.GetNodeGatewayIfAddr(nodeCIDR).IP
+	nodeCIDR.IP = nodeIP
+
+	return &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: nodeName,
+			Annotations: map[string]string{
+				"k8s.ovn.org/node-primary-ifaddr": fmt.Sprintf("{\"ipv4\": \"%s\", \"ipv6\": \"%s\"}", nodeIPv4CIDR, ""),
+				"k8s.ovn.org/node-subnets":        fmt.Sprintf("{\"default\":\"%s\", %s}", v4Node1Subnet, strings.Join(nodeSubnetInfo, ",")),
+				util.OVNNodeHostCIDRs:             fmt.Sprintf("[\"%s\"]", nodeIPv4CIDR),
+				"k8s.ovn.org/zone-name":           "global",
+				"k8s.ovn.org/l3-gateway-config":   fmt.Sprintf("{\"default\":{\"mode\":\"shared\",\"bridge-id\":\"breth0\",\"interface-id\":\"breth0_ovn-worker\",\"mac-address\":%q,\"ip-addresses\":[%[2]q],\"ip-address\":%[2]q,\"next-hops\":[%[3]q],\"next-hop\":%[3]q,\"node-port-enable\":\"true\",\"vlan-id\":\"0\"}}", util.IPAddrToHWAddr(nodeIP), nodeCIDR, nextHopIP),
+				util.OvnNodeChassisID:             "abdcef",
+				"k8s.ovn.org/network-ids":         "{\"default\":\"0\",\"isolatednet\":\"2\"}",
+				//RAMSAMSAM util.OvnNodeManagementPortMacAddresses: fmt.Sprintf("{\"isolatednet\":%q}", dummyMACAddr),
+				//RAMSAMSAM util.OVNNodeGRLRPAddrs:                 fmt.Sprintf("{\"isolatednet\":{\"ipv4\":%q}}", gwRouterIPAddress()),
+			},
+			Labels: map[string]string{
+				"k8s.ovn.org/egress-assignable": "",
+			},
+		},
+		Status: v1.NodeStatus{
+			Conditions: []v1.NodeCondition{
+				{
+					Type:   v1.NodeReady,
+					Status: v1.ConditionTrue,
+				},
+			},
+		},
+	}, nil
+}
+
+func dummyMasqueradeSubnet() *net.IPNet {
+	return &net.IPNet{
+		IP:   net.ParseIP("169.254.169.0"),
+		Mask: net.CIDRMask(24, 32),
+	}
+}


### PR DESCRIPTION
## 📑 Description
Currently all pods have the LSP.Enabled option set to nil (which later
translates to &true) by default.

During live-migration of kubevirt pods, in order to prevent unneeded
packet loss the lsp.Enabled of the migration pods (source and target)
need to be as follows:

until target pod is domain ready: source pod lsp is enabled, target
pod lsp is disabled.
when target pod is domain-ready: source pod lsp is disabled, target
pod lsp is enabled.
This switch significantly reduces the migration downtime to <0.5s (see details below).

This PR also handles the scenario of a failed migration, where the lsp
of the source pod needs to be re-enabled.

Apart from playing with lsp Enabled field for localnet is also needed to remove Addresses field to be sure that OVN is removing the L2 lookup table so traffic is steering to the localnet LSP.

This PR is a manual cherry-pick of 2 PRs:
- https://github.com/ovn-kubernetes/ovn-kubernetes/pull/4774
- https://github.com/ovn-kubernetes/ovn-kubernetes/pull/4917

*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #50595

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
