### PR TITLE
WIP Add retry diagnostic logging and enable pprof on all metrics servers

### DIFF
--- a/go-controller/pkg/retry/obj_retry.go
+++ b/go-controller/pkg/retry/obj_retry.go
@@ -359,7 +359,7 @@ func (r *RetryFramework) resourceRetry(objKey string, now time.Time) {
 			initObj = entry.oldObj
 		}
 
-		klog.Infof("%s: retry object setup: %s %s", r.name, r.ResourceHandler.ObjType, objKey)
+		klog.V(5).Infof("%s: retry object setup: %s %s (attempt %d, backoff %s)", r.name, r.ResourceHandler.ObjType, objKey, entry.failedAttempts, entry.backoff)
 
 		if entry.newObj != nil {
 			// get the latest version of the object from the informer;
@@ -423,7 +423,7 @@ func (r *RetryFramework) resourceRetry(objKey string, now time.Time) {
 
 			// create new object if needed
 			if entry.newObj != nil {
-				klog.Infof("%s: adding new object: %s %s", r.name, r.ResourceHandler.ObjType, objKey)
+				klog.V(5).Infof("%s: adding new object: %s %s", r.name, r.ResourceHandler.ObjType, objKey)
 				if !r.ResourceHandler.IsResourceScheduled(entry.newObj) {
 					// unscheduled resources (pods) will be retried again later we do not track these as failures, and should not retry.
 					// we should avoid queuing objects to the retry handler that are not scheduled. Thus treat this as an error.
@@ -795,7 +795,7 @@ func (r *RetryFramework) WatchResourceFiltered(namespaceForFilteredHandler strin
 					// See: https://github.com/ovn-kubernetes/ovn-kubernetes/pull/3318#issuecomment-1349804450
 					if _, loaded := r.terminatedObjects.LoadAndDelete(key); loaded {
 						// object was already terminated
-						klog.Infof("%s: ignoring delete event for resource in terminal state %s %s",
+						klog.V(5).Infof("%s: ignoring delete event for resource in terminal state %s %s",
 							r.name, r.ResourceHandler.ObjType, key)
 						return
 					}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description

Seeing a lot of retries sometimes. Need to run some tests from a PR to see if I can get more information.

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Made metrics profiling and endpoint-sharing behavior more predictable by changing how profiling is enabled for the metrics server.

* **Chores**
  * Improved retry-queue observability: first-failure enqueue logs, periodic warnings with backoff, per-object attempt/backoff info, and sweep start/completion timing summaries.
  * Reduced log noise by moving many informational messages to verbose-only logging (visible at higher verbosity).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->