### PR TITLE
CORENET-6105: [OTE] Add automatic filtering for Feature:NoOverlay tests

### DIFF
--- a/openshift/cmd/ovn-kubernetes-tests-ext/main.go
+++ b/openshift/cmd/ovn-kubernetes-tests-ext/main.go
@@ -6,8 +6,13 @@ import (
 
 	"github.com/ovn-kubernetes/ovn-kubernetes/openshift/test"
 	"github.com/ovn-kubernetes/ovn-kubernetes/openshift/test/generated"
+
 	// import ovn-kubernetes tests
+	ocpdeploymentconfig "github.com/ovn-kubernetes/ovn-kubernetes/openshift/test/deploymentconfig"
+	ocpinfraprovider "github.com/ovn-kubernetes/ovn-kubernetes/openshift/test/infraprovider"
 	_ "github.com/ovn-kubernetes/ovn-kubernetes/test/e2e"
+	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/deploymentconfig"
+	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/infraprovider"
 
 	"github.com/openshift-eng/openshift-tests-extension/pkg/cmd"
 	"github.com/openshift-eng/openshift-tests-extension/pkg/extension"
@@ -26,6 +31,35 @@ import (
 	// ensure that logging flags are part of the command line.
 	_ "k8s.io/component-base/logs/testinit"
 )
+
+const (
+	// Feature labels used for test categorization and filtering
+	featureLabelEVPN                = "Feature:EVPN"
+	featureLabelNetworkSegmentation = "Feature:NetworkSegmentation"
+)
+
+// shouldIncludeTest determines if a test should be included based on cluster capabilities
+// and test labels.
+func shouldIncludeTest(spec *extensiontests.ExtensionTestSpec) bool {
+	// Exclude explicitly disabled tests
+	if strings.Contains(spec.Name, "[Disabled:") {
+		return false
+	}
+
+	// EVPN tests: only include if EVPN is enabled in the cluster
+	evpnEnabled := os.Getenv(ocpinfraprovider.EnvVarEVPNFeatureEnabled) == "true"
+	if !evpnEnabled && spec.Labels.Has(featureLabelEVPN) {
+		return false
+	}
+
+	// Future feature-based filters can be added here
+	// Example:
+	// if !someFeatureEnabled && spec.Labels.Has(featureLabelSomeFeature) {
+	//     return false
+	// }
+
+	return true
+}
 
 func loadBlockingTests() map[string]bool {
 	blockingTests := make(map[string]bool)
@@ -63,10 +97,30 @@ func main() {
 		panic(err)
 	}
 
+	kubeConfig, err := getKubeConfig()
+	if err != nil {
+		panic(err)
+	}
+
+	// Initialize test framework first.
+	if err := initializeTestFramework(kubeConfig, os.Getenv("TEST_PROVIDER")); err != nil {
+		panic(err)
+	}
+	ocpInfra, err := ocpinfraprovider.New(kubeConfig)
+	if err != nil {
+		panic(err)
+	}
+	err = ocpInfra.LoadTestConfigs()
+	if err != nil {
+		panic(err)
+	}
+	infraprovider.Set(ocpInfra)
+	deploymentconfig.Set(ocpdeploymentconfig.New())
+
 	// Initialization for kube ginkgo test framework needs to run before all tests execute
 	specs.AddBeforeAll(func() {
-		if err := initializeTestFramework(os.Getenv("TEST_PROVIDER")); err != nil {
-			panic(err)
+		if initErr := ocpInfra.InitProvider(); initErr != nil {
+			panic(initErr)
 		}
 	})
 
@@ -79,7 +133,7 @@ func main() {
 
 		// Exclude Network Segmentation tests on SingleReplica topology (e.g., MicroShift, SNO)
 		// These tests require at least 2 nodes and will fail on single-node deployments
-		if spec.Labels.Has("Feature:NetworkSegmentation") {
+		if spec.Labels.Has(featureLabelNetworkSegmentation) {
 			spec.Exclude(extensiontests.TopologyEquals("SingleReplica"))
 		}
 
@@ -93,9 +147,7 @@ func main() {
 		}
 	})
 
-	specs = specs.Select(func(spec *extensiontests.ExtensionTestSpec) bool {
-		return !strings.Contains(spec.Name, "[Disabled:")
-	})
+	specs = specs.Select(shouldIncludeTest)
 
 	ovnTestsExtension.AddSpecs(specs)
 	extensionRegistry.Register(ovnTestsExtension)

--- a/openshift/cmd/ovn-kubernetes-tests-ext/main.go
+++ b/openshift/cmd/ovn-kubernetes-tests-ext/main.go
@@ -36,6 +36,7 @@ const (
 	// Feature labels used for test categorization and filtering
 	featureLabelEVPN                = "Feature:EVPN"
 	featureLabelNetworkSegmentation = "Feature:NetworkSegmentation"
+	featureLabelNoOverlay           = "Feature:NoOverlay"
 )
 
 // shouldIncludeTest determines if a test should be included based on cluster capabilities
@@ -52,11 +53,11 @@ func shouldIncludeTest(spec *extensiontests.ExtensionTestSpec) bool {
 		return false
 	}
 
-	// Future feature-based filters can be added here
-	// Example:
-	// if !someFeatureEnabled && spec.Labels.Has(featureLabelSomeFeature) {
-	//     return false
-	// }
+	// No-Overlay tests: only include if no-overlay is enabled in the cluster
+	noOverlayEnabled := os.Getenv(ocpinfraprovider.EnvVarNoOverlayEnabled) == "true"
+	if !noOverlayEnabled && spec.Labels.Has(featureLabelNoOverlay) {
+		return false
+	}
 
 	return true
 }

--- a/openshift/cmd/ovn-kubernetes-tests-ext/provider.go
+++ b/openshift/cmd/ovn-kubernetes-tests-ext/provider.go
@@ -9,24 +9,18 @@ import (
 	"strings"
 
 	ocphacke2e "github.com/ovn-kubernetes/ovn-kubernetes/openshift/test"
-	ocpdeploymentconfig "github.com/ovn-kubernetes/ovn-kubernetes/openshift/test/deploymentconfig"
-	ocpinfraprovider "github.com/ovn-kubernetes/ovn-kubernetes/openshift/test/infraprovider"
-	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/deploymentconfig"
-	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/infraprovider"
 
-	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/ginkgo/v2/reporters"
-	"github.com/onsi/ginkgo/v2/types"
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	kclientset "k8s.io/client-go/kubernetes"
+	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/kubernetes/test/e2e/framework"
 )
 
 // partially copied from https://github.com/openshift/origin/blob/17371a2c6a91e0426045fdd0ab3455c5b457622a/pkg/test/extensions/binary.go
 // and https://github.com/openshift/origin/blob/e0a2fbc82ac1f97dc4fa84a00ed5739c94366926/pkg/clioptions/clusterdiscovery/provider.go
-func initializeTestFramework(provider string) error {
+func initializeTestFramework(cfg *restclient.Config, provider string) error {
 	if len(provider) == 0 {
 		provider = "{\"type\":\"skeleton\"}"
 	}
@@ -72,47 +66,24 @@ func initializeTestFramework(provider string) error {
 	// (There is no option for "rhel" or "centos".)
 	testContext.NodeOSDistro = "custom"
 	testContext.MasterOSDistro = "custom"
-	// load and set the host variable for kubectl
-	clientConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(&clientcmd.ClientConfigLoadingRules{ExplicitPath: testContext.KubeConfig}, &clientcmd.ConfigOverrides{})
-	cfg, err := clientConfig.ClientConfig()
-	if err != nil {
-		return fmt.Errorf("failed to get client config: %v", err)
-	}
+	// set the host variable for kubectl
 	testContext.Host = cfg.Host
 	testContext.CreateTestingNS = func(ctx context.Context, baseName string, c kclientset.Interface, labels map[string]string) (*corev1.Namespace, error) {
 		return ocphacke2e.CreateTestingNS(ctx, baseName, c, labels, true)
 	}
 	testContext.DumpLogsOnFailure = true
 	testContext.ReportDir = os.Getenv("TEST_JUNIT_DIR")
-	ocpInfra, err := ocpinfraprovider.New(cfg)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-	gomega.Expect(ocpInfra).NotTo(gomega.BeNil())
-	infraprovider.Set(ocpInfra)
-	ocpDeployment := ocpdeploymentconfig.New()
-	gomega.Expect(ocpDeployment).NotTo(gomega.BeNil())
-	deploymentconfig.Set(ocpDeployment)
 	return nil
 }
 
-// WriteJUnitReport generates a JUnit file that is shorter than the one
-// normally written by `ginkgo --junit-report`. This is needed because the full
-// report can become too large for tools like Spyglass
-// (https://github.com/kubernetes/kubernetes/issues/111510).
-func writeJUnitReport(report ginkgo.Report, filename string) error {
-	config := reporters.JunitReportConfig{
-		// Remove details for specs where we don't care.
-		OmitTimelinesForSpecState: types.SpecStatePassed | types.SpecStateSkipped,
-
-		// Don't write <failure message="summary">. The same text is
-		// also in the full text for the failure. If we were to write
-		// both, then tools like kettle and spyglass would concatenate
-		// the two strings and thus show duplicated information.
-		OmitFailureMessageAttr: true,
-
-		// All labels are also part of the spec texts in inline [] tags,
-		// so we don't need to write them separately.
-		OmitSpecLabels: true,
+func getKubeConfig() (*restclient.Config, error) {
+	kubeConfig := os.Getenv("KUBECONFIG")
+	if kubeConfig == "" {
+		return nil, fmt.Errorf("KUBECONFIG env variable not set")
 	}
-
-	return reporters.GenerateJUnitReportWithConfig(report, filename, config)
+	if _, err := os.Stat(kubeConfig); err != nil {
+		return nil, fmt.Errorf("KUBECONFIG file %q not accessible: %w", kubeConfig, err)
+	}
+	clientConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(&clientcmd.ClientConfigLoadingRules{ExplicitPath: kubeConfig}, &clientcmd.ConfigOverrides{})
+	return clientConfig.ClientConfig()
 }

--- a/openshift/go.mod
+++ b/openshift/go.mod
@@ -8,7 +8,8 @@ require (
 	github.com/onsi/ginkgo/v2 v2.27.2
 	github.com/onsi/gomega v1.38.2
 	github.com/openshift-eng/openshift-tests-extension v0.0.0-20260127124016-0fed2b824818
-	github.com/openshift/api v0.0.0-20260311143357-f6ee4c095675
+	github.com/openshift/api v0.0.0-20260330162214-96f1f5ac7ff2
+	github.com/openshift/client-go v0.0.0-20260330134249-7e1499aaacd7
 	github.com/ovn-kubernetes/ovn-kubernetes/go-controller v1.0.0
 	github.com/ovn-kubernetes/ovn-kubernetes/test/e2e v0.0.0-00010101000000-000000000000
 	github.com/spf13/cobra v1.10.0
@@ -123,7 +124,6 @@ require (
 	github.com/opencontainers/runtime-spec v1.2.1 // indirect
 	github.com/opencontainers/selinux v1.13.0 // indirect
 	github.com/openshift-kni/k8sreporter v1.0.6 // indirect
-	github.com/openshift/client-go v0.0.0-20260306160707-3935d929fc7d // indirect
 	github.com/openshift/custom-resource-status v1.1.2 // indirect
 	github.com/openshift/library-go v0.0.0-20260303171201-5d9eb6295ff6 // indirect
 	github.com/pkg/errors v0.9.1 // indirect

--- a/openshift/go.sum
+++ b/openshift/go.sum
@@ -400,8 +400,12 @@ github.com/openshift-kni/k8sreporter v1.0.6 h1:aaxDzZx3s9bo1I3nopR63RGVZxcJgR94j
 github.com/openshift-kni/k8sreporter v1.0.6/go.mod h1:tX6LOg0m0oXje7WNLFo8LKHC9Ix8VV0a7vUc6eyeFBQ=
 github.com/openshift/api v0.0.0-20260311143357-f6ee4c095675 h1:5yWWatBRhf5p1t0B+UGgWIAMNkz/YeoXyHqW6qm2GK0=
 github.com/openshift/api v0.0.0-20260311143357-f6ee4c095675/go.mod h1:pyVjK0nZ4sRs4fuQVQ4rubsJdahI1PB94LnQ8sGdvxo=
+github.com/openshift/api v0.0.0-20260330162214-96f1f5ac7ff2 h1:q89bR1UvKEH9kNh9me1oqLYszKuhaeghorpkO3+DNwY=
+github.com/openshift/api v0.0.0-20260330162214-96f1f5ac7ff2/go.mod h1:pyVjK0nZ4sRs4fuQVQ4rubsJdahI1PB94LnQ8sGdvxo=
 github.com/openshift/client-go v0.0.0-20260306160707-3935d929fc7d h1:T+9HFgEEcnu1TDDfsO5JcJC6N0/Kzob5AtG9IpITHJ8=
 github.com/openshift/client-go v0.0.0-20260306160707-3935d929fc7d/go.mod h1:tIA3XSb/WsC/Fg0YNRfs/JrMrloBKPGF+NKVutd7nMI=
+github.com/openshift/client-go v0.0.0-20260330134249-7e1499aaacd7 h1:5GSoQlywIwYsRCw3qN+ZDmN6HrXTMZfI33bdRNm2jRQ=
+github.com/openshift/client-go v0.0.0-20260330134249-7e1499aaacd7/go.mod h1:HhXTUIMhgzxR3Ln/zEkr4QjTL0NN7A+t9Py/we9j2ug=
 github.com/openshift/custom-resource-status v1.1.2 h1:C3DL44LEbvlbItfd8mT5jWrqPfHnSOQoQf/sypqA6A4=
 github.com/openshift/custom-resource-status v1.1.2/go.mod h1:DB/Mf2oTeiAmVVX1gN+NEqweonAPY0TKUwADizj8+ZA=
 github.com/openshift/kubernetes v1.30.1-0.20260313023409-2034d92b4a3a h1:YMcmbHtdDnBHU8AnbESirN5o4phdKH3htyncsldvo/g=

--- a/openshift/test/annotate/rules.go
+++ b/openshift/test/annotate/rules.go
@@ -28,7 +28,7 @@ var (
 			`[Feature:NodeIPMACMigration]`,
 			`[Feature:OVSCPUPin]`,
 			`[Feature:Unidle]`,
-			`[Feature:RouteAdvertisements]`,
+			`[Feature:NoOverlay]`,
 		},
 	}
 	// if a test name partially or fully contains one of the map value strings, then add the label to the test
@@ -92,6 +92,21 @@ var (
 			// TODO: Fix flakiness in this test. Pod connectivity checks may need
 			// to be wrapped in an Eventually block.
 			"perform east/west traffic between nodes following OVN Kube node pod restart",
+			// TODO: this test perma failing panicing at ipalloc.(*primaryIPAllocator).AllocateNextV4.
+			// Fix it later.
+			"integration should recover ovnkube pods after restart with primary and secondary UDN resources",
+			// Disable BGP and VRF Lite tests.
+			"VRF-Lite",
+			"BGP: When default podNetwork is advertised",
+			"BGP: Pod to external server when CUDN network is advertised",
+			"BGP: isolation between advertised networks",
+			// Disable EVPN isolation test with other CUDN advertised network because
+			// it doesn't have required FRR configuration yet.
+			"When there is other network Of type Layer 3 CUDN advertised",
+			"When there is other network Of type Layer 2 CUDN advertised",
+			// These tests need bgpServerNetwork "bgpnet" which is not configured
+			// for downstream tests, so disable it.
+			"It cannot reach an external server on a different network",
 		},
 		// tests that rely on special configuration that we do not yet support
 		"[Disabled:SpecialConfig]": {},

--- a/openshift/test/generated/zz_generated.annotations.go
+++ b/openshift/test/generated/zz_generated.annotations.go
@@ -53,425 +53,315 @@ var AppendedAnnotations = map[string]string{
 
 	"ACL Logging for NetworkPolicy when the namespace's ACL logging annotation is updated the ACL logs are updated accordingly": "[Disabled:Unimplemented]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network Can reach KAPI service": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 2 CUDN EVPN MAC-VRF When a pod runs on the tested network Can reach KAPI service": "[Suite:openshift/conformance/parallel]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network It can be reached by an external server on the same network When the network is IPv4": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 2 CUDN EVPN MAC-VRF When a pod runs on the tested network It can be reached by an external server on the same network When the network is IPv4": "[Suite:openshift/conformance/parallel]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network It can be reached by an external server on the same network When the network is IPv6": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 2 CUDN EVPN MAC-VRF When a pod runs on the tested network It can be reached by an external server on the same network When the network is IPv6": "[Suite:openshift/conformance/parallel]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network It can reach an external server on the same network When the network is IPv4": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 2 CUDN EVPN MAC-VRF When a pod runs on the tested network It can reach external servers on the same network When the network is IPv4": "[Suite:openshift/conformance/parallel]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network It can reach an external server on the same network When the network is IPv6": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 2 CUDN EVPN MAC-VRF When a pod runs on the tested network It can reach external servers on the same network When the network is IPv6": "[Suite:openshift/conformance/parallel]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network It cannot be reached by a cluster node When it is a different node When the network is IPv4": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 2 CUDN EVPN MAC-VRF When a pod runs on the tested network It cannot be reached by a cluster node When it is a different node When the network is IPv4": "[Suite:openshift/conformance/parallel]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network It cannot be reached by a cluster node When it is a different node When the network is IPv6": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 2 CUDN EVPN MAC-VRF When a pod runs on the tested network It cannot be reached by a cluster node When it is a different node When the network is IPv6": "[Suite:openshift/conformance/parallel]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network It cannot be reached by a cluster node When it is the same node When the network is IPv4": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 2 CUDN EVPN MAC-VRF When a pod runs on the tested network It cannot be reached by a cluster node When it is the same node When the network is IPv4": "[Suite:openshift/conformance/parallel]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network It cannot be reached by a cluster node When it is the same node When the network is IPv6": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 2 CUDN EVPN MAC-VRF When a pod runs on the tested network It cannot be reached by a cluster node When it is the same node When the network is IPv6": "[Suite:openshift/conformance/parallel]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network It cannot be reached by an external server on a different network When the network is IPv4": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 2 CUDN EVPN MAC-VRF When a pod runs on the tested network It cannot be reached by an external server on a different network When the network is IPv4": "[Suite:openshift/conformance/parallel]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network It cannot be reached by an external server on a different network When the network is IPv6": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 2 CUDN EVPN MAC-VRF When a pod runs on the tested network It cannot be reached by an external server on a different network When the network is IPv6": "[Suite:openshift/conformance/parallel]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network It cannot reach an external server on a different network When the network is IPv4": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 2 CUDN EVPN MAC-VRF When a pod runs on the tested network It cannot reach an external server on a different network When the network is IPv4": "[Disabled:Unimplemented]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network It cannot reach an external server on a different network When the network is IPv6": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 2 CUDN EVPN MAC-VRF When a pod runs on the tested network It cannot reach an external server on a different network When the network is IPv6": "[Disabled:Unimplemented]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network When other pod runs on the tested network On a different node Backing a ClusterIP service The first pod can reach the ClusterIP service on the same network When the networks are IPv4": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 2 CUDN EVPN MAC-VRF When a pod runs on the tested network When other pod runs on the tested network On a different node Backing a ClusterIP service The first pod can reach the ClusterIP service on the same network When the networks are IPv4": "[Suite:openshift/conformance/parallel]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network When other pod runs on the tested network On a different node Backing a ClusterIP service The first pod can reach the ClusterIP service on the same network When the networks are IPv6": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 2 CUDN EVPN MAC-VRF When a pod runs on the tested network When other pod runs on the tested network On a different node Backing a ClusterIP service The first pod can reach the ClusterIP service on the same network When the networks are IPv6": "[Suite:openshift/conformance/parallel]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network When other pod runs on the tested network On a different node The pods on the tested network can reach each other When the networks are IPv4": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 2 CUDN EVPN MAC-VRF When a pod runs on the tested network When other pod runs on the tested network On a different node The pods on the tested network can reach each other When the networks are IPv4": "[Suite:openshift/conformance/parallel]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network When other pod runs on the tested network On a different node The pods on the tested network can reach each other When the networks are IPv6": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 2 CUDN EVPN MAC-VRF When a pod runs on the tested network When other pod runs on the tested network On a different node The pods on the tested network can reach each other When the networks are IPv6": "[Suite:openshift/conformance/parallel]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network When other pod runs on the tested network On the same node Backing a ClusterIP service The first pod can reach the ClusterIP service on the same network When the networks are IPv4": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 2 CUDN EVPN MAC-VRF When a pod runs on the tested network When other pod runs on the tested network On the same node Backing a ClusterIP service The first pod can reach the ClusterIP service on the same network When the networks are IPv4": "[Suite:openshift/conformance/parallel]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network When other pod runs on the tested network On the same node Backing a ClusterIP service The first pod can reach the ClusterIP service on the same network When the networks are IPv6": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 2 CUDN EVPN MAC-VRF When a pod runs on the tested network When other pod runs on the tested network On the same node Backing a ClusterIP service The first pod can reach the ClusterIP service on the same network When the networks are IPv6": "[Suite:openshift/conformance/parallel]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network When other pod runs on the tested network On the same node The pods on the tested network can reach each other When the networks are IPv4": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 2 CUDN EVPN MAC-VRF When a pod runs on the tested network When other pod runs on the tested network On the same node The pods on the tested network can reach each other When the networks are IPv4": "[Suite:openshift/conformance/parallel]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network When other pod runs on the tested network On the same node The pods on the tested network can reach each other When the networks are IPv6": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 2 CUDN EVPN MAC-VRF When a pod runs on the tested network When other pod runs on the tested network On the same node The pods on the tested network can reach each other When the networks are IPv6": "[Suite:openshift/conformance/parallel]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network When there is other network Of type Default And a pod runs on the other network On a different node Backing a ClusterIP service The pod on the tested network cannot reach the service on the other network When the networks are IPv4": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 2 CUDN EVPN MAC-VRF When a pod runs on the tested network When there is other network Of type Default Both networks are isolated": "[Suite:openshift/conformance/parallel]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network When there is other network Of type Default And a pod runs on the other network On a different node Backing a ClusterIP service The pod on the tested network cannot reach the service on the other network When the networks are IPv6": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 2 CUDN EVPN MAC-VRF When a pod runs on the tested network When there is other network Of type Layer 2 CUDN EVPN MAC-VRF Both networks are isolated": "[Suite:openshift/conformance/parallel]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network When there is other network Of type Default And a pod runs on the other network On a different node The pod on the other network cannot reach the pod on the tested network When the networks are IPv4": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 2 CUDN EVPN MAC-VRF When a pod runs on the tested network When there is other network Of type Layer 2 CUDN EVPN MAC-VRF and IP-VRF Both networks are isolated": "[Suite:openshift/conformance/parallel]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network When there is other network Of type Default And a pod runs on the other network On a different node The pod on the other network cannot reach the pod on the tested network When the networks are IPv6": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 2 CUDN EVPN MAC-VRF When a pod runs on the tested network When there is other network Of type Layer 2 CUDN VRF-Lite Both networks are isolated": "[Disabled:Unimplemented]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network When there is other network Of type Default And a pod runs on the other network On a different node The pod on the tested network cannot reach the pod on the other network When the networks are IPv4": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 2 CUDN EVPN MAC-VRF When a pod runs on the tested network When there is other network Of type Layer 2 CUDN advertised Both networks are isolated": "[Disabled:Unimplemented]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network When there is other network Of type Default And a pod runs on the other network On a different node The pod on the tested network cannot reach the pod on the other network When the networks are IPv6": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 2 CUDN EVPN MAC-VRF When a pod runs on the tested network When there is other network Of type Layer 2 UDN Both networks are isolated": "[Suite:openshift/conformance/parallel]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network When there is other network Of type Default And a pod runs on the other network On the same node Backing a ClusterIP service The pod on the tested network cannot reach the service on the other network When the networks are IPv4": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 2 CUDN EVPN MAC-VRF When a pod runs on the tested network When there is other network Of type Layer 3 CUDN EVPN IP-VRF Both networks are isolated": "[Suite:openshift/conformance/parallel]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network When there is other network Of type Default And a pod runs on the other network On the same node Backing a ClusterIP service The pod on the tested network cannot reach the service on the other network When the networks are IPv6": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 2 CUDN EVPN MAC-VRF When a pod runs on the tested network When there is other network Of type Layer 3 CUDN VRF-Lite Both networks are isolated": "[Disabled:Unimplemented]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network When there is other network Of type Default And a pod runs on the other network On the same node The pod on the other network cannot reach the pod on the tested network When the networks are IPv4": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 2 CUDN EVPN MAC-VRF When a pod runs on the tested network When there is other network Of type Layer 3 CUDN advertised Both networks are isolated": "[Disabled:Unimplemented]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network When there is other network Of type Default And a pod runs on the other network On the same node The pod on the other network cannot reach the pod on the tested network When the networks are IPv6": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 2 CUDN EVPN MAC-VRF When a pod runs on the tested network When there is other network Of type Layer 3 UDN Both networks are isolated": "[Suite:openshift/conformance/parallel]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network When there is other network Of type Default And a pod runs on the other network On the same node The pod on the tested network cannot reach the pod on the other network When the networks are IPv4": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 2 CUDN EVPN MAC-VRF and IP-VRF When a pod runs on the tested network Can reach KAPI service": "[Suite:openshift/conformance/parallel]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network When there is other network Of type Default And a pod runs on the other network On the same node The pod on the tested network cannot reach the pod on the other network When the networks are IPv6": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 2 CUDN EVPN MAC-VRF and IP-VRF When a pod runs on the tested network It can be reached by an external server on the same network When the network is IPv4": "[Suite:openshift/conformance/parallel]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network When there is other network Of type Layer 2 CUDN advertised And a pod runs on the other network On a different node Backing a ClusterIP service The pod on the tested network cannot reach the service on the other network When the networks are IPv4": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 2 CUDN EVPN MAC-VRF and IP-VRF When a pod runs on the tested network It can be reached by an external server on the same network When the network is IPv6": "[Suite:openshift/conformance/parallel]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network When there is other network Of type Layer 2 CUDN advertised And a pod runs on the other network On a different node Backing a ClusterIP service The pod on the tested network cannot reach the service on the other network When the networks are IPv6": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 2 CUDN EVPN MAC-VRF and IP-VRF When a pod runs on the tested network It can reach external servers on the same network When the network is IPv4": "[Suite:openshift/conformance/parallel]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network When there is other network Of type Layer 2 CUDN advertised And a pod runs on the other network On a different node The pod on the other network cannot reach the pod on the tested network When the networks are IPv4": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 2 CUDN EVPN MAC-VRF and IP-VRF When a pod runs on the tested network It can reach external servers on the same network When the network is IPv6": "[Suite:openshift/conformance/parallel]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network When there is other network Of type Layer 2 CUDN advertised And a pod runs on the other network On a different node The pod on the other network cannot reach the pod on the tested network When the networks are IPv6": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 2 CUDN EVPN MAC-VRF and IP-VRF When a pod runs on the tested network It cannot be reached by a cluster node When it is a different node When the network is IPv4": "[Suite:openshift/conformance/parallel]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network When there is other network Of type Layer 2 CUDN advertised And a pod runs on the other network On a different node The pod on the tested network cannot reach the pod on the other network When the networks are IPv4": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 2 CUDN EVPN MAC-VRF and IP-VRF When a pod runs on the tested network It cannot be reached by a cluster node When it is a different node When the network is IPv6": "[Suite:openshift/conformance/parallel]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network When there is other network Of type Layer 2 CUDN advertised And a pod runs on the other network On a different node The pod on the tested network cannot reach the pod on the other network When the networks are IPv6": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 2 CUDN EVPN MAC-VRF and IP-VRF When a pod runs on the tested network It cannot be reached by a cluster node When it is the same node When the network is IPv4": "[Suite:openshift/conformance/parallel]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network When there is other network Of type Layer 2 CUDN advertised And a pod runs on the other network On the same node Backing a ClusterIP service The pod on the tested network cannot reach the service on the other network When the networks are IPv4": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 2 CUDN EVPN MAC-VRF and IP-VRF When a pod runs on the tested network It cannot be reached by a cluster node When it is the same node When the network is IPv6": "[Suite:openshift/conformance/parallel]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network When there is other network Of type Layer 2 CUDN advertised And a pod runs on the other network On the same node Backing a ClusterIP service The pod on the tested network cannot reach the service on the other network When the networks are IPv6": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 2 CUDN EVPN MAC-VRF and IP-VRF When a pod runs on the tested network It cannot be reached by an external server on a different network When the network is IPv4": "[Suite:openshift/conformance/parallel]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network When there is other network Of type Layer 2 CUDN advertised And a pod runs on the other network On the same node The pod on the other network cannot reach the pod on the tested network When the networks are IPv4": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 2 CUDN EVPN MAC-VRF and IP-VRF When a pod runs on the tested network It cannot be reached by an external server on a different network When the network is IPv6": "[Suite:openshift/conformance/parallel]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network When there is other network Of type Layer 2 CUDN advertised And a pod runs on the other network On the same node The pod on the other network cannot reach the pod on the tested network When the networks are IPv6": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 2 CUDN EVPN MAC-VRF and IP-VRF When a pod runs on the tested network It cannot reach an external server on a different network When the network is IPv4": "[Disabled:Unimplemented]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network When there is other network Of type Layer 2 CUDN advertised And a pod runs on the other network On the same node The pod on the tested network cannot reach the pod on the other network When the networks are IPv4": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 2 CUDN EVPN MAC-VRF and IP-VRF When a pod runs on the tested network It cannot reach an external server on a different network When the network is IPv6": "[Disabled:Unimplemented]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network When there is other network Of type Layer 2 CUDN advertised And a pod runs on the other network On the same node The pod on the tested network cannot reach the pod on the other network When the networks are IPv6": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 2 CUDN EVPN MAC-VRF and IP-VRF When a pod runs on the tested network When other pod runs on the tested network On a different node Backing a ClusterIP service The first pod can reach the ClusterIP service on the same network When the networks are IPv4": "[Suite:openshift/conformance/parallel]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network When there is other network Of type Layer 2 CUDN advertised VRF-Lite And a pod runs on the other network On a different node Backing a ClusterIP service The pod on the tested network cannot reach the service on the other network When the networks are IPv4": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 2 CUDN EVPN MAC-VRF and IP-VRF When a pod runs on the tested network When other pod runs on the tested network On a different node Backing a ClusterIP service The first pod can reach the ClusterIP service on the same network When the networks are IPv6": "[Suite:openshift/conformance/parallel]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network When there is other network Of type Layer 2 CUDN advertised VRF-Lite And a pod runs on the other network On a different node Backing a ClusterIP service The pod on the tested network cannot reach the service on the other network When the networks are IPv6": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 2 CUDN EVPN MAC-VRF and IP-VRF When a pod runs on the tested network When other pod runs on the tested network On a different node The pods on the tested network can reach each other When the networks are IPv4": "[Suite:openshift/conformance/parallel]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network When there is other network Of type Layer 2 CUDN advertised VRF-Lite And a pod runs on the other network On a different node The pod on the other network cannot reach the pod on the tested network When the networks are IPv4": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 2 CUDN EVPN MAC-VRF and IP-VRF When a pod runs on the tested network When other pod runs on the tested network On a different node The pods on the tested network can reach each other When the networks are IPv6": "[Suite:openshift/conformance/parallel]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network When there is other network Of type Layer 2 CUDN advertised VRF-Lite And a pod runs on the other network On a different node The pod on the other network cannot reach the pod on the tested network When the networks are IPv6": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 2 CUDN EVPN MAC-VRF and IP-VRF When a pod runs on the tested network When other pod runs on the tested network On the same node Backing a ClusterIP service The first pod can reach the ClusterIP service on the same network When the networks are IPv4": "[Suite:openshift/conformance/parallel]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network When there is other network Of type Layer 2 CUDN advertised VRF-Lite And a pod runs on the other network On a different node The pod on the tested network cannot reach the pod on the other network When the networks are IPv4": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 2 CUDN EVPN MAC-VRF and IP-VRF When a pod runs on the tested network When other pod runs on the tested network On the same node Backing a ClusterIP service The first pod can reach the ClusterIP service on the same network When the networks are IPv6": "[Suite:openshift/conformance/parallel]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network When there is other network Of type Layer 2 CUDN advertised VRF-Lite And a pod runs on the other network On a different node The pod on the tested network cannot reach the pod on the other network When the networks are IPv6": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 2 CUDN EVPN MAC-VRF and IP-VRF When a pod runs on the tested network When other pod runs on the tested network On the same node The pods on the tested network can reach each other When the networks are IPv4": "[Suite:openshift/conformance/parallel]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network When there is other network Of type Layer 2 CUDN advertised VRF-Lite And a pod runs on the other network On the same node Backing a ClusterIP service The pod on the tested network cannot reach the service on the other network When the networks are IPv4": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 2 CUDN EVPN MAC-VRF and IP-VRF When a pod runs on the tested network When other pod runs on the tested network On the same node The pods on the tested network can reach each other When the networks are IPv6": "[Suite:openshift/conformance/parallel]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network When there is other network Of type Layer 2 CUDN advertised VRF-Lite And a pod runs on the other network On the same node Backing a ClusterIP service The pod on the tested network cannot reach the service on the other network When the networks are IPv6": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 2 CUDN EVPN MAC-VRF and IP-VRF When a pod runs on the tested network When there is other network Of type Default Both networks are isolated": "[Suite:openshift/conformance/parallel]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network When there is other network Of type Layer 2 CUDN advertised VRF-Lite And a pod runs on the other network On the same node The pod on the other network cannot reach the pod on the tested network When the networks are IPv4": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 2 CUDN EVPN MAC-VRF and IP-VRF When a pod runs on the tested network When there is other network Of type Layer 2 CUDN EVPN MAC-VRF Both networks are isolated": "[Suite:openshift/conformance/parallel]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network When there is other network Of type Layer 2 CUDN advertised VRF-Lite And a pod runs on the other network On the same node The pod on the other network cannot reach the pod on the tested network When the networks are IPv6": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 2 CUDN EVPN MAC-VRF and IP-VRF When a pod runs on the tested network When there is other network Of type Layer 2 CUDN EVPN MAC-VRF and IP-VRF Both networks are isolated": "[Suite:openshift/conformance/parallel]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network When there is other network Of type Layer 2 CUDN advertised VRF-Lite And a pod runs on the other network On the same node The pod on the tested network cannot reach the pod on the other network When the networks are IPv4": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 2 CUDN EVPN MAC-VRF and IP-VRF When a pod runs on the tested network When there is other network Of type Layer 2 CUDN VRF-Lite Both networks are isolated": "[Disabled:Unimplemented]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network When there is other network Of type Layer 2 CUDN advertised VRF-Lite And a pod runs on the other network On the same node The pod on the tested network cannot reach the pod on the other network When the networks are IPv6": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 2 CUDN EVPN MAC-VRF and IP-VRF When a pod runs on the tested network When there is other network Of type Layer 2 CUDN advertised Both networks are isolated": "[Disabled:Unimplemented]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network When there is other network Of type Layer 2 UDN non advertised And a pod runs on the other network On a different node Backing a ClusterIP service The pod on the tested network cannot reach the service on the other network When the networks are IPv4": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 2 CUDN EVPN MAC-VRF and IP-VRF When a pod runs on the tested network When there is other network Of type Layer 2 UDN Both networks are isolated": "[Suite:openshift/conformance/parallel]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network When there is other network Of type Layer 2 UDN non advertised And a pod runs on the other network On a different node Backing a ClusterIP service The pod on the tested network cannot reach the service on the other network When the networks are IPv6": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 2 CUDN EVPN MAC-VRF and IP-VRF When a pod runs on the tested network When there is other network Of type Layer 3 CUDN EVPN IP-VRF Both networks are isolated": "[Suite:openshift/conformance/parallel]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network When there is other network Of type Layer 2 UDN non advertised And a pod runs on the other network On a different node The pod on the other network cannot reach the pod on the tested network When the networks are IPv4": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 2 CUDN EVPN MAC-VRF and IP-VRF When a pod runs on the tested network When there is other network Of type Layer 3 CUDN VRF-Lite Both networks are isolated": "[Disabled:Unimplemented]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network When there is other network Of type Layer 2 UDN non advertised And a pod runs on the other network On a different node The pod on the other network cannot reach the pod on the tested network When the networks are IPv6": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 2 CUDN EVPN MAC-VRF and IP-VRF When a pod runs on the tested network When there is other network Of type Layer 3 CUDN advertised Both networks are isolated": "[Disabled:Unimplemented]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network When there is other network Of type Layer 2 UDN non advertised And a pod runs on the other network On a different node The pod on the tested network cannot reach the pod on the other network When the networks are IPv4": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 2 CUDN EVPN MAC-VRF and IP-VRF When a pod runs on the tested network When there is other network Of type Layer 3 UDN Both networks are isolated": "[Suite:openshift/conformance/parallel]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network When there is other network Of type Layer 2 UDN non advertised And a pod runs on the other network On a different node The pod on the tested network cannot reach the pod on the other network When the networks are IPv6": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 2 CUDN VRF-Lite When a pod runs on the tested network Can reach KAPI service": "[Disabled:Unimplemented]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network When there is other network Of type Layer 2 UDN non advertised And a pod runs on the other network On the same node Backing a ClusterIP service The pod on the tested network cannot reach the service on the other network When the networks are IPv4": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 2 CUDN VRF-Lite When a pod runs on the tested network It can be reached by an external server on the same network When the network is IPv4": "[Disabled:Unimplemented]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network When there is other network Of type Layer 2 UDN non advertised And a pod runs on the other network On the same node Backing a ClusterIP service The pod on the tested network cannot reach the service on the other network When the networks are IPv6": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 2 CUDN VRF-Lite When a pod runs on the tested network It can be reached by an external server on the same network When the network is IPv6": "[Disabled:Unimplemented]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network When there is other network Of type Layer 2 UDN non advertised And a pod runs on the other network On the same node The pod on the other network cannot reach the pod on the tested network When the networks are IPv4": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 2 CUDN VRF-Lite When a pod runs on the tested network It can reach external servers on the same network When the network is IPv4": "[Disabled:Unimplemented]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network When there is other network Of type Layer 2 UDN non advertised And a pod runs on the other network On the same node The pod on the other network cannot reach the pod on the tested network When the networks are IPv6": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 2 CUDN VRF-Lite When a pod runs on the tested network It can reach external servers on the same network When the network is IPv6": "[Disabled:Unimplemented]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network When there is other network Of type Layer 2 UDN non advertised And a pod runs on the other network On the same node The pod on the tested network cannot reach the pod on the other network When the networks are IPv4": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 2 CUDN VRF-Lite When a pod runs on the tested network It cannot be reached by a cluster node When it is a different node When the network is IPv4": "[Disabled:Unimplemented]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network When there is other network Of type Layer 2 UDN non advertised And a pod runs on the other network On the same node The pod on the tested network cannot reach the pod on the other network When the networks are IPv6": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 2 CUDN VRF-Lite When a pod runs on the tested network It cannot be reached by a cluster node When it is a different node When the network is IPv6": "[Disabled:Unimplemented]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network When there is other network Of type Layer 3 CUDN advertised And a pod runs on the other network On a different node Backing a ClusterIP service The pod on the tested network cannot reach the service on the other network When the networks are IPv4": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 2 CUDN VRF-Lite When a pod runs on the tested network It cannot be reached by a cluster node When it is the same node When the network is IPv4": "[Disabled:Unimplemented]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network When there is other network Of type Layer 3 CUDN advertised And a pod runs on the other network On a different node Backing a ClusterIP service The pod on the tested network cannot reach the service on the other network When the networks are IPv6": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 2 CUDN VRF-Lite When a pod runs on the tested network It cannot be reached by a cluster node When it is the same node When the network is IPv6": "[Disabled:Unimplemented]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network When there is other network Of type Layer 3 CUDN advertised And a pod runs on the other network On a different node The pod on the other network cannot reach the pod on the tested network When the networks are IPv4": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 2 CUDN VRF-Lite When a pod runs on the tested network It cannot be reached by an external server on a different network When the network is IPv4": "[Disabled:Unimplemented]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network When there is other network Of type Layer 3 CUDN advertised And a pod runs on the other network On a different node The pod on the other network cannot reach the pod on the tested network When the networks are IPv6": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 2 CUDN VRF-Lite When a pod runs on the tested network It cannot be reached by an external server on a different network When the network is IPv6": "[Disabled:Unimplemented]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network When there is other network Of type Layer 3 CUDN advertised And a pod runs on the other network On a different node The pod on the tested network cannot reach the pod on the other network When the networks are IPv4": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 2 CUDN VRF-Lite When a pod runs on the tested network It cannot reach an external server on a different network When the network is IPv4": "[Disabled:Unimplemented]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network When there is other network Of type Layer 3 CUDN advertised And a pod runs on the other network On a different node The pod on the tested network cannot reach the pod on the other network When the networks are IPv6": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 2 CUDN VRF-Lite When a pod runs on the tested network It cannot reach an external server on a different network When the network is IPv6": "[Disabled:Unimplemented]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network When there is other network Of type Layer 3 CUDN advertised And a pod runs on the other network On the same node Backing a ClusterIP service The pod on the tested network cannot reach the service on the other network When the networks are IPv4": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 2 CUDN VRF-Lite When a pod runs on the tested network When other pod runs on the tested network On a different node Backing a ClusterIP service The first pod can reach the ClusterIP service on the same network When the networks are IPv4": "[Disabled:Unimplemented]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network When there is other network Of type Layer 3 CUDN advertised And a pod runs on the other network On the same node Backing a ClusterIP service The pod on the tested network cannot reach the service on the other network When the networks are IPv6": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 2 CUDN VRF-Lite When a pod runs on the tested network When other pod runs on the tested network On a different node Backing a ClusterIP service The first pod can reach the ClusterIP service on the same network When the networks are IPv6": "[Disabled:Unimplemented]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network When there is other network Of type Layer 3 CUDN advertised And a pod runs on the other network On the same node The pod on the other network cannot reach the pod on the tested network When the networks are IPv4": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 2 CUDN VRF-Lite When a pod runs on the tested network When other pod runs on the tested network On a different node The pods on the tested network can reach each other When the networks are IPv4": "[Disabled:Unimplemented]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network When there is other network Of type Layer 3 CUDN advertised And a pod runs on the other network On the same node The pod on the other network cannot reach the pod on the tested network When the networks are IPv6": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 2 CUDN VRF-Lite When a pod runs on the tested network When other pod runs on the tested network On a different node The pods on the tested network can reach each other When the networks are IPv6": "[Disabled:Unimplemented]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network When there is other network Of type Layer 3 CUDN advertised And a pod runs on the other network On the same node The pod on the tested network cannot reach the pod on the other network When the networks are IPv4": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 2 CUDN VRF-Lite When a pod runs on the tested network When other pod runs on the tested network On the same node Backing a ClusterIP service The first pod can reach the ClusterIP service on the same network When the networks are IPv4": "[Disabled:Unimplemented]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network When there is other network Of type Layer 3 CUDN advertised And a pod runs on the other network On the same node The pod on the tested network cannot reach the pod on the other network When the networks are IPv6": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 2 CUDN VRF-Lite When a pod runs on the tested network When other pod runs on the tested network On the same node Backing a ClusterIP service The first pod can reach the ClusterIP service on the same network When the networks are IPv6": "[Disabled:Unimplemented]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network When there is other network Of type Layer 3 CUDN advertised VRF-Lite And a pod runs on the other network On a different node Backing a ClusterIP service The pod on the tested network cannot reach the service on the other network When the networks are IPv4": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 2 CUDN VRF-Lite When a pod runs on the tested network When other pod runs on the tested network On the same node The pods on the tested network can reach each other When the networks are IPv4": "[Disabled:Unimplemented]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network When there is other network Of type Layer 3 CUDN advertised VRF-Lite And a pod runs on the other network On a different node Backing a ClusterIP service The pod on the tested network cannot reach the service on the other network When the networks are IPv6": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 2 CUDN VRF-Lite When a pod runs on the tested network When other pod runs on the tested network On the same node The pods on the tested network can reach each other When the networks are IPv6": "[Disabled:Unimplemented]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network When there is other network Of type Layer 3 CUDN advertised VRF-Lite And a pod runs on the other network On a different node The pod on the other network cannot reach the pod on the tested network When the networks are IPv4": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 2 CUDN VRF-Lite When a pod runs on the tested network When there is other network Of type Default Both networks are isolated": "[Disabled:Unimplemented]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network When there is other network Of type Layer 3 CUDN advertised VRF-Lite And a pod runs on the other network On a different node The pod on the other network cannot reach the pod on the tested network When the networks are IPv6": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 2 CUDN VRF-Lite When a pod runs on the tested network When there is other network Of type Layer 2 CUDN EVPN MAC-VRF Both networks are isolated": "[Disabled:Unimplemented]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network When there is other network Of type Layer 3 CUDN advertised VRF-Lite And a pod runs on the other network On a different node The pod on the tested network cannot reach the pod on the other network When the networks are IPv4": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 2 CUDN VRF-Lite When a pod runs on the tested network When there is other network Of type Layer 2 CUDN EVPN MAC-VRF and IP-VRF Both networks are isolated": "[Disabled:Unimplemented]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network When there is other network Of type Layer 3 CUDN advertised VRF-Lite And a pod runs on the other network On a different node The pod on the tested network cannot reach the pod on the other network When the networks are IPv6": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 2 CUDN VRF-Lite When a pod runs on the tested network When there is other network Of type Layer 2 CUDN VRF-Lite Both networks are isolated": "[Disabled:Unimplemented]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network When there is other network Of type Layer 3 CUDN advertised VRF-Lite And a pod runs on the other network On the same node Backing a ClusterIP service The pod on the tested network cannot reach the service on the other network When the networks are IPv4": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 2 CUDN VRF-Lite When a pod runs on the tested network When there is other network Of type Layer 2 CUDN advertised Both networks are isolated": "[Disabled:Unimplemented]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network When there is other network Of type Layer 3 CUDN advertised VRF-Lite And a pod runs on the other network On the same node Backing a ClusterIP service The pod on the tested network cannot reach the service on the other network When the networks are IPv6": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 2 CUDN VRF-Lite When a pod runs on the tested network When there is other network Of type Layer 2 UDN Both networks are isolated": "[Disabled:Unimplemented]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network When there is other network Of type Layer 3 CUDN advertised VRF-Lite And a pod runs on the other network On the same node The pod on the other network cannot reach the pod on the tested network When the networks are IPv4": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 2 CUDN VRF-Lite When a pod runs on the tested network When there is other network Of type Layer 3 CUDN EVPN IP-VRF Both networks are isolated": "[Disabled:Unimplemented]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network When there is other network Of type Layer 3 CUDN advertised VRF-Lite And a pod runs on the other network On the same node The pod on the other network cannot reach the pod on the tested network When the networks are IPv6": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 2 CUDN VRF-Lite When a pod runs on the tested network When there is other network Of type Layer 3 CUDN VRF-Lite Both networks are isolated": "[Disabled:Unimplemented]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network When there is other network Of type Layer 3 CUDN advertised VRF-Lite And a pod runs on the other network On the same node The pod on the tested network cannot reach the pod on the other network When the networks are IPv4": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 2 CUDN VRF-Lite When a pod runs on the tested network When there is other network Of type Layer 3 CUDN advertised Both networks are isolated": "[Disabled:Unimplemented]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network When there is other network Of type Layer 3 CUDN advertised VRF-Lite And a pod runs on the other network On the same node The pod on the tested network cannot reach the pod on the other network When the networks are IPv6": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 2 CUDN VRF-Lite When a pod runs on the tested network When there is other network Of type Layer 3 UDN Both networks are isolated": "[Disabled:Unimplemented]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network When there is other network Of type Layer 3 UDN non advertised And a pod runs on the other network On a different node Backing a ClusterIP service The pod on the tested network cannot reach the service on the other network When the networks are IPv4": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 3 CUDN EVPN IP-VRF When a pod runs on the tested network Can reach KAPI service": "[Suite:openshift/conformance/parallel]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network When there is other network Of type Layer 3 UDN non advertised And a pod runs on the other network On a different node Backing a ClusterIP service The pod on the tested network cannot reach the service on the other network When the networks are IPv6": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 3 CUDN EVPN IP-VRF When a pod runs on the tested network It can be reached by an external server on the same network When the network is IPv4": "[Suite:openshift/conformance/parallel]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network When there is other network Of type Layer 3 UDN non advertised And a pod runs on the other network On a different node The pod on the other network cannot reach the pod on the tested network When the networks are IPv4": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 3 CUDN EVPN IP-VRF When a pod runs on the tested network It can be reached by an external server on the same network When the network is IPv6": "[Suite:openshift/conformance/parallel]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network When there is other network Of type Layer 3 UDN non advertised And a pod runs on the other network On a different node The pod on the other network cannot reach the pod on the tested network When the networks are IPv6": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 3 CUDN EVPN IP-VRF When a pod runs on the tested network It can reach external servers on the same network When the network is IPv4": "[Suite:openshift/conformance/parallel]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network When there is other network Of type Layer 3 UDN non advertised And a pod runs on the other network On a different node The pod on the tested network cannot reach the pod on the other network When the networks are IPv4": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 3 CUDN EVPN IP-VRF When a pod runs on the tested network It can reach external servers on the same network When the network is IPv6": "[Suite:openshift/conformance/parallel]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network When there is other network Of type Layer 3 UDN non advertised And a pod runs on the other network On a different node The pod on the tested network cannot reach the pod on the other network When the networks are IPv6": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 3 CUDN EVPN IP-VRF When a pod runs on the tested network It cannot be reached by a cluster node When it is a different node When the network is IPv4": "[Suite:openshift/conformance/parallel]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network When there is other network Of type Layer 3 UDN non advertised And a pod runs on the other network On the same node Backing a ClusterIP service The pod on the tested network cannot reach the service on the other network When the networks are IPv4": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 3 CUDN EVPN IP-VRF When a pod runs on the tested network It cannot be reached by a cluster node When it is a different node When the network is IPv6": "[Suite:openshift/conformance/parallel]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network When there is other network Of type Layer 3 UDN non advertised And a pod runs on the other network On the same node Backing a ClusterIP service The pod on the tested network cannot reach the service on the other network When the networks are IPv6": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 3 CUDN EVPN IP-VRF When a pod runs on the tested network It cannot be reached by a cluster node When it is the same node When the network is IPv4": "[Suite:openshift/conformance/parallel]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network When there is other network Of type Layer 3 UDN non advertised And a pod runs on the other network On the same node The pod on the other network cannot reach the pod on the tested network When the networks are IPv4": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 3 CUDN EVPN IP-VRF When a pod runs on the tested network It cannot be reached by a cluster node When it is the same node When the network is IPv6": "[Suite:openshift/conformance/parallel]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network When there is other network Of type Layer 3 UDN non advertised And a pod runs on the other network On the same node The pod on the other network cannot reach the pod on the tested network When the networks are IPv6": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 3 CUDN EVPN IP-VRF When a pod runs on the tested network It cannot be reached by an external server on a different network When the network is IPv4": "[Suite:openshift/conformance/parallel]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network When there is other network Of type Layer 3 UDN non advertised And a pod runs on the other network On the same node The pod on the tested network cannot reach the pod on the other network When the networks are IPv4": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 3 CUDN EVPN IP-VRF When a pod runs on the tested network It cannot be reached by an external server on a different network When the network is IPv6": "[Suite:openshift/conformance/parallel]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 2 When a pod runs on the tested network When there is other network Of type Layer 3 UDN non advertised And a pod runs on the other network On the same node The pod on the tested network cannot reach the pod on the other network When the networks are IPv6": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 3 CUDN EVPN IP-VRF When a pod runs on the tested network It cannot reach an external server on a different network When the network is IPv4": "[Disabled:Unimplemented]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network Can reach KAPI service": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 3 CUDN EVPN IP-VRF When a pod runs on the tested network It cannot reach an external server on a different network When the network is IPv6": "[Disabled:Unimplemented]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network It can be reached by an external server on the same network When the network is IPv4": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 3 CUDN EVPN IP-VRF When a pod runs on the tested network When other pod runs on the tested network On a different node Backing a ClusterIP service The first pod can reach the ClusterIP service on the same network When the networks are IPv4": "[Suite:openshift/conformance/parallel]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network It can be reached by an external server on the same network When the network is IPv6": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 3 CUDN EVPN IP-VRF When a pod runs on the tested network When other pod runs on the tested network On a different node Backing a ClusterIP service The first pod can reach the ClusterIP service on the same network When the networks are IPv6": "[Suite:openshift/conformance/parallel]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network It can reach an external server on the same network When the network is IPv4": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 3 CUDN EVPN IP-VRF When a pod runs on the tested network When other pod runs on the tested network On a different node The pods on the tested network can reach each other When the networks are IPv4": "[Suite:openshift/conformance/parallel]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network It can reach an external server on the same network When the network is IPv6": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 3 CUDN EVPN IP-VRF When a pod runs on the tested network When other pod runs on the tested network On a different node The pods on the tested network can reach each other When the networks are IPv6": "[Suite:openshift/conformance/parallel]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network It cannot be reached by a cluster node When it is a different node When the network is IPv4": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 3 CUDN EVPN IP-VRF When a pod runs on the tested network When other pod runs on the tested network On the same node Backing a ClusterIP service The first pod can reach the ClusterIP service on the same network When the networks are IPv4": "[Suite:openshift/conformance/parallel]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network It cannot be reached by a cluster node When it is a different node When the network is IPv6": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 3 CUDN EVPN IP-VRF When a pod runs on the tested network When other pod runs on the tested network On the same node Backing a ClusterIP service The first pod can reach the ClusterIP service on the same network When the networks are IPv6": "[Suite:openshift/conformance/parallel]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network It cannot be reached by a cluster node When it is the same node When the network is IPv4": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 3 CUDN EVPN IP-VRF When a pod runs on the tested network When other pod runs on the tested network On the same node The pods on the tested network can reach each other When the networks are IPv4": "[Suite:openshift/conformance/parallel]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network It cannot be reached by a cluster node When it is the same node When the network is IPv6": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 3 CUDN EVPN IP-VRF When a pod runs on the tested network When other pod runs on the tested network On the same node The pods on the tested network can reach each other When the networks are IPv6": "[Suite:openshift/conformance/parallel]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network It cannot be reached by an external server on a different network When the network is IPv4": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 3 CUDN EVPN IP-VRF When a pod runs on the tested network When there is other network Of type Default Both networks are isolated": "[Suite:openshift/conformance/parallel]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network It cannot be reached by an external server on a different network When the network is IPv6": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 3 CUDN EVPN IP-VRF When a pod runs on the tested network When there is other network Of type Layer 2 CUDN EVPN MAC-VRF Both networks are isolated": "[Suite:openshift/conformance/parallel]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network It cannot reach an external server on a different network When the network is IPv4": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 3 CUDN EVPN IP-VRF When a pod runs on the tested network When there is other network Of type Layer 2 CUDN EVPN MAC-VRF and IP-VRF Both networks are isolated": "[Suite:openshift/conformance/parallel]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network It cannot reach an external server on a different network When the network is IPv6": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 3 CUDN EVPN IP-VRF When a pod runs on the tested network When there is other network Of type Layer 2 CUDN VRF-Lite Both networks are isolated": "[Disabled:Unimplemented]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network When other pod runs on the tested network On a different node Backing a ClusterIP service The first pod can reach the ClusterIP service on the same network When the networks are IPv4": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 3 CUDN EVPN IP-VRF When a pod runs on the tested network When there is other network Of type Layer 2 CUDN advertised Both networks are isolated": "[Disabled:Unimplemented]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network When other pod runs on the tested network On a different node Backing a ClusterIP service The first pod can reach the ClusterIP service on the same network When the networks are IPv6": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 3 CUDN EVPN IP-VRF When a pod runs on the tested network When there is other network Of type Layer 2 UDN Both networks are isolated": "[Suite:openshift/conformance/parallel]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network When other pod runs on the tested network On a different node The pods on the tested network can reach each other When the networks are IPv4": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 3 CUDN EVPN IP-VRF When a pod runs on the tested network When there is other network Of type Layer 3 CUDN EVPN IP-VRF Both networks are isolated": "[Suite:openshift/conformance/parallel]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network When other pod runs on the tested network On a different node The pods on the tested network can reach each other When the networks are IPv6": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 3 CUDN EVPN IP-VRF When a pod runs on the tested network When there is other network Of type Layer 3 CUDN VRF-Lite Both networks are isolated": "[Disabled:Unimplemented]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network When other pod runs on the tested network On the same node Backing a ClusterIP service The first pod can reach the ClusterIP service on the same network When the networks are IPv4": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 3 CUDN EVPN IP-VRF When a pod runs on the tested network When there is other network Of type Layer 3 CUDN advertised Both networks are isolated": "[Disabled:Unimplemented]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network When other pod runs on the tested network On the same node Backing a ClusterIP service The first pod can reach the ClusterIP service on the same network When the networks are IPv6": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 3 CUDN EVPN IP-VRF When a pod runs on the tested network When there is other network Of type Layer 3 UDN Both networks are isolated": "[Suite:openshift/conformance/parallel]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network When other pod runs on the tested network On the same node The pods on the tested network can reach each other When the networks are IPv4": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 3 CUDN VRF-Lite When a pod runs on the tested network Can reach KAPI service": "[Disabled:Unimplemented]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network When other pod runs on the tested network On the same node The pods on the tested network can reach each other When the networks are IPv6": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 3 CUDN VRF-Lite When a pod runs on the tested network It can be reached by an external server on the same network When the network is IPv4": "[Disabled:Unimplemented]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network When there is other network Of type Default And a pod runs on the other network On a different node Backing a ClusterIP service The pod on the tested network cannot reach the service on the other network When the networks are IPv4": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 3 CUDN VRF-Lite When a pod runs on the tested network It can be reached by an external server on the same network When the network is IPv6": "[Disabled:Unimplemented]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network When there is other network Of type Default And a pod runs on the other network On a different node Backing a ClusterIP service The pod on the tested network cannot reach the service on the other network When the networks are IPv6": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 3 CUDN VRF-Lite When a pod runs on the tested network It can reach external servers on the same network When the network is IPv4": "[Disabled:Unimplemented]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network When there is other network Of type Default And a pod runs on the other network On a different node The pod on the other network cannot reach the pod on the tested network When the networks are IPv4": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 3 CUDN VRF-Lite When a pod runs on the tested network It can reach external servers on the same network When the network is IPv6": "[Disabled:Unimplemented]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network When there is other network Of type Default And a pod runs on the other network On a different node The pod on the other network cannot reach the pod on the tested network When the networks are IPv6": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 3 CUDN VRF-Lite When a pod runs on the tested network It cannot be reached by a cluster node When it is a different node When the network is IPv4": "[Disabled:Unimplemented]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network When there is other network Of type Default And a pod runs on the other network On a different node The pod on the tested network cannot reach the pod on the other network When the networks are IPv4": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 3 CUDN VRF-Lite When a pod runs on the tested network It cannot be reached by a cluster node When it is a different node When the network is IPv6": "[Disabled:Unimplemented]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network When there is other network Of type Default And a pod runs on the other network On a different node The pod on the tested network cannot reach the pod on the other network When the networks are IPv6": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 3 CUDN VRF-Lite When a pod runs on the tested network It cannot be reached by a cluster node When it is the same node When the network is IPv4": "[Disabled:Unimplemented]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network When there is other network Of type Default And a pod runs on the other network On the same node Backing a ClusterIP service The pod on the tested network cannot reach the service on the other network When the networks are IPv4": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 3 CUDN VRF-Lite When a pod runs on the tested network It cannot be reached by a cluster node When it is the same node When the network is IPv6": "[Disabled:Unimplemented]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network When there is other network Of type Default And a pod runs on the other network On the same node Backing a ClusterIP service The pod on the tested network cannot reach the service on the other network When the networks are IPv6": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 3 CUDN VRF-Lite When a pod runs on the tested network It cannot be reached by an external server on a different network When the network is IPv4": "[Disabled:Unimplemented]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network When there is other network Of type Default And a pod runs on the other network On the same node The pod on the other network cannot reach the pod on the tested network When the networks are IPv4": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 3 CUDN VRF-Lite When a pod runs on the tested network It cannot be reached by an external server on a different network When the network is IPv6": "[Disabled:Unimplemented]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network When there is other network Of type Default And a pod runs on the other network On the same node The pod on the other network cannot reach the pod on the tested network When the networks are IPv6": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 3 CUDN VRF-Lite When a pod runs on the tested network It cannot reach an external server on a different network When the network is IPv4": "[Disabled:Unimplemented]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network When there is other network Of type Default And a pod runs on the other network On the same node The pod on the tested network cannot reach the pod on the other network When the networks are IPv4": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 3 CUDN VRF-Lite When a pod runs on the tested network It cannot reach an external server on a different network When the network is IPv6": "[Disabled:Unimplemented]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network When there is other network Of type Default And a pod runs on the other network On the same node The pod on the tested network cannot reach the pod on the other network When the networks are IPv6": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 3 CUDN VRF-Lite When a pod runs on the tested network When other pod runs on the tested network On a different node Backing a ClusterIP service The first pod can reach the ClusterIP service on the same network When the networks are IPv4": "[Disabled:Unimplemented]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network When there is other network Of type Layer 2 CUDN advertised And a pod runs on the other network On a different node Backing a ClusterIP service The pod on the tested network cannot reach the service on the other network When the networks are IPv4": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 3 CUDN VRF-Lite When a pod runs on the tested network When other pod runs on the tested network On a different node Backing a ClusterIP service The first pod can reach the ClusterIP service on the same network When the networks are IPv6": "[Disabled:Unimplemented]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network When there is other network Of type Layer 2 CUDN advertised And a pod runs on the other network On a different node Backing a ClusterIP service The pod on the tested network cannot reach the service on the other network When the networks are IPv6": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 3 CUDN VRF-Lite When a pod runs on the tested network When other pod runs on the tested network On a different node The pods on the tested network can reach each other When the networks are IPv4": "[Disabled:Unimplemented]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network When there is other network Of type Layer 2 CUDN advertised And a pod runs on the other network On a different node The pod on the other network cannot reach the pod on the tested network When the networks are IPv4": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 3 CUDN VRF-Lite When a pod runs on the tested network When other pod runs on the tested network On a different node The pods on the tested network can reach each other When the networks are IPv6": "[Disabled:Unimplemented]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network When there is other network Of type Layer 2 CUDN advertised And a pod runs on the other network On a different node The pod on the other network cannot reach the pod on the tested network When the networks are IPv6": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 3 CUDN VRF-Lite When a pod runs on the tested network When other pod runs on the tested network On the same node Backing a ClusterIP service The first pod can reach the ClusterIP service on the same network When the networks are IPv4": "[Disabled:Unimplemented]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network When there is other network Of type Layer 2 CUDN advertised And a pod runs on the other network On a different node The pod on the tested network cannot reach the pod on the other network When the networks are IPv4": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 3 CUDN VRF-Lite When a pod runs on the tested network When other pod runs on the tested network On the same node Backing a ClusterIP service The first pod can reach the ClusterIP service on the same network When the networks are IPv6": "[Disabled:Unimplemented]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network When there is other network Of type Layer 2 CUDN advertised And a pod runs on the other network On a different node The pod on the tested network cannot reach the pod on the other network When the networks are IPv6": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 3 CUDN VRF-Lite When a pod runs on the tested network When other pod runs on the tested network On the same node The pods on the tested network can reach each other When the networks are IPv4": "[Disabled:Unimplemented]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network When there is other network Of type Layer 2 CUDN advertised And a pod runs on the other network On the same node Backing a ClusterIP service The pod on the tested network cannot reach the service on the other network When the networks are IPv4": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 3 CUDN VRF-Lite When a pod runs on the tested network When other pod runs on the tested network On the same node The pods on the tested network can reach each other When the networks are IPv6": "[Disabled:Unimplemented]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network When there is other network Of type Layer 2 CUDN advertised And a pod runs on the other network On the same node Backing a ClusterIP service The pod on the tested network cannot reach the service on the other network When the networks are IPv6": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 3 CUDN VRF-Lite When a pod runs on the tested network When there is other network Of type Default Both networks are isolated": "[Disabled:Unimplemented]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network When there is other network Of type Layer 2 CUDN advertised And a pod runs on the other network On the same node The pod on the other network cannot reach the pod on the tested network When the networks are IPv4": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 3 CUDN VRF-Lite When a pod runs on the tested network When there is other network Of type Layer 2 CUDN EVPN MAC-VRF Both networks are isolated": "[Disabled:Unimplemented]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network When there is other network Of type Layer 2 CUDN advertised And a pod runs on the other network On the same node The pod on the other network cannot reach the pod on the tested network When the networks are IPv6": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 3 CUDN VRF-Lite When a pod runs on the tested network When there is other network Of type Layer 2 CUDN EVPN MAC-VRF and IP-VRF Both networks are isolated": "[Disabled:Unimplemented]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network When there is other network Of type Layer 2 CUDN advertised And a pod runs on the other network On the same node The pod on the tested network cannot reach the pod on the other network When the networks are IPv4": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 3 CUDN VRF-Lite When a pod runs on the tested network When there is other network Of type Layer 2 CUDN VRF-Lite Both networks are isolated": "[Disabled:Unimplemented]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network When there is other network Of type Layer 2 CUDN advertised And a pod runs on the other network On the same node The pod on the tested network cannot reach the pod on the other network When the networks are IPv6": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 3 CUDN VRF-Lite When a pod runs on the tested network When there is other network Of type Layer 2 CUDN advertised Both networks are isolated": "[Disabled:Unimplemented]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network When there is other network Of type Layer 2 CUDN advertised VRF-Lite And a pod runs on the other network On a different node Backing a ClusterIP service The pod on the tested network cannot reach the service on the other network When the networks are IPv4": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 3 CUDN VRF-Lite When a pod runs on the tested network When there is other network Of type Layer 2 UDN Both networks are isolated": "[Disabled:Unimplemented]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network When there is other network Of type Layer 2 CUDN advertised VRF-Lite And a pod runs on the other network On a different node Backing a ClusterIP service The pod on the tested network cannot reach the service on the other network When the networks are IPv6": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 3 CUDN VRF-Lite When a pod runs on the tested network When there is other network Of type Layer 3 CUDN EVPN IP-VRF Both networks are isolated": "[Disabled:Unimplemented]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network When there is other network Of type Layer 2 CUDN advertised VRF-Lite And a pod runs on the other network On a different node The pod on the other network cannot reach the pod on the tested network When the networks are IPv4": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 3 CUDN VRF-Lite When a pod runs on the tested network When there is other network Of type Layer 3 CUDN VRF-Lite Both networks are isolated": "[Disabled:Unimplemented]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network When there is other network Of type Layer 2 CUDN advertised VRF-Lite And a pod runs on the other network On a different node The pod on the other network cannot reach the pod on the tested network When the networks are IPv6": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 3 CUDN VRF-Lite When a pod runs on the tested network When there is other network Of type Layer 3 CUDN advertised Both networks are isolated": "[Disabled:Unimplemented]",
 
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network When there is other network Of type Layer 2 CUDN advertised VRF-Lite And a pod runs on the other network On a different node The pod on the tested network cannot reach the pod on the other network When the networks are IPv4": "[Disabled:Unimplemented]",
-
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network When there is other network Of type Layer 2 CUDN advertised VRF-Lite And a pod runs on the other network On a different node The pod on the tested network cannot reach the pod on the other network When the networks are IPv6": "[Disabled:Unimplemented]",
-
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network When there is other network Of type Layer 2 CUDN advertised VRF-Lite And a pod runs on the other network On the same node Backing a ClusterIP service The pod on the tested network cannot reach the service on the other network When the networks are IPv4": "[Disabled:Unimplemented]",
-
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network When there is other network Of type Layer 2 CUDN advertised VRF-Lite And a pod runs on the other network On the same node Backing a ClusterIP service The pod on the tested network cannot reach the service on the other network When the networks are IPv6": "[Disabled:Unimplemented]",
-
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network When there is other network Of type Layer 2 CUDN advertised VRF-Lite And a pod runs on the other network On the same node The pod on the other network cannot reach the pod on the tested network When the networks are IPv4": "[Disabled:Unimplemented]",
-
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network When there is other network Of type Layer 2 CUDN advertised VRF-Lite And a pod runs on the other network On the same node The pod on the other network cannot reach the pod on the tested network When the networks are IPv6": "[Disabled:Unimplemented]",
-
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network When there is other network Of type Layer 2 CUDN advertised VRF-Lite And a pod runs on the other network On the same node The pod on the tested network cannot reach the pod on the other network When the networks are IPv4": "[Disabled:Unimplemented]",
-
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network When there is other network Of type Layer 2 CUDN advertised VRF-Lite And a pod runs on the other network On the same node The pod on the tested network cannot reach the pod on the other network When the networks are IPv6": "[Disabled:Unimplemented]",
-
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network When there is other network Of type Layer 2 UDN non advertised And a pod runs on the other network On a different node Backing a ClusterIP service The pod on the tested network cannot reach the service on the other network When the networks are IPv4": "[Disabled:Unimplemented]",
-
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network When there is other network Of type Layer 2 UDN non advertised And a pod runs on the other network On a different node Backing a ClusterIP service The pod on the tested network cannot reach the service on the other network When the networks are IPv6": "[Disabled:Unimplemented]",
-
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network When there is other network Of type Layer 2 UDN non advertised And a pod runs on the other network On a different node The pod on the other network cannot reach the pod on the tested network When the networks are IPv4": "[Disabled:Unimplemented]",
-
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network When there is other network Of type Layer 2 UDN non advertised And a pod runs on the other network On a different node The pod on the other network cannot reach the pod on the tested network When the networks are IPv6": "[Disabled:Unimplemented]",
-
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network When there is other network Of type Layer 2 UDN non advertised And a pod runs on the other network On a different node The pod on the tested network cannot reach the pod on the other network When the networks are IPv4": "[Disabled:Unimplemented]",
-
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network When there is other network Of type Layer 2 UDN non advertised And a pod runs on the other network On a different node The pod on the tested network cannot reach the pod on the other network When the networks are IPv6": "[Disabled:Unimplemented]",
-
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network When there is other network Of type Layer 2 UDN non advertised And a pod runs on the other network On the same node Backing a ClusterIP service The pod on the tested network cannot reach the service on the other network When the networks are IPv4": "[Disabled:Unimplemented]",
-
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network When there is other network Of type Layer 2 UDN non advertised And a pod runs on the other network On the same node Backing a ClusterIP service The pod on the tested network cannot reach the service on the other network When the networks are IPv6": "[Disabled:Unimplemented]",
-
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network When there is other network Of type Layer 2 UDN non advertised And a pod runs on the other network On the same node The pod on the other network cannot reach the pod on the tested network When the networks are IPv4": "[Disabled:Unimplemented]",
-
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network When there is other network Of type Layer 2 UDN non advertised And a pod runs on the other network On the same node The pod on the other network cannot reach the pod on the tested network When the networks are IPv6": "[Disabled:Unimplemented]",
-
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network When there is other network Of type Layer 2 UDN non advertised And a pod runs on the other network On the same node The pod on the tested network cannot reach the pod on the other network When the networks are IPv4": "[Disabled:Unimplemented]",
-
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network When there is other network Of type Layer 2 UDN non advertised And a pod runs on the other network On the same node The pod on the tested network cannot reach the pod on the other network When the networks are IPv6": "[Disabled:Unimplemented]",
-
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network When there is other network Of type Layer 3 CUDN advertised And a pod runs on the other network On a different node Backing a ClusterIP service The pod on the tested network cannot reach the service on the other network When the networks are IPv4": "[Disabled:Unimplemented]",
-
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network When there is other network Of type Layer 3 CUDN advertised And a pod runs on the other network On a different node Backing a ClusterIP service The pod on the tested network cannot reach the service on the other network When the networks are IPv6": "[Disabled:Unimplemented]",
-
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network When there is other network Of type Layer 3 CUDN advertised And a pod runs on the other network On a different node The pod on the other network cannot reach the pod on the tested network When the networks are IPv4": "[Disabled:Unimplemented]",
-
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network When there is other network Of type Layer 3 CUDN advertised And a pod runs on the other network On a different node The pod on the other network cannot reach the pod on the tested network When the networks are IPv6": "[Disabled:Unimplemented]",
-
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network When there is other network Of type Layer 3 CUDN advertised And a pod runs on the other network On a different node The pod on the tested network cannot reach the pod on the other network When the networks are IPv4": "[Disabled:Unimplemented]",
-
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network When there is other network Of type Layer 3 CUDN advertised And a pod runs on the other network On a different node The pod on the tested network cannot reach the pod on the other network When the networks are IPv6": "[Disabled:Unimplemented]",
-
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network When there is other network Of type Layer 3 CUDN advertised And a pod runs on the other network On the same node Backing a ClusterIP service The pod on the tested network cannot reach the service on the other network When the networks are IPv4": "[Disabled:Unimplemented]",
-
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network When there is other network Of type Layer 3 CUDN advertised And a pod runs on the other network On the same node Backing a ClusterIP service The pod on the tested network cannot reach the service on the other network When the networks are IPv6": "[Disabled:Unimplemented]",
-
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network When there is other network Of type Layer 3 CUDN advertised And a pod runs on the other network On the same node The pod on the other network cannot reach the pod on the tested network When the networks are IPv4": "[Disabled:Unimplemented]",
-
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network When there is other network Of type Layer 3 CUDN advertised And a pod runs on the other network On the same node The pod on the other network cannot reach the pod on the tested network When the networks are IPv6": "[Disabled:Unimplemented]",
-
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network When there is other network Of type Layer 3 CUDN advertised And a pod runs on the other network On the same node The pod on the tested network cannot reach the pod on the other network When the networks are IPv4": "[Disabled:Unimplemented]",
-
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network When there is other network Of type Layer 3 CUDN advertised And a pod runs on the other network On the same node The pod on the tested network cannot reach the pod on the other network When the networks are IPv6": "[Disabled:Unimplemented]",
-
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network When there is other network Of type Layer 3 CUDN advertised VRF-Lite And a pod runs on the other network On a different node Backing a ClusterIP service The pod on the tested network cannot reach the service on the other network When the networks are IPv4": "[Disabled:Unimplemented]",
-
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network When there is other network Of type Layer 3 CUDN advertised VRF-Lite And a pod runs on the other network On a different node Backing a ClusterIP service The pod on the tested network cannot reach the service on the other network When the networks are IPv6": "[Disabled:Unimplemented]",
-
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network When there is other network Of type Layer 3 CUDN advertised VRF-Lite And a pod runs on the other network On a different node The pod on the other network cannot reach the pod on the tested network When the networks are IPv4": "[Disabled:Unimplemented]",
-
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network When there is other network Of type Layer 3 CUDN advertised VRF-Lite And a pod runs on the other network On a different node The pod on the other network cannot reach the pod on the tested network When the networks are IPv6": "[Disabled:Unimplemented]",
-
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network When there is other network Of type Layer 3 CUDN advertised VRF-Lite And a pod runs on the other network On a different node The pod on the tested network cannot reach the pod on the other network When the networks are IPv4": "[Disabled:Unimplemented]",
-
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network When there is other network Of type Layer 3 CUDN advertised VRF-Lite And a pod runs on the other network On a different node The pod on the tested network cannot reach the pod on the other network When the networks are IPv6": "[Disabled:Unimplemented]",
-
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network When there is other network Of type Layer 3 CUDN advertised VRF-Lite And a pod runs on the other network On the same node Backing a ClusterIP service The pod on the tested network cannot reach the service on the other network When the networks are IPv4": "[Disabled:Unimplemented]",
-
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network When there is other network Of type Layer 3 CUDN advertised VRF-Lite And a pod runs on the other network On the same node Backing a ClusterIP service The pod on the tested network cannot reach the service on the other network When the networks are IPv6": "[Disabled:Unimplemented]",
-
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network When there is other network Of type Layer 3 CUDN advertised VRF-Lite And a pod runs on the other network On the same node The pod on the other network cannot reach the pod on the tested network When the networks are IPv4": "[Disabled:Unimplemented]",
-
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network When there is other network Of type Layer 3 CUDN advertised VRF-Lite And a pod runs on the other network On the same node The pod on the other network cannot reach the pod on the tested network When the networks are IPv6": "[Disabled:Unimplemented]",
-
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network When there is other network Of type Layer 3 CUDN advertised VRF-Lite And a pod runs on the other network On the same node The pod on the tested network cannot reach the pod on the other network When the networks are IPv4": "[Disabled:Unimplemented]",
-
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network When there is other network Of type Layer 3 CUDN advertised VRF-Lite And a pod runs on the other network On the same node The pod on the tested network cannot reach the pod on the other network When the networks are IPv6": "[Disabled:Unimplemented]",
-
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network When there is other network Of type Layer 3 UDN non advertised And a pod runs on the other network On a different node Backing a ClusterIP service The pod on the tested network cannot reach the service on the other network When the networks are IPv4": "[Disabled:Unimplemented]",
-
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network When there is other network Of type Layer 3 UDN non advertised And a pod runs on the other network On a different node Backing a ClusterIP service The pod on the tested network cannot reach the service on the other network When the networks are IPv6": "[Disabled:Unimplemented]",
-
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network When there is other network Of type Layer 3 UDN non advertised And a pod runs on the other network On a different node The pod on the other network cannot reach the pod on the tested network When the networks are IPv4": "[Disabled:Unimplemented]",
-
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network When there is other network Of type Layer 3 UDN non advertised And a pod runs on the other network On a different node The pod on the other network cannot reach the pod on the tested network When the networks are IPv6": "[Disabled:Unimplemented]",
-
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network When there is other network Of type Layer 3 UDN non advertised And a pod runs on the other network On a different node The pod on the tested network cannot reach the pod on the other network When the networks are IPv4": "[Disabled:Unimplemented]",
-
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network When there is other network Of type Layer 3 UDN non advertised And a pod runs on the other network On a different node The pod on the tested network cannot reach the pod on the other network When the networks are IPv6": "[Disabled:Unimplemented]",
-
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network When there is other network Of type Layer 3 UDN non advertised And a pod runs on the other network On the same node Backing a ClusterIP service The pod on the tested network cannot reach the service on the other network When the networks are IPv4": "[Disabled:Unimplemented]",
-
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network When there is other network Of type Layer 3 UDN non advertised And a pod runs on the other network On the same node Backing a ClusterIP service The pod on the tested network cannot reach the service on the other network When the networks are IPv6": "[Disabled:Unimplemented]",
-
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network When there is other network Of type Layer 3 UDN non advertised And a pod runs on the other network On the same node The pod on the other network cannot reach the pod on the tested network When the networks are IPv4": "[Disabled:Unimplemented]",
-
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network When there is other network Of type Layer 3 UDN non advertised And a pod runs on the other network On the same node The pod on the other network cannot reach the pod on the tested network When the networks are IPv6": "[Disabled:Unimplemented]",
-
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network When there is other network Of type Layer 3 UDN non advertised And a pod runs on the other network On the same node The pod on the tested network cannot reach the pod on the other network When the networks are IPv4": "[Disabled:Unimplemented]",
-
-	"BGP: For a VRF-Lite configured network When the tested network is of type Layer 3 When a pod runs on the tested network When there is other network Of type Layer 3 UDN non advertised And a pod runs on the other network On the same node The pod on the tested network cannot reach the pod on the other network When the networks are IPv6": "[Disabled:Unimplemented]",
+	"BGP: For BGP configured networks When the tested network is of type Layer 3 CUDN VRF-Lite When a pod runs on the tested network When there is other network Of type Layer 3 UDN Both networks are isolated": "[Disabled:Unimplemented]",
 
 	"BGP: Pod to external server when CUDN network is advertised Route Advertisements layer2": "[Disabled:Unimplemented]",
 
@@ -609,6 +499,8 @@ var AppendedAnnotations = map[string]string{
 
 	"ClusterNetworkConnect ClusterManagerController full lifecycle workflow comprehensive workflow - create, add, update, remove networks through CNC lifecycle": "[Disabled:Unimplemented]",
 
+	"ClusterNetworkConnect ClusterManagerController reports error on selected networks subnet overlap": "[Disabled:Unimplemented]",
+
 	"ClusterNetworkConnect ClusterManagerController when CNC has no matching networks has only tunnel ID annotation": "[Disabled:Unimplemented]",
 
 	"ClusterNetworkConnect ClusterManagerController when CNC is created before networks full matrix created after CNC - annotations are updated with all 8 networks": "[Disabled:Unimplemented]",
@@ -677,9 +569,19 @@ var AppendedAnnotations = map[string]string{
 
 	"ClusterNetworkConnect ClusterManagerController when networks exist before CNC creation single network: has both subnet and tunnel ID annotations L3 P-UDN": "[Disabled:Unimplemented]",
 
-	"ClusterNetworkConnect OVN-Kubernetes Controller End-to-end connectivity validation should manage cross-network connectivity through CNC lifecycle": "[Disabled:Unimplemented]",
-
 	"ClusterNetworkConnect OVN-Kubernetes Controller Multiple CNCs with overlapping network selection should maintain non-transitive connectivity when a network is selected by multiple CNCs": "[Disabled:Unimplemented]",
+
+	"ClusterNetworkConnect OVN-Kubernetes Controller Multiple CNCs with overlapping network selection should maintain non-transitive service connectivity when a network is selected by multiple CNCs": "[Disabled:Unimplemented]",
+
+	"ClusterNetworkConnect OVN-Kubernetes Controller Multiple CNCs with overlapping network selection should maintain service connectivity when both CNCs select the exact same networks": "[Disabled:Unimplemented]",
+
+	"ClusterNetworkConnect OVN-Kubernetes Controller Pod to pod connectivity validation should manage cross-network connectivity through CNC lifecycle": "[Disabled:Unimplemented]",
+
+	"ClusterNetworkConnect OVN-Kubernetes Controller Service connectivity validation pod and service connectivity through CNC connectivity types toggling [Feature:NetworkConnect]": "[Disabled:Unimplemented]",
+
+	"ClusterNetworkConnect OVN-Kubernetes Controller Service connectivity validation should maintain cross-network service connectivity after service protocol update": "[Disabled:Unimplemented]",
+
+	"ClusterNetworkConnect OVN-Kubernetes Controller Service connectivity validation should manage cross-network service connectivity through CNC lifecycle": "[Disabled:Unimplemented]",
 
 	"ClusterNetworkConnect: API validations api-server should accept valid ClusterNetworkConnect CRs Valid ClusterNetworkConnect configurations": "[Disabled:Unimplemented]",
 
@@ -687,9 +589,9 @@ var AppendedAnnotations = map[string]string{
 
 	"Creating a static pod on a node Should successfully create then remove a static pod": "[Disabled:Unimplemented]",
 
-	"EVPN: VTEP API validations api-server should accept valid VTEP CRs Valid VTEP configurations": "[Disabled:Unimplemented]",
+	"EVPN: VTEP API validations api-server should accept valid VTEP CRs Valid VTEP configurations": "[Suite:openshift/conformance/parallel]",
 
-	"EVPN: VTEP API validations api-server should reject invalid VTEP CRs Invalid VTEP configurations": "[Disabled:Unimplemented]",
+	"EVPN: VTEP API validations api-server should reject invalid VTEP CRs Invalid VTEP configurations": "[Suite:openshift/conformance/parallel]",
 
 	"EgressService Multiple Networks, external clients sharing ip [LGW] Should validate pods on different networks can reach different clients with same ip without SNAT ipv4 pods": "[Disabled:Unimplemented]",
 
@@ -1002,6 +904,8 @@ var AppendedAnnotations = map[string]string{
 	"Multi Homing A pod with multiple attachments to the same secondary NAD features multiple different IPs and connectivity redundancy L2 secondary NAD": "[Disabled:Unimplemented]",
 
 	"Multi Homing A pod with multiple attachments to the same secondary NAD features multiple different IPs and connectivity redundancy L3 secondary NAD": "[Disabled:Unimplemented]",
+
+	"Multi Homing A pod with multiple attachments to the same secondary NAD features multiple different IPs and connectivity redundancy Localnet secondary NAD": "[Disabled:Unimplemented]",
 
 	"Multi Homing A single pod with an OVN-K secondary network attached to a localnet network mapped to external primary interface bridge can be reached by a client pod in the default network on a different node, when the localnet uses a VLAN and an external router": "[Disabled:Unimplemented]",
 
@@ -1373,13 +1277,15 @@ var AppendedAnnotations = map[string]string{
 
 	"Network Segmentation: Preconfigured Layer2 UDN unmasked reserved / infrastructure subnets are not allowed Layer2 with unmasked IPv6 reserved subnets": "[Suite:openshift/conformance/parallel]",
 
-	"Network Segmentation: integration should recover ovnkube pods after restart with primary and secondary UDN resources": "[Suite:openshift/conformance/parallel]",
+	"Network Segmentation: integration should recover ovnkube pods after restart with primary and secondary UDN resources": "[Disabled:Unimplemented]",
 
 	"Network Segmentation: services on a user defined primary network should be reachable through their cluster IP, node port and load balancer L2 primary UDN with custom network, cluster-networked pods, NodePort service": "[Suite:openshift/conformance/parallel]",
 
 	"Network Segmentation: services on a user defined primary network should be reachable through their cluster IP, node port and load balancer L2 primary UDN, cluster-networked pods, NodePort service": "[Disabled:Unimplemented]",
 
 	"Network Segmentation: services on a user defined primary network should be reachable through their cluster IP, node port and load balancer L3 primary UDN, cluster-networked pods, NodePort service": "[Disabled:Unimplemented]",
+
+	"No-Overlay: Default network is enabled with no-overlay when connectivity tests should maintain pod2pod/pod2service/host2pod/host2service connectivity without overlay before and after ovnkube-node pod restarted": "[Disabled:Unimplemented]",
 
 	"Node IP and MAC address migration when the node IPv4 address is updated when ETP=Local service with host network backend is configured makes sure that the flows are updated with new IP address (update kubelet first, the IP address later)": "[Disabled:Unimplemented]",
 

--- a/openshift/test/infraprovider/openshift.go
+++ b/openshift/test/infraprovider/openshift.go
@@ -39,6 +39,7 @@ const (
 	// These are set during infra provider initialization and consumed by test selection logic
 	EnvVarOVNGatewayMode     = "OVN_GATEWAY_MODE"
 	EnvVarEVPNFeatureEnabled = "EVPN_FEATURE_ENABLED"
+	EnvVarNoOverlayEnabled   = "NO_OVERLAY_ENABLED"
 )
 
 // Provider extends the base api.Provider interface with OpenShift-specific
@@ -129,6 +130,7 @@ func (o *openshift) LoadTestConfigs() error {
 	if err != nil {
 		return fmt.Errorf("failed to check EVPN capability with the cluster: %w", err)
 	}
+	o.detectNoOverlayCapability(network)
 	// Future feature detection can be added here, reusing network and clusterFeatureGate
 
 	return nil
@@ -207,6 +209,16 @@ func isLocalGatewayMode(network *operv1.Network) bool {
 
 	return network.Spec.DefaultNetwork.OVNKubernetesConfig.GatewayConfig != nil &&
 		network.Spec.DefaultNetwork.OVNKubernetesConfig.GatewayConfig.RoutingViaHost
+}
+
+// detectNoOverlayCapability checks if no-overlay mode is enabled and sets the env var
+func (o *openshift) detectNoOverlayCapability(network *operv1.Network) {
+	if network.Spec.DefaultNetwork.OVNKubernetesConfig == nil {
+		return
+	}
+	if network.Spec.DefaultNetwork.OVNKubernetesConfig.Transport == operv1.TransportOptionNoOverlay {
+		os.Setenv(EnvVarNoOverlayEnabled, "true")
+	}
 }
 
 // hasFRRExternalContainer checks if the FRR external container is available.

--- a/openshift/test/infraprovider/openshift.go
+++ b/openshift/test/infraprovider/openshift.go
@@ -2,11 +2,19 @@ package infraprovider
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
 	"time"
+
+	configv1 "github.com/openshift/api/config/v1"
+	operv1 "github.com/openshift/api/operator/v1"
+	configclient "github.com/openshift/client-go/config/clientset/versioned"
+	operatorv1client "github.com/openshift/client-go/operator/clientset/versioned"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	ovnkconfig "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/infraprovider/api"
@@ -18,24 +26,44 @@ import (
 	"k8s.io/kubernetes/test/e2e/framework"
 )
 
+const (
+	// use network name created for attaching frr container with
+	// cluster primary network as per changes in the link:
+	// https://github.com/openshift/release/blob/db6697de61f4ae7e05c5a2db782a87c459e849bf/ci-operator/step-registry/baremetalds/e2e/ovn/bgp/pre/baremetalds-e2e-ovn-bgp-pre-commands.sh#L123-L124
+	primaryNetworkName         = "ostestbm_net"
+	frrContainerPrimaryNetIPv4 = "192.168.111.3"
+	frrContainerPrimaryNetIPv6 = "fd2e:6f44:5dd8:c956::3"
+	externalFRRContainerName   = "frr"
+
+	// Environment variable names for test configuration
+	// These are set during infra provider initialization and consumed by test selection logic
+	EnvVarOVNGatewayMode     = "OVN_GATEWAY_MODE"
+	EnvVarEVPNFeatureEnabled = "EVPN_FEATURE_ENABLED"
+)
+
+// Provider extends the base api.Provider interface with OpenShift-specific
+// initialization that uses lazy loading to optimize performance for non-test commands.
+//
+// The initialization is split into two phases:
+//  1. New() and LoadTestConfigs() performs lightweight initialization - loads cluster
+//     capabilities (EVPN, gateway mode) needed for test filtering in 'list' command.
+//     This phase MUST avoid verbose logging (e.g., from RunHostCmd/builder.go)
+//     to keep metadata commands clean and user-friendly.
+//  2. InitProvider() performs heavyweight initialization - discovers nodes,
+//     network interfaces, and external container setup. This should only be called
+//     before tests execute (e.g., in a BeforeAll hook) to avoid expensive operations
+//     and verbose logging during metadata-only commands like 'list', 'info', or 'images'
+type Provider interface {
+	api.Provider
+	LoadTestConfigs() error
+	InitProvider() error
+}
+
 type openshift struct {
+	config                     *rest.Config
 	externalContainerPortAlloc *portalloc.PortAllocator
 	hostPortAlloc              *portalloc.PortAllocator
 	kubeClient                 *kubernetes.Clientset
-}
-
-func (o openshift) ShutdownNode(nodeName string) error {
-	panic("not implemented")
-}
-
-func (o openshift) StartNode(nodeName string) error {
-	panic("not implemented")
-}
-
-func (m openshift) GetDefaultTimeoutContext() *framework.TimeoutContext {
-	timeouts := framework.NewTimeoutContext()
-	timeouts.PodStart = 10 * time.Minute
-	return timeouts
 }
 
 func IsProvider(config *rest.Config) (bool, error) {
@@ -56,59 +84,193 @@ func IsProvider(config *rest.Config) (bool, error) {
 	return false, nil
 }
 
-func New(config *rest.Config) (api.Provider, error) {
+func New(config *rest.Config) (Provider, error) {
 	ovnkconfig.Kubernetes.DNSServiceNamespace = "openshift-dns"
 	ovnkconfig.Kubernetes.DNSServiceName = "dns-default"
 	kubeClient, err := kubernetes.NewForConfig(config)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create kubernetes client: %w", err)
 	}
-	return openshift{
+	return &openshift{
+		config:                     config,
 		externalContainerPortAlloc: portalloc.New(30000, 32767),
 		hostPortAlloc:              portalloc.New(30000, 32767),
 		kubeClient:                 kubeClient,
 	}, nil
 }
 
-func (o openshift) PreloadImages(images []string) {
+func (o *openshift) LoadTestConfigs() error {
+	// Fetch cluster configs once and reuse for all checks.
+	// This optimization makes it easy to add more feature gate or network config checks
+	// in the future without additional API calls.
+	operatorClient, err := operatorv1client.NewForConfig(o.config)
+	if err != nil {
+		return fmt.Errorf("failed to retrieve operator client: %w", err)
+	}
+
+	configClient, err := configclient.NewForConfig(o.config)
+	if err != nil {
+		return fmt.Errorf("failed to retrieve config client: %w", err)
+	}
+
+	network, err := operatorClient.OperatorV1().Networks().Get(context.Background(), "cluster", metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to retrieve network operator cluster object: %w", err)
+	}
+
+	clusterFeatureGate, err := configClient.ConfigV1().FeatureGates().Get(context.Background(), "cluster", metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to retrieve cluster feature gate: %w", err)
+	}
+
+	// Configure test environment based on cluster configuration
+	o.configureOVNGatewayMode(network)
+	err = o.detectEVPNCapability(network, clusterFeatureGate)
+	if err != nil {
+		return fmt.Errorf("failed to check EVPN capability with the cluster: %w", err)
+	}
+	// Future feature detection can be added here, reusing network and clusterFeatureGate
+
+	return nil
+}
+
+func (o *openshift) InitProvider() error {
+	return nil
+}
+
+// configureOVNGatewayMode detects and configures the OVN gateway mode for tests
+func (o *openshift) configureOVNGatewayMode(network *operv1.Network) {
+	if network.Spec.DefaultNetwork.OVNKubernetesConfig == nil {
+		return
+	}
+
+	if network.Spec.DefaultNetwork.OVNKubernetesConfig.GatewayConfig != nil &&
+		network.Spec.DefaultNetwork.OVNKubernetesConfig.GatewayConfig.RoutingViaHost {
+		os.Setenv(EnvVarOVNGatewayMode, "local")
+	}
+}
+
+// detectEVPNCapability checks all EVPN prerequisites and enables EVPN tests if available
+func (o *openshift) detectEVPNCapability(network *operv1.Network, featureGate *configv1.FeatureGate) error {
+	if !hasEVPNFeatureGate(featureGate) {
+		return nil
+	}
+	if !hasFRRRouteProvider(network) {
+		return nil
+	}
+	if !isLocalGatewayMode(network) {
+		return nil
+	}
+	exists, err := o.hasFRRExternalContainer()
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return nil
+	}
+	// All prerequisites met - enable EVPN tests
+	os.Setenv(EnvVarEVPNFeatureEnabled, "true")
+	return nil
+}
+
+// hasEVPNFeatureGate checks if the EVPN feature gate is enabled in the cluster
+func hasEVPNFeatureGate(clusterFeatureGate *configv1.FeatureGate) bool {
+	for _, featureGate := range clusterFeatureGate.Status.FeatureGates {
+		for _, feature := range featureGate.Enabled {
+			if feature.Name == "EVPN" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// hasFRRRouteProvider checks if FRR is configured as a routing capability provider.
+func hasFRRRouteProvider(network *operv1.Network) bool {
+	if network.Spec.AdditionalRoutingCapabilities == nil {
+		return false
+	}
+
+	for _, raProvider := range network.Spec.AdditionalRoutingCapabilities.Providers {
+		if raProvider == operv1.RoutingCapabilitiesProviderFRR {
+			return true
+		}
+	}
+	return false
+}
+
+// isLocalGatewayMode checks if OVN is configured with local gateway mode (routing via host).
+func isLocalGatewayMode(network *operv1.Network) bool {
+	if network.Spec.DefaultNetwork.OVNKubernetesConfig == nil {
+		return false
+	}
+
+	return network.Spec.DefaultNetwork.OVNKubernetesConfig.GatewayConfig != nil &&
+		network.Spec.DefaultNetwork.OVNKubernetesConfig.GatewayConfig.RoutingViaHost
+}
+
+// hasFRRExternalContainer checks if the FRR external container is available.
+// Returns false when the container engine is not configured (e.g., non-baremetal clusters).
+func (o *openshift) hasFRRExternalContainer() (bool, error) {
+	return false, nil
+}
+
+func (o *openshift) ShutdownNode(nodeName string) error {
+	return fmt.Errorf("ShutdownNode not implemented for OpenShift provider")
+}
+
+func (o *openshift) StartNode(nodeName string) error {
+	return fmt.Errorf("StartNode not implemented for OpenShift provider")
+}
+
+func (o *openshift) GetDefaultTimeoutContext() *framework.TimeoutContext {
+	timeouts := framework.NewTimeoutContext()
+	timeouts.PodStart = 10 * time.Minute
+	return timeouts
+}
+
+func (o *openshift) PreloadImages(images []string) {
 	// no-op: OpenShift clusters pull images at runtime
 }
 
-func (o openshift) Name() string {
+func (o *openshift) Name() string {
 	return "openshift"
 }
 
-func (o openshift) PrimaryNetwork() (api.Network, error) {
+func (o *openshift) PrimaryNetwork() (api.Network, error) {
 	panic("not implemented")
 }
 
-func (o openshift) ExternalContainerPrimaryInterfaceName() string {
+func (o *openshift) ExternalContainerPrimaryInterfaceName() string {
 	panic("not implemented")
 }
 
-func (o openshift) GetNetwork(name string) (api.Network, error) {
+func (o *openshift) GetNetwork(name string) (api.Network, error) {
 	panic("not implemented")
 }
 
-func (o openshift) GetExternalContainerNetworkInterface(container api.ExternalContainer, network api.Network) (api.NetworkInterface, error) {
+func (o *openshift) GetExternalContainerNetworkInterface(container api.ExternalContainer, network api.Network) (api.NetworkInterface, error) {
 	panic("not implemented")
 }
 
-func (o openshift) GetK8NodeNetworkInterface(instance string, network api.Network) (api.NetworkInterface, error) {
+func (o *openshift) GetK8NodeNetworkInterface(instance string, network api.Network) (api.NetworkInterface, error) {
 	panic("not implemented")
 }
 
-func (o openshift) GetExternalContainerLogs(container api.ExternalContainer) (string, error) {
+func (o *openshift) GetExternalContainerLogs(container api.ExternalContainer) (string, error) {
 	panic("not implemented")
 }
 
-func (o openshift) ExecK8NodeCommand(nodeName string, cmd []string) (string, error) {
+func (o *openshift) ExecK8NodeCommand(nodeName string, cmd []string) (string, error) {
 	if len(cmd) == 0 {
-		panic("ExecK8NodeCommand(): insufficient command arguments")
+		return "", fmt.Errorf("insufficient command arguments")
 	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
 	cmd = append([]string{"debug", fmt.Sprintf("node/%s", nodeName), "--to-namespace=default",
 		"--", "chroot", "/host"}, cmd...)
-	ocDebugCmd := exec.Command("oc", cmd...)
+	ocDebugCmd := exec.CommandContext(ctx, "oc", cmd...)
 	var stdout, stderr bytes.Buffer
 	ocDebugCmd.Stdout = &stdout
 	ocDebugCmd.Stderr = &stderr
@@ -119,22 +281,26 @@ func (o openshift) ExecK8NodeCommand(nodeName string, cmd []string) (string, err
 	return stdout.String(), nil
 }
 
-func (o openshift) ExecExternalContainerCommand(container api.ExternalContainer, cmd []string) (string, error) {
+func (o *openshift) ExecExternalContainerCommand(container api.ExternalContainer, cmd []string) (string, error) {
 	panic("not implemented")
 }
 
-func (o openshift) GetExternalContainerPort() uint16 {
+func (o *openshift) GetExternalContainerPort() uint16 {
 	return o.externalContainerPortAlloc.Allocate()
 }
 
-func (o openshift) GetK8HostPort() uint16 {
+func (o *openshift) GetK8HostPort() uint16 {
 	return o.hostPortAlloc.Allocate()
 }
 
-func (o openshift) NewTestContext() api.Context {
+func (o *openshift) NewTestContext() api.Context {
 	co := &contextOpenshift{make([]func() error, 0)}
 	ginkgo.DeferCleanup(co.CleanUp)
 	return co
+}
+
+func (o *openshift) ListNetworks() ([]string, error) {
+	panic("not implemented")
 }
 
 type contextOpenshift struct {
@@ -154,10 +320,6 @@ func (c *contextOpenshift) DeleteExternalContainer(container api.ExternalContain
 }
 
 func (c *contextOpenshift) GetExternalContainerLogs(container api.ExternalContainer) (string, error) {
-	panic("not implemented")
-}
-
-func (o openshift) ListNetworks() ([]string, error) {
 	panic("not implemented")
 }
 
@@ -192,7 +354,6 @@ func (c *contextOpenshift) AddCleanUpFn(cleanUpFn func() error) {
 func (c *contextOpenshift) CleanUp() error {
 	ginkgo.By("Cleaning up openshift test context")
 	var errs []error
-	// generic cleanup activities
 	for i := len(c.cleanUpFns) - 1; i >= 0; i-- {
 		if err := c.cleanUpFns[i](); err != nil {
 			errs = append(errs, err)

--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -120,7 +120,6 @@ require (
 	go.opentelemetry.io/proto/otlp v1.5.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
-	golang.org/x/crypto v0.45.0 // indirect
 	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 // indirect
 	golang.org/x/mod v0.29.0 // indirect
 	golang.org/x/net v0.47.0 // indirect
@@ -167,6 +166,7 @@ require (
 	github.com/openshift-kni/k8sreporter v1.0.6
 	github.com/ovn-kubernetes/ovn-kubernetes/go-controller v1.0.0
 	go.universe.tf/metallb v0.0.0-00010101000000-000000000000
+	golang.org/x/crypto v0.45.0
 	google.golang.org/grpc v1.72.2
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/klog/v2 v2.130.1


### PR DESCRIPTION
Implement automatic detection and filtering of no-overlay tests in OpenShift Tests Extension (OTE) based on cluster configuration.

Implementation:
1. Added IsNoOverlayEnabled() to openshift deployment config
   - Queries ovnkube-config ConfigMap via Kubernetes API
   - Parses transport configuration (geneve vs no-overlay)
   - Uses clientcmd for flexible KUBECONFIG loading

2. Added detectNoOverlayEnabled() in main()
   - Runs at OTE startup before test spec finalization
   - Calls IsNoOverlayEnabled() to check cluster config
   - Defaults to false (disabled) when cluster unavailable

3. Added filtering logic in specs.Walk() and specs.Select()
   - Marks Feature:NoOverlay tests when no-overlay is disabled
   - Filters marked tests during test selection
   - Follows same pattern as NetworkSegmentation filtering

This ensures Feature:NoOverlay tests only run on clusters that actually have no-overlay enabled.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
tested in my local:

1. On cluster which enabled the no-overlay for default network 
`# ./bin/ovn-kubernetes-tests-ext list tests | grep -i nooverlay

  I0326 05:58:27.240993 829266 openshift.go:98] IsNoOverlayEnabled: detected no-overlay=true
    "name": "[Feature:NoOverlay][ovn-kubernetes-ote][sig-network] No-Overlay: Default network is enabled with no-overlay when connectivity tests should maintain pod2pod/pod2service/host2pod/host2service connectivity without overlay before and after ovnkube-node pod restarted",
      "Feature:NoOverlay": {},`

2. On cluster which not enable no-overlay
`# ./bin/ovn-kubernetes-tests-ext list tests | grep -i nooverlay

  I0326 06:01:24.982476 830243 openshift.go:98] IsNoOverlayEnabled: detected no-overlay=false`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic detection of cluster no-overlay mode configuration.
  * Tests labeled with no-overlay features are now automatically marked as disabled when the feature is unavailable on the cluster.
  * Enhanced test filtering for improved compatibility across different OpenShift configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->