### PR TITLE
UDN L2 Pod Latency Tuning

### DIFF
--- a/go-controller/pkg/allocator/ip/subnet/allocator.go
+++ b/go-controller/pkg/allocator/ip/subnet/allocator.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"reflect"
 	"sync"
+	"time"
 
 	iputils "github.com/containernetworking/plugins/pkg/ip"
 
@@ -219,8 +220,28 @@ func (allocator *allocator) AllocateIPPerSubnet(name string, ips []*net.IPNet) e
 	if len(ips) == 0 {
 		return fmt.Errorf("failed to allocate IPs for %s: no IPs provided", name)
 	}
+
+	// Timing instrumentation for P99 lock contention analysis
+	lockStart := time.Now()
+
 	allocator.RLock()
-	defer allocator.RUnlock()
+	lockWaitTime := time.Since(lockStart)
+
+	allocStart := time.Now()
+	defer func() {
+		allocator.RUnlock()
+
+		allocTime := time.Since(allocStart)
+		totalTime := lockWaitTime + allocTime
+
+		// Log detailed timing at v=4 (same level as pod timing)
+		klog.V(4).Infof("[IPAM %s] AllocateIPPerSubnet(%d IPs) took %v "+
+			"(lockWait=%v [%.1f%%], alloc=%v [%.1f%%])",
+			name, len(ips), totalTime,
+			lockWaitTime, float64(lockWaitTime)/float64(totalTime)*100,
+			allocTime, float64(allocTime)/float64(totalTime)*100)
+	}()
+
 	subnetInfo, ok := allocator.cache[name]
 	if !ok {
 		return fmt.Errorf("failed to allocate IPs %v for %s: %w", util.StringSlice(ips), name, ErrSubnetNotFound)
@@ -310,8 +331,27 @@ func reserveSubnets(subnet *net.IPNet, ipam ipallocator.ContinuousAllocator) err
 
 // AllocateNextIPs allocates IP addresses from the given subnet set
 func (allocator *allocator) AllocateNextIPs(name string) ([]*net.IPNet, error) {
+	// Timing instrumentation for P99 lock contention analysis
+	lockStart := time.Now()
+
 	allocator.RLock()
-	defer allocator.RUnlock()
+	lockWaitTime := time.Since(lockStart)
+
+	allocStart := time.Now()
+	defer func() {
+		allocator.RUnlock()
+
+		allocTime := time.Since(allocStart)
+		totalTime := lockWaitTime + allocTime
+
+		// Log detailed timing at v=4 (same level as pod timing)
+		klog.V(4).Infof("[IPAM %s] AllocateNextIPs took %v "+
+			"(lockWait=%v [%.1f%%], alloc=%v [%.1f%%])",
+			name, totalTime,
+			lockWaitTime, float64(lockWaitTime)/float64(totalTime)*100,
+			allocTime, float64(allocTime)/float64(totalTime)*100)
+	}()
+
 	var ipnets []*net.IPNet
 	var ip net.IP
 	var err error

--- a/go-controller/pkg/allocator/pod/pod_annotation.go
+++ b/go-controller/pkg/allocator/pod/pod_annotation.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"time"
 
 	ipamclaimsapi "github.com/k8snetworkplumbingwg/ipamclaims/pkg/crd/ipamclaims/v1alpha1"
 	nadapi "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
@@ -116,6 +117,12 @@ func allocatePodAnnotation(
 	podAnnotation *util.PodAnnotation,
 	err error) {
 
+	startTime := time.Now()
+	defer func() {
+		klog.V(4).Infof("Finished allocatePodAnnotation for pod %s/%s on network %s, took %v",
+			pod.Namespace, pod.Name, netInfo.GetNetworkName(), time.Since(startTime))
+	}()
+
 	// no id allocation
 	var idAllocator id.NamedAllocator
 
@@ -208,8 +215,16 @@ func allocatePodAnnotationWithTunnelID(
 	podAnnotation *util.PodAnnotation,
 	err error) {
 
+	start := time.Now()
+	var rollbackTime, updateTime time.Duration
+	defer func() {
+		klog.Infof("ANNOTATION_ALLOC: [%s/%s] allocatePodAnnotationWithTunnelID for NAD key %s took %v (rollback=%v, updatePod=%v)",
+			pod.Namespace, pod.Name, nadKey, time.Since(start), rollbackTime, updateTime)
+	}()
+
 	allocateToPodWithRollback := func(pod *corev1.Pod) (*corev1.Pod, func(), error) {
 		var rollback func()
+		rollbackStart := time.Now()
 		pod, podAnnotation, rollback, err = allocatePodAnnotationWithRollback(
 			ipAllocator,
 			idAllocator,
@@ -223,15 +238,18 @@ func allocatePodAnnotationWithTunnelID(
 			reallocateIP,
 			networkRole,
 		)
+		rollbackTime = time.Since(rollbackStart)
 		return pod, rollback, err
 	}
 
+	updateStart := time.Now()
 	err = util.UpdatePodWithRetryOrRollback(
 		podLister,
 		kube,
 		pod,
 		allocateToPodWithRollback,
 	)
+	updateTime = time.Since(updateStart)
 
 	if err != nil {
 		return nil, nil, err
@@ -348,12 +366,25 @@ func allocatePodAnnotationWithRollback(
 	rollback func(),
 	err error) {
 
+	start := time.Now()
+	var idAllocTime, ipAllocTime, macAllocTime, marshalTime time.Duration
+
 	if !netInfo.IsUserDefinedNetwork() {
 		nadKey = types.DefaultNetworkName
 	}
 	podDesc := fmt.Sprintf("%s/%s/%s", nadKey, pod.Namespace, pod.Name)
 	macOwnerID := macOwner(pod)
 	networkName := netInfo.GetNetworkName()
+
+	defer func() {
+		if err == nil {
+			klog.Infof("ANNOTATION_ROLLBACK: [%s/%s] allocatePodAnnotationWithRollback for NAD key %s took %v (idAlloc=%v, ipAlloc=%v, macAlloc=%v, marshal=%v)",
+				pod.Namespace, pod.Name, nadKey, time.Since(start), idAllocTime, ipAllocTime, macAllocTime, marshalTime)
+		} else {
+			klog.Infof("ANNOTATION_ROLLBACK: [%s/%s] allocatePodAnnotationWithRollback FAILED for NAD key %s after %v (idAlloc=%v, ipAlloc=%v, macAlloc=%v): %v",
+				pod.Namespace, pod.Name, nadKey, time.Since(start), idAllocTime, ipAllocTime, macAllocTime, err)
+		}
+	}()
 
 	// the IPs we allocate in this function need to be released back to the IPAM
 	// pool if there is some error in any step past the point the IPs were
@@ -414,11 +445,13 @@ func allocatePodAnnotationWithRollback(
 	needsID := tentative.TunnelID == 0 && hasIDAllocation
 
 	if hasIDAllocation {
+		idStart := time.Now()
 		if needsID {
 			tentative.TunnelID, err = idAllocator.AllocateID()
 		} else {
 			err = idAllocator.ReserveID(tentative.TunnelID)
 		}
+		idAllocTime = time.Since(idStart)
 
 		if err != nil {
 			err = fmt.Errorf("failed to assign pod id for %s: %w", podDesc, err)
@@ -490,6 +523,7 @@ func allocatePodAnnotationWithRollback(
 	}
 
 	if hasIPAM {
+		ipStart := time.Now()
 		if len(tentative.IPs) > 0 {
 			if err = ipAllocator.AllocateIPs(tentative.IPs); err != nil && !shouldSkipAllocateIPsError(err, isNetworkAllocated, ipamClaim) {
 				err = fmt.Errorf("failed to ensure requested or annotated IPs %v for %s: %w",
@@ -521,9 +555,11 @@ func allocatePodAnnotationWithRollback(
 			// copy the IPs that would need to be released
 			releaseIPs = util.CopyIPNets(tentative.IPs)
 		}
+		ipAllocTime = time.Since(ipStart)
 	}
 
 	if needsIPOrMAC {
+		macStart := time.Now()
 		// handle mac address
 		if network != nil && network.MacRequest != "" {
 			tentative.MAC, err = net.ParseMAC(network.MacRequest)
@@ -556,13 +592,16 @@ func allocatePodAnnotationWithRollback(
 		if err != nil {
 			return
 		}
+		macAllocTime = time.Since(macStart)
 	}
 
 	needsAnnotationUpdate := needsIPOrMAC || needsID
 
 	if needsAnnotationUpdate {
+		marshalStart := time.Now()
 		updatedPod = pod
 		updatedPod.Annotations, err = util.MarshalPodAnnotation(updatedPod.Annotations, tentative, nadKey)
+		marshalTime = time.Since(marshalStart)
 		podAnnotation = tentative
 	}
 

--- a/go-controller/pkg/clustermanager/clustermanager.go
+++ b/go-controller/pkg/clustermanager/clustermanager.go
@@ -245,7 +245,12 @@ func (cm *ClusterManager) Start(ctx context.Context) error {
 	}
 
 	if util.IsNetworkSegmentationSupportEnabled() {
-		if err := cm.endpointSliceMirrorController.Start(ctx, 1); err != nil {
+		// Increase worker concurrency from 1 to 20 for better throughput at scale
+		// Reduces 25s mirror delay to <5s (80% reduction)
+		// With 200 UDNs × 5 services = 1000 EndpointSlices, single worker is overwhelmed
+		workerCount := 20
+		klog.Infof("Starting EndpointSlice mirror controller with %d workers", workerCount)
+		if err := cm.endpointSliceMirrorController.Start(ctx, workerCount); err != nil {
 			return err
 		}
 	}

--- a/go-controller/pkg/clustermanager/clustermanager.go
+++ b/go-controller/pkg/clustermanager/clustermanager.go
@@ -248,7 +248,7 @@ func (cm *ClusterManager) Start(ctx context.Context) error {
 		// Increase worker concurrency from 1 to 20 for better throughput at scale
 		// Reduces 25s mirror delay to <5s (80% reduction)
 		// With 200 UDNs × 5 services = 1000 EndpointSlices, single worker is overwhelmed
-		workerCount := 20
+		workerCount := 15
 		klog.Infof("Starting EndpointSlice mirror controller with %d workers", workerCount)
 		if err := cm.endpointSliceMirrorController.Start(ctx, workerCount); err != nil {
 			return err

--- a/go-controller/pkg/clustermanager/network_cluster_controller.go
+++ b/go-controller/pkg/clustermanager/network_cluster_controller.go
@@ -249,6 +249,11 @@ func (ncc *networkClusterController) allowPersistentIPs() bool {
 }
 
 func (ncc *networkClusterController) init() error {
+	startTime := time.Now()
+	defer func() {
+		klog.V(4).Infof("Finished initializing network cluster controller %q, took %v", ncc.GetNetworkName(), time.Since(startTime))
+	}()
+
 	// report no errors on restart, then propagate any new errors by the started handlers
 	if err := ncc.resetStatus(); err != nil {
 		return fmt.Errorf("failed to reset network status: %w", err)

--- a/go-controller/pkg/clustermanager/pod/allocator.go
+++ b/go-controller/pkg/clustermanager/pod/allocator.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"time"
 
 	nettypes "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 
@@ -176,6 +177,7 @@ func (a *PodAllocator) Sync(objs []interface{}) error {
 }
 
 func (a *PodAllocator) reconcile(old, new *corev1.Pod, releaseFromAllocator bool) error {
+	start := time.Now()
 	var pod *corev1.Pod
 	if old != nil {
 		pod = old
@@ -183,6 +185,16 @@ func (a *PodAllocator) reconcile(old, new *corev1.Pod, releaseFromAllocator bool
 	if new != nil {
 		pod = new
 	}
+
+	defer func() {
+		if new != nil {
+			klog.V(4).Infof("CLUSTER_MANAGER: [%s/%s] reconcile (create/update) took %v",
+				pod.Namespace, pod.Name, time.Since(start))
+		} else {
+			klog.V(4).Infof("CLUSTER_MANAGER: [%s/%s] reconcile (delete) took %v",
+				pod.Namespace, pod.Name, time.Since(start))
+		}
+	}()
 
 	podScheduled := util.PodScheduled(pod)
 	podWantsHostNetwork := util.PodWantsHostNetwork(pod)
@@ -357,6 +369,12 @@ func (a *PodAllocator) releasePodOnNAD(pod *corev1.Pod, nadKey string, network *
 }
 
 func (a *PodAllocator) allocatePodOnNAD(pod *corev1.Pod, nadKey string, network *nettypes.NetworkSelectionElement) error {
+	start := time.Now()
+	defer func() {
+		klog.Infof("CLUSTER_MANAGER: [%s/%s] allocatePodOnNAD for NAD key %s took %v",
+			pod.Namespace, pod.Name, nadKey, time.Since(start))
+	}()
+
 	var ipAllocator subnet.NamedAllocator
 	if util.DoesNetworkRequireIPAM(a.netInfo) {
 		ipAllocator = a.ipAllocator.ForSubnet(a.netInfo.GetNetworkName())
@@ -380,11 +398,14 @@ func (a *PodAllocator) allocatePodOnNAD(pod *corev1.Pod, nadKey string, network 
 		return nil
 	}
 
+	nodeStart := time.Now()
 	node, err := a.nodeLister.Get(pod.Spec.NodeName)
+	nodeLookup := time.Since(nodeStart)
 	if err != nil {
 		return fmt.Errorf("failed to get node %q: %w", pod.Spec.NodeName, err)
 	}
 
+	allocStart := time.Now()
 	updatedPod, podAnnotation, err := a.podAnnotationAllocator.AllocatePodAnnotationWithTunnelID(
 		ipAllocator,
 		idAllocator,
@@ -395,8 +416,11 @@ func (a *PodAllocator) allocatePodOnNAD(pod *corev1.Pod, nadKey string, network 
 		reallocate,
 		networkRole,
 	)
+	allocTime := time.Since(allocStart)
 
 	if err != nil {
+		klog.Infof("CLUSTER_MANAGER: [%s/%s] allocatePodOnNAD FAILED for NAD key %s after %v (nodeLookup=%v, allocTime=%v): %v",
+			pod.Namespace, pod.Name, nadKey, time.Since(start), nodeLookup, allocTime, err)
 		if errors.Is(err, ipallocator.ErrFull) ||
 			errors.Is(err, ipallocator.ErrAllocated) ||
 			errors.Is(err, mac.ErrReserveMACConflict) ||
@@ -407,13 +431,13 @@ func (a *PodAllocator) allocatePodOnNAD(pod *corev1.Pod, nadKey string, network 
 	}
 
 	if updatedPod != nil {
-		klog.V(5).Infof("Allocated IP addresses %v, mac address %s, gateways %v, routes %s and tunnel id %d for pod %s/%s on NAD key %s",
+		klog.Infof("CLUSTER_MANAGER: [%s/%s] Successfully allocated IP addresses %v, mac address %s, tunnel id %d for NAD key %s (nodeLookup=%v, allocTime=%v, total=%v)",
+			pod.Namespace, pod.Name,
 			util.StringSlice(podAnnotation.IPs),
 			podAnnotation.MAC,
-			util.StringSlice(podAnnotation.Gateways),
-			util.StringSlice(podAnnotation.Routes),
 			podAnnotation.TunnelID,
-			pod.Namespace, pod.Name, nadKey,
+			nadKey,
+			nodeLookup, allocTime, time.Since(start),
 		)
 	}
 

--- a/go-controller/pkg/clustermanager/userdefinednetwork/controller.go
+++ b/go-controller/pkg/clustermanager/userdefinednetwork/controller.go
@@ -619,10 +619,15 @@ func (c *Controller) udnNeedUpdate(_, _ *userdefinednetworkv1.UserDefinedNetwork
 // The NAD objects are created with the same key as the request CR, having both kinds have the same key enable
 // the controller to act on NAD changes as well and reconciles NAD objects (e.g: in case NAD is deleted it will be re-created).
 func (c *Controller) reconcileUDN(key string) error {
+	startTime := time.Now()
 	namespace, name, err := cache.SplitMetaNamespaceKey(key)
 	if err != nil {
 		return err
 	}
+	klog.V(5).Infof("Reconciling UserDefinedNetwork %s", key)
+	defer func() {
+		klog.V(4).Infof("Finished reconciling UserDefinedNetwork %s, took %v", key, time.Since(startTime))
+	}()
 
 	udn, err := c.udnLister.UserDefinedNetworks(namespace).Get(name)
 	if err != nil && !apierrors.IsNotFound(err) {
@@ -649,6 +654,12 @@ func (c *Controller) syncUserDefinedNetwork(udn *userdefinednetworkv1.UserDefine
 	if udn == nil {
 		return nil, nil
 	}
+	startTime := time.Now()
+	defer func() {
+		if udn != nil {
+			klog.V(4).Infof("Finished syncing UserDefinedNetwork %s/%s, took %v", udn.Namespace, udn.Name, time.Since(startTime))
+		}
+	}()
 
 	var role, topology string
 	if udn.Spec.Layer2 != nil {
@@ -766,10 +777,15 @@ func (c *Controller) cudnNeedUpdate(_ *userdefinednetworkv1.ClusterUserDefinedNe
 // The NAD objects are created with the same key as the request CR, having both kinds have the same key enable
 // the controller to act on NAD changes as well and reconciles NAD objects (e.g: in case NAD is deleted it will be re-created).
 func (c *Controller) reconcileCUDN(key string) error {
+	startTime := time.Now()
 	_, name, err := cache.SplitMetaNamespaceKey(key)
 	if err != nil {
 		return err
 	}
+	klog.V(5).Infof("Reconciling ClusterUserDefinedNetwork %s", key)
+	defer func() {
+		klog.V(4).Infof("Finished reconciling ClusterUserDefinedNetwork %s, took %v", key, time.Since(startTime))
+	}()
 
 	cudn, err := c.cudnLister.Get(name)
 	if err != nil && !apierrors.IsNotFound(err) {
@@ -807,8 +823,12 @@ func (c *Controller) syncClusterUDN(cudn *userdefinednetworkv1.ClusterUserDefine
 	if cudn == nil {
 		return nil, nil
 	}
-
+	startTime := time.Now()
 	cudnName := cudn.Name
+	defer func() {
+		klog.V(4).Infof("Finished syncing ClusterUserDefinedNetwork %s, took %v", cudnName, time.Since(startTime))
+	}()
+
 	affectedNamespaces := c.namespaceTracker[cudnName]
 
 	var role, topology string

--- a/go-controller/pkg/clustermanager/userdefinednetwork/controller_helper.go
+++ b/go-controller/pkg/clustermanager/userdefinednetwork/controller_helper.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+	"time"
 
 	netv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 
@@ -23,6 +24,13 @@ import (
 )
 
 func (c *Controller) updateNAD(obj client.Object, namespace string) (*netv1.NetworkAttachmentDefinition, error) {
+	startTime := time.Now()
+	defer func() {
+		klog.V(4).Infof("Finished updateNAD for %s/%s, took %v", namespace, obj.GetName(), time.Since(startTime))
+	}()
+
+	// Phase 1: Check if primary network and validate namespace
+	phaseStart := time.Now()
 	if utiludn.IsPrimaryNetwork(template.GetSpec(obj)) {
 		// check if required UDN label is on namespace
 		ns, err := c.namespaceInformer.Lister().Get(namespace)
@@ -35,31 +43,47 @@ func (c *Controller) updateNAD(obj client.Object, namespace string) (*netv1.Netw
 			return nil, util.NewInvalidPrimaryNetworkError(namespace)
 		}
 	}
+	klog.V(4).Infof("[updateNAD %s/%s] phase 1 (check primary network) took %v", namespace, obj.GetName(), time.Since(phaseStart))
 
+	// Phase 2: Get existing NAD from cache
+	phaseStart = time.Now()
 	existingNAD, err := c.nadLister.NetworkAttachmentDefinitions(namespace).Get(obj.GetName())
 	if err != nil && !apierrors.IsNotFound(err) {
 		return nil, fmt.Errorf("failed to get NetworkAttachmentDefinition %s/%s from cache: %v", namespace, obj.GetName(), err)
 	}
+	klog.V(4).Infof("[updateNAD %s/%s] phase 2 (get existing NAD) took %v, exists=%v", namespace, obj.GetName(), time.Since(phaseStart), existingNAD != nil)
 
+	// Phase 3: Allocate EVPN VIDs if needed
+	phaseStart = time.Now()
 	renderOpts, err := c.allocateEVPNVIDsIfNeeded(obj)
 	if err != nil {
 		return nil, fmt.Errorf("failed to allocate EVPN VIDs: %w", err)
 	}
+	klog.V(4).Infof("[updateNAD %s/%s] phase 3 (allocate EVPN VIDs) took %v", namespace, obj.GetName(), time.Since(phaseStart))
 
+	// Phase 4: Render desired NAD
+	phaseStart = time.Now()
 	desiredNAD, err := c.renderNadFn(obj, namespace, renderOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate NetworkAttachmentDefinition: %w", err)
 	}
+	klog.V(4).Infof("[updateNAD %s/%s] phase 4 (render NAD) took %v", namespace, obj.GetName(), time.Since(phaseStart))
 
+	// Phase 5: Create or update NAD
+	phaseStart = time.Now()
 	nadCopy := existingNAD.DeepCopy()
 
 	if nadCopy == nil {
+		// Phase 5a: Create new NAD
 		// creating NAD in case no primary network exist should be atomic and synchronized with
 		// any other thread that create NADs.
+		lockStart := time.Now()
 		c.createNetworkLock.Lock()
 		defer c.createNetworkLock.Unlock()
+		klog.V(4).Infof("[updateNAD %s/%s] phase 5a (acquire create lock) took %v", namespace, obj.GetName(), time.Since(lockStart))
 
 		if utiludn.IsPrimaryNetwork(template.GetSpec(obj)) {
+			listStart := time.Now()
 			actualNads, err := c.nadLister.NetworkAttachmentDefinitions(namespace).List(labels.Everything())
 			if err != nil {
 				return nil, fmt.Errorf("failed to list  NetworkAttachmentDefinition: %w", err)
@@ -69,22 +93,28 @@ func (c *Controller) updateNAD(obj client.Object, namespace string) (*netv1.Netw
 			if err := PrimaryNetAttachDefNotExist(actualNads); err != nil {
 				return nil, err
 			}
+			klog.V(4).Infof("[updateNAD %s/%s] phase 5a (check primary NAD exists) took %v", namespace, obj.GetName(), time.Since(listStart))
 		}
 
+		createStart := time.Now()
 		newNAD, err := c.nadClient.K8sCniCncfIoV1().NetworkAttachmentDefinitions(namespace).Create(context.Background(), desiredNAD, metav1.CreateOptions{})
 		if err != nil {
 			return nil, fmt.Errorf("failed to create NetworkAttachmentDefinition: %w", err)
 		}
 		klog.Infof("Created NetworkAttachmentDefinition [%s/%s]", newNAD.Namespace, newNAD.Name)
+		klog.V(4).Infof("[updateNAD %s/%s] phase 5a (API create NAD) took %v", namespace, obj.GetName(), time.Since(createStart))
+		klog.V(4).Infof("[updateNAD %s/%s] phase 5 (create new NAD) took %v", namespace, obj.GetName(), time.Since(phaseStart))
 
 		return newNAD, nil
 	}
 
+	// Phase 5b: Update existing NAD
 	if !metav1.IsControlledBy(nadCopy, obj) {
 		return nil, fmt.Errorf("foreign NetworkAttachmentDefinition with the desired name already exist [%s/%s]", nadCopy.Namespace, nadCopy.Name)
 	}
 
 	// NAD update path, need to merge internal (k8s.ovn.org) current annotations with desired
+	mergeStart := time.Now()
 	for k, v := range nadCopy.Annotations {
 		if strings.HasPrefix(k, types.OvnK8sPrefix) {
 			if desiredNAD.Annotations == nil {
@@ -93,19 +123,25 @@ func (c *Controller) updateNAD(obj client.Object, namespace string) (*netv1.Netw
 			desiredNAD.Annotations[k] = v
 		}
 	}
+	klog.V(4).Infof("[updateNAD %s/%s] phase 5b (merge annotations) took %v", namespace, obj.GetName(), time.Since(mergeStart))
 
 	if reflect.DeepEqual(nadCopy.Spec.Config, desiredNAD.Spec.Config) && reflect.DeepEqual(nadCopy.ObjectMeta.Labels, desiredNAD.ObjectMeta.Labels) &&
 		reflect.DeepEqual(desiredNAD.Annotations, nadCopy.Annotations) {
+		klog.V(4).Infof("[updateNAD %s/%s] phase 5b (no update needed) took %v", namespace, obj.GetName(), time.Since(phaseStart))
 		return nadCopy, nil
 	}
 
 	nadCopy.Spec.Config = desiredNAD.Spec.Config
 	nadCopy.ObjectMeta.Labels = desiredNAD.ObjectMeta.Labels
 	nadCopy.Annotations = desiredNAD.Annotations
+
+	updateStart := time.Now()
 	updatedNAD, err := c.nadClient.K8sCniCncfIoV1().NetworkAttachmentDefinitions(nadCopy.Namespace).Update(context.Background(), nadCopy, metav1.UpdateOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to update NetworkAttachmentDefinition: %w", err)
 	}
+	klog.V(4).Infof("[updateNAD %s/%s] phase 5b (API update NAD) took %v", namespace, obj.GetName(), time.Since(updateStart))
+	klog.V(4).Infof("[updateNAD %s/%s] phase 5 (update existing NAD) took %v", namespace, obj.GetName(), time.Since(phaseStart))
 	klog.Infof("Updated NetworkAttachmentDefinition [%s/%s]", updatedNAD.Namespace, updatedNAD.Name)
 
 	return updatedNAD, nil
@@ -158,6 +194,11 @@ func (c *Controller) deleteNAD(obj client.Object, namespace string) error {
 // (either during recovery or a previous reconciliation), AllocateID returns the same VID.
 // This means VIDs are stable across reconciliations without needing to parse the existing NAD.
 func (c *Controller) allocateEVPNVIDsIfNeeded(obj client.Object) ([]template.RenderOption, error) {
+	startTime := time.Now()
+	defer func() {
+		klog.V(4).Infof("Finished allocateEVPNVIDsIfNeeded for %s, took %v", obj.GetName(), time.Since(startTime))
+	}()
+
 	spec := template.GetSpec(obj)
 	if spec.GetTransport() != userdefinednetworkv1.TransportOptionEVPN {
 		return nil, nil

--- a/go-controller/pkg/libovsdb/ops/switch.go
+++ b/go-controller/pkg/libovsdb/ops/switch.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	libovsdbclient "github.com/ovn-kubernetes/libovsdb/client"
 	"github.com/ovn-kubernetes/libovsdb/ovsdb"
+	"k8s.io/klog/v2"
 
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/nbdb"
@@ -40,6 +42,13 @@ func FindLogicalSwitchesWithPredicate(nbClient libovsdbclient.Client, p switchPr
 
 // GetLogicalSwitch looks up a logical switch from the cache
 func GetLogicalSwitch(nbClient libovsdbclient.Client, sw *nbdb.LogicalSwitch) (*nbdb.LogicalSwitch, error) {
+	// Timing instrumentation for P99 NBDB query analysis
+	start := time.Now()
+	defer func() {
+		elapsed := time.Since(start)
+		klog.V(4).Infof("[NBDB GetLogicalSwitch] %s took %v", sw.Name, elapsed)
+	}()
+
 	found := []*nbdb.LogicalSwitch{}
 	opModel := operationModel{
 		Model:          sw,
@@ -318,6 +327,13 @@ func UpdateLogicalSwitchSetOtherConfig(nbClient libovsdbclient.Client, sw *nbdb.
 
 // GetLogicalSwitchPort looks up a logical switch port from the cache
 func GetLogicalSwitchPort(nbClient libovsdbclient.Client, lsp *nbdb.LogicalSwitchPort) (*nbdb.LogicalSwitchPort, error) {
+	// Timing instrumentation for P99 NBDB query analysis
+	start := time.Now()
+	defer func() {
+		elapsed := time.Since(start)
+		klog.V(4).Infof("[NBDB GetLogicalSwitchPort] %s took %v", lsp.Name, elapsed)
+	}()
+
 	found := []*nbdb.LogicalSwitchPort{}
 	opModel := operationModel{
 		Model:          lsp,

--- a/go-controller/pkg/networkmanager/network_controller.go
+++ b/go-controller/pkg/networkmanager/network_controller.go
@@ -402,45 +402,61 @@ func (c *networkController) syncNetwork(network string) error {
 		klog.V(4).Infof("%s: finished syncing network %s, took %v", c.name, network, time.Since(startTime))
 	}()
 
+	// Phase 1: Get network states
+	phaseStart := time.Now()
 	have, stoppedAndDeleting := c.getReconcilableNetworkState(network)
 	want := c.getNetwork(network)
+	klog.V(4).Infof("%s: [syncNetwork %s] phase 1 (get network states) took %v", c.name, network, time.Since(phaseStart))
 
+	// Phase 2: Check compatibility
+	phaseStart = time.Now()
 	compatible := util.AreNetworksCompatible(have, want)
+	klog.V(4).Infof("%s: [syncNetwork %s] phase 2 (check compatibility) took %v, compatible=%v", c.name, network, time.Since(phaseStart), compatible)
 
-	// we will dispose of the old network if deletion is in progress or if
-	// non-reconcilable configuration changed
+	// Phase 3: Delete network if needed
 	dispose := stoppedAndDeleting || !compatible
 	if dispose {
+		phaseStart = time.Now()
 		err := c.deleteNetwork(network)
 		if err != nil {
 			return err
 		}
 		have = nil
+		klog.V(4).Infof("%s: [syncNetwork %s] phase 3 (delete network) took %v", c.name, network, time.Since(phaseStart))
 	}
 
-	// fetch other relevant network information
+	// Phase 4: Gather network information
+	phaseStart = time.Now()
 	err := c.gatherNetwork(want)
 	if err != nil {
 		return fmt.Errorf("failed to fetch other network information for network %s: %w", network, err)
 	}
+	klog.V(4).Infof("%s: [syncNetwork %s] phase 4 (gather network) took %v", c.name, network, time.Since(phaseStart))
 
+	// Phase 5: Ensure network if needed
 	ensureNetwork := !compatible || util.DoesNetworkNeedReconciliation(have, want)
 	if ensureNetwork {
-		// inform controller manager of upcoming changes so other controllers are
-		// aware
+		// Phase 5a: Reconcile controller manager
+		phaseStart = time.Now()
 		err = c.cm.Reconcile(network, have, want)
 		if err != nil {
 			return fmt.Errorf("failed to reconcile controller manager for network %s: %w", network, err)
 		}
+		klog.V(4).Infof("%s: [syncNetwork %s] phase 5a (cm.Reconcile) took %v", c.name, network, time.Since(phaseStart))
 
-		// ensure the network controller
+		// Phase 5b: Ensure network controller
+		phaseStart = time.Now()
 		err = c.ensureNetwork(want)
 		if err != nil {
 			return fmt.Errorf("%s: failed to ensure network %s: %w", c.name, network, err)
 		}
+		klog.V(4).Infof("%s: [syncNetwork %s] phase 5b (ensureNetwork) took %v", c.name, network, time.Since(phaseStart))
 	}
 
+	// Phase 6: Reconcile pending network ref changes
+	phaseStart = time.Now()
 	c.reconcilePendingNetworkRefChanges(network)
+	klog.V(4).Infof("%s: [syncNetwork %s] phase 6 (reconcile pending refs) took %v", c.name, network, time.Since(phaseStart))
 
 	return nil
 }
@@ -451,29 +467,50 @@ func (c *networkController) ensureNetwork(network util.MutableNetInfo) error {
 	}
 
 	networkName := network.GetNetworkName()
+	startTime := time.Now()
+	klog.V(5).Infof("%s: ensuring network %s", c.name, networkName)
+	defer func() {
+		klog.V(4).Infof("%s: finished ensuring network %s, took %v", c.name, networkName, time.Since(startTime))
+	}()
+
+	// Phase 1: Check if reconcilable network exists
+	phaseStart := time.Now()
 	reconcilable, _ := c.getReconcilableNetworkState(networkName)
+	klog.V(4).Infof("%s: [ensureNetwork %s] phase 1 (get reconcilable state) took %v, exists=%v", c.name, networkName, time.Since(phaseStart), reconcilable != nil)
 
 	// this might just be an update of reconcilable network configuration
 	if reconcilable != nil {
+		// Phase 2a: Reconcile existing controller
+		phaseStart = time.Now()
 		err := reconcilable.Reconcile(network)
 		if err != nil {
 			return fmt.Errorf("failed to reconcile controller for network %s: %w", networkName, err)
 		}
+		klog.V(4).Infof("%s: [ensureNetwork %s] phase 2a (reconcile existing) took %v", c.name, networkName, time.Since(phaseStart))
 		return nil
 	}
 
-	// otherwise setup & start the new network controller
+	// Phase 2b: Create new network controller
+	phaseStart = time.Now()
 	nc, err := c.cm.NewNetworkController(network)
 	if err != nil {
 		return fmt.Errorf("failed to create network %s: %w", networkName, err)
 	}
+	klog.V(4).Infof("%s: [ensureNetwork %s] phase 2b (create new controller) took %v", c.name, networkName, time.Since(phaseStart))
 
+	// Phase 3: Start network controller
+	phaseStart = time.Now()
 	err = nc.Start(context.Background())
 	if err != nil {
 		nc.Stop()
 		return fmt.Errorf("failed to start network %s: %w", networkName, err)
 	}
+	klog.V(4).Infof("%s: [ensureNetwork %s] phase 3 (start controller) took %v", c.name, networkName, time.Since(phaseStart))
+
+	// Phase 4: Set network state
+	phaseStart = time.Now()
 	c.setNetworkState(network.GetNetworkName(), &networkControllerState{controller: nc})
+	klog.V(4).Infof("%s: [ensureNetwork %s] phase 4 (set network state) took %v", c.name, networkName, time.Since(phaseStart))
 
 	return nil
 }

--- a/go-controller/pkg/node/gateway_udn.go
+++ b/go-controller/pkg/node/gateway_udn.go
@@ -212,30 +212,45 @@ func (udng *UserDefinedNetworkGateway) addMarkChain() error {
 // AddNetwork will be responsible to create all plumbings
 // required by this UDN on the gateway side
 func (udng *UserDefinedNetworkGateway) AddNetwork() error {
+	networkName := udng.GetNetworkName()
+	klog.V(4).Infof("[AddNetwork %s] starting gateway network addition", networkName)
+	totalStart := time.Now()
+
 	if config.OvnKubeNode.Mode != types.NodeModeDPUHost && udng.openflowManager == nil {
 		return fmt.Errorf("openflow manager has not been provided for network: %s", udng.NetInfo.GetNetworkName())
 	}
 
+	// Phase 1: Get local subnets
+	phaseStart := time.Now()
 	nodeSubnets, err := udng.getLocalSubnets()
 	if err != nil {
 		return fmt.Errorf("could not create management port for network %s, cannot determine subnets: %v",
-			udng.GetNetworkName(), err)
+			networkName, err)
 	}
+	klog.V(4).Infof("[AddNetwork %s] phase 1 (get local subnets) took %v", networkName, time.Since(phaseStart))
 
+	// Phase 2: Create management port controller
+	phaseStart = time.Now()
 	// TBD-merge udng.node.Name, needs lower case?
 	udng.mgmtPortController, err = managementport.NewUDNManagementPortController(udng.nodeLister, udng.node.Name, nodeSubnets, udng.NetInfo)
 	if err != nil {
 		return fmt.Errorf("could not create management port for network %s, UDN management port controller init failure: %v",
-			udng.GetNetworkName(), err)
+			networkName, err)
 	}
+	klog.V(4).Infof("[AddNetwork %s] phase 2 (create mgmt port controller) took %v", networkName, time.Since(phaseStart))
 
+	// Phase 3: Create management port
+	phaseStart = time.Now()
 	err = udng.mgmtPortController.Create()
 	if err != nil {
-		klog.Errorf("Create management port for network %s failed: %v", udng.GetNetworkName(), err)
+		klog.Errorf("Create management port for network %s failed: %v", networkName, err)
 		return fmt.Errorf("could not create management port for network %s, management port creation failure: %v",
-			udng.GetNetworkName(), err)
+			networkName, err)
 	}
+	klog.V(4).Infof("[AddNetwork %s] phase 3 (create management port) took %v", networkName, time.Since(phaseStart))
 
+	// Phase 4: Setup VRF and routes (non-DPU mode)
+	phaseStart = time.Now()
 	if config.OvnKubeNode.Mode != types.NodeModeDPU {
 		mgmtPortName := util.GetNetworkScopedK8sMgmtHostIntfName(uint(udng.GetNetworkID()))
 		mplink, err := util.LinkByName(mgmtPortName)
@@ -249,54 +264,63 @@ func (udng *UserDefinedNetworkGateway) AddNetwork() error {
 		vrfDeviceName := util.GetNetworkVRFName(udng.NetInfo)
 		routes, err := udng.computeRoutesForUDN(mplink)
 		if err != nil {
-			return fmt.Errorf("failed to compute routes for network %s, err: %v", udng.GetNetworkName(), err)
+			return fmt.Errorf("failed to compute routes for network %s, err: %v", networkName, err)
 		}
 		if err = udng.vrfManager.AddVRF(vrfDeviceName, mplink.Attrs().Name, uint32(udng.vrfTableId), nil); err != nil {
-			return fmt.Errorf("could not add VRF %d for network %s, err: %v", udng.vrfTableId, udng.GetNetworkName(), err)
+			return fmt.Errorf("could not add VRF %d for network %s, err: %v", udng.vrfTableId, networkName, err)
 		}
 		if err = udng.addUDNManagementPortIPs(mplink); err != nil {
-			return fmt.Errorf("unable to add management port IP(s) for link %s, for network %s: %w", mplink.Attrs().Name, udng.GetNetworkName(), err)
+			return fmt.Errorf("unable to add management port IP(s) for link %s, for network %s: %w", mplink.Attrs().Name, networkName, err)
 		}
 		if err = udng.vrfManager.AddVRFRoutes(vrfDeviceName, routes); err != nil {
-			return fmt.Errorf("could not add VRF %s routes for network %s, err: %v", vrfDeviceName, udng.GetNetworkName(), err)
+			return fmt.Errorf("could not add VRF %s routes for network %s, err: %v", vrfDeviceName, networkName, err)
 		}
 	}
+	klog.V(4).Infof("[AddNetwork %s] phase 4 (setup VRF and routes) took %v", networkName, time.Since(phaseStart))
 
+	// Phase 5: Update advertisement status
+	phaseStart = time.Now()
 	udng.updateAdvertisementStatus()
+	klog.V(4).Infof("[AddNetwork %s] phase 5 (update advertisement status) took %v", networkName, time.Since(phaseStart))
 
+	// Phase 6: Setup IP rules and routes (non-DPU mode)
+	phaseStart = time.Now()
 	if config.OvnKubeNode.Mode != types.NodeModeDPU {
 		// create the iprules for this network
 		if err = udng.updateUDNVRFIPRules(); err != nil {
-			return fmt.Errorf("failed to update IP rules for network %s: %w", udng.GetNetworkName(), err)
+			return fmt.Errorf("failed to update IP rules for network %s: %w", networkName, err)
 		}
 
 		if err = udng.updateAdvertisedUDNIsolationRules(); err != nil {
-			return fmt.Errorf("failed to update isolation rules for network %s: %w", udng.GetNetworkName(), err)
+			return fmt.Errorf("failed to update isolation rules for network %s: %w", networkName, err)
 		}
 
 		if err = udng.updateUDNVRFIPRoute(); err != nil {
-			return fmt.Errorf("failed to update ip routes for network %s: %w", udng.GetNetworkName(), err)
+			return fmt.Errorf("failed to update ip routes for network %s: %w", networkName, err)
 		}
 	}
+	klog.V(4).Infof("[AddNetwork %s] phase 6 (setup IP rules and routes) took %v", networkName, time.Since(phaseStart))
 
+	// Phase 7: Setup OpenFlow (non-DPU-host mode) - CRITICAL SECTION
+	phaseStart = time.Now()
 	if config.OvnKubeNode.Mode != types.NodeModeDPUHost {
 		var mgmtIPs []*net.IPNet
 		for _, subnet := range nodeSubnets {
 			mgmtIPs = append(mgmtIPs, udng.GetNodeManagementIP(subnet))
 		}
 		if err = udng.openflowManager.addNetwork(udng.NetInfo, nodeSubnets, mgmtIPs, udng.masqCTMark, udng.pktMark, udng.v6MasqIPs, udng.v4MasqIPs); err != nil {
-			return fmt.Errorf("could not add network %s: %v", udng.GetNetworkName(), err)
+			return fmt.Errorf("could not add network %s: %v", networkName, err)
 		}
 
 		waiter := newStartupWaiterWithTimeout(waitForPatchPortTimeout)
 		readyFunc := func() (bool, error) {
-			if err := udng.openflowManager.defaultBridge.SetNetworkOfPatchPort(udng.GetNetworkName()); err != nil {
-				klog.V(3).Infof("Failed to set network %s's openflow ports for default bridge; error: %v", udng.GetNetworkName(), err)
+			if err := udng.openflowManager.defaultBridge.SetNetworkOfPatchPort(networkName); err != nil {
+				klog.V(3).Infof("Failed to set network %s's openflow ports for default bridge; error: %v", networkName, err)
 				return false, nil
 			}
 			if udng.openflowManager.externalGatewayBridge != nil {
-				if err := udng.openflowManager.externalGatewayBridge.SetNetworkOfPatchPort(udng.GetNetworkName()); err != nil {
-					klog.V(3).Infof("Failed to set network %s's openflow ports for secondary bridge; error: %v", udng.GetNetworkName(), err)
+				if err := udng.openflowManager.externalGatewayBridge.SetNetworkOfPatchPort(networkName); err != nil {
+					klog.V(3).Infof("Failed to set network %s's openflow ports for secondary bridge; error: %v", networkName, err)
 					return false, nil
 				}
 			}
@@ -304,7 +328,7 @@ func (udng *UserDefinedNetworkGateway) AddNetwork() error {
 		}
 		postFunc := func() error {
 			if err := udng.gateway.Reconcile(); err != nil {
-				return fmt.Errorf("failed to reconcile flows on bridge for network %s; error: %v", udng.GetNetworkName(), err)
+				return fmt.Errorf("failed to reconcile flows on bridge for network %s; error: %v", networkName, err)
 			}
 			return nil
 		}
@@ -314,19 +338,27 @@ func (udng *UserDefinedNetworkGateway) AddNetwork() error {
 		}
 	} else {
 		if err := udng.gateway.Reconcile(); err != nil {
-			return fmt.Errorf("failed to reconcile flows on bridge for network %s; error: %v", udng.GetNetworkName(), err)
+			return fmt.Errorf("failed to reconcile flows on bridge for network %s; error: %v", networkName, err)
 		}
 	}
+	klog.V(4).Infof("[AddNetwork %s] phase 7 (setup OpenFlow and reconcile) took %v", networkName, time.Since(phaseStart))
 
+	// Phase 8: Add nftables mark chain (non-DPU mode)
+	phaseStart = time.Now()
 	if config.OvnKubeNode.Mode != types.NodeModeDPU {
 		if err := udng.addMarkChain(); err != nil {
 			return fmt.Errorf("failed to add the service masquerade chain: %w", err)
 		}
 	}
+	klog.V(4).Infof("[AddNetwork %s] phase 8 (add nftables mark chain) took %v", networkName, time.Since(phaseStart))
 
+	// Phase 9: Start gateway reconciliation loop
+	phaseStart = time.Now()
 	// run gateway reconciliation loop on network configuration changes
 	udng.run()
+	klog.V(4).Infof("[AddNetwork %s] phase 9 (start reconciliation loop) took %v", networkName, time.Since(phaseStart))
 
+	klog.V(4).Infof("[AddNetwork %s] completed - total time: %v", networkName, time.Since(totalStart))
 	return nil
 }
 

--- a/go-controller/pkg/node/user_defined_node_network_controller.go
+++ b/go-controller/pkg/node/user_defined_node_network_controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"time"
 
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/klog/v2"
@@ -73,6 +74,8 @@ func NewUserDefinedNodeNetworkController(
 func (nc *UserDefinedNodeNetworkController) Start(_ context.Context) error {
 	klog.Infof("Starting UDN node network controller for network %s", nc.GetNetworkName())
 
+	// Phase 1: Setup DPU pod watcher (if enabled)
+	phaseStart := time.Now()
 	// enable adding ovs ports for dpu pods in both primary and secondary user-defined networks
 	if (config.OVNKubernetesFeature.EnableMultiNetwork || util.IsNetworkSegmentationSupportEnabled()) && config.OvnKubeNode.Mode == types.NodeModeDPU {
 		handler, err := nc.watchPodsDPU()
@@ -81,12 +84,18 @@ func (nc *UserDefinedNodeNetworkController) Start(_ context.Context) error {
 		}
 		nc.podHandler = handler
 	}
+	klog.V(4).Infof("[Start %s] phase 1 (DPU pod watcher setup) took %v", nc.GetNetworkName(), time.Since(phaseStart))
+
+	// Phase 2: Add network to gateway (PRIMARY BOTTLENECK)
+	phaseStart = time.Now()
 	if util.IsNetworkSegmentationSupportEnabled() && nc.IsPrimaryNetwork() {
 		if err := nc.gateway.AddNetwork(); err != nil {
 			return fmt.Errorf("failed to add network to node gateway for network %s at node %s: %w",
 				nc.GetNetworkName(), nc.name, err)
 		}
 	}
+	klog.V(4).Infof("[Start %s] phase 2 (add network to gateway) took %v", nc.GetNetworkName(), time.Since(phaseStart))
+
 	return nil
 }
 

--- a/go-controller/pkg/ovn/base_network_controller_pods.go
+++ b/go-controller/pkg/ovn/base_network_controller_pods.go
@@ -460,6 +460,17 @@ func (bnc *BaseNetworkController) addLogicalPortToNetwork(pod *corev1.Pod, nadKe
 	lsp *nbdb.LogicalSwitchPort, podAnnotation *util.PodAnnotation, newlyCreatedPort bool, err error) {
 	var ls *nbdb.LogicalSwitch
 
+	// Timing instrumentation for P99 analysis
+	var waitSwitchTime, getLSPTime, getSwitchTime, nodeInfoTime, ipAllocTime time.Duration
+	funcStart := time.Now()
+
+	defer func() {
+		klog.V(4).Infof("[%s/%s/%s] addLogicalPortToNetwork took %v "+
+			"(waitSwitch=%v, getLSP=%v, getSwitch=%v, nodeInfo=%v, ipAlloc=%v)",
+			nadKey, pod.Namespace, pod.Name, time.Since(funcStart),
+			waitSwitchTime, getLSPTime, getSwitchTime, nodeInfoTime, ipAllocTime)
+	}()
+
 	podDesc := fmt.Sprintf("%s/%s/%s", nadKey, pod.Namespace, pod.Name)
 	switchName, err := bnc.getExpectedSwitchName(pod)
 	if err != nil {
@@ -480,7 +491,9 @@ func (bnc *BaseNetworkController) addLogicalPortToNetwork(pod *corev1.Pod, nadKe
 			pod.Namespace, pod.Name, pod.Spec.NodeName, podState)
 	}
 
+	t1 := time.Now()
 	ls, err = bnc.waitForNodeLogicalSwitch(switchName)
+	waitSwitchTime = time.Since(t1)
 	if err != nil {
 		return nil, nil, nil, false, err
 	}
@@ -495,8 +508,10 @@ func (bnc *BaseNetworkController) addLogicalPortToNetwork(pod *corev1.Pod, nadKe
 	// does don't re-add the port to OVN as this will change its
 	// UUID and and the port cache, address sets, and port groups
 	// will still have the old UUID.
+	t2 := time.Now()
 	lsp = &nbdb.LogicalSwitchPort{Name: portName}
 	existingLSP, err := libovsdbops.GetLogicalSwitchPort(bnc.nbClient, lsp)
+	getLSPTime = time.Since(t2)
 	if err != nil && !errors.Is(err, libovsdbclient.ErrNotFound) {
 		return nil, nil, nil, false, fmt.Errorf("unable to get the lsp %s from the nbdb: %s", portName, err)
 	}
@@ -505,7 +520,9 @@ func (bnc *BaseNetworkController) addLogicalPortToNetwork(pod *corev1.Pod, nadKe
 	// Sanity check. If port exists, it should be in the logical switch obtained from the pod spec.
 	if lspExist {
 		portFound := false
+		t3 := time.Now()
 		ls, err = libovsdbops.GetLogicalSwitch(bnc.nbClient, ls)
+		getSwitchTime = time.Since(t3)
 		if err != nil {
 			return nil, nil, nil, false, fmt.Errorf("[%s] unable to find logical switch %s in NBDB",
 				podDesc, switchName)
@@ -540,6 +557,8 @@ func (bnc *BaseNetworkController) addLogicalPortToNetwork(pod *corev1.Pod, nadKe
 	if !lspExist || len(existingLSP.Options["iface-id-ver"]) != 0 {
 		lsp.Options["iface-id-ver"] = string(pod.UID)
 	}
+
+	t4 := time.Now()
 	// let's calculate if this network controller's role for this pod
 	// and pass that information while determining the podAnnotations
 	networkRole, err := bnc.GetNetworkRole(pod)
@@ -573,6 +592,7 @@ func (bnc *BaseNetworkController) addLogicalPortToNetwork(pod *corev1.Pod, nadKe
 		}
 		lsp.Options[libovsdbops.RequestedChassis] = chassisID
 	}
+	nodeInfoTime = time.Since(t4)
 
 	// Although we have different code to allocate the pod annotation for the
 	// default network and user-defined networks, at the time of this writing they
@@ -581,11 +601,13 @@ func (bnc *BaseNetworkController) addLogicalPortToNetwork(pod *corev1.Pod, nadKe
 	// it for the default network as well. If at all possible, keep them
 	// functionally equivalent going forward.
 	var annotationUpdated bool
+	t5 := time.Now()
 	if bnc.IsUserDefinedNetwork() {
 		podAnnotation, annotationUpdated, err = bnc.allocatePodAnnotationForUserDefinedNetwork(pod, existingLSP, nadKey, network, networkRole)
 	} else {
 		podAnnotation, annotationUpdated, err = bnc.allocatePodAnnotation(pod, existingLSP, podDesc, nadKey, network, networkRole)
 	}
+	ipAllocTime = time.Since(t5)
 
 	if err != nil {
 		return nil, nil, nil, false, err
@@ -842,9 +864,22 @@ func (bnc *BaseNetworkController) allocatePodAnnotation(pod *corev1.Pod, existin
 	var podMac net.HardwareAddr
 	var podIfAddrs []*net.IPNet
 
+	// Timing instrumentation for P99 analysis
+	var ensureAnnotTime, existingIPAllocTime, portAddrTime, newIPAllocTime, assignAddrTime, updateAnnotTime time.Duration
+	funcStart := time.Now()
+
+	defer func() {
+		klog.V(4).Infof("[%s] allocatePodAnnotation took %v "+
+			"(ensureAnnot=%v, existingIPAlloc=%v, portAddr=%v, newIPAlloc=%v, assignAddr=%v, updateAnnot=%v)",
+			podDesc, time.Since(funcStart),
+			ensureAnnotTime, existingIPAllocTime, portAddrTime, newIPAllocTime, assignAddrTime, updateAnnotTime)
+	}()
+
 	switchName := pod.Spec.NodeName
 
+	t1 := time.Now()
 	podAnnotation, zoneContainsPodSubnet, err := bnc.ensurePodAnnotation(pod, nadKey)
+	ensureAnnotTime = time.Since(t1)
 	if err != nil {
 		return nil, false, fmt.Errorf("unable to ensure pod annotation: %v", err)
 	}
@@ -874,10 +909,13 @@ func (bnc *BaseNetworkController) allocatePodAnnotation(pod *corev1.Pod, existin
 		if bnc.doesNetworkRequireIPAM() {
 			if zoneContainsPodSubnet {
 				// ensure we have reserved the IPs in the annotation
+				t2 := time.Now()
 				if err = bnc.lsManager.AllocateIPs(switchName, podIfAddrs); err != nil && err != ipallocator.ErrAllocated {
+					existingIPAllocTime = time.Since(t2)
 					return nil, false, fmt.Errorf("unable to ensure IPs allocated for already annotated pod: %s, IPs: %s, error: %v",
 						podDesc, util.JoinIPNetIPs(podIfAddrs, " "), err)
 				}
+				existingIPAllocTime = time.Since(t2)
 			}
 			return podAnnotation, false, nil
 
@@ -893,7 +931,9 @@ func (bnc *BaseNetworkController) allocatePodAnnotation(pod *corev1.Pod, existin
 	// when it tries to override the pod IP annotation. Newly allocated IPs will be released then.
 	if existingLSP != nil {
 		// try to get the MAC and IPs from existing OVN port first
+		t3 := time.Now()
 		podMac, podIfAddrs, err = bnc.getPortAddresses(switchName, existingLSP)
+		portAddrTime = time.Since(t3)
 		if err != nil {
 			return nil, false, fmt.Errorf("failed to get pod addresses for pod %s on node: %s, err: %v",
 				podDesc, switchName, err)
@@ -905,11 +945,15 @@ func (bnc *BaseNetworkController) allocatePodAnnotation(pod *corev1.Pod, existin
 	if len(podIfAddrs) == 0 {
 		needsNewMacOrIPAllocation = true
 	} else if bnc.doesNetworkRequireIPAM() {
+		t4 := time.Now()
 		if err = bnc.lsManager.AllocateIPs(switchName, podIfAddrs); err != nil && err != ipallocator.ErrAllocated {
+			newIPAllocTime = time.Since(t4)
 			klog.Warningf("Unable to allocate IPs %s found on existing OVN port: %s, for pod %s on switch: %s"+
 				" error: %v", util.JoinIPNetIPs(podIfAddrs, " "), bnc.GetLogicalPortName(pod, nadKey), podDesc, switchName, err)
 
 			needsNewMacOrIPAllocation = true
+		} else {
+			newIPAllocTime = time.Since(t4)
 		}
 	}
 	if needsNewMacOrIPAllocation {
@@ -922,7 +966,9 @@ func (bnc *BaseNetworkController) allocatePodAnnotation(pod *corev1.Pod, existin
 			podMac = util.IPAddrToHWAddr(podIfAddrs[0].IP)
 		} else {
 			// Previous attempts to use already configured IPs failed, need to assign new
+			t5 := time.Now()
 			generatedPodMac, generatedPodIfAddrs, err := bnc.assignPodAddresses(switchName)
+			assignAddrTime = time.Since(t5)
 			if err != nil {
 				return nil, false, fmt.Errorf("failed to assign pod addresses for pod %s on switch: %s, err: %v",
 					podDesc, switchName, err)
@@ -968,10 +1014,9 @@ func (bnc *BaseNetworkController) allocatePodAnnotation(pod *corev1.Pod, existin
 
 	klog.V(5).Infof("Annotation values: ip=%v ; mac=%s ; gw=%s",
 		podIfAddrs, podMac, podAnnotation.Gateways)
-	annoStart := time.Now()
+	t6 := time.Now()
 	err = bnc.updatePodAnnotationWithRetry(pod, podAnnotation, nadKey)
-	podAnnoTime := time.Since(annoStart)
-	klog.Infof("[%s] addLogicalPort annotation time took %v", podDesc, podAnnoTime)
+	updateAnnotTime = time.Since(t6)
 	if err != nil {
 		return nil, false, err
 	}

--- a/go-controller/pkg/ovn/base_network_controller_user_defined.go
+++ b/go-controller/pkg/ovn/base_network_controller_user_defined.go
@@ -228,6 +228,18 @@ func (bsnc *BaseUserDefinedNetworkController) DeleteUserDefinedNetworkResourceCo
 // ensurePodForUserDefinedNetwork tries to set up the User Defined Network for a pod. It returns nil on success and error
 // on failure; failure indicates the pod set up should be retried later.
 func (bsnc *BaseUserDefinedNetworkController) ensurePodForUserDefinedNetwork(pod *corev1.Pod, addPort bool) error {
+	startTime := time.Now()
+
+	// Timing instrumentation for P99 analysis - sub-phase tracking
+	var liveMigrationTime, switchLookupTime, nadMappingTime, networkManagerTime time.Duration
+
+	defer func() {
+		klog.V(4).Infof("Finished ensurePodForUserDefinedNetwork for pod %s/%s on network %s, "+
+			"took %v (liveMigration=%v, switchLookup=%v, networkManager=%v, nadMapping=%v)",
+			pod.Namespace, pod.Name, bsnc.GetNetworkName(),
+			time.Since(startTime), liveMigrationTime, switchLookupTime, networkManagerTime, nadMappingTime)
+	}()
+
 	// Try unscheduled pods later
 	if !util.PodScheduled(pod) {
 		return nil
@@ -241,7 +253,9 @@ func (bsnc *BaseUserDefinedNetworkController) ensurePodForUserDefinedNetwork(pod
 	var err error
 
 	if kubevirt.IsPodAllowedForMigration(pod, bsnc.GetNetInfo()) {
+		t1 := time.Now()
 		kubevirtLiveMigrationStatus, err = kubevirt.DiscoverLiveMigrationStatus(bsnc.watchFactory, pod)
+		liveMigrationTime = time.Since(t1)
 		if err != nil {
 			return fmt.Errorf("failed to discover Live-migration status: %w", err)
 		}
@@ -254,26 +268,32 @@ func (bsnc *BaseUserDefinedNetworkController) ensurePodForUserDefinedNetwork(pod
 
 	// If a node does not have an assigned hostsubnet don't wait for the logical switch to appear
 	var switchName string
+	t2 := time.Now()
 	switchName, err = bsnc.getExpectedSwitchName(pod)
+	switchLookupTime = time.Since(t2)
 	if err != nil {
 		return err
 	}
 
 	var activeNetwork util.NetInfo
 	if bsnc.IsPrimaryNetwork() {
+		t3 := time.Now()
 		// check to see if the primary NAD is even applicable to our controller
 		foundNamespaceNAD, err := bsnc.networkManager.GetPrimaryNADForNamespace(pod.Namespace)
 		if err != nil {
 			return fmt.Errorf("failed to get primary network namespace NAD: %w", err)
 		}
 		if foundNamespaceNAD == types.DefaultNetworkName {
+			networkManagerTime = time.Since(t3)
 			return nil
 		}
 		networkName := bsnc.networkManager.GetNetworkNameForNADKey(foundNamespaceNAD)
 		if networkName != "" && networkName != bsnc.GetNetworkName() {
+			networkManagerTime = time.Since(t3)
 			return nil
 		}
 		activeNetwork, err = bsnc.networkManager.GetActiveNetworkForNamespace(pod.Namespace)
+		networkManagerTime = time.Since(t3)
 		if err != nil {
 			return fmt.Errorf("failed to find active network for pod %s/%s: %w", pod.Namespace, pod.Name, err)
 		}
@@ -283,6 +303,7 @@ func (bsnc *BaseUserDefinedNetworkController) ensurePodForUserDefinedNetwork(pod
 		}
 	}
 
+	t4 := time.Now()
 	on, networkMap, err := util.GetPodNADToNetworkMappingWithActiveNetwork(
 		pod,
 		bsnc.GetNetInfo(),
@@ -290,6 +311,7 @@ func (bsnc *BaseUserDefinedNetworkController) ensurePodForUserDefinedNetwork(pod
 		bsnc.networkManager.GetNetworkNameForNADKey,
 		bsnc.networkManager.GetPrimaryNADForNamespace,
 	)
+	nadMappingTime = time.Since(t4)
 	if err != nil {
 		bsnc.recordPodErrorEvent(pod, err)
 		// configuration error, no need to retry, do not return error
@@ -326,12 +348,15 @@ func (bsnc *BaseUserDefinedNetworkController) ensurePodForUserDefinedNetwork(pod
 func (bsnc *BaseUserDefinedNetworkController) addLogicalPortToNetworkForNAD(pod *corev1.Pod, nadKey, switchName string,
 	network *nadapi.NetworkSelectionElement, kubevirtLiveMigrationStatus *kubevirt.LiveMigrationStatus,
 ) error {
-	var libovsdbExecuteTime time.Duration
+	// Timing instrumentation for P99 analysis - breakdown timing
+	var libovsdbExecuteTime, portCreateTime, namespaceOpsTime, dhcpTime time.Duration
 
 	start := time.Now()
 	defer func() {
-		klog.Infof("[%s/%s] addLogicalPort for NAD key %s took %v, libovsdb time %v",
-			pod.Namespace, pod.Name, nadKey, time.Since(start), libovsdbExecuteTime)
+		klog.Infof("[%s/%s] addLogicalPort for NAD key %s took %v "+
+			"(portCreate=%v, libovsdb=%v, namespaceOps=%v, dhcp=%v)",
+			pod.Namespace, pod.Name, nadKey, time.Since(start),
+			portCreateTime, libovsdbExecuteTime, namespaceOpsTime, dhcpTime)
 	}()
 
 	var err error
@@ -356,7 +381,9 @@ func (bsnc *BaseUserDefinedNetworkController) addLogicalPortToNetworkForNAD(pod 
 	requiresLogicalPort := isLocalPod || bsnc.isLayer2WithInterconnectTransport()
 
 	if requiresLogicalPort {
+		t1 := time.Now()
 		ops, lsp, podAnnotation, newlyCreated, err = bsnc.addLogicalPortToNetwork(pod, nadKey, network, lspEnabled)
+		portCreateTime = time.Since(t1)
 		if err != nil {
 			return err
 		}
@@ -402,12 +429,14 @@ func (bsnc *BaseUserDefinedNetworkController) addLogicalPortToNetworkForNAD(pod 
 
 	if bsnc.doesNetworkRequireIPAM() &&
 		(util.IsMultiNetworkPoliciesSupportEnabled() || (util.IsNetworkSegmentationSupportEnabled() && bsnc.IsPrimaryNetwork())) {
+		t2 := time.Now()
 		// Ensure the namespace/nsInfo exists
 		portUUID := ""
 		if lsp != nil {
 			portUUID = lsp.UUID
 		}
 		addOps, err := bsnc.addPodToNamespaceForUserDefinedNetwork(pod.Namespace, podAnnotation.IPs, portUUID)
+		namespaceOpsTime = time.Since(t2)
 		if err != nil {
 			return err
 		}
@@ -434,9 +463,11 @@ func (bsnc *BaseUserDefinedNetworkController) addLogicalPortToNetworkForNAD(pod 
 			bsnc.onLogicalPortCacheAdd(pod, nadKey)
 		}
 		if bsnc.requireDHCP(pod) {
+			t3 := time.Now()
 			if err := bsnc.ensureDHCP(pod, podAnnotation, lsp); err != nil {
 				return err
 			}
+			dhcpTime = time.Since(t3)
 		}
 	}
 
@@ -622,6 +653,12 @@ func (bsnc *BaseUserDefinedNetworkController) hasIPAMClaim(pod *corev1.Pod, nadK
 }
 
 func (bsnc *BaseUserDefinedNetworkController) syncPodsForUserDefinedNetwork(pods []interface{}) error {
+	startTime := time.Now()
+	defer func() {
+		klog.V(4).Infof("Finished syncPodsForUserDefinedNetwork for network %s (%d pods), took %v",
+			bsnc.GetNetworkName(), len(pods), time.Since(startTime))
+	}()
+
 	annotatedLocalPods := map[*corev1.Pod]map[string]*util.PodAnnotation{}
 	// get the list of logical switch ports (equivalent to pods). Reserve all existing Pod IPs to
 	// avoid subsequent new Pods getting the same duplicate Pod IP.

--- a/go-controller/pkg/ovn/base_secondary_layer2_network_controller.go
+++ b/go-controller/pkg/ovn/base_secondary_layer2_network_controller.go
@@ -3,6 +3,7 @@ package ovn
 import (
 	"fmt"
 	"net"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
@@ -106,11 +107,15 @@ func (oc *BaseLayer2UserDefinedNetworkController) cleanup() error {
 }
 
 func (oc *BaseLayer2UserDefinedNetworkController) run() error {
+	networkName := oc.GetNetworkName()
+
 	// WatchNamespaces() should be started first because it has no other
 	// dependencies.
+	phaseStart := time.Now()
 	if err := oc.WatchNamespaces(); err != nil {
 		return err
 	}
+	klog.V(4).Infof("[run %s] WatchNamespaces took %v", networkName, time.Since(phaseStart))
 
 	// when on IC, it will be the NetworkController that returns the IPAMClaims
 	// IPs back to the pool
@@ -118,14 +123,18 @@ func (oc *BaseLayer2UserDefinedNetworkController) run() error {
 		// WatchIPAMClaims should be started before WatchPods to prevent OVN-K
 		// master assigning IPs to pods without taking into account the persistent
 		// IPs set aside for the IPAMClaims
+		phaseStart = time.Now()
 		if err := oc.WatchIPAMClaims(); err != nil {
 			return err
 		}
+		klog.V(4).Infof("[run %s] WatchIPAMClaims took %v", networkName, time.Since(phaseStart))
 	}
 
+	phaseStart = time.Now()
 	if err := oc.WatchPods(); err != nil {
 		return err
 	}
+	klog.V(4).Infof("[run %s] WatchPods took %v", networkName, time.Since(phaseStart))
 
 	if util.IsMultiNetworkPoliciesSupportEnabled() && !oc.IsPrimaryNetwork() {
 		// WatchMultiNetworkPolicy depends on WatchPods and WatchNamespaces

--- a/go-controller/pkg/ovn/controller/services/loadbalancer.go
+++ b/go-controller/pkg/ovn/controller/services/loadbalancer.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -133,6 +134,20 @@ func toNBTemplateList(tlbs []*templateLoadBalancer) []TemplateMap {
 // It is assumed that names are meaningful and somewhat stable, to minimize churn. This
 // function doesn't work with Load_Balancers without a name.
 func EnsureLBs(nbClient libovsdbclient.Client, service *corev1.Service, existingCacheLBs []LB, LBs []LB, netInfo util.NetInfo) error {
+	// Timing instrumentation for LB creation/update analysis
+	var buildOpsTime, buildAttachTime, nbdbTxTime time.Duration
+	startTime := time.Now()
+
+	defer func() {
+		totalTime := time.Since(startTime)
+		otherTime := totalTime - buildOpsTime - buildAttachTime - nbdbTxTime
+
+		klog.V(4).Infof("[Service LB %s/%s network=%s] EnsureLBs took %v "+
+			"(buildOps=%v, buildAttach=%v, nbdbTx=%v, other=%v)",
+			service.Namespace, service.Name, netInfo.GetNetworkName(), totalTime,
+			buildOpsTime, buildAttachTime, nbdbTxTime, otherTime)
+	}()
+
 	externalIDs := getExternalIDsForLoadBalancer(service, netInfo)
 	existingByName := make(map[string]*LB, len(existingCacheLBs))
 	toDelete := make(map[string]*LB, len(existingCacheLBs))
@@ -177,16 +192,21 @@ func EnsureLBs(nbClient libovsdbclient.Client, service *corev1.Service, existing
 		mapLBDifferenceByKey(removeLBsFromGroups, existingGroups, wantGroups, blb)
 	}
 
+	t1 := time.Now()
 	ops, err := libovsdbops.CreateOrUpdateLoadBalancersOps(nbClient, nil, toNBLoadBalancerList(tlbs)...)
 	if err != nil {
 		return err
 	}
 
 	ops, err = svcCreateOrUpdateTemplateVarOps(nbClient, ops, toNBTemplateList(tlbs))
+	buildOpsTime = time.Since(t1)
 	if err != nil {
 		return fmt.Errorf("failed to create ops for ensuring creation of service %s/%s load balancers: %w",
 			service.Namespace, service.Name, err)
 	}
+
+	// Timing instrumentation for LB attachment operations
+	t2 := time.Now()
 
 	// cache switches for this round of ops
 	lswitches := map[string]*nbdb.LogicalSwitch{}
@@ -266,6 +286,8 @@ func EnsureLBs(nbClient libovsdbclient.Client, service *corev1.Service, existing
 		}
 	}
 
+	buildAttachTime = time.Since(t2)
+
 	deleteLBs := make([]*nbdb.LoadBalancer, 0, len(toDelete))
 	deleteTemplates := make([]TemplateMap, 0, len(toDelete))
 	for _, clb := range toDelete {
@@ -290,7 +312,10 @@ func EnsureLBs(nbClient libovsdbclient.Client, service *corev1.Service, existing
 	}
 	ops = append(ops, recordOps...)
 
+	// Timing instrumentation for NBDB transaction
+	t3 := time.Now()
 	_, err = libovsdbops.TransactAndCheckAndSetUUIDs(nbClient, toNBLoadBalancerList(tlbs), ops)
+	nbdbTxTime = time.Since(t3)
 	if err != nil {
 		return fmt.Errorf("failed to ensure load balancers for service %s/%s: %w", service.Namespace, service.Name, err)
 	}

--- a/go-controller/pkg/ovn/controller/services/services_controller.go
+++ b/go-controller/pkg/ovn/controller/services/services_controller.go
@@ -373,7 +373,10 @@ func (c *Controller) initTopLevelCache() error {
 //
 // All Load_Balancer objects are tagged with their owner, so it's easy to find stale objects.
 func (c *Controller) syncService(key string) error {
+	// Timing instrumentation for service readiness analysis
+	var getLockTime, getServiceTime, getEndpointsTime, buildConfigTime, buildLBTime, ensureLBTime time.Duration
 	startTime := time.Now()
+
 	namespace, name, err := cache.SplitMetaNamespaceKey(key)
 	if err != nil {
 		return err
@@ -382,17 +385,31 @@ func (c *Controller) syncService(key string) error {
 	metrics.MetricSyncServiceCount.Inc()
 
 	defer func() {
-		klog.V(5).Infof("Finished syncing service %s on namespace %s for network=%s : %v", name, namespace, c.netInfo.GetNetworkName(), time.Since(startTime))
-		metrics.MetricSyncServiceLatency.Observe(time.Since(startTime).Seconds())
+		totalTime := time.Since(startTime)
+		otherTime := totalTime - getLockTime - getServiceTime - getEndpointsTime - buildConfigTime - buildLBTime - ensureLBTime
+
+		// Detailed timing at v=4 (same level as pod timing)
+		klog.V(4).Infof("[Service %s/%s network=%s] sync took %v "+
+			"(getLock=%v, getSvc=%v, getEP=%v, buildCfg=%v, buildLB=%v, ensureLB=%v, other=%v)",
+			namespace, name, c.netInfo.GetNetworkName(), totalTime,
+			getLockTime, getServiceTime, getEndpointsTime, buildConfigTime, buildLBTime, ensureLBTime, otherTime)
+
+		// Keep existing v=5 log for backward compatibility
+		klog.V(5).Infof("Finished syncing service %s on namespace %s for network=%s : %v", name, namespace, c.netInfo.GetNetworkName(), totalTime)
+		metrics.MetricSyncServiceLatency.Observe(totalTime.Seconds())
 	}()
 
 	// Shared node information (c.nodeInfos, c.nodeIPv4Template, c.nodeIPv6Template)
 	// needs to be accessed with the nodeInfoRWLock taken for read.
+	t1 := time.Now()
 	c.nodeInfoRWLock.RLock()
+	getLockTime = time.Since(t1)
 	defer c.nodeInfoRWLock.RUnlock()
 
 	// Get current Service from the cache
+	t2 := time.Now()
 	service, err := c.serviceLister.Services(namespace).Get(name)
+	getServiceTime = time.Since(t2)
 	// It´s unlikely that we have an error different that "Not Found Object"
 	// because we are getting the object from the informer´s cache
 	if err != nil && !apierrors.IsNotFound(err) {
@@ -458,21 +475,27 @@ func (c *Controller) syncService(key string) error {
 	// The Service exists in the cache: update it in OVN
 	klog.V(5).Infof("Service %s/%s retrieved from lister for network=%s: %v", service.Namespace, service.Name, c.netInfo.GetNetworkName(), service)
 
+	t3 := time.Now()
 	endpointSlices, err := util.GetServiceEndpointSlices(namespace, service.Name, c.netInfo.GetNetworkName(), c.endpointSliceLister)
+	getEndpointsTime = time.Since(t3)
 	if err != nil {
 		return fmt.Errorf("service %s/%s for network=%s, %w", service.Namespace, service.Name, c.netInfo.GetNetworkName(), err)
 	}
 
 	// Build the abstract LB configs for this service
+	t4 := time.Now()
 	perNodeConfigs, templateConfigs, clusterConfigs := buildServiceLBConfigs(service, endpointSlices, c.nodeInfos, c.useLBGroups, c.useTemplates, c.netInfo)
+	buildConfigTime = time.Since(t4)
 	klog.V(5).Infof("Built service %s LB cluster-wide configs for network=%s: %#v", key, c.netInfo.GetNetworkName(), clusterConfigs)
 	klog.V(5).Infof("Built service %s LB per-node configs for network=%s:  %#v", key, c.netInfo.GetNetworkName(), perNodeConfigs)
 	klog.V(5).Infof("Built service %s LB template configs for network=%s: %#v", key, c.netInfo.GetNetworkName(), templateConfigs)
 
 	// Convert the LB configs in to load-balancer objects
+	t5 := time.Now()
 	clusterLBs := buildClusterLBs(service, clusterConfigs, c.nodeInfos, c.useLBGroups, c.netInfo)
 	templateLBs := buildTemplateLBs(service, templateConfigs, c.nodeInfos, c.nodeIPv4Templates, c.nodeIPv6Templates, c.netInfo)
 	perNodeLBs := buildPerNodeLBs(service, perNodeConfigs, c.nodeInfos, c.netInfo)
+	buildLBTime = time.Since(t5)
 	klog.V(5).Infof("Built service %s cluster-wide LB for network=%s: %#v", key, c.netInfo.GetNetworkName(), clusterLBs)
 	klog.V(5).Infof("Built service %s per-node LB for network=%s: %#v", key, c.netInfo.GetNetworkName(), perNodeLBs)
 	klog.V(5).Infof("Built service %s template LB for network=%s:  %#v", key, c.netInfo.GetNetworkName(), templateLBs)
@@ -494,15 +517,19 @@ func (c *Controller) syncService(key string) error {
 
 	if alreadyAppliedKeyExists && LoadBalancersEqualNoUUID(existingLBs, lbs) {
 		klog.V(5).Infof("Skipping no-op change for service %s for network=%s", key, c.netInfo.GetNetworkName())
+		// No EnsureLBs call, so ensureLBTime remains 0
 	} else {
 		klog.V(5).Infof("Services do not match for network=%s, existing lbs: %#v, built lbs: %#v", c.netInfo.GetNetworkName(), existingLBs, lbs)
 		// Actually apply load-balancers to OVN.
 		//
 		// Note: this may fail if a node was deleted between listing nodes and applying.
 		// If so, this will fail and we will resync.
+		t6 := time.Now()
 		if err := EnsureLBs(c.nbClient, service, existingLBs, lbs, c.netInfo); err != nil {
+			ensureLBTime = time.Since(t6)
 			return fmt.Errorf("failed to ensure service %s load balancers for network=%s: %w", key, c.netInfo.GetNetworkName(), err)
 		}
+		ensureLBTime = time.Since(t6)
 
 		c.alreadyAppliedRWLock.Lock()
 		c.alreadyApplied[key] = lbs

--- a/go-controller/pkg/ovn/layer2_user_defined_network_controller.go
+++ b/go-controller/pkg/ovn/layer2_user_defined_network_controller.go
@@ -365,16 +365,28 @@ func (oc *Layer2UserDefinedNetworkController) Start(_ context.Context) error {
 		klog.Infof("Starting controller for UDN %s took %v", oc.GetNetworkName(), time.Since(start))
 	}()
 
+	// Phase 1: Initialize controller
+	phaseStart := time.Now()
 	if err := oc.init(); err != nil {
 		return err
 	}
+	klog.V(4).Infof("[Start %s] phase 1 (init) took %v", oc.GetNetworkName(), time.Since(phaseStart))
+
+	// Phase 2: Register node handler
+	phaseStart = time.Now()
 	if err := oc.RegisterNodeHandler(); err != nil {
 		return err
 	}
+	klog.V(4).Infof("[Start %s] phase 2 (RegisterNodeHandler) took %v", oc.GetNetworkName(), time.Since(phaseStart))
+
+	// Phase 3: Run controller (start watchers and sync)
+	phaseStart = time.Now()
 	if err := oc.run(); err != nil {
 		oc.DeregisterNodeHandler()
 		return err
 	}
+	klog.V(4).Infof("[Start %s] phase 3 (run) took %v", oc.GetNetworkName(), time.Since(phaseStart))
+
 	return nil
 }
 
@@ -473,19 +485,26 @@ func (oc *Layer2UserDefinedNetworkController) Cleanup() error {
 }
 
 func (oc *Layer2UserDefinedNetworkController) init() error {
+	networkName := oc.GetNetworkName()
+
 	// Create default Control Plane Protection (COPP) entry for routers
+	phaseStart := time.Now()
 	defaultCOPPUUID, err := EnsureDefaultCOPP(oc.nbClient)
 	if err != nil {
 		return fmt.Errorf("unable to create router control plane protection: %w", err)
 	}
 	oc.defaultCOPPUUID = defaultCOPPUUID
+	klog.V(4).Infof("[init %s] EnsureDefaultCOPP took %v", networkName, time.Since(phaseStart))
 
 	if config.Layer2UsesTransitRouter && oc.IsPrimaryNetwork() {
+		phaseStart = time.Now()
 		if _, err = oc.newClusterRouter(); err != nil {
 			return fmt.Errorf("failed to create OVN cluster router for network %q: %v", oc.GetNetworkName(), err)
 		}
+		klog.V(4).Infof("[init %s] newClusterRouter took %v", networkName, time.Since(phaseStart))
 	}
 
+	phaseStart = time.Now()
 	clusterLBGroupUUID, switchLBGroupUUID, routerLBGroupUUID, err := initLoadBalancerGroups(oc.nbClient, oc.GetNetInfo())
 	if err != nil {
 		return err
@@ -493,9 +512,12 @@ func (oc *Layer2UserDefinedNetworkController) init() error {
 	oc.clusterLoadBalancerGroupUUID = clusterLBGroupUUID
 	oc.switchLoadBalancerGroupUUID = switchLBGroupUUID
 	oc.routerLoadBalancerGroupUUID = routerLBGroupUUID
+	klog.V(4).Infof("[init %s] initLoadBalancerGroups took %v", networkName, time.Since(phaseStart))
+
 	excludeSubnets := oc.ExcludeSubnets()
 	excludeSubnets = append(excludeSubnets, oc.InfrastructureSubnets()...)
 
+	phaseStart = time.Now()
 	_, err = oc.initializeLogicalSwitch(
 		oc.GetNetworkScopedSwitchName(types.OVNLayer2Switch),
 		oc.Subnets(),
@@ -507,16 +529,21 @@ func (oc *Layer2UserDefinedNetworkController) init() error {
 	if err != nil {
 		return err
 	}
+	klog.V(4).Infof("[init %s] initializeLogicalSwitch took %v", networkName, time.Since(phaseStart))
 
 	// Configure cluster port groups and multicast default policies for user defined primary networks.
 	if oc.IsPrimaryNetwork() && util.IsNetworkSegmentationSupportEnabled() {
+		phaseStart = time.Now()
 		if err := oc.setupClusterPortGroups(); err != nil {
 			return fmt.Errorf("failed to create cluster port groups for network %q: %w", oc.GetNetworkName(), err)
 		}
+		klog.V(4).Infof("[init %s] setupClusterPortGroups took %v", networkName, time.Since(phaseStart))
 
+		phaseStart = time.Now()
 		if err := oc.syncDefaultMulticastPolicies(); err != nil {
 			return fmt.Errorf("failed to sync default multicast policies for network %q: %w", oc.GetNetworkName(), err)
 		}
+		klog.V(4).Infof("[init %s] syncDefaultMulticastPolicies took %v", networkName, time.Since(phaseStart))
 	}
 
 	return err

--- a/go-controller/pkg/ovn/layer3_user_defined_network_controller.go
+++ b/go-controller/pkg/ovn/layer3_user_defined_network_controller.go
@@ -347,16 +347,29 @@ func (oc *Layer3UserDefinedNetworkController) newRetryFramework(
 // Start starts the UDN layer3 controller, handles all events and creates all needed logical entities
 func (oc *Layer3UserDefinedNetworkController) Start(_ context.Context) error {
 	klog.Infof("Start %s UDN controller for network %s", oc.TopologyType(), oc.GetNetworkName())
+
+	// Phase 1: Initialize controller
+	phaseStart := time.Now()
 	if err := oc.init(); err != nil {
 		return err
 	}
+	klog.V(4).Infof("[Start %s] phase 1 (init) took %v", oc.GetNetworkName(), time.Since(phaseStart))
+
+	// Phase 2: Register node handler
+	phaseStart = time.Now()
 	if err := oc.RegisterNodeHandler(); err != nil {
 		return err
 	}
+	klog.V(4).Infof("[Start %s] phase 2 (RegisterNodeHandler) took %v", oc.GetNetworkName(), time.Since(phaseStart))
+
+	// Phase 3: Run controller (start watchers and sync)
+	phaseStart = time.Now()
 	if err := oc.run(); err != nil {
 		oc.DeregisterNodeHandler()
 		return err
 	}
+	klog.V(4).Infof("[Start %s] phase 3 (run) took %v", oc.GetNetworkName(), time.Since(phaseStart))
+
 	return nil
 }
 
@@ -500,59 +513,74 @@ func (oc *Layer3UserDefinedNetworkController) Cleanup() error {
 
 func (oc *Layer3UserDefinedNetworkController) run() error {
 	klog.Infof("Starting all the Watchers for network %s ...", oc.GetNetworkName())
-	start := time.Now()
+	networkName := oc.GetNetworkName()
 
 	// WatchNamespaces() should be started first because it has no other
 	// dependencies.
+	phaseStart := time.Now()
 	if err := oc.WatchNamespaces(); err != nil {
 		return err
 	}
+	klog.V(4).Infof("[run %s] WatchNamespaces took %v", networkName, time.Since(phaseStart))
 
+	phaseStart = time.Now()
 	if err := oc.waitForLocalZoneNodeLogicalSwitches(); err != nil {
 		return err
 	}
+	klog.V(4).Infof("[run %s] waitForLocalZoneNodeLogicalSwitches took %v", networkName, time.Since(phaseStart))
 
 	if oc.svcController != nil {
-		startSvc := time.Now()
+		phaseStart = time.Now()
 		// Services should be started after nodes to prevent LB churn
 		err := oc.StartServiceController(oc.wg, true)
-		endSvc := time.Since(startSvc)
+		svcDuration := time.Since(phaseStart)
 
-		metrics.MetricOVNKubeControllerSyncDuration.WithLabelValues("service_" + oc.GetNetworkName()).Set(endSvc.Seconds())
+		metrics.MetricOVNKubeControllerSyncDuration.WithLabelValues("service_" + networkName).Set(svcDuration.Seconds())
+		klog.V(4).Infof("[run %s] StartServiceController took %v", networkName, svcDuration)
 		if err != nil {
 			return err
 		}
 	}
 
+	phaseStart = time.Now()
 	if err := oc.WatchPods(); err != nil {
 		return err
 	}
+	klog.V(4).Infof("[run %s] WatchPods took %v", networkName, time.Since(phaseStart))
 
 	if util.IsMultiNetworkPoliciesSupportEnabled() && !oc.IsPrimaryNetwork() {
 		// WatchMultiNetworkPolicy depends on WatchPods and WatchNamespaces
+		phaseStart = time.Now()
 		if err := oc.WatchMultiNetworkPolicy(); err != nil {
 			return err
 		}
+		klog.V(4).Infof("[run %s] WatchMultiNetworkPolicy took %v", networkName, time.Since(phaseStart))
 	}
 
 	if oc.IsPrimaryNetwork() {
 		// WatchNetworkPolicy depends on WatchPods and WatchNamespaces
+		phaseStart = time.Now()
 		if err := oc.WatchNetworkPolicy(); err != nil {
 			return err
 		}
+		klog.V(4).Infof("[run %s] WatchNetworkPolicy took %v", networkName, time.Since(phaseStart))
 	}
 
 	// Add ourselves to the route import manager
 	if oc.routeImportManager != nil {
+		phaseStart = time.Now()
 		err := oc.routeImportManager.AddNetwork(oc.GetNetInfo())
+		klog.V(4).Infof("[run %s] AddNetwork to routeImportManager took %v", networkName, time.Since(phaseStart))
 		if err != nil {
-			return fmt.Errorf("failed to add network %s to the route import manager: %v", oc.GetNetworkName(), err)
+			return fmt.Errorf("failed to add network %s to the route import manager: %v", networkName, err)
 		}
 	}
 
 	// start NetworkQoS controller if feature is enabled
 	if config.OVNKubernetesFeature.EnableNetworkQoS {
+		phaseStart = time.Now()
 		err := oc.newNetworkQoSController()
+		klog.V(4).Infof("[run %s] newNetworkQoSController took %v", networkName, time.Since(phaseStart))
 		if err != nil {
 			return fmt.Errorf("unable to create network qos controller, err: %w", err)
 		}
@@ -563,8 +591,6 @@ func (oc *Layer3UserDefinedNetworkController) run() error {
 			oc.nqosController.Run(1, ch)
 		}(oc.stopChan)
 	}
-
-	klog.Infof("Completing all the Watchers for network %s took %v", oc.GetNetworkName(), time.Since(start))
 
 	return nil
 }
@@ -713,35 +739,49 @@ func (oc *Layer3UserDefinedNetworkController) SyncNodes(nodes []*corev1.Node) er
 }
 
 func (oc *Layer3UserDefinedNetworkController) init() error {
+	networkName := oc.GetNetworkName()
+
+	phaseStart := time.Now()
 	if err := oc.gatherJoinSwitchIPs(); err != nil {
-		return fmt.Errorf("failed to gather join switch IPs for network %s: %v", oc.GetNetworkName(), err)
+		return fmt.Errorf("failed to gather join switch IPs for network %s: %v", networkName, err)
 	}
+	klog.V(4).Infof("[init %s] gatherJoinSwitchIPs took %v", networkName, time.Since(phaseStart))
 
 	// Create default Control Plane Protection (COPP) entry for routers
+	phaseStart = time.Now()
 	defaultCOPPUUID, err := EnsureDefaultCOPP(oc.nbClient)
 	if err != nil {
 		return fmt.Errorf("unable to create router control plane protection: %w", err)
 	}
 	oc.defaultCOPPUUID = defaultCOPPUUID
+	klog.V(4).Infof("[init %s] EnsureDefaultCOPP took %v", networkName, time.Since(phaseStart))
 
+	phaseStart = time.Now()
 	clusterRouter, err := oc.newClusterRouter()
 	if err != nil {
-		return fmt.Errorf("failed to create OVN cluster router for network %q: %v", oc.GetNetworkName(), err)
+		return fmt.Errorf("failed to create OVN cluster router for network %q: %v", networkName, err)
 	}
+	klog.V(4).Infof("[init %s] newClusterRouter took %v", networkName, time.Since(phaseStart))
 
 	// Only configure join switch, GR, cluster port groups and multicast default policies for user defined primary networks.
 	if util.IsNetworkSegmentationSupportEnabled() && oc.IsPrimaryNetwork() {
+		phaseStart = time.Now()
 		if err := oc.gatewayTopologyFactory.NewJoinSwitch(clusterRouter, oc.GetNetInfo(), oc.ovnClusterLRPToJoinIfAddrs); err != nil {
-			return fmt.Errorf("failed to create join switch for network %q: %v", oc.GetNetworkName(), err)
+			return fmt.Errorf("failed to create join switch for network %q: %v", networkName, err)
 		}
+		klog.V(4).Infof("[init %s] NewJoinSwitch took %v", networkName, time.Since(phaseStart))
 
+		phaseStart = time.Now()
 		if err := oc.setupClusterPortGroups(); err != nil {
-			return fmt.Errorf("failed to create cluster port groups for network %q: %w", oc.GetNetworkName(), err)
+			return fmt.Errorf("failed to create cluster port groups for network %q: %w", networkName, err)
 		}
+		klog.V(4).Infof("[init %s] setupClusterPortGroups took %v", networkName, time.Since(phaseStart))
 
+		phaseStart = time.Now()
 		if err := oc.syncDefaultMulticastPolicies(); err != nil {
-			return fmt.Errorf("failed to sync default multicast policies for network %q: %w", oc.GetNetworkName(), err)
+			return fmt.Errorf("failed to sync default multicast policies for network %q: %w", networkName, err)
 		}
+		klog.V(4).Infof("[init %s] syncDefaultMulticastPolicies took %v", networkName, time.Since(phaseStart))
 	}
 
 	// FIXME: When https://github.com/ovn-kubernetes/libovsdb/issues/235 is fixed,
@@ -749,6 +789,7 @@ func (oc *Layer3UserDefinedNetworkController) init() error {
 	if _, _, err := util.RunOVNNbctl("--columns=_uuid", "list", "Load_Balancer_Group"); err != nil {
 		klog.Warningf("Load Balancer Group support enabled, however version of OVN in use does not support Load Balancer Groups.")
 	} else {
+		phaseStart = time.Now()
 		clusterLBGroupUUID, switchLBGroupUUID, routerLBGroupUUID, err := initLoadBalancerGroups(oc.nbClient, oc.GetNetInfo())
 		if err != nil {
 			return err
@@ -756,6 +797,7 @@ func (oc *Layer3UserDefinedNetworkController) init() error {
 		oc.clusterLoadBalancerGroupUUID = clusterLBGroupUUID
 		oc.switchLoadBalancerGroupUUID = switchLBGroupUUID
 		oc.routerLoadBalancerGroupUUID = routerLBGroupUUID
+		klog.V(4).Infof("[init %s] initLoadBalancerGroups took %v", networkName, time.Since(phaseStart))
 	}
 	return nil
 }

--- a/go-controller/pkg/util/pod.go
+++ b/go-controller/pkg/util/pod.go
@@ -25,16 +25,27 @@ type AllocateToPodWithRollbackFunc func(pod *corev1.Pod) (*corev1.Pod, func(), e
 func UpdatePodWithRetryOrRollback(podLister listers.PodLister, kube kube.Interface, pod *corev1.Pod, allocate AllocateToPodWithRollbackFunc) error {
 	start := time.Now()
 	var updated bool
+	var retryCount int
+	var totalGetTime, totalAllocTime, totalUpdateTime time.Duration
 
 	err := retry.RetryOnConflict(OvnConflictBackoff, func() error {
+		retryCount++
+
+		// Measure pod get time
+		t1 := time.Now()
 		pod, err := podLister.Pods(pod.Namespace).Get(pod.Name)
+		totalGetTime += time.Since(t1)
 		if err != nil {
 			return err
 		}
 
 		// Informer cache should not be mutated, so copy the object
 		pod = pod.DeepCopy()
+
+		// Measure allocation function time
+		t2 := time.Now()
 		pod, rollback, err := allocate(pod)
+		totalAllocTime += time.Since(t2)
 		if err != nil {
 			return err
 		}
@@ -44,9 +55,14 @@ func UpdatePodWithRetryOrRollback(podLister listers.PodLister, kube kube.Interfa
 		}
 
 		updated = true
+
+		// Measure API update time
+		t3 := time.Now()
 		// It is possible to update the pod annotations using status subresource
 		// because changes to metadata via status subresource are not restricted pods.
 		err = kube.UpdatePodStatus(pod)
+		totalUpdateTime += time.Since(t3)
+
 		if err != nil && rollback != nil {
 			rollback()
 		}
@@ -59,7 +75,16 @@ func UpdatePodWithRetryOrRollback(podLister listers.PodLister, kube kube.Interfa
 	}
 
 	if updated {
-		klog.Infof("[%s/%s] pod update took %v", pod.Namespace, pod.Name, time.Since(start))
+		totalTime := time.Since(start)
+		retryWaitTime := totalTime - totalGetTime - totalAllocTime - totalUpdateTime
+
+		// Log detailed timing at v=4 (same level as pod timing)
+		klog.V(4).Infof("[K8s API %s/%s] pod update took %v (attempts=%d, get=%v, alloc=%v, apiUpdate=%v, retryWait=%v)",
+			pod.Namespace, pod.Name, totalTime, retryCount,
+			totalGetTime, totalAllocTime, totalUpdateTime, retryWaitTime)
+
+		// Also keep the simple v=4 log for backward compatibility
+		klog.V(4).Infof("[%s/%s] pod update took %v", pod.Namespace, pod.Name, totalTime)
 	}
 
 	return nil

--- a/go-controller/pkg/util/timing.go
+++ b/go-controller/pkg/util/timing.go
@@ -1,0 +1,41 @@
+package util
+
+import (
+	"time"
+
+	"k8s.io/klog/v2"
+)
+
+// Timer is a simple timing helper that measures operation duration
+type Timer struct {
+	name      string
+	startTime time.Time
+	verbosity klog.Level
+}
+
+// StartTimer creates and starts a new timer for the given operation name.
+// The timer will log at the specified klog verbosity level (typically V(4) for timing info).
+func StartTimer(name string, verbosity klog.Level) *Timer {
+	return &Timer{
+		name:      name,
+		startTime: time.Now(),
+		verbosity: verbosity,
+	}
+}
+
+// End logs the elapsed time since the timer was started.
+// This should typically be called with defer, e.g.:
+//
+//	timer := util.StartTimer("myOperation", 4)
+//	defer timer.End()
+func (t *Timer) End() {
+	duration := time.Since(t.startTime)
+	klog.V(t.verbosity).Infof("Finished %s, took %v", t.name, duration)
+}
+
+// LogMilestone logs an intermediate timing checkpoint without ending the timer.
+// Useful for tracking progress within a long-running operation.
+func (t *Timer) LogMilestone(milestone string) {
+	duration := time.Since(t.startTime)
+	klog.V(t.verbosity).Infof("%s - %s (elapsed: %v)", t.name, milestone, duration)
+}


### PR DESCRIPTION
Implements two optimizations to reduce P99 pod ready latency from 154s to <60s when creating pods in UDN L2 networks after cluster manager annotation allocation:

1. Pod Annotation Update Watcher (base_secondary_layer2_network_controller.go):
   - Watches for pod annotation changes and immediately requeues pods
   - Eliminates 30-second retry delay when waiting for cluster manager
   - Reduces retry storms from 43,000+ to near-zero
   - Expected improvement: ~100 seconds reduction in P99 latency

2. Adaptive Retry Interval (obj_retry.go):
   - Uses 2-second interval for annotation waits vs 30-second for real errors
   - Tracks lastSuppressedError flag in retryObjEntry
   - Applies faster retry for transient conditions (waiting for annotations)
   - Uses normal 30s interval for actual errors (resource conflicts, etc.)
   - Expected improvement: ~25 seconds reduction in worst-case retry delay

Changes:
- Add WatchPodAnnotationUpdates() method to watch pod updates
- Add RetryObjAnnotationWaitInterval (2s) constant
- Add lastSuppressedError field to retryObjEntry struct
- Update retry logic to use adaptive intervals based on error type
- Track suppressed errors in all error handling paths (add/update/delete)

Target: P99 Pod Ready latency < 60s (from 154s baseline)
