### PR TITLE
[release-4.20] OCPBUGS-82115: egressip: Skip bridge configuration for secondary network IPs

### DIFF
--- a/go-controller/pkg/node/egressip/gateway_egressip.go
+++ b/go-controller/pkg/node/egressip/gateway_egressip.go
@@ -208,115 +208,94 @@ func (g *BridgeEIPAddrManager) GetCache() *MarkIPsCache {
 }
 
 func (g *BridgeEIPAddrManager) AddEgressIP(eip *egressipv1.EgressIP) (bool, error) {
-	var isUpdated bool
-	if !util.IsEgressIPMarkSet(eip.Annotations) {
-		return isUpdated, nil
+	ip, pktMark, shouldSkip, err := g.parseAndValidateEIP(eip)
+	if err != nil {
+		return false, fmt.Errorf("failed to add EgressIP gateway config because unable to parse and validate EgressIP: %v", err)
 	}
-	for _, status := range eip.Status.Items {
-		if status.Node != g.nodeName {
-			continue
-		}
-		ip, pktMark, err := parseEIPMarkIP(eip.Annotations, status.EgressIP)
-		if err != nil {
-			return isUpdated, fmt.Errorf("failed to add EgressIP gateway config because unable to extract config from EgressIP obj: %v", err)
-		}
-		// must always add to cache before adding IP because we want to inform node ip handler that this is not a valid node IP
-		g.cache.insertMarkIP(pktMark, ip)
-		if err = g.addIPToAnnotation(ip); err != nil {
-			return isUpdated, fmt.Errorf("failed to add EgressIP gateway config because unable to add EgressIP IP to Node annotation: %v", err)
-		}
-		if err = g.addIPBridge(ip); err != nil {
-			return isUpdated, fmt.Errorf("failed to add EgressIP gateway config because failed to add address to link: %v", err)
-		}
-		isUpdated = true
-		break // no need to continue as only one EIP IP is assigned to a node
+	if shouldSkip {
+		return false, nil
 	}
-	return isUpdated, nil
+	// must always add to cache before adding IP because we want to inform node ip handler that this is not a valid node IP
+	g.cache.insertMarkIP(pktMark, ip)
+	if err = g.addIPToAnnotation(ip); err != nil {
+		return false, fmt.Errorf("failed to add EgressIP gateway config because unable to add EgressIP IP to Node annotation: %v", err)
+	}
+	if err = g.addIPBridge(ip); err != nil {
+		return false, fmt.Errorf("failed to add EgressIP gateway config because failed to add address to link: %v", err)
+	}
+	return true, nil
 }
 
 func (g *BridgeEIPAddrManager) UpdateEgressIP(oldEIP, newEIP *egressipv1.EgressIP) (bool, error) {
+	// Parse and validate old EgressIP
+	oldIP, oldMark, oldSkip, err := g.parseAndValidateEIP(oldEIP)
+	if err != nil {
+		return false, fmt.Errorf("unable to parse and validate old EgressIP: %v", err)
+	}
+
+	// Parse and validate new EgressIP
+	newIP, newMark, newSkip, err := g.parseAndValidateEIP(newEIP)
+	if err != nil {
+		return false, fmt.Errorf("unable to parse and validate new EgressIP: %v", err)
+	}
+
+	// Both should be skipped - no change
+	if oldSkip && newSkip {
+		return false, nil
+	}
+
+	// Both exist and are the same - no change
+	if !oldSkip && !newSkip && oldIP.Equal(newIP) {
+		return false, nil
+	}
+
 	var isUpdated bool
-	// at most, one status item for this node will be found.
-	for _, oldStatus := range oldEIP.Status.Items {
-		if oldStatus.Node != g.nodeName {
-			continue
-		}
-		if !util.IsEgressIPMarkSet(oldEIP.Annotations) {
-			// this scenario may occur during upgrade from when ovn-k didn't apply marks to EIP objs
-			break
-		}
-		if util.IsItemInSlice(newEIP.Status.Items, oldStatus) {
-			// if one status entry exists in both status items, then nothing needs to be done because no status update.
-			// also, because at most only one status item can be assigned to a node, we can return early.
-			return isUpdated, nil
-		}
-		ip, pktMark, err := parseEIPMarkIP(oldEIP.Annotations, oldStatus.EgressIP)
-		if err != nil {
-			return isUpdated, fmt.Errorf("failed to update EgressIP SNAT for ext bridge cache because unable to extract config from old EgressIP obj: %v", err)
-		}
-		if err = g.deleteIPBridge(ip); err != nil {
+
+	// Delete old if it exists and is different from new
+	if !oldSkip {
+		if err = g.deleteIPBridge(oldIP); err != nil {
 			return isUpdated, fmt.Errorf("failed to update EgressIP gateway config because failed to delete address from link: %v", err)
 		}
-		g.cache.deleteMarkIP(pktMark, ip)
-		if err = g.deleteIPsFromAnnotation(ip); err != nil {
+		g.cache.deleteMarkIP(oldMark, oldIP)
+		if err = g.deleteIPsFromAnnotation(oldIP); err != nil {
 			return isUpdated, fmt.Errorf("failed to update EgressIP gateway config because unable to delete EgressIP IP from Node annotation: %v", err)
 		}
 		isUpdated = true
-		break
 	}
-	for _, newStatus := range newEIP.Status.Items {
-		if newStatus.Node != g.nodeName {
-			continue
-		}
-		if !util.IsEgressIPMarkSet(newEIP.Annotations) {
-			// this scenario may occur during upgrade from when ovn-k didn't apply marks to EIP objs
-			return isUpdated, nil
-		}
-		ip, pktMark, err := parseEIPMarkIP(newEIP.Annotations, newStatus.EgressIP)
-		if err != nil {
-			return isUpdated, fmt.Errorf("failed to update EgressIP gateway config because unable to extract config from EgressIP obj: %v", err)
-		}
-		// must always add to OF cache before adding IP because we want to inform node ip handler that this is not a valid node IP
-		g.cache.insertMarkIP(pktMark, ip)
-		if err = g.addIPToAnnotation(ip); err != nil {
+
+	// Add new if it exists
+	if !newSkip {
+		// must always add to cache before adding IP because we want to inform node ip handler that this is not a valid node IP
+		g.cache.insertMarkIP(newMark, newIP)
+		if err = g.addIPToAnnotation(newIP); err != nil {
 			return isUpdated, fmt.Errorf("failed to update EgressIP gateway config because unable to add EgressIP IP to Node annotation: %v", err)
 		}
-		if err = g.addIPBridge(ip); err != nil {
+		if err = g.addIPBridge(newIP); err != nil {
 			return isUpdated, fmt.Errorf("failed to update EgressIP gateway config because failed to add address to link: %v", err)
 		}
 		isUpdated = true
-		break
 	}
+
 	return isUpdated, nil
 }
 
 func (g *BridgeEIPAddrManager) DeleteEgressIP(eip *egressipv1.EgressIP) (bool, error) {
-	var isUpdated bool
-	if !util.IsEgressIPMarkSet(eip.Annotations) {
-		return isUpdated, nil
+	ip, pktMark, shouldSkip, err := g.parseAndValidateEIP(eip)
+	if err != nil {
+		return false, fmt.Errorf("failed to delete EgressIP gateway config because unable to parse and validate EgressIP: %v", err)
 	}
-	for _, status := range eip.Status.Items {
-		if status.Node != g.nodeName {
-			continue
-		}
-		if !util.IsEgressIPMarkSet(eip.Annotations) {
-			continue
-		}
-		ip, pktMark, err := parseEIPMarkIP(eip.Annotations, status.EgressIP)
-		if err != nil {
-			return isUpdated, fmt.Errorf("failed to delete EgressIP gateway config because unable to extract config from EgressIP obj: %v", err)
-		}
-		if err = g.deleteIPBridge(ip); err != nil {
-			return isUpdated, fmt.Errorf("failed to delete EgressIP gateway config because failed to delete address from link: %v", err)
-		}
-		g.cache.deleteMarkIP(pktMark, ip)
-		if err = g.deleteIPsFromAnnotation(ip); err != nil {
-			return isUpdated, fmt.Errorf("failed to delete EgressIP gateway config because failed to delete EgressIP IP from Node annotation: %v", err)
-		}
-		isUpdated = true
-		break // no need to continue as only one EIP IP is assigned per node
+	// Skip secondary network IPs. Cleanup of stale secondary IPs from old code is handled in SyncEgressIP.
+	if shouldSkip {
+		return false, nil
 	}
-	return isUpdated, nil
+	if err = g.deleteIPBridge(ip); err != nil {
+		return false, fmt.Errorf("failed to delete EgressIP gateway config because failed to delete address from link: %v", err)
+	}
+	g.cache.deleteMarkIP(pktMark, ip)
+	if err = g.deleteIPsFromAnnotation(ip); err != nil {
+		return false, fmt.Errorf("failed to delete EgressIP gateway config because failed to delete EgressIP IP from Node annotation: %v", err)
+	}
+	return true, nil
 }
 
 func (g *BridgeEIPAddrManager) SyncEgressIP(objs []interface{}) error {
@@ -331,27 +310,21 @@ func (g *BridgeEIPAddrManager) SyncEgressIP(objs []interface{}) error {
 		if !ok {
 			return fmt.Errorf("expected EgressIP type but received %T", obj)
 		}
-		// This may happen during upgrade when node controllers upgrade before cluster manager upgrades when cluster manager doesn't contain func
-		// to add a pkt mark to EgressIPs.
-		if !util.IsEgressIPMarkSet(eip.Annotations) {
+		ip, pktMark, shouldSkip, err := g.parseAndValidateEIP(eip)
+		if err != nil {
+			klog.Errorf("Failed to sync EgressIP %s gateway config because unable to parse and validate EgressIP: %v", eip.Name, err)
 			continue
 		}
-		for _, status := range eip.Status.Items {
-			if status.Node != g.nodeName {
-				continue
-			}
-			if ip, pktMark, err := parseEIPMarkIP(eip.Annotations, status.EgressIP); err != nil {
-				klog.Errorf("Failed to sync EgressIP %s gateway config because unable to extract config from EIP obj: %v", eip.Name, err)
-			} else {
-				configs.insert(pktMark, ip)
-				if err = g.addIPToAnnotation(ip); err != nil {
-					return fmt.Errorf("failed to sync EgressIP gateway config because unable to add EgressIP IP to Node annotation: %v", err)
-				}
-				if err = g.addIPBridge(ip); err != nil {
-					return fmt.Errorf("failed to sync EgressIP gateway config because failed to add address to link: %v", err)
-				}
-			}
-			break
+		if shouldSkip {
+			// Skip IPs not on OVN network (i.e., secondary network IPs)
+			continue
+		}
+		configs.insert(pktMark, ip)
+		if err = g.addIPToAnnotation(ip); err != nil {
+			return fmt.Errorf("failed to sync EgressIP gateway config because unable to add EgressIP IP to Node annotation: %v", err)
+		}
+		if err = g.addIPBridge(ip); err != nil {
+			return fmt.Errorf("failed to sync EgressIP gateway config because failed to add address to link: %v", err)
 		}
 	}
 	ipsToDel := make([]net.IP, 0)
@@ -360,12 +333,12 @@ func (g *BridgeEIPAddrManager) SyncEgressIP(objs []interface{}) error {
 			continue
 		}
 		if err = g.deleteIPBridge(annotIP); err != nil {
-			klog.Errorf("Failed to delete stale EgressIP IP %s from gateway: %v", annotIP, err)
-			continue
+			return fmt.Errorf("failed to delete stale EgressIP IP %s from bridge: %v", annotIP, err)
 		}
 		ipsToDel = append(ipsToDel, annotIP)
 	}
 	if len(ipsToDel) > 0 {
+		klog.V(5).Infof("Deleting stale EgressIP IPs from Node annotation: %v", getIPsStr(ipsToDel...))
 		if err = g.deleteIPsFromAnnotation(ipsToDel...); err != nil {
 			return fmt.Errorf("failed to delete EgressIP IPs from Node annotation: %v", err)
 		}
@@ -485,23 +458,80 @@ func (g *BridgeEIPAddrManager) getAnnotationIPs() ([]net.IP, error) {
 	return ips, nil
 }
 
-func parseEIPMarkIP(annotations map[string]string, eip string) (net.IP, util.EgressIPMark, error) {
-	pktMark, err := util.ParseEgressIPMark(annotations)
+// isOVNNetworkIP checks if the given IP belongs to the OVN (primary) network
+// Returns true if the IP is on the OVN network, false if it's on a secondary network
+func (g *BridgeEIPAddrManager) isOVNNetworkIP(ip net.IP) (bool, error) {
+	node, err := g.nodeLister.Get(g.nodeName)
 	if err != nil {
-		return nil, pktMark, fmt.Errorf("failed to extract packet mark from EgressIP annotations: %v", err)
+		return false, fmt.Errorf("failed to get node %s: %v", g.nodeName, err)
 	}
-	// status update and pkt mark should be configured as one operation by cluster manager
+	nodePrimaryIPs, err := util.ParseNodePrimaryIfAddr(node)
+	if err != nil {
+		return false, fmt.Errorf("failed to parse node primary interface address for node %s: %v", g.nodeName, err)
+	}
+	return util.IsOVNNetwork(nodePrimaryIPs, ip), nil
+}
+
+// parseAndValidateEIP parses and validates an EgressIP for this node
+// Returns:
+// - ip: the parsed IP address
+// - pktMark: the parsed packet mark
+// - shouldSkip: true if this EgressIP should be skipped (e.g., no mark set, not assigned to this node, belongs to secondary network)
+// - error: any error encountered during parsing/validation
+func (g *BridgeEIPAddrManager) parseAndValidateEIP(eip *egressipv1.EgressIP) (net.IP, util.EgressIPMark, bool, error) {
+	var pktMark util.EgressIPMark
+
+	// Check if packet mark is set
+	// This scenario may occur during upgrade from when ovn-k didn't apply marks to EIP objs
+	if !util.IsEgressIPMarkSet(eip.Annotations) {
+		return nil, pktMark, true, nil
+	}
+
+	// Find the EgressIP assigned to this node
+	var eipAddr string
+	for _, status := range eip.Status.Items {
+		if status.Node == g.nodeName {
+			eipAddr = status.EgressIP
+			break
+		}
+	}
+	if eipAddr == "" {
+		return nil, pktMark, true, nil
+	}
+
+	// Parse the IP address
+	ip := net.ParseIP(eipAddr)
+	if ip == nil {
+		return nil, pktMark, false, fmt.Errorf("failed to parse EgressIP %s", eipAddr)
+	}
+
+	// Parse the packet mark
+	var err error
+	pktMark, err = util.ParseEgressIPMark(eip.Annotations)
+	if err != nil {
+		return nil, pktMark, false, fmt.Errorf("failed to extract packet mark from EgressIP annotations: %v", err)
+	}
+
+	// Validate packet mark
 	if !pktMark.IsAvailable() {
-		return nil, pktMark, fmt.Errorf("packet mark is not set")
+		return nil, pktMark, false, fmt.Errorf("packet mark is not set")
 	}
 	if !pktMark.IsValid() {
-		return nil, pktMark, fmt.Errorf("packet mark is not valid")
+		return nil, pktMark, false, fmt.Errorf("packet mark is not valid")
 	}
-	ip := net.ParseIP(eip)
-	if ip == nil {
-		return nil, pktMark, fmt.Errorf("invalid IP")
+
+	// Check if this IP belongs to the OVN (primary) network
+	isOVN, err := g.isOVNNetworkIP(ip)
+	if err != nil {
+		return nil, pktMark, false, fmt.Errorf("failed to check if IP is OVN network: %w", err)
 	}
-	return ip, pktMark, nil
+	if !isOVN {
+		// Skip IPs not on OVN network (i.e., secondary network IPs)
+		klog.V(5).Infof("Skipping EgressIP %s on bridge %s because it does not belong to the OVN network", ip.String(), g.bridgeName)
+		return ip, pktMark, true, nil
+	}
+
+	return ip, pktMark, false, nil
 }
 
 func getIPsStr(ips ...net.IP) []string {

--- a/go-controller/pkg/node/egressip/gateway_egressip_test.go
+++ b/go-controller/pkg/node/egressip/gateway_egressip_test.go
@@ -1,6 +1,7 @@
 package egressip
 
 import (
+	"encoding/json"
 	"fmt"
 	"net"
 	"strings"
@@ -127,6 +128,25 @@ var _ = ginkgo.Describe("Gateway EgressIP", func() {
 			gomega.Expect(nlMock.AssertCalled(ginkgo.GinkgoT(), "AddrAdd", nlLinkMock,
 				egressip.GetNetlinkAddress(net.ParseIP(ipV4Addr), bridgeLinkIndex))).Should(gomega.BeTrue())
 		})
+
+		ginkgo.It("doesn't configure when EgressIP is on a secondary host network", func() {
+			// Setup a node with host-cidrs annotation containing a secondary network subnet
+			secondarySubnet := "10.10.10.0/24"
+			secondaryIP := "10.10.10.5"
+
+			nlMock.On("AddrAdd", nlLinkMock, egressip.GetNetlinkAddress(net.ParseIP(secondaryIP), bridgeLinkIndex)).Return(nil)
+			addrMgr, stopFn := initBridgeEIPAddrManagerWithHostCIDRs(nodeName, bridgeName, emptyAnnotation, []string{secondarySubnet})
+			defer stopFn()
+			eip := getEIPAssignedToNode(nodeName, mark, secondaryIP)
+			isUpdated, err := addrMgr.AddEgressIP(eip)
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "should not error for secondary network IP")
+			gomega.Expect(isUpdated).Should(gomega.BeFalse(), "should not update for secondary network IP")
+			node, err := addrMgr.nodeLister.Get(nodeName)
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "node should be present within kapi")
+			gomega.Expect(parseEIPsFromAnnotation(node)).ShouldNot(gomega.ConsistOf(secondaryIP), "secondary IP should not be in annotation")
+			gomega.Expect(nlMock.AssertNotCalled(ginkgo.GinkgoT(), "AddrAdd", nlLinkMock,
+				egressip.GetNetlinkAddress(net.ParseIP(secondaryIP), bridgeLinkIndex))).Should(gomega.BeTrue(), "should not add IP to bridge")
+		})
 	})
 
 	ginkgo.Context("update EgressIP", func() {
@@ -198,9 +218,11 @@ var _ = ginkgo.Describe("Gateway EgressIP", func() {
 			isUpdated, err = addrMgr.UpdateEgressIP(assignedEIP1, assignedEIP2)
 			gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "should process a valid EgressIP")
 			gomega.Expect(isUpdated).Should(gomega.BeTrue())
-			node, err := addrMgr.nodeLister.Get(nodeName)
-			gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "node should be present within kapi")
-			gomega.Expect(parseEIPsFromAnnotation(node)).Should(gomega.ConsistOf(ipV4Addr2))
+			gomega.Eventually(func() []string {
+				node, err := addrMgr.nodeLister.Get(nodeName)
+				gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "node should be present within kapi")
+				return parseEIPsFromAnnotation(node)
+			}).Should(gomega.ConsistOf(ipV4Addr2))
 			gomega.Expect(nlMock.AssertCalled(ginkgo.GinkgoT(), "AddrAdd", nlLinkMock,
 				egressip.GetNetlinkAddress(net.ParseIP(ipV4Addr), bridgeLinkIndex))).Should(gomega.BeTrue())
 			gomega.Expect(nlMock.AssertCalled(ginkgo.GinkgoT(), "AddrAdd", nlLinkMock,
@@ -292,9 +314,11 @@ var _ = ginkgo.Describe("Gateway EgressIP", func() {
 			eipAssigned2 := getEIPAssignedToNode(nodeName, mark2, ipV4Addr2)
 			err := addrMgr.SyncEgressIP([]interface{}{eipAssigned1, eipAssigned2})
 			gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "should process valid EgressIPs")
-			node, err := addrMgr.nodeLister.Get(nodeName)
-			gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "node should be present within kapi")
-			gomega.Expect(parseEIPsFromAnnotation(node)).Should(gomega.ConsistOf(ipV4Addr, ipV4Addr2))
+			gomega.Eventually(func() []string {
+				node, err := addrMgr.nodeLister.Get(nodeName)
+				gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "node should be present within kapi")
+				return parseEIPsFromAnnotation(node)
+			}).Should(gomega.ConsistOf(ipV4Addr, ipV4Addr2))
 			gomega.Expect(nlMock.AssertCalled(ginkgo.GinkgoT(), "AddrAdd", nlLinkMock,
 				egressip.GetNetlinkAddress(net.ParseIP(ipV4Addr), bridgeLinkIndex))).Should(gomega.BeTrue())
 			gomega.Expect(nlMock.AssertCalled(ginkgo.GinkgoT(), "AddrAdd", nlLinkMock,
@@ -313,15 +337,74 @@ var _ = ginkgo.Describe("Gateway EgressIP", func() {
 			gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "node should be present within kapi")
 			gomega.Expect(parseEIPsFromAnnotation(node)).Should(gomega.BeEmpty())
 		})
+
+		ginkgo.It("cleans up mistakenly configured secondary network EgressIP", func() {
+			// Setup: secondary network IP that was mistakenly configured by old buggy code
+			secondaryIP := "10.10.10.5"
+			secondarySubnet := "10.10.10.0/24"
+
+			nlLinkMock.On("Attrs").Return(&netlink.LinkAttrs{Name: bridgeName, Index: bridgeLinkIndex}, nil)
+			nlMock.On("LinkByName", bridgeName).Return(nlLinkMock, nil)
+			nlMock.On("LinkByIndex", bridgeLinkIndex).Return(nlLinkMock, nil)
+			nlMock.On("LinkList").Return([]netlink.Link{nlLinkMock}, nil)
+			nlMock.On("AddrList", nlLinkMock, 0).Return([]netlink.Addr{}, nil)
+			nlMock.On("AddrDel", nlLinkMock, egressip.GetNetlinkAddress(net.ParseIP(secondaryIP), bridgeLinkIndex)).Return(nil)
+			nlMock.On("AddrAdd", nlLinkMock, egressip.GetNetlinkAddress(net.ParseIP(ipV4Addr), bridgeLinkIndex)).Return(nil)
+
+			// Initialize with host-cidrs that includes the secondary network and mistakenly configured secondary IP
+			addrMgr, stopFn := initBridgeEIPAddrManagerWithHostCIDRs(nodeName, bridgeName, generateAnnotFromIPs(secondaryIP), []string{secondarySubnet})
+			defer stopFn()
+
+			// Simulate mistaken configuration by old buggy code: IP is in cache
+			secondaryEIP := getEIPAssignedToNode(nodeName, mark, secondaryIP)
+			pktMark, err := util.ParseEgressIPMark(secondaryEIP.Annotations)
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+			addrMgr.cache.insertMarkIP(pktMark, net.ParseIP(secondaryIP))
+
+			// Verify mistaken state exists
+			gomega.Expect(addrMgr.cache.IsIPPresent(net.ParseIP(secondaryIP))).Should(gomega.BeTrue(), "IP should be in cache (mistaken state)")
+			node, err := addrMgr.nodeLister.Get(nodeName)
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+			gomega.Expect(parseEIPsFromAnnotation(node)).Should(gomega.ConsistOf(secondaryIP), "IP should be in annotation (mistaken state)")
+
+			// Sync with a valid OVN network EgressIP - should clean up the secondary IP and add the new one
+			validEIP := getEIPAssignedToNode(nodeName, mark2, ipV4Addr)
+			err = addrMgr.SyncEgressIP([]interface{}{validEIP})
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "should sync and clean up mistaken secondary network EgressIP")
+
+			// Verify cleanup: secondary IP removed from cache, annotation, and bridge
+			gomega.Expect(addrMgr.cache.IsIPPresent(net.ParseIP(secondaryIP))).Should(gomega.BeFalse(), "secondary IP should be removed from cache")
+			node, err = addrMgr.nodeLister.Get(nodeName)
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+			gomega.Expect(parseEIPsFromAnnotation(node)).Should(gomega.ConsistOf(ipV4Addr), "only valid OVN IP should be in annotation")
+			gomega.Expect(nlMock.AssertCalled(ginkgo.GinkgoT(), "AddrDel", nlLinkMock,
+				egressip.GetNetlinkAddress(net.ParseIP(secondaryIP), bridgeLinkIndex))).Should(gomega.BeTrue(), "should delete secondary IP from bridge")
+			gomega.Expect(nlMock.AssertCalled(ginkgo.GinkgoT(), "AddrAdd", nlLinkMock,
+				egressip.GetNetlinkAddress(net.ParseIP(ipV4Addr), bridgeLinkIndex))).Should(gomega.BeTrue(), "should add valid OVN IP to bridge")
+		})
 	})
 })
 
 func initBridgeEIPAddrManager(nodeName, bridgeName string, bridgeEIPAnnot string) (*BridgeEIPAddrManager, func()) {
+	return initBridgeEIPAddrManagerWithHostCIDRs(nodeName, bridgeName, bridgeEIPAnnot, nil)
+}
+
+// initBridgeEIPAddrManagerWithHostCIDRs is a variant of initBridgeEIPAddrManager that sets the host-cidrs annotation
+func initBridgeEIPAddrManagerWithHostCIDRs(nodeName, bridgeName string, bridgeEIPAnnot string, hostCIDRs []string) (*BridgeEIPAddrManager, func()) {
 	node := &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{Name: nodeName, Annotations: map[string]string{}},
 	}
 	if bridgeEIPAnnot != "" {
 		node.Annotations[util.OVNNodeBridgeEgressIPs] = bridgeEIPAnnot
+	}
+	// Add OVN network annotation - required for isOVNNetworkIP to work
+	node.Annotations[util.OvnNodeIfAddr] = `{"ipv4":"192.168.1.10/24"}`
+	if len(hostCIDRs) > 0 {
+		// Add OVN (primary) network to host-cidrs
+		hostCIDRs = append(hostCIDRs, "192.168.1.0/24")
+		cidrsJSON, err := json.Marshal(hostCIDRs)
+		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+		node.Annotations[util.OVNNodeHostCIDRs] = string(cidrsJSON)
 	}
 	client := fake.NewSimpleClientset(node)
 	watchFactory, err := factory.NewNodeWatchFactory(&util.OVNNodeClientset{KubeClient: client}, nodeName)

--- a/go-controller/pkg/node/linkmanager/link_network_manager.go
+++ b/go-controller/pkg/node/linkmanager/link_network_manager.go
@@ -1,11 +1,13 @@
 package linkmanager
 
 import (
+	"errors"
 	"fmt"
 	"sync"
 	"time"
 
 	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
 
 	"k8s.io/klog/v2"
 	utilnet "k8s.io/utils/net"
@@ -152,7 +154,7 @@ func (c *Controller) DelAddress(address netlink.Addr) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if err := util.GetNetLinkOps().AddrDel(link, &address); err != nil {
-		if !util.GetNetLinkOps().IsLinkNotFoundError(err) {
+		if !util.GetNetLinkOps().IsLinkNotFoundError(err) && !errors.Is(err, unix.EADDRNOTAVAIL) {
 			return fmt.Errorf("failed to delete address %s: %v", address.String(), err)
 		}
 	}


### PR DESCRIPTION
This is clean manual cherrypick.

Skip configuring EgressIPs on the bridge when they don't belong to the OVN (primary) network. This prevents conflicts when EgressIPs are assigned to secondary host networks. SyncEgressIP() will clean up existing mistaken configurations during bootup while uprading OVN-K.

Uses util.IsOVNNetwork() to check network membership and adds a helper function parseAndValidateEIP() to consolidate validation logic and fix missing packet mark validation.

Tests have been added to verify that secondary network IPs are ignored and that existing mistaken configurations are cleaned up.


(cherry picked from commit 2d4a479ca4c5f884ef54e5323148e1103cfccdb2)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
