### PR TITLE
OCPBUGS-84636, CORENET-6055: [release-4.12] Dockerfile: Unpin OVN and consume the latest from FDP

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -13,15 +13,13 @@ RUN yum install -y  \
 	yum clean all
 
 ARG ovsver=3.1
-ARG ovnver=23.06.4-26.el8fdp
+ARG ovnver=23.06
 
 RUN \
     yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False "openvswitch$ovsver" "python3-openvswitch$ovsver" && \
-    yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False "ovn23.06 = $ovnver" "ovn23.06-central = $ovnver" "ovn23.06-host = $ovnver" && \
-    yum clean all && rm -rf /var/cache/*
-
-RUN ovnver_short=$(echo "$ovnver" | cut -d'.' -f1,2) && \
-	sed 's/%/"/g' <<<"%openvswitch$ovsver-devel% %openvswitch$ovsver-ipsec% %ovn$ovnver_short-vtep = $ovnver%" > /more-pkgs
+    yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False "ovn$ovnver" "ovn$ovnver-central" "ovn$ovnver-host" && \
+    yum clean all && rm -rf /var/cache/* && \
+    sed 's/%/"/g' <<<"%openvswitch$ovsver-devel% %openvswitch$ovsver-ipsec% %ovn$ovnver-vtep%" > /more-pkgs
 
 RUN mkdir -p /var/run/openvswitch && \
     mkdir -p /var/run/ovn && \


### PR DESCRIPTION
OVN-Kubernetes is always lagging behind on the version of OVN it pins. This is causing a lot of trouble with keeping up with bug fixes and especially CVE fixes on older branches, resulting in scanners flagging this image with poor security grades and much longer time for bug fixes to be delivered to customers as the PR backporting process can take weeks or even months.

Removing the pin, so every time the new build is released in FDP, it automatically gets into versions of OpneShift that use it. There is a pre-release testing process in place between FDP and OCP QE that ensures the required test coverage before the new build is released through FDP.

This PR will allow picking up newer ones automatically as soon as they are released in the future. Major version upgrades still require a separate PR.

Note however, that this PR doesn't really change anything right now, as `23.06.4-26.el8fdp` is the latest available version.

Manual cherry pick of the change from 4.13: https://github.com/openshift/ovn-kubernetes/pull/3074