### PR TITLE
[release-4.17] OCPBUGS-81639: External gateway: Remove routes for external gateway pods in terminating or not ready state

### DIFF
--- a/go-controller/pkg/ovn/controller/apbroute/external_controller.go
+++ b/go-controller/pkg/ovn/controller/apbroute/external_controller.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
+	v1pod "k8s.io/kubernetes/pkg/api/v1/pod"
 
 	nettypes "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	adminpolicybasedrouteapi "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/adminpolicybasedroute/v1"
@@ -564,10 +565,14 @@ func (m *externalPolicyManager) onPodUpdate(oldObj, newObj interface{}) {
 		utilruntime.HandleError(errors.New("invalid Pod provided to onPodUpdate()"))
 		return
 	}
-	// if labels AND assigned Pod IPs AND the multus network status annotations are the same, skip processing changes to the pod.
+	// if labels AND assigned Pod IPs AND the multus network status annotations AND
+	// pod PodReady condition AND deletion timestamp (PodTerminating) are
+	// the same, skip processing changes to the pod.
 	if reflect.DeepEqual(o.Labels, n.Labels) &&
 		reflect.DeepEqual(o.Status.PodIPs, n.Status.PodIPs) &&
-		reflect.DeepEqual(o.Annotations[nettypes.NetworkStatusAnnot], n.Annotations[nettypes.NetworkStatusAnnot]) {
+		reflect.DeepEqual(o.Annotations[nettypes.NetworkStatusAnnot], n.Annotations[nettypes.NetworkStatusAnnot]) &&
+		reflect.DeepEqual(v1pod.GetPodReadyCondition(o.Status), v1pod.GetPodReadyCondition(n.Status)) &&
+		reflect.DeepEqual(o.DeletionTimestamp, n.DeletionTimestamp) {
 		return
 	}
 	m.podQueue.Add(newObj)

--- a/go-controller/pkg/ovn/controller/apbroute/external_controller_namespace_test.go
+++ b/go-controller/pkg/ovn/controller/apbroute/external_controller_namespace_test.go
@@ -200,14 +200,32 @@ var _ = Describe("OVN External Gateway namespace", func() {
 					"k8s.ovn.org/routing-network": "",
 					nettypes.NetworkStatusAnnot:   fmt.Sprintf(network_status, annotatedPodIP)},
 			},
-			Status: corev1.PodStatus{PodIPs: []corev1.PodIP{{IP: annotatedPodIP}}, Phase: corev1.PodRunning},
+			Status: corev1.PodStatus{
+				PodIPs: []corev1.PodIP{{IP: annotatedPodIP}},
+				Phase:  corev1.PodRunning,
+				Conditions: []corev1.PodCondition{
+					{
+						Type:   corev1.PodReady,
+						Status: corev1.ConditionTrue,
+					},
+				},
+			},
 		}
 
 		podGW = &corev1.Pod{
 			ObjectMeta: v1.ObjectMeta{Name: "pod", Namespace: namespaceGW.Name,
 				Labels:      map[string]string{"name": "pod"},
 				Annotations: map[string]string{nettypes.NetworkStatusAnnot: fmt.Sprintf(network_status, dynamicHopHostNetPodIP)}},
-			Status: corev1.PodStatus{PodIPs: []corev1.PodIP{{IP: dynamicHopHostNetPodIP}}, Phase: corev1.PodRunning},
+			Status: corev1.PodStatus{
+				PodIPs: []corev1.PodIP{{IP: dynamicHopHostNetPodIP}},
+				Phase:  corev1.PodRunning,
+				Conditions: []corev1.PodCondition{
+					{
+						Type:   corev1.PodReady,
+						Status: corev1.ConditionTrue,
+					},
+				},
+			},
 		}
 		namespaceTargetWithPod, namespaceTarget2WithPod, namespaceTarget2WithoutPod, namespaceGWWithPod *namespaceWithPods
 	)

--- a/go-controller/pkg/ovn/controller/apbroute/external_controller_pod.go
+++ b/go-controller/pkg/ovn/controller/apbroute/external_controller_pod.go
@@ -10,7 +10,10 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
+	v1pod "k8s.io/kubernetes/pkg/api/v1/pod"
 	utilnet "k8s.io/utils/net"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 )
 
 func (m *externalPolicyManager) syncPod(pod *v1.Pod, routeQueue workqueue.RateLimitingInterface) error {
@@ -27,6 +30,13 @@ func (m *externalPolicyManager) syncPod(pod *v1.Pod, routeQueue workqueue.RateLi
 }
 
 func getExGwPodIPs(gatewayPod *v1.Pod, networkName string) (sets.Set[string], error) {
+	// If an external gateway pod is in terminating or not ready state then don't return the
+	// IPs for the external gateway pod
+	if util.PodTerminating(gatewayPod) || !v1pod.IsPodReadyConditionTrue(gatewayPod.Status) {
+		klog.Warningf("External gateway pod cannot serve traffic; it's in terminating or not ready state: %s/%s", gatewayPod.Namespace, gatewayPod.Name)
+		return nil, nil
+	}
+
 	if networkName != "" {
 		return getMultusIPsFromNetworkName(gatewayPod, networkName)
 	}

--- a/go-controller/pkg/ovn/controller/apbroute/external_controller_pod_test.go
+++ b/go-controller/pkg/ovn/controller/apbroute/external_controller_pod_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 
@@ -448,6 +449,163 @@ var _ = Describe("OVN External Gateway pod", func() {
 		})
 
 	})
