### PR TITLE
OCPBUGS-55950: Bump ovs and ovn to latest patch releases

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -12,8 +12,8 @@ RUN dnf install -y --nodocs \
 	selinux-policy procps-ng && \
 	dnf clean all
 
-ARG ovsver=3.1.0-88.el9fdp
-ARG ovnver=23.06.1-112.el9fdp
+ARG ovsver=3.1.0-149.el9fdp
+ARG ovnver=23.06.4-26.el9fdp
 
 RUN INSTALL_PKGS="iptables" && \
 	dnf install -y --nodocs $INSTALL_PKGS && \


### PR DESCRIPTION
Bump ovn and ovs to latest patch releases for their major.minor version to address image grading issues.