### PR TITLE
[release-4.16] OCPBUGS-57396: Fix predicate for cluster subnet route to gateway router

### DIFF
--- a/go-controller/pkg/libovsdb/util/router.go
+++ b/go-controller/pkg/libovsdb/util/router.go
@@ -3,12 +3,14 @@ package util
 import (
 	"fmt"
 	"net"
+	"strings"
 
 	libovsdbclient "github.com/ovn-org/libovsdb/client"
 	libovsdbops "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdb/ops"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	"k8s.io/klog/v2"
 	utilnet "k8s.io/utils/net"
 )
 
@@ -34,25 +36,47 @@ func CreateDefaultRouteToExternal(nbClient libovsdbclient.Client, nodeName strin
 	if err != nil {
 		return fmt.Errorf("attempt at finding node gateway router %s network information failed, err: %w", nodeName, err)
 	}
-	clusterSubnets := util.GetAllClusterSubnets()
-	for _, subnet := range clusterSubnets {
-		gatewayIP, err := util.MatchFirstIPNetFamily(utilnet.IsIPv6String(subnet.IP.String()), gatewayIPs)
+	clusterSubnetsV4, clusterSubnetsV6 := util.GetClusterSubnetsWithHostPrefix()
+
+	for _, clusterSubnet := range append(clusterSubnetsV4, clusterSubnetsV6...) {
+		isClusterSubnetIPV6 := utilnet.IsIPv6String(clusterSubnet.CIDR.IP.String())
+		gatewayIP, err := util.MatchFirstIPNetFamily(isClusterSubnetIPV6, gatewayIPs)
 		if err != nil {
 			return fmt.Errorf("could not find gateway IP for node %s with family %v: %v", nodeName, false, err)
 		}
 		lrsr := nbdb.LogicalRouterStaticRoute{
-			IPPrefix: subnet.String(),
+			IPPrefix: clusterSubnet.CIDR.String(),
 			Nexthop:  gatewayIP.IP.String(),
 			Policy:   &nbdb.LogicalRouterStaticRoutePolicySrcIP,
 		}
+
+		clusterSubnetPrefixLen, _ := clusterSubnet.CIDR.Mask.Size()
 		p := func(lrsr *nbdb.LogicalRouterStaticRoute) bool {
-			_, itemCIDR, err := net.ParseCIDR(lrsr.IPPrefix)
-			if err != nil {
+			// Replace any existing LRSR for the cluster subnet.
+			// Make sure you don't wipe out the existing LRSR via mp0 for the local node subnet
+			// (e.g. 10.244.1.0/24 10.244.1.2 src-ip) and take into account cluster subnet expansion,
+			// which imposes the IP address part of the subnet to stay the same and only allows
+			// the mask length to be decreased (e.g. from 10.244.0.0/16 to 10.244.0.0/15, as long
+			// as 10.244.0.0 stays the same).
+			if utilnet.IsIPv6String(lrsr.Nexthop) != isClusterSubnetIPV6 {
 				return false
 			}
-			return util.ContainsCIDR(subnet, itemCIDR) &&
-				lrsr.Nexthop == gatewayIP.IP.String() &&
+			if !strings.Contains(lrsr.IPPrefix, "/") {
+				// skip /32 (v4) or /128 (v6) routes, not rendered with prefix length in OVN
+				return false
+			}
+			_, itemCIDR, err := net.ParseCIDR(lrsr.IPPrefix)
+			if err != nil {
+				klog.Errorf("Failed to parse CIDR %s of lrsr %+v: %v", lrsr.IPPrefix, lrsr, err)
+				return false
+			}
+			itemPrefixLen, _ := itemCIDR.Mask.Size()
+
+			return clusterSubnet.CIDR.IP.Equal(itemCIDR.IP) && // even after expansion, cluster network address cannot change
+				clusterSubnetPrefixLen <= itemPrefixLen && // cluster subnet mask len can only be decreased
+				itemPrefixLen < clusterSubnet.HostSubnetLength && // don't match the local node subnet route
 				lrsr.Policy != nil && *lrsr.Policy == nbdb.LogicalRouterStaticRoutePolicySrcIP
+
 		}
 		if err := libovsdbops.CreateOrReplaceLogicalRouterStaticRouteWithPredicate(nbClient, types.OVNClusterRouter, &lrsr, p); err != nil {
 			return fmt.Errorf("unable to create pod to external catch-all reroute for node %s, err: %v", nodeName, err)

--- a/go-controller/pkg/libovsdb/util/router_test.go
+++ b/go-controller/pkg/libovsdb/util/router_test.go
@@ -1,0 +1,237 @@
+package util
+
+import (
+	"fmt"
+	"net"
+	"testing"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
+	libovsdbtest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
+)
+
+func TestCreateDefaultRouteToExternal(t *testing.T) {
+
+	config.PrepareTestConfig()
+	nodeName := "ovn-worker"
+
+	_, clusterSubnetV4, _ := net.ParseCIDR("10.128.0.0/16")
+	_, clusterSubnetV6, _ := net.ParseCIDR("fe00::/48")
+	config.Default.ClusterSubnets = []config.CIDRNetworkEntry{{clusterSubnetV4, 24}, {clusterSubnetV6, 64}}
+
+	ovnClusterRouterName := types.OVNClusterRouter
+	gwRouterName := types.GWRouterPrefix + nodeName
+	gwRouterPortName := types.GWRouterToJoinSwitchPrefix + gwRouterName
+	gwRouterIPAddressV4 := "100.64.0.3"
+	gwRouterIPAddressV6 := "fd98::3"
+	gwRouterPort := &nbdb.LogicalRouterPort{
+		UUID:     gwRouterPortName + "-uuid",
+		Name:     gwRouterPortName,
+		Networks: []string{gwRouterIPAddressV4 + "/16", gwRouterIPAddressV6 + "/64"},
+	}
+
+	clusterSubnetRouteV4 := &nbdb.LogicalRouterStaticRoute{
+		IPPrefix: clusterSubnetV4.String(),
+		Nexthop:  gwRouterIPAddressV4,
+		Policy:   &nbdb.LogicalRouterStaticRoutePolicySrcIP,
+		UUID:     "cluster-subnet-route-v4-uuid",
+	}
+	clusterSubnetRouteV6 := &nbdb.LogicalRouterStaticRoute{
+		IPPrefix: clusterSubnetV6.String(),
+		Nexthop:  gwRouterIPAddressV6,
+		Policy:   &nbdb.LogicalRouterStaticRoutePolicySrcIP,
+		UUID:     "cluster-subnet-route-v6-uuid",
+	}
+
+	// to test that we won't erase the old cluster subnet route that had a different next hop
+	wrongNextHopClusterSubnetRouteV4 := &nbdb.LogicalRouterStaticRoute{
+		IPPrefix: clusterSubnetV4.String(),
+		Nexthop:  "100.64.0.33",
+		Policy:   &nbdb.LogicalRouterStaticRoutePolicySrcIP,
+		UUID:     "old-cluster-subnet-route-v4-uuid",
+	}
+	wrongNextHopClusterSubnetRouteV6 := &nbdb.LogicalRouterStaticRoute{
+		IPPrefix: clusterSubnetV6.String(),
+		Nexthop:  "fd98::33",
+		Policy:   &nbdb.LogicalRouterStaticRoutePolicySrcIP,
+		UUID:     "old-cluster-subnet-route-v6-uuid",
+	}
+
+	// to test that we won't erase the existing route for the node subnet via mp0
+	_, nodeSubnetV4, _ := net.ParseCIDR("10.128.0.0/24")
+	_, nodeSubnetV6, _ := net.ParseCIDR("fe00::/64")
+	mp0IPAddressV4 := "100.244.0.2"
+	mp0IPAddressV6 := "fe00::2"
+
+	nodeSubnetRouteV4 := &nbdb.LogicalRouterStaticRoute{
+		IPPrefix: nodeSubnetV4.String(),
+		Nexthop:  mp0IPAddressV4,
+		Policy:   &nbdb.LogicalRouterStaticRoutePolicySrcIP,
+		UUID:     "node-subnet-route-v4-uuid",
+	}
+	nodeSubnetRouteV6 := &nbdb.LogicalRouterStaticRoute{
+		IPPrefix: nodeSubnetV6.String(),
+		Nexthop:  mp0IPAddressV6,
+		Policy:   &nbdb.LogicalRouterStaticRoutePolicySrcIP,
+		UUID:     "node-subnet-route-v6-uuid",
+	}
+
+	// to test that, after cluster subnet expansion, we replace the old cluster subnet route with the new one
+	_, newClusterSubnetV4, _ := net.ParseCIDR("10.128.0.0/15")
+	_, newClusterSubnetV6, _ := net.ParseCIDR("fe00::/46")
+	newClusterSubnetRouteAfterExpansionV4 := &nbdb.LogicalRouterStaticRoute{
+		IPPrefix: newClusterSubnetV4.String(),
+		Nexthop:  gwRouterIPAddressV4,
+		Policy:   &nbdb.LogicalRouterStaticRoutePolicySrcIP,
+		UUID:     "new-cluster-subnet-route-v4-uuid",
+	}
+	newClusterSubnetRouteAfterExpansionV6 := &nbdb.LogicalRouterStaticRoute{
+		IPPrefix: newClusterSubnetV6.String(),
+		Nexthop:  gwRouterIPAddressV6,
+		Policy:   &nbdb.LogicalRouterStaticRoutePolicySrcIP,
+		UUID:     "new-cluster-subnet-route-v6-uuid",
+	}
+
+	gatewayRouter := &nbdb.LogicalRouter{
+		Name:  gwRouterName,
+		UUID:  gwRouterName + "-uuid",
+		Ports: []string{gwRouterPort.UUID},
+	}
+
+	tests := []struct {
+		desc          string
+		initialNbdb   libovsdbtest.TestSetup
+		expectedNbdb  libovsdbtest.TestSetup
+		preTestAction func()
+	}{
+		{
+			desc: "Add a cluster subnet route to GW router when no cluster subnet route exists",
+			initialNbdb: libovsdbtest.TestSetup{
+				NBData: []libovsdbtest.TestData{
+					&nbdb.LogicalRouter{
+						Name:         ovnClusterRouterName,
+						UUID:         ovnClusterRouterName + "-uuid",
+						StaticRoutes: []string{nodeSubnetRouteV4.UUID, nodeSubnetRouteV6.UUID}, // should not be replaced
+					},
+					gatewayRouter,
+					gwRouterPort,
+					nodeSubnetRouteV4,
+					nodeSubnetRouteV6,
+				},
+			},
+			expectedNbdb: libovsdbtest.TestSetup{
+				NBData: []libovsdbtest.TestData{
+					&nbdb.LogicalRouter{
+						Name:         ovnClusterRouterName,
+						UUID:         ovnClusterRouterName + "-uuid",
+						StaticRoutes: []string{nodeSubnetRouteV4.UUID, nodeSubnetRouteV6.UUID, clusterSubnetRouteV4.UUID, clusterSubnetRouteV6.UUID},
+					},
+					gatewayRouter,
+					gwRouterPort,
+					nodeSubnetRouteV4,
+					nodeSubnetRouteV6,
+					clusterSubnetRouteV4,
+					clusterSubnetRouteV6,
+				},
+			},
+		},
+		{
+			desc: "Add a cluster subnet route to GW router when a cluster subnet route already exists", // should replace the existing one
+			initialNbdb: libovsdbtest.TestSetup{
+				NBData: []libovsdbtest.TestData{
+					wrongNextHopClusterSubnetRouteV4,
+					wrongNextHopClusterSubnetRouteV6,
+					&nbdb.LogicalRouter{
+						Name:         ovnClusterRouterName,
+						UUID:         ovnClusterRouterName + "-uuid",
+						StaticRoutes: []string{nodeSubnetRouteV4.UUID, nodeSubnetRouteV6.UUID, wrongNextHopClusterSubnetRouteV4.UUID, wrongNextHopClusterSubnetRouteV6.UUID},
+					},
+					gatewayRouter,
+					gwRouterPort,
+					nodeSubnetRouteV4,
+					nodeSubnetRouteV6,
+				},
+			},
+			expectedNbdb: libovsdbtest.TestSetup{
+				NBData: []libovsdbtest.TestData{
+					&nbdb.LogicalRouter{
+						Name:         ovnClusterRouterName,
+						UUID:         ovnClusterRouterName + "-uuid",
+						StaticRoutes: []string{nodeSubnetRouteV4.UUID, nodeSubnetRouteV6.UUID, clusterSubnetRouteV4.UUID, clusterSubnetRouteV6.UUID},
+					},
+					gatewayRouter,
+					gwRouterPort,
+					nodeSubnetRouteV4,
+					nodeSubnetRouteV6,
+					clusterSubnetRouteV4,
+					clusterSubnetRouteV6,
+				},
+			},
+		},
+		{
+			desc: "Update the cluster subnet route to GW router after cluster subnet expansion", // should replace the existing one
+			initialNbdb: libovsdbtest.TestSetup{
+				NBData: []libovsdbtest.TestData{
+					clusterSubnetRouteV4,
+					clusterSubnetRouteV6,
+					&nbdb.LogicalRouter{
+						Name:         ovnClusterRouterName,
+						UUID:         ovnClusterRouterName + "-uuid",
+						StaticRoutes: []string{nodeSubnetRouteV4.UUID, nodeSubnetRouteV6.UUID, clusterSubnetRouteV4.UUID, clusterSubnetRouteV6.UUID},
+					},
+					gatewayRouter,
+					gwRouterPort,
+					nodeSubnetRouteV4,
+					nodeSubnetRouteV6,
+				},
+			},
+			preTestAction: func() {
+				// Apply the new cluster subnets
+				config.Default.ClusterSubnets = []config.CIDRNetworkEntry{{newClusterSubnetV4, 24}, {newClusterSubnetV6, 64}}
+
+			},
+			expectedNbdb: libovsdbtest.TestSetup{
+				NBData: []libovsdbtest.TestData{
+					&nbdb.LogicalRouter{
+						Name:         ovnClusterRouterName,
+						UUID:         ovnClusterRouterName + "-uuid",
+						StaticRoutes: []string{nodeSubnetRouteV4.UUID, nodeSubnetRouteV6.UUID, newClusterSubnetRouteAfterExpansionV4.UUID, newClusterSubnetRouteAfterExpansionV6.UUID},
+					},
+					gatewayRouter,
+					gwRouterPort,
+					nodeSubnetRouteV4,
+					nodeSubnetRouteV6,
+					newClusterSubnetRouteAfterExpansionV4,
+					newClusterSubnetRouteAfterExpansionV6,
+				},
+			},
+		},
+	}
+	for i, tc := range tests {
+		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
+			nbClient, cleanup, err := libovsdbtest.NewNBTestHarness(tc.initialNbdb, nil)
+			if err != nil {
+				t.Fatal(fmt.Errorf("test: \"%s\" failed to create test harness: %v", tc.desc, err))
+			}
+			t.Cleanup(cleanup.Cleanup)
+
+			if tc.preTestAction != nil {
+				tc.preTestAction()
+			}
+
+			if err = CreateDefaultRouteToExternal(nbClient, nodeName); err != nil {
+				t.Fatal(fmt.Errorf("failed to run CreateDefaultRouteToExternal: %v", err))
+			}
+
+			matcher := libovsdbtest.HaveDataIgnoringUUIDs(tc.expectedNbdb.NBData)
+			success, err := matcher.Match(nbClient)
+			if !success {
+				t.Fatal(fmt.Errorf("test: \"%s\" didn't match expected with actual, err: %v", tc.desc, matcher.FailureMessage(nbClient)))
+			}
+			if err != nil {
+				t.Fatal(fmt.Errorf("test: \"%s\" encountered error: %v", tc.desc, err))
+			}
+		})
+	}
+}

--- a/go-controller/pkg/util/kube.go
+++ b/go-controller/pkg/util/kube.go
@@ -559,24 +559,38 @@ func ServiceInternalTrafficPolicyLocal(service *kapi.Service) bool {
 	return service.Spec.InternalTrafficPolicy != nil && *service.Spec.InternalTrafficPolicy == kapi.ServiceInternalTrafficPolicyLocal
 }
 
-// GetClusterSubnets returns the v4&v6 cluster subnets in a cluster separately
-func GetClusterSubnets() ([]*net.IPNet, []*net.IPNet) {
-	var v4ClusterSubnets = []*net.IPNet{}
-	var v6ClusterSubnets = []*net.IPNet{}
+// GetClusterSubnetsWithHostPrefix returns the v4 and v6 cluster subnets, along with their host prefix,
+// in two separate slices
+func GetClusterSubnetsWithHostPrefix() ([]*config.CIDRNetworkEntry, []*config.CIDRNetworkEntry) {
+	var v4ClusterSubnets = []*config.CIDRNetworkEntry{}
+	var v6ClusterSubnets = []*config.CIDRNetworkEntry{}
 	for _, clusterSubnet := range config.Default.ClusterSubnets {
+		clusterSubnet := clusterSubnet
 		if !utilnet.IsIPv6CIDR(clusterSubnet.CIDR) {
-			v4ClusterSubnets = append(v4ClusterSubnets, clusterSubnet.CIDR)
+			v4ClusterSubnets = append(v4ClusterSubnets, &clusterSubnet)
 		} else {
-			v6ClusterSubnets = append(v6ClusterSubnets, clusterSubnet.CIDR)
+			v6ClusterSubnets = append(v6ClusterSubnets, &clusterSubnet)
 		}
 	}
 	return v4ClusterSubnets, v6ClusterSubnets
 }
 
-// GetAllClusterSubnets returns all (v4&v6) cluster subnets in a cluster
-func GetAllClusterSubnets() []*net.IPNet {
-	v4ClusterSubnets, v6ClusterSubnets := GetClusterSubnets()
-	return append(v4ClusterSubnets, v6ClusterSubnets...)
+// GetClusterSubnets returns the v4 and v6 cluster subnets in two separate slices
+func GetClusterSubnets() ([]*net.IPNet, []*net.IPNet) {
+	var v4ClusterSubnets = []*net.IPNet{}
+	var v6ClusterSubnets = []*net.IPNet{}
+
+	v4ClusterSubnetsWithHostPrefix, v6ClusterSubnetsWithHostPrefix := GetClusterSubnetsWithHostPrefix()
+
+	for _, entry := range v4ClusterSubnetsWithHostPrefix {
+		v4ClusterSubnets = append(v4ClusterSubnets, entry.CIDR)
+	}
+
+	for _, entry := range v6ClusterSubnetsWithHostPrefix {
+		v6ClusterSubnets = append(v6ClusterSubnets, entry.CIDR)
+	}
+
+	return v4ClusterSubnets, v6ClusterSubnets
 }
 
 // GetNodePrimaryIP extracts the primary IP address from the node status in the  API


### PR DESCRIPTION
Taking over from https://github.com/openshift/ovn-kubernetes/pull/2637, where tide is stuck.

Cherry-pick of https://github.com/openshift/ovn-kubernetes/pull/2578

Replacing https://github.com/openshift/ovn-kubernetes/pull/2630, where unit tests were failing. 

No conflicts, but I had to apply the following change to make the patch compatible with 4.16 code:
```
--- a/go-controller/pkg/libovsdb/util/router_test.go
+++ b/go-controller/pkg/libovsdb/util/router_test.go
@@ -220,7 +220,7 @@ func TestCreateDefaultRouteToExternal(t *testing.T) {
                                tc.preTestAction()
                        }
 
-                       if err = CreateDefaultRouteToExternal(nbClient, ovnClusterRouterName, gwRouterName); err != nil {
+                       if err = CreateDefaultRouteToExternal(nbClient, nodeName); err != nil {
                                t.Fatal(fmt.Errorf("failed to run CreateDefaultRouteToExternal: %v", err))
                        }
```

