### PR TITLE
CORENET-5382: unpin libreswan version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN INSTALL_PKGS=" \
 	openssl firewalld-filesystem \
 	libpcap iproute iproute-tc strace \
 	tcpdump iputils \
-	libreswan-4.6-3.el9_0.3 \
+	libreswan \
 	ethtool conntrack-tools \
 	openshift-clients \
 	" && \


### PR DESCRIPTION
This PR unpins the ovnk libreswan-4.6 version which was introduced through [OCPBUGS-41823](https://issues.redhat.com/browse/OCPBUGS-41823?focusedId=26369393&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-26369393). It allows to consume the latest libreswan 5 version from FDP repo which includes recent improvement and enhancement from upstream libreswan, that would otherwise only be made available until RHEL-10. This PR depends on [OS](https://github.com/openshift/os/pull/1771) update which was already merged.