### PR TITLE
OCPBUGS-59381:[release-4.17] Fix default network -> localnet

### DIFF
--- a/go-controller/pkg/node/gateway.go
+++ b/go-controller/pkg/node/gateway.go
@@ -406,8 +406,8 @@ func (g *gateway) Reconcile() error {
 	if err != nil {
 		return fmt.Errorf("failed to get subnets for node: %s for OpenFlow cache update; err: %w", node.Name, err)
 	}
-	nodeIPs, _ := g.nodeIPManager.ListAddresses()
-	if err := g.openflowManager.updateBridgeFlowCache(subnets, nodeIPs); err != nil {
+	hostIPs, hostSubnets := g.nodeIPManager.ListAddresses()
+	if err := g.openflowManager.updateBridgeFlowCache(subnets, hostSubnets, hostIPs); err != nil {
 		return err
 	}
 	// Services create OpenFlow flows as well, need to update them all

--- a/go-controller/pkg/node/gateway_localnet.go
+++ b/go-controller/pkg/node/gateway_localnet.go
@@ -20,16 +20,16 @@ import (
 	utilnet "k8s.io/utils/net"
 )
 
-func newLocalGateway(nodeName string, hostSubnets []*net.IPNet, gwNextHops []net.IP, gwIntf, egressGWIntf string, gwIPs []*net.IPNet,
+func newLocalGateway(nodeName string, subnets []*net.IPNet, gwNextHops []net.IP, gwIntf, egressGWIntf string, gwIPs []*net.IPNet,
 	nodeAnnotator kube.Annotator, cfg *managementPortConfig, kube kube.Interface, watchFactory factory.NodeWatchFactory,
 	routeManager *routemanager.Controller) (*gateway, error) {
 	klog.Info("Creating new local gateway")
 	gw := &gateway{}
 
-	for _, hostSubnet := range hostSubnets {
+	for _, subnet := range subnets {
 		// local gateway mode uses mp0 as default path for all ingress traffic into OVN
 		var nextHop *net.IPNet
-		if utilnet.IsIPv6CIDR(hostSubnet) {
+		if utilnet.IsIPv6CIDR(subnet) {
 			nextHop = cfg.ipv6.ifAddr
 		} else {
 			nextHop = cfg.ipv4.ifAddr
@@ -158,7 +158,7 @@ func newLocalGateway(nodeName string, hostSubnets []*net.IPNet, gwNextHops []net
 		if config.Gateway.NodeportEnable {
 			if config.OvnKubeNode.Mode == types.NodeModeFull {
 				// (TODO): Internal Traffic Policy is not supported in DPU mode
-				if err := initSvcViaMgmPortRoutingRules(hostSubnets); err != nil {
+				if err := initSvcViaMgmPortRoutingRules(subnets); err != nil {
 					return err
 				}
 			}

--- a/go-controller/pkg/node/gateway_localnet.go
+++ b/go-controller/pkg/node/gateway_localnet.go
@@ -129,16 +129,16 @@ func newLocalGateway(nodeName string, subnets []*net.IPNet, gwNextHops []net.IP,
 			return fmt.Errorf("failed to update masquerade subnet annotation on node: %s, error: %v", nodeName, err)
 		}
 
-		nodeIPs, _ := gw.nodeIPManager.ListAddresses()
-		gw.openflowManager, err = newGatewayOpenFlowManager(gwBridge, exGwBridge, hostSubnets, nodeIPs)
+		hostIPs, hostSubnets := gw.nodeIPManager.ListAddresses()
+		gw.openflowManager, err = newGatewayOpenFlowManager(gwBridge, exGwBridge, subnets, hostSubnets, hostIPs)
 		if err != nil {
 			return err
 		}
 		// resync flows on IP change
 		gw.nodeIPManager.OnChanged = func() {
 			klog.V(5).Info("Node addresses changed, re-syncing bridge flows")
-			nodeIPs, _ := gw.nodeIPManager.ListAddresses()
-			if err := gw.openflowManager.updateBridgeFlowCache(hostSubnets, nodeIPs); err != nil {
+			hostIPs, hostSubnets := gw.nodeIPManager.ListAddresses()
+			if err := gw.openflowManager.updateBridgeFlowCache(subnets, hostSubnets, hostIPs); err != nil {
 				// very unlikely - somehow node has lost its IP address
 				klog.Errorf("Failed to re-generate gateway flows after address change: %v", err)
 			}

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -1371,7 +1371,7 @@ func flowsForDefaultBridge(bridge *bridgeConfiguration, extraIPs []net.IP) ([]st
 	return dftFlows, nil
 }
 
-func commonFlows(subnets []*net.IPNet, bridge *bridgeConfiguration) ([]string, error) {
+func commonFlows(subnets, hostSubnets []*net.IPNet, bridge *bridgeConfiguration) ([]string, error) {
 	// CAUTION: when adding new flows where the in_port is ofPortPatch and the out_port is ofPortPhys, ensure
 	// that dl_src is included in match criteria!
 	ofPortPhys := bridge.ofPortPhys
@@ -1432,7 +1432,7 @@ func commonFlows(subnets []*net.IPNet, bridge *bridgeConfiguration) ([]string, e
 
 					// Allow OVN->Host traffic on the same node
 					if config.Gateway.Mode == config.GatewayModeShared || config.Gateway.Mode == config.GatewayModeLocal {
-						dftFlows = append(dftFlows, ovnToHostNetworkNormalActionFlows(netConfig, bridgeMacAddress, subnets, false)...)
+						dftFlows = append(dftFlows, ovnToHostNetworkNormalActionFlows(netConfig, bridgeMacAddress, hostSubnets, false)...)
 					}
 				} else {
 					//  for UDN we additionally SNAT the packet from masquerade IP -> node IP
@@ -1512,7 +1512,7 @@ func commonFlows(subnets []*net.IPNet, bridge *bridgeConfiguration) ([]string, e
 
 					// Allow OVN->Host traffic on the same node
 					if config.Gateway.Mode == config.GatewayModeShared || config.Gateway.Mode == config.GatewayModeLocal {
-						dftFlows = append(dftFlows, ovnToHostNetworkNormalActionFlows(netConfig, bridgeMacAddress, subnets, true)...)
+						dftFlows = append(dftFlows, ovnToHostNetworkNormalActionFlows(netConfig, bridgeMacAddress, hostSubnets, true)...)
 					}
 				} else {
 					//  for UDN we additionally SNAT the packet from masquerade IP -> node IP
@@ -1895,7 +1895,7 @@ func newSharedGateway(nodeName string, subnets []*net.IPNet, gwNextHops []net.IP
 			}
 		}
 		gw.nodeIPManager = newAddressManager(nodeName, kube, cfg, watchFactory, gwBridge)
-		nodeIPs, _ := gw.nodeIPManager.ListAddresses()
+		hostIPs, hostSubnets := gw.nodeIPManager.ListAddresses()
 
 		if config.OvnKubeNode.Mode == types.NodeModeFull {
 			// Delete stale masquerade resources if there are any. This is to make sure that there
@@ -1919,7 +1919,7 @@ func newSharedGateway(nodeName string, subnets []*net.IPNet, gwNextHops []net.IP
 			}
 		}
 
-		gw.openflowManager, err = newGatewayOpenFlowManager(gwBridge, exGwBridge, subnets, nodeIPs)
+		gw.openflowManager, err = newGatewayOpenFlowManager(gwBridge, exGwBridge, subnets, hostSubnets, hostIPs)
 		if err != nil {
 			return err
 		}
@@ -1928,7 +1928,7 @@ func newSharedGateway(nodeName string, subnets []*net.IPNet, gwNextHops []net.IP
 		gw.nodeIPManager.OnChanged = func() {
 			klog.V(5).Info("Node addresses changed, re-syncing bridge flows")
 			nodeIPs, _ := gw.nodeIPManager.ListAddresses()
-			if err := gw.openflowManager.updateBridgeFlowCache(subnets, nodeIPs); err != nil {
+			if err := gw.openflowManager.updateBridgeFlowCache(subnets, hostSubnets, nodeIPs); err != nil {
 				// very unlikely - somehow node has lost its IP address
 				klog.Errorf("Failed to re-generate gateway flows after address change: %v", err)
 			}

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -1771,11 +1771,11 @@ func setBridgeOfPorts(bridge *bridgeConfiguration) error {
 
 // initSvcViaMgmPortRoutingRules creates the svc2managementport routing table, routes and rules
 // that let's us forward service traffic to ovn-k8s-mp0 as opposed to the default route towards breth0
-func initSvcViaMgmPortRoutingRules(hostSubnets []*net.IPNet) error {
+func initSvcViaMgmPortRoutingRules(subnets []*net.IPNet) error {
 	// create ovnkubeSvcViaMgmPortRT and service route towards ovn-k8s-mp0
-	for _, hostSubnet := range hostSubnets {
-		isIPv6 := utilnet.IsIPv6CIDR(hostSubnet)
-		gatewayIP := util.GetNodeGatewayIfAddr(hostSubnet).IP.String()
+	for _, subnet := range subnets {
+		isIPv6 := utilnet.IsIPv6CIDR(subnet)
+		gatewayIP := util.GetNodeGatewayIfAddr(subnet).IP.String()
 		for _, svcCIDR := range config.Kubernetes.ServiceCIDRs {
 			if isIPv6 == utilnet.IsIPv6CIDR(svcCIDR) {
 				if stdout, stderr, err := util.RunIP("route", "replace", "table", ovnkubeSvcViaMgmPortRT, svcCIDR.String(), "via", gatewayIP, "dev", types.K8sMgmtIntfName); err != nil {


### PR DESCRIPTION
Pass `hostSubnets` to `commonFlows` to fix default network -> localnet
    
We need to pass the host subnets when adding the flows at priority 102 that allow connections from pods in the default network to pods in a localnet attached to breth0 on the same node. We were previously passing the pod subnets for the node as IP dest, which is not correct:

```
sh-5.2# ovs-ofctl dump-flows breth0 | grep y=102
 cookie=0xdeff105, duration=3418.445s, table=0, n_packets=0, n_bytes=0, idle_age=3418, priority=102,ip,in_port=2,dl_src=02:42:ac:12:00:04,nw_dst=10.244.0.0/24 actions=ct(commit,zone=64000,exec(load:0x1->NXM_NX_CT_MARK[])),NORMAL
```

We're now adding one such flow for each host subnet found on the node:
```
sh-5.2# ovs-ofctl dump-flows breth0 | grep y=102
 cookie=0xdeff105, duration=374.624s, table=0, n_packets=462, n_bytes=63993, idle_age=0, priority=102,ip,in_port=2,dl_src=02:42:ac:12:00:04,nw_dst=172.18.0.0/16 actions=ct(commit,zone=64000,exec(load:0x1->NXM_NX_CT_MARK[])),NORMAL
 cookie=0xdeff105, duration=374.624s, table=0, n_packets=0, n_bytes=0, idle_age=374, priority=102,ip,in_port=2,dl_src=02:42:ac:12:00:04,nw_dst=172.19.0.0/16 actions=ct(commit,zone=64000,exec(load:0x1->NXM_NX_CT_MARK[])),NORMAL
```

This fixes https://issues.redhat.com/browse/OCPBUGS-56244 
Ticket for this 4.17 backport: OCPBUGS-59381
Original backport for 4.17: https://github.com/openshift/ovn-kubernetes/pull/2572 

No fix needed for 4.20, 4.19, 4.18, because the original patch was backported automatically, since the code is the same, and the existing e2e tests verify its correctness (https://github.com/openshift/ovn-kubernetes/pull/2505/commits/362653b17c219852bb25f2a646a9bb24a5832c56)
For 4.17 the ovnk code differed and the manual backport I did in https://github.com/openshift/ovn-kubernetes/pull/2572  was flawed, for the reason explained above. We don't currently run e2e tests in 4.17, so I successfully tested these changes on kind for both gateway modes, reproducing manually the e2e test I added for the original upstream changes: https://github.com/ovn-kubernetes/ovn-kubernetes/pull/5041/commits/362653b17c219852bb25f2a646a9bb24a5832c56 . 