### PR TITLE
NO-JIRA: Bump OVN to 25.03

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -17,13 +17,13 @@ RUN dnf --setopt=retries=2 --setopt=timeout=2 install -y --nodocs \
 # reduces the number of variables in the system) and receive all the CVE and
 # bug fixes automatically.
 ARG ovsver=3.5
-ARG ovnver=24.09.2-69.el9fdp
+ARG ovnver=25.03.0-73.el9fdp
 # NOTE: Ensure that the versions of OVS and OVN are overriden for OKD in each of the subsequent layers.
 # Centos and RHEL releases for ovn are built out of sync, so please make sure to bump for OKD with
 # the corresponding Centos version when updating the OCP version.
 ARG ovsver_okd=3.5
 # We are not bumping the OVN version for OKD since the FDP release is not done yet.
-ARG ovnver_okd=24.09.1-10.el9s
+ARG ovnver_okd=25.03.1-36.el9s
 
 RUN INSTALL_PKGS="iptables nftables" && \
     source /etc/os-release && \


### PR DESCRIPTION
Bump OVN to 25.03.0-73.el9fdp for OCP and 25.03.1-36.el9s for OKD.
Using a different version for OKD as it is currently the only one available.

This is a list of relevant bug fixes and new core OVN features picked up by the bump:
```
Bug fixes:
==========
- pinctrl: Fix missing garp.
- binding: Avoid 100% CPU when postponing claims.
- northd: Sample_Collector.set_ids can actually be 32-bit values.

New Features:
=============
- Added support to choose selection methods - dp_hash or
  hash (with specified hash fields) for ECMP routes
  while choosing nexthop.
- Added support for Spine-Leaf topology of logical switches by adding
  a new LSP type 'switch' that can directly connect two logical switches.
  Supported for both distributed and transit switches.
- SSL/TLS:
  * TLSv1 and TLSv1.1 protocols are deprecated and disabled by default
    on OpenFlow and database connections.  Use --ssl-protocols to turn
    them back on.  Support will be fully removed in the next release.
  * OpenSSL 1.1.1 or newer is now required for SSL/TLS support.
  * The protocol list in --ssl-protocols or corresponding database column
    now supports specifying simple protocol ranges like:
      - "TLSv1-TLSv1.2" to enable all protocols between TLSv1 and TLSv1.2.
      - "TLSv1.2+" to enable protocol TLSv1.2 and later.
    The value must be a list of protocols or exactly one protocol range.
  * Added explicit support for TLSv1.3.  It can now be enabled via
    --ssl-protocols (TLSv1.3 was supported in earlier versions only when
    this option was not set).  TLS ciphersuites for TLSv1.3 and later can
    be configured via --ssl-ciphersuites (--ssl-ciphers only applies to
    TLSv1.2 and earlier).
- Add "arp-nd-max-timeout-sec" config option to vswitchd external-ids to
  configure the interval (in seconds) between ovn-controller originated
  ARP/ND packets used for tracking ECMP next hop MAC addresses.
- Auto flush ECMP symmetric reply connection states when an ECMP route is
  removed by the CMS.  This behavior is controlled by the
  "ecmp_nexthop_monitor_enable" config option in the NB_Global table.
  Disabled by default.
- Improved handling of IPv6 traffic by enabling address prefix tracking
  in OVS for both IPv4 and IPv6 addresses, whenever possible, reducing
  the amount of IPv6 datapath flows.
- Add concept of Transit Routers, users are now allowed to specify
  options:requested-chassis for router ports; if the chassis is remote
  then the router port will behave as a remote port.
- Added a new ACL option "persist-established" that allows for
  established connections to bypass ACL matching. This way, if an ACL
  match changes, traffic on the established connection can still pass.
- Logical router policies can now be arranged in chains. Using the new
  "jump" action, combined with new "chain" and "jump_chain" columns,
  allows for policies to be chained together.
- Dynamic Routing support (FRR BGP integration for unicast routing)
- Add "options:ct-commit-all" to LR, that enables commit of all traffic
  to DNAT and SNAT zone when LR is stateful.
```

There is a slight error in the commit message as pointed out [here](https://github.com/openshift/ovn-kubernetes/pull/2701#issuecomment-3161208399). Due to time constraints we've [decided](https://github.com/openshift/ovn-kubernetes/pull/2701#issuecomment-3162651720) to go with it to avoid re-running CI.