### PR TITLE
[release-4.20] OCPBUGS-61239: Skip node-encap-ips annotation in DPU host mode

### DIFF
--- a/go-controller/pkg/node/default_node_network_controller.go
+++ b/go-controller/pkg/node/default_node_network_controller.go
@@ -1008,10 +1008,14 @@ func (nc *DefaultNodeNetworkController) Init(ctx context.Context) error {
 		return fmt.Errorf("failed to set node zone annotation for node %s: %w", nc.name, err)
 	}
 
-	encapIPList := sets.New[string]()
-	encapIPList.Insert(strings.Split(config.Default.EffectiveEncapIP, ",")...)
-	if err := util.SetNodeEncapIPs(nodeAnnotator, encapIPList); err != nil {
-		return fmt.Errorf("failed to set node-encap-ips annotation for node %s: %w", nc.name, err)
+	// Set the node-encap-ips annotation with the configured encap IP.
+	// This encap IP is unavailable on the DPU host mode, so we don't need to set it there.
+	if config.OvnKubeNode.Mode != types.NodeModeDPUHost {
+		encapIPList := sets.New[string]()
+		encapIPList.Insert(strings.Split(config.Default.EffectiveEncapIP, ",")...)
+		if err := util.SetNodeEncapIPs(nodeAnnotator, encapIPList); err != nil {
+			return fmt.Errorf("failed to set node-encap-ips annotation for node %s: %w", nc.name, err)
+		}
 	}
 
 	if err := nodeAnnotator.Run(); err != nil {

--- a/go-controller/pkg/node/node_ip_handler_linux.go
+++ b/go-controller/pkg/node/node_ip_handler_linux.go
@@ -243,7 +243,7 @@ func (c *addressManager) handleNodePrimaryAddrChange() {
 		klog.Errorf("Address Manager failed to check node primary address change: %v", err)
 		return
 	}
-	if nodePrimaryAddrChanged && config.Default.EncapIP == "" {
+	if nodePrimaryAddrChanged && config.Default.EncapIP == "" && config.OvnKubeNode.Mode != types.NodeModeDPUHost {
 		klog.Infof("Node primary address changed to %v. Updating OVN encap IP.", c.nodePrimaryAddr)
 		c.updateOVNEncapIPAndReconnect(c.nodePrimaryAddr)
 	}


### PR DESCRIPTION
[release-4.20] OCPBUGS-61239: Skip node-encap-ips annotation in DPU host mode
The node-encap-ips annotation should not be set when running in DPU host mode since the encap IP is not available on the DPU host. This prevents errors during node initialization when the encap IP cannot be determined.

- Add conditional check for NodeModeDPUHost before setting encap IP annotation
- Maintain existing behavior for non-DPU host modes
- Fixes initialization errors in DPU host mode deployments

cherry pick from https://github.com/openshift/ovn-kubernetes/pull/2750
exact commit is https://github.com/openshift/ovn-kubernetes/pull/2750/commits/d70e444e6fbdeb962b4cf5ed79af45e5faf2689a

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
