### PR TITLE
[DNM] [release-4.18] : Fix LSP deletion race when multiple NADs map to the same network during upgrade

### DIFF
--- a/go-controller/pkg/ovn/base_network_controller_user_defined.go
+++ b/go-controller/pkg/ovn/base_network_controller_user_defined.go
@@ -582,6 +582,7 @@ func (bsnc *BaseUserDefinedNetworkController) syncPodsForUserDefinedNetwork(pods
 	// get the list of logical switch ports (equivalent to pods). Reserve all existing Pod IPs to
 	// avoid subsequent new Pods getting the same duplicate Pod IP.
 	expectedLogicalPorts := make(map[string]bool)
+	hasUnregisteredNADPods := false
 	for _, podInterface := range pods {
 		pod, ok := podInterface.(*corev1.Pod)
 		if !ok {
@@ -610,6 +611,12 @@ func (bsnc *BaseUserDefinedNetworkController) syncPodsForUserDefinedNetwork(pods
 				bsnc.recordPodErrorEvent(pod, err)
 				klog.Errorf("Failed to determine if pod %s/%s needs to be plumb interface on network %s: %v",
 					pod.Namespace, pod.Name, bsnc.GetNetworkName(), err)
+			} else if bsnc.podMayReferenceNetwork(pod) {
+				// Pod's NADs may not be registered with this controller yet
+				// (race during startup when multiple NADs map to the same
+				// network). Skip stale LSP deletion to avoid removing ports
+				// for pods whose NADs haven't been synced yet.
+				hasUnregisteredNADPods = true
 			}
 			continue
 		}
@@ -652,7 +659,52 @@ func (bsnc *BaseUserDefinedNetworkController) syncPodsForUserDefinedNetwork(pods
 	// keep track of which pods might have already been released
 	bsnc.trackPodsReleasedBeforeStartup(annotatedLocalPods)
 
+	if hasUnregisteredNADPods {
+		klog.Warningf("Skipping stale LSP deletion for network %s: some pods may reference NADs not yet registered with this controller",
+			bsnc.GetNetworkName())
+		return nil
+	}
+
 	return bsnc.deleteStaleLogicalSwitchPorts(expectedLogicalPorts)
+}
+
+// podMayReferenceNetwork checks if a pod references a NAD that belongs to this
+// network but hasn't been registered with the controller yet. This can happen
+// during startup when multiple NADs map to the same network and they arrive at
+// different times (e.g. during upgrades when the cluster manager hasn't
+// annotated all NADs with network IDs yet).
+func (bsnc *BaseUserDefinedNetworkController) podMayReferenceNetwork(pod *corev1.Pod) bool {
+	if !util.PodScheduled(pod) || util.PodWantsHostNetwork(pod) {
+		return false
+	}
+	networks, err := util.GetK8sPodAllNetworkSelections(pod)
+	if err != nil {
+		return false
+	}
+	for _, network := range networks {
+		nadNamespace := network.Namespace
+		if nadNamespace == "" {
+			nadNamespace = pod.Namespace
+		}
+		nad, err := bsnc.watchFactory.GetNAD(nadNamespace, network.Name)
+		if err != nil {
+			continue
+		}
+		// Check if the NAD belongs to this network. First try the annotation
+		// (set by cluster manager), then fall back to parsing the NAD config
+		// (needed during upgrades when the annotation hasn't been set yet).
+		nadNetworkName := util.GetAnnotatedNetworkName(nad)
+		if nadNetworkName == "" {
+			nadInfo, err := util.ParseNADInfo(nad)
+			if err == nil {
+				nadNetworkName = nadInfo.GetNetworkName()
+			}
+		}
+		if nadNetworkName == bsnc.GetNetworkName() {
+			return true
+		}
+	}
+	return false
 }
 
 // addPodToNamespaceForUserDefinedNetwork returns the ops needed to add pod's IP to the namespace's address set.

--- a/go-controller/pkg/ovn/base_network_controller_user_defined_test.go
+++ b/go-controller/pkg/ovn/base_network_controller_user_defined_test.go
@@ -3,10 +3,13 @@ package ovn
 import (
 	"context"
 
+	nadapi "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+	fakenadclient "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/clientset/versioned/fake"
 	kubevirtv1 "kubevirt.io/api/core/v1"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
@@ -207,6 +210,178 @@ var _ = Describe("BaseUserDefinedNetworkController", func() {
 			},
 		}),
 	)
+	It("should not delete localnet LSPs for pods whose NADs are not yet registered", func() {
+		// This test reproduces a race condition where multiple NADs map to the same
+		// localnet network. When the network controller starts (triggered by the first
+		// NAD), syncPodsForUserDefinedNetwork only sees pods whose NADs are registered.
+		// Pods using later-arriving NADs are skipped, and their existing LSPs get
+		// deleted as stale.
+		config.OVNKubernetesFeature.EnableNetworkSegmentation = true
+		config.OVNKubernetesFeature.EnableMultiNetwork = true
+		config.OVNKubernetesFeature.EnableInterconnect = true
+
+		const (
+			networkName = "localnet1"
+			namespace   = "myvms"
+			nodeName    = "worker1"
+		)
+
+		// Create 4 ipamless localnet NADs all for the same network.
+		makeNAD := func(name string) *nadapi.NetworkAttachmentDefinition {
+			nad := ovntest.GenerateNAD(networkName, name, namespace,
+				types.LocalnetTopology, "", types.NetworkRoleSecondary)
+			ovntest.AnnotateNADWithNetworkID("1", nad)
+			if nad.Annotations == nil {
+				nad.Annotations = map[string]string{}
+			}
+			nad.Annotations[types.OvnNetworkNameAnnotation] = networkName
+			return nad
+		}
+		nad0 := makeNAD("vm0")
+		nad1 := makeNAD("vm1")
+		nad2 := makeNAD("vm2")
+		nad3 := makeNAD("vm3")
+
+		// Remove network annotations from unregistered NADs (nad1-3) to simulate
+		// the upgrade scenario where the cluster manager hasn't annotated them yet.
+		// This exercises the ParseNADInfo() fallback in trackPodsWithUnregisteredNADs.
+		for _, nad := range []*nadapi.NetworkAttachmentDefinition{nad1, nad2, nad3} {
+			delete(nad.Annotations, types.OvnNetworkNameAnnotation)
+			delete(nad.Annotations, types.OvnNetworkIDAnnotation)
+		}
+
+		// Compute localnet switch name and LSP names using the real helpers
+		nInfo, err := util.ParseNADInfo(nad0)
+		Expect(err).NotTo(HaveOccurred())
+		localnetSwitchName := nInfo.GetNetworkScopedName(types.OVNLocalnetSwitch)
+
+		// LSP names
+		lspName := func(nadNS, nadName, podNS, podName string) string {
+			return util.GetUserDefinedNetworkLogicalPortName(podNS, podName, nadNS+"/"+nadName)
+		}
+		lsp0Name := lspName(namespace, "vm0", namespace, "pod-0")
+		lsp1Name := lspName(namespace, "vm1", namespace, "pod-1")
+		lsp2Name := lspName(namespace, "vm2", namespace, "pod-2")
+		lsp3Name := lspName(namespace, "vm3", namespace, "pod-3")
+
+		// Pre-populate OVN DB with all 4 LSPs on the localnet switch
+		lsp0 := &nbdb.LogicalSwitchPort{UUID: "lsp0-UUID", Name: lsp0Name, ExternalIDs: map[string]string{"pod": "true", "namespace": namespace}}
+		lsp1 := &nbdb.LogicalSwitchPort{UUID: "lsp1-UUID", Name: lsp1Name, ExternalIDs: map[string]string{"pod": "true", "namespace": namespace}}
+		lsp2 := &nbdb.LogicalSwitchPort{UUID: "lsp2-UUID", Name: lsp2Name, ExternalIDs: map[string]string{"pod": "true", "namespace": namespace}}
+		lsp3 := &nbdb.LogicalSwitchPort{UUID: "lsp3-UUID", Name: lsp3Name, ExternalIDs: map[string]string{"pod": "true", "namespace": namespace}}
+
+		localnetSwitch := &nbdb.LogicalSwitch{
+			UUID:  localnetSwitchName + "-UUID",
+			Name:  localnetSwitchName,
+			Ports: []string{lsp0.UUID, lsp1.UUID, lsp2.UUID, lsp3.UUID},
+		}
+
+		initialDB := libovsdbtest.TestSetup{
+			NBData: []libovsdbtest.TestData{localnetSwitch, lsp0, lsp1, lsp2, lsp3},
+		}
+
+		fakeOVN := NewFakeOVN(false)
+		fakeOVN.startWithDBSetup(
+			initialDB,
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}},
+			&corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: nodeName,
+					Labels: map[string]string{
+						"kubernetes.io/hostname": nodeName,
+					},
+					Annotations: map[string]string{
+						"k8s.ovn.org/zone":        nodeName,
+						"k8s.ovn.org/network-ids": `{"localnet1": "1"}`,
+					},
+				},
+			},
+			// Add only nad0 via the standard mechanism
+			&nadapi.NetworkAttachmentDefinitionList{Items: []nadapi.NetworkAttachmentDefinition{*nad0}},
+		)
+		defer fakeOVN.shutdown()
+
+		// Add nad1-3 directly to the watch factory's NAD informer cache.
+		// They exist in the API server but the NAD controller hasn't registered
+		// them with the network controller yet (simulating the race).
+		for _, nad := range []*nadapi.NetworkAttachmentDefinition{nad1, nad2, nad3} {
+			_, err = fakeOVN.watcher.GetNAD(nad.Namespace, nad.Name)
+			if err != nil {
+				nadCopy := nad.DeepCopy()
+				tracker := fakeOVN.fakeClient.NetworkAttchDefClient.(*fakenadclient.Clientset).Tracker()
+				Expect(tracker.Create(schema.GroupVersionResource{
+					Group: "k8s.cni.cncf.io", Version: "v1", Resource: "network-attachment-definitions",
+				}, nadCopy, nadCopy.Namespace)).To(Succeed())
+			}
+		}
+		// Wait for the informer to pick up the NADs
+		Eventually(func() error {
+			for _, nad := range []*nadapi.NetworkAttachmentDefinition{nad1, nad2, nad3} {
+				_, err := fakeOVN.watcher.GetNAD(nad.Namespace, nad.Name)
+				if err != nil {
+					return err
+				}
+			}
+			return nil
+		}).Should(Succeed())
+
+		// Register ONLY the first NAD (vm0) with the controller.
+		Expect(fakeOVN.NewUserDefinedNetworkController(nad0)).To(Succeed())
+		controller, ok := fakeOVN.userDefinedNetworkControllers[networkName]
+		Expect(ok).To(BeTrue())
+
+		By("verifying only vm0 NAD is registered")
+		Expect(controller.bnc.HasNAD(namespace + "/vm0")).To(BeTrue())
+		Expect(controller.bnc.HasNAD(namespace + "/vm1")).To(BeFalse())
+		Expect(controller.bnc.HasNAD(namespace + "/vm2")).To(BeFalse())
+		Expect(controller.bnc.HasNAD(namespace + "/vm3")).To(BeFalse())
+
+		By("building pod list with all 4 pods referencing their respective NADs")
+		makePod := func(name, nadName string) *corev1.Pod {
+			nadKey := namespace + "/" + nadName
+			return &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      name,
+					Annotations: map[string]string{
+						"k8s.v1.cni.cncf.io/networks": `[{"name":"` + nadName + `"}]`,
+						"k8s.ovn.org/pod-networks":    `{"` + nadKey + `":{"mac_address":"0a:58:01:02:03:04","role":"secondary"}}`,
+					},
+				},
+				Spec:   corev1.PodSpec{NodeName: nodeName},
+				Status: corev1.PodStatus{Phase: corev1.PodRunning},
+			}
+		}
+		podList := []interface{}{
+			makePod("pod-0", "vm0"),
+			makePod("pod-1", "vm1"),
+			makePod("pod-2", "vm2"),
+			makePod("pod-3", "vm3"),
+		}
+
+		By("calling syncPodsForUserDefinedNetwork (this is where the race manifests)")
+		err = controller.bnc.syncPodsForUserDefinedNetwork(podList)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("checking how many LSPs remain on the localnet switch")
+		obtainedSwitches := []*nbdb.LogicalSwitch{}
+		Expect(fakeOVN.nbClient.List(context.Background(), &obtainedSwitches)).To(Succeed())
+
+		var localnetSW *nbdb.LogicalSwitch
+		for _, sw := range obtainedSwitches {
+			if sw.Name == localnetSwitchName {
+				localnetSW = sw
+				break
+			}
+		}
+		Expect(localnetSW).NotTo(BeNil(), "localnet switch should exist")
+
+		// With the fix, all 4 LSPs should be preserved because the sync function
+		// skips stale LSP deletion when it detects pods referencing unregistered NADs.
+		Expect(localnetSW.Ports).To(HaveLen(4),
+			"all 4 localnet LSPs should be preserved when multiple NADs map to the same network")
+	})
+
 	It("should not fail to sync pods if namespace is gone", func() {
 		config.OVNKubernetesFeature.EnableNetworkSegmentation = true
 		config.OVNKubernetesFeature.EnableMultiNetwork = true

--- a/test/e2e/network_segmentation_localnet.go
+++ b/test/e2e/network_segmentation_localnet.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/rand"
 
 	nadapi "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+	nadclient "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/clientset/versioned/typed/k8s.cni.cncf.io/v1"
 
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2ekubectl "k8s.io/kubernetes/test/e2e/framework/kubectl"
@@ -281,6 +282,237 @@ var _ = Describe("Network Segmentation: Localnet", func() {
 		Expect(err).NotTo(HaveOccurred())
 		_, hasAnnotation := pod.Annotations["k8s.ovn.org/pod-networks"]
 		Expect(hasAnnotation).To(BeTrue(), "pod should still have network annotation")
+	})
+
+	It("should preserve LSPs for IPAM-less localnet pods with multiple NADs after simulated upgrade", func() {
+		const (
+			vlan    = 203
+			numNADs = 4
+		)
+		var (
+			ovsBrName           = "ovsbr-upgrade"
+			networkName         = uniqueMetaName("localnet-upgrade")
+			physicalNetworkName = uniqueMetaName("physnet-upgrade")
+		)
+
+		nadClient, err := nadclient.NewForConfig(f.ClientConfig())
+		Expect(err).NotTo(HaveOccurred())
+
+		By("setup the localnet underlay")
+		Expect(providerCtx.SetupUnderlay(f, infraapi.Underlay{
+			BridgeName:         ovsBrName,
+			LogicalNetworkName: physicalNetworkName,
+			VlanID:             vlan,
+		})).To(Succeed())
+
+		By("create test namespace")
+		namespace, err := f.CreateNamespace(context.TODO(), f.BaseName, map[string]string{
+			"e2e-framework": f.BaseName,
+		})
+		f.Namespace = namespace
+		Expect(err).NotTo(HaveOccurred())
+		nsName := namespace.Name
+
+		By(fmt.Sprintf("create %d IPAM-less localnet NADs sharing network %s", numNADs, networkName))
+		type podInfo struct {
+			nadName string
+			podName string
+		}
+		var pods []podInfo
+		for i := 0; i < numNADs; i++ {
+			nadName := fmt.Sprintf("vm%d", i)
+			nad := generateNetAttachDef(nsName, nadName, fmt.Sprintf(`
+{
+	"cniVersion": "0.3.1",
+	"name": %q,
+	"type": "ovn-k8s-cni-overlay",
+	"topology": "localnet",
+	"physicalNetworkName": %q,
+	"netAttachDefName": "%s/%s",
+	"vlanID": %d,
+	"role": "secondary"
+}`, networkName, physicalNetworkName, nsName, nadName, vlan))
+			_, err := nadClient.NetworkAttachmentDefinitions(nsName).Create(context.Background(), nad, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			pods = append(pods, podInfo{nadName: nadName, podName: fmt.Sprintf("pod-%d", i)})
+		}
+		DeferCleanup(func() {
+			for _, p := range pods {
+				_ = nadClient.NetworkAttachmentDefinitions(nsName).Delete(context.Background(), p.nadName, metav1.DeleteOptions{})
+			}
+		})
+
+		By("pick a target worker node")
+		workerNodes, err := f.ClientSet.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		var nodeName string
+		for _, node := range workerNodes.Items {
+			if _, isCP := node.Labels["node-role.kubernetes.io/control-plane"]; !isCP {
+				nodeName = node.Name
+				break
+			}
+		}
+		if nodeName == "" {
+			// schedulable control plane (e.g. 3-node cluster)
+			nodeName = workerNodes.Items[0].Name
+		}
+		framework.Logf("Target node: %s", nodeName)
+
+		By("create pods pinned to the target node")
+		for _, p := range pods {
+			podCfg := podConfiguration{
+				name:         p.podName,
+				namespace:    nsName,
+				attachments:  []nadapi.NetworkSelectionElement{{Name: p.nadName}},
+				nodeSelector: map[string]string{"kubernetes.io/hostname": nodeName},
+			}
+			_, err := f.ClientSet.CoreV1().Pods(nsName).Create(context.Background(), generatePodSpec(podCfg), metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+		}
+
+		By("wait for all pods to be running")
+		for _, p := range pods {
+			Expect(e2epod.WaitForPodNameRunningInNamespace(context.Background(), f.ClientSet, p.podName, nsName)).To(Succeed())
+		}
+
+		ovnNamespace := deploymentconfig.Get().OVNKubernetesNamespace()
+
+		By("verify all localnet LSPs exist before simulated upgrade and capture UUIDs")
+		ovnkubeNodePods, err := f.ClientSet.CoreV1().Pods(ovnNamespace).List(context.Background(), metav1.ListOptions{
+			LabelSelector: "app=ovnkube-node",
+			FieldSelector: fmt.Sprintf("spec.nodeName=%s", nodeName),
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ovnkubeNodePods.Items).NotTo(BeEmpty())
+		ovnkubeNodePod := ovnkubeNodePods.Items[0]
+
+		lspUUIDs := map[string]string{}
+		for _, p := range pods {
+			nadFullName := fmt.Sprintf("%s/%s", nsName, p.nadName)
+			nadNameWithDots := strings.ReplaceAll(strings.ReplaceAll(nadFullName, "-", "."), "/", ".")
+			lspName := fmt.Sprintf("%s_%s_%s", nadNameWithDots, nsName, p.podName)
+			stdout, stderr, err := ExecCommandInContainerWithFullOutput(f, ovnNamespace, ovnkubeNodePod.Name, "nb-ovsdb",
+				"ovn-nbctl", "get", "logical-switch-port", lspName, "_uuid")
+			Expect(err).ToNot(HaveOccurred(), "LSP %s should exist before upgrade simulation, stderr: %s", lspName, stderr)
+			Expect(stdout).ToNot(BeEmpty())
+			lspUUIDs[lspName] = strings.TrimSpace(stdout)
+			framework.Logf("Found LSP %s (UUID %s) for pod %s", lspName, lspUUIDs[lspName], p.podName)
+		}
+
+		By("simulate upgrade: scale down ovnkube-control-plane")
+		cpDeploy, err := f.ClientSet.AppsV1().Deployments(ovnNamespace).Get(context.Background(), "ovnkube-control-plane", metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		originalReplicas := *cpDeploy.Spec.Replicas
+		zero := int32(0)
+		cpDeploy.Spec.Replicas = &zero
+		_, err = f.ClientSet.AppsV1().Deployments(ovnNamespace).Update(context.Background(), cpDeploy, metav1.UpdateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func() {
+			By("restore ovnkube-control-plane replicas")
+			cpDeploy, err := f.ClientSet.AppsV1().Deployments(ovnNamespace).Get(context.Background(), "ovnkube-control-plane", metav1.GetOptions{})
+			if err == nil {
+				cpDeploy.Spec.Replicas = &originalReplicas
+				_, _ = f.ClientSet.AppsV1().Deployments(ovnNamespace).Update(context.Background(), cpDeploy, metav1.UpdateOptions{})
+			}
+		})
+
+		By("wait for control plane pods to terminate")
+		Eventually(func() int {
+			cpPods, err := f.ClientSet.CoreV1().Pods(ovnNamespace).List(context.Background(), metav1.ListOptions{
+				LabelSelector: "app=ovnkube-control-plane",
+			})
+			if err != nil {
+				return -1
+			}
+			return len(cpPods.Items)
+		}).WithTimeout(60*time.Second).WithPolling(2*time.Second).Should(Equal(0), "control plane pods should be gone")
+
+		By("remove network-id and network-name annotations from NADs (simulates pre-upgrade state)")
+		for _, p := range pods {
+			nad, err := nadClient.NetworkAttachmentDefinitions(nsName).Get(context.Background(), p.nadName, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			delete(nad.Annotations, "k8s.ovn.org/network-id")
+			delete(nad.Annotations, "k8s.ovn.org/network-name")
+			_, err = nadClient.NetworkAttachmentDefinitions(nsName).Update(context.Background(), nad, metav1.UpdateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+		}
+
+		By("restart ovnkube-node on target node (without control plane)")
+		err = restartOVNKubeNodePod(f.ClientSet, ovnNamespace, nodeName)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("wait for new ovnkube-node to be ready and hit the deferral path")
+		Eventually(func() bool {
+			pods, err := f.ClientSet.CoreV1().Pods(ovnNamespace).List(context.Background(), metav1.ListOptions{
+				LabelSelector: "app=ovnkube-node",
+				FieldSelector: fmt.Sprintf("spec.nodeName=%s", nodeName),
+			})
+			if err != nil || len(pods.Items) == 0 {
+				return false
+			}
+			for _, c := range pods.Items[0].Status.Conditions {
+				if c.Type == corev1.PodReady && c.Status == corev1.ConditionTrue {
+					return true
+				}
+			}
+			return false
+		}).WithTimeout(3*time.Minute).WithPolling(5*time.Second).Should(BeTrue(), "ovnkube-node should be ready")
+
+		By("scale control plane back up (triggers network ID allocation and controller start)")
+		cpDeploy, err = f.ClientSet.AppsV1().Deployments(ovnNamespace).Get(context.Background(), "ovnkube-control-plane", metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		cpDeploy.Spec.Replicas = &originalReplicas
+		_, err = f.ClientSet.AppsV1().Deployments(ovnNamespace).Update(context.Background(), cpDeploy, metav1.UpdateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("wait for control plane to be available")
+		Eventually(func() bool {
+			deploy, err := f.ClientSet.AppsV1().Deployments(ovnNamespace).Get(context.Background(), "ovnkube-control-plane", metav1.GetOptions{})
+			if err != nil {
+				return false
+			}
+			return deploy.Status.AvailableReplicas == *deploy.Spec.Replicas
+		}).WithTimeout(3*time.Minute).WithPolling(5*time.Second).Should(BeTrue(), "control plane should be available")
+
+		By("wait for NAD annotations to be restored by cluster manager")
+		Eventually(func() bool {
+			for _, p := range pods {
+				nad, err := nadClient.NetworkAttachmentDefinitions(nsName).Get(context.Background(), p.nadName, metav1.GetOptions{})
+				if err != nil {
+					return false
+				}
+				if nad.Annotations["k8s.ovn.org/network-id"] == "" {
+					return false
+				}
+			}
+			return true
+		}).WithTimeout(2*time.Minute).WithPolling(5*time.Second).Should(BeTrue(), "NADs should have network-id annotation restored")
+
+		By("find new ovnkube-node pod")
+		ovnkubeNodePods, err = f.ClientSet.CoreV1().Pods(ovnNamespace).List(context.Background(), metav1.ListOptions{
+			LabelSelector: "app=ovnkube-node",
+			FieldSelector: fmt.Sprintf("spec.nodeName=%s", nodeName),
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ovnkubeNodePods.Items).NotTo(BeEmpty())
+		ovnkubeNodePod = ovnkubeNodePods.Items[0]
+
+		By("verify ALL localnet LSPs are preserved with same UUIDs after simulated upgrade")
+		for _, p := range pods {
+			nadFullName := fmt.Sprintf("%s/%s", nsName, p.nadName)
+			nadNameWithDots := strings.ReplaceAll(strings.ReplaceAll(nadFullName, "-", "."), "/", ".")
+			lspName := fmt.Sprintf("%s_%s_%s", nadNameWithDots, nsName, p.podName)
+			framework.Logf("Checking LSP %s for pod %s (NAD %s)", lspName, p.podName, p.nadName)
+			stdout, stderr, err := ExecCommandInContainerWithFullOutput(f, ovnNamespace, ovnkubeNodePod.Name, "nb-ovsdb",
+				"ovn-nbctl", "get", "logical-switch-port", lspName, "_uuid")
+			Expect(err).ToNot(HaveOccurred(),
+				"LSP %s for pod %s (NAD %s) should be preserved after simulated upgrade, stderr: %s",
+				lspName, p.podName, p.nadName, stderr)
+			currentUUID := strings.TrimSpace(stdout)
+			Expect(currentUUID).To(Equal(lspUUIDs[lspName]),
+				"LSP %s for pod %s (NAD %s) UUID changed from %s to %s — LSP was deleted and recreated instead of being preserved",
+				lspName, p.podName, p.nadName, lspUUIDs[lspName], currentUUID)
+		}
 	})
 })
 


### PR DESCRIPTION
## Description

Backport of https://github.com/ovn-kubernetes/ovn-kubernetes/pull/6137 to release-4.18.

During 4.17→4.18 upgrades, NADs lack `k8s.ovn.org/network-id` annotation until the cluster manager allocates it. When ovnkube-node restarts and multiple NADs reference the same network, only the first NAD triggers the controller start. Pods using the remaining NADs fail `HasNAD()` and their LSPs are deleted as stale.

Fix: when `syncPodsForUserDefinedNetwork` detects pods that may reference unregistered NADs (by looking up the NAD from the informer cache and checking the network name via annotation or CNI config parsing), skip stale LSP deletion entirely. The next sync after all NADs are registered will handle cleanup properly.

Fixes: https://issues.redhat.com/browse/OCPBUGS-78777