+
+	var _ = Context("When pod goes into terminating or not ready state", func() {
+
+		DescribeTable("reconciles a pod gateway in terminating or not ready state that matches two policies", func(
+			terminating bool,
+		) {
+			initController([]runtime.Object{namespaceGW, namespaceTarget, namespaceTarget2, targetPod1, targetPod2, pod1},
+				[]runtime.Object{dynamicPolicy, dynamicPolicyDiffTargetNS})
+
+			expectedPolicy1, expectedRefs1 := expectedPolicyStateAndRefs(
+				[]*namespaceWithPods{namespaceTarget2WithPod},
+				nil,
+				[]*namespaceWithPods{namespaceGWWithPod}, false)
+
+			expectedPolicy2, expectedRefs2 := expectedPolicyStateAndRefs(
+				[]*namespaceWithPods{namespaceTargetWithPod},
+				nil,
+				[]*namespaceWithPods{namespaceGWWithPod}, false)
+
+			eventuallyExpectNumberOfPolicies(2)
+			eventuallyExpectConfig(dynamicPolicy.Name, expectedPolicy1, expectedRefs1)
+			eventuallyExpectConfig(dynamicPolicyDiffTargetNS.Name, expectedPolicy2, expectedRefs2)
+
+			if terminating {
+				By("Setting deletion timestamp for the ex gw pod")
+				setPodDeletionTimestamp(pod1, &v1.Time{Time: time.Now().Add(1000 * time.Second)}, fakeClient)
+			} else {
+				By("Updating the ex gw pod status to mark it as not ready")
+				setPodConditionReady(pod1, corev1.ConditionFalse, fakeClient)
+			}
+
+			expectedPolicy1, expectedRefs1 = expectedPolicyStateAndRefs(
+				[]*namespaceWithPods{namespaceTarget2WithPod},
+				nil,
+				[]*namespaceWithPods{namespaceGWWithoutPod}, false)
+
+			expectedPolicy2, expectedRefs2 = expectedPolicyStateAndRefs(
+				[]*namespaceWithPods{namespaceTargetWithPod},
+				nil,
+				[]*namespaceWithPods{namespaceGWWithoutPod}, false)
+
+			eventuallyExpectNumberOfPolicies(2)
+			eventuallyExpectConfig(dynamicPolicy.Name, expectedPolicy1, expectedRefs1)
+			eventuallyExpectConfig(dynamicPolicyDiffTargetNS.Name, expectedPolicy2, expectedRefs2)
+		},
+			Entry("Gateway pod in terminating state", true),
+			Entry("Gateway pod in not ready state", false),
+		)
+
+		DescribeTable("reconciles a pod gateway in terminating or not ready state that does not match any policy", func(
+			terminating bool,
+		) {
+			noMatchPolicy := newPolicy(
+				"noMatchPolicy",
+				&v1.LabelSelector{MatchLabels: targetNamespace1Match},
+				nil,
+				&v1.LabelSelector{MatchLabels: gatewayNamespaceMatch},
+				&v1.LabelSelector{MatchLabels: map[string]string{"key": "nomatch"}},
+				false,
+			)
+			initController([]runtime.Object{namespaceGW, namespaceTarget, pod1}, []runtime.Object{noMatchPolicy})
+
+			expectedPolicy, expectedRefs := expectedPolicyStateAndRefs(
+				[]*namespaceWithPods{namespaceTargetWithoutPod},
+				nil,
+				[]*namespaceWithPods{namespaceGWWithoutPod}, false)
+
+			eventuallyExpectNumberOfPolicies(1)
+			eventuallyExpectConfig(noMatchPolicy.Name, expectedPolicy, expectedRefs)
+
+			if terminating {
+				By("Setting deletion timestamp for the ex gw pod")
+				setPodDeletionTimestamp(pod1, &v1.Time{Time: time.Now().Add(1000 * time.Second)}, fakeClient)
+			} else {
+				By("Updating the ex gw pod status to mark it as not ready")
+				setPodConditionReady(pod1, corev1.ConditionFalse, fakeClient)
+			}
+			//  make sure pod event is handled
+			time.Sleep(100 * time.Millisecond)
+
+			eventuallyExpectNumberOfPolicies(1)
+			eventuallyExpectConfig(noMatchPolicy.Name, expectedPolicy, expectedRefs)
+		},
+			Entry("Gateway pod in terminating state", true),
+			Entry("Gateway pod in not ready state", false),
+		)
+
+		DescribeTable("reconciles a pod gateway in terminating or not ready state that is one of two pods that matches two policies", func(
+			terminating bool,
+		) {
+			initController([]runtime.Object{namespaceGW, namespaceTarget, namespaceTarget2, targetPod1, targetPod2, pod1, pod2},
+				[]runtime.Object{dynamicPolicy, dynamicPolicyDiffTargetNS})
+			namespaceGWWith2Pods := newNamespaceWithPods(namespaceGW.Name, pod1, pod2)
+			expectedPolicy1, expectedRefs1 := expectedPolicyStateAndRefs(
+				[]*namespaceWithPods{namespaceTarget2WithPod},
+				nil,
+				[]*namespaceWithPods{namespaceGWWith2Pods}, false)
+
+			expectedPolicy2, expectedRefs2 := expectedPolicyStateAndRefs(
+				[]*namespaceWithPods{namespaceTargetWithPod},
+				nil,
+				[]*namespaceWithPods{namespaceGWWith2Pods}, false)
+
+			eventuallyExpectNumberOfPolicies(2)
+			eventuallyExpectConfig(dynamicPolicy.Name, expectedPolicy1, expectedRefs1)
+			eventuallyExpectConfig(dynamicPolicyDiffTargetNS.Name, expectedPolicy2, expectedRefs2)
+
+			if terminating {
+				By("Setting deletion timestamp for the ex gw pod")
+				setPodDeletionTimestamp(pod1, &v1.Time{Time: time.Now().Add(1000 * time.Second)}, fakeClient)
+			} else {
+				By("Updating the ex gw pod status to mark it as not ready")
+				setPodConditionReady(pod1, corev1.ConditionFalse, fakeClient)
+			}
+
+			namespaceGWWith1Pod := newNamespaceWithPods(namespaceGW.Name, pod2)
+
+			expectedPolicy1, expectedRefs1 = expectedPolicyStateAndRefs(
+				[]*namespaceWithPods{namespaceTarget2WithPod},
+				nil,
+				[]*namespaceWithPods{namespaceGWWith1Pod}, false)
+
+			expectedPolicy2, expectedRefs2 = expectedPolicyStateAndRefs(
+				[]*namespaceWithPods{namespaceTargetWithPod},
+				nil,
+				[]*namespaceWithPods{namespaceGWWith1Pod}, false)
+
+			eventuallyExpectNumberOfPolicies(2)
+			eventuallyExpectConfig(dynamicPolicy.Name, expectedPolicy1, expectedRefs1)
+			eventuallyExpectConfig(dynamicPolicyDiffTargetNS.Name, expectedPolicy2, expectedRefs2)
+
+			if terminating {
+				By("Removing deletion timestamp for the ex gw pod")
+				setPodDeletionTimestamp(pod1, nil, fakeClient)
+			} else {
+				By("Updating the ex gw pod status to mark it as ready")
+				setPodConditionReady(pod1, corev1.ConditionTrue, fakeClient)
+			}
+
+			expectedPolicy1, expectedRefs1 = expectedPolicyStateAndRefs(
+				[]*namespaceWithPods{namespaceTarget2WithPod},
+				nil,
+				[]*namespaceWithPods{namespaceGWWith2Pods}, false)
+
+			expectedPolicy2, expectedRefs2 = expectedPolicyStateAndRefs(
+				[]*namespaceWithPods{namespaceTargetWithPod},
+				nil,
+				[]*namespaceWithPods{namespaceGWWith2Pods}, false)
+
+			eventuallyExpectNumberOfPolicies(2)
+			eventuallyExpectConfig(dynamicPolicy.Name, expectedPolicy1, expectedRefs1)
+			eventuallyExpectConfig(dynamicPolicyDiffTargetNS.Name, expectedPolicy2, expectedRefs2)
+		},
+			Entry("Gateway pod in terminating state", true),
+			Entry("Gateway pod in not ready state", false),
+		)
+	})
 })
 
 func deletePod(pod *corev1.Pod, fakeClient *fake.Clientset) {
@@ -474,6 +632,36 @@ func updatePodStatus(pod *corev1.Pod, podStatus corev1.PodStatus) {
 	Expect(err).NotTo(HaveOccurred())
 	incrementResourceVersion(p)
 	p.Status = podStatus
+	_, err = fakeClient.CoreV1().Pods(pod.Namespace).Update(context.Background(), p, v1.UpdateOptions{})
+	Expect(err).NotTo(HaveOccurred())
+}
+
+func setPodDeletionTimestamp(pod *corev1.Pod, deletionTimestamp *v1.Time, fakeClient *fake.Clientset) {
+	p, err := fakeClient.CoreV1().Pods(pod.Namespace).Get(context.TODO(), pod.Name, v1.GetOptions{})
+	Expect(err).NotTo(HaveOccurred())
+	incrementResourceVersion(p)
+	p.DeletionTimestamp = deletionTimestamp
+	_, err = fakeClient.CoreV1().Pods(pod.Namespace).Update(context.Background(), p, v1.UpdateOptions{})
+	Expect(err).NotTo(HaveOccurred())
+}
+
+func setPodConditionReady(pod *corev1.Pod, condStatus corev1.ConditionStatus, fakeClient *fake.Clientset) {
+	p, err := fakeClient.CoreV1().Pods(pod.Namespace).Get(context.TODO(), pod.Name, v1.GetOptions{})
+	Expect(err).NotTo(HaveOccurred())
+	incrementResourceVersion(p)
+	if p.Status.Conditions != nil {
+		for i := range p.Status.Conditions {
+			if p.Status.Conditions[i].Type == corev1.PodReady {
+				p.Status.Conditions[i].Status = condStatus
+			}
+		}
+	} else {
+		notReadyCondition := corev1.PodCondition{
+			Type:   corev1.PodReady,
+			Status: corev1.ConditionFalse,
+		}
+		p.Status.Conditions = []corev1.PodCondition{notReadyCondition}
+	}
 	_, err = fakeClient.CoreV1().Pods(pod.Namespace).Update(context.Background(), p, v1.UpdateOptions{})
 	Expect(err).NotTo(HaveOccurred())
 }

--- a/go-controller/pkg/ovn/controller/apbroute/external_controller_policy_test.go
+++ b/go-controller/pkg/ovn/controller/apbroute/external_controller_policy_test.go
@@ -39,8 +39,16 @@ func newPodWithPhaseAndIP(podName, namespace string, phase corev1.PodPhase, podI
 	p := &corev1.Pod{
 		ObjectMeta: v1.ObjectMeta{Name: podName, Namespace: namespace,
 			Labels: labels},
-		Spec:   corev1.PodSpec{NodeName: "node"},
-		Status: corev1.PodStatus{Phase: phase},
+		Spec: corev1.PodSpec{NodeName: "node"},
+		Status: corev1.PodStatus{
+			Phase: phase,
+			Conditions: []corev1.PodCondition{
+				{
+					Type:   corev1.PodReady,
+					Status: corev1.ConditionTrue,
+				},
+			},
+		},
 	}
 	if len(podIP) > 0 {
 		p.Annotations = map[string]string{nettypes.NetworkStatusAnnot: fmt.Sprintf(network_status, podIP)}

--- a/go-controller/pkg/ovn/egressgw.go
+++ b/go-controller/pkg/ovn/egressgw.go
@@ -28,6 +28,7 @@ import (
 	ktypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
+	v1pod "k8s.io/kubernetes/pkg/api/v1/pod"
 )
 
 type gatewayInfo struct {
@@ -48,6 +49,13 @@ func (oc *DefaultNetworkController) addPodExternalGW(pod *kapi.Pod) error {
 	}
 
 	klog.Infof("External gateway pod: %s, detected for namespace(s) %s", pod.Name, podRoutingNamespaceAnno)
+
+	// If an external gateway pod is in terminating or not ready state then don't add the
+	// routes for the external gateway pod
+	if util.PodTerminating(pod) || !v1pod.IsPodReadyConditionTrue(pod.Status) {
+		klog.Warningf("External gateway pod cannot serve traffic; it's in terminating or not ready state: %s/%s", pod.Namespace, pod.Name)
+		return nil
+	}
 
 	foundGws, err := getExGwPodIPs(pod)
 	if err != nil {

--- a/go-controller/pkg/ovn/egressgw_test.go
+++ b/go-controller/pkg/ovn/egressgw_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"sync"
+	"time"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	adminpolicybasedrouteapi "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/adminpolicybasedroute/v1"
@@ -1730,6 +1731,591 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 				&adminpolicybasedrouteapi.AdminPolicyBasedExternalRouteList{},
 			),
 			table.Entry("No BFD and with overlapping APB External Route CR and annotation", false,
+				[]libovsdbtest.TestData{
+					&nbdb.LogicalSwitchPort{
+						UUID:      "lsp1",
+						Addresses: []string{"0a:58:0a:80:01:03 10.128.1.3"},
+						ExternalIDs: map[string]string{
+							"pod":       "true",
+							"namespace": namespaceName,
+						},
+						Name: "namespace1_myPod",
+						Options: map[string]string{
+							"iface-id-ver":      "myPod",
+							"requested-chassis": "node1",
+						},
+						PortSecurity: []string{"0a:58:0a:80:01:03 10.128.1.3"},
+					},
+					&nbdb.LogicalSwitch{
+						UUID:  "node1",
+						Name:  "node1",
+						Ports: []string{"lsp1"},
+					},
+					&nbdb.LogicalSwitch{
+						UUID: "node2",
+						Name: "node2",
+					},
+					&nbdb.LogicalRouterStaticRoute{
+						UUID:       "static-route-1-UUID",
+						IPPrefix:   "10.128.1.3/32",
+						Nexthop:    "9.0.0.1",
+						Policy:     &nbdb.LogicalRouterStaticRoutePolicySrcIP,
+						OutputPort: &logicalRouterPort,
+						Options: map[string]string{
+							"ecmp_symmetric_reply": "true",
+						},
+					},
+					&nbdb.LogicalRouter{
+						UUID:         "GR_node1-UUID",
+						Name:         "GR_node1",
+						StaticRoutes: []string{"static-route-1-UUID"},
+					},
+				},
+				[]libovsdbtest.TestData{
+					&nbdb.LogicalSwitchPort{
+						UUID:      "lsp1",
+						Addresses: []string{"0a:58:0a:80:01:03 10.128.1.3"},
+						ExternalIDs: map[string]string{
+							"pod":       "true",
+							"namespace": namespaceName,
+						},
+						Name: "namespace1_myPod",
+						Options: map[string]string{
+							"iface-id-ver":      "myPod",
+							"requested-chassis": "node1",
+						},
+						PortSecurity: []string{"0a:58:0a:80:01:03 10.128.1.3"},
+					},
+					&nbdb.LogicalSwitch{
+						UUID:  "node1",
+						Name:  "node1",
+						Ports: []string{"lsp1"},
+					},
+					&nbdb.LogicalSwitch{
+						UUID: "node2",
+						Name: "node2",
+					},
+					&nbdb.LogicalRouter{
+						UUID:         "GR_node1-UUID",
+						Name:         "GR_node1",
+						StaticRoutes: []string{},
+					},
+				},
+				"",
+				&adminpolicybasedrouteapi.AdminPolicyBasedExternalRouteList{
+					Items: []adminpolicybasedrouteapi.AdminPolicyBasedExternalRoute{
+						newPolicy("policy",
+							&metav1.LabelSelector{MatchLabels: map[string]string{"name": namespaceName}},
+							nil,
+							false,
+							&metav1.LabelSelector{MatchLabels: map[string]string{"name": namespace2Name}},
+							&metav1.LabelSelector{MatchLabels: map[string]string{"name": gwPodName}},
+							false,
+							""),
+					},
+				},
+			),
+		)
+		table.DescribeTable("reconciles a host networked pod in terminating or not ready state acting as a exgw for another namespace for existing pod",
+			func(bfd bool,
+				terminating bool,
+				beforeUpdateNB []libovsdbtest.TestData,
+				afterUpdateNB []libovsdbtest.TestData,
+				expectedNamespaceAnnotation string,
+				apbExternalRouteCRList *adminpolicybasedrouteapi.AdminPolicyBasedExternalRouteList) {
+				app.Action = func(*cli.Context) error {
+
+					namespaceT := *newNamespace(namespaceName)
+					namespaceX := *newNamespace(namespace2Name)
+					t := newTPod(
+						"node1",
+						"10.128.1.0/24",
+						"10.128.1.2",
+						"10.128.1.1",
+						"myPod",
+						"10.128.1.3",
+						"0a:58:0a:80:01:03",
+						namespaceT.Name,
+					)
+					gwPod := *newPod(namespaceX.Name, gwPodName, "node2", "9.0.0.1")
+					gwPod.Annotations = map[string]string{"k8s.ovn.org/routing-namespaces": namespaceT.Name}
+					if bfd {
+						gwPod.Annotations["k8s.ovn.org/bfd-enabled"] = ""
+					}
+					gwPod.Spec.HostNetwork = true
+					fakeOvn.startWithDBSetup(
+						libovsdbtest.TestSetup{
+							NBData: []libovsdbtest.TestData{
+								&nbdb.LogicalSwitch{
+									UUID: "node1",
+									Name: "node1",
+								},
+								&nbdb.LogicalSwitch{
+									UUID: "node2",
+									Name: "node2",
+								},
+								&nbdb.LogicalRouter{
+									UUID: "GR_node1-UUID",
+									Name: "GR_node1",
+								},
+							},
+						},
+						&v1.NamespaceList{
+							Items: []v1.Namespace{
+								namespaceT, namespaceX,
+							},
+						},
+						&v1.NodeList{
+							Items: []v1.Node{
+								*newNode("node1", "192.168.126.202/24"),
+								*newNode("node2", "192.168.126.50/24"),
+							},
+						},
+						&v1.PodList{
+							Items: []v1.Pod{
+								*newPod(t.namespace, t.podName, t.nodeName, t.podIP),
+							},
+						},
+						apbExternalRouteCRList,
+					)
+					t.populateLogicalSwitchCache(fakeOvn)
+					err := fakeOvn.controller.lsManager.AddOrUpdateSwitch("node2", []*net.IPNet{ovntest.MustParseIPNet("10.128.2.0/24")})
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					injectNode(fakeOvn)
+					err = fakeOvn.controller.WatchNamespaces()
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					err = fakeOvn.controller.WatchPods()
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					fakeOvn.RunAPBExternalPolicyController()
+
+					_, err = fakeOvn.fakeClient.KubeClient.CoreV1().Pods(namespaceX.Name).Create(context.TODO(), &gwPod, metav1.CreateOptions{})
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(beforeUpdateNB))
+					gomega.Eventually(func() string {
+						return getNamespaceAnnotations(fakeOvn.fakeClient.KubeClient, namespaceT.Name)[util.ExternalGatewayPodIPsAnnotation]
+					}).Should(gomega.Equal("9.0.0.1"))
+
+					if terminating {
+						ginkgo.By("Setting deletion timestamp for the ex gw pod")
+						gwPod.DeletionTimestamp = &metav1.Time{Time: time.Now().Add(1000 * time.Second)}
+						_, err = fakeOvn.fakeClient.KubeClient.CoreV1().Pods(namespaceX.Name).Update(context.TODO(), &gwPod, metav1.UpdateOptions{})
+						gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					} else {
+						ginkgo.By("Updating the ex gw pod status to mark it as not ready")
+						notReadyCondition := v1.PodCondition{
+							Type:   v1.PodReady,
+							Status: v1.ConditionFalse,
+						}
+						gwPod.Status.Conditions = []v1.PodCondition{notReadyCondition}
+						_, err = fakeOvn.fakeClient.KubeClient.CoreV1().Pods(namespaceX.Name).UpdateStatus(context.TODO(), &gwPod, metav1.UpdateOptions{})
+						gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					}
+
+					gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(afterUpdateNB))
+					gomega.Eventually(func() string {
+						return getNamespaceAnnotations(fakeOvn.fakeClient.KubeClient, namespaceT.Name)[util.ExternalGatewayPodIPsAnnotation]
+					}).Should(gomega.Equal(expectedNamespaceAnnotation))
+					for _, apbRoutePolicy := range apbExternalRouteCRList.Items {
+						checkAPBRouteStatus(fakeOvn, apbRoutePolicy.Name, false)
+					}
+					return nil
+				}
+
+				err := app.Run([]string{app.Name})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			},
+			table.Entry("No BFD with ex gw pod in terminating state", false, true,
+				[]libovsdbtest.TestData{
+					&nbdb.LogicalSwitchPort{
+						UUID:      "lsp1",
+						Addresses: []string{"0a:58:0a:80:01:03 10.128.1.3"},
+						ExternalIDs: map[string]string{
+							"pod":       "true",
+							"namespace": namespaceName,
+						},
+						Name: "namespace1_myPod",
+						Options: map[string]string{
+							"iface-id-ver":      "myPod",
+							"requested-chassis": "node1",
+						},
+						PortSecurity: []string{"0a:58:0a:80:01:03 10.128.1.3"},
+					},
+					&nbdb.LogicalSwitch{
+						UUID:  "node1",
+						Name:  "node1",
+						Ports: []string{"lsp1"},
+					},
+					&nbdb.LogicalSwitch{
+						UUID: "node2",
+						Name: "node2",
+					},
+					&nbdb.LogicalRouterStaticRoute{
+						UUID:       "static-route-1-UUID",
+						IPPrefix:   "10.128.1.3/32",
+						Nexthop:    "9.0.0.1",
+						Policy:     &nbdb.LogicalRouterStaticRoutePolicySrcIP,
+						OutputPort: &logicalRouterPort,
+						Options: map[string]string{
+							"ecmp_symmetric_reply": "true",
+						},
+					},
+					&nbdb.LogicalRouter{
+						UUID:         "GR_node1-UUID",
+						Name:         "GR_node1",
+						StaticRoutes: []string{"static-route-1-UUID"},
+					},
+				},
+				[]libovsdbtest.TestData{
+					&nbdb.LogicalSwitchPort{
+						UUID:      "lsp1",
+						Addresses: []string{"0a:58:0a:80:01:03 10.128.1.3"},
+						ExternalIDs: map[string]string{
+							"pod":       "true",
+							"namespace": namespaceName,
+						},
+						Name: "namespace1_myPod",
+						Options: map[string]string{
+							"iface-id-ver":      "myPod",
+							"requested-chassis": "node1",
+						},
+						PortSecurity: []string{"0a:58:0a:80:01:03 10.128.1.3"},
+					},
+					&nbdb.LogicalSwitch{
+						UUID:  "node1",
+						Name:  "node1",
+						Ports: []string{"lsp1"},
+					},
+					&nbdb.LogicalSwitch{
+						UUID: "node2",
+						Name: "node2",
+					},
+					&nbdb.LogicalRouter{
+						UUID:         "GR_node1-UUID",
+						Name:         "GR_node1",
+						StaticRoutes: []string{},
+					},
+				},
+				"",
+				&adminpolicybasedrouteapi.AdminPolicyBasedExternalRouteList{},
+			),
+			table.Entry("No BFD with ex gw pod in not ready state", false, false,
+				[]libovsdbtest.TestData{
+					&nbdb.LogicalSwitchPort{
+						UUID:      "lsp1",
+						Addresses: []string{"0a:58:0a:80:01:03 10.128.1.3"},
+						ExternalIDs: map[string]string{
+							"pod":       "true",
+							"namespace": namespaceName,
+						},
+						Name: "namespace1_myPod",
+						Options: map[string]string{
+							"iface-id-ver":      "myPod",
+							"requested-chassis": "node1",
+						},
+						PortSecurity: []string{"0a:58:0a:80:01:03 10.128.1.3"},
+					},
+					&nbdb.LogicalSwitch{
+						UUID:  "node1",
+						Name:  "node1",
+						Ports: []string{"lsp1"},
+					},
+					&nbdb.LogicalSwitch{
+						UUID: "node2",
+						Name: "node2",
+					},
+					&nbdb.LogicalRouterStaticRoute{
+						UUID:       "static-route-1-UUID",
+						IPPrefix:   "10.128.1.3/32",
+						Nexthop:    "9.0.0.1",
+						Policy:     &nbdb.LogicalRouterStaticRoutePolicySrcIP,
+						OutputPort: &logicalRouterPort,
+						Options: map[string]string{
+							"ecmp_symmetric_reply": "true",
+						},
+					},
+					&nbdb.LogicalRouter{
+						UUID:         "GR_node1-UUID",
+						Name:         "GR_node1",
+						StaticRoutes: []string{"static-route-1-UUID"},
+					},
+				},
+				[]libovsdbtest.TestData{
+					&nbdb.LogicalSwitchPort{
+						UUID:      "lsp1",
+						Addresses: []string{"0a:58:0a:80:01:03 10.128.1.3"},
+						ExternalIDs: map[string]string{
+							"pod":       "true",
+							"namespace": namespaceName,
+						},
+						Name: "namespace1_myPod",
+						Options: map[string]string{
+							"iface-id-ver":      "myPod",
+							"requested-chassis": "node1",
+						},
+						PortSecurity: []string{"0a:58:0a:80:01:03 10.128.1.3"},
+					},
+					&nbdb.LogicalSwitch{
+						UUID:  "node1",
+						Name:  "node1",
+						Ports: []string{"lsp1"},
+					},
+					&nbdb.LogicalSwitch{
+						UUID: "node2",
+						Name: "node2",
+					},
+					&nbdb.LogicalRouter{
+						UUID:         "GR_node1-UUID",
+						Name:         "GR_node1",
+						StaticRoutes: []string{},
+					},
+				},
+				"",
+				&adminpolicybasedrouteapi.AdminPolicyBasedExternalRouteList{},
+			),
+			table.Entry("BFD Enabled with ex gw pod in terminating state", true, true, []libovsdbtest.TestData{
+				&nbdb.LogicalSwitchPort{
+					UUID:      "lsp1",
+					Addresses: []string{"0a:58:0a:80:01:03 10.128.1.3"},
+					ExternalIDs: map[string]string{
+						"pod":       "true",
+						"namespace": namespaceName,
+					},
+					Name: "namespace1_myPod",
+					Options: map[string]string{
+						"iface-id-ver":      "myPod",
+						"requested-chassis": "node1",
+					},
+					PortSecurity: []string{"0a:58:0a:80:01:03 10.128.1.3"},
+				},
+				&nbdb.LogicalSwitch{
+					UUID:  "node1",
+					Name:  "node1",
+					Ports: []string{"lsp1"},
+				},
+				&nbdb.LogicalSwitch{
+					UUID: "node2",
+					Name: "node2",
+				},
+				&nbdb.BFD{
+					UUID:        bfd1NamedUUID,
+					DstIP:       "9.0.0.1",
+					LogicalPort: "rtoe-GR_node1",
+				},
+				&nbdb.LogicalRouterStaticRoute{
+					UUID:       "static-route-1-UUID",
+					IPPrefix:   "10.128.1.3/32",
+					Nexthop:    "9.0.0.1",
+					BFD:        &bfd1NamedUUID,
+					Policy:     &nbdb.LogicalRouterStaticRoutePolicySrcIP,
+					OutputPort: &logicalRouterPort,
+					Options: map[string]string{
+						"ecmp_symmetric_reply": "true",
+					},
+				},
+				&nbdb.LogicalRouter{
+					UUID:         "GR_node1-UUID",
+					Name:         "GR_node1",
+					StaticRoutes: []string{"static-route-1-UUID"},
+				},
+			},
+				[]libovsdbtest.TestData{
+					&nbdb.LogicalSwitchPort{
+						UUID:      "lsp1",
+						Addresses: []string{"0a:58:0a:80:01:03 10.128.1.3"},
+						ExternalIDs: map[string]string{
+							"pod":       "true",
+							"namespace": namespaceName,
+						},
+						Name: "namespace1_myPod",
+						Options: map[string]string{
+							"iface-id-ver":      "myPod",
+							"requested-chassis": "node1",
+						},
+						PortSecurity: []string{"0a:58:0a:80:01:03 10.128.1.3"},
+					},
+					&nbdb.LogicalSwitch{
+						UUID:  "node1",
+						Name:  "node1",
+						Ports: []string{"lsp1"},
+					},
+					&nbdb.LogicalSwitch{
+						UUID: "node2",
+						Name: "node2",
+					},
+					&nbdb.LogicalRouter{
+						UUID:         "GR_node1-UUID",
+						Name:         "GR_node1",
+						StaticRoutes: []string{},
+					},
+				},
+				"",
+				&adminpolicybasedrouteapi.AdminPolicyBasedExternalRouteList{},
+			),
+			table.Entry("BFD Enabled with ex gw pod in not ready state", true, false, []libovsdbtest.TestData{
+				&nbdb.LogicalSwitchPort{
+					UUID:      "lsp1",
+					Addresses: []string{"0a:58:0a:80:01:03 10.128.1.3"},
+					ExternalIDs: map[string]string{
+						"pod":       "true",
+						"namespace": namespaceName,
+					},
+					Name: "namespace1_myPod",
+					Options: map[string]string{
+						"iface-id-ver":      "myPod",
+						"requested-chassis": "node1",
+					},
+					PortSecurity: []string{"0a:58:0a:80:01:03 10.128.1.3"},
+				},
+				&nbdb.LogicalSwitch{
+					UUID:  "node1",
+					Name:  "node1",
+					Ports: []string{"lsp1"},
+				},
+				&nbdb.LogicalSwitch{
+					UUID: "node2",
+					Name: "node2",
+				},
+				&nbdb.BFD{
+					UUID:        bfd1NamedUUID,
+					DstIP:       "9.0.0.1",
+					LogicalPort: "rtoe-GR_node1",
+				},
+				&nbdb.LogicalRouterStaticRoute{
+					UUID:       "static-route-1-UUID",
+					IPPrefix:   "10.128.1.3/32",
+					Nexthop:    "9.0.0.1",
+					BFD:        &bfd1NamedUUID,
+					Policy:     &nbdb.LogicalRouterStaticRoutePolicySrcIP,
+					OutputPort: &logicalRouterPort,
+					Options: map[string]string{
+						"ecmp_symmetric_reply": "true",
+					},
+				},
+				&nbdb.LogicalRouter{
+					UUID:         "GR_node1-UUID",
+					Name:         "GR_node1",
+					StaticRoutes: []string{"static-route-1-UUID"},
+				},
+			},
+				[]libovsdbtest.TestData{
+					&nbdb.LogicalSwitchPort{
+						UUID:      "lsp1",
+						Addresses: []string{"0a:58:0a:80:01:03 10.128.1.3"},
+						ExternalIDs: map[string]string{
+							"pod":       "true",
+							"namespace": namespaceName,
+						},
+						Name: "namespace1_myPod",
+						Options: map[string]string{
+							"iface-id-ver":      "myPod",
+							"requested-chassis": "node1",
+						},
+						PortSecurity: []string{"0a:58:0a:80:01:03 10.128.1.3"},
+					},
+					&nbdb.LogicalSwitch{
+						UUID:  "node1",
+						Name:  "node1",
+						Ports: []string{"lsp1"},
+					},
+					&nbdb.LogicalSwitch{
+						UUID: "node2",
+						Name: "node2",
+					},
+					&nbdb.LogicalRouter{
+						UUID:         "GR_node1-UUID",
+						Name:         "GR_node1",
+						StaticRoutes: []string{},
+					},
+				},
+				"",
+				&adminpolicybasedrouteapi.AdminPolicyBasedExternalRouteList{},
+			),
+			table.Entry("No BFD with ex gw pod in terminating state and with overlapping APB External Route CR and annotation", false, true,
+				[]libovsdbtest.TestData{
+					&nbdb.LogicalSwitchPort{
+						UUID:      "lsp1",
+						Addresses: []string{"0a:58:0a:80:01:03 10.128.1.3"},
+						ExternalIDs: map[string]string{
+							"pod":       "true",
+							"namespace": namespaceName,
+						},
+						Name: "namespace1_myPod",
+						Options: map[string]string{
+							"iface-id-ver":      "myPod",
+							"requested-chassis": "node1",
+						},
+						PortSecurity: []string{"0a:58:0a:80:01:03 10.128.1.3"},
+					},
+					&nbdb.LogicalSwitch{
+						UUID:  "node1",
+						Name:  "node1",
+						Ports: []string{"lsp1"},
+					},
+					&nbdb.LogicalSwitch{
+						UUID: "node2",
+						Name: "node2",
+					},
+					&nbdb.LogicalRouterStaticRoute{
+						UUID:       "static-route-1-UUID",
+						IPPrefix:   "10.128.1.3/32",
+						Nexthop:    "9.0.0.1",
+						Policy:     &nbdb.LogicalRouterStaticRoutePolicySrcIP,
+						OutputPort: &logicalRouterPort,
+						Options: map[string]string{
+							"ecmp_symmetric_reply": "true",
+						},
+					},
+					&nbdb.LogicalRouter{
+						UUID:         "GR_node1-UUID",
+						Name:         "GR_node1",
+						StaticRoutes: []string{"static-route-1-UUID"},
+					},
+				},
+				[]libovsdbtest.TestData{
+					&nbdb.LogicalSwitchPort{
+						UUID:      "lsp1",
+						Addresses: []string{"0a:58:0a:80:01:03 10.128.1.3"},
+						ExternalIDs: map[string]string{
+							"pod":       "true",
+							"namespace": namespaceName,
+						},
+						Name: "namespace1_myPod",
+						Options: map[string]string{
+							"iface-id-ver":      "myPod",
+							"requested-chassis": "node1",
+						},
+						PortSecurity: []string{"0a:58:0a:80:01:03 10.128.1.3"},
+					},
+					&nbdb.LogicalSwitch{
+						UUID:  "node1",
+						Name:  "node1",
+						Ports: []string{"lsp1"},
+					},
+					&nbdb.LogicalSwitch{
+						UUID: "node2",
+						Name: "node2",
+					},
+					&nbdb.LogicalRouter{
+						UUID:         "GR_node1-UUID",
+						Name:         "GR_node1",
+						StaticRoutes: []string{},
+					},
+				},
+				"",
+				&adminpolicybasedrouteapi.AdminPolicyBasedExternalRouteList{
+					Items: []adminpolicybasedrouteapi.AdminPolicyBasedExternalRoute{
+						newPolicy("policy",
+							&metav1.LabelSelector{MatchLabels: map[string]string{"name": namespaceName}},
+							nil,
+							false,
+							&metav1.LabelSelector{MatchLabels: map[string]string{"name": namespace2Name}},
+							&metav1.LabelSelector{MatchLabels: map[string]string{"name": gwPodName}},
+							false,
+							""),
+					},
+				},
+			),
+			table.Entry("No BFD with ex gw pod in not ready state and with overlapping APB External Route CR and annotation", false, false,
 				[]libovsdbtest.TestData{
 					&nbdb.LogicalSwitchPort{
 						UUID:      "lsp1",

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -27,6 +27,7 @@ import (
 	listers "k8s.io/client-go/listers/core/v1"
 	ref "k8s.io/client-go/tools/reference"
 	"k8s.io/klog/v2"
+	v1pod "k8s.io/kubernetes/pkg/api/v1/pod"
 )
 
 const egressFirewallDNSDefaultDuration = 30 * time.Minute
@@ -116,6 +117,10 @@ func networkStatusAnnotationsChanged(oldPod, newPod *kapi.Pod) bool {
 	return oldPod.Annotations[nettypes.NetworkStatusAnnot] != newPod.Annotations[nettypes.NetworkStatusAnnot]
 }
 
+func podBecameReady(oldPod, newPod *kapi.Pod) bool {
+	return !v1pod.IsPodReadyConditionTrue(oldPod.Status) && v1pod.IsPodReadyConditionTrue(newPod.Status)
+}
+
 // ensurePod tries to set up a pod. It returns nil on success and error on failure; failure
 // indicates the pod set up should be retried later.
 func (oc *DefaultNetworkController) ensurePod(oldPod, pod *kapi.Pod, addPort bool) error {
@@ -128,6 +133,14 @@ func (oc *DefaultNetworkController) ensurePod(oldPod, pod *kapi.Pod, addPort boo
 	switchName := pod.Spec.NodeName
 	if oc.lsManager.IsNonHostSubnetSwitch(switchName) {
 		return oc.ensureRemotePodIP(oldPod, pod, addPort)
+	}
+
+	// If an external gateway pod is in terminating or not ready state then remove the
+	// routes for the external gateway pod
+	if util.PodTerminating(pod) || !v1pod.IsPodReadyConditionTrue(pod.Status) {
+		if err := oc.deletePodExternalGW(pod); err != nil {
+			return fmt.Errorf("ensurePod failed %s/%s: %w", pod.Namespace, pod.Name, err)
+		}
 	}
 
 	if oc.isPodScheduledinLocalZone(pod) {
@@ -169,7 +182,7 @@ func (oc *DefaultNetworkController) ensureLocalZonePod(oldPod, pod *kapi.Pod, ad
 		}
 	} else {
 		// either pod is host-networked or its an update for a normal pod (addPort=false case)
-		if oldPod == nil || exGatewayAnnotationsChanged(oldPod, pod) || networkStatusAnnotationsChanged(oldPod, pod) {
+		if oldPod == nil || exGatewayAnnotationsChanged(oldPod, pod) || networkStatusAnnotationsChanged(oldPod, pod) || podBecameReady(oldPod, pod) {
 			if err := oc.addPodExternalGW(pod); err != nil {
 				return fmt.Errorf("addPodExternalGW failed for %s/%s: %w", pod.Namespace, pod.Name, err)
 			}
@@ -217,7 +230,7 @@ func (oc *DefaultNetworkController) ensureRemoteZonePod(oldPod, pod *kapi.Pod, a
 	}
 
 	// either pod is host-networked or its an update for a normal pod (addPort=false case)
-	if oldPod == nil || exGatewayAnnotationsChanged(oldPod, pod) || networkStatusAnnotationsChanged(oldPod, pod) {
+	if oldPod == nil || exGatewayAnnotationsChanged(oldPod, pod) || networkStatusAnnotationsChanged(oldPod, pod) || podBecameReady(oldPod, pod) {
 		// check if this remote pod is serving as an external GW. If so add the routes in the namespace
 		// associated with this remote pod
 		if err := oc.addPodExternalGW(pod); err != nil {

--- a/go-controller/pkg/ovn/pods_test.go
+++ b/go-controller/pkg/ovn/pods_test.go
@@ -123,6 +123,12 @@ func newPod(namespace, name, node, podIP string) *v1.Pod {
 			Phase:  v1.PodRunning,
 			PodIP:  podIP,
 			PodIPs: podIPs,
+			Conditions: []v1.PodCondition{
+				{
+					Type:   v1.PodReady,
+					Status: v1.ConditionTrue,
+				},
+			},
 		},
 	}
 }

--- a/go-controller/vendor/k8s.io/kubernetes/pkg/api/v1/pod/util.go
+++ b/go-controller/vendor/k8s.io/kubernetes/pkg/api/v1/pod/util.go
@@ -1,0 +1,418 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pod
+
+import (
+	"fmt"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+// FindPort locates the container port for the given pod and portName.  If the
+// targetPort is a number, use that.  If the targetPort is a string, look that
+// string up in all named ports in all containers in the target pod.  If no
+// match is found, fail.
+func FindPort(pod *v1.Pod, svcPort *v1.ServicePort) (int, error) {
+	portName := svcPort.TargetPort
+	switch portName.Type {
+	case intstr.String:
+		name := portName.StrVal
+		for _, container := range pod.Spec.Containers {
+			for _, port := range container.Ports {
+				if port.Name == name && port.Protocol == svcPort.Protocol {
+					return int(port.ContainerPort), nil
+				}
+			}
+		}
+		// also support sidecar container (initContainer with restartPolicy=Always)
+		for _, container := range pod.Spec.InitContainers {
+			if container.RestartPolicy == nil || *container.RestartPolicy != v1.ContainerRestartPolicyAlways {
+				continue
+			}
+			for _, port := range container.Ports {
+				if port.Name == name && port.Protocol == svcPort.Protocol {
+					return int(port.ContainerPort), nil
+				}
+			}
+		}
+	case intstr.Int:
+		return portName.IntValue(), nil
+	}
+
+	return 0, fmt.Errorf("no suitable port for manifest: %s", pod.UID)
+}
+
+// ContainerType signifies container type
+type ContainerType int
+
+const (
+	// Containers is for normal containers
+	Containers ContainerType = 1 << iota
+	// InitContainers is for init containers
+	InitContainers
+	// EphemeralContainers is for ephemeral containers
+	EphemeralContainers
+)
+
+// AllContainers specifies that all containers be visited
+const AllContainers ContainerType = InitContainers | Containers | EphemeralContainers
+
+// AllFeatureEnabledContainers returns a ContainerType mask which includes all container
+// types except for the ones guarded by feature gate.
+func AllFeatureEnabledContainers() ContainerType {
+	return AllContainers
+}
+
+// ContainerVisitor is called with each container spec, and returns true
+// if visiting should continue.
+type ContainerVisitor func(container *v1.Container, containerType ContainerType) (shouldContinue bool)
+
+// Visitor is called with each object name, and returns true if visiting should continue
+type Visitor func(name string) (shouldContinue bool)
+
+func skipEmptyNames(visitor Visitor) Visitor {
+	return func(name string) bool {
+		if len(name) == 0 {
+			// continue visiting
+			return true
+		}
+		// delegate to visitor
+		return visitor(name)
+	}
+}
+
+// VisitContainers invokes the visitor function with a pointer to every container
+// spec in the given pod spec with type set in mask. If visitor returns false,
+// visiting is short-circuited. VisitContainers returns true if visiting completes,
+// false if visiting was short-circuited.
+func VisitContainers(podSpec *v1.PodSpec, mask ContainerType, visitor ContainerVisitor) bool {
+	if mask&InitContainers != 0 {
+		for i := range podSpec.InitContainers {
+			if !visitor(&podSpec.InitContainers[i], InitContainers) {
+				return false
+			}
+		}
+	}
+	if mask&Containers != 0 {
+		for i := range podSpec.Containers {
+			if !visitor(&podSpec.Containers[i], Containers) {
+				return false
+			}
+		}
+	}
+	if mask&EphemeralContainers != 0 {
+		for i := range podSpec.EphemeralContainers {
+			if !visitor((*v1.Container)(&podSpec.EphemeralContainers[i].EphemeralContainerCommon), EphemeralContainers) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// VisitPodSecretNames invokes the visitor function with the name of every secret
+// referenced by the pod spec. If visitor returns false, visiting is short-circuited.
+// Transitive references (e.g. pod -> pvc -> pv -> secret) are not visited.
+// Returns true if visiting completed, false if visiting was short-circuited.
+func VisitPodSecretNames(pod *v1.Pod, visitor Visitor) bool {
+	visitor = skipEmptyNames(visitor)
+	for _, reference := range pod.Spec.ImagePullSecrets {
+		if !visitor(reference.Name) {
+			return false
+		}
+	}
+	VisitContainers(&pod.Spec, AllContainers, func(c *v1.Container, containerType ContainerType) bool {
+		return visitContainerSecretNames(c, visitor)
+	})
+	var source *v1.VolumeSource
+
+	for i := range pod.Spec.Volumes {
+		source = &pod.Spec.Volumes[i].VolumeSource
+		switch {
+		case source.AzureFile != nil:
+			if len(source.AzureFile.SecretName) > 0 && !visitor(source.AzureFile.SecretName) {
+				return false
+			}
+		case source.CephFS != nil:
+			if source.CephFS.SecretRef != nil && !visitor(source.CephFS.SecretRef.Name) {
+				return false
+			}
+		case source.Cinder != nil:
+			if source.Cinder.SecretRef != nil && !visitor(source.Cinder.SecretRef.Name) {
+				return false
+			}
+		case source.FlexVolume != nil:
+			if source.FlexVolume.SecretRef != nil && !visitor(source.FlexVolume.SecretRef.Name) {
+				return false
+			}
+		case source.Projected != nil:
+			for j := range source.Projected.Sources {
+				if source.Projected.Sources[j].Secret != nil {
+					if !visitor(source.Projected.Sources[j].Secret.Name) {
+						return false
+					}
+				}
+			}
+		case source.RBD != nil:
+			if source.RBD.SecretRef != nil && !visitor(source.RBD.SecretRef.Name) {
+				return false
+			}
+		case source.Secret != nil:
+			if !visitor(source.Secret.SecretName) {
+				return false
+			}
+		case source.ScaleIO != nil:
+			if source.ScaleIO.SecretRef != nil && !visitor(source.ScaleIO.SecretRef.Name) {
+				return false
+			}
+		case source.ISCSI != nil:
+			if source.ISCSI.SecretRef != nil && !visitor(source.ISCSI.SecretRef.Name) {
+				return false
+			}
+		case source.StorageOS != nil:
+			if source.StorageOS.SecretRef != nil && !visitor(source.StorageOS.SecretRef.Name) {
+				return false
+			}
+		case source.CSI != nil:
+			if source.CSI.NodePublishSecretRef != nil && !visitor(source.CSI.NodePublishSecretRef.Name) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// visitContainerSecretNames returns true unless the visitor returned false when invoked with a secret reference
+func visitContainerSecretNames(container *v1.Container, visitor Visitor) bool {
+	for _, env := range container.EnvFrom {
+		if env.SecretRef != nil {
+			if !visitor(env.SecretRef.Name) {
+				return false
+			}
+		}
+	}
+	for _, envVar := range container.Env {
+		if envVar.ValueFrom != nil && envVar.ValueFrom.SecretKeyRef != nil {
+			if !visitor(envVar.ValueFrom.SecretKeyRef.Name) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// VisitPodConfigmapNames invokes the visitor function with the name of every configmap
+// referenced by the pod spec. If visitor returns false, visiting is short-circuited.
+// Transitive references (e.g. pod -> pvc -> pv -> secret) are not visited.
+// Returns true if visiting completed, false if visiting was short-circuited.
+func VisitPodConfigmapNames(pod *v1.Pod, visitor Visitor) bool {
+	visitor = skipEmptyNames(visitor)
+	VisitContainers(&pod.Spec, AllContainers, func(c *v1.Container, containerType ContainerType) bool {
+		return visitContainerConfigmapNames(c, visitor)
+	})
+	var source *v1.VolumeSource
+	for i := range pod.Spec.Volumes {
+		source = &pod.Spec.Volumes[i].VolumeSource
+		switch {
+		case source.Projected != nil:
+			for j := range source.Projected.Sources {
+				if source.Projected.Sources[j].ConfigMap != nil {
+					if !visitor(source.Projected.Sources[j].ConfigMap.Name) {
+						return false
+					}
+				}
+			}
+		case source.ConfigMap != nil:
+			if !visitor(source.ConfigMap.Name) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// visitContainerConfigmapNames returns true unless the visitor returned false when invoked with a configmap reference
+func visitContainerConfigmapNames(container *v1.Container, visitor Visitor) bool {
+	for _, env := range container.EnvFrom {
+		if env.ConfigMapRef != nil {
+			if !visitor(env.ConfigMapRef.Name) {
+				return false
+			}
+		}
+	}
+	for _, envVar := range container.Env {
+		if envVar.ValueFrom != nil && envVar.ValueFrom.ConfigMapKeyRef != nil {
+			if !visitor(envVar.ValueFrom.ConfigMapKeyRef.Name) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// GetContainerStatus extracts the status of container "name" from "statuses".
+// It returns true if "name" exists, else returns false.
+func GetContainerStatus(statuses []v1.ContainerStatus, name string) (v1.ContainerStatus, bool) {
+	for i := range statuses {
+		if statuses[i].Name == name {
+			return statuses[i], true
+		}
+	}
+	return v1.ContainerStatus{}, false
+}
+
+// GetExistingContainerStatus extracts the status of container "name" from "statuses",
+// It also returns if "name" exists.
+func GetExistingContainerStatus(statuses []v1.ContainerStatus, name string) v1.ContainerStatus {
+	status, _ := GetContainerStatus(statuses, name)
+	return status
+}
+
+// GetIndexOfContainerStatus gets the index of status of container "name" from "statuses",
+// It returns (index, true) if "name" exists, else returns (0, false).
+func GetIndexOfContainerStatus(statuses []v1.ContainerStatus, name string) (int, bool) {
+	for i := range statuses {
+		if statuses[i].Name == name {
+			return i, true
+		}
+	}
+	return 0, false
+}
+
+// IsPodAvailable returns true if a pod is available; false otherwise.
+// Precondition for an available pod is that it must be ready. On top
+// of that, there are two cases when a pod can be considered available:
+// 1. minReadySeconds == 0, or
+// 2. LastTransitionTime (is set) + minReadySeconds < current time
+func IsPodAvailable(pod *v1.Pod, minReadySeconds int32, now metav1.Time) bool {
+	if !IsPodReady(pod) {
+		return false
+	}
+
+	c := GetPodReadyCondition(pod.Status)
+	minReadySecondsDuration := time.Duration(minReadySeconds) * time.Second
+	if minReadySeconds == 0 || (!c.LastTransitionTime.IsZero() && c.LastTransitionTime.Add(minReadySecondsDuration).Before(now.Time)) {
+		return true
+	}
+	return false
+}
+
+// IsPodReady returns true if a pod is ready; false otherwise.
+func IsPodReady(pod *v1.Pod) bool {
+	return IsPodReadyConditionTrue(pod.Status)
+}
+
+// IsPodTerminal returns true if a pod is terminal, all containers are stopped and cannot ever regress.
+func IsPodTerminal(pod *v1.Pod) bool {
+	return IsPodPhaseTerminal(pod.Status.Phase)
+}
+
+// IsPodPhaseTerminal returns true if the pod's phase is terminal.
+func IsPodPhaseTerminal(phase v1.PodPhase) bool {
+	return phase == v1.PodFailed || phase == v1.PodSucceeded
+}
+
+// IsPodReadyConditionTrue returns true if a pod is ready; false otherwise.
+func IsPodReadyConditionTrue(status v1.PodStatus) bool {
+	condition := GetPodReadyCondition(status)
+	return condition != nil && condition.Status == v1.ConditionTrue
+}
+
+// IsContainersReadyConditionTrue returns true if a pod is ready; false otherwise.
+func IsContainersReadyConditionTrue(status v1.PodStatus) bool {
+	condition := GetContainersReadyCondition(status)
+	return condition != nil && condition.Status == v1.ConditionTrue
+}
+
+// GetPodReadyCondition extracts the pod ready condition from the given status and returns that.
+// Returns nil if the condition is not present.
+func GetPodReadyCondition(status v1.PodStatus) *v1.PodCondition {
+	_, condition := GetPodCondition(&status, v1.PodReady)
+	return condition
+}
+
+// GetContainersReadyCondition extracts the containers ready condition from the given status and returns that.
+// Returns nil if the condition is not present.
+func GetContainersReadyCondition(status v1.PodStatus) *v1.PodCondition {
+	_, condition := GetPodCondition(&status, v1.ContainersReady)
+	return condition
+}
+
+// GetPodCondition extracts the provided condition from the given status and returns that.
+// Returns nil and -1 if the condition is not present, and the index of the located condition.
+func GetPodCondition(status *v1.PodStatus, conditionType v1.PodConditionType) (int, *v1.PodCondition) {
+	if status == nil {
+		return -1, nil
+	}
+	return GetPodConditionFromList(status.Conditions, conditionType)
+}
+
+// GetPodConditionFromList extracts the provided condition from the given list of condition and
+// returns the index of the condition and the condition. Returns -1 and nil if the condition is not present.
+func GetPodConditionFromList(conditions []v1.PodCondition, conditionType v1.PodConditionType) (int, *v1.PodCondition) {
+	if conditions == nil {
+		return -1, nil
+	}
+	for i := range conditions {
+		if conditions[i].Type == conditionType {
+			return i, &conditions[i]
+		}
+	}
+	return -1, nil
+}
+
+// UpdatePodCondition updates existing pod condition or creates a new one. Sets LastTransitionTime to now if the
+// status has changed.
+// Returns true if pod condition has changed or has been added.
+func UpdatePodCondition(status *v1.PodStatus, condition *v1.PodCondition) bool {
+	condition.LastTransitionTime = metav1.Now()
+	// Try to find this pod condition.
+	conditionIndex, oldCondition := GetPodCondition(status, condition.Type)
+
+	if oldCondition == nil {
+		// We are adding new pod condition.
+		status.Conditions = append(status.Conditions, *condition)
+		return true
+	}
+	// We are updating an existing condition, so we need to check if it has changed.
+	if condition.Status == oldCondition.Status {
+		condition.LastTransitionTime = oldCondition.LastTransitionTime
+	}
+
+	isEqual := condition.Status == oldCondition.Status &&
+		condition.Reason == oldCondition.Reason &&
+		condition.Message == oldCondition.Message &&
+		condition.LastProbeTime.Equal(&oldCondition.LastProbeTime) &&
+		condition.LastTransitionTime.Equal(&oldCondition.LastTransitionTime)
+
+	status.Conditions[conditionIndex] = *condition
+	// Return true if one of the fields have changed.
+	return !isEqual
+}
+
+// IsRestartableInitContainer returns true if the container has ContainerRestartPolicyAlways.
+// This function is not checking if the container passed to it is indeed an init container.
+// It is just checking if the container restart policy has been set to always.
+func IsRestartableInitContainer(initContainer *v1.Container) bool {
+	if initContainer == nil || initContainer.RestartPolicy == nil {
+		return false
+	}
+	return *initContainer.RestartPolicy == v1.ContainerRestartPolicyAlways
+}

--- a/go-controller/vendor/k8s.io/kubernetes/pkg/api/v1/pod/util.go
+++ b/go-controller/vendor/k8s.io/kubernetes/pkg/api/v1/pod/util.go
@@ -41,17 +41,6 @@ func FindPort(pod *v1.Pod, svcPort *v1.ServicePort) (int, error) {
 				}
 			}
 		}
-		// also support sidecar container (initContainer with restartPolicy=Always)
-		for _, container := range pod.Spec.InitContainers {
-			if container.RestartPolicy == nil || *container.RestartPolicy != v1.ContainerRestartPolicyAlways {
-				continue
-			}
-			for _, port := range container.Ports {
-				if port.Name == name && port.Protocol == svcPort.Protocol {
-					return int(port.ContainerPort), nil
-				}
-			}
-		}
 	case intstr.Int:
 		return portName.IntValue(), nil
 	}
@@ -405,14 +394,4 @@ func UpdatePodCondition(status *v1.PodStatus, condition *v1.PodCondition) bool {
 	status.Conditions[conditionIndex] = *condition
 	// Return true if one of the fields have changed.
 	return !isEqual
-}
-
-// IsRestartableInitContainer returns true if the container has ContainerRestartPolicyAlways.
-// This function is not checking if the container passed to it is indeed an init container.
-// It is just checking if the container restart policy has been set to always.
-func IsRestartableInitContainer(initContainer *v1.Container) bool {
-	if initContainer == nil || initContainer.RestartPolicy == nil {
-		return false
-	}
-	return *initContainer.RestartPolicy == v1.ContainerRestartPolicyAlways
 }

--- a/go-controller/vendor/modules.txt
+++ b/go-controller/vendor/modules.txt
@@ -1146,6 +1146,7 @@ k8s.io/kube-openapi/pkg/util/proto
 k8s.io/kube-openapi/pkg/validation/spec
 # k8s.io/kubernetes v1.30.2
 ## explicit; go 1.22.0
+k8s.io/kubernetes/pkg/api/v1/pod
 k8s.io/kubernetes/pkg/apis/core
 k8s.io/kubernetes/pkg/probe
 k8s.io/kubernetes/pkg/probe/http


### PR DESCRIPTION
Manual cherry pick of 3d32558bd903bcc0703bbc40c4cd3b98064f0b67 and d942a7d81433a4f1dc1d12e59de1feede60254f3.

For 3d32558bd903bcc0703bbc40c4cd3b98064f0b67 resolved conflicts in:
- `go-controller/pkg/ovn/controller/apbroute/external_controller_pod.go`
- `go-controller/pkg/ovn/egressgw.go`
- `go-controller/pkg/ovn/ovn.go`
- `go-controller/vendor/modules.txt`

Then ran `go mod tidy` and `go mod vendor`

For d942a7d81433a4f1dc1d12e59de1feede60254f3 resolved conflicts in:
- `go-controller/pkg/ovn/controller/apbroute/external_controller_pod_test.go`

Additionally, for d942a7d81433a4f1dc1d12e59de1feede60254f3 fixed issue of imported packages and package names in:
- `go-controller/pkg/ovn/controller/apbroute/external_controller_pod_test.go`
- `go-controller/pkg/ovn/controller/apbroute/external_controller_namespace_test.go`
- `go-controller/pkg/ovn/egressgw_test.go`