### PR TITLE
[release-4.16] OCPBUGS-60079: Always enable global IPv6 forwarding

### DIFF
--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -1,22 +1,21 @@
 ## Disable Forwarding Config
 
-OVN-Kubernetes allows to enable or disable IP forwarding for all traffic on OVN-Kubernetes managed interfaces (such as br-ex). By default forwarding is enabled and this allows host to forward traffic across OVN-Kubernetes managed interfaces. If forwarding is disabled then Kubernetes related traffic is still forwarded appropriately, but other IP traffic will not be routed by cluster nodes.
+OVN-Kubernetes allows to enable or disable IP forwarding for all traffic on OVN-Kubernetes managed interfaces (such as br-ex).
+By default forwarding is enabled and this allows host to forward traffic across OVN-Kubernetes managed interfaces.
+If forwarding is disabled then Kubernetes related traffic is still forwarded appropriately, but other IP traffic will not be routed by cluster nodes.
 
 IP forwarding is implemented at cluster node level by modifying both iptables `FORWARD` chain and IP forwarding `sysctl` parameters. 
 
-- If forwarding is enabled(default) then system administrators need to set following sysctl parameters. An operator can be built to manage forwarding sysctl parameters based on forwarding mode. No extra iptables rules are added by OVN-Kubernetes to FORWARD chain while using this IP forwarding mode.
+#### IPv4
+
+If forwarding is enabled(default) and it is desired to allow forwarding for traffic on unmanaged ovn-kubernetes interfaces, then system administrators need to set the following sysctl parameters on the desired interfaces or globally.
+OVN-Kubernetes already sets sysctl forwarding for interfaces it manages, such as the ovn-k8s-mp0 interface and the shared gateway bridge interface. An operator can be built to manage forwarding sysctl parameters based on forwarding mode.
+No extra iptables rules are added by OVN-Kubernetes to FORWARD chain while using this IP forwarding mode.
 
 ```
 net.ipv4.ip_forward=1
-net.ipv6.conf.all.forwarding=1
 ```
