### PR TITLE
[WIP] 4.19 test: Add allow-stateless ACLs for advertised L2 UDNs

### DIFF
--- a/go-controller/pkg/clustermanager/routeadvertisements/controller.go
+++ b/go-controller/pkg/clustermanager/routeadvertisements/controller.go
@@ -373,8 +373,8 @@ func (c *Controller) generateFRRConfigurations(ra *ratypes.RouteAdvertisements) 
 			return nil, nil, fmt.Errorf("%w: selected network %q has unsupported topology %q", errConfig, networkName, network.TopologyType())
 		}
 
-		if config.Gateway.Mode == config.GatewayModeLocal && network.TopologyType() == types.Layer2Topology {
-			return nil, nil, fmt.Errorf("%w: BGP is currenty not supported for Layer2 networks in local gateway mode, network: %s", errConfig, network.GetNetworkName())
+		if advertisements.Has(ratypes.EgressIP) && network.TopologyType() == types.Layer2Topology {
+			return nil, nil, fmt.Errorf("%w: EgressIP advertisement is currently not supported for Layer2 networks, network: %s", errConfig, network.GetNetworkName())
 		}
 
 		vrf := util.GetNetworkVRFName(network)

--- a/go-controller/pkg/ovn/base_network_controller.go
+++ b/go-controller/pkg/ovn/base_network_controller.go
@@ -730,6 +730,14 @@ func (bnc *BaseNetworkController) syncNodeManagementPort(node *corev1.Node, swit
 	var v4Subnet *net.IPNet
 	addresses := macAddress.String()
 	mgmtPortIPs := []net.IP{}
+
+	if config.Gateway.Mode == config.GatewayModeLocal &&
+		bnc.TopologyType() == types.Layer2Topology &&
+		util.IsPodNetworkAdvertisedAtNode(bnc.GetNetInfo(), node.Name) {
+		if err := bnc.addNetworkSubnetAllowACL(node.Name, switchName, hostSubnets); err != nil {
+			return nil, err
+		}
+	}
 	for _, hostSubnet := range hostSubnets {
 		mgmtIfAddr := util.GetNodeManagementIfAddr(hostSubnet)
 		addresses += " " + mgmtIfAddr.IP.String()

--- a/go-controller/pkg/ovn/secondary_layer2_network_controller.go
+++ b/go-controller/pkg/ovn/secondary_layer2_network_controller.go
@@ -515,7 +515,10 @@ func (oc *SecondaryLayer2NetworkController) Stop() {
 func (oc *SecondaryLayer2NetworkController) Reconcile(netInfo util.NetInfo) error {
 	return oc.BaseNetworkController.reconcile(
 		netInfo,
-		func(node string) { oc.gatewaysFailed.Store(node, true) },
+		func(node string) {
+			oc.gatewaysFailed.Store(node, true)
+			oc.mgmtPortFailed.Store(node, true)
+		},
 	)
 }
 

--- a/go-controller/pkg/types/const.go
+++ b/go-controller/pkg/types/const.go
@@ -91,7 +91,8 @@ const (
 	PrimaryUDNAllowPriority = 1001
 	// Default deny acl rule priority
 	PrimaryUDNDenyPriority = 1000
-
+	// UDN subnet allow acl priority used for enabling assymetric traffic for L2 networks in LGW with BGP
+	UDNSubnetAllowPriority = 999
 	// ACL Tiers
 	// Tier 0 is called Primary as it is evaluated before any other feature-related Tiers.
 	// Currently used for User Defined Network Feature.

--- a/test/e2e/route_advertisements.go
+++ b/test/e2e/route_advertisements.go
@@ -288,11 +288,6 @@ var _ = ginkgo.Describe("BGP: Pod to external server when CUDN network is advert
 				Values:   []string{f.Namespace.Name},
 			}}}
 
-			if IsGatewayModeLocal() && cudnTemplate.Spec.Network.Topology == udnv1.NetworkTopologyLayer2 {
-				e2eskipper.Skipf(
-					"BGP for L2 networks on LGW is currently unsupported",
-				)
-			}
 			// Create CUDN
 			ginkgo.By("create ClusterUserDefinedNetwork")
 			udnClient, err := udnclientset.NewForConfig(f.ClientConfig())


### PR DESCRIPTION
This change adds the following ACLs to allow assymetric traffic to skip being commited to conntrack by OVN:
from-lport   999 (inport == "<management-port>" && (ip4.dst == <l2UDN-subnet>)) allow-stateless
  to-lport   999 (outport == "<management-port>" && (ip4.src == <l2UDN-subnet>)) allow-stateless


(cherry picked from commit 24a9942c09d861bb3ac20dd4c6f9f903706b7a4d)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
