### PR TITLE
Test first 1

### DIFF
--- a/go-controller/pkg/clustermanager/network_cluster_controller.go
+++ b/go-controller/pkg/clustermanager/network_cluster_controller.go
@@ -475,7 +475,7 @@ func (ncc *networkClusterController) Reconcile(netInfo util.NetInfo) error {
 		klog.Errorf("Failed to reconcile network %s: %v", ncc.GetNetworkName(), err)
 	}
 	if reconcilePendingPods && ncc.retryPods != nil {
-		if err := objretry.RequeuePendingPods(ncc.kube, ncc.GetNetInfo(), ncc.retryPods); err != nil {
+		if err := objretry.RequeuePendingPods(ncc.watchFactory, ncc.GetNetInfo(), ncc.retryPods); err != nil {
 			klog.Errorf("Failed to requeue pending pods for network %s: %v", ncc.GetNetworkName(), err)
 		}
 	}

--- a/go-controller/pkg/ovn/base_network_controller.go
+++ b/go-controller/pkg/ovn/base_network_controller.go
@@ -14,8 +14,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	knet "k8s.io/api/networking/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/util/sets"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -241,7 +239,7 @@ func (oc *BaseNetworkController) reconcile(netInfo util.NetInfo, setNodeFailed f
 	}
 
 	if reconcilePendingPods {
-		if err := ovnretry.RequeuePendingPods(oc.kube, oc.GetNetInfo(), oc.retryPods); err != nil {
+		if err := ovnretry.RequeuePendingPods(oc.watchFactory, oc.GetNetInfo(), oc.retryPods); err != nil {
 			klog.Errorf("Failed to requeue pending pods for network %s: %v", oc.GetNetworkName(), err)
 		}
 	}
@@ -579,18 +577,19 @@ func (bnc *BaseNetworkController) deleteNodeLogicalNetwork(nodeName string) erro
 
 func (bnc *BaseNetworkController) addAllPodsOnNode(nodeName string) []error {
 	errs := []error{}
-	pods, err := bnc.kube.GetPods(metav1.NamespaceAll, metav1.ListOptions{
-		FieldSelector: fields.OneTermEqualSelector("spec.nodeName", nodeName).String(),
-	})
+	pods, err := bnc.watchFactory.GetAllPods()
 	if err != nil {
 		errs = append(errs, err)
-		klog.Errorf("Unable to list existing pods on node: %s, existing pods on this node may not function",
+		klog.Errorf("Unable to list existing pods for synchronizing node: %s, existing pods on this node may not function",
 			nodeName)
 	} else {
 		klog.V(5).Infof("When adding node %s for network %s, found %d pods to add to retryPods", nodeName, bnc.GetNetworkName(), len(pods))
 		for _, pod := range pods {
 			pod := *pod
 			if util.PodCompleted(&pod) {
+				continue
+			}
+			if pod.Spec.NodeName != nodeName {
 				continue
 			}
 			klog.V(5).Infof("Adding pod %s/%s to retryPods for network %s", pod.Namespace, pod.Name, bnc.GetNetworkName())

--- a/go-controller/pkg/retry/obj_retry.go
+++ b/go-controller/pkg/retry/obj_retry.go
@@ -9,14 +9,11 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/metrics"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/syncmap"
 	ovntypes "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
@@ -772,38 +769,35 @@ func (r *RetryFramework) WatchResourceFiltered(namespaceForFilteredHandler strin
 	return handler, nil
 }
 
-// getPendingPods returns all pods that are in the Pending state
-func getPendingPods(kubeClient kube.InterfaceOVN) ([]*corev1.Pod, error) {
-	var allPods []*corev1.Pod
-
-	pods, err := kubeClient.GetPods(corev1.NamespaceAll, metav1.ListOptions{
-		FieldSelector: fields.OneTermEqualSelector("status.phase", string(corev1.PodPending)).String(),
-	})
-	if err != nil {
-		return nil, err
-	}
-	allPods = append(allPods, pods...)
-	return allPods, nil
-}
-
 // RequeuePendingPods enqueues all Pending pods into the retryPods associated with netInfo.
-func RequeuePendingPods(kubeClient kube.InterfaceOVN, netInfo util.NetInfo, retryPods *RetryFramework) error {
+func RequeuePendingPods(wf *factory.WatchFactory, netInfo util.NetInfo, retryPods *RetryFramework) error {
 	var errs []error
 
 	// NOTE: A pod may reference a NAD from a different namespace, so check all pending pods.
-	allPods, err := getPendingPods(kubeClient)
+	allPods, err := wf.GetAllPods()
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to get all pods: %w", err)
 	}
 
+	podsAdded := false
 	for _, pod := range allPods {
 		pod := *pod
+		if !util.PodScheduled(&pod) {
+			continue
+		}
+		if pod.Status.Phase != corev1.PodPending {
+			continue
+		}
 		klog.V(5).Infof("Adding pending pod %s/%s to retryPods for network %s", pod.Namespace, pod.Name, netInfo.GetNetworkName())
 		err := retryPods.AddRetryObjWithAddNoBackoff(&pod)
 		if err != nil {
 			errs = append(errs, err)
+			continue
 		}
+		podsAdded = true
 	}
-	retryPods.RequestRetryObjs()
+	if podsAdded {
+		retryPods.RequestRetryObjs()
+	}
 	return utilerrors.Join(errs...)
 }


### PR DESCRIPTION
Related to investigating the root cause for: #5260. This commit removes adding pods that are not scheduled to the retry framework. When the pod is scheduled the controller will receive an event.

Additionally these functions that add pods were using the kubeclient instead of informer cache. That means everytime a UDN was added we would issue kubeclient command to get all pods, which is really bad for performance.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
