### PR TITLE
OCPBUGS-54497: [release-4.18] ovspinning: Enable the feature at runtime

### DIFF
--- a/go-controller/pkg/node/ovspinning/ovspinning_linux.go
+++ b/go-controller/pkg/node/ovspinning/ovspinning_linux.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -45,7 +46,9 @@ func Run(stopCh <-chan struct{}) {
 
 	var fsnotifyEvents chan fsnotify.Event
 	var fsnotifyErrors chan error
-	fileWatcher, err := createFileWatcherFor(featureEnablerFile)
+
+	// Watch the parent folder, as it's the only way to get events when the file is deleted and recreated.
+	fileWatcher, err := createFileWatcherFor(filepath.Dir(featureEnablerFile))
 	if err != nil {
 		klog.Warningf("Can't create a watcher for %s. Pinning will not stop by deleting it: %v", featureEnablerFile, err)
 		fsnotifyEvents = make(chan fsnotify.Event)
@@ -66,20 +69,21 @@ func Run(stopCh <-chan struct{}) {
 				continue
 			}
 
-			if event.Op.Has(fsnotify.Remove) {
-				klog.Infof("File [%s] has been removed. To re-enable the feature, restart ovnkube-node", featureEnablerFile)
-				return
+			// Since we are watching the entire folder, skip all the events not related to the enabler file
+			if event.Name != featureEnablerFile {
+				continue
 			}
 
 			isFeatureEnabled, err = isFileNotEmpty(featureEnablerFile)
 			if err != nil {
 				klog.Warningf("Error while reading [%s]: %v", featureEnablerFile, err)
-				return
+				continue
 			}
 
-			if !isFeatureEnabled {
-				klog.Infof("File [%s] is empty or missing. To re-enable the feature, restart ovnkube-node", featureEnablerFile)
-				return
+			if isFeatureEnabled {
+				klog.Infof("OVS daemon CPU pinning feature enabled")
+			} else {
+				klog.Infof("OVS daemon CPU pinning feature NOT enabled")
 			}
 
 		case err, ok := <-fsnotifyErrors:


### PR DESCRIPTION
A configuration manager like the `machine-config-operator` is often used to enable the OVS CPU pinning feature. During reconciliation loop, the configurator might remove and recreate a file for a very short time. When it comes to the `/etc/openvswitch/enable_dynamic_cpu_affinity` file, it might disable the CPU pinning permanently and an ovnkube-controller restart is needed.

Make the OVS CPU pinning be enabled without restarting `ovnkube-controller` pod. Watch the parent folder instead of the enabler file because if the file gets deleted, the file watch will not emit any further fsevent.

Backport of
- https://github.com/ovn-kubernetes/ovn-kubernetes/pull/5015

