### PR TITLE
OCPBUGS-61065: Adding ovndb-raft-functions.sh to ovnk image

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -48,7 +48,9 @@ COPY .git/refs/heads/ /root/.git/refs/heads/
 
 # ovnkube.sh is the entry point. This script examines environment
 # variables to direct operation and configure ovn
-COPY dist/images/ovnkube.sh /root/
+# ovndb-raft-functions.sh is a dependency of ovnkube.sh
+COPY dist/images/ovnkube.sh dist/images/ovndb-raft-functions.sh /root/
+
 
 WORKDIR /root
 ENTRYPOINT /root/ovnkube.sh


### PR DESCRIPTION
OCPBUGS-61065: OVNK downstream with DPF failing to run upstream script

Fix missing ovndb-raft-functions.sh dependency in DPU service image

Add missing ovndb-raft-functions.sh script to Dockerfile.base as it's required
by the upstream ovnkube.sh script used by DPU service in OCP downstream images.


## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
