### PR TITLE
CORENET-5371: Dockerfile: Bump OVS version to 3.5.0-0.9

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -12,12 +12,12 @@ RUN dnf --setopt=retries=2 --setopt=timeout=2 install -y --nodocs \
 	selinux-policy procps-ng && \
 	dnf clean all
 
-ARG ovsver=3.4.0-18.el9fdp
+ARG ovsver=3.5.0-0.9.el9fdp
 ARG ovnver=24.09.2-41.el9fdp
 # NOTE: Ensure that the versions of OVS and OVN are overriden for OKD in each of the subsequent layers.
 # Centos and RHEL releases for ovn are built out of sync, so please make sure to bump for OKD with
 # the corresponding Centos version when updating the OCP version.
-ARG ovsver_okd=3.4.0-12.el9s
+ARG ovsver_okd=3.5.0-10.el9s
 # We are not bumping the OVN version for OKD since the FDP release is not done yet.
 ARG ovnver_okd=24.09.1-10.el9s
 


### PR DESCRIPTION
This new version provides configuration flexibility for `openvswitch-ipsec` systemd service which enables OCP to run `ovs-monitor-ipsec` as a service on host instead of running it inside a container.

This PR as such only bumps OVS version to `3.5.0-0.9`, so it doesn't have any harm in merging it. 

The changes https://github.com/openshift/cluster-network-operator/pull/2662, https://github.com/openshift/machine-config-operator/pull/4878 in the PRs get `openvswitch-ipsec` systemd service running on the host and OVN uses it to configure IPsec for east west traffic. 

Until these two PRs are merged, CNO would just continue to use `ovs-monitor-ipsec` process running in the `ovn-ipsec-host` pod container.