### PR TITLE
NO-JIRA: Disable informing tests for the time being

### DIFF
--- a/openshift/cmd/ovn-kubernetes-tests-ext/main.go
+++ b/openshift/cmd/ovn-kubernetes-tests-ext/main.go
@@ -94,6 +94,11 @@ func main() {
 	})
 
 	specs = specs.Select(func(spec *extensiontests.ExtensionTestSpec) bool {
+		// Disable informing specs for now
+		if spec.Lifecycle == extensiontests.LifecycleInforming {
+			return false
+		}
+
 		return !strings.Contains(spec.Name, "[Disabled:")
 	})
 


### PR DESCRIPTION
Until we decide when it is the best time to run them



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Modified test filtering to exclude informing-type test specs from extension tests, preventing their unintended execution alongside other test suites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->