### PR TITLE
[release-4.20] OCPBUGS-76473: Remove forced V(5) logging during startup

### DIFF
--- a/go-controller/pkg/node/default_node_network_controller.go
+++ b/go-controller/pkg/node/default_node_network_controller.go
@@ -864,13 +864,6 @@ func (nc *DefaultNodeNetworkController) Init(ctx context.Context) error {
 	var subnets []*net.IPNet
 	var cniServer *cni.Server
 
-	// Setting debug log level during node bring up to expose bring up process.
-	// Log level is returned to configured value when bring up is complete.
-	var level klog.Level
-	if err := level.Set("5"); err != nil {
-		klog.Errorf("Setting klog \"loglevel\" to 5 failed, err: %v", err)
-	}
-
 	if config.OvnKubeNode.Mode != types.NodeModeDPU {
 		if err = configureGlobalForwarding(); err != nil {
 			return err
@@ -1055,9 +1048,6 @@ func (nc *DefaultNodeNetworkController) Init(ctx context.Context) error {
 		}
 	}
 
-	if err := level.Set(strconv.Itoa(config.Logging.Level)); err != nil {
-		klog.Errorf("Reset of initial klog \"loglevel\" failed, err: %v", err)
-	}
 	nc.sbZone = sbZone
 
 	return nil
@@ -1073,13 +1063,6 @@ func (nc *DefaultNodeNetworkController) Start(ctx context.Context) error {
 
 	if nc.mgmtPortController == nil {
 		return fmt.Errorf("default node network controller hasn't been pre-started")
-	}
-
-	// Setting debug log level during node bring up to expose bring up process.
-	// Log level is returned to configured value when bring up is complete.
-	var level klog.Level
-	if err := level.Set("5"); err != nil {
-		klog.Errorf("Setting klog \"loglevel\" to 5 failed, err: %v", err)
 	}
 
 	if node, err = nc.watchFactory.GetNode(nc.name); err != nil {
@@ -1285,10 +1268,6 @@ func (nc *DefaultNodeNetworkController) Start(ctx context.Context) error {
 		if err != nil {
 			klog.Errorf("Deletion of port int on  br-int failed: %v (%v)", err, stderr)
 		}
-	}
-
-	if err := level.Set(strconv.Itoa(config.Logging.Level)); err != nil {
-		klog.Errorf("Reset of initial klog \"loglevel\" failed, err: %v", err)
 	}
 
 	// start management port controller

--- a/go-controller/pkg/node/default_node_network_controller.go
+++ b/go-controller/pkg/node/default_node_network_controller.go
@@ -810,13 +810,6 @@ func (nc *DefaultNodeNetworkController) Init(ctx context.Context) error {
 	var subnets []*net.IPNet
 	var cniServer *cni.Server
 
-	// Setting debug log level during node bring up to expose bring up process.
-	// Log level is returned to configured value when bring up is complete.
-	var level klog.Level
-	if err := level.Set("5"); err != nil {
-		klog.Errorf("Setting klog \"loglevel\" to 5 failed, err: %v", err)
-	}
-
 	if config.OvnKubeNode.Mode != types.NodeModeDPU {
 		if err = configureGlobalForwarding(); err != nil {
 			return err
@@ -998,9 +991,6 @@ func (nc *DefaultNodeNetworkController) Init(ctx context.Context) error {
 		}
 	}
 
-	if err := level.Set(strconv.Itoa(config.Logging.Level)); err != nil {
-		klog.Errorf("Reset of initial klog \"loglevel\" failed, err: %v", err)
-	}
 	nc.sbZone = sbZone
 
 	return nil
@@ -1015,13 +1005,6 @@ func (nc *DefaultNodeNetworkController) Start(ctx context.Context) error {
 
 	if nc.mgmtPortController == nil {
 		return fmt.Errorf("default node network controller hasn't been pre-started")
-	}
-
-	// Setting debug log level during node bring up to expose bring up process.
-	// Log level is returned to configured value when bring up is complete.
-	var level klog.Level
-	if err := level.Set("5"); err != nil {
-		klog.Errorf("Setting klog \"loglevel\" to 5 failed, err: %v", err)
 	}
 
 	waiter := newStartupWaiter()
@@ -1103,10 +1086,6 @@ func (nc *DefaultNodeNetworkController) Start(ctx context.Context) error {
 		if err != nil {
 			klog.Errorf("Deletion of port int on  br-int failed: %v (%v)", err, stderr)
 		}
-	}
-
-	if err := level.Set(strconv.Itoa(config.Logging.Level)); err != nil {
-		klog.Errorf("Reset of initial klog \"loglevel\" failed, err: %v", err)
 	}
 
 	// start management port controller


### PR DESCRIPTION
Manual cherry-pick of [b52e40b](https://github.com/openshift/ovn-kubernetes/pull/2896/changes/b52e40b0ed63ff73af75d4c1963b9b50aad961d3).

This PR removes the hardcoded log level override to V(5) during ovnkube-node 
startup. The Init() and Start() functions were forcing log level to 5 regardless 
of user configuration.

Related:
- Upstream PR: https://github.com/ovn-kubernetes/ovn-kubernetes/pull/5771
- Downstream merge: https://github.com/openshift/ovn-kubernetes/pull/2896
- Original bug: https://issues.redhat.com/browse/OCPBUGS-43677
