### PR TITLE
OCPBUGS-53384: [release-4.15] Dockerfile.base: bump OVS version to 3.3

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -12,7 +12,7 @@ RUN dnf install -y --nodocs \
 	selinux-policy procps-ng && \
 	dnf clean all
 
-ARG ovsver=3.1.0-137.el9fdp
+ARG ovsver=3.3.0-62.el9fdp
 ARG ovnver=23.09.4-16.el9fdp
 
 RUN INSTALL_PKGS="iptables" && \


### PR DESCRIPTION
Open vSwitch 3.1 is EoL upstream and so the support of this version in FDP is limited.  To ensure timely bug fix delivery for OCP 4.14+ we need to upgrade to the current LTS stream, which is Open vSwitch 3.3. It will be fully supported for much longer.

Consolidation of versions used across releases of OpenShift will also reduce pressure on QE teams allowing to drop older releases not used by any products.

We're moving RHCOS to this version as well in https://github.com/openshift/os/pull/1774, and we should keep the versions in the container and on the host in sync.  The exact build in this PR is the one that is currently used in OCP 4.16.

The plan is to get this into 4.15 and then backport to 4.14.