### PR TITLE
OCPBUGS-52462: Bump OVN to 24.09.2-69.el9fdp

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -17,7 +17,7 @@ RUN dnf --setopt=retries=2 --setopt=timeout=2 install -y --nodocs \
 # reduces the number of variables in the system) and receive all the CVE and
 # bug fixes automatically.
 ARG ovsver=3.5
-ARG ovnver=24.09.2-41.el9fdp
+ARG ovnver=24.09.2-69.el9fdp
 # NOTE: Ensure that the versions of OVS and OVN are overriden for OKD in each of the subsequent layers.
 # Centos and RHEL releases for ovn are built out of sync, so please make sure to bump for OKD with
 # the corresponding Centos version when updating the OCP version.


### PR DESCRIPTION
Change log since 24.09.2-41:

```
* Tue May 06 2025 Mark Michelson <mmichels@redhat.com> - 24.09.2-69
- northd: Set REGBIT_CONNTRACK_COMMIT earlier. (#FDP-1321) [Upstream: f8d6d7b46322d83bbaaacb6970ff15085dd31fcc]

* Tue Apr 29 2025 Ales Musil <amusil@redhat.com> - 24.09.2-68
- contoller, northd: Limit number of claims for virtual ports. (#FDP-443) [Upstream: c2d34d96ba24dea60d843d633b3794ef3be11146]

* Tue Apr 29 2025 Ales Musil <amusil@redhat.com> - 24.09.2-67
- controller: Remove only commited virtual port binding requests. [Upstream: a99aa6e2f08c4d34194fae44e0f3068dd8eaa700]

* Tue Apr 29 2025 Ales Musil <amusil@redhat.com> - 24.09.2-66
- inc-engine: Adjust the force recompute API. (#FDP-753) [Upstream: f0d9df0259f29b817d345f4b77cd1548618225f8]

* Thu Apr 24 2025 Felix Huettner <felix.huettner@stackit.cloud> - 24.09.2-65
- tests: Fix racy hard_age value. [Upstream: 0f8d255c8765ddfdcfa8a0680bf4f14a37175b3a]

* Wed Apr 23 2025 Rosemarie O'Riorden <rosemarie@redhat.com> - 24.09.2-64
- ovn-nb: Improve docs for nbctl --template lb-add. (#FDP-1066) [Upstream: cf97cd9152221e0631d97e0794e812ae427a9000]

* Wed Apr 23 2025 Martin Morgenstern <martin.morgenstern@cloudandheat.com> - 24.09.2-63
- ovn-nbctl.8: Document the "--route-table" option. [Upstream: 2b722a651b7ded4a4c0281fa1fd119cdeccdeb3b]

* Wed Apr 23 2025 Martin Morgenstern <martin.morgenstern@cloudandheat.com> - 24.09.2-62
- ovn-architecture.7: Fix outdated nb_cfg description. [Upstream: af13b3e2131a71d6622cc9f257b8c636a36ed7be]

* Wed Apr 23 2025 Dumitru Ceara <dceara@redhat.com> - 24.09.2-61
- tests: Don't hardcode table numbers in the default flows test. [Upstream: 3c34785edd76cfea353fb065a85d72e6a6435358]

* Tue Apr 15 2025 Dumitru Ceara <dceara@redhat.com> - 24.09.2-60
- northd: Avoid matching on ct_state.dnat in logical flows. (#FDP-1271) [Upstream: 9a1e9de500d3e060a29dfc7b7e55e2d840f64e06]

* Tue Apr 15 2025 Dumitru Ceara <dceara@redhat.com> - 24.09.2-59
- lib: northd: Add a new ct-state-save feature flag. [Upstream: 410c478850baa562d6d996600fe0dcd50097c91c]

* Tue Apr 15 2025 Dumitru Ceara <dceara@redhat.com> - 24.09.2-58
- lib: ovn-controller: Add a new ct_state_save() logical action. [Upstream: 4a1350fea0eaf07feb1274f7f834de705b93e02b]

* Tue Apr 08 2025 Numan Siddique <numans@ovn.org> - 24.09.2-57
- northd: Limit flooding the self originated neigh disc packets. [Upstream: c05c5655483f7db0a0c584717df71c6bd8bd614d]

* Thu Apr 03 2025 Dumitru Ceara <dceara@redhat.com> - 24.09.2-56
- northd: Fix network_id computation for IPv6 LRP networks. [Upstream: c4a7ee0c3e166f2a25b0f8d92c89d87f80bcbfff]

* Thu Apr 03 2025 Rosemarie O'Riorden <rosemarie@redhat.com> - 24.09.2-55
- ovn-nbctl: Add --template option for lb-add. (#FDP-1050) [Upstream: 48ca151a81f87a3ac9c5a90eef6ecf70f40fc367]

* Thu Apr 03 2025 Frode Nordahl <fnordahl@ubuntu.com> - 24.09.2-54
- tests: Use scapy contrib BFD implementation. [Upstream: 905433722343700a130b3595aed69b01111f5538]

* Thu Apr 03 2025 Ales Musil <amusil@redhat.com> - 24.09.2-53
- controller, northd: Add command to enable time warp. [Upstream: 17adb99fcc9832264567768a76a86790920f92ab]

* Wed Apr 02 2025 Dumitru Ceara <dceara@redhat.com> - 24.09.2-52
- statctrl: Add visibility into how long each stats node run lasts. [Upstream: 5000c80709a6d2ac6a69d65e36156b3b3f0e335c]

* Tue Apr 01 2025 Dumitru Ceara <dceara@redhat.com> - 24.09.2-51
- docs: Fix up stage-hint ovn-sb documentation. [Upstream: c36cfa6861bd6d8154454428eadbad9280397913]

* Tue Apr 01 2025 Lorenzo Bianconi <lorenzo.bianconi@redhat.com> - 24.09.2-50
- northd: Do not drop ip traffic with destination vip expressed via template vars. (#FDP-988) [Upstream: 9a417e613b579cbdc316ef46cf6357944fc68b2b]

* Tue Apr 01 2025 Rosemarie O'Riorden <rosemarie@redhat.com> - 24.09.2-49
- northd: Use next-hop network for SNAT when lb_force_snat_ip=router_ip. (#FDP-871) [Upstream: 73a236071981356cf9420e92a31765bd53313654]

* Mon Mar 31 2025 Frode Nordahl <fnordahl@ubuntu.com> - 24.09.2-48
- ovs: Update the submodule to include python F824 fix. [Upstream: 561a46e8d7c2defc31beed758e04f4d3b3ff3c81]

* Fri Mar 21 2025 Ales Musil <amusil@redhat.com> - 24.09.2-47
- ci: Add missing llvm package into Fedora. [Upstream: 39938eedad46b042964fc19023c65e4d60ad2b89]

* Thu Mar 20 2025 Xavier Simonart <xsimonar@redhat.com> - 24.09.2-46
- controller: Redirect traffic for container port. (#FDP-1223) [Upstream: 02eaf7e710e6ec460c3e9edfef06c0d4cee843fb]

* Thu Mar 20 2025 Xavier Simonart <xsimonar@redhat.com> - 24.09.2-45
- multinode tests: Simplify/Cleanup migration test. [Upstream: 385ac9a54eb7684c7dc5dda9c84d5641e27a9e04]

* Thu Mar 20 2025 Ales Musil <amusil@redhat.com> - 24.09.2-44
- lb: Make the LB validation consistent. [Upstream: 8f97a69082b9d53ff56cd5479c3183c88bc1843f]

* Tue Mar 18 2025 Ales Musil <amusil@redhat.com> - 24.09.2-43
- tests: Ignore FDB transaction errors. [Upstream: 7746a7b87d27acf205de34288c6c6ac568958a5e]

* Tue Mar 18 2025 Lorenzo Bianconi <lorenzo.bianconi@redhat.com> - 24.09.2-42
- controller: Fix active mac-binding refresh for IPv6. [Upstream: cec696bb40e51920c54ddeab7bda8e22f99b1e79]
```