### PR TITLE
[release-4.15] OCPBUGS-54618: bump ovnver to prevent CVE-2025-0650 being flagged

### DIFF
--- a/dist/images/Dockerfile.fedora
+++ b/dist/images/Dockerfile.fedora
@@ -15,7 +15,7 @@ USER root
 
 ENV PYTHONDONTWRITEBYTECODE yes
 
-ARG ovnver=ovn-23.09.0-139.fc39
+ARG ovnver=ovn-23.09.6-12.fc39
 # Automatically populated when using docker buildx
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM


### PR DESCRIPTION
Dockerfile.fedora in dist/images/ was using and
23.09.0-139 and this Security Advisory [0] shows that it was resolved in 23.09.6-12

[0] https://access.redhat.com/errata/RHSA-2025:1095

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
