### PR TITLE
OCPBUGS-84037: OTE: tolerate missing OpenShift CRDs on MicroShift

### DIFF
--- a/openshift/test/infraprovider/openshift.go
+++ b/openshift/test/infraprovider/openshift.go
@@ -12,6 +12,7 @@ import (
 	operv1 "github.com/openshift/api/operator/v1"
 	configclient "github.com/openshift/client-go/config/clientset/versioned"
 	operatorv1client "github.com/openshift/client-go/operator/clientset/versioned"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	ovnkconfig "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
@@ -60,11 +61,17 @@ func (o *OpenshiftInfraProvider) initClusterObjects(config *rest.Config) error {
 	}
 	o.operNetwork, err = operatorClient.OperatorV1().Networks().Get(context.Background(), "cluster", metav1.GetOptions{})
 	if err != nil {
-		return fmt.Errorf("failed to retrieve network operator cluster object: %w", err)
+		if !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to retrieve network operator cluster object: %w", err)
+		}
+		o.operNetwork = nil
 	}
 	o.clusterFeatureGate, err = configClient.ConfigV1().FeatureGates().Get(context.Background(), "cluster", metav1.GetOptions{})
 	if err != nil {
-		return fmt.Errorf("failed to retrieve cluster feature gate: %w", err)
+		if !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to retrieve cluster feature gate: %w", err)
+		}
+		o.clusterFeatureGate = nil
 	}
 	// check ovn gateway mode and export required env variable
 	o.configureOVNGatewayMode()
@@ -79,7 +86,7 @@ func (o *OpenshiftInfraProvider) initClusterObjects(config *rest.Config) error {
 
 // configureOVNGatewayMode detects and configures the OVN gateway mode for tests
 func (o *OpenshiftInfraProvider) configureOVNGatewayMode() {
-	if o.operNetwork.Spec.DefaultNetwork.OVNKubernetesConfig == nil {
+	if o.operNetwork == nil || o.operNetwork.Spec.DefaultNetwork.OVNKubernetesConfig == nil {
 		return
 	}
 
@@ -94,6 +101,9 @@ func (o *OpenshiftInfraProvider) configureOVNGatewayMode() {
 
 // CheckForEVPN checks all EVPN prerequisites
 func (o *OpenshiftInfraProvider) CheckForEVPN() bool {
+	if o.operNetwork == nil {
+		return false
+	}
 	return hasEVPNFeatureGate(o.clusterFeatureGate) &&
 		hasFRRRouteProvider(o.operNetwork) &&
 		isLocalGatewayMode(o.operNetwork) &&
@@ -102,6 +112,9 @@ func (o *OpenshiftInfraProvider) CheckForEVPN() bool {
 
 // hasEVPNFeatureGate checks if the EVPN feature gate is enabled in the cluster
 func hasEVPNFeatureGate(clusterFeatureGate *configv1.FeatureGate) bool {
+	if clusterFeatureGate == nil {
+		return false
+	}
 	for _, featureGate := range clusterFeatureGate.Status.FeatureGates {
 		for _, feature := range featureGate.Enabled {
 			if feature.Name == "EVPN" {


### PR DESCRIPTION
The ovn-kubernetes-tests-ext binary panics during test discovery on MicroShift because it lacks OpenShift-specific CRDs. Handle missing `networks.operator.openshift.io` and `featuregates.config.openshift.io` gracefully so the binary can enumerate tests on MicroShift clusters.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Safely handle missing OpenShift network and feature gate resources: treat absent resources as unset instead of failing, avoid null dereferences, and return safe defaults for related infrastructure checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->