### PR TITLE
WIP: OpenShift provider support using kcli for e2e

### DIFF
--- a/openshift/cmd/ovn-kubernetes-tests-ext/provider.go
+++ b/openshift/cmd/ovn-kubernetes-tests-ext/provider.go
@@ -68,6 +68,11 @@ func initializeTestFramework(provider string) error {
 	if ad := os.Getenv("ARTIFACT_DIR"); len(strings.TrimSpace(ad)) == 0 {
 		os.Setenv("ARTIFACT_DIR", filepath.Join(os.TempDir(), "artifacts"))
 	}
+	// Set default SSH key path if not provided
+	if sshKeyPath := os.Getenv("SSH_KEY_PATH"); len(sshKeyPath) == 0 {
+		defaultPath := filepath.Join(os.Getenv("HOME"), ".ssh", "id_rsa")
+		os.Setenv("SSH_KEY_PATH", defaultPath)
+	}
 	// "debian" is used when not set. At least GlusterFS tests need "custom".
 	// (There is no option for "rhel" or "centos".)
 	testContext.NodeOSDistro = "custom"

--- a/openshift/go.mod
+++ b/openshift/go.mod
@@ -9,14 +9,17 @@ require (
 	github.com/onsi/gomega v1.36.1
 	github.com/openshift-eng/openshift-tests-extension v0.0.0-20250916161632-d81c09058835
 	github.com/openshift/api v0.0.0-20251020135558-286504b695bc
+	github.com/openshift/client-go v0.0.0-20251015124057-db0dee36e235
 	github.com/ovn-org/ovn-kubernetes/go-controller v1.0.0
 	github.com/ovn-org/ovn-kubernetes/test/e2e v0.0.0-20250827185716-56d14a3074ba
 	github.com/spf13/cobra v1.9.1
+	golang.org/x/crypto v0.43.0
 	k8s.io/api v0.34.1
 	k8s.io/apimachinery v0.34.1
 	k8s.io/client-go v0.34.1
 	k8s.io/component-base v0.34.1
 	k8s.io/kubernetes v1.34.1
+	k8s.io/utils v0.0.0-20251002143259-bc988d571ff4
 )
 
 require (
@@ -122,7 +125,6 @@ require (
 	github.com/opencontainers/runtime-spec v1.2.0 // indirect
 	github.com/opencontainers/selinux v1.11.1 // indirect
 	github.com/openshift-kni/k8sreporter v1.0.6 // indirect
-	github.com/openshift/client-go v0.0.0-20251015124057-db0dee36e235 // indirect
 	github.com/openshift/custom-resource-status v1.1.2 // indirect
 	github.com/openshift/library-go v0.0.0-20251015151611-6fc7a74b67c5 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
@@ -165,7 +167,6 @@ require (
 	go.universe.tf/metallb v0.0.0-00010101000000-000000000000 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
-	golang.org/x/crypto v0.43.0 // indirect
 	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 // indirect
 	golang.org/x/net v0.46.0 // indirect
 	golang.org/x/oauth2 v0.27.0 // indirect
@@ -203,7 +204,6 @@ require (
 	k8s.io/kubelet v0.34.1 // indirect
 	k8s.io/mount-utils v0.34.1 // indirect
 	k8s.io/pod-security-admission v0.34.1 // indirect
-	k8s.io/utils v0.0.0-20251002143259-bc988d571ff4 // indirect
 	kubevirt.io/api v1.4.0 // indirect
 	kubevirt.io/containerized-data-importer-api v1.57.0-alpha1 // indirect
 	kubevirt.io/controller-lifecycle-operator-sdk/api v0.0.0-20220329064328-f3cc58c6ed90 // indirect

--- a/openshift/test/annotate/rules.go
+++ b/openshift/test/annotate/rules.go
@@ -42,8 +42,6 @@ var (
 			`Pod to external server PMTUD`,
 			`Pod to pod TCP with low MTU`,
 			`blocking ICMP needs frag`,
-			// UDN test requires egress
-			`pod2Egress on a user defined primary network`,
 			`is isolated from the default network`,
 			// requires host net port collision avoidance
 			`EndpointSlices mirroring`,
@@ -81,6 +79,7 @@ var (
 			`Network Segmentation UserDefinedNetwork CRD Controller should correctly report subsystem error on node subnet allocation`,
 			// requires implementation of overlay method (provider API)
 			`Network Segmentation: Localnet using ClusterUserDefinedNetwork CR, pods in different namespaces, should communicate over localnet topology`,
+			`should preserve LSPs for IPAM-less localnet pods after ovnkube-node restart`,
 			// pods dont drop privileges
 			`should be able to send multicast UDP traffic between nodes`,
 			// TODO: fix the flakiness with net-seg overlapping CIDRs test in downstream.

--- a/openshift/test/generated/zz_generated.annotations.go
+++ b/openshift/test/generated/zz_generated.annotations.go
@@ -1231,23 +1231,23 @@ var AppendedAnnotations = map[string]string{
 
 	"Network Segmentation a user defined primary network with multicast feature enabled for namespace should be able to send multicast UDP traffic between nodes with primary layer3 UDN": "[Disabled:Unimplemented]",
 
-	"Network Segmentation pod2Egress on a user defined primary network created using ClusterUserDefinedNetwork can be accessed to from the pods running in the Kubernetes cluster by one pod over a layer2 network with custom network": "[Disabled:Unimplemented]",
+	"Network Segmentation pod2Egress on a user defined primary network created using ClusterUserDefinedNetwork can be accessed to from the pods running in the Kubernetes cluster by one pod over a layer2 network with custom network": "[Suite:openshift/conformance/parallel]",
 
-	"Network Segmentation pod2Egress on a user defined primary network created using ClusterUserDefinedNetwork can be accessed to from the pods running in the Kubernetes cluster by one pod over a layer2 network": "[Disabled:Unimplemented]",
+	"Network Segmentation pod2Egress on a user defined primary network created using ClusterUserDefinedNetwork can be accessed to from the pods running in the Kubernetes cluster by one pod over a layer2 network": "[Suite:openshift/conformance/parallel]",
 
-	"Network Segmentation pod2Egress on a user defined primary network created using ClusterUserDefinedNetwork can be accessed to from the pods running in the Kubernetes cluster by one pod over a layer3 network": "[Disabled:Unimplemented]",
+	"Network Segmentation pod2Egress on a user defined primary network created using ClusterUserDefinedNetwork can be accessed to from the pods running in the Kubernetes cluster by one pod over a layer3 network": "[Suite:openshift/conformance/parallel]",
 
-	"Network Segmentation pod2Egress on a user defined primary network created using NetworkAttachmentDefinitions can be accessed to from the pods running in the Kubernetes cluster by one pod over a layer2 network with custom network": "[Disabled:Unimplemented]",
+	"Network Segmentation pod2Egress on a user defined primary network created using NetworkAttachmentDefinitions can be accessed to from the pods running in the Kubernetes cluster by one pod over a layer2 network with custom network": "[Suite:openshift/conformance/parallel]",
 
-	"Network Segmentation pod2Egress on a user defined primary network created using NetworkAttachmentDefinitions can be accessed to from the pods running in the Kubernetes cluster by one pod over a layer2 network": "[Disabled:Unimplemented]",
+	"Network Segmentation pod2Egress on a user defined primary network created using NetworkAttachmentDefinitions can be accessed to from the pods running in the Kubernetes cluster by one pod over a layer2 network": "[Suite:openshift/conformance/parallel]",
 
-	"Network Segmentation pod2Egress on a user defined primary network created using NetworkAttachmentDefinitions can be accessed to from the pods running in the Kubernetes cluster by one pod over a layer3 network": "[Disabled:Unimplemented]",
+	"Network Segmentation pod2Egress on a user defined primary network created using NetworkAttachmentDefinitions can be accessed to from the pods running in the Kubernetes cluster by one pod over a layer3 network": "[Suite:openshift/conformance/parallel]",
 
-	"Network Segmentation pod2Egress on a user defined primary network created using UserDefinedNetwork can be accessed to from the pods running in the Kubernetes cluster by one pod over a layer2 network with custom network": "[Disabled:Unimplemented]",
+	"Network Segmentation pod2Egress on a user defined primary network created using UserDefinedNetwork can be accessed to from the pods running in the Kubernetes cluster by one pod over a layer2 network with custom network": "[Suite:openshift/conformance/parallel]",
 
-	"Network Segmentation pod2Egress on a user defined primary network created using UserDefinedNetwork can be accessed to from the pods running in the Kubernetes cluster by one pod over a layer2 network": "[Disabled:Unimplemented]",
+	"Network Segmentation pod2Egress on a user defined primary network created using UserDefinedNetwork can be accessed to from the pods running in the Kubernetes cluster by one pod over a layer2 network": "[Suite:openshift/conformance/parallel]",
 
-	"Network Segmentation pod2Egress on a user defined primary network created using UserDefinedNetwork can be accessed to from the pods running in the Kubernetes cluster by one pod over a layer3 network": "[Disabled:Unimplemented]",
+	"Network Segmentation pod2Egress on a user defined primary network created using UserDefinedNetwork can be accessed to from the pods running in the Kubernetes cluster by one pod over a layer3 network": "[Suite:openshift/conformance/parallel]",
 
 	"Network Segmentation when primary network exist, ClusterUserDefinedNetwork status should report not-ready": "[Suite:openshift/conformance/parallel]",
 
@@ -1284,6 +1284,8 @@ var AppendedAnnotations = map[string]string{
 	"Network Segmentation: Default network multus annotation when added with static IP and MAC to a pod belonging to primary UDN should create the pod with the specified static IP and MAC address with persistent IPAM": "[Suite:openshift/conformance/parallel]",
 
 	"Network Segmentation: Default network multus annotation when added with static IP and MAC to a pod belonging to primary UDN should create the pod with the specified static IP and MAC address without persistent IPAM enabled": "[Suite:openshift/conformance/parallel]",
+
+	"Network Segmentation: Localnet should preserve LSPs for IPAM-less localnet pods after ovnkube-node restart": "[Disabled:Unimplemented]",
 
 	"Network Segmentation: Localnet using ClusterUserDefinedNetwork CR, pods in different namespaces, should communicate over localnet topology": "[Disabled:Unimplemented]",
 

--- a/openshift/test/infraprovider/machine.go
+++ b/openshift/test/infraprovider/machine.go
@@ -107,15 +107,6 @@ func showMachine(machineName string) (*Machine, error) {
 	return vm, nil
 }
 
-func removeMachine(machineName string) error {
-	cmd := exec.Command("kcli", "remove", "-y", "vm", machineName)
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("failed to delete libvirt machine: %s, output: %s, err: %w", machineName, string(output), err)
-	}
-	return nil
-}
-
 func (m *Machine) attachNetwork(networkName string) error {
 	cmd := exec.Command("kcli", "add", "nic", m.Name, "-n", networkName)
 	output, err := cmd.CombinedOutput()

--- a/openshift/test/infraprovider/machine.go
+++ b/openshift/test/infraprovider/machine.go
@@ -1,0 +1,143 @@
+package infraprovider
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"os/exec"
+
+	utilnet "k8s.io/utils/net"
+)
+
+const (
+	testMachineName = "ovn-kubernetes-e2e"
+)
+
+type Net struct {
+	Device string `json:"device"`
+	Mac    string `json:"mac"`
+	Net    string `json:"net"`
+	Type   string `json:"type"`
+}
+
+type Disk struct {
+	Device string `json:"device"`
+	Size   int    `json:"size"`
+	Format string `json:"format"`
+	Type   string `json:"type"`
+	Path   string `json:"path"`
+}
+
+type Machine struct {
+	Name         string   `json:"name"`
+	Nets         []Net    `json:"nets"`
+	Disks        []Disk   `json:"disks"`
+	ID           string   `json:"id"`
+	User         string   `json:"user"`
+	Image        string   `json:"image"`
+	Plan         string   `json:"plan"`
+	Profile      string   `json:"profile"`
+	CreationDate string   `json:"creationdate"`
+	IP           string   `json:"ip"`
+	IPs          []string `json:"ips"`
+	Status       string   `json:"status"`
+	Autostart    bool     `json:"autostart"`
+	NumCPUs      int      `json:"numcpus"`
+	Memory       int      `json:"memory"`
+}
+
+func ensureTestMachine(machineName string) (*machine, error) {
+	// Check if machine already exists
+	checkCmd := exec.Command("kcli", "show", "vm", machineName)
+	if err := checkCmd.Run(); err != nil {
+		// Machine doesn't exist, create it
+		createCmd := exec.Command("kcli", "create", "vm", "-i", "fedora42", machineName, "--wait",
+			"-P", "cmds=['dnf install -y docker','systemctl enable --now docker']")
+		output, err := createCmd.CombinedOutput()
+		if err != nil {
+			return nil, fmt.Errorf("failed to create libvirt machine: %v, output: %s", err, string(output))
+		}
+	}
+	// Retrieve machine information (whether it existed or was just created)
+	testMachine, err := showMachine(machineName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to show libvirt virtual machine %s, err: %w", machineName, err)
+	}
+	if len(testMachine.Nets) == 0 {
+		return nil, fmt.Errorf("no networks configured for libvirt virtual machine %s", machineName)
+	}
+	m := &machine{
+		name:          testMachine.Name,
+		ipv4Addresses: map[string]string{},
+		ipv6Addresses: map[string]string{},
+	}
+	for _, net := range testMachine.Nets {
+		network, err := getOpenshiftNetwork(net.Net)
+		if err != nil {
+			return nil, fmt.Errorf("failed to retrieve network %s, err: %w", net.Net, err)
+		}
+		ips := append([]string{}, testMachine.IPs...)
+		ips = append(ips, testMachine.IP)
+		for _, ip := range ips {
+			in, err := ipInCIDR(ip, network.CIDR)
+			if err != nil {
+				return nil, fmt.Errorf("error while checking machine %s IP address with network %s CIDR, err: %w",
+					machineName, net.Net, err)
+			}
+			if in && utilnet.IsIPv4String(ip) {
+				m.ipv4Addresses[net.Net] = ip
+			} else if in {
+				m.ipv6Addresses[net.Net] = ip
+			}
+		}
+	}
+	return m, nil
+}
+
+func showMachine(machineName string) (*Machine, error) {
+	cmd := exec.Command("kcli", "show", "vm", machineName, "-o", "json")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("failed to show libvirt virtual machine %s, output: %s, err: %w", machineName, string(output), err)
+	}
+	vm := &Machine{}
+	if err := json.Unmarshal(output, vm); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal libvirt virtual machine %s, output: %s, err: %w", machineName, string(output), err)
+	}
+	return vm, nil
+}
+
+func removeMachine(machineName string) error {
+	cmd := exec.Command("kcli", "remove", "-y", "vm", machineName)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to delete libvirt machine: %s, output: %s, err: %w", machineName, string(output), err)
+	}
+	return nil
+}
+
+func (m *Machine) attachNetwork(networkName string) error {
+	cmd := exec.Command("kcli", "add", "nic", m.Name, "-n", networkName)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf(
+			"failed to attach network %s to machine %s, output: %s, err: %w",
+			networkName,
+			m.Name,
+			string(output),
+			err)
+	}
+	return nil
+}
+
+func ipInCIDR(ipStr, cidrStr string) (bool, error) {
+	ip := net.ParseIP(ipStr)
+	if ip == nil {
+		return false, fmt.Errorf("invalid IP address: %q", ipStr)
+	}
+	_, ipNet, err := net.ParseCIDR(cidrStr)
+	if err != nil {
+		return false, err
+	}
+	return ipNet.Contains(ip), nil
+}

--- a/openshift/test/infraprovider/machine.go
+++ b/openshift/test/infraprovider/machine.go
@@ -1,153 +1,40 @@
 package infraprovider
 
 import (
-	"encoding/json"
 	"fmt"
-	"net"
-	"os/exec"
-
-	utilnet "k8s.io/utils/net"
+	"os"
 )
 
 const (
-	testMachineName = "ovn-kubernetes-e2e"
+	vmIPEnvKey              = "VM_IP"
+	hypervisorIPEnvKey      = "HYPERVISOR_IP"
+	testMachineName         = "ovn-kubernetes-e2e"
+	hypervisorKeyPathEnvKey = "HYPERVISOR_SSH_KEY"
+	vmKeyPathEnvKey         = "VM_SSH_KEY"
 )
 
-type Net struct {
-	Device string `json:"device"`
-	Mac    string `json:"mac"`
-	Net    string `json:"net"`
-	Type   string `json:"type"`
-}
-
-type Disk struct {
-	Device string `json:"device"`
-	Size   int    `json:"size"`
-	Format string `json:"format"`
-	Type   string `json:"type"`
-	Path   string `json:"path"`
-}
-
-type Machine struct {
-	Name         string   `json:"name"`
-	Nets         []Net    `json:"nets"`
-	Disks        []Disk   `json:"disks"`
-	ID           string   `json:"id"`
-	User         string   `json:"user"`
-	Image        string   `json:"image"`
-	Plan         string   `json:"plan"`
-	Profile      string   `json:"profile"`
-	CreationDate string   `json:"creationdate"`
-	IP           string   `json:"ip"`
-	IPs          []string `json:"ips"`
-	Status       string   `json:"status"`
-	Autostart    bool     `json:"autostart"`
-	NumCPUs      int      `json:"numcpus"`
-	Memory       int      `json:"memory"`
-}
-
-func ensureTestMachine(machineName string) (*machine, error) {
-	// Check if machine already exists
-	checkCmd := exec.Command("kcli", "show", "vm", machineName)
-	if err := checkCmd.Run(); err != nil {
-		// Machine doesn't exist, create it
-		createCmd := exec.Command("kcli", "create", "vm", "-i", "fedora42", machineName, "--wait",
-			"-P", "cmds=['dnf install -y docker','systemctl enable --now docker']")
-		output, err := createCmd.CombinedOutput()
-		if err != nil {
-			return nil, fmt.Errorf("failed to create libvirt machine: %v, output: %s", err, string(output))
-		}
+func ensureTestMachine() (*machine, error) {
+	hypervisorIP := os.Getenv(hypervisorIPEnvKey)
+	if len(hypervisorIP) == 0 {
+		return nil, fmt.Errorf("no hypervisor found for test machine")
 	}
-	// Retrieve machine information (whether it existed or was just created)
-	testMachine, err := showMachine(machineName)
+	machineIP := os.Getenv(vmIPEnvKey)
+	if len(machineIP) == 0 {
+		return nil, fmt.Errorf("machine IP is not found for test machine")
+	}
+	signerForHypervisor, err := getSigner(hypervisorKeyPathEnvKey)
 	if err != nil {
-		return nil, fmt.Errorf("failed to show libvirt virtual machine %s, err: %w", machineName, err)
+		return nil, fmt.Errorf("error getting ssh proxy signer: %w", err)
 	}
-	if len(testMachine.Nets) == 0 {
-		return nil, fmt.Errorf("no networks configured for libvirt virtual machine %s", machineName)
+	signerForMachine, err := getSigner(vmKeyPathEnvKey)
+	if err != nil {
+		return nil, fmt.Errorf("error getting ssh machine signer: %w", err)
 	}
-	m := &machine{
-		name:          testMachine.Name,
-		ipv4Addresses: map[string]string{},
-		ipv6Addresses: map[string]string{},
-	}
-	for _, net := range testMachine.Nets {
-		network, err := getNetwork(net.Net)
-		if err != nil {
-			return nil, fmt.Errorf("failed to retrieve network %s, err: %w", net.Net, err)
-		}
-		ips := append([]string{}, testMachine.IPs...)
-		ips = append(ips, testMachine.IP)
-		for _, ip := range ips {
-			in, err := ipInCIDR(ip, network.CIDR)
-			if err != nil {
-				return nil, fmt.Errorf("error while checking machine %s IP address with network %s CIDR, err: %w",
-					machineName, net.Net, err)
-			}
-			if in && utilnet.IsIPv4String(ip) {
-				m.ipv4Addresses[net.Net] = ip
-			} else if in {
-				m.ipv6Addresses[net.Net] = ip
-			}
-		}
+	m := &machine{name: testMachineName,
+		proxyIP:        hypervisorIP,
+		defaultIP:      machineIP,
+		proxySshSigner: signerForHypervisor,
+		sshSigner:      signerForMachine,
 	}
 	return m, nil
-}
-
-func showMachine(machineName string) (*Machine, error) {
-	cmd := exec.Command("kcli", "show", "vm", machineName, "-o", "json")
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		return nil, fmt.Errorf("failed to show libvirt virtual machine %s, output: %s, err: %w", machineName, string(output), err)
-	}
-	vm := &Machine{}
-	if err := json.Unmarshal(output, vm); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal libvirt virtual machine %s, output: %s, err: %w", machineName, string(output), err)
-	}
-	return vm, nil
-}
-
-func (m *Machine) attachNetwork(networkName string) error {
-	cmd := exec.Command("kcli", "add", "nic", m.Name, "-n", networkName)
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf(
-			"failed to attach network %s to machine %s, output: %s, err: %w",
-			networkName,
-			m.Name,
-			string(output),
-			err)
-	}
-	return nil
-}
-
-func (m *Machine) detachNetwork(networkName, interfaceName string) error {
-	cmd := exec.Command("kcli", "remove", "nic", "-y", m.Name, "-n", networkName, "-i", interfaceName)
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf(
-			"failed to detach network %s from machine %s, output: %s, err: %w",
-			networkName,
-			m.Name,
-			string(output),
-			err)
-	}
-	return nil
-}
-
-func ipInCIDR(ipStr, cidrStr string) (bool, error) {
-	ip := net.ParseIP(ipStr)
-	if ip == nil {
-		return false, fmt.Errorf("invalid IP address: %q", ipStr)
-	}
-	_, ipNet, err := net.ParseCIDR(cidrStr)
-	if err != nil {
-		return false, err
-	}
-	return ipNet.Contains(ip), nil
-}
-
-func isKcliInstalled() bool {
-	_, err := exec.LookPath("kcli")
-	return err == nil
 }

--- a/openshift/test/infraprovider/network.go
+++ b/openshift/test/infraprovider/network.go
@@ -1,0 +1,80 @@
+package infraprovider
+
+import (
+	"encoding/json"
+	"fmt"
+	"os/exec"
+
+	"github.com/ovn-org/ovn-kubernetes/test/e2e/infraprovider/api"
+	utilnet "k8s.io/utils/net"
+)
+
+const (
+	defaultNetworkName = "ostestbm"
+)
+
+// openshiftNetwork implements the api.Network interface for OpenShift test provider.
+// Contains the raw kcli network JSON fields from 'kcli show network' command.
+type openshiftNetwork struct {
+	name string
+	CIDR   string `json:"cidr"`
+	Dhcp   bool   `json:"dhcp"`
+	Domain string `json:"domain"`
+	Type   string `json:"type"`
+	Mode   string `json:"mode"`
+	Plan   string `json:"plan"`
+}
+
+func (n openshiftNetwork) Name() string {
+	return n.name
+}
+
+func (n openshiftNetwork) IPv4IPv6Subnets() (string, string, error) {
+	if n.CIDR == "" {
+		return "", "", fmt.Errorf("network %s has no CIDR configured", n.Name())
+	}
+
+	var v4, v6 string
+	if utilnet.IsIPv4CIDRString(n.CIDR) {
+		v4 = n.CIDR
+	} else if utilnet.IsIPv6CIDRString(n.CIDR) {
+		v6 = n.CIDR
+	} else {
+		return "", "", fmt.Errorf("network %s CIDR %s is neither valid IPv4 nor IPv6", n.Name(), n.CIDR)
+	}
+	return v4, v6, nil
+}
+
+func (n openshiftNetwork) Equal(candidate api.Network) bool {
+	if n.name != candidate.Name() {
+		return false
+	}
+	return true
+}
+
+func (n openshiftNetwork) String() string {
+	return n.name
+}
+
+func getOpenshiftNetwork(networkName string) (openshiftNetwork, error) {
+	cmd := exec.Command("kcli", "show", "network", networkName, "-o", "json")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return openshiftNetwork{}, fmt.Errorf("failed to retrieve network %s, output: %s, err: %w", networkName, string(output), err)
+	}
+
+	network := openshiftNetwork{name: networkName}
+	if err := json.Unmarshal(output, &network); err != nil {
+		return network, fmt.Errorf("failed to unmarshal network %s output: %v, err: %w", networkName, string(output), err)
+	}
+
+	if network.CIDR == "" {
+		return network, fmt.Errorf("network %s has no CIDR configured", networkName)
+	}
+
+	if !utilnet.IsIPv4CIDRString(network.CIDR) && !utilnet.IsIPv6CIDRString(network.CIDR) {
+		return network, fmt.Errorf("network %s CIDR %s is neither valid IPv4 nor IPv6", networkName, network.CIDR)
+	}
+
+	return network, nil
+}

--- a/openshift/test/infraprovider/network.go
+++ b/openshift/test/infraprovider/network.go
@@ -1,9 +1,8 @@
 package infraprovider
 
 import (
-	"encoding/json"
 	"fmt"
-	"os/exec"
+	"net"
 
 	"github.com/ovn-org/ovn-kubernetes/test/e2e/infraprovider/api"
 	utilnet "k8s.io/utils/net"
@@ -16,100 +15,49 @@ const (
 // hostNetwork implements the api.Network interface for OpenShift test provider.
 // Contains the raw kcli network JSON fields from 'kcli show network' command.
 type hostNetwork struct {
-	Net    string `json:"-"`
-	CIDR   string `json:"cidr"`
-	Dhcp   bool   `json:"dhcp"`
-	Domain string `json:"domain"`
-	Type   string `json:"type"`
-	Mode   string `json:"mode"`
-	Plan   string `json:"plan"`
+	name string
+	cidr string
 }
 
 func (n hostNetwork) Name() string {
-	return n.Net
+	return n.name
 }
 
 func (n hostNetwork) IPv4IPv6Subnets() (string, string, error) {
-	if n.CIDR == "" {
+	if n.cidr == "" {
 		return "", "", fmt.Errorf("network %s has no CIDR configured", n.Name())
 	}
 
 	var v4, v6 string
-	if utilnet.IsIPv4CIDRString(n.CIDR) {
-		v4 = n.CIDR
-	} else if utilnet.IsIPv6CIDRString(n.CIDR) {
-		v6 = n.CIDR
+	if utilnet.IsIPv4CIDRString(n.cidr) {
+		v4 = n.cidr
+	} else if utilnet.IsIPv6CIDRString(n.cidr) {
+		v6 = n.cidr
 	} else {
-		return "", "", fmt.Errorf("network %s CIDR %s is neither valid IPv4 nor IPv6", n.Name(), n.CIDR)
+		return "", "", fmt.Errorf("network %s CIDR %s is neither valid IPv4 nor IPv6", n.Name(), n.cidr)
 	}
 	return v4, v6, nil
 }
 
 func (n hostNetwork) Equal(candidate api.Network) bool {
-	if n.Net != candidate.Name() {
+	if n.name != candidate.Name() {
 		return false
 	}
 	return true
 }
 
 func (n hostNetwork) String() string {
-	return n.Net
+	return n.name
 }
 
-func listNetworks() (map[string]hostNetwork, error) {
-	cmd := exec.Command("kcli", "list", "net", "-o", "json")
-	output, err := cmd.CombinedOutput()
+func ipInCIDR(ipStr, cidrStr string) (bool, error) {
+	ip := net.ParseIP(ipStr)
+	if ip == nil {
+		return false, fmt.Errorf("invalid IP address: %q", ipStr)
+	}
+	_, ipNet, err := net.ParseCIDR(cidrStr)
 	if err != nil {
-		return nil, fmt.Errorf("failed to list networks, output: %s, err: %w", string(output), err)
+		return false, err
 	}
-	var networks map[string]hostNetwork
-	if err := json.Unmarshal(output, &networks); err != nil {
-		return nil, fmt.Errorf("failed to parse networks, output: %s, err: %w", string(output), err)
-	}
-	for name, network := range networks {
-		network.Net = name
-		networks[name] = network
-	}
-	return networks, nil
-}
-
-func getNetwork(name string) (*hostNetwork, error) {
-	cmd := exec.Command("kcli", "show", "network", name, "-o", "json")
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve network %s, output: %s, err: %w", name, string(output), err)
-	}
-
-	network := &hostNetwork{Net: name}
-	if err := json.Unmarshal(output, network); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal network %s output: %v, err: %w", name, string(output), err)
-	}
-
-	if network.CIDR == "" {
-		return nil, fmt.Errorf("network %s has no CIDR configured", name)
-	}
-
-	if !utilnet.IsIPv4CIDRString(network.CIDR) && !utilnet.IsIPv6CIDRString(network.CIDR) {
-		return nil, fmt.Errorf("network %s CIDR %s is neither valid IPv4 nor IPv6", name, network.CIDR)
-	}
-
-	return network, nil
-}
-
-func createNetwork(name, cidr string) (*hostNetwork, error) {
-	cmd := exec.Command("kcli", "create", "network", name, "-c", cidr, "-i")
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		return nil, fmt.Errorf("failed to create network %s, output: %s, err: %w", name, string(output), err)
-	}
-	return getNetwork(name)
-}
-
-func deleteNetwork(name string) error {
-	cmd := exec.Command("kcli", "remove", "network", name, "-y")
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("failed to delete network %s, output: %s, err: %w", name, string(output), err)
-	}
-	return nil
+	return ipNet.Contains(ip), nil
 }

--- a/openshift/test/infraprovider/openshift.go
+++ b/openshift/test/infraprovider/openshift.go
@@ -2,34 +2,242 @@ package infraprovider
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
+	"sync"
 	"time"
 
+	configv1 "github.com/openshift/api/config/v1"
+	configclient "github.com/openshift/client-go/config/clientset/versioned"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	ovnkconfig "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/ovn-org/ovn-kubernetes/test/e2e/containerengine"
 	"github.com/ovn-org/ovn-kubernetes/test/e2e/infraprovider/api"
 	"github.com/ovn-org/ovn-kubernetes/test/e2e/infraprovider/portalloc"
 
 	"github.com/onsi/ginkgo/v2"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/kubernetes/test/e2e/framework"
+	utilnet "k8s.io/utils/net"
 )
+
+const (
+	machineUserName      = "fedora"
+	machineCreationLimit = 5
+)
+
+// machine maps 1-1 with OpenShift machine and therefore represents either a VM or BM host
+type machine struct {
+	name          string
+	ipv4Addresses map[string]string      // network name -> IPv4
+	ipv6Addresses map[string]string      // network name -> IPv6
+	container     *api.ExternalContainer // container that is hosted by this machine
+	active        bool
+}
+
+func (m *machine) getAnyIP() (string, error) {
+	for _, ipv4 := range m.ipv4Addresses {
+		return ipv4, nil
+	}
+	for _, ipv6 := range m.ipv6Addresses {
+		return ipv6, nil
+	}
+	return "", fmt.Errorf("no ip address found in the machine %s", m.name)
+}
+
+func (m *machine) getIP(hostNetwork string) (string, error) {
+	if ipv4, ok := m.ipv4Addresses[hostNetwork]; ok {
+		return ipv4, nil
+	}
+	if ipv6, ok := m.ipv6Addresses[hostNetwork]; ok {
+		return ipv6, nil
+	}
+	return "", fmt.Errorf("no ip address found in the machine %s for network %s", m.name, hostNetwork)
+}
+
+func (m *machine) isHostingContainer() bool {
+	return m.active
+}
+
+func (m *machine) addContainer(container api.ExternalContainer) (api.ExternalContainer, error) {
+	if m.isHostingContainer() {
+		return container, fmt.Errorf("unable to add container to a machine which already hosts a container")
+	}
+	testMachine, err := showMachine(m.name)
+	if err != nil {
+		return container, fmt.Errorf("failed retrieving test machine: %w", err)
+	}
+	hostNetwork := container.Network.Name()
+	if err := testMachine.attachNetwork(hostNetwork); err != nil {
+		return container, fmt.Errorf("failed attaching network %q to machine %q: %w", hostNetwork, testMachine.Name, err)
+	}
+	cmd := buildDaemonContainerCmd(container.Name, container.Image, container.CmdArgs)
+	cmd = addElevatedPrivileges(cmd)
+	if _, err := m.execCmd("", cmd); err != nil {
+		return container, fmt.Errorf("failed to execute command on machine %s: %w", m.name, err)
+	}
+
+	network, err := getOpenshiftNetwork(hostNetwork)
+	if err != nil {
+		return container, fmt.Errorf("failed to retrieve network %s, err: %w", hostNetwork, err)
+	}
+
+	// Poll for IPs with timeout - wait for machine to get IPs in the container network
+	err = wait.PollUntilContextTimeout(context.TODO(), 2*time.Second, 60*time.Second, true, func(ctx context.Context) (bool, error) {
+		updatedMachine, err := showMachine(m.name)
+		if err != nil {
+			ginkgo.GinkgoLogr.Info("Failed to retrieve machine, retrying", "machine", m.name, "error", err)
+			return false, nil
+		}
+
+		// Find and assign IPs from the container network
+		foundIP := false
+		for _, ip := range updatedMachine.IPs {
+			in, err := ipInCIDR(ip, network.CIDR)
+			if err != nil {
+				ginkgo.GinkgoLogr.Info("Error checking IP against CIDR, retrying", "ip", ip, "cidr", network.CIDR, "error", err)
+				return false, nil
+			}
+			if in && utilnet.IsIPv4String(ip) {
+				container.IPv4 = ip
+				m.ipv4Addresses[hostNetwork] = ip
+				foundIP = true
+			} else if in {
+				container.IPv6 = ip
+				m.ipv6Addresses[hostNetwork] = ip
+				foundIP = true
+			}
+		}
+		if !foundIP {
+			ginkgo.GinkgoLogr.Info("Machine IPs not yet populated in network, retrying", "machine", m.name, "network", hostNetwork)
+			return false, nil
+		}
+		return true, nil
+	})
+	if err != nil {
+		return container, fmt.Errorf("timeout waiting for machine %s to get IPs in network %s: %w", m.name, hostNetwork, err)
+	}
+
+	m.container = &container
+	m.active = true
+	return container, nil
+}
+
+func (m *machine) deleteContainer(container api.ExternalContainer) error {
+	if !m.isHostingContainer() {
+		return fmt.Errorf("attempted to delete a container when the machine doesn't host one")
+	}
+	isRunning, err := m.isContainerRunning(container)
+	if err != nil {
+		return fmt.Errorf("failed to check if container is running: %v", err)
+	}
+	if !isRunning {
+		m.active = false
+		return nil
+	}
+	// remove the container
+	hostNetwork := container.Network.Name()
+	cmd := buildRemoveContainerCmd(container.Name)
+	cmd = addElevatedPrivileges(cmd)
+	if _, err := m.execCmd(hostNetwork, cmd); err != nil {
+		return fmt.Errorf("failed to execute command on machine %s: %w", m.name, err)
+	}
+	delete(m.ipv4Addresses, hostNetwork)
+	delete(m.ipv6Addresses, hostNetwork)
+	m.container = nil
+	m.active = false
+	return nil
+}
+
+func (m *machine) getContainerLogs(container api.ExternalContainer) (string, error) {
+	isRunning, err := m.isContainerRunning(container)
+	if err != nil {
+		return "", fmt.Errorf("failed to check if container is running: %v", err)
+	}
+	if !isRunning {
+		return "", fmt.Errorf("external container is not running on machine")
+	}
+	logsCmd := buildContainerLogsCmd(container.Name)
+	logsCmd = addElevatedPrivileges(logsCmd)
+	res, err := m.execCmd(container.Network.Name(), logsCmd)
+	if err != nil {
+		return "", fmt.Errorf("failed to execute command (%s) within machine %s: err: %v", logsCmd, m.name, err)
+	}
+	return res.stdout, nil
+}
+
+func (m *machine) execCmd(network, cmd string) (result, error) {
+	ginkgo.By("Running command on test machine: " + cmd)
+	var r result
+	signer, err := getSigner()
+	if err != nil {
+		return r, fmt.Errorf("error getting signer: %w", err)
+	}
+	var ip string
+	// When network string is empty, then retrieve any available IP address
+	// from the machine.
+	if network == "" {
+		ip, err = m.getAnyIP()
+	} else {
+		ip, err = m.getIP(network)
+	}
+	if err != nil {
+		return r, fmt.Errorf("failed to get valid IP: %w", err)
+	}
+	r, err = runSSHCommand(cmd, ip+":22", signer)
+	if err != nil {
+		return r, fmt.Errorf("failed to run SSH command for %s@%s: %w: %+v", machineUserName, ip, err, r)
+	}
+	return r, nil
+
+}
+
+func (m *machine) execContainerCmd(container api.ExternalContainer, cmd []string) (result, error) {
+	containerCmd := buildContainerCmd(container.Name, cmd)
+	containerCmd = addElevatedPrivileges(containerCmd)
+	return m.execCmd(container.Network.Name(), containerCmd)
+}
+
+func (m *machine) isContainerRunning(container api.ExternalContainer) (bool, error) {
+	// check to see if the container is running before attempting to delete it
+	isPresentCmd := buildContainerCheckCmd(container.Name)
+	isPresentCmd = addElevatedPrivileges(isPresentCmd)
+	r, err := m.execCmd(container.Network.Name(), isPresentCmd)
+	if err != nil {
+		return false, fmt.Errorf("failed to execute command on machine %s: %s", m.name, r)
+	}
+	if r.getStdOut() != "" {
+		return true, nil
+	}
+	return false, nil
+}
+
+type machines struct {
+	mu   *sync.Mutex
+	list []*machine
+}
 
 type openshift struct {
 	externalContainerPortAlloc *portalloc.PortAllocator
 	hostPortAlloc              *portalloc.PortAllocator
 	kubeClient                 *kubernetes.Clientset
+	platform                   configv1.PlatformType
+	sharedExternalMachines     *machines
 }
 
 func (o openshift) ShutdownNode(nodeName string) error {
-	panic("not implemented")
+	return fmt.Errorf("ShutdownNode not implemented for OpenShift provider")
 }
 
 func (o openshift) StartNode(nodeName string) error {
-	panic("not implemented")
+	return fmt.Errorf("StartNode not implemented for OpenShift provider")
 }
 
 func (m openshift) GetDefaultTimeoutContext() *framework.TimeoutContext {
@@ -59,15 +267,22 @@ func IsProvider(config *rest.Config) (bool, error) {
 func New(config *rest.Config) (api.Provider, error) {
 	ovnkconfig.Kubernetes.DNSServiceNamespace = "openshift-dns"
 	ovnkconfig.Kubernetes.DNSServiceName = "dns-default"
+	configClient, err := configclient.NewForConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create config client: %w", err)
+	}
+	infra, err := configClient.ConfigV1().Infrastructures().Get(context.Background(), "cluster", metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("unable to get cluster infrastructure: %w", err)
+	}
 	kubeClient, err := kubernetes.NewForConfig(config)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create kubernetes client: %w", err)
 	}
-	return openshift{
-		externalContainerPortAlloc: portalloc.New(30000, 32767),
-		hostPortAlloc:              portalloc.New(30000, 32767),
-		kubeClient:                 kubeClient,
-	}, nil
+	o := openshift{externalContainerPortAlloc: portalloc.New(30000, 32767), hostPortAlloc: portalloc.New(30000, 32767),
+		kubeClient: kubeClient, platform: infra.Spec.PlatformSpec.Type,
+		sharedExternalMachines: &machines{mu: &sync.Mutex{}, list: make([]*machine, 0)}}
+	return o, nil
 }
 
 func (o openshift) Name() string {
@@ -75,11 +290,16 @@ func (o openshift) Name() string {
 }
 
 func (o openshift) PrimaryNetwork() (api.Network, error) {
-	panic("not implemented")
+	networkName := os.Getenv("BAREMETAL_NETWORK_NAME")
+	if networkName == "" {
+		ginkgo.GinkgoLogr.Info("Network name env is not set, using default network name")
+		networkName = defaultNetworkName
+	}
+	return getOpenshiftNetwork(networkName)
 }
 
 func (o openshift) ExternalContainerPrimaryInterfaceName() string {
-	panic("not implemented")
+	return "eth0"
 }
 
 func (o openshift) GetNetwork(name string) (api.Network, error) {
@@ -95,7 +315,10 @@ func (o openshift) GetK8NodeNetworkInterface(instance string, network api.Networ
 }
 
 func (o openshift) GetExternalContainerLogs(container api.ExternalContainer) (string, error) {
-	panic("not implemented")
+	if !container.IsIPv6() && !container.IsIPv4() {
+		return "", fmt.Errorf("expected either IPv4 or IPv6 address to be set")
+	}
+	return o.execMachine(container, []string{containerengine.Get().String(), "logs", container.Name})
 }
 
 func (o openshift) ExecK8NodeCommand(nodeName string, cmd []string) (string, error) {
@@ -116,7 +339,13 @@ func (o openshift) ExecK8NodeCommand(nodeName string, cmd []string) (string, err
 }
 
 func (o openshift) ExecExternalContainerCommand(container api.ExternalContainer, cmd []string) (string, error) {
-	panic("not implemented")
+	if len(cmd) == 0 {
+		panic("ExecExternalContainerCommand(): insufficient command arguments")
+	}
+	if !container.IsIPv6() && !container.IsIPv4() {
+		return "", fmt.Errorf("expected either IPv4 or IPv6 address to be set")
+	}
+	return o.execContainer(container, cmd)
 }
 
 func (o openshift) GetExternalContainerPort() uint16 {
@@ -128,29 +357,113 @@ func (o openshift) GetK8HostPort() uint16 {
 }
 
 func (o openshift) NewTestContext() api.Context {
-	co := &contextOpenshift{make([]func() error, 0)}
+	co := &contextOpenshift{32700, o.kubeClient, o.platform, o.sharedExternalMachines,
+		make([]api.ExternalContainer, 0), make([]func() error, 0)}
 	ginkgo.DeferCleanup(co.CleanUp)
 	return co
 }
 
+func (o openshift) cleanUp() {
+	// Clean up all machines that were created
+	o.sharedExternalMachines.mu.Lock()
+	defer o.sharedExternalMachines.mu.Unlock()
+
+	for _, m := range o.sharedExternalMachines.list {
+		if err := removeMachine(m.name); err != nil {
+			ginkgo.GinkgoLogr.Error(err, "Failed to remove test machine during cleanup", "machine", m.name)
+		}
+	}
+}
+
+func (o *openshift) execMachine(container api.ExternalContainer, cmd []string) (string, error) {
+	o.sharedExternalMachines.mu.Lock()
+	defer o.sharedExternalMachines.mu.Unlock()
+	m, err := getMachineForExternalContainer(container, o.sharedExternalMachines.list)
+	if err != nil {
+		return "", err
+	}
+	r, err := m.execCmd(container.Network.Name(), strings.Join(cmd, " "))
+	if err != nil {
+		return "", fmt.Errorf("failed to execute command on remote machine: %v - result: %q", err, r)
+	}
+	return r.getStdOut(), nil
+}
+
+func (o *openshift) execContainer(container api.ExternalContainer, cmd []string) (string, error) {
+	o.sharedExternalMachines.mu.Lock()
+	defer o.sharedExternalMachines.mu.Unlock()
+	m, err := getMachineForExternalContainer(container, o.sharedExternalMachines.list)
+	if err != nil {
+		return "", err
+	}
+	r, err := m.execContainerCmd(container, cmd)
+	if err != nil {
+		return "", fmt.Errorf("failed to execute command on remote container within machine: %v - result: %q", err, r)
+	}
+	return r.getStdOut(), nil
+}
+
 type contextOpenshift struct {
-	cleanUpFns []func() error
+	containerPort     int
+	kubeClient        *kubernetes.Clientset
+	platform          configv1.PlatformType
+	sharedMachines    *machines
+	cleanUpContainers []api.ExternalContainer
+	cleanUpFns        []func() error
 }
 
 func (c *contextOpenshift) GetAllowedExternalContainerPort() int {
-	panic("not implemented")
+	port := c.containerPort
+	c.containerPort += 1
+	return port
 }
 
 func (c *contextOpenshift) CreateExternalContainer(container api.ExternalContainer) (api.ExternalContainer, error) {
-	panic("not implemented")
+	if c.platform != configv1.BareMetalPlatformType {
+		ginkgo.Skip(fmt.Sprintf("creation of external container is unsupported with platform %s", c.platform))
+	}
+	if valid, err := container.IsValidPreCreateContainer(); !valid {
+		return container, fmt.Errorf("failed to create external container: %w", err)
+	}
+	c.sharedMachines.mu.Lock()
+	defer c.sharedMachines.mu.Unlock()
+
+	m, err := c.getInActiveMachine()
+	if err != nil {
+		return container, fmt.Errorf("failed to find an available machine to host the container: %v", err)
+	}
+	container, err = m.addContainer(container)
+	if err != nil {
+		return container, fmt.Errorf("failed to add container to machine %s: %w", m.name, err)
+	}
+	if valid, err := container.IsValidPostCreate(); !valid {
+		return container, fmt.Errorf("failed to validate external container post creation: %w", err)
+	}
+	c.cleanUpContainers = append(c.cleanUpContainers, container)
+	return container, nil
 }
 
 func (c *contextOpenshift) DeleteExternalContainer(container api.ExternalContainer) error {
-	panic("not implemented")
+	if valid, err := container.IsValidPreDelete(); !valid {
+		return fmt.Errorf("external container is invalid: %v", err)
+	}
+	c.sharedMachines.mu.Lock()
+	defer c.sharedMachines.mu.Unlock()
+	m, err := getMachineForExternalContainer(container, c.sharedMachines.list)
+	if err != nil {
+		return err
+	}
+	return m.deleteContainer(container)
 }
 
 func (c *contextOpenshift) GetExternalContainerLogs(container api.ExternalContainer) (string, error) {
-	panic("not implemented")
+	c.sharedMachines.mu.Lock()
+	defer c.sharedMachines.mu.Unlock()
+	m, err := getMachineForExternalContainer(container, c.sharedMachines.list)
+	if err != nil {
+		return "", err
+	}
+	return m.getContainerLogs(container)
 }
 
 func (c contextOpenshift) CreateNetwork(name string, subnets ...string) (api.Network, error) {
@@ -184,7 +497,16 @@ func (c *contextOpenshift) AddCleanUpFn(cleanUpFn func() error) {
 func (c *contextOpenshift) CleanUp() error {
 	ginkgo.By("Cleaning up openshift test context")
 	var errs []error
-	// generic cleanup activities
+
+	// Clean up external containers
+	for i := len(c.cleanUpContainers) - 1; i >= 0; i-- {
+		if err := c.DeleteExternalContainer(c.cleanUpContainers[i]); err != nil {
+			errs = append(errs, fmt.Errorf("failed to delete external container %s: %w", c.cleanUpContainers[i].Name, err))
+		}
+	}
+	c.cleanUpContainers = nil
+
+	// Generic cleanup activities
 	for i := len(c.cleanUpFns) - 1; i >= 0; i-- {
 		if err := c.cleanUpFns[i](); err != nil {
 			errs = append(errs, err)
@@ -192,6 +514,32 @@ func (c *contextOpenshift) CleanUp() error {
 	}
 	c.cleanUpFns = nil
 	return condenseErrors(errs)
+}
+
+// getInActiveMachine finds a machine that is inactive or creates a new machine
+func (c *contextOpenshift) getInActiveMachine() (*machine, error) {
+
+	// check if there's a machine that is free
+	for _, m := range c.sharedMachines.list {
+		if !m.active {
+			return m, nil
+		}
+	}
+	if len(c.sharedMachines.list) >= machineCreationLimit {
+		return nil, fmt.Errorf("cannot create more machines because limit (%d) reached", machineCreationLimit)
+	}
+	newMachine, err := c.addMachine()
+	if err != nil {
+		return nil, fmt.Errorf("failed to add test machine: %v", err)
+	}
+	c.sharedMachines.list = append(c.sharedMachines.list, newMachine)
+	return newMachine, nil
+}
+
+func (c contextOpenshift) addMachine() (*machine, error) {
+	// Generate unique machine name using the index
+	machineName := fmt.Sprintf("%s-%d", testMachineName, len(c.sharedMachines.list))
+	return ensureTestMachine(machineName)
 }
 
 func condenseErrors(errs []error) error {
@@ -206,4 +554,82 @@ func condenseErrors(errs []error) error {
 		err = errors.Join(err, e)
 	}
 	return err
+}
+
+func getMachineForExternalContainer(container api.ExternalContainer, machines []*machine) (*machine, error) {
+	for _, machine := range machines {
+		if !machine.active {
+			continue
+		}
+		hostNetwork := container.Network.Name()
+		if ipv4, ok := machine.ipv4Addresses[hostNetwork]; ok && ipv4 == container.IPv4 {
+			return machine, nil
+		}
+		if ipv6, ok := machine.ipv6Addresses[hostNetwork]; ok && ipv6 == container.IPv6 {
+			return machine, nil
+		}
+	}
+	return nil, fmt.Errorf("failed to find machine which hosts external container: %q", container.String())
+}
+
+func addElevatedPrivileges(cmd string) string {
+	return fmt.Sprintf("sudo %s", cmd)
+}
+
+// escapeShellArgument properly quotes a string for use as a single argument in a shell command.
+// This is a simplified version and might not cover all edge cases for all shells.
+// For robust shell escaping, consider using a dedicated library if available,
+// or ensure your remote shell is predictable (e.g., always bash).
+func escapeShellArgument(arg string) string {
+	// Simple rule: if it contains spaces or special characters, single-quote it.
+	// Within single quotes, single quotes themselves need to be handled: '\''
+	if strings.ContainsAny(arg, " \t\n\r\"'\\`$!{}[]()<>*?~#&;|") {
+		return "'" + strings.ReplaceAll(arg, "'", `'\''`) + "'"
+	}
+	return arg
+}
+
+func buildContainerCmd(name string, cmd []string) string {
+	var b strings.Builder
+	b.WriteString(containerengine.Get().String())
+	b.WriteString(" exec -t ")
+	b.WriteString(escapeShellArgument(name))
+	b.WriteString(" ") // Add space after container name
+
+	for i, arg := range cmd {
+		if i > 0 { // Add space before subsequent arguments
+			b.WriteString(" ")
+		}
+		b.WriteString(escapeShellArgument(arg))
+	}
+
+	return b.String()
+}
+
+func buildDaemonContainerCmd(name, image string, cmd []string) string {
+	var b strings.Builder
+	b.WriteString(containerengine.Get().String())
+	b.WriteString(" run -itd --privileged --name ")
+	b.WriteString(escapeShellArgument(name))
+	b.WriteString(" --network host --hostname ")
+	b.WriteString(escapeShellArgument(name))
+	b.WriteString(" ")
+	b.WriteString(escapeShellArgument(image))
+	for _, arg := range cmd {
+		b.WriteString(" ")
+		b.WriteString(escapeShellArgument(arg))
+	}
+	return b.String()
+}
+
+func buildContainerCheckCmd(name string) string {
+	return fmt.Sprintf("%s ps -f name=%s -q", containerengine.Get(), escapeShellArgument(name))
+}
+
+func buildContainerLogsCmd(name string) string {
+	return fmt.Sprintf("%s logs %s", containerengine.Get(), escapeShellArgument(name))
+}
+
+func buildRemoveContainerCmd(name string) string {
+	return fmt.Sprintf("%s rm -f %s", containerengine.Get(), escapeShellArgument(name))
 }

--- a/openshift/test/infraprovider/result.go
+++ b/openshift/test/infraprovider/result.go
@@ -1,0 +1,21 @@
+package infraprovider
+
+import "fmt"
+
+// result holds the execution result of SSH command
+type result struct {
+	user   string
+	ip     string
+	cmd    string
+	stdout string
+	stderr string
+}
+
+func (r result) String() string {
+	return fmt.Sprintf("User: %q, IP: %q, Command: %q, Stdout: %q, Stderr: %q",
+		r.user, r.ip, r.cmd, r.stdout, r.stderr)
+}
+
+func (r result) getStdOut() string {
+	return r.stdout
+}

--- a/openshift/test/infraprovider/ssh.go
+++ b/openshift/test/infraprovider/ssh.go
@@ -1,0 +1,80 @@
+package infraprovider
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+const sshKeyPathEnvKey = "SSH_KEY_PATH" //TODO: check if theres ocp env var already
+
+// runSSHCommand returns the stdout, stderr, and exit code from running cmd on
+// host as specific user, along with any SSH-level error.
+func runSSHCommand(cmd, addr string, signer ssh.Signer) (result, error) {
+	res := result{}
+	config := &ssh.ClientConfig{
+		User: machineUserName,
+		Auth: []ssh.AuthMethod{ssh.PublicKeys(signer)},
+		// NOTE: InsecureIgnoreHostKey is used here because this is a test environment
+		// where we're connecting to ephemeral VMs. In production, use proper host key verification.
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+	}
+	client, err := ssh.Dial("tcp", addr, config)
+	if err != nil {
+		err = wait.PollUntilContextTimeout(context.TODO(), 5*time.Second, 20*time.Second, true, func(ctx context.Context) (bool, error) {
+			var dialErr error
+			client, dialErr = ssh.Dial("tcp", addr, config)
+			if dialErr != nil {
+				fmt.Printf("error dialing %s@%s: %v, retrying\n", machineUserName, addr, dialErr)
+				return false, nil
+			}
+			return true, nil
+		})
+	}
+	if err != nil {
+		return res, fmt.Errorf("failed to initiate SSH connection to %s@%s: %v", machineUserName, addr, err)
+	}
+	defer client.Close()
+	session, err := client.NewSession()
+	if err != nil {
+		return res, fmt.Errorf("failed creating new session to %s@%s: %w", machineUserName, addr, err)
+	}
+	defer session.Close()
+
+	// Run the command.
+	var bout, berr bytes.Buffer
+	session.Stdout, session.Stderr = &bout, &berr
+	if err = session.Run(cmd); err != nil {
+		err = fmt.Errorf("failed running `%s` on %s@%s: %w", cmd, machineUserName, addr, err)
+	}
+	res.cmd = cmd
+	res.stdout = bout.String()
+	res.stderr = berr.String()
+	res.user = machineUserName
+	res.ip = addr
+	return res, err
+}
+
+func getSigner() (ssh.Signer, error) {
+	if path := os.Getenv(sshKeyPathEnvKey); len(path) > 0 {
+		return makePrivateKeySignerFromFile(path)
+	}
+	return nil, fmt.Errorf("environment key %q is not set or doesn't have a valid value", sshKeyPathEnvKey)
+}
+
+func makePrivateKeySignerFromFile(key string) (ssh.Signer, error) {
+	buffer, err := os.ReadFile(key)
+	if err != nil {
+		return nil, fmt.Errorf("error reading SSH key %s: %w", key, err)
+	}
+	signer, err := ssh.ParsePrivateKey(buffer)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing SSH key: %w", err)
+	}
+	return signer, err
+}

--- a/openshift/test/infraprovider/ssh.go
+++ b/openshift/test/infraprovider/ssh.go
@@ -11,14 +11,62 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
-const sshKeyPathEnvKey = "SSH_KEY_PATH" //TODO: check if theres ocp env var already
-
 // runSSHCommand returns the stdout, stderr, and exit code from running cmd on
 // host as specific user, along with any SSH-level error.
-func runSSHCommand(cmd, addr string, signer ssh.Signer) (result, error) {
+func runSSHCommand(user, cmd string, proxyClient *ssh.Client, addr string, signer ssh.Signer) (result, error) {
 	res := result{}
+	targetConn, err := proxyClient.Dial("tcp", addr)
+	if err != nil {
+		err = wait.PollUntilContextTimeout(context.TODO(), 5*time.Second, 20*time.Second, true, func(ctx context.Context) (bool, error) {
+			var dialErr error
+			targetConn, dialErr = proxyClient.Dial("tcp", addr)
+			if dialErr != nil {
+				fmt.Printf("error dialing %s: %v, retrying\n", addr, dialErr)
+				return false, nil
+			}
+			return true, nil
+		})
+	}
+	if err != nil {
+		return res, fmt.Errorf("failed to initiate SSH connection to %s: %v", addr, err)
+	}
+	defer targetConn.Close()
+	targetConfig := &ssh.ClientConfig{
+		User:            user,
+		Auth:            []ssh.AuthMethod{ssh.PublicKeys(signer)},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+	}
+	conn, chans, reqs, err := ssh.NewClientConn(targetConn, addr, targetConfig)
+	if err != nil {
+		return res, fmt.Errorf("ssh handshake failed for address %s: %w", addr, err)
+	}
+	defer conn.Close()
+
+	targetClient := ssh.NewClient(conn, chans, reqs)
+	defer targetClient.Close()
+	session, err := targetClient.NewSession()
+	if err != nil {
+		return res, fmt.Errorf("failed creating new session to %s@%s: %w", user, addr, err)
+	}
+	defer session.Close()
+
+	// Run the command.
+	var bout, berr bytes.Buffer
+	session.Stdout, session.Stderr = &bout, &berr
+	if err = session.Run(cmd); err != nil {
+		err = fmt.Errorf("failed running `%s` on %s@%s: %w", cmd, user, addr, err)
+	}
+	res.cmd = cmd
+	res.stdout = bout.String()
+	res.stderr = berr.String()
+	res.user = user
+	res.ip = addr
+	return res, err
+}
+
+func getSshClient(user, addr string, signer ssh.Signer) (*ssh.Client, error) {
 	config := &ssh.ClientConfig{
-		User: machineUserName,
+		User: user,
 		Auth: []ssh.AuthMethod{ssh.PublicKeys(signer)},
 		// NOTE: InsecureIgnoreHostKey is used here because this is a test environment
 		// where we're connecting to ephemeral VMs. In production, use proper host key verification.
@@ -30,37 +78,19 @@ func runSSHCommand(cmd, addr string, signer ssh.Signer) (result, error) {
 			var dialErr error
 			client, dialErr = ssh.Dial("tcp", addr, config)
 			if dialErr != nil {
-				fmt.Printf("error dialing %s@%s: %v, retrying\n", machineUserName, addr, dialErr)
+				fmt.Printf("error dialing %s@%s: %v, retrying\n", user, addr, dialErr)
 				return false, nil
 			}
 			return true, nil
 		})
 	}
 	if err != nil {
-		return res, fmt.Errorf("failed to initiate SSH connection to %s@%s: %v", machineUserName, addr, err)
+		return nil, fmt.Errorf("failed to initiate SSH connection to %s@%s: %v", user, addr, err)
 	}
-	defer client.Close()
-	session, err := client.NewSession()
-	if err != nil {
-		return res, fmt.Errorf("failed creating new session to %s@%s: %w", machineUserName, addr, err)
-	}
-	defer session.Close()
-
-	// Run the command.
-	var bout, berr bytes.Buffer
-	session.Stdout, session.Stderr = &bout, &berr
-	if err = session.Run(cmd); err != nil {
-		err = fmt.Errorf("failed running `%s` on %s@%s: %w", cmd, machineUserName, addr, err)
-	}
-	res.cmd = cmd
-	res.stdout = bout.String()
-	res.stderr = berr.String()
-	res.user = machineUserName
-	res.ip = addr
-	return res, err
+	return client, nil
 }
 
-func getSigner() (ssh.Signer, error) {
+func getSigner(sshKeyPathEnvKey string) (ssh.Signer, error) {
 	if path := os.Getenv(sshKeyPathEnvKey); len(path) > 0 {
 		return makePrivateKeySignerFromFile(path)
 	}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
Currently in WIP. Built on https://github.com/openshift/ovn-kubernetes/pull/2641/commits/d7b2c1f0002333232ea76e81dc9ac7ca491b0b00

- Fixes index out of range errors at Ipv6 code 
- updated fedora 42 image on KCLI (fedora 41 is pruned from fedor project)
- updated 10.4.1 as frrimage version,  v0.0.21 as frr-k8s image version
- fix the IP allocation code to handle /24 subnets properly.

cc @jcaamano @pperiyasamy (Peri please use this branch to contribute as discussed)

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
