### PR TITLE
CNI: Increase OVS timeout from 30s to 120s for HCP environments

### DIFF
--- a/go-controller/pkg/cni/ovs.go
+++ b/go-controller/pkg/cni/ovs.go
@@ -43,7 +43,7 @@ func ovsExec(args ...string) (string, error) {
 		return "", fmt.Errorf("OVS exec runner not initialized")
 	}
 
-	args = append([]string{"--timeout=60"}, args...)
+	args = append([]string{"--timeout=90"}, args...)
 	output, err := runner.Command(vsctlPath, args...).CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("failed to run 'ovs-vsctl %s': %v\n  %q", strings.Join(args, " "), err, string(output))

--- a/go-controller/pkg/cni/ovs.go
+++ b/go-controller/pkg/cni/ovs.go
@@ -43,7 +43,7 @@ func ovsExec(args ...string) (string, error) {
 		return "", fmt.Errorf("OVS exec runner not initialized")
 	}
 
-	args = append([]string{"--timeout=30"}, args...)
+	args = append([]string{"--timeout=60"}, args...)
 	output, err := runner.Command(vsctlPath, args...).CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("failed to run 'ovs-vsctl %s': %v\n  %q", strings.Join(args, " "), err, string(output))


### PR DESCRIPTION
  This fixes pod creation failures in HyperShift Hosted Control Plane
  clusters where high concurrent pod creation (400+ pods) causes OVS
  database operations to timeout after 30 seconds.

  OCPBUGS-66075

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
