### PR TITLE
[release-4.16] OCPBUGS-57062: Increase InformerSyncTimeout to 60s

### DIFF
--- a/go-controller/pkg/types/const.go
+++ b/go-controller/pkg/types/const.go
@@ -187,8 +187,12 @@ const (
 
 	// InformerSyncTimeout is used when waiting for the initial informer cache sync
 	// (i.e. all existing objects should be listed by the informer).
-	// It allows ~4 list() retries with the default reflector exponential backoff config
-	InformerSyncTimeout = 20 * time.Second
+	// It allows ~5 list() retries with the default reflector exponential backoff config
+	// Also considers listing a high number of items on high load scenarios
+	// (last observed 4k egress firewall taking > 30s)
+	// TODO: consider not using a timeout, potentially shifting to configurable
+	// readiness probe
+	InformerSyncTimeout = 60 * time.Second
 
 	// HandlerSyncTimeout is used when waiting for initial object handler sync.
 	// (i.e. all the ADD events should be processed for the existing objects by the event handler)


### PR DESCRIPTION
The cache synce time could take longer time when pulling a large number of objects for apiserver.


(cherry picked from commit c57e83c96b2fc676aa75eb588c574b08d118ea59)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
