### PR TITLE
[for testing DNM] Dockerfile: Remove redundant iproute and iproute-tc from INSTALL_PKGS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ ENV PYTHONDONTWRITEBYTECODE yes
 # - ovn-vtep
 RUN INSTALL_PKGS=" \
 	openssl firewalld-filesystem \
-	libpcap iproute iproute-tc strace \
+	libpcap strace \
 	tcpdump iputils \
 	libreswan \
 	ethtool conntrack-tools \


### PR DESCRIPTION
## Summary
- Remove `iproute` and `iproute-tc` from the explicit `INSTALL_PKGS` list in the Dockerfile
- `iproute` is already installed in the base image as a dependency of OVS/OVN packages from the Fast Datapath repo
- Explicitly requesting it again causes an intermittent dnf depsolve failure when the FDP version (e.g. 6.11.0) conflicts with the `iproute-tc` version available in rhel-9-baseos (e.g. 6.2.0)
- `iproute-tc` provides the `tc` binary which is not used anywhere in ovn-kubernetes

## Test plan
- [ ] Verify `ci/prow/images` passes
- [ ] Verify upgrade image jobs pass

Generated with [Claude Code](https://claude.com/claude-code)