### PR TITLE
CORENET-6055: Dockerfile: Unpin OVN and consume the latest from FDP.

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -12,28 +12,22 @@ RUN dnf --setopt=retries=2 --setopt=timeout=2 install -y --nodocs \
 	selinux-policy procps-ng && \
 	dnf clean all
 
-# NOTE: OVS is not pinned to a particular patch version in order to stay in
-# sync with the OVS running on the host (it is not strictly necessary, but
-# reduces the number of variables in the system) and receive all the CVE and
-# bug fixes automatically.
 ARG ovsver=3.5
-ARG ovnver=25.03.0-73.el9fdp
+ARG ovnver=25.03
 # NOTE: Ensure that the versions of OVS and OVN are overriden for OKD in each of the subsequent layers.
 # Centos and RHEL releases for ovn are built out of sync, so please make sure to bump for OKD with
 # the corresponding Centos version when updating the OCP version.
 ARG ovsver_okd=3.5
-# We are not bumping the OVN version for OKD since the FDP release is not done yet.
-ARG ovnver_okd=25.03.1-36.el9s
+ARG ovnver_okd=25.03
 
 RUN INSTALL_PKGS="iptables nftables" && \
     source /etc/os-release && \
     [ "${ID}" == "centos" ] && ovsver=$ovsver_okd && ovnver=$ovnver_okd; \
-	ovnver_short=$(echo "$ovnver" | cut -d'.' -f1,2) && \
 	dnf --setopt=retries=2 --setopt=timeout=2 install -y --nodocs $INSTALL_PKGS && \
 	dnf --setopt=retries=2 --setopt=timeout=2 install -y --nodocs "openvswitch$ovsver" "python3-openvswitch$ovsver" && \
-	dnf --setopt=retries=2 --setopt=timeout=2 install -y --nodocs "ovn$ovnver_short = $ovnver" "ovn$ovnver_short-central = $ovnver" "ovn$ovnver_short-host = $ovnver" && \
+	dnf --setopt=retries=2 --setopt=timeout=2 install -y --nodocs "ovn$ovnver" "ovn$ovnver-central" "ovn$ovnver-host" && \
 	dnf clean all && rm -rf /var/cache/* && \
-	sed 's/%/"/g' <<<"%openvswitch$ovsver-devel% %openvswitch$ovsver-ipsec% %ovn$ovnver_short-vtep = $ovnver%" > /more-pkgs
+	sed 's/%/"/g' <<<"%openvswitch$ovsver-devel% %openvswitch$ovsver-ipsec% %ovn$ovnver-vtep%" > /more-pkgs
 
 RUN mkdir -p /var/run/openvswitch && \
     mkdir -p /var/run/ovn && \


### PR DESCRIPTION
OVN-Kubernetes is always lagging behind on the version of OVN it pins. This is causing a lot of trouble with keeping up with bug fixes and especially CVE fixes on older branches, resulting in scanners flagging this image with poor security grades and much longer time for bug fixes to be delivered to customers as the PR backporting process can take weeks or even months.

Removing the pin, so every time the new build is released in FDP, it automatically gets into versions of OpneShift that use it.  There is a pre-release testing process in place between FDP and OCP QE that ensures the required test coverage before the new build is released through FDP.

Keeping OKD versions separate since sometimes new major versions are not released at the same time in FDP/RHEL and CentOS, so we may need them different at some point in time.

OVN-Kubernetes is currently using the latest OVN builds already, so this PR doesn't actually change anything for the current images.  But it will bring newer OVN builds automatically as soon as they are released in the future.  Major version upgrades still require a separate PR.