### PR TITLE
Fix egress firewall ACL deletion security vulnerability

### DIFF
--- a/go-controller/pkg/ovn/base_event_handler.go
+++ b/go-controller/pkg/ovn/base_event_handler.go
@@ -32,6 +32,7 @@ func hasResourceAnUpdateFunc(objType reflect.Type) bool {
 		factory.EgressIPNamespaceType,
 		factory.EgressIPPodType,
 		factory.EgressNodeType,
+		factory.EgressFirewallType,
 		factory.NamespaceType,
 		factory.MultiNetworkPolicyType,
 		factory.IPAMClaimsType:

--- a/go-controller/pkg/ovn/default_network_controller.go
+++ b/go-controller/pkg/ovn/default_network_controller.go
@@ -1094,6 +1094,43 @@ func (h *defaultNetworkControllerEventHandler) UpdateResource(oldObj, newObj int
 		}
 		return nil
 
+	case factory.EgressFirewallType:
+		oldEgressFirewall := oldObj.(*egressfirewall.EgressFirewall)
+		newEgressFirewall := newObj.(*egressfirewall.EgressFirewall).DeepCopy()
+
+		// Validate the new egress firewall rules FIRST before deleting the old ACLs.
+		// This prevents a security gap where ACLs are deleted but validation fails,
+		// leaving the namespace without egress firewall protection.
+		//
+		// IMPORTANT: We validate once here and reuse the validated construct to avoid
+		// TOCTOU issues where node state could change between validation and application.
+		validatedEF, err := h.oc.buildEgressFirewallConstruct(newEgressFirewall)
+		if err != nil {
+			if statusErr := h.oc.setEgressFirewallStatus(newEgressFirewall, err); statusErr != nil {
+				klog.Errorf("Failed to update egress firewall status %s, error: %v",
+					getEgressFirewallNamespacedName(newEgressFirewall), statusErr)
+			}
+			return err
+		}
+
+		// Validation passed, now safe to delete old and add new.
+		// Decrement metrics for old firewall (mirroring DeleteResource logic).
+		if err := h.oc.deleteEgressFirewall(oldEgressFirewall); err != nil {
+			return err
+		}
+		metrics.UpdateEgressFirewallRuleCount(float64(-len(oldEgressFirewall.Spec.Egress)))
+		metrics.DecrementEgressFirewallCount()
+
+		// Add new firewall using the pre-validated construct to avoid re-validation.
+		err = h.oc.addEgressFirewallWithConstruct(newEgressFirewall, validatedEF)
+		if statusErr := h.oc.setEgressFirewallStatus(newEgressFirewall, err); statusErr != nil {
+			klog.Errorf("Failed to update egress firewall status %s, error: %v",
+				getEgressFirewallNamespacedName(newEgressFirewall), statusErr)
+		}
+		// Note: setEgressFirewallStatus increments metrics on success, so no additional
+		// metrics calls needed here.
+		return err
+
 	case factory.NamespaceType:
 		oldNs, newNs := oldObj.(*corev1.Namespace), newObj.(*corev1.Namespace)
 		return h.oc.updateNamespace(oldNs, newNs)

--- a/go-controller/pkg/ovn/egressfirewall.go
+++ b/go-controller/pkg/ovn/egressfirewall.go
@@ -287,21 +287,10 @@ func (oc *DefaultNetworkController) moveACLsToNamespacedPortGroups(existingEFNam
 	return err
 }
 
-func (oc *DefaultNetworkController) addEgressFirewall(egressFirewall *egressfirewallapi.EgressFirewall) error {
-	klog.Infof("Adding egressFirewall %s in namespace %s", egressFirewall.Name, egressFirewall.Namespace)
-
+// buildEgressFirewallConstruct validates and builds an egressFirewall construct from the API object.
+// This ensures validation happens before any database modifications.
+func (oc *DefaultNetworkController) buildEgressFirewallConstruct(egressFirewall *egressfirewallapi.EgressFirewall) (*egressFirewall, error) {
 	ef := cloneEgressFirewall(egressFirewall)
-	ef.Lock()
-	defer ef.Unlock()
-	// egressFirewall may already exist, if previous add failed, cleanup
-	if _, loaded := oc.egressFirewalls.Load(egressFirewall.Namespace); loaded {
-		klog.Infof("Egress firewall in namespace %s already exists, cleanup", egressFirewall.Namespace)
-		err := oc.deleteEgressFirewall(egressFirewall)
-		if err != nil {
-			return fmt.Errorf("failed to cleanup existing egress firewall %s on add: %v", egressFirewall.Namespace, err)
-		}
-	}
-
 	var errorList []error
 	for i, egressFirewallRule := range egressFirewall.Spec.Egress {
 		// process Rules into egressFirewallRules for egressFirewall struct
@@ -315,12 +304,42 @@ func (oc *DefaultNetworkController) addEgressFirewall(egressFirewall *egressfire
 			errorList = append(errorList, fmt.Errorf("cannot create EgressFirewall Rule to destination %s for namespace %s: %w",
 				egressFirewallRule.To.CIDRSelector, egressFirewall.Namespace, err))
 			continue
-
 		}
 		ef.egressRules = append(ef.egressRules, efr)
 	}
 	if len(errorList) > 0 {
-		return utilerrors.Join(errorList...)
+		return nil, utilerrors.Join(errorList...)
+	}
+	return ef, nil
+}
+
+func (oc *DefaultNetworkController) addEgressFirewall(egressFirewall *egressfirewallapi.EgressFirewall) error {
+	klog.Infof("Adding egressFirewall %s in namespace %s", egressFirewall.Name, egressFirewall.Namespace)
+
+	// Validate rules FIRST before making any database changes.
+	// This prevents a security gap where ACLs are deleted but validation fails,
+	// leaving the namespace without egress firewall protection.
+	ef, err := oc.buildEgressFirewallConstruct(egressFirewall)
+	if err != nil {
+		return err
+	}
+
+	return oc.addEgressFirewallWithConstruct(egressFirewall, ef)
+}
+
+// addEgressFirewallWithConstruct adds an egress firewall using a pre-validated construct.
+// This is used by the update path to avoid TOCTOU issues where validation could
+// change between the initial validation and the actual add.
+func (oc *DefaultNetworkController) addEgressFirewallWithConstruct(egressFirewall *egressfirewallapi.EgressFirewall, ef *egressFirewall) error {
+	ef.Lock()
+	defer ef.Unlock()
+	// egressFirewall may already exist, if previous add failed, cleanup
+	if _, loaded := oc.egressFirewalls.Load(egressFirewall.Namespace); loaded {
+		klog.Infof("Egress firewall in namespace %s already exists, cleanup", egressFirewall.Namespace)
+		err := oc.deleteEgressFirewall(egressFirewall)
+		if err != nil {
+			return fmt.Errorf("failed to cleanup existing egress firewall %s on add: %v", egressFirewall.Namespace, err)
+		}
 	}
 
 	pgName := oc.getNamespacePortGroupName(egressFirewall.Namespace)


### PR DESCRIPTION
## Summary

This PR fixes a critical security vulnerability where EgressFirewall updates could leave namespaces without egress protection.

## Problem

When an EgressFirewall is updated with invalid rules, the existing code deleted ACLs before validation. If validation failed, the namespace was left without egress firewall protection, allowing unrestricted egress traffic (fail-open instead of fail-closed).

## Solution

This PR adds an UpdateResource handler that validates new rules BEFORE deleting existing ACLs:

1. **buildEgressFirewallConstruct()** - validates rules before any DB changes
2. **UpdateResource handler** - validates BEFORE deleting ACLs on updates  
3. **Register EgressFirewall** in hasResourceAnUpdateFunc()

## Result

Invalid updates now preserve existing ACLs instead of deleting them, ensuring the namespace remains protected (fail-closed).

## Changes

- `go-controller/pkg/ovn/base_event_handler.go` - Register EgressFirewall update handler
- `go-controller/pkg/ovn/default_network_controller.go` - Add UpdateResource case
- `go-controller/pkg/ovn/egressfirewall.go` - Add validation function

## Technical Details

### Vulnerable Code Flow (4.19/4.20):
```
Delete existing ACLs → Validate new rules → Create new ACLs (if validation passes)
```
If validation fails after deletion, no ACLs are present, resulting in unrestricted egress traffic.

### Fixed Code Flow (4.21):
```
Validate new rules → Create new ACLs → Delete stale ACLs (if creation succeeds)
```
If validation fails, the operation terminates before modifying existing ACLs, preserving the current security posture.

## Associated Bug 

https://redhat.atlassian.net/browse/OCPBUGS-78765

## Upstream Fix

**Upstream PR:** https://github.com/ovn-org/ovn-kubernetes/pull/5688  
**Commit:** ecabc89d77b35fe5c250ef77e955caae33c1831c

The fix has been confirmed in the OpenShift downstream repository:

1. **Commit history in release-4.21:**  
   https://github.com/openshift/ovn-kubernetes/commits/release-4.21/go-controller/pkg/ovn/controller/egressfirewall/egressfirewall.go

2. **Direct commit link:**  
   https://github.com/openshift/ovn-kubernetes/commit/ecabc89d77b35fe5c250ef77e955caae33c1831c

## Testing

1. Create a valid EgressFirewall with deny-all rule
2. Update it with an invalid CIDR (e.g., "random-text")
3. Verify: Old ACLs remain in place (namespace still protected)
4. Verify: Status shows "EgressFirewall Rules not correctly applied"
5. Verify: Traffic that was blocked remains blocked

## Backport Conflict

1. Different controller architectures
2. OCP 4.20: Uses a monolithic DefaultNetworkController.
OCP 4.21: Uses a dedicated EFController with new features like caching (cacheEntry), DNS resolvers, network manager interfaces (for UDN support), and different function signatures for ACL building and status updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Egress firewall updates now validate new rules before applying changes to avoid partial or inconsistent configurations; invalid rules are rejected and prior state preserved.
* **Refactor**
  * Egress firewall processing separated into a build/validation phase and a subsequent apply phase to improve reliability and error handling.
* **Chores**
  * Added several Docker build files for different builder/runtime workflows and updated CI/configuration settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->