-
-- IP forwarding can be disabled either by setting `disable-forwarding` command line option to `true` while starting ovnkube or by setting `disable-forwarding` to `true` in config file. If forwarding is disabled then system administrators need to set following sysctl parameters to stop routing other IP traffic. An operator can be built to manage forwarding sysctl parameters based on forwarding mode.
-
-```
-net.ipv4.ip_forward=0
-net.ipv6.conf.all.forwarding=0
-```
+IP forwarding can be disabled either by setting `disable-forwarding` command line option to `true` while starting ovnkube or by setting `disable-forwarding` to `true` in config file. If forwarding is disabled the default policy for the [FORWARD iptables chain is set as DROP](#forwarding-rules) and system administrators can add use-case specific ACCEPT rules.
 
 When IP forwarding is disabled, following sysctl parameters are modified by OVN-Kubernetes to allow forwarding Kubernetes related traffic on OVN-Kubernetes managed bridge interfaces and management port interface.
 
@@ -25,15 +24,93 @@ net.ipv4.conf.br-ex.forwarding=1
 net.ipv4.conf.ovn-k8s-mp0.forwarding = 1
 ```
 
-Additionally following iptables rules are added at FORWARD chain to forward clusterNetwork and serviceNetwork traffic to their intended destinations. 
+#### IPv6
+
+IP forwarding works differently for IPv6:
+```
+/proc/sys/net/ipv6/* Variables:
+
+conf/all/forwarding - BOOLEAN
+  Enable global IPv6 forwarding between all interfaces.
+  IPv4 and IPv6 work differently here; e.g. netfilter must be used
+  to control which interfaces may forward packets and which not.
+
+...
+
+conf/interface/*:
+
+forwarding - INTEGER
+	Configure interface-specific Host/Router behaviour.
+
+	Note: It is recommended to have the same setting on all
+	interfaces; mixed router/host scenarios are rather uncommon.
+
+	Possible values are:
+		0 Forwarding disabled
+		1 Forwarding enabled
+
+	FALSE (0):
+
+	By default, Host behaviour is assumed.  This means:
+
+	1. IsRouter flag is not set in Neighbour Advertisements.
+	2. If accept_ra is TRUE (default), transmit Router
+	   Solicitations.
+	3. If accept_ra is TRUE (default), accept Router
+	   Advertisements (and do autoconfiguration).
+	4. If accept_redirects is TRUE (default), accept Redirects.
+
+	TRUE (1):
+
+	If local forwarding is enabled, Router behaviour is assumed.
+	This means exactly the reverse from the above:
+
+	1. IsRouter flag is set in Neighbour Advertisements.
+	2. Router Solicitations are not sent unless accept_ra is 2.
+	3. Router Advertisements are ignored unless accept_ra is 2.
+	4. Redirects are ignored.
+
+	Default: 0 (disabled) if global forwarding is disabled (default),
+		 otherwise 1 (enabled).
+```
+https://www.kernel.org/doc/Documentation/networking/ip-sysctl.txt
+
+It is not possible to configure the IPv6 forwarding per interface by setting the 
+`net.ipv6.conf.IFNAME.forwarding` sysctl (it just configures the interface-specific Host/Router 
+behaviour). \
+Instead, the opposite approach is required where the global forwarding is always enabled and 
+the traffic is restricted through iptables.
+
+#### Forwarding rules
+
+When the `disable-forwarding` parameter is configured specific iptables rules are added to
+the FORWARD chain to forward clusterNetwork and serviceNetwork traffic to their intended destinations.
+Additionally, the default policy for the FORWARD chain is set as `DROP`. Otherwise, the policy
+defaults to `ACCEPT` and no custom rules are added. This behavior is the same for both IPv6 and IPv4
+networks:
 
 ```
--A FORWARD -s 10.128.0.0/14 -j ACCEPT
--A FORWARD -d 10.128.0.0/14 -j ACCEPT
--A FORWARD -s 169.254.169.1 -j ACCEPT
--A FORWARD -d 169.254.169.1 -j ACCEPT
--A FORWARD -d 172.16.1.0/24 -j ACCEPT
--A FORWARD -s 172.16.1.0/24 -j ACCEPT
--A FORWARD -i breth1 -j DROP
--A FORWARD -o breth1 -j DROP
+# In IPv4 with disable-forwarding=true the FORWARD policy is set to DROP
+Chain FORWARD (policy DROP 0 packets, 0 bytes)
+ pkts bytes target     prot opt in     out     source               destination         
+    0     0 ACCEPT     0    --  *      *       0.0.0.0/0            169.254.169.1       
+    0     0 ACCEPT     0    --  *      *       169.254.169.1        0.0.0.0/0           
+    0     0 ACCEPT     0    --  *      *       0.0.0.0/0            10.96.0.0/16        
+    0     0 ACCEPT     0    --  *      *       10.96.0.0/16         0.0.0.0/0           
+    0     0 ACCEPT     0    --  *      *       0.0.0.0/0            10.244.0.0/16       
+    0     0 ACCEPT     0    --  *      *       10.244.0.0/16        0.0.0.0/0           
+    0     0 ACCEPT     0    --  ovn-k8s-mp0 *       0.0.0.0/0            0.0.0.0/0           
+    0     0 ACCEPT     0    --  *      ovn-k8s-mp0  0.0.0.0/0            0.0.0.0/0
+    
+# In IPv6 with disable-forwarding=true the FORWARD policy is set to DROP
+Chain FORWARD (policy DROP 0 packets, 0 bytes)
+ pkts bytes target     prot opt in     out     source               destination         
+    0     0 ACCEPT     0    --  *      *       ::/0                 fd69::1             
+    0     0 ACCEPT     0    --  *      *       fd69::1              ::/0                
+    0     0 ACCEPT     0    --  *      *       ::/0                 fd00:10:96::/112    
+    0     0 ACCEPT     0    --  *      *       fd00:10:96::/112     ::/0                
+    0     0 ACCEPT     0    --  *      *       ::/0                 fd00:10:244::/48    
+    0     0 ACCEPT     0    --  *      *       fd00:10:244::/48     ::/0                
+    0     0 ACCEPT     0    --  ovn-k8s-mp0 *       ::/0                 ::/0                
+    0     0 ACCEPT     0    --  *      ovn-k8s-mp0  ::/0                 ::/0          
 ```

--- a/go-controller/pkg/node/default_node_network_controller.go
+++ b/go-controller/pkg/node/default_node_network_controller.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/klog/v2"
 	utilnet "k8s.io/utils/net"
 
+	"github.com/containernetworking/plugins/pkg/ip"
 	v1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	honode "github.com/ovn-org/ovn-kubernetes/go-controller/hybrid-overlay/pkg/controller"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/cni"
@@ -40,7 +41,6 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 
-	"github.com/containernetworking/plugins/pkg/ip"
 	"github.com/vishvananda/netlink"
 )
 
@@ -700,6 +700,10 @@ func (nc *DefaultNodeNetworkController) Start(ctx context.Context) error {
 		nc.routeManager.Run(nc.stopChan, 4*time.Minute)
 	}()
 
+	if err = configureGlobalForwarding(); err != nil {
+		return err
+	}
+
 	// Bootstrap flows in OVS if just normal flow is present
 	if err := bootstrapOVSFlows(nc.name); err != nil {
 		return fmt.Errorf("failed to bootstrap OVS flows: %w", err)
@@ -1320,4 +1324,44 @@ func DummyNextHopIPs() []net.IP {
 		nextHops = append(nextHops, config.Gateway.MasqueradeIPs.V6DummyNextHopMasqueradeIP)
 	}
 	return nextHops
+}
+
+// configureGlobalForwarding configures the global forwarding settings.
+// It sets the FORWARD policy to DROP/ACCEPT based on the config.Gateway.DisableForwarding value for all enabled IP families.
+// For IPv6 it additionally always enables the global forwarding.
+func configureGlobalForwarding() error {
+	// Global forwarding works differently for IPv6:
+	//   conf/all/forwarding - BOOLEAN
+	//    Enable global IPv6 forwarding between all interfaces.
+	//	  IPv4 and IPv6 work differently here; e.g. netfilter must be used
+	//	  to control which interfaces may forward packets and which not.
+	// https://www.kernel.org/doc/Documentation/networking/ip-sysctl.txt
+	//
+	// It is not possible to configure the IPv6 forwarding per interface by
+	// setting the net.ipv6.conf.<ifname>.forwarding sysctl. Instead,
+	// the opposite approach is required where the global forwarding
+	// is enabled and an iptables rule is added to restrict it by default.
+	if config.IPv6Mode {
+		if err := ip.EnableIP6Forward(); err != nil {
+			return fmt.Errorf("could not set the correct global forwarding value for ipv6:  %w", err)
+		}
+
+	}
+
+	for _, proto := range clusterIPTablesProtocols() {
+		ipt, err := util.GetIPTablesHelper(proto)
+		if err != nil {
+			return fmt.Errorf("failed to get the iptables helper: %w", err)
+		}
+
+		target := "ACCEPT"
+		if config.Gateway.DisableForwarding {
+			target = "DROP"
+
+		}
+		if err := ipt.ChangePolicy("filter", "FORWARD", target); err != nil {
+			return fmt.Errorf("failed to change the forward policy to %q: %w", target, err)
+		}
+	}
+	return nil
 }

--- a/go-controller/pkg/node/egress_service_test.go
+++ b/go-controller/pkg/node/egress_service_test.go
@@ -291,7 +291,7 @@ var _ = Describe("Egress Service Operations", func() {
 
 				f4 := iptV4.(*util.FakeIPTables)
 				Eventually(func() error {
-					return f4.MatchState(expectedTables)
+					return f4.MatchState(expectedTables, nil)
 				}).ShouldNot(HaveOccurred())
 
 				Expect(fakeOvnNode.fakeExec.CalledMatchesExpected()).To(BeTrue(), fakeOvnNode.fakeExec.ErrorDesc)
@@ -400,7 +400,7 @@ var _ = Describe("Egress Service Operations", func() {
 
 				f4 := iptV4.(*util.FakeIPTables)
 				Eventually(func() error {
-					return f4.MatchState(expectedTables)
+					return f4.MatchState(expectedTables, nil)
 				}).ShouldNot(HaveOccurred())
 
 				expectedTables = map[string]util.FakeTable{
@@ -415,7 +415,7 @@ var _ = Describe("Egress Service Operations", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				Eventually(func() error {
-					return f4.MatchState(expectedTables)
+					return f4.MatchState(expectedTables, nil)
 				}).ShouldNot(HaveOccurred())
 
 				Expect(fakeOvnNode.fakeExec.CalledMatchesExpected()).To(BeTrue(), fakeOvnNode.fakeExec.ErrorDesc)
@@ -629,11 +629,11 @@ var _ = Describe("Egress Service Operations", func() {
 				}
 				f4 := iptV4.(*util.FakeIPTables)
 				Eventually(func() error {
-					err := f4.MatchState(expectedTables)
+					err := f4.MatchState(expectedTables, nil)
 					if err == nil {
 						return nil
 					}
-					return f4.MatchState(expectedTables2)
+					return f4.MatchState(expectedTables2, nil)
 				}).ShouldNot(HaveOccurred())
 
 				expectedTables = map[string]util.FakeTable{
@@ -651,7 +651,7 @@ var _ = Describe("Egress Service Operations", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				Eventually(func() error {
-					return f4.MatchState(expectedTables)
+					return f4.MatchState(expectedTables, nil)
 				}).ShouldNot(HaveOccurred())
 
 				Expect(fakeOvnNode.fakeExec.CalledMatchesExpected()).To(BeTrue(), fakeOvnNode.fakeExec.ErrorDesc)
@@ -836,7 +836,7 @@ var _ = Describe("Egress Service Operations", func() {
 				}
 				f4 := iptV4.(*util.FakeIPTables)
 				Eventually(func() error {
-					return f4.MatchState(expectedTables)
+					return f4.MatchState(expectedTables, nil)
 				}).ShouldNot(HaveOccurred())
 
 				Eventually(func() bool {
@@ -871,7 +871,7 @@ var _ = Describe("Egress Service Operations", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				Eventually(func() error {
-					return f4.MatchState(expectedTables)
+					return f4.MatchState(expectedTables, nil)
 				}).ShouldNot(HaveOccurred())
 
 				Eventually(func() bool {
@@ -999,7 +999,7 @@ var _ = Describe("Egress Service Operations", func() {
 				}
 				f4 := iptV4.(*util.FakeIPTables)
 				Eventually(func() error {
-					return f4.MatchState(expectedTables)
+					return f4.MatchState(expectedTables, nil)
 				}).ShouldNot(HaveOccurred())
 
 				Eventually(func() bool {
@@ -1017,7 +1017,7 @@ var _ = Describe("Egress Service Operations", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				Eventually(func() error {
-					return f4.MatchState(expectedTables)
+					return f4.MatchState(expectedTables, nil)
 				}).ShouldNot(HaveOccurred())
 
 				Eventually(func() bool {
@@ -1035,7 +1035,7 @@ var _ = Describe("Egress Service Operations", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				Eventually(func() error {
-					return f4.MatchState(expectedTables)
+					return f4.MatchState(expectedTables, nil)
 				}).ShouldNot(HaveOccurred())
 
 				Eventually(func() bool {
@@ -1056,7 +1056,7 @@ var _ = Describe("Egress Service Operations", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				Eventually(func() error {
-					return f4.MatchState(expectedTables)
+					return f4.MatchState(expectedTables, nil)
 				}).ShouldNot(HaveOccurred())
 
 				Eventually(func() bool {

--- a/go-controller/pkg/node/gateway_init.go
+++ b/go-controller/pkg/node/gateway_init.go
@@ -21,23 +21,12 @@ import (
 // bridgedGatewayNodeSetup enables forwarding on bridge interface, sets up the physical network name mappings for the bridge,
 // and returns an ifaceID created from the bridge name and the node name
 func bridgedGatewayNodeSetup(nodeName, bridgeName, physicalNetworkName string) (string, error) {
-	// enable forwarding on bridge interface always
-	createForwardingRule := func(family string) error {
-		stdout, stderr, err := util.RunSysctl("-w", fmt.Sprintf("net.%s.conf.%s.forwarding=1", family, bridgeName))
-		if err != nil || stdout != fmt.Sprintf("net.%s.conf.%s.forwarding = 1", family, bridgeName) {
-			return fmt.Errorf("could not set the correct forwarding value for interface %s: stdout: %v, stderr: %v, err: %v",
-				bridgeName, stdout, stderr, err)
-		}
-		return nil
-	}
+	// IPv6 forwarding is enabled globally
 	if config.IPv4Mode {
-		if err := createForwardingRule("ipv4"); err != nil {
-			return "", fmt.Errorf("could not add IPv4 forwarding rule: %v", err)
-		}
-	}
-	if config.IPv6Mode {
-		if err := createForwardingRule("ipv6"); err != nil {
-			return "", fmt.Errorf("could not add IPv6 forwarding rule: %v", err)
+		stdout, stderr, err := util.RunSysctl("-w", fmt.Sprintf("net.ipv4.conf.%s.forwarding=1", bridgeName))
+		if err != nil || stdout != fmt.Sprintf("net.ipv4.conf.%s.forwarding = 1", bridgeName) {
+			return "", fmt.Errorf("could not set the correct forwarding value for interface %s: stdout: %v, stderr: %v, err: %v",
+				bridgeName, stdout, stderr, err)
 		}
 	}
 

--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -109,12 +109,7 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 				Output: "net.ipv4.conf.breth0.forwarding = 1",
 			})
 		}
-		if config.IPv6Mode {
-			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-				Cmd:    "sysctl -w net.ipv6.conf.breth0.forwarding=1",
-				Output: "net.ipv6.conf.breth0.forwarding = 1",
-			})
-		}
+
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 			Cmd:    "ovs-vsctl --timeout=15 --if-exists get interface breth0 mac_in_use",
 			Output: eth0MAC,
@@ -386,7 +381,7 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 		expectedTables["filter"]["OUTPUT"] = append(expectedMCSRules, expectedTables["filter"]["OUTPUT"]...)
 		// END OCP HACK
 		f4 := iptV4.(*util.FakeIPTables)
-		err = f4.MatchState(expectedTables)
+		err = f4.MatchState(expectedTables, nil)
 		Expect(err).NotTo(HaveOccurred())
 
 		expectedTables = map[string]util.FakeTable{
@@ -395,7 +390,7 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 			"mangle": {},
 		}
 		f6 := iptV6.(*util.FakeIPTables)
-		err = f6.MatchState(expectedTables)
+		err = f6.MatchState(expectedTables, nil)
 		Expect(err).NotTo(HaveOccurred())
 		return nil
 	}
@@ -917,12 +912,7 @@ OFPT_GET_CONFIG_REPLY (xid=0x4): frags=normal miss_send_len=0`
 				Output: "net.ipv4.conf.breth0.forwarding = 1",
 			})
 		}
-		if config.IPv6Mode {
-			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-				Cmd:    "sysctl -w net.ipv6.conf.breth0.forwarding=1",
-				Output: "net.ipv6.conf.breth0.forwarding = 1",
-			})
-		}
+
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 			Cmd:    "ovs-vsctl --timeout=15 --if-exists get interface breth0 mac_in_use",
 			Output: eth0MAC,
@@ -1092,6 +1082,8 @@ OFPT_GET_CONFIG_REPLY (xid=0x4): frags=normal miss_send_len=0`
 		})
 		err = testNS.Do(func(ns.NetNS) error {
 			defer GinkgoRecover()
+
+			Expect(configureGlobalForwarding()).To(Succeed())
 			gatewayNextHops, gatewayIntf, err := getGatewayNextHops()
 			Expect(err).NotTo(HaveOccurred())
 			ifAddrs := ovntest.MustParseIPNets(eth0CIDR)
@@ -1191,8 +1183,6 @@ OFPT_GET_CONFIG_REPLY (xid=0x4): frags=normal miss_send_len=0`
 					"-s 10.1.0.0/16 -j ACCEPT",
 					"-i ovn-k8s-mp0 -j ACCEPT",
 					"-o ovn-k8s-mp0 -j ACCEPT",
-					"-i breth0 -j DROP",
-					"-o breth0 -j DROP",
 				},
 				"INPUT": []string{
 					"-i ovn-k8s-mp0 -m comment --comment from OVN to localhost -j ACCEPT",
@@ -1214,7 +1204,10 @@ OFPT_GET_CONFIG_REPLY (xid=0x4): frags=normal miss_send_len=0`
 		expectedTables["filter"]["OUTPUT"] = append(expectedMCSRules, expectedTables["filter"]["OUTPUT"]...)
 		// END OCP HACK
 		f4 := iptV4.(*util.FakeIPTables)
-		err = f4.MatchState(expectedTables)
+		err = f4.MatchState(expectedTables, map[util.FakePolicyKey]string{{
+			Table: "filter",
+			Chain: "FORWARD",
+		}: "DROP"})
 		Expect(err).NotTo(HaveOccurred())
 
 		expectedTables = map[string]util.FakeTable{
@@ -1223,7 +1216,7 @@ OFPT_GET_CONFIG_REPLY (xid=0x4): frags=normal miss_send_len=0`
 			"mangle": {},
 		}
 		f6 := iptV6.(*util.FakeIPTables)
-		err = f6.MatchState(expectedTables)
+		err = f6.MatchState(expectedTables, nil)
 		Expect(err).NotTo(HaveOccurred())
 		return nil
 	}

--- a/go-controller/pkg/node/gateway_iptables.go
+++ b/go-controller/pkg/node/gateway_iptables.go
@@ -365,33 +365,6 @@ func getGatewayForwardRules(cidrs []*net.IPNet) []nodeipt.Rule {
 	return returnRules
 }
 
-func getGatewayDropRules(ifName string) []nodeipt.Rule {
-	var dropRules []nodeipt.Rule
-	for _, protocol := range clusterIPTablesProtocols() {
-		dropRules = append(dropRules, []nodeipt.Rule{
-			{
-				Table: "filter",
-				Chain: "FORWARD",
-				Args: []string{
-					"-i", ifName,
-					"-j", "DROP",
-				},
-				Protocol: protocol,
-			},
-			{
-				Table: "filter",
-				Chain: "FORWARD",
-				Args: []string{
-					"-o", ifName,
-					"-j", "DROP",
-				},
-				Protocol: protocol,
-			},
-		}...)
-	}
-	return dropRules
-}
-
 // initExternalBridgeForwardingRules sets up iptables rules for br-* interface svc traffic forwarding
 // -A FORWARD -s 10.96.0.0/16 -j ACCEPT
 // -A FORWARD -d 10.96.0.0/16 -j ACCEPT
@@ -405,20 +378,6 @@ func initExternalBridgeServiceForwardingRules(cidrs []*net.IPNet) error {
 // have been added to disable forwarding
 func delExternalBridgeServiceForwardingRules(cidrs []*net.IPNet) error {
 	return deleteIptRules(getGatewayForwardRules(cidrs))
-}
-
-// initExternalBridgeDropRules sets up iptables rules to block forwarding
-// in br-* interfaces (also for 2ndary bridge) - we block for v4 and v6 based on clusterStack
-// -A FORWARD -i breth1 -j DROP
-// -A FORWARD -o breth1 -j DROP
-func initExternalBridgeDropForwardingRules(ifName string) error {
-	return appendIptRules(getGatewayDropRules(ifName))
-}
-
-// delExternalBridgeDropForwardingRules removes iptables rules which might
-// have been added to disable forwarding
-func delExternalBridgeDropForwardingRules(ifName string) error {
-	return deleteIptRules(getGatewayDropRules(ifName))
 }
 
 func getLocalGatewayFilterRules(ifname string, cidr *net.IPNet) []nodeipt.Rule {

--- a/go-controller/pkg/node/gateway_localnet.go
+++ b/go-controller/pkg/node/gateway_localnet.go
@@ -85,15 +85,7 @@ func newLocalGateway(nodeName string, hostSubnets []*net.IPNet, gwNextHops []net
 			if err != nil {
 				return err
 			}
-			if config.Gateway.DisableForwarding {
-				if err := initExternalBridgeDropForwardingRules(exGwBridge.bridgeName); err != nil {
-					return fmt.Errorf("failed to add drop rules in forwarding table for bridge %s: err %v", exGwBridge.bridgeName, err)
-				}
-			} else {
-				if err := delExternalBridgeDropForwardingRules(exGwBridge.bridgeName); err != nil {
-					return fmt.Errorf("failed to delete drop rules in forwarding table for bridge %s: err %v", exGwBridge.bridgeName, err)
-				}
-			}
+
 		}
 
 		gw.nodeIPManager = newAddressManager(nodeName, kube, cfg, watchFactory, gwBridge)

--- a/go-controller/pkg/node/gateway_localnet_linux_test.go
+++ b/go-controller/pkg/node/gateway_localnet_linux_test.go
@@ -44,11 +44,11 @@ func initFakeNodePortWatcher(iptV4, iptV6 util.IPTablesHelper) *nodePortWatcher 
 	}
 
 	f4 := iptV4.(*util.FakeIPTables)
-	err := f4.MatchState(initIPTable)
+	err := f4.MatchState(initIPTable, nil)
 	Expect(err).NotTo(HaveOccurred())
 
 	f6 := iptV6.(*util.FakeIPTables)
-	err = f6.MatchState(initIPTable)
+	err = f6.MatchState(initIPTable, nil)
 	Expect(err).NotTo(HaveOccurred())
 
 	gwMACParsed, _ := net.ParseMAC(gwMAC)
@@ -89,15 +89,9 @@ func startNodePortWatcher(n *nodePortWatcher, fakeClient *util.OVNNodeClientset,
 		if err := initExternalBridgeServiceForwardingRules(subnets); err != nil {
 			return fmt.Errorf("failed to add accept rules in forwarding table for bridge %s: err %v", linkName, err)
 		}
-		if err := initExternalBridgeDropForwardingRules(linkName); err != nil {
-			return fmt.Errorf("failed to add drop rules in forwarding table for bridge %s: err %v", linkName, err)
-		}
 	} else {
 		if err := delExternalBridgeServiceForwardingRules(subnets); err != nil {
 			return fmt.Errorf("failed to delete accept rules in forwarding table for bridge %s: err %v", linkName, err)
-		}
-		if err := delExternalBridgeDropForwardingRules(linkName); err != nil {
-			return fmt.Errorf("failed to delete drop rules in forwarding table for bridge %s: err %v", linkName, err)
 		}
 	}
 
@@ -361,7 +355,7 @@ var _ = Describe("Node Operations", func() {
 				}
 
 				f4 := iptV4.(*util.FakeIPTables)
-				err := f4.MatchState(expectedTables)
+				err := f4.MatchState(expectedTables, nil)
 				Expect(err).NotTo(HaveOccurred())
 
 				fakeOvnNode.start(ctx,
@@ -410,7 +404,7 @@ var _ = Describe("Node Operations", func() {
 				}
 
 				f4 = iptV4.(*util.FakeIPTables)
-				err = f4.MatchState(expectedTables)
+				err = f4.MatchState(expectedTables, nil)
 				Expect(err).NotTo(HaveOccurred())
 
 				return nil
@@ -487,7 +481,7 @@ var _ = Describe("Node Operations", func() {
 				}
 
 				f4 := iptV4.(*util.FakeIPTables)
-				err = f4.MatchState(expectedTables)
+				err = f4.MatchState(expectedTables, nil)
 				Expect(err).NotTo(HaveOccurred())
 				return nil
 			}
@@ -566,7 +560,7 @@ var _ = Describe("Node Operations", func() {
 				}
 
 				f4 := iptV4.(*util.FakeIPTables)
-				err = f4.MatchState(expectedTables)
+				err = f4.MatchState(expectedTables, nil)
 				Expect(err).NotTo(HaveOccurred())
 				return nil
 			}
@@ -659,7 +653,7 @@ var _ = Describe("Node Operations", func() {
 				}
 
 				f4 := iptV4.(*util.FakeIPTables)
-				err = f4.MatchState(expectedTables)
+				err = f4.MatchState(expectedTables, nil)
 				Expect(err).NotTo(HaveOccurred())
 				flows := fNPW.ofm.flowCache["NodePort_namespace1_service1_tcp_31111"]
 				Expect(flows).To(BeNil())
@@ -754,7 +748,7 @@ var _ = Describe("Node Operations", func() {
 				}
 
 				f4 := iptV4.(*util.FakeIPTables)
-				err = f4.MatchState(expectedTables)
+				err = f4.MatchState(expectedTables, nil)
 				Expect(err).NotTo(HaveOccurred())
 				return nil
 			}
@@ -864,7 +858,7 @@ var _ = Describe("Node Operations", func() {
 				}
 
 				f4 := iptV4.(*util.FakeIPTables)
-				err = f4.MatchState(expectedTables)
+				err = f4.MatchState(expectedTables, nil)
 				Expect(err).NotTo(HaveOccurred())
 				flows := fNPW.ofm.flowCache["NodePort_namespace1_service1_tcp_31111"]
 				Expect(flows).To(BeNil())
@@ -1003,7 +997,7 @@ var _ = Describe("Node Operations", func() {
 				}
 
 				f4 := iptV4.(*util.FakeIPTables)
-				Expect(f4.MatchState(expectedTables)).To(Succeed())
+				Expect(f4.MatchState(expectedTables, nil)).To(Succeed())
 				Expect(fNPW.ofm.flowCache["Ingress_namespace1_service1_5.5.5.5_80"]).To(Equal(expectedLBIngressFlows))
 				Expect(fNPW.ofm.flowCache["External_namespace1_service1_1.1.1.1_80"]).To(Equal(expectedLBExternalIPFlows))
 				return nil
@@ -1108,7 +1102,7 @@ var _ = Describe("Node Operations", func() {
 				}
 
 				f4 := iptV4.(*util.FakeIPTables)
-				err = f4.MatchState(expectedTables)
+				err = f4.MatchState(expectedTables, nil)
 				Expect(err).NotTo(HaveOccurred())
 				flows := fNPW.ofm.flowCache["NodePort_namespace1_service1_tcp_31111"]
 				Expect(flows).To(BeNil())
@@ -1237,7 +1231,7 @@ var _ = Describe("Node Operations", func() {
 				}
 
 				f4 := iptV4.(*util.FakeIPTables)
-				err = f4.MatchState(expectedTables)
+				err = f4.MatchState(expectedTables, nil)
 				Expect(err).NotTo(HaveOccurred())
 				flows := fNPW.ofm.flowCache["NodePort_namespace1_service1_tcp_31111"]
 				Expect(flows).To(Equal(expectedNodePortFlows))
@@ -1327,7 +1321,7 @@ var _ = Describe("Node Operations", func() {
 				}
 
 				f4 := iptV4.(*util.FakeIPTables)
-				err = f4.MatchState(expectedTables4)
+				err = f4.MatchState(expectedTables4, nil)
 				Expect(err).NotTo(HaveOccurred())
 
 				expectedTables6 := map[string]util.FakeTable{
@@ -1340,7 +1334,7 @@ var _ = Describe("Node Operations", func() {
 					"mangle": {},
 				}
 				f6 := iptV6.(*util.FakeIPTables)
-				err = f6.MatchState(expectedTables6)
+				err = f6.MatchState(expectedTables6, nil)
 				Expect(err).NotTo(HaveOccurred())
 				return nil
 			}
@@ -1423,7 +1417,7 @@ var _ = Describe("Node Operations", func() {
 				}
 
 				f4 := iptV4.(*util.FakeIPTables)
-				err = f4.MatchState(expectedTables4)
+				err = f4.MatchState(expectedTables4, nil)
 				Expect(err).NotTo(HaveOccurred())
 
 				expectedTables6 := map[string]util.FakeTable{
@@ -1437,7 +1431,7 @@ var _ = Describe("Node Operations", func() {
 				}
 
 				f6 := iptV6.(*util.FakeIPTables)
-				err = f6.MatchState(expectedTables6)
+				err = f6.MatchState(expectedTables6, nil)
 				Expect(err).NotTo(HaveOccurred())
 				return nil
 			}
@@ -1516,7 +1510,7 @@ var _ = Describe("Node Operations", func() {
 				}
 
 				f4 := iptV4.(*util.FakeIPTables)
-				err = f4.MatchState(expectedTables)
+				err = f4.MatchState(expectedTables, nil)
 				Expect(err).NotTo(HaveOccurred())
 				expectedTables = map[string]util.FakeTable{
 					"nat":    {},
@@ -1524,7 +1518,7 @@ var _ = Describe("Node Operations", func() {
 					"mangle": {},
 				}
 				f6 := iptV6.(*util.FakeIPTables)
-				err = f6.MatchState(expectedTables)
+				err = f6.MatchState(expectedTables, nil)
 				Expect(err).NotTo(HaveOccurred())
 				return nil
 			}
@@ -1597,7 +1591,7 @@ var _ = Describe("Node Operations", func() {
 				}
 
 				f4 := iptV4.(*util.FakeIPTables)
-				err = f4.MatchState(expectedTables)
+				err = f4.MatchState(expectedTables, nil)
 				Expect(err).NotTo(HaveOccurred())
 
 				expectedTables = map[string]util.FakeTable{
@@ -1607,7 +1601,7 @@ var _ = Describe("Node Operations", func() {
 				}
 
 				f6 := iptV6.(*util.FakeIPTables)
-				err = f6.MatchState(expectedTables)
+				err = f6.MatchState(expectedTables, nil)
 				Expect(err).NotTo(HaveOccurred())
 				return nil
 			}
@@ -1687,7 +1681,7 @@ var _ = Describe("Node Operations", func() {
 				}
 
 				f4 := iptV4.(*util.FakeIPTables)
-				err = f4.MatchState(expectedTables)
+				err = f4.MatchState(expectedTables, nil)
 				Expect(err).NotTo(HaveOccurred())
 
 				addConntrackMocks(netlinkMock, []ctFilterDesc{{"10.10.10.1", 8034}, {"10.129.0.2", 8034}})
@@ -1726,7 +1720,7 @@ var _ = Describe("Node Operations", func() {
 				}
 
 				f4 = iptV4.(*util.FakeIPTables)
-				err = f4.MatchState(expectedTables)
+				err = f4.MatchState(expectedTables, nil)
 				Expect(err).NotTo(HaveOccurred())
 				return nil
 			}
@@ -1915,7 +1909,7 @@ var _ = Describe("Node Operations", func() {
 				retry.CheckRetryObjectEventually(key, true, nodePortWatcherRetry)
 				// check iptables
 				f4 := iptV4.(*util.FakeIPTables)
-				err = f4.MatchState(expectedTables)
+				err = f4.MatchState(expectedTables, nil)
 				Expect(err).NotTo(HaveOccurred())
 
 				// HACK: Fix the service by setting a correct external IP address in newObj field
@@ -1940,7 +1934,7 @@ var _ = Describe("Node Operations", func() {
 				expectedTables["nat"]["OVN-KUBE-EXTERNALIP"] = ovn_kube_external_ip_field
 				Eventually(func(g Gomega) {
 					f4 := iptV4.(*util.FakeIPTables)
-					err = f4.MatchState(expectedTables)
+					err = f4.MatchState(expectedTables, nil)
 					g.Expect(err).NotTo(HaveOccurred())
 				})
 
@@ -2016,7 +2010,7 @@ var _ = Describe("Node Operations", func() {
 				}
 
 				f4 := iptV4.(*util.FakeIPTables)
-				err = f4.MatchState(expectedTables)
+				err = f4.MatchState(expectedTables, nil)
 				Expect(err).NotTo(HaveOccurred())
 
 				addConntrackMocks(netlinkMock, []ctFilterDesc{{"10.129.0.2", 8080}, {"192.168.18.15", 38034}})
@@ -2055,7 +2049,7 @@ var _ = Describe("Node Operations", func() {
 				}
 
 				f4 = iptV4.(*util.FakeIPTables)
-				err = f4.MatchState(expectedTables)
+				err = f4.MatchState(expectedTables, nil)
 				Expect(err).NotTo(HaveOccurred())
 
 				return nil
@@ -2149,7 +2143,7 @@ var _ = Describe("Node Operations", func() {
 				}
 
 				f4 := iptV4.(*util.FakeIPTables)
-				err = f4.MatchState(expectedTables)
+				err = f4.MatchState(expectedTables, nil)
 				Expect(err).NotTo(HaveOccurred())
 				flows := fNPW.ofm.flowCache["NodePort_namespace1_service1_tcp_31111"]
 				Expect(flows).To(BeNil())
@@ -2190,7 +2184,7 @@ var _ = Describe("Node Operations", func() {
 				}
 
 				f4 = iptV4.(*util.FakeIPTables)
-				err = f4.MatchState(expectedTables)
+				err = f4.MatchState(expectedTables, nil)
 				Expect(err).NotTo(HaveOccurred())
 
 				flows = fNPW.ofm.flowCache["NodePort_namespace1_service1_tcp_31111"]
@@ -2292,7 +2286,7 @@ var _ = Describe("Node Operations", func() {
 				}
 
 				f4 := iptV4.(*util.FakeIPTables)
-				err = f4.MatchState(expectedTables)
+				err = f4.MatchState(expectedTables, nil)
 				Expect(err).NotTo(HaveOccurred())
 				flows := fNPW.ofm.flowCache["NodePort_namespace1_service1_tcp_31111"]
 				Expect(flows).To(Equal(expectedFlows))
@@ -2333,7 +2327,7 @@ var _ = Describe("Node Operations", func() {
 				}
 
 				f4 = iptV4.(*util.FakeIPTables)
-				err = f4.MatchState(expectedTables)
+				err = f4.MatchState(expectedTables, nil)
 				Expect(err).NotTo(HaveOccurred())
 
 				flows = fNPW.ofm.flowCache["NodePort_namespace1_service1_tcp_31111"]
@@ -2439,7 +2433,7 @@ var _ = Describe("Node Operations", func() {
 				}
 
 				f4 := iptV4.(*util.FakeIPTables)
-				err = f4.MatchState(expectedTables)
+				err = f4.MatchState(expectedTables, nil)
 				Expect(err).NotTo(HaveOccurred())
 				flows := fNPW.ofm.flowCache["NodePort_namespace1_service1_tcp_31111"]
 				Expect(flows).To(Equal(expectedFlows))
@@ -2480,7 +2474,7 @@ var _ = Describe("Node Operations", func() {
 				}
 
 				f4 = iptV4.(*util.FakeIPTables)
-				err = f4.MatchState(expectedTables)
+				err = f4.MatchState(expectedTables, nil)
 				Expect(err).NotTo(HaveOccurred())
 
 				flows = fNPW.ofm.flowCache["NodePort_namespace1_service1_tcp_31111"]
@@ -2583,7 +2577,7 @@ var _ = Describe("Node Operations", func() {
 				}
 
 				f4 := iptV4.(*util.FakeIPTables)
-				err = f4.MatchState(expectedTables)
+				err = f4.MatchState(expectedTables, nil)
 				Expect(err).NotTo(HaveOccurred())
 				flows := fNPW.ofm.flowCache["NodePort_namespace1_service1_tcp_31111"]
 				Expect(flows).To(Equal(expectedFlows))
@@ -2624,7 +2618,7 @@ var _ = Describe("Node Operations", func() {
 				}
 
 				f4 = iptV4.(*util.FakeIPTables)
-				err = f4.MatchState(expectedTables)
+				err = f4.MatchState(expectedTables, nil)
 				Expect(err).NotTo(HaveOccurred())
 
 				flows = fNPW.ofm.flowCache["NodePort_namespace1_service1_tcp_31111"]
@@ -2729,7 +2723,7 @@ var _ = Describe("Node Operations", func() {
 				}
 
 				f4 := iptV4.(*util.FakeIPTables)
-				err = f4.MatchState(expectedTables)
+				err = f4.MatchState(expectedTables, nil)
 				Expect(err).NotTo(HaveOccurred())
 				flows := fNPW.ofm.flowCache["NodePort_namespace1_service1_tcp_31111"]
 				Expect(flows).To(Equal(expectedFlows))
@@ -2770,7 +2764,7 @@ var _ = Describe("Node Operations", func() {
 				}
 
 				f4 = iptV4.(*util.FakeIPTables)
-				err = f4.MatchState(expectedTables)
+				err = f4.MatchState(expectedTables, nil)
 				Expect(err).NotTo(HaveOccurred())
 
 				flows = fNPW.ofm.flowCache["NodePort_namespace1_service1_tcp_31111"]
@@ -2820,8 +2814,6 @@ var _ = Describe("Node Operations", func() {
 							"-s 172.16.1.0/24 -j ACCEPT",
 							"-d 10.1.0.0/16 -j ACCEPT",
 							"-s 10.1.0.0/16 -j ACCEPT",
-							"-i breth0 -j DROP",
-							"-o breth0 -j DROP",
 						},
 					},
 					"mangle": {
@@ -2833,7 +2825,10 @@ var _ = Describe("Node Operations", func() {
 				}
 
 				f4 := iptV4.(*util.FakeIPTables)
-				err := f4.MatchState(expectedTables)
+				err := f4.MatchState(expectedTables, map[util.FakePolicyKey]string{{
+					Table: "filter",
+					Chain: "FORWARD",
+				}: "DROP"})
 				Expect(err).NotTo(HaveOccurred())
 				expectedTables = map[string]util.FakeTable{
 					"nat":    {},
@@ -2841,12 +2836,13 @@ var _ = Describe("Node Operations", func() {
 					"mangle": {},
 				}
 				f6 := iptV6.(*util.FakeIPTables)
-				err = f6.MatchState(expectedTables)
+				err = f6.MatchState(expectedTables, nil)
 				Expect(err).NotTo(HaveOccurred())
 
 				// Enable forwarding and test deletion of iptables rules from FORWARD chain
 				config.Gateway.DisableForwarding = false
 				fNPW.watchFactory = fakeOvnNode.watcher
+				Expect(configureGlobalForwarding()).To(Succeed())
 				Expect(startNodePortWatcher(fNPW, fakeOvnNode.fakeClient, &fakeMgmtPortConfig)).To(Succeed())
 				expectedTables = map[string]util.FakeTable{
 					"nat": {
@@ -2882,7 +2878,10 @@ var _ = Describe("Node Operations", func() {
 				}
 
 				f4 = iptV4.(*util.FakeIPTables)
-				err = f4.MatchState(expectedTables)
+				err = f4.MatchState(expectedTables, map[util.FakePolicyKey]string{{
+					Table: "filter",
+					Chain: "FORWARD",
+				}: "ACCEPT"})
 				Expect(err).NotTo(HaveOccurred())
 				expectedTables = map[string]util.FakeTable{
 					"nat":    {},
@@ -2890,7 +2889,7 @@ var _ = Describe("Node Operations", func() {
 					"mangle": {},
 				}
 				f6 = iptV6.(*util.FakeIPTables)
-				err = f6.MatchState(expectedTables)
+				err = f6.MatchState(expectedTables, nil)
 				Expect(err).NotTo(HaveOccurred())
 				return nil
 			}

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -1764,15 +1764,6 @@ func newSharedGateway(nodeName string, subnets []*net.IPNet, gwNextHops []net.IP
 			if err != nil {
 				return err
 			}
-			if config.Gateway.DisableForwarding {
-				if err := initExternalBridgeDropForwardingRules(exGwBridge.bridgeName); err != nil {
-					return fmt.Errorf("failed to add drop rules in forwarding table for bridge %s: err %v", exGwBridge.bridgeName, err)
-				}
-			} else {
-				if err := delExternalBridgeDropForwardingRules(exGwBridge.bridgeName); err != nil {
-					return fmt.Errorf("failed to delete drop rules in forwarding table for bridge %s: err %v", exGwBridge.bridgeName, err)
-				}
-			}
 		}
 		gw.nodeIPManager = newAddressManager(nodeName, kube, cfg, watchFactory, gwBridge)
 		nodeIPs := gw.nodeIPManager.ListAddresses()
@@ -1884,15 +1875,9 @@ func newNodePortWatcher(gwBridge *bridgeConfiguration, ofm *openflowManager,
 		if err := initExternalBridgeServiceForwardingRules(subnets); err != nil {
 			return nil, fmt.Errorf("failed to add accept rules in forwarding table for bridge %s: err %v", gwBridge.bridgeName, err)
 		}
-		if err := initExternalBridgeDropForwardingRules(gwBridge.bridgeName); err != nil {
-			return nil, fmt.Errorf("failed to add drop rules in forwarding table for bridge %s: err %v", gwBridge.bridgeName, err)
-		}
 	} else {
 		if err := delExternalBridgeServiceForwardingRules(subnets); err != nil {
 			return nil, fmt.Errorf("failed to delete accept rules in forwarding table for bridge %s: err %v", gwBridge.bridgeName, err)
-		}
-		if err := delExternalBridgeDropForwardingRules(gwBridge.bridgeName); err != nil {
-			return nil, fmt.Errorf("failed to delete drop rules in forwarding table for bridge %s: err %v", gwBridge.bridgeName, err)
 		}
 	}
 

--- a/go-controller/pkg/node/management-port_linux.go
+++ b/go-controller/pkg/node/management-port_linux.go
@@ -212,23 +212,12 @@ func setupManagementPortIPFamilyConfig(routeManager *routemanager.Controller, mp
 		return warnings, err
 	}
 
-	createForwardingRule := func(family string) error {
-		stdout, stderr, err := util.RunSysctl("-w", fmt.Sprintf("net.%s.conf.%s.forwarding=1", family, types.K8sMgmtIntfName))
-		if err != nil || stdout != fmt.Sprintf("net.%s.conf.%s.forwarding = 1", family, types.K8sMgmtIntfName) {
-			return fmt.Errorf("could not set the correct forwarding value for interface %s: stdout: %v, stderr: %v, err: %v",
-				types.K8sMgmtIntfName, stdout, stderr, err)
-		}
-		return nil
-	}
-
+	// IPv6 forwarding is enabled globally
 	if mpcfg.ipv4 != nil && cfg == mpcfg.ipv4 {
-		if err := createForwardingRule("ipv4"); err != nil {
-			return warnings, fmt.Errorf("could not add IPv4 forwarding rule: %v", err)
-		}
-	}
-	if mpcfg.ipv6 != nil && cfg == mpcfg.ipv6 {
-		if err := createForwardingRule("ipv6"); err != nil {
-			return warnings, fmt.Errorf("could not add IPv6 forwarding rule: %v", err)
+		stdout, stderr, err := util.RunSysctl("-w", fmt.Sprintf("net.ipv4.conf.%s.forwarding=1", types.K8sMgmtIntfName))
+		if err != nil || stdout != fmt.Sprintf("net.ipv4.conf.%s.forwarding = 1", types.K8sMgmtIntfName) {
+			return warnings, fmt.Errorf("could not set the correct forwarding value for interface %s: stdout: %v, stderr: %v, err: %v",
+				types.K8sMgmtIntfName, stdout, stderr, err)
 		}
 	}
 

--- a/go-controller/pkg/node/management-port_linux_test.go
+++ b/go-controller/pkg/node/management-port_linux_test.go
@@ -121,10 +121,10 @@ func checkMgmtPortTestIptables(configs []managementPortTestConfig, mgmtPortName 
 			"mangle": {},
 		}
 		if cfg.protocol == iptables.ProtocolIPv4 {
-			err = fakeIpv4.MatchState(expectedTables)
+			err = fakeIpv4.MatchState(expectedTables, nil)
 			Expect(err).NotTo(HaveOccurred())
 		} else {
-			err = fakeIpv6.MatchState(expectedTables)
+			err = fakeIpv6.MatchState(expectedTables, nil)
 			Expect(err).NotTo(HaveOccurred())
 		}
 	}
@@ -221,15 +221,11 @@ func testManagementPort(ctx *cli.Context, fexec *ovntest.FakeExec, testNS ns.Net
 		"ovs-vsctl --timeout=15 set interface " + mgtPort + " " + fmt.Sprintf("mac=%s", strings.ReplaceAll(mgtPortMAC, ":", "\\:")),
 	})
 	for _, cfg := range configs {
+		// We do not enable per-interface forwarding for IPv6
 		if cfg.family == netlink.FAMILY_V4 {
 			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 				Cmd:    "sysctl -w net.ipv4.conf.ovn-k8s-mp0.forwarding=1",
 				Output: "net.ipv4.conf.ovn-k8s-mp0.forwarding = 1",
-			})
-		} else {
-			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-				Cmd:    "sysctl -w net.ipv6.conf.ovn-k8s-mp0.forwarding=1",
-				Output: "net.ipv6.conf.ovn-k8s-mp0.forwarding = 1",
 			})
 		}
 	}
@@ -422,16 +418,11 @@ func testManagementPortDPUHost(ctx *cli.Context, fexec *ovntest.FakeExec, testNS
 	})
 
 	for _, cfg := range configs {
+		// We do not enable per-interface forwarding for IPv6
 		if cfg.family == netlink.FAMILY_V4 {
 			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 				Cmd:    "sysctl -w net.ipv4.conf.ovn-k8s-mp0.forwarding=1",
 				Output: "net.ipv4.conf.ovn-k8s-mp0.forwarding = 1",
-			})
-		}
-		if cfg.family == netlink.FAMILY_V6 {
-			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-				Cmd:    "sysctl -w net.ipv6.conf.ovn-k8s-mp0.forwarding=1",
-				Output: "net.ipv6.conf.ovn-k8s-mp0.forwarding = 1",
 			})
 		}
 	}


### PR DESCRIPTION
Global forwarding works differently for IPv6:
  conf/all/forwarding - BOOLEAN
   Enable global IPv6 forwarding between all interfaces.
	  IPv4 and IPv6 work differently here; e.g. netfilter must be used
	  to control which interfaces may forward packets and which not.
https://www.kernel.org/doc/Documentation/networking/ip-sysctl.txt

It is not possible to configure the IPv6 forwarding per interface by setting the net.ipv6.conf.<ifname>.forwarding sysctl. Instead, the opposite approach is required where the global forwarding is enabled and an iptables policy is added to restrict it by default.

To ensure consistent behavior between IPv4/IPv6 and limit the forwarding scope for IPv4 networks this commit configures the default DROP policy for all configured IP families.


(cherry picked from commit 681f7cabc2aa5782bfea93506044f292df631cb7)

Resolved two merge conflicts:
* docs/getting-started/configuration.md: bottom of the file
* go-controller/pkg/node/egress_service_test.go: add `nil` to f4.MatchState function calls