### PR TITLE
Revert "unpin libreswan version"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN INSTALL_PKGS=" \
 	openssl firewalld-filesystem \
 	libpcap iproute iproute-tc strace \
 	tcpdump iputils \
-	libreswan \
+	libreswan-4.6-3.el9_0.3 \
 	ethtool conntrack-tools \
 	openshift-clients \
 	" && \


### PR DESCRIPTION
This reverts commit 764685a5631fffa992875afa49483b59062df75d.

unpinning libreswan in 4.18 would expose us to https://issues.redhat.com/browse/OCPBUGS-55453