### PR TITLE
[DNM] [release-4.20] Bump OVSDB client connect timeout to 40s

### DIFF
--- a/go-controller/pkg/libovsdb/libovsdb.go
+++ b/go-controller/pkg/libovsdb/libovsdb.go
@@ -73,7 +73,7 @@ func newClientLogger(dbModelName string) (logger logr.Logger, err error) {
 // the stopCh is required to ensure the goroutine for ssl cert
 // update is not leaked
 func newClient(cfg config.OvnAuthConfig, dbModel model.ClientDBModel, stopCh <-chan struct{}, opts ...client.Option) (client.Client, error) {
-	const connectTimeout time.Duration = types.OVSDBTimeout * 2
+	const connectTimeout time.Duration = types.OVSDBTimeout * 4
 	const inactivityTimeout time.Duration = types.OVSDBTimeout * 18
 	logger, err := newClientLogger(dbModel.Name())
 	if err != nil {


### PR DESCRIPTION
This PR increases the OVSDB client connection timeout to 40 seconds. It helps prevent ovnkube-controller container from entering CLBO when NBDB/SBDB is slow or unresponsive during startup, which can happen when databases are very large and still syncing.


(cherry picked from commit b6dafa218d7719ab29d16d503a52cfe32101dd5b)
