### PR TITLE
Add webhook readiness probe and nodeAnnotator retry logic

### DIFF
--- a/go-controller/cmd/ovnkube-identity/ovnkubeidentity.go
+++ b/go-controller/cmd/ovnkube-identity/ovnkubeidentity.go
@@ -371,6 +371,11 @@ func runWebhook(ctx context.Context, restCfg *rest.Config) error {
 		webhookMux.Handle("/pod", podHandler)
 	}
 
+	webhookMux.HandleFunc("/readyz", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ok"))
+	})
+
 	cfg := &tls.Config{
 		NextProtos: []string{"h2"},
 		MinVersion: tls.VersionTLS10,

--- a/go-controller/cmd/ovnkube-identity/ovnkubeidentity.go
+++ b/go-controller/cmd/ovnkube-identity/ovnkubeidentity.go
@@ -371,9 +371,11 @@ func runWebhook(ctx context.Context, restCfg *rest.Config) error {
 		webhookMux.Handle("/pod", podHandler)
 	}
 
-	webhookMux.HandleFunc("/readyz", func(w http.ResponseWriter, r *http.Request) {
+	webhookMux.HandleFunc("/readyz", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("ok"))
+		if _, err := w.Write([]byte("ok")); err != nil {
+			klog.Errorf("Failed to write readyz response: %v", err)
+		}
 	})
 
 	cfg := &tls.Config{

--- a/go-controller/pkg/node/default_node_network_controller.go
+++ b/go-controller/pkg/node/default_node_network_controller.go
@@ -875,8 +875,15 @@ func (nc *DefaultNodeNetworkController) Init(ctx context.Context) error {
 		}
 	}
 
-	if err := nodeAnnotator.Run(); err != nil {
-		return fmt.Errorf("failed to set node %s annotations: %w", nc.name, err)
+	err = wait.PollUntilContextTimeout(ctx, 500*time.Millisecond, 300*time.Second, true, func(_ context.Context) (bool, error) {
+		if err := nodeAnnotator.Run(); err != nil {
+			klog.Infof("Waiting for node %s annotation update to succeed: %v", nc.name, err)
+			return false, nil
+		}
+		return true, nil
+	})
+	if err != nil {
+		return fmt.Errorf("timed out trying to set node %s annotations: %w", nc.name, err)
 	}
 
 	// Connect ovn-controller to SBDB
@@ -895,13 +902,13 @@ func (nc *DefaultNodeNetworkController) Init(ctx context.Context) error {
 			return fmt.Errorf("IPv6 mode is not supported on a DPU enabled node")
 		}
 		// Initialize gateway for OVS internal port or representor management port
-		gw, err := nc.initGatewayPreStart(subnets, nodeAnnotator, nc.mgmtPortController)
+		gw, err := nc.initGatewayPreStart(ctx, subnets, nodeAnnotator, nc.mgmtPortController)
 		if err != nil {
 			return err
 		}
 		nc.Gateway = gw
 	} else {
-		err = nc.initGatewayDPUHostPreStart(nc.nodeAddress, nodeAnnotator)
+		err = nc.initGatewayDPUHostPreStart(ctx, nc.nodeAddress, nodeAnnotator)
 		if err != nil {
 			return err
 		}

--- a/go-controller/pkg/node/default_node_network_controller.go
+++ b/go-controller/pkg/node/default_node_network_controller.go
@@ -875,15 +875,8 @@ func (nc *DefaultNodeNetworkController) Init(ctx context.Context) error {
 		}
 	}
 
-	err = wait.PollUntilContextTimeout(ctx, 500*time.Millisecond, 300*time.Second, true, func(_ context.Context) (bool, error) {
-		if err := nodeAnnotator.Run(); err != nil {
-			klog.Infof("Waiting for node %s annotation update to succeed: %v", nc.name, err)
-			return false, nil
-		}
-		return true, nil
-	})
-	if err != nil {
-		return fmt.Errorf("timed out trying to set node %s annotations: %w", nc.name, err)
+	if err := runNodeAnnotatorWithRetry(ctx, nodeAnnotator, nc.name, "init"); err != nil {
+		return err
 	}
 
 	// Connect ovn-controller to SBDB

--- a/go-controller/pkg/node/gateway_init.go
+++ b/go-controller/pkg/node/gateway_init.go
@@ -313,15 +313,8 @@ func (nc *DefaultNodeNetworkController) initGatewayPreStart(
 		return gw.readyFunc()
 	}
 
-	err = wait.PollUntilContextTimeout(ctx, 500*time.Millisecond, 300*time.Second, true, func(_ context.Context) (bool, error) {
-		if err := nodeAnnotator.Run(); err != nil {
-			klog.Infof("Waiting for node %s gateway annotation update to succeed: %v", nc.name, err)
-			return false, nil
-		}
-		return true, nil
-	})
-	if err != nil {
-		return nil, fmt.Errorf("timed out trying to set node %s gateway annotations: %w", nc.name, err)
+	if err := runNodeAnnotatorWithRetry(ctx, nodeAnnotator, nc.name, "gateway"); err != nil {
+		return nil, err
 	}
 
 	waiter.AddWait(readyGwFunc, initGwFunc)
@@ -447,15 +440,8 @@ func (nc *DefaultNodeNetworkController) initGatewayDPUHostPreStart(ctx context.C
 	}
 
 	// Apply all node annotations to the Kubernetes node object
-	err = wait.PollUntilContextTimeout(ctx, 500*time.Millisecond, 300*time.Second, true, func(_ context.Context) (bool, error) {
-		if err := nodeAnnotator.Run(); err != nil {
-			klog.Infof("Waiting for node %s DPU host annotation update to succeed: %v", nc.name, err)
-			return false, nil
-		}
-		return true, nil
-	})
-	if err != nil {
-		return fmt.Errorf("timed out trying to set node %s DPU host annotations: %w", nc.name, err)
+	if err := runNodeAnnotatorWithRetry(ctx, nodeAnnotator, nc.name, "DPU host"); err != nil {
+		return err
 	}
 
 	// Delete stale masquerade resources if there are any. This is to make sure that there
@@ -614,4 +600,20 @@ func (nc *DefaultNodeNetworkController) updateGatewayMAC(link netlink.Link) erro
 
 	return nil
 
+}
+
+// runNodeAnnotatorWithRetry retries nodeAnnotator.Run() with exponential backoff
+// to handle transient API server connectivity issues during node startup.
+func runNodeAnnotatorWithRetry(ctx context.Context, nodeAnnotator kube.Annotator, nodeName, annotationType string) error {
+	err := wait.PollUntilContextTimeout(ctx, 500*time.Millisecond, 300*time.Second, true, func(_ context.Context) (bool, error) {
+		if err := nodeAnnotator.Run(); err != nil {
+			klog.Infof("Waiting for node %s %s annotation update to succeed: %v", nodeName, annotationType, err)
+			return false, nil
+		}
+		return true, nil
+	})
+	if err != nil {
+		return fmt.Errorf("timed out trying to set node %s %s annotations: %w", nodeName, annotationType, err)
+	}
+	return nil
 }

--- a/go-controller/pkg/node/gateway_init.go
+++ b/go-controller/pkg/node/gateway_init.go
@@ -1,6 +1,7 @@
 package node
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net"
@@ -10,6 +11,7 @@ import (
 	"github.com/vishvananda/netlink"
 
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 	utilnet "k8s.io/utils/net"
 
@@ -226,6 +228,7 @@ func getNodePrimaryIfAddrs(watchFactory factory.NodeWatchFactory, nodeName strin
 // It is split from initGatewayMainStart to allow for the gateway object and openflow manager to be created
 // before the rest of the gateway functionality is started.
 func (nc *DefaultNodeNetworkController) initGatewayPreStart(
+	ctx context.Context,
 	subnets []*net.IPNet,
 	nodeAnnotator kube.Annotator,
 	mgmtPort managementport.Interface,
@@ -310,8 +313,15 @@ func (nc *DefaultNodeNetworkController) initGatewayPreStart(
 		return gw.readyFunc()
 	}
 
-	if err := nodeAnnotator.Run(); err != nil {
-		return nil, fmt.Errorf("failed to set node %s annotations: %w", nc.name, err)
+	err = wait.PollUntilContextTimeout(ctx, 500*time.Millisecond, 300*time.Second, true, func(_ context.Context) (bool, error) {
+		if err := nodeAnnotator.Run(); err != nil {
+			klog.Infof("Waiting for node %s gateway annotation update to succeed: %v", nc.name, err)
+			return false, nil
+		}
+		return true, nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("timed out trying to set node %s gateway annotations: %w", nc.name, err)
 	}
 
 	waiter.AddWait(readyGwFunc, initGwFunc)
@@ -385,7 +395,7 @@ func interfaceForEXGW(intfName string) string {
 }
 
 // TODO(adrianc): revisit if support for nodeIPManager is needed.
-func (nc *DefaultNodeNetworkController) initGatewayDPUHostPreStart(kubeNodeIP net.IP, nodeAnnotator kube.Annotator) error {
+func (nc *DefaultNodeNetworkController) initGatewayDPUHostPreStart(ctx context.Context, kubeNodeIP net.IP, nodeAnnotator kube.Annotator) error {
 	klog.Info("Initializing Shared Gateway Functionality for Gateway PreStart on DPU host")
 
 	// Find the network interface that has the Kubernetes node IP assigned to it
@@ -437,8 +447,15 @@ func (nc *DefaultNodeNetworkController) initGatewayDPUHostPreStart(kubeNodeIP ne
 	}
 
 	// Apply all node annotations to the Kubernetes node object
-	if err := nodeAnnotator.Run(); err != nil {
-		return fmt.Errorf("failed to set node %s annotations: %w", nc.name, err)
+	err = wait.PollUntilContextTimeout(ctx, 500*time.Millisecond, 300*time.Second, true, func(_ context.Context) (bool, error) {
+		if err := nodeAnnotator.Run(); err != nil {
+			klog.Infof("Waiting for node %s DPU host annotation update to succeed: %v", nc.name, err)
+			return false, nil
+		}
+		return true, nil
+	})
+	if err != nil {
+		return fmt.Errorf("timed out trying to set node %s DPU host annotations: %w", nc.name, err)
 	}
 
 	// Delete stale masquerade resources if there are any. This is to make sure that there

--- a/go-controller/pkg/node/gateway_init.go
+++ b/go-controller/pkg/node/gateway_init.go
@@ -602,17 +602,25 @@ func (nc *DefaultNodeNetworkController) updateGatewayMAC(link netlink.Link) erro
 
 }
 
-// runNodeAnnotatorWithRetry retries nodeAnnotator.Run() with exponential backoff
+const (
+	nodeAnnotatorRetryInterval = 500 * time.Millisecond
+	nodeAnnotatorRetryTimeout  = 300 * time.Second
+)
+
+// runNodeAnnotatorWithRetry retries nodeAnnotator.Run() with fixed-interval polling
 // to handle transient API server connectivity issues during node startup.
 func runNodeAnnotatorWithRetry(ctx context.Context, nodeAnnotator kube.Annotator, nodeName, annotationType string) error {
-	err := wait.PollUntilContextTimeout(ctx, 500*time.Millisecond, 300*time.Second, true, func(_ context.Context) (bool, error) {
+	err := wait.PollUntilContextTimeout(ctx, nodeAnnotatorRetryInterval, nodeAnnotatorRetryTimeout, true, func(_ context.Context) (bool, error) {
 		if err := nodeAnnotator.Run(); err != nil {
-			klog.Infof("Waiting for node %s %s annotation update to succeed: %v", nodeName, annotationType, err)
+			klog.V(2).Infof("Waiting for node %s %s annotation update to succeed: %v", nodeName, annotationType, err)
 			return false, nil
 		}
 		return true, nil
 	})
 	if err != nil {
+		if ctx.Err() != nil {
+			return fmt.Errorf("context canceled while setting node %s %s annotations: %w", nodeName, annotationType, err)
+		}
 		return fmt.Errorf("timed out trying to set node %s %s annotations: %w", nodeName, annotationType, err)
 	}
 	return nil

--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -959,7 +959,7 @@ func shareGatewayInterfaceDPUHostTest(app *cli.App, testNS ns.NetNS, uplinkName,
 
 			nodeAnnotator := kube.NewNodeAnnotator(k, existingNode.Name)
 
-			err := nc.initGatewayDPUHostPreStart(net.ParseIP(hostIP), nodeAnnotator)
+			err := nc.initGatewayDPUHostPreStart(context.TODO(), net.ParseIP(hostIP), nodeAnnotator)
 			Expect(err).NotTo(HaveOccurred())
 			err = nc.initGatewayDPUHost()
 			Expect(err).NotTo(HaveOccurred())

--- a/helm/ovn-kubernetes/charts/ovnkube-identity/templates/ovnkube-identity.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-identity/templates/ovnkube-identity.yaml
@@ -49,6 +49,15 @@ spec:
         securityContext:
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 9443
+            scheme: HTTPS
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 3
         resources:
           requests:
             cpu: 100m

--- a/helm/ovn-kubernetes/charts/ovnkube-identity/templates/ovnkube-identity.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-identity/templates/ovnkube-identity.yaml
@@ -52,7 +52,7 @@ spec:
         readinessProbe:
           httpGet:
             path: /readyz
-            port: 9443
+            port: {{ .Values.webhookPort | default 9443 }}
             scheme: HTTPS
           initialDelaySeconds: 5
           periodSeconds: 10

--- a/helm/ovn-kubernetes/charts/ovnkube-identity/values.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-identity/values.yaml
@@ -2,3 +2,4 @@ logLevel: 4
 logFileMaxSize: 100
 logFileMaxBackups: 5
 logFileMaxAge: 5
+webhookPort: 9443


### PR DESCRIPTION
/hold

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a /readyz readiness endpoint on the webhook server.

* **Improvements**
  * Node annotation setup now retries with timeout and respects caller cancellation, improving robustness and failure reporting.

* **Configuration**
  * Added an HTTPS readinessProbe and a configurable webhook port in the ovnkube-identity chart to improve deployment health monitoring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->