### PR TITLE
OCPBUGS-55951: Bump ovn and ovs to latest 23.06 and 3.1 respectively

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -12,15 +12,15 @@ RUN yum install -y  \
 	selinux-policy && \
 	yum clean all
 
-ARG ovsver=2.17.0-148.el8fdp
-ARG ovnver=23.06.1-112.el8fdp
+ARG ovsver=3.1.0-159.el8fdp
+ARG ovnver=23.06.4-26.el8fdp
 
 RUN \
-    yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False "openvswitch2.17 = $ovsver" "python3-openvswitch2.17 = $ovsver" && \
+    yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False "openvswitch3.1 = $ovsver" "python3-openvswitch3.1 = $ovsver" && \
     yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False "ovn23.06 = $ovnver" "ovn23.06-central = $ovnver" "ovn23.06-host = $ovnver" && \
     yum clean all && rm -rf /var/cache/*
 
-RUN sed 's/%/"/g' <<<"%openvswitch2.17-devel = $ovsver% %openvswitch2.17-ipsec = $ovsver% %ovn23.06-vtep = $ovnver%" > /more-pkgs
+RUN sed 's/%/"/g' <<<"%openvswitch3.1-devel = $ovsver% %openvswitch3.1-ipsec = $ovsver% %ovn23.06-vtep = $ovnver%" > /more-pkgs
 
 RUN mkdir -p /var/run/openvswitch && \
     mkdir -p /var/run/ovn && \


### PR DESCRIPTION
This moves ovs from 2.17 in the container image to 3.1 matching RHCOS as used since Feb 2024, see https://issues.redhat.com/browse/OCPBUGS-22701

Regression testing only, no specific functional fixes