### PR TITLE
OCPBUGS-82533: openshift tests: demote to informing

### DIFF
--- a/openshift/cmd/ovn-kubernetes-tests-ext/main.go
+++ b/openshift/cmd/ovn-kubernetes-tests-ext/main.go
@@ -15,6 +15,8 @@ import (
 	"github.com/openshift-eng/openshift-tests-extension/pkg/ginkgo"
 	"github.com/spf13/cobra"
 
+	"k8s.io/apimachinery/pkg/util/sets"
+
 	// ensure providers are initialised for configuring infra
 	_ "k8s.io/kubernetes/test/e2e/framework/providers/aws"
 	_ "k8s.io/kubernetes/test/e2e/framework/providers/azure"
@@ -26,14 +28,6 @@ import (
 	// ensure that logging flags are part of the command line.
 	_ "k8s.io/component-base/logs/testinit"
 )
-
-func loadBlockingTests() map[string]bool {
-	blockingTests := make(map[string]bool)
-	for _, testName := range test.BlockingTests {
-		blockingTests[testName] = true
-	}
-	return blockingTests
-}
 
 func main() {
 	// Create our registry of openshift-tests extensions
@@ -70,7 +64,8 @@ func main() {
 		}
 	})
 
-	blockingTests := loadBlockingTests()
+	informingTests := sets.New(test.InformingTests...)
+	blockingTests := sets.New(test.BlockingTests...)
 
 	specs.Walk(func(spec *extensiontests.ExtensionTestSpec) {
 		for _, label := range getTestExtensionLabels() {
@@ -88,14 +83,19 @@ func main() {
 		}
 		spec.Name = generatePrependedLabelsStr(spec.Labels) + " " + spec.Name // prepend ginkgo labels to test name
 
-		if !blockingTests[spec.Name] {
+		switch {
+		case informingTests.Has(spec.Name):
 			spec.Lifecycle = extensiontests.LifecycleInforming
+		case blockingTests.Has(spec.Name):
+			spec.Lifecycle = extensiontests.LifecycleBlocking
+		default:
+			spec.Lifecycle = ""
 		}
 	})
 
 	specs = specs.Select(func(spec *extensiontests.ExtensionTestSpec) bool {
-		// Disable informing specs for now
-		if spec.Lifecycle == extensiontests.LifecycleInforming {
+		// Disable specs that are not explicitly assigned a lifecycle
+		if spec.Lifecycle == "" {
 			return false
 		}
 

--- a/openshift/test/tests.go
+++ b/openshift/test/tests.go
@@ -1,16 +1,17 @@
 package test
 
-// BlockingTests lists tests that are considered stable and should block CI jobs if they fail.
-// Tests NOT in this list or explicitly "Disabled" in annotations will be marked as "informing"
-//   - they run but failures don't fail the job.
-//
-// To graduate a test from informing to blocking:
-//  1. Add the full test name to this slice (with proper quotes and comma)
+// This list contains separate lists of informing and blocking tests. Tests not
+// on either of these lists do not run. To graduate a test from informing to
+// blocking:
+//  1. Remove the tests from InformingTests list and add it to the BlockingTests list
 //  2. Rebuild: ./hack/build-tests-ext.sh
 //  3. Verify: ./bin/ovn-kubernetes-tests-ext list tests | jq -r '.[] | select(.name == "test name here") | .lifecycle'
 //
 // Used by: openshift/cmd/ovn-kubernetes-tests-ext/main.go
-var BlockingTests = []string{
+
+// InformingTests lists tests that generally pass but are not considered stable
+// and should not block CI jobs if they fail.
+var InformingTests = []string{
 	"[Feature:NetworkSegmentation][ovn-kubernetes-ote][sig-network] Network Segmentation a user defined primary network created using ClusterUserDefinedNetwork can perform east/west traffic between nodes two pods connected over a L2 primary UDN [Suite:openshift/conformance/parallel]",
 	"[Feature:NetworkSegmentation][ovn-kubernetes-ote][sig-network] Network Segmentation a user defined primary network created using ClusterUserDefinedNetwork can perform east/west traffic between nodes two pods connected over a L2 primary UDN with custom network [Suite:openshift/conformance/parallel]",
 	"[Feature:NetworkSegmentation][ovn-kubernetes-ote][sig-network] Network Segmentation a user defined primary network created using ClusterUserDefinedNetwork can perform east/west traffic between nodes two pods connected over a L3 primary UDN [Suite:openshift/conformance/parallel]",
@@ -61,3 +62,7 @@ var BlockingTests = []string{
 	"[Feature:NetworkSegmentation][ovn-kubernetes-ote][sig-network] Network Segmentation when primary network exist, ClusterUserDefinedNetwork status should report not-ready [Suite:openshift/conformance/parallel]",
 	"[Feature:NetworkSegmentation][ovn-kubernetes-ote][sig-network] Network Segmentation when primary network exist, UserDefinedNetwork status should report not-ready [Suite:openshift/conformance/parallel]",
 }
+
+// BlockingTests lists tests that are considered stable and should block CI jobs
+// if they fail.
+var BlockingTests = []string{}


### PR DESCRIPTION
Introduce tests as informing. Once data is available and 95% pass rate confirmed, manually promote to blocking.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Test lifecycle handling was reworked to use explicit membership sets; informing and blocking statuses are now assigned based on membership.
* **Chores**
  * Added a dedicated informing list and cleared the previous blocking list; tests must now be explicitly listed as informing or blocking to be eligible to run.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->