### PR TITLE
OCPBUGS-76403, CORENET-6055: [release-4.15] Dockerfile: Unpin OVN and consume the latest from FDP

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -13,17 +13,14 @@ RUN dnf install -y --nodocs \
 	dnf clean all
 
 ARG ovsver=3.3
-ARG ovnver=24.03.5-40.el9fdp
+ARG ovnver=24.03
 
 RUN INSTALL_PKGS="iptables" && \
-	ovnver_short=$(echo "$ovnver" | cut -d'.' -f1,2) && \
 	dnf install -y --nodocs $INSTALL_PKGS && \
 	dnf install -y --nodocs "openvswitch$ovsver" "python3-openvswitch$ovsver" && \
-	dnf install -y --nodocs "ovn$ovnver_short = $ovnver" "ovn$ovnver_short-central = $ovnver" "ovn$ovnver_short-host = $ovnver" && \
-	dnf clean all && rm -rf /var/cache/*
-
-RUN ovnver_short=$(echo "$ovnver" | cut -d'.' -f1,2) && \
-	sed 's/%/"/g' <<<"%openvswitch$ovsver-devel% %openvswitch$ovsver-ipsec% %ovn$ovnver_short-vtep = $ovnver%" > /more-pkgs
+	dnf install -y --nodocs "ovn$ovnver" "ovn$ovnver-central" "ovn$ovnver-host" && \
+	dnf clean all && rm -rf /var/cache/* && \
+	sed 's/%/"/g' <<<"%openvswitch$ovsver-devel% %openvswitch$ovsver-ipsec% %ovn$ovnver-vtep%" > /more-pkgs
 
 RUN mkdir -p /var/run/openvswitch && \
     mkdir -p /var/run/ovn && \


### PR DESCRIPTION
OVN-Kubernetes is always lagging behind on the version of OVN it pins. This is causing a lot of trouble with keeping up with bug fixes and especially CVE fixes on older branches, resulting in scanners flagging this image with poor security grades and much longer time for bug fixes to be delivered to customers as the PR backporting process can take weeks or even months.

Removing the pin, so every time the new build is released in FDP, it automatically gets into versions of OpneShift that use it. There is a pre-release testing process in place between FDP and OCP QE that ensures the required test coverage before the new build is released through FDP.

This PR will bring updated OVN builds and will allow picking up newer ones automatically as soon as they are released in the future. Major version upgrades still require a separate PR.

(cherry picked from commit 3771a89f5b6d172758671d7c743e3568db421549)

Manual cherry pick of the change from 4.16: https://github.com/openshift/ovn-kubernetes/pull/2972