### PR TITLE
Add node IP to HostNetworkNamespace address_set

### DIFF
--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -1838,6 +1838,66 @@ var _ = ginkgo.Describe("Default network controller operations", func() {
 		})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
+
+	ginkgo.It("includes node primary IP in host-network-namespace address_set when NoOverlay mode is enabled", func() {
+		app.Action = func(ctx *cli.Context) error {
+			_, err := config.InitConfig(ctx, nil, nil)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			config.Kubernetes.HostNetworkNamespace = "ovn-host-network"
+			// Enable NoOverlay transport mode
+			config.Default.Transport = "no-overlay"
+
+			// Start with empty NodeList, then add node after namespace is created
+			fakeOvn.startWithDBSetup(dbSetup,
+				&corev1.NamespaceList{
+					Items: []corev1.Namespace{*ovntest.NewNamespace(config.Kubernetes.HostNetworkNamespace)},
+				},
+				&corev1.NodeList{
+					Items: []corev1.Node{},
+				},
+			)
+
+			gomega.Expect(fakeOvn.controller.WatchNamespaces()).To(gomega.Succeed(), "Namespace should be created fine")
+			startDefaultNodeController(fakeOvn.controller)
+
+			// Wait for empty address set to be created
+			fakeOvn.asf.EventuallyExpectEmptyAddressSetExist(config.Kubernetes.HostNetworkNamespace)
+
+			// Now create the node with all required annotations
+			newNodeSubnet := "10.1.1.0/24"
+			testNode.Annotations["k8s.ovn.org/node-subnets"] = fmt.Sprintf("{\"default\":[\"%s\"]}", newNodeSubnet)
+			testNode.Annotations["k8s.ovn.org/node-chassis-id"] = chassisIDForNode(testNode.Name)
+			testNode.Annotations["k8s.ovn.org/node-primary-ifaddr"] = "{\"ipv4\":\"192.168.1.10/24\"}"
+			createdNode, err := fakeOvn.fakeClient.KubeClient.CoreV1().Nodes().Create(context.TODO(), &testNode, metav1.CreateOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			// Build expected IPs following the same pattern as the remote zone test
+			var ips []string
+			hostSubnets, err := util.ParseNodeHostSubnetAnnotation(createdNode, types.DefaultNetworkName)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			mgmt_ips := util.GetNodeManagementIfAddr(hostSubnets[0])
+			ips = append(ips, mgmt_ips.IP.String())
+			lrpips, err := udn.GetGWRouterIPs(createdNode, fakeOvn.controller.GetNetInfo())
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			lrpip, _, _ := net.ParseCIDR(lrpips[0].String())
+			ips = append(ips, lrpip.String())
+
+			// When NoOverlay is enabled, primary interface IPv4 should also be included
+			ips = append(ips, "192.168.1.10") // IPv4 primary interface IP
+
+			fakeOvn.asf.EventuallyExpectAddressSetWithAddresses(config.Kubernetes.HostNetworkNamespace, ips)
+
+			return nil
+		}
+
+		err := app.Run([]string{
+			app.Name,
+			"-cluster-subnets=" + clusterCIDR,
+			"--init-gateways",
+			"--nodeport",
+		})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
 })
 
 func nodeNoHostSubnetAnnotation() map[string]string {

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -1858,7 +1858,8 @@ var _ = ginkgo.Describe("Default network controller operations", func() {
 			)
 
 			gomega.Expect(fakeOvn.controller.WatchNamespaces()).To(gomega.Succeed(), "Namespace should be created fine")
-			startDefaultNodeController(fakeOvn.controller)
+			err = fakeOvn.controller.WatchNodes()
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			// Wait for empty address set to be created
 			fakeOvn.asf.EventuallyExpectEmptyAddressSetExist(config.Kubernetes.HostNetworkNamespace)

--- a/go-controller/pkg/ovn/namespace.go
+++ b/go-controller/pkg/ovn/namespace.go
@@ -386,5 +386,31 @@ func (oc *DefaultNetworkController) getHostNamespaceAddressesForNode(node *corev
 	for _, lrpIP := range lrpIPs {
 		ips = append(ips, lrpIP.IP)
 	}
+
+	// When NoOverlay mode is enabled, also include the node's primary physical interface IP
+	if oc.GetNetInfo().Transport() == types.NetworkTransportNoOverlay {
+		nodeIfAddr, err := util.GetNodeIfAddrAnnotation(node)
+		if err != nil {
+			if !util.IsAnnotationNotSetError(err) {
+				return nil, fmt.Errorf("failed to get node primary interface address: %w", err)
+			}
+		} else {
+			if nodeIfAddr.IPv4 != "" {
+				ipv4, _, err := net.ParseCIDR(nodeIfAddr.IPv4)
+				if err != nil {
+					return nil, fmt.Errorf("failed to parse node primary IPv4 address %s: %w", nodeIfAddr.IPv4, err)
+				}
+				ips = append(ips, ipv4)
+			}
+			if nodeIfAddr.IPv6 != "" {
+				ipv6, _, err := net.ParseCIDR(nodeIfAddr.IPv6)
+				if err != nil {
+					return nil, fmt.Errorf("failed to parse node primary IPv6 address %s: %w", nodeIfAddr.IPv6, err)
+				}
+				ips = append(ips, ipv6)
+			}
+		}
+	}
+
 	return ips, nil
 }


### PR DESCRIPTION
When NoOverlay mode is used for a network, it uses learned route with proto bgp and that sets Node IP as source IP.

10.129.2.0/23 nhid 157 via 192.168.100.100 dev br-ex proto bgp metric 20

So, it is essential to add node IP to HostNetworkNamespace address_set to let host network POD use network-policy while using NoOverlay mode.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
This PR is just to pre merge upstream commit with CNO PR https://github.com/openshift/cluster-network-operator/pull/2960 for bug https://redhat.atlassian.net/browse/OCPBUGS-83406

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Host‑network namespace address set in NoOverlay mode now includes nodes' primary interface addresses.

* **Tests**
  * Added a test verifying the host‑network address set contains the node primary IPs when NoOverlay mode is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->