### PR TITLE
Dockerfile: Unpin OVS and consume the latest from FDP.

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -12,25 +12,28 @@ RUN dnf --setopt=retries=2 --setopt=timeout=2 install -y --nodocs \
 	selinux-policy procps-ng && \
 	dnf clean all
 
-ARG ovsver=3.5.0-0.9.el9fdp
+# NOTE: OVS is not pinned to a particular patch version in order to stay in
+# sync with the OVS running on the host (it is not strictly necessary, but
+# reduces the number of variables in the system) and receive all the CVE and
+# bug fixes automatically.
+ARG ovsver=3.5
 ARG ovnver=24.09.2-41.el9fdp
 # NOTE: Ensure that the versions of OVS and OVN are overriden for OKD in each of the subsequent layers.
 # Centos and RHEL releases for ovn are built out of sync, so please make sure to bump for OKD with
 # the corresponding Centos version when updating the OCP version.
-ARG ovsver_okd=3.5.0-10.el9s
+ARG ovsver_okd=3.5
 # We are not bumping the OVN version for OKD since the FDP release is not done yet.
 ARG ovnver_okd=24.09.1-10.el9s
 
 RUN INSTALL_PKGS="iptables nftables" && \
     source /etc/os-release && \
     [ "${ID}" == "centos" ] && ovsver=$ovsver_okd && ovnver=$ovnver_okd; \
-	ovsver_short=$(echo "$ovsver" | cut -d'.' -f1,2) && \
 	ovnver_short=$(echo "$ovnver" | cut -d'.' -f1,2) && \
 	dnf --setopt=retries=2 --setopt=timeout=2 install -y --nodocs $INSTALL_PKGS && \
-	dnf --setopt=retries=2 --setopt=timeout=2 install -y --nodocs "openvswitch$ovsver_short = $ovsver" "python3-openvswitch$ovsver_short = $ovsver" && \
+	dnf --setopt=retries=2 --setopt=timeout=2 install -y --nodocs "openvswitch$ovsver" "python3-openvswitch$ovsver" && \
 	dnf --setopt=retries=2 --setopt=timeout=2 install -y --nodocs "ovn$ovnver_short = $ovnver" "ovn$ovnver_short-central = $ovnver" "ovn$ovnver_short-host = $ovnver" && \
 	dnf clean all && rm -rf /var/cache/* && \
-	sed 's/%/"/g' <<<"%openvswitch$ovsver_short-devel = $ovsver% %openvswitch$ovsver_short-ipsec = $ovsver% %ovn$ovnver_short-vtep = $ovnver%" > /more-pkgs
+	sed 's/%/"/g' <<<"%openvswitch$ovsver-devel% %openvswitch$ovsver-ipsec% %ovn$ovnver_short-vtep = $ovnver%" > /more-pkgs
 
 RUN mkdir -p /var/run/openvswitch && \
     mkdir -p /var/run/ovn && \


### PR DESCRIPTION
OVN-Kubernetes is always lagging behind on the version of OVS it pins. This is causing a lot of trouble with keeping up with bug fixes and especially CVE fixes on older branches, resulting in scanners constantly flagging this image with poor security grades.

OVS package inside the container is responsible for the following:

  1. Command line utilities to talk with OVS from the host.
  2. ovsdb-server processes serving OVN databases.
  3. ovs-monitor-ipsec script for managing ipsec configuration on OVN tunnels.

These tools/programs are not changing that much between patch releases, and bug fix releases in FDP are going through a lot of testing before becoming available in the repo.  So, benefits of timely delivery of bug and CVE fixes significantly outweighs the small risks that automatic consumption of new builds incurs.  Main OVS is working on the host and follows FDP for a very long time now, and it's also better to keep the minor versions between host and container in sync, just to decrease the amount of variables in the system.