### PR TITLE
OCPBUGS-56419: Update to FDP25.A.1 24.03.5-40.

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -13,7 +13,7 @@ RUN dnf install -y --nodocs \
 	dnf clean all
 
 ARG ovsver=3.3.0-62.el9fdp
-ARG ovnver=23.09.6-12.el9fdp
+ARG ovnver=24.03.5-40.el9fdp
 
 RUN INSTALL_PKGS="iptables" && \
 	ovsver_short=$(echo "$ovsver" | cut -d'.' -f1,2) && \


### PR DESCRIPTION
This contains the following relevant changes:
  - controller: Fix active mac-binding refresh for IPv6.
  - controller: Send ARP/ND for stale mac_bindings entries. (#[FDP-1135](https://issues.redhat.com//browse/FDP-1135)) https://issues.redhat.com/browse/FDP-1135
  - northd: Fix action parsing in build_lb_vip_actions(). (#[FDP-1095](https://issues.redhat.com//browse/FDP-1095)) https://issues.redhat.com/browse/FDP-1095
  - northd: Fix missing tier related ACL flows. (#[FDP-1154](https://issues.redhat.com//browse/FDP-1154)) https://issues.redhat.com/browse/FDP-1154
  - mac-cache: Fix expiration of active FDB entry due to skipped update. (#[FDP-1132](https://issues.redhat.com//browse/FDP-1132)) https://issues.redhat.com/browse/FDP-1132
  - mac-cache: Fix expiration of active MAC binding due to skipped update. (#[FDP-1130](https://issues.redhat.com//browse/FDP-1130)) https://issues.redhat.com/browse/FDP-1130
  - mac-cache: Fix MAC binding entry lookup for timestamp refresh. (#[FDP-1131](https://issues.redhat.com//browse/FDP-1131)) https://issues.redhat.com/browse/FDP-1131
  - controller: Fix IPv6 dp flow explosion by setting flow table prefixes. (#[FDP-1024](https://issues.redhat.com//browse/FDP-1024)) https://issues.redhat.com/browse/FDP-1024
  - northd: Don't SNAT reply packets on LBs with lb_force_snat_ip set. (#[FDP-1009](https://issues.redhat.com//browse/FDP-1009)) https://issues.redhat.com/browse/FDP-1009
  - Fix load balanced hairpin traffic for fragmented packets. (#[FDP-905](https://issues.redhat.com//browse/FDP-905)) https://issues.redhat.com/browse/FDP-905
  - mac-cache: Properly handle deletion of SB mac_bindings. (#[FDP-906](https://issues.redhat.com//browse/FDP-906)) https://issues.redhat.com/browse/FDP-906
  - ipam: Do not report error for static assigned IPs. (#[FDP-752](https://issues.redhat.com//browse/FDP-752)) https://issues.redhat.com/browse/FDP-752
  - northd: Respect --ecmp-symmetric-reply for single routes. (#[FDP-786](https://issues.redhat.com//browse/FDP-786)) https://issues.redhat.com/browse/FDP-786

Other relevant changes (23.09->24.03):
  - Fix missing load balancer hairpin flows.
  - controller: Fix IPv6 dp flow explosion by setting flow table prefixes.
  - controller: Update physical flows for peer port when the patch port is removed.
  - northd: Don't SNAT reply packets on LBs with lb_force_snat_ip set.
  - logical-fields: Reuse registers for ct_*_dst() actions.
  - lex: Indicate that the template wasn't found during parsing.
  - controller: Prevent crash when db is empty.
  - pinctrl: Skip non-local mac bindings in run_buffered_binding().
  - pinctrl: Skip deleted mac bindings in run_buffered_binding().
  - mac-cache: Properly handle deletion of SB mac_bindings.
  - northd, controller: Use ct_next to get the CT state for direct SNAT.
  - ovn-nbctl: Show bfd option man for lr-policy-add command.
  - northd: Fix an issue wrt mac binding aging.
  - northd, controller: Handle tunnel_key change consistently.
  - northd: Fix direct access to SNAT network.
  - actions: New action ct_commit_to_zone.
  - northd: Fix BFD for policy routing.
  - northd: Fix NAT configuration with --add-route option for gw-router.
  - northd: lflow-mgr: Allocate DP reference counters on a second use.
  - northd: Fix lflow ref node's reference counting.
  - northd: Don't add ARP request responder flows for NAT multiple times.
  - northd: Don't add lr_out_delivery default drop flow for each lrp.
  - northd: Add I-P for NB_Global and SB_Global.
  - northd: Add northd change handler for sync_to_sb_lb node.
  - northd: Add a noop handler for northd SB mac binding.
  - northd: Add ls_stateful handler for lflow engine node.
  - northd: Add lr_stateful handler for lflow engine node.
  - northd: Handle lb changes in lflow engine.
  - northd: Move ovn_lb_datapaths from lib to northd module.
  - northd: Use lflow_ref when adding all logical flows.
  - northd: Refactor lflow management into a separate module.
  - northd: Add a new node 'ls_stateful'.
  - northd: Generate router's stateful flows using lr_stateful data.
  - northd: Add a new engine 'lr_stateful' to manage lr's stateful data.
  - northd: Add a new engine 'lr_nat' to manage lr NAT data.
  - northd: Add qos packet marking.
  - northd: Add BFD support for ECMP route policy.
  - ovn-nbctl: Fix nbctl_pre_lr_route_add for BFD.
  - northd: Add option to enable conntrack for router port
  - northd: Support CIDR-based MAC binding aging threshold.
  - controller: split mg action in table 39 and 40 to fit kernel netlink buffer size
  - nbctl: Add optional ha-chassis-group arg to ha-chassis-group-list
  - controller: disable OpenFlow inactivity probing
  - northd: Improve HA reference chassis build logic.
  - northd: Fix naming and comments related to HA reference chassis.
  - northd: Don't check ct_lb_related feature for skip_snat/force_snat.
  - northd: Support an option to ignore chassis features.
