### PR TITLE
OCPBUGS-84054: [release 4.20] virt: fix SyncVirtualMachines deleting UDN DHCP options during startup

### DIFF
--- a/go-controller/pkg/kubevirt/external_ids.go
+++ b/go-controller/pkg/kubevirt/external_ids.go
@@ -49,11 +49,25 @@ func externalIDsContainsVM(externalIDs map[string]string, vm *ktypes.NamespacedN
 // OwnsItAndIsOrphanOrWrongZone return true if kubevirt owns this OVN NB
 // resource by checking if it has the VM name in external_ids and also checks
 // if the expected ovn zone corresponds with the one it created via the
-// OvnZoneExternalIDKey
-func ownsItAndIsOrphanOrWrongZone(externalIDs map[string]string, vms map[ktypes.NamespacedName]bool) bool {
+// OvnZoneExternalIDKey.
+// The controllerName parameter ensures that only resources owned by the
+// specified controller are considered for deletion, preventing cross-controller
+// interference (e.g. default network controller deleting UDN DHCP options).
+func ownsItAndIsOrphanOrWrongZone(externalIDs map[string]string, vms map[ktypes.NamespacedName]bool, controllerName string) bool {
 	// FIXME: VM IDs have no DB IDs and therefore may clash with other LRPs that do contain DB IBs. They will always have ObjectNameKey
 	// set therefore we now depend on the following key to be present. Remove this when DB IDs are implemented.
 	if _, ok := externalIDs[OvnZoneExternalIDKey]; !ok {
+		return false
+	}
+
+	const DefaultNetworkControllerName = "default-network-controller"
+	// Only consider resources owned by this controller. Resources created by
+	// other controllers (e.g. UDN controllers) must not be deleted here.
+	owner := externalIDs[string(libovsdbops.OwnerControllerKey)]
+	if owner == "" {
+		owner = DefaultNetworkControllerName
+	}
+	if owner != controllerName {
 		return false
 	}
 	vm := extractVMFromExternalIDs(externalIDs)

--- a/go-controller/pkg/kubevirt/external_ids_test.go
+++ b/go-controller/pkg/kubevirt/external_ids_test.go
@@ -1,0 +1,122 @@
+package kubevirt
+
+import (
+	ktypes "k8s.io/apimachinery/pkg/types"
+
+	libovsdbops "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdb/ops"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("ownsItAndIsOrphanOrWrongZone", func() {
+	const (
+		defaultControllerName = "default-network-controller"
+		udnControllerName     = "cluster_udn_happy-tenant-network-controller"
+	)
+
+	var (
+		vmKey = ktypes.NamespacedName{Namespace: "ns1", Name: "vm1"}
+	)
+
+	makeExternalIDs := func(controllerName string, vm ktypes.NamespacedName) map[string]string {
+		return map[string]string{
+			OvnZoneExternalIDKey:                   OvnLocalZone,
+			string(libovsdbops.OwnerControllerKey): controllerName,
+			string(libovsdbops.ObjectNameKey):      vm.String(),
+		}
+	}
+
+	DescribeTable("controller filtering",
+		func(externalIDs map[string]string, vms map[ktypes.NamespacedName]bool, controllerName string, expected bool) {
+			Expect(ownsItAndIsOrphanOrWrongZone(externalIDs, vms, controllerName)).To(Equal(expected))
+		},
+
+		// --- Core fix: cross-controller protection ---
+		Entry("returns false when DHCP options belong to a different controller (UDN)",
+			makeExternalIDs(udnControllerName, vmKey),
+			map[ktypes.NamespacedName]bool{}, // VM not in default controller's map
+			defaultControllerName,
+			false,
+		),
+		Entry("returns false when DHCP options belong to a different controller (default)",
+			makeExternalIDs(defaultControllerName, vmKey),
+			map[ktypes.NamespacedName]bool{},
+			udnControllerName,
+			false,
+		),
+
+		// --- Orphan detection still works for matching controller ---
+		Entry("returns true for orphan resource owned by the matching controller",
+			makeExternalIDs(defaultControllerName, vmKey),
+			map[ktypes.NamespacedName]bool{}, // VM not found → orphan
+			defaultControllerName,
+			true,
+		),
+
+		// --- VM present and local: not orphan ---
+		Entry("returns false when VM is present and zone is local",
+			makeExternalIDs(defaultControllerName, vmKey),
+			map[ktypes.NamespacedName]bool{vmKey: true}, // VM is local
+			defaultControllerName,
+			false,
+		),
+
+		// --- Wrong zone detection still works ---
+		Entry("returns true when VM is local but resource zone is remote",
+			map[string]string{
+				OvnZoneExternalIDKey:                   OvnRemoteZone,
+				string(libovsdbops.OwnerControllerKey): defaultControllerName,
+				string(libovsdbops.ObjectNameKey):      vmKey.String(),
+			},
+			map[ktypes.NamespacedName]bool{vmKey: true},
+			defaultControllerName,
+			true,
+		),
+
+		// --- Non-local VM is not considered wrong zone ---
+		Entry("returns false when VM is remote (not local) even if resource zone is remote",
+			map[string]string{
+				OvnZoneExternalIDKey:                   OvnRemoteZone,
+				string(libovsdbops.OwnerControllerKey): defaultControllerName,
+				string(libovsdbops.ObjectNameKey):      vmKey.String(),
+			},
+			map[ktypes.NamespacedName]bool{vmKey: false}, // VM is remote
+			defaultControllerName,
+			false,
+		),
+
+		// --- Existing behavior: no zone key → not kubevirt-managed ---
+		Entry("returns false when zone external ID is missing",
+			map[string]string{
+				string(libovsdbops.OwnerControllerKey): defaultControllerName,
+				string(libovsdbops.ObjectNameKey):      vmKey.String(),
+			},
+			map[ktypes.NamespacedName]bool{},
+			defaultControllerName,
+			false,
+		),
+
+		// --- Existing behavior: no VM key → not kubevirt-related ---
+		Entry("returns false when VM cannot be extracted from external IDs",
+			map[string]string{
+				OvnZoneExternalIDKey:                   OvnLocalZone,
+				string(libovsdbops.OwnerControllerKey): defaultControllerName,
+			},
+			map[ktypes.NamespacedName]bool{},
+			defaultControllerName,
+			false,
+		),
+
+		// --- Legacy resources without OwnerControllerKey ---
+		Entry("returns true for orphan resource without OwnerControllerKey (legacy)",
+			map[string]string{
+				OvnZoneExternalIDKey:              OvnLocalZone,
+				string(libovsdbops.ObjectNameKey): vmKey.String(),
+			},
+			map[ktypes.NamespacedName]bool{}, // VM not found → orphan
+			defaultControllerName,
+			true,
+		),
+	)
+})

--- a/go-controller/pkg/kubevirt/pod.go
+++ b/go-controller/pkg/kubevirt/pod.go
@@ -272,19 +272,19 @@ func CleanUpLiveMigratablePod(nbClient libovsdbclient.Client, watchFactory *fact
 	return nil
 }
 
-func SyncVirtualMachines(nbClient libovsdbclient.Client, vms map[ktypes.NamespacedName]bool) error {
+func SyncVirtualMachines(nbClient libovsdbclient.Client, vms map[ktypes.NamespacedName]bool, controllerName string) error {
 	if err := libovsdbops.DeleteLogicalRouterStaticRoutesWithPredicate(nbClient, ovntypes.OVNClusterRouter, func(item *nbdb.LogicalRouterStaticRoute) bool {
-		return ownsItAndIsOrphanOrWrongZone(item.ExternalIDs, vms)
+		return ownsItAndIsOrphanOrWrongZone(item.ExternalIDs, vms, controllerName)
 	}); err != nil {
 		return fmt.Errorf("failed deleting stale vm static routes: %v", err)
 	}
 	if err := libovsdbops.DeleteLogicalRouterPoliciesWithPredicate(nbClient, ovntypes.OVNClusterRouter, func(item *nbdb.LogicalRouterPolicy) bool {
-		return ownsItAndIsOrphanOrWrongZone(item.ExternalIDs, vms)
+		return ownsItAndIsOrphanOrWrongZone(item.ExternalIDs, vms, controllerName)
 	}); err != nil {
 		return fmt.Errorf("failed deleting stale vm policies: %v", err)
 	}
 	if err := libovsdbops.DeleteDHCPOptionsWithPredicate(nbClient, func(item *nbdb.DHCPOptions) bool {
-		return ownsItAndIsOrphanOrWrongZone(item.ExternalIDs, vms)
+		return ownsItAndIsOrphanOrWrongZone(item.ExternalIDs, vms, controllerName)
 	}); err != nil {
 		return fmt.Errorf("failed deleting stale dhcp options: %v", err)
 	}

--- a/go-controller/pkg/ovn/layer2_user_defined_network_controller_test.go
+++ b/go-controller/pkg/ovn/layer2_user_defined_network_controller_test.go
@@ -15,10 +15,12 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	ktypes "k8s.io/apimachinery/pkg/types"
 	knet "k8s.io/utils/net"
 	"k8s.io/utils/ptr"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kubevirt"
 	libovsdbops "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdb/ops"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
@@ -464,6 +466,59 @@ var _ = Describe("OVN Multi-Homed pod operations for layer 2 network", func() {
 		),
 	)
 
+	It("default network controller syncPods should not delete DHCP options owned by UDN controllers", func() {
+		// Regression test for: during cluster upgrade, the default network
+		// controller's SyncVirtualMachines deleted DHCP options created by UDN
+		// controllers because ownsItAndIsOrphanOrWrongZone did not filter by owner
+		// controller name. This caused VMs on primary UDNs (layer2) to lose their
+		// IP when the DHCP lease expired.
+		app.Action = func(*cli.Context) error {
+			vmKey := ktypes.NamespacedName{Namespace: ns, Name: "test-vm"}
+
+			// Build DHCP options as the UDN controller would for a VM on a primary
+			// layer2 UDN. The controller name follows the getNetworkControllerName
+			// convention: "<networkName>-network-controller".
+			udnControllerName := getNetworkControllerName(userDefinedNetworkName)
+			udnDHCPOptions := kubevirt.ComposeDHCPv4Options("100.200.0.100/16", udnControllerName, vmKey)
+			udnDHCPOptions.UUID = "udn-dhcp-options-uuid"
+
+			// Pre-populate the DB with the UDN-owned DHCP options, simulating the
+			// state right before the default network controller restarts (e.g.,
+			// during a rolling cluster upgrade): the UDN controller has already
+			// created DHCP options for the VM, but the default controller hasn't
+			// started yet.
+			initialDB.NBData = append(initialDB.NBData, udnDHCPOptions)
+
+			fakeOvn.startWithDBSetup(
+				initialDB,
+				&corev1.NamespaceList{Items: []corev1.Namespace{*newUDNNamespace(ns)}},
+				&corev1.NodeList{},
+				&corev1.PodList{},
+			)
+
+			// Call syncPods with an empty pod list, as happens when the default
+			// network controller starts up without any tracked VM pods.  Before the
+			// fix, this deleted the UDN-owned DHCP options because the VM was absent
+			// from the default controller's vms map (treated as an orphan).
+			Expect(fakeOvn.controller.syncPods(nil)).To(Succeed())
+
+			// The UDN-owned DHCP options must survive the default controller's sync.
+			Expect(fakeOvn.nbClient).To(libovsdbtest.HaveDataSubset(
+				[]libovsdbtest.TestData{udnDHCPOptions},
+			))
+
+			Consistently(fakeOvn.nbClient).
+				WithTimeout(5 * time.Second).
+				Should(
+					libovsdbtest.HaveDataSubset(
+						[]libovsdbtest.TestData{udnDHCPOptions},
+					),
+				)
+
+			return nil
+		}
+		Expect(app.Run([]string{app.Name})).To(Succeed())
+	})
 })
 
 func dummySecondaryLayer2UserDefinedNetwork(subnets string) userDefinedNetInfo {

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -161,7 +161,7 @@ func (oc *DefaultNetworkController) syncPods(pods []interface{}) error {
 			}
 		}
 	}
-	if err := kubevirt.SyncVirtualMachines(oc.nbClient, vms); err != nil {
+	if err := kubevirt.SyncVirtualMachines(oc.nbClient, vms, DefaultNetworkControllerName); err != nil {
 		return fmt.Errorf("failed syncing running virtual machines: %v", err)
 	}
 

--- a/go-controller/pkg/testing/libovsdb/matchers.go
+++ b/go-controller/pkg/testing/libovsdb/matchers.go
@@ -224,6 +224,26 @@ func HaveEmptyData() gomegatypes.GomegaMatcher {
 	return gomega.WithTransform(transform, gomega.BeEmpty())
 }
 
+// HaveDataSubset asserts that all expected TestData objects exist in the actual database,
+// but ignores any extra data. UUIDs are ignored when comparing.
+func HaveDataSubset(expected ...TestData) gomegatypes.GomegaMatcher {
+	if len(expected) == 1 {
+		if e, ok := expected[0].([]TestData); ok {
+			expected = e
+		}
+	}
+	matchers := []*testDataMatcher{}
+	for _, e := range expected {
+		matchers = append(matchers, matchTestData(true, e))
+	}
+
+	transform := func(client libovsdbclient.Client) []TestData {
+		return getTestDataFromClientCache(client)
+	}
+
+	return gomega.WithTransform(transform, gomega.ContainElements(matchers))
+}
+
 func haveData(ignoreUUIDs, nameUUIDs bool, expected []TestData) gomegatypes.GomegaMatcher {
 	if len(expected) == 1 {
 		if e, ok := expected[0].([]TestData); ok {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->
During cluster upgrade, the default network controller's `SyncVirtualMachines` deletes DHCP options created by UDN controllers because the `ownsItAndIsOrphanOrWrongZone` predicate does not filter by owner controller.

This causes VMs on primary UDNs (layer2) to lose their IP when the DHCP lease expires.

Add a `controllerName` parameter to `ownsItAndIsOrphanOrWrongZone` and `SyncVirtualMachines` so that only resources owned by the calling controller are considered for deletion; the default network controller now passes its own name, preventing it from deleting DHCP options owned by UDN controllers.

(cherry picked from commit a54565fb46313716d62ac92c06dcef0e2c8d3259)

There were cherry-pick conflicts in the following file:
- go-controller/pkg/ovn/layer2_user_defined_network_controller_test.go

I've fixed them by bringing over **only** the required test, plus the new libovsdb `HaveDataSubset` function, and adjusting the imports. These were:

1. imports:
```
++<<<<<<< HEAD
 +	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 +	libovsdbops "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdb/ops"
 +	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
 +	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
 +	libovsdbtest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
 +	testnm "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/networkmanager"
 +	ovntypes "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 +	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
++=======
+ 	ovnkcnitypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/cni/types"
+ 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
+ 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/factory"
+ 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/kubevirt"
+ 	libovsdbops "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/libovsdb/ops"
+ 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/nbdb"
+ 	testnm "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/networkmanager"
+ 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing"
+ 	libovsdbtest "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
+ 	ovntypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
+ 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
++>>>>>>> a54565fb4 (virt: fix SyncVirtualMachines deleting UDN DHCP options during startup)

```
2. test:
```
++<<<<<<< HEAD
++=======
+ 	It("primary layer 2 UDN: controller creates entities via init/watchers, then dummy Cleanup() removes them", func() {
+ 		config.OVNKubernetesFeature.EnableMultiNetwork = true
+ 		setupConfig(dummyLayer2PrimaryUserDefinedNetwork("192.168.0.0/16"), testConfiguration{}, config.GatewayModeShared)
+ 		app.Action = func(ctx *cli.Context) error {
+ 			netInfo := dummyLayer2PrimaryUserDefinedNetwork("192.168.0.0/16")
+ 			netConf := netInfo.netconf()
+ 			networkConfig, err := util.NewNetInfo(netConf)
+ 			Expect(err).NotTo(HaveOccurred())
+ 			mutableNetInfo := util.NewMutableNetInfo(networkConfig)
+ 			mutableNetInfoCleanup := util.NewMutableNetInfo(networkConfig)
+ 			mutableNetInfoCleanup.SetNetworkID(ovntypes.InvalidID)
+ 
+ 			nad, err := newNetworkAttachmentDefinition(ns, nadName, *netConf)
+ 			Expect(err).NotTo(HaveOccurred())
+ 			fakeNetworkManager := &testnm.FakeNetworkManager{
+ 				PrimaryNetworks: map[string]util.NetInfo{},
+ 			}
+ 			fakeNetworkManager.PrimaryNetworks[ns] = mutableNetInfo
+ 
+ 			const nodeIPv4CIDR = "192.168.126.202/24"
+ 			testNode, err := newNodeWithUserDefinedNetworks(nodeName, nodeIPv4CIDR, netInfo)
+ 			Expect(err).NotTo(HaveOccurred())
+ 			nbZone := &nbdb.NBGlobal{Name: config.Default.Zone, UUID: config.Default.Zone}
+ 
+ 			// Minimal initialDB: no UDN entities. init() + watchers create them.
+ 			initialDB.NBData = append(initialDB.NBData, nbZone)
+ 
+ 			fakeOvn.startWithDBSetup(
+ 				initialDB,
+ 				&corev1.NamespaceList{Items: []corev1.Namespace{*newUDNNamespace(ns)}},
+ 				&corev1.NodeList{Items: []corev1.Node{*testNode}},
+ 				&corev1.PodList{Items: []corev1.Pod{}},
+ 				&nadapi.NetworkAttachmentDefinitionList{Items: []nadapi.NetworkAttachmentDefinition{*nad}},
+ 			)
+ 
+ 			Expect(fakeOvn.networkManager.Start()).To(Succeed())
+ 			defer fakeOvn.networkManager.Stop()
+ 			Expect(fakeOvn.controller.WatchNamespaces()).To(Succeed())
+ 			Expect(fakeOvn.controller.WatchPods()).To(Succeed())
+ 
+ 			// Run init() to create cluster-level entities, then watchers so node sync creates per-node entities.
+ 			l2Controller, ok := fakeOvn.fullL2UDNControllers[userDefinedNetworkName]
+ 			Expect(ok).To(BeTrue())
+ 			Expect(l2Controller.init()).To(Succeed())
+ 			udnNetController, ok := fakeOvn.userDefinedNetworkControllers[userDefinedNetworkName]
+ 			Expect(ok).To(BeTrue())
+ 			udnNetController.bnc.ovnClusterLRPToJoinIfAddrs = dummyJoinIPs()
+ 			Expect(l2Controller.WatchNodes()).To(Succeed())
+ 			Expect(l2Controller.WatchPods()).To(Succeed())
+ 			Expect(l2Controller.WatchNetworkPolicy()).To(Succeed())
+ 
+ 			// Wait for the controller to create the Layer2 switch.
+ 			udnLSName := l2Controller.GetNetworkScopedSwitchName(ovntypes.OVNLayer2Switch)
+ 			Eventually(func(g Gomega) {
+ 				switches, err := libovsdbops.FindLogicalSwitchesWithPredicate(fakeOvn.nbClient, func(ls *nbdb.LogicalSwitch) bool {
+ 					return ls.Name == udnLSName
+ 				})
+ 				g.Expect(err).NotTo(HaveOccurred())
+ 				g.Expect(switches).NotTo(BeEmpty())
+ 			}).WithTimeout(10 * time.Second).Should(Succeed())
+ 
+ 			// Assert gateway router was created before cleanup.
+ 			udnGWRouterName := l2Controller.GetNetworkScopedGWRouterName(nodeName)
+ 			Eventually(func(g Gomega) {
+ 				routers, err := libovsdbops.FindLogicalRoutersWithPredicate(fakeOvn.nbClient, func(lr *nbdb.LogicalRouter) bool {
+ 					return lr.Name == udnGWRouterName
+ 				})
+ 				g.Expect(err).NotTo(HaveOccurred())
+ 				g.Expect(routers).NotTo(BeEmpty())
+ 			}).WithTimeout(10 * time.Second).Should(Succeed())
+ 
+ 			// Dummy controller with InvalidID runs Cleanup() to remove all entities for this network.
+ 			dummyController, err := NewLayer2UserDefinedNetworkController(
+ 				&l2Controller.CommonNetworkControllerInfo,
+ 				mutableNetInfoCleanup,
+ 				fakeOvn.networkManager.Interface(),
+ 				nil,
+ 				NewPortCache(ctx.Done()),
+ 				nil,
+ 				nil,
+ 			)
+ 			Expect(err).NotTo(HaveOccurred())
+ 			Expect(dummyController.Cleanup()).To(Succeed())
+ 			Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(generateUDNPostInitDB([]libovsdbtest.TestData{nbZone})))
+ 			return nil
+ 		}
+ 		Expect(app.Run([]string{app.Name})).To(Succeed())
+ 	})
+ 
+ 	It("controller should cleanup stale nodes on startup", func() {
+ 		app.Action = func(*cli.Context) error {
+ 			netInfo := dummyLayer2PrimaryUserDefinedNetwork("192.168.0.0/16")
+ 			netConf := netInfo.netconf()
+ 			networkConfig, err := util.NewNetInfo(netConf)
+ 			Expect(err).NotTo(HaveOccurred())
+ 
+ 			nad, err := newNetworkAttachmentDefinition(
+ 				ns,
+ 				nadName,
+ 				*netConf,
+ 			)
+ 			Expect(err).NotTo(HaveOccurred())
+ 
+ 			const nodeIPv4CIDR = "192.168.126.202/24"
+ 			testNode, err := newNodeWithUserDefinedNetworks(nodeName, nodeIPv4CIDR)
+ 			Expect(err).NotTo(HaveOccurred())
+ 
+ 			gwConfig, err := util.ParseNodeL3GatewayAnnotation(testNode)
+ 			Expect(err).NotTo(HaveOccurred())
+ 			Expect(gwConfig.NextHops).NotTo(BeEmpty())
+ 			nbZone := &nbdb.NBGlobal{Name: ovntypes.OvnDefaultZone, UUID: ovntypes.OvnDefaultZone}
+ 
+ 			n := newUDNNamespace(ns)
+ 			initialDB.NBData = generateUDNPostInitDB([]libovsdbtest.TestData{})
+ 			initialDB.NBData = append(
+ 				initialDB.NBData,
+ 				expectedGWEntitiesLayer2(nodeName, networkConfig, *gwConfig)...)
+ 			initialDB.NBData = append(initialDB.NBData, newLoadBalancerGroup(networkConfig.GetNetworkScopedLoadBalancerGroupName(ovntypes.ClusterLBGroupName)))
+ 			initialDB.NBData = append(initialDB.NBData, newLoadBalancerGroup(networkConfig.GetNetworkScopedLoadBalancerGroupName(ovntypes.ClusterRouterLBGroupName)))
+ 			initialDB.NBData = append(initialDB.NBData, newLoadBalancerGroup(networkConfig.GetNetworkScopedLoadBalancerGroupName(ovntypes.ClusterSwitchLBGroupName)))
+ 			initialDB.NBData = append(initialDB.NBData, nbZone)
+ 			// save current state of DB, it will be preserved through the test
+ 			finalDB := append([]libovsdbtest.TestData{}, initialDB.NBData...)
+ 			// add stale node to the initial db
+ 			initialDB.NBData = append(
+ 				initialDB.NBData,
+ 				expectedLayer2EgressEntities(networkConfig, *gwConfig, networkConfig.Subnets()[0].CIDR, true)...)
+ 			// final db should not have the stale node
+ 			finalDB = append(finalDB, expectedLayer2EgressEntities(networkConfig, *gwConfig, networkConfig.Subnets()[0].CIDR, false)...)
+ 
+ 			// the db setup doesn't have layer2 switch, which makes nodeAdd fail, but simplifies the test
+ 			// we only care about the initial Sync for nodes
+ 			fakeOvn.startWithDBSetup(
+ 				initialDB,
+ 				&corev1.NamespaceList{
+ 					Items: []corev1.Namespace{
+ 						*n,
+ 					},
+ 				},
+ 				&corev1.NodeList{
+ 					Items: []corev1.Node{*testNode},
+ 				},
+ 				&nadapi.NetworkAttachmentDefinitionList{
+ 					Items: []nadapi.NetworkAttachmentDefinition{*nad},
+ 				},
+ 			)
+ 
+ 			udnNetController, ok := fakeOvn.fullL2UDNControllers[userDefinedNetworkName]
+ 			Expect(ok).To(BeTrue())
+ 
+ 			udnNetController.defaultCOPPUUID, err = EnsureDefaultCOPP(fakeOvn.nbClient)
+ 			Expect(err).ToNot(HaveOccurred())
+ 
+ 			udnNetController.clusterLoadBalancerGroupUUID, udnNetController.switchLoadBalancerGroupUUID, udnNetController.routerLoadBalancerGroupUUID, err = initLoadBalancerGroups(fakeOvn.nbClient, networkConfig)
+ 			Expect(err).ToNot(HaveOccurred())
+ 
+ 			// start watching nodes to trigger initial node cleanup
+ 			Expect(udnNetController.WatchNodes()).To(Succeed())
+ 			Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(finalDB))
+ 			// check if the remoteNodesNoRouter map is empty
+ 			isEmpty := true
+ 			udnNetController.remoteNodesNoRouter.Range(func(_, _ interface{}) bool {
+ 				isEmpty = false // A key was found, so it's not empty
+ 				return false    // Stop iterating immediately
+ 			})
+ 			Expect(isEmpty).To(BeTrue())
+ 			return nil
+ 		}
+ 		Expect(app.Run([]string{app.Name})).To(Succeed())
+ 	})
+ 
+ 	It("controller should correctly assigns dummy joinSubnet IPs", func() {
+ 		config.IPv6Mode = true
+ 		// add a fake node with last-joinIP nodeID to make sure that large subnets don't check for nodeIDs at all
+ 		testNode := &corev1.Node{
+ 			ObjectMeta: metav1.ObjectMeta{
+ 				Name: "test",
+ 				Annotations: map[string]string{
+ 					ovnNodeID: "65534",
+ 				},
+ 			},
+ 		}
+ 		fakeOvn.startWithDBSetup(initialDB, &corev1.NodeList{Items: []corev1.Node{*testNode}})
+ 		controller := &Layer2UserDefinedNetworkController{}
+ 		controller.watchFactory = fakeOvn.watcher
+ 		// this network won't invoke nodeID check, so it should pass
+ 		netInfo, err := util.NewNetInfo(&ovnkcnitypes.NetConf{
+ 			NetConf:    cnitypes.NetConf{Name: "test"},
+ 			Topology:   ovntypes.Layer2Topology,
+ 			JoinSubnet: "100.65.0.0/16,fd99::/64",
+ 		})
+ 		Expect(err).NotTo(HaveOccurred())
+ 		controller.ReconcilableNetInfo = util.NewReconcilableNetInfo(netInfo)
+ 		res, err := controller.getLastJoinIPs()
+ 		Expect(err).NotTo(HaveOccurred())
+ 		Expect(res).To(HaveLen(2))
+ 		Expect(res).To(Equal([]*net.IPNet{
+ 			{IP: net.ParseIP("100.65.255.254"), Mask: net.CIDRMask(16, 32)},
+ 			{IP: net.ParseIP("fd99::ffff:ffff:ffff:fffe"), Mask: net.CIDRMask(64, 128)},
+ 		}))
+ 		// this network has a small subnet, it will do the nodeID check
+ 		// it will fail if there is a node with nodeID 1022, which doesn't exist for now
+ 		netInfo, err = util.NewNetInfo(&ovnkcnitypes.NetConf{
+ 			NetConf:    cnitypes.NetConf{Name: "test"},
+ 			Topology:   ovntypes.Layer2Topology,
+ 			JoinSubnet: "100.65.0.0/22",
+ 		})
+ 		Expect(err).NotTo(HaveOccurred())
+ 		controller.ReconcilableNetInfo = util.NewReconcilableNetInfo(netInfo)
+ 		res, err = controller.getLastJoinIPs()
+ 		Expect(err).ToNot(HaveOccurred())
+ 		Expect(res).To(Equal([]*net.IPNet{
+ 			{IP: net.ParseIP("100.65.3.254"), Mask: net.CIDRMask(22, 32)},
+ 			{IP: net.ParseIP("fd99::ffff:ffff:ffff:fffe"), Mask: net.CIDRMask(64, 128)},
+ 		}))
+ 		// now update the node to have a last-IP nodeID
+ 		testNode.Annotations[ovnNodeID] = "1022"
+ 		_, err = fakeOvn.fakeClient.KubeClient.CoreV1().Nodes().Update(context.TODO(), testNode, metav1.UpdateOptions{})
+ 		Expect(err).NotTo(HaveOccurred())
+ 		// wait for node update to be propagated to the watchFactory
+ 		time.Sleep(10 * time.Millisecond)
+ 		_, err = controller.getLastJoinIPs()
+ 		Expect(err).To(HaveOccurred())
+ 		Expect(err.Error()).To(ContainSubstring("cannot use the last IP of the join subnet"))
+ 	})
+ 
+ 	It("default network controller syncPods should not delete DHCP options owned by UDN controllers", func() {
+ 		// Regression test for: during cluster upgrade, the default network
+ 		// controller's SyncVirtualMachines deleted DHCP options created by UDN
+ 		// controllers because ownsItAndIsOrphanOrWrongZone did not filter by owner
+ 		// controller name. This caused VMs on primary UDNs (layer2) to lose their
+ 		// IP when the DHCP lease expired.
+ 		app.Action = func(*cli.Context) error {
+ 			vmKey := ktypes.NamespacedName{Namespace: ns, Name: "test-vm"}
+ 
+ 			// Build DHCP options as the UDN controller would for a VM on a primary
+ 			// layer2 UDN. The controller name follows the getNetworkControllerName
+ 			// convention: "<networkName>-network-controller".
+ 			udnControllerName := getNetworkControllerName(userDefinedNetworkName)
+ 			udnDHCPOptions := kubevirt.ComposeDHCPv4Options("100.200.0.100/16", udnControllerName, vmKey)
+ 			udnDHCPOptions.UUID = "udn-dhcp-options-uuid"
+ 
+ 			// Pre-populate the DB with the UDN-owned DHCP options, simulating the
+ 			// state right before the default network controller restarts (e.g.,
+ 			// during a rolling cluster upgrade): the UDN controller has already
+ 			// created DHCP options for the VM, but the default controller hasn't
+ 			// started yet.
+ 			initialDB.NBData = append(initialDB.NBData, udnDHCPOptions)
+ 
+ 			fakeOvn.startWithDBSetup(
+ 				initialDB,
+ 				&corev1.NamespaceList{Items: []corev1.Namespace{*newUDNNamespace(ns)}},
+ 				&corev1.NodeList{},
+ 				&corev1.PodList{},
+ 			)
+ 
+ 			// Call syncPods with an empty pod list, as happens when the default
+ 			// network controller starts up without any tracked VM pods.  Before the
+ 			// fix, this deleted the UDN-owned DHCP options because the VM was absent
+ 			// from the default controller's vms map (treated as an orphan).
+ 			Expect(fakeOvn.controller.syncPods(nil)).To(Succeed())
+ 
+ 			// The UDN-owned DHCP options must survive the default controller's sync.
+ 			Expect(fakeOvn.nbClient).To(libovsdbtest.HaveDataSubset(
+ 				[]libovsdbtest.TestData{udnDHCPOptions},
+ 			))
+ 
+ 			Consistently(fakeOvn.nbClient).
+ 				WithTimeout(5 * time.Second).
+ 				Should(
+ 					libovsdbtest.HaveDataSubset(
+ 						[]libovsdbtest.TestData{udnDHCPOptions},
+ 					),
+ 				)
+ 
+ 			return nil
+ 		}
+ 		Expect(app.Run([]string{app.Name})).To(Succeed())
+ 	})
+ 
+ 	Describe("Dynamic UDN allocation with remote node", func() {
+ 		It("activates a remote node when a NAD becomes active and cleans it up when inactive", func() {
+ 			Expect(config.PrepareTestConfig()).To(Succeed())
+ 			config.OVNKubernetesFeature.EnableDynamicUDNAllocation = true
+ 			config.OVNKubernetesFeature.EnableInterconnect = true
+ 			config.OVNKubernetesFeature.EnableMultiNetwork = true
+ 			config.OVNKubernetesFeature.EnableNetworkSegmentation = true
+ 			config.Default.Zone = testICZone
+ 			config.Gateway.V4MasqueradeSubnet = "169.254.0.0/16"
+ 
+ 			// Basic UDN setup
+ 			netInfo := dummyLayer2PrimaryUserDefinedNetwork("100.200.0.0/16")
+ 			n := newUDNNamespace(ns)
+ 			nad, err := newNetworkAttachmentDefinition(ns, nadName, *netInfo.netconf())
+ 			Expect(err).NotTo(HaveOccurred())
+ 
+ 			// Local node and remote node with NAD
+ 			localNode, err := newNodeWithUserDefinedNetworks(nodeName, "192.168.126.202/24", netInfo)
+ 			Expect(err).NotTo(HaveOccurred())
+ 			localNode.Annotations[util.OvnTransitSwitchPortAddr] = `{"ipv4":"100.88.0.3/16"}`
+ 
+ 			remoteNode, err := newNodeWithUserDefinedNetworks("remoteNode", "192.168.127.202/24", netInfo)
+ 			Expect(err).NotTo(HaveOccurred())
+ 			remoteNode.Annotations["k8s.ovn.org/zone-name"] = "other-zone" // force remote
+ 			remoteNode.Annotations[util.OvnTransitSwitchPortAddr] = `{"ipv4":"100.88.0.4/16"}`
+ 
+ 			remotePod := corev1.Pod{
+ 				ObjectMeta: metav1.ObjectMeta{
+ 					Name:      "remote-pod",
+ 					Namespace: ns,
+ 				},
+ 				Spec: corev1.PodSpec{
+ 					NodeName:   remoteNode.Name,
+ 					Containers: []corev1.Container{{Name: "c", Image: "scratch"}},
+ 				},
+ 			}
+ 
+ 			localPod := corev1.Pod{
+ 				ObjectMeta: metav1.ObjectMeta{
+ 					Name:      "local-pod",
+ 					Namespace: ns,
+ 				},
+ 				Spec: corev1.PodSpec{
+ 					NodeName:   localNode.Name,
+ 					Containers: []corev1.Container{{Name: "c", Image: "scratch"}},
+ 				},
+ 			}
+ 
+ 			// Preload DB
+ 			fakeOvn.startWithDBSetup(libovsdbtest.TestSetup{}, &corev1.NamespaceList{Items: []corev1.Namespace{*n}},
+ 				&corev1.NodeList{Items: []corev1.Node{*localNode, *remoteNode}},
+ 				&corev1.PodList{Items: []corev1.Pod{localPod}},
+ 				&nadapi.NetworkAttachmentDefinitionList{Items: []nadapi.NetworkAttachmentDefinition{*nad}})
+ 
+ 			Expect(fakeOvn.networkManager.Start()).To(Succeed())
+ 			defer fakeOvn.networkManager.Stop()
+ 
+ 			userDefinedNetController, ok := fakeOvn.userDefinedNetworkControllers[userDefinedNetworkName]
+ 			Expect(ok).To(BeTrue())
+ 			userDefinedNetController.bnc.ovnClusterLRPToJoinIfAddrs = dummyJoinIPs()
+ 			l2Controller, ok := fakeOvn.fullL2UDNControllers[netInfo.netName]
+ 			Expect(ok).To(BeTrue())
+ 			mutableNetInfo := util.NewMutableNetInfo(l2Controller.GetNetInfo())
+ 			mutableNetInfo.SetNetworkID(2)
+ 			err = util.ReconcileNetInfo(l2Controller.ReconcilableNetInfo, mutableNetInfo)
+ 			Expect(err).NotTo(HaveOccurred())
+ 			err = l2Controller.init()
+ 			Expect(err).NotTo(HaveOccurred())
+ 			Expect(userDefinedNetController.bnc.WatchNodes()).To(Succeed())
+ 
+ 			By("Remote node should not have a transit-router port before activation")
+ 			Consistently(func() bool {
+ 				p := func(item *nbdb.LogicalRouterPort) bool {
+ 					return item.ExternalIDs[ovntypes.NodeExternalID] == remoteNode.Name && item.ExternalIDs[ovntypes.NetworkExternalID] == l2Controller.GetNetworkName()
+ 				}
+ 				ports, err := libovsdbops.FindLogicalRouterPortWithPredicate(fakeOvn.nbClient, p)
+ 				return err == nil && len(ports) > 0
+ 			}).WithTimeout(500 * time.Millisecond).Should(BeFalse())
+ 
+ 			By("Creating a pod on the remote node should activate it")
+ 			_, err = fakeOvn.fakeClient.KubeClient.CoreV1().Pods(ns).Create(context.TODO(), &remotePod, metav1.CreateOptions{})
+ 			Expect(err).NotTo(HaveOccurred())
+ 			Eventually(func() bool {
+ 				return fakeOvn.networkManager.Interface().NodeHasNetwork(remoteNode.Name, netInfo.netName)
+ 			}).WithTimeout(3 * time.Second).Should(BeTrue())
+ 			By("Triggering networkRefChange callback after updating remote node as active on NAD")
+ 			l2Controller.HandleNetworkRefChange(remoteNode.Name, true)
+ 
+ 			By("Remote node should have a transit-router port created")
+ 			Eventually(func() bool {
+ 				p := func(item *nbdb.LogicalRouterPort) bool {
+ 					return item.ExternalIDs[ovntypes.NodeExternalID] == remoteNode.Name && item.ExternalIDs[ovntypes.NetworkExternalID] == l2Controller.GetNetworkName()
+ 				}
+ 				ports, err := libovsdbops.FindLogicalRouterPortWithPredicate(fakeOvn.nbClient, p)
+ 				if err == nil && len(ports) > 0 {
+ 					return true
+ 				}
+ 				return false
+ 			}).WithTimeout(3 * time.Second).Should(BeTrue())
+ 
+ 			By("Deleting a pod on the remote node should set it as inactive")
+ 			err = fakeOvn.fakeClient.KubeClient.CoreV1().Pods(ns).Delete(context.TODO(), remotePod.Name, metav1.DeleteOptions{})
+ 			Expect(err).NotTo(HaveOccurred())
+ 			Eventually(func() bool {
+ 				return fakeOvn.networkManager.Interface().NodeHasNetwork(remoteNode.Name, netInfo.netName)
+ 			}).WithTimeout(3 * time.Second).Should(BeFalse())
+ 			By("Triggering networkRefChange callback after updating remote node as inactive on NAD")
+ 			l2Controller.HandleNetworkRefChange(remoteNode.Name, false)
+ 			By("Remote node should not have a port on transit subnet")
+ 			Eventually(func() bool {
+ 				p := func(item *nbdb.LogicalRouterPort) bool {
+ 					return item.ExternalIDs[ovntypes.NodeExternalID] == remoteNode.Name && item.ExternalIDs[ovntypes.NetworkExternalID] == l2Controller.GetNetworkName()
+ 				}
+ 				ports, err := libovsdbops.FindLogicalRouterPortWithPredicate(fakeOvn.nbClient, p)
+ 				if err == nil && len(ports) > 0 {
+ 					return true
+ 				}
+ 				return false
+ 			}).WithTimeout(3 * time.Second).Should(BeFalse())
+ 
+ 			By("verifying that local node trtos and stotr ports still exist after remote node removal")
+ 			expectedLRP := &nbdb.LogicalRouterPort{
+ 				Name: "trtos-isolatednet_ovn_layer2_switch",
+ 				MAC:  "0a:58:64:c8:00:01",
+ 				GatewayChassis: []string{
+ 					"00000000-0000-0000-0000-000000000000",
+ 				},
+ 				Networks: []string{
+ 					"100.200.0.1/16",
+ 				},
+ 				Options: map[string]string{
+ 					"gateway_mtu":       "1400",
+ 					"requested-tnl-key": "1",
+ 				},
+ 			}
+ 
+ 			expectedLSP := &nbdb.LogicalSwitchPort{
+ 				Name:      "stotr-isolatednet_ovn_layer2_switch",
+ 				Type:      "router",
+ 				Addresses: []string{"router"},
+ 				Options: map[string]string{
+ 					"router-port": "trtos-isolatednet_ovn_layer2_switch",
+ 				},
+ 				ExternalIDs: map[string]string{
+ 					"k8s.ovn.org/network":  "isolatednet",
+ 					"k8s.ovn.org/topology": "layer2",
+ 				},
+ 			}
+ 
+ 			Eventually(fakeOvn.nbClient).WithTimeout(3 * time.Second).Should(
+ 				libovsdbtest.HaveDataSubset([]libovsdbtest.TestData{expectedLRP, expectedLSP}),
+ 			)
+ 		})
+ 
+ 		It("does not filter pods from other namespaces of the same primary UDN", func() {
+ 			Expect(config.PrepareTestConfig()).To(Succeed())
+ 			config.OVNKubernetesFeature.EnableDynamicUDNAllocation = true
+ 			config.OVNKubernetesFeature.EnableInterconnect = true
+ 			config.OVNKubernetesFeature.EnableMultiNetwork = true
+ 			config.OVNKubernetesFeature.EnableNetworkSegmentation = true
+ 			config.Default.Zone = testICZone
+ 
+ 			netInfo := dummyLayer2PrimaryUserDefinedNetwork("100.200.0.0/16")
+ 			nsA := "namespace-a"
+ 			nsB := "namespace-b"
+ 			nsAObj := newUDNNamespace(nsA)
+ 			nsBObj := newUDNNamespace(nsB)
+ 
+ 			netInfoA := netInfo
+ 			netInfoA.nadName = namespacedName(nsA, nadName)
+ 			netInfoB := netInfo
+ 			netInfoB.nadName = namespacedName(nsB, nadName)
+ 
+ 			nadA, err := newNetworkAttachmentDefinition(nsA, nadName, *netInfoA.netconf())
+ 			Expect(err).NotTo(HaveOccurred())
+ 			nadB, err := newNetworkAttachmentDefinition(nsB, nadName, *netInfoB.netconf())
+ 			Expect(err).NotTo(HaveOccurred())
+ 
+ 			parsedNetInfoA, err := util.NewNetInfo(netInfoA.netconf())
+ 			Expect(err).NotTo(HaveOccurred())
+ 			mutableA := util.NewMutableNetInfo(parsedNetInfoA)
+ 			mutableA.SetNADs(namespacedName(nsA, nadName))
+ 
+ 			parsedNetInfoB, err := util.NewNetInfo(netInfoB.netconf())
+ 			Expect(err).NotTo(HaveOccurred())
+ 			mutableB := util.NewMutableNetInfo(parsedNetInfoB)
+ 			mutableB.SetNADs(namespacedName(nsB, nadName))
+ 
+ 			fakeOvn.networkManager = &testnm.FakeNetworkManager{
+ 				PrimaryNetworks: map[string]util.NetInfo{
+ 					nsA: mutableA,
+ 					nsB: mutableB,
+ 				},
+ 				NADNetworks: map[string]util.NetInfo{
+ 					namespacedName(nsA, nadName): mutableA,
+ 					namespacedName(nsB, nadName): mutableB,
+ 				},
+ 			}
+ 
+ 			localNode, err := newNodeWithUserDefinedNetworks(nodeName, "192.168.126.202/24", netInfo)
+ 			Expect(err).NotTo(HaveOccurred())
+ 
+ 			fakeOvn.startWithDBSetup(libovsdbtest.TestSetup{},
+ 				&corev1.NamespaceList{Items: []corev1.Namespace{*nsAObj, *nsBObj}},
+ 				&corev1.NodeList{Items: []corev1.Node{*localNode}},
+ 				&nadapi.NetworkAttachmentDefinitionList{Items: []nadapi.NetworkAttachmentDefinition{*nadA, *nadB}},
+ 			)
+ 
+ 			Expect(fakeOvn.NewUserDefinedNetworkController(nadB)).To(Succeed())
+ 			l2Controller, ok := fakeOvn.fullL2UDNControllers[netInfo.netName]
+ 			Expect(ok).To(BeTrue())
+ 			mutableNetInfo := util.NewMutableNetInfo(l2Controller.GetNetInfo())
+ 			mutableNetInfo.SetNADs(namespacedName(nsB, nadName))
+ 			err = util.ReconcileNetInfo(l2Controller.ReconcilableNetInfo, mutableNetInfo)
+ 			Expect(err).NotTo(HaveOccurred())
+ 			By("confirming the controller only tracks the local namespace NAD")
+ 			Expect(l2Controller.GetNetInfo().GetNADNamespaces()).To(ConsistOf(nsB))
+ 
+ 			remotePod := &corev1.Pod{
+ 				ObjectMeta: metav1.ObjectMeta{
+ 					Name:      "remote-pod",
+ 					Namespace: nsA,
+ 				},
+ 				Spec: corev1.PodSpec{
+ 					NodeName:   localNode.Name,
+ 					Containers: []corev1.Container{{Name: "c", Image: "scratch"}},
+ 				},
+ 			}
+ 
+ 			By("ensuring the pod is not filtered out by the UDN controller")
+ 			Expect(l2Controller.FilterOutResource(factory.PodType, remotePod)).To(BeFalse())
+ 		})
+ 	})
++>>>>>>> a54565fb4 (virt: fix SyncVirtualMachines deleting UDN DHCP options during startup)
  })
```

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [x] My code requires tests
- [x] if so, I have added and/or updated the tests as required
- [x] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
