### PR TITLE
Dockerfile: Bump libreswan version to 5.2-1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN INSTALL_PKGS=" \
 	openssl firewalld-filesystem \
 	libpcap iproute iproute-tc strace \
 	tcpdump iputils \
-	libreswan-4.6-3.el9_0.3 \
+	libreswan-5.2-1.el9fdp \
 	ethtool conntrack-tools \
 	openshift-clients \
 	" && \


### PR DESCRIPTION
It consumes libreswan rpm from FDP repository now. 
https://brewweb.engineering.redhat.com/brew/taskinfo?taskID=66972299

@huiran0826 @zshi-redhat 