### PR TITLE
DNM/TEST Add [UDN-DEBUG] logging to diagnose intermittent UDN network isolatio…

### DIFF
--- a/go-controller/pkg/ovn/base_network_controller_pods.go
+++ b/go-controller/pkg/ovn/base_network_controller_pods.go
@@ -150,7 +150,12 @@ func (bnc *BaseNetworkController) deleteStaleLogicalSwitchPortsOnSwitches(switch
 	var err error
 	for _, switchName := range switchNames {
 		p := func(item *nbdb.LogicalSwitchPort) bool {
-			return item.ExternalIDs["pod"] == "true" && !expectedLogicalPorts[item.Name]
+			isStale := item.ExternalIDs["pod"] == "true" && !expectedLogicalPorts[item.Name]
+			if isStale {
+				klog.Infof("[UDN-DEBUG] deleteStaleLogicalSwitchPortsOnSwitches: STALE port found: name=%s uuid=%s switch=%s network=%s externalIDs=%v",
+					item.Name, item.UUID, switchName, bnc.GetNetworkName(), item.ExternalIDs)
+			}
+			return isStale
 		}
 		sw := nbdb.LogicalSwitch{
 			Name: switchName,
@@ -162,6 +167,10 @@ func (bnc *BaseNetworkController) deleteStaleLogicalSwitchPortsOnSwitches(switch
 		}
 	}
 
+	if len(ops) > 0 {
+		klog.Infof("[UDN-DEBUG] deleteStaleLogicalSwitchPortsOnSwitches: transacting %d ops to delete stale ports across %d switches for network=%s expectedPorts=%d",
+			len(ops), len(switchNames), bnc.GetNetworkName(), len(expectedLogicalPorts))
+	}
 	_, err = libovsdbops.TransactAndCheck(bnc.nbClient, ops)
 	if err != nil {
 		return fmt.Errorf("could not remove stale logicalPorts from switches for network %s (%+v)", bnc.GetNetworkName(), err)
@@ -207,6 +216,8 @@ func (bnc *BaseNetworkController) deletePodLogicalPort(pod *corev1.Pod, portInfo
 
 	podDesc := fmt.Sprintf("pod %s/%s/%s", nadKey, pod.Namespace, pod.Name)
 	logicalPort = bnc.GetLogicalPortName(pod, nadKey)
+	klog.Infof("[UDN-DEBUG] deletePodLogicalPort: entry for %s logicalPort=%s expectedSwitch=%s network=%s hasCachedPortInfo=%v",
+		podDesc, logicalPort, expectedSwitchName, bnc.GetNetworkName(), portInfo != nil)
 	if portInfo == nil {
 		// If ovnkube-master restarts, it is also possible the Pod's logical switch port
 		// is not re-added into the cache. Delete logical switch port anyway.
@@ -505,6 +516,14 @@ func (bnc *BaseNetworkController) addLogicalPortToNetwork(pod *corev1.Pod, nadKe
 	}
 	lspExist = !errors.Is(err, libovsdbclient.ErrNotFound)
 
+	if lspExist {
+		klog.Infof("[UDN-DEBUG] addLogicalPortToNetwork: LSP ALREADY EXISTS port=%s uuid=%s switch=%s network=%s — UUID will be preserved",
+			portName, existingLSP.UUID, switchName, bnc.GetNetworkName())
+	} else {
+		klog.Infof("[UDN-DEBUG] addLogicalPortToNetwork: LSP does NOT exist port=%s switch=%s network=%s — new UUID will be assigned",
+			portName, switchName, bnc.GetNetworkName())
+	}
+
 	// Sanity check. If port exists, it should be in the logical switch obtained from the pod spec.
 	if lspExist {
 		portFound := false
@@ -521,6 +540,8 @@ func (bnc *BaseNetworkController) addLogicalPortToNetwork(pod *corev1.Pod, nadKe
 		}
 		if !portFound {
 			// This should never happen and indicates we failed to clean up an LSP for a pod that was recreated
+			klog.Errorf("[UDN-DEBUG] addLogicalPortToNetwork: CRITICAL - existing LSP %s (uuid=%s) NOT FOUND in switch %s ports list! This breaks port group membership.",
+				existingLSP.Name, existingLSP.UUID, switchName)
 			return nil, nil, nil, false, fmt.Errorf("[%s] failed to locate existing logical port %s (%s) in logical switch %s",
 				podDesc, existingLSP.Name, existingLSP.UUID, switchName)
 		}
@@ -749,6 +770,8 @@ func (bnc *BaseNetworkController) deletePodFromNamespace(ns string, podIfAddrs [
 	}
 
 	if nsInfo.portGroupName != "" && len(portUUID) > 0 {
+		klog.Infof("[UDN-DEBUG] deletePodFromNamespace: removing portUUID=%s from portGroup=%s in namespace=%s network=%s",
+			portUUID, nsInfo.portGroupName, ns, bnc.GetNetworkName())
 		if ops, err = libovsdbops.DeletePortsFromPortGroupOps(bnc.nbClient, ops, nsInfo.portGroupName, portUUID); err != nil {
 			return nil, err
 		}

--- a/go-controller/pkg/ovn/controller/services/node_tracker.go
+++ b/go-controller/pkg/ovn/controller/services/node_tracker.go
@@ -188,6 +188,7 @@ func (nt *nodeTracker) updateNodeInfo(nodeName, switchName, routerName, chassisI
 // removeNodeWithServiceReSync removes a node from the LB -> node mapper
 // *and* forces full reconciliation of services.
 func (nt *nodeTracker) removeNodeWithServiceReSync(nodeName string) {
+	klog.Infof("[UDN-DEBUG] nodeTracker.removeNodeWithServiceReSync: removing node=%s network=%q and triggering full resync", nodeName, nt.netInfo.GetNetworkName())
 	nt.removeNode(nodeName)
 	nt.Lock()
 	nt.resyncFn(nt.getZoneNodes())
@@ -215,12 +216,14 @@ func (nt *nodeTracker) updateNode(node *corev1.Node) {
 		for _, subnet := range nt.netInfo.Subnets() {
 			hsn = append(hsn, subnet.CIDR)
 		}
+		klog.Infof("[UDN-DEBUG] nodeTracker.updateNode: node=%s network=%q topology=L2 subnets=%v", node.Name, nt.netInfo.GetNetworkName(), hsn)
 	} else {
 		hsn, err = util.ParseNodeHostSubnetAnnotation(node, nt.netInfo.GetNetworkName())
+		klog.Infof("[UDN-DEBUG] nodeTracker.updateNode: node=%s network=%q topology=L3 ParseNodeHostSubnetAnnotation result: hsn=%v err=%v", node.Name, nt.netInfo.GetNetworkName(), hsn, err)
 	}
 	if err != nil || hsn == nil || util.NoHostSubnet(node) {
 		// usually normal; means the node's gateway hasn't been initialized yet
-		klog.Infof("Node %s has invalid / no HostSubnet annotations (probably waiting on initialization), or it's a hybrid overlay node: %v", node.Name, err)
+		klog.Infof("[UDN-DEBUG] nodeTracker.updateNode: REMOVING node=%s network=%q (err=%v hsn=%v noHostSubnet=%v)", node.Name, nt.netInfo.GetNetworkName(), err, hsn, util.NoHostSubnet(node))
 		nt.removeNode(node.Name)
 		return
 	}
@@ -260,6 +263,8 @@ func (nt *nodeTracker) updateNode(node *corev1.Node) {
 	for _, hostSubnet := range hsn {
 		mgmtIPs = append(mgmtIPs, nt.netInfo.GetNodeManagementIP(hostSubnet).IP)
 	}
+	klog.Infof("[UDN-DEBUG] nodeTracker.updateNode: node=%s network=%q switchName=%s grName=%s chassisID=%s mgmtIPs=%v l3gatewayAddresses=%v hostAddresses=%v",
+		node.Name, nt.netInfo.GetNetworkName(), switchName, grName, chassisID, mgmtIPs, l3gatewayAddresses, hostAddressesIPs)
 
 	nt.updateNodeInfo(
 		node.Name,

--- a/go-controller/pkg/ovn/controller/services/services_controller.go
+++ b/go-controller/pkg/ovn/controller/services/services_controller.go
@@ -407,9 +407,11 @@ func (c *Controller) syncService(key string) error {
 		util.IsUDNEnabledService(key) {
 
 		if service == nil {
+			klog.Infof("[UDN-DEBUG] syncService: UDN-enabled service %s deleted, cleaning up route for network=%s", key, c.netInfo.GetNetworkName())
 			return c.cleanupUDNEnabledServiceRoute(key)
 		}
 
+		klog.Infof("[UDN-DEBUG] syncService: UDN-enabled service %s found, configuring route for network=%s", key, c.netInfo.GetNetworkName())
 		err = c.configureUDNEnabledServiceRoute(service)
 		if err != nil {
 			return fmt.Errorf("failed to configure the UDN enabled service route: %v", err)
@@ -574,7 +576,10 @@ func (c *Controller) syncNodeInfos(nodeInfos []nodeInfo) {
 
 // RequestFullSync re-syncs every service that currently exists
 func (c *Controller) RequestFullSync(nodeInfos []nodeInfo) {
-	klog.Infof("Full service sync requested for network=%s", c.netInfo.GetNetworkName())
+	c.startupDoneLock.RLock()
+	startupDone := c.startupDone
+	c.startupDoneLock.RUnlock()
+	klog.Infof("[UDN-DEBUG] RequestFullSync: called for network=%s nodeInfos=%d startupDone=%v", c.netInfo.GetNetworkName(), len(nodeInfos), startupDone)
 
 	// Resync node infos and node IP templates.
 	c.syncNodeInfos(nodeInfos)
@@ -591,9 +596,12 @@ func (c *Controller) RequestFullSync(nodeInfos []nodeInfo) {
 			return
 		}
 
+		klog.Infof("[UDN-DEBUG] RequestFullSync: requeuing %d services for network=%s", len(services), c.netInfo.GetNetworkName())
 		for _, service := range services {
 			c.onServiceAdd(service)
 		}
+	} else {
+		klog.Infof("[UDN-DEBUG] RequestFullSync: skipping service requeue because startupDone=false for network=%s", c.netInfo.GetNetworkName())
 	}
 }
 
@@ -813,7 +821,8 @@ func (c *Controller) cleanupUDNEnabledServiceRoute(key string) error {
 }
 
 func (c *Controller) configureUDNEnabledServiceRoute(service *corev1.Service) error {
-	klog.Infof("Configuring UDN enabled service route for service %s/%s in network: %s", service.Namespace, service.Name, c.netInfo.GetNetworkName())
+	klog.Infof("[UDN-DEBUG] configureUDNEnabledServiceRoute: entry for service=%s/%s network=%s topology=%s clusterIP=%s nodeInfos=%d",
+		service.Namespace, service.Name, c.netInfo.GetNetworkName(), c.netInfo.TopologyType(), service.Spec.ClusterIP, len(c.nodeInfos))
 
 	extIDs := map[string]string{
 		types.NetworkExternalID:           c.netInfo.GetNetworkName(),
@@ -830,7 +839,7 @@ func (c *Controller) configureUDNEnabledServiceRoute(service *corev1.Service) er
 
 	}
 	var ops []ovsdb.Operation
-	for _, nodeInfo := range c.nodeInfos {
+	for i, nodeInfo := range c.nodeInfos {
 		mgmtIP, err := util.MatchFirstIPFamily(utilnet.IsIPv6String(service.Spec.ClusterIP), nodeInfo.mgmtIPs)
 		if err != nil {
 			return err
@@ -845,6 +854,10 @@ func (c *Controller) configureUDNEnabledServiceRoute(service *corev1.Service) er
 		if c.netInfo.TopologyType() == types.Layer2Topology && !globalconfig.Layer2UsesTransitRouter {
 			routerName = nodeInfo.gatewayRouterName
 		}
+		klog.Infof("[UDN-DEBUG] configureUDNEnabledServiceRoute: iteration %d/%d node=%s mgmtIP=%s routerName=%s ipPrefix=%s nexthop=%s",
+			i+1, len(c.nodeInfos), nodeInfo.name, mgmtIP.String(), routerName, staticRoute.IPPrefix, staticRoute.Nexthop)
+		// NOTE: passing nil instead of ops here means each iteration overwrites previous ops
+		klog.Warningf("[UDN-DEBUG] configureUDNEnabledServiceRoute: BUG - passing nil instead of accumulated ops to CreateOrUpdateLogicalRouterStaticRoutesWithPredicateOps (iteration %d, previous ops count=%d)", i+1, len(ops))
 		ops, err = libovsdbops.CreateOrUpdateLogicalRouterStaticRoutesWithPredicateOps(c.nbClient, nil, routerName, &staticRoute, func(item *nbdb.LogicalRouterStaticRoute) bool {
 			return routesEqual(item, &staticRoute)
 		})
@@ -853,7 +866,34 @@ func (c *Controller) configureUDNEnabledServiceRoute(service *corev1.Service) er
 		}
 	}
 
+	klog.Infof("[UDN-DEBUG] configureUDNEnabledServiceRoute: transacting %d ops for service=%s/%s network=%s (NOTE: only last node's ops survive due to nil bug)",
+		len(ops), service.Namespace, service.Name, c.netInfo.GetNetworkName())
 	_, err := libovsdbops.TransactAndCheck(c.nbClient, ops)
+	if err != nil {
+		klog.Errorf("[UDN-DEBUG] configureUDNEnabledServiceRoute: TransactAndCheck FAILED: %v", err)
+	} else {
+		klog.Infof("[UDN-DEBUG] configureUDNEnabledServiceRoute: TransactAndCheck succeeded")
+		// POST-TX VERIFICATION: read back routes to confirm they were installed
+		serviceKey := ktypes.NamespacedName{Namespace: service.Namespace, Name: service.Name}.String()
+		verifyRoutes, verifyErr := libovsdbops.FindLogicalRouterStaticRoutesWithPredicate(c.nbClient, func(route *nbdb.LogicalRouterStaticRoute) bool {
+			return route.ExternalIDs[types.UDNEnabledServiceExternalID] == serviceKey &&
+				route.ExternalIDs[types.NetworkExternalID] == c.netInfo.GetNetworkName()
+		})
+		if verifyErr != nil {
+			klog.Errorf("[UDN-DEBUG] configureUDNEnabledServiceRoute: POST-TX route verification FAILED to query: %v", verifyErr)
+		} else {
+			klog.Infof("[UDN-DEBUG] configureUDNEnabledServiceRoute: POST-TX found %d routes for service=%s network=%s (expected %d for nodes)",
+				len(verifyRoutes), serviceKey, c.netInfo.GetNetworkName(), len(c.nodeInfos))
+			for i, r := range verifyRoutes {
+				klog.Infof("[UDN-DEBUG] configureUDNEnabledServiceRoute: POST-TX route[%d] uuid=%s prefix=%s nexthop=%s",
+					i, r.UUID, r.IPPrefix, r.Nexthop)
+			}
+			if len(verifyRoutes) < len(c.nodeInfos) {
+				klog.Errorf("[UDN-DEBUG] configureUDNEnabledServiceRoute: POST-TX VERIFICATION FAILED - only %d routes installed for %d nodes. KAPI access may be broken on some nodes.",
+					len(verifyRoutes), len(c.nodeInfos))
+			}
+		}
+	}
 	return err
 }
 

--- a/go-controller/pkg/ovn/default_network_controller.go
+++ b/go-controller/pkg/ovn/default_network_controller.go
@@ -707,6 +707,24 @@ func (oc *DefaultNetworkController) run(_ context.Context) error {
 		return err
 	}
 
+	// [UDN-DEBUG] Start periodic isolation state verification goroutine
+	oc.wg.Add(1)
+	go func() {
+		defer oc.wg.Done()
+		klog.Infof("[UDN-DEBUG] Starting periodic UDN isolation state verifier (every 5s)")
+		ticker := time.NewTicker(5 * time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				oc.debugVerifyUDNIsolationState()
+			case <-oc.stopChan:
+				klog.Infof("[UDN-DEBUG] Stopping periodic UDN isolation state verifier")
+				return
+			}
+		}
+	}()
+
 	if config.OVNKubernetesFeature.EnableAdminNetworkPolicy {
 		err := oc.newANPController()
 		if err != nil {

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -397,10 +397,15 @@ func (oc *DefaultNetworkController) syncNodeGateway(node *corev1.Node) error {
 		return fmt.Errorf("error creating gateway for node %s: %v", node.Name, err)
 	}
 
-	if util.IsPodNetworkAdvertisedAtNode(oc, node.Name) &&
-		config.OVNKubernetesFeature.AdvertisedUDNIsolationMode == config.AdvertisedUDNIsolationModeStrict {
+	isAdvertised := util.IsPodNetworkAdvertisedAtNode(oc, node.Name)
+	isolationMode := config.OVNKubernetesFeature.AdvertisedUDNIsolationMode
+	if isAdvertised && isolationMode == config.AdvertisedUDNIsolationModeStrict {
+		klog.Infof("[UDN-DEBUG] syncNodeGateway: node=%s -> addAdvertisedNetworkIsolation (isAdvertised=%v isolationMode=%s)",
+			node.Name, isAdvertised, isolationMode)
 		return oc.addAdvertisedNetworkIsolation(node.Name)
 	}
+	klog.Infof("[UDN-DEBUG] syncNodeGateway: node=%s -> deleteAdvertisedNetworkIsolation (isAdvertised=%v isolationMode=%s)",
+		node.Name, isAdvertised, isolationMode)
 	return oc.deleteAdvertisedNetworkIsolation(node.Name)
 }
 

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -191,6 +191,7 @@ func (oc *DefaultNetworkController) deleteLogicalPort(pod *corev1.Pod, portInfo 
 
 	// delete open port ACLs for UDN pods
 	if util.IsNetworkSegmentationSupportEnabled() {
+		klog.Infof("[UDN-DEBUG] deleteLogicalPort: cleaning up UDN open port ACLs for pod=%s/%s", pod.Namespace, pod.Name)
 		// safe to call for non-UDN pods
 		err = oc.setUDNPodOpenPorts(pod.Namespace+"/"+pod.Name, pod.Annotations, "")
 		if err != nil {
@@ -285,8 +286,11 @@ func (oc *DefaultNetworkController) addLogicalPort(pod *corev1.Pod) (err error) 
 	if err != nil {
 		return err
 	}
+	klog.Infof("[UDN-DEBUG] addLogicalPort: pod=%s/%s node=%s networkRole=%s lsp.Name=%s lsp.UUID=%s newlyCreatedPort=%v segmentationEnabled=%v",
+		pod.Namespace, pod.Name, pod.Spec.NodeName, networkRole, lsp.Name, lsp.UUID, newlyCreatedPort, util.IsNetworkSegmentationSupportEnabled())
 	if networkRole == types.NetworkRoleInfrastructure && util.IsNetworkSegmentationSupportEnabled() {
 		pgName := libovsdbutil.GetPortGroupName(oc.getSecondaryPodsPortGroupDbIDs())
+		klog.Infof("[UDN-DEBUG] addLogicalPort: adding UDN pod %s/%s LSP %s (UUID=%s) to isolation portGroup=%s", pod.Namespace, pod.Name, lsp.Name, lsp.UUID, pgName)
 		if ops, err = libovsdbops.AddPortsToPortGroupOps(oc.nbClient, ops, pgName, lsp.UUID); err != nil {
 			return err
 		}
@@ -297,6 +301,7 @@ func (oc *DefaultNetworkController) addLogicalPort(pod *corev1.Pod) (err error) 
 		if err != nil {
 			return fmt.Errorf("failed to set UDN pod %s/%s open ports: %w", pod.Namespace, pod.Name, err)
 		}
+		klog.Infof("[UDN-DEBUG] addLogicalPort: UDN pod %s/%s isolation setup complete, total ops=%d", pod.Namespace, pod.Name, len(ops))
 	}
 
 	// Ensure the namespace/nsInfo exists
@@ -354,6 +359,32 @@ func (oc *DefaultNetworkController) addLogicalPort(pod *corev1.Pod) (err error) 
 	}
 	txOkCallBack()
 	oc.podRecorder.AddLSP(pod.UID, oc.GetNetInfo())
+
+	// [UDN-DEBUG] Post-transaction verification: confirm port group membership is correct
+	if networkRole == types.NetworkRoleInfrastructure && util.IsNetworkSegmentationSupportEnabled() {
+		pgIDs := oc.getSecondaryPodsPortGroupDbIDs()
+		pgName := libovsdbutil.GetPortGroupName(pgIDs)
+		verifyPG := &nbdb.PortGroup{Name: pgName}
+		verifyPG, verifyErr := libovsdbops.GetPortGroup(oc.nbClient, verifyPG)
+		if verifyErr != nil {
+			klog.Errorf("[UDN-DEBUG] addLogicalPort: POST-TX VERIFICATION FAILED - cannot read portGroup=%s: %v", pgName, verifyErr)
+		} else {
+			found := false
+			for _, pUUID := range verifyPG.Ports {
+				if pUUID == lsp.UUID {
+					found = true
+					break
+				}
+			}
+			if !found {
+				klog.Errorf("[UDN-DEBUG] addLogicalPort: POST-TX VERIFICATION FAILED - LSP uuid=%s (name=%s) for pod %s/%s NOT FOUND in portGroup=%s (has %d ports). ISOLATION IS BROKEN.",
+					lsp.UUID, lsp.Name, pod.Namespace, pod.Name, pgName, len(verifyPG.Ports))
+			} else {
+				klog.Infof("[UDN-DEBUG] addLogicalPort: POST-TX VERIFICATION OK - LSP uuid=%s for pod %s/%s confirmed in portGroup=%s (total ports=%d)",
+					lsp.UUID, pod.Namespace, pod.Name, pgName, len(verifyPG.Ports))
+			}
+		}
+	}
 
 	// check if this pod is serving as an external GW
 	err = oc.addPodExternalGW(pod)

--- a/go-controller/pkg/ovn/udn_isolation.go
+++ b/go-controller/pkg/ovn/udn_isolation.go
@@ -138,6 +138,13 @@ func (oc *DefaultNetworkController) setupUDNACLs(mgmtPortIPs []net.IP) error {
 	ingressAllowACL := libovsdbutil.BuildACL(ingressAllowIDs, types.PrimaryUDNAllowPriority, match, nbdb.ACLActionAllowRelated,
 		nil, libovsdbutil.LportIngress, isolationTier)
 
+	klog.Infof("[UDN-DEBUG] setupUDNACLs: creating/updating isolation ACLs for portGroup=%s with mgmtPortIPs=%v", pgName, mgmtPortIPs)
+	klog.Infof("[UDN-DEBUG] setupUDNACLs: egressDenyACL match=%q action=%s", egressDenyACL.Match, egressDenyACL.Action)
+	klog.Infof("[UDN-DEBUG] setupUDNACLs: egressARPACL match=%q action=%s", egressARPACL.Match, egressARPACL.Action)
+	klog.Infof("[UDN-DEBUG] setupUDNACLs: ingressDenyACL match=%q action=%s", ingressDenyACL.Match, ingressDenyACL.Action)
+	klog.Infof("[UDN-DEBUG] setupUDNACLs: ingressARPACL match=%q action=%s", ingressARPACL.Match, ingressARPACL.Action)
+	klog.Infof("[UDN-DEBUG] setupUDNACLs: ingressAllowACL match=%q action=%s", ingressAllowACL.Match, ingressAllowACL.Action)
+
 	ops, err := libovsdbops.CreateOrUpdateACLsOps(oc.nbClient, nil, oc.GetSamplingConfig(), egressDenyACL, egressARPACL, ingressARPACL, ingressDenyACL, ingressAllowACL)
 	if err != nil {
 		return fmt.Errorf("failed to create or update UDN ACLs: %v", err)
@@ -148,7 +155,13 @@ func (oc *DefaultNetworkController) setupUDNACLs(mgmtPortIPs []net.IP) error {
 		return fmt.Errorf("failed to add UDN ACLs to portGroup %s: %v", pgName, err)
 	}
 
+	klog.Infof("[UDN-DEBUG] setupUDNACLs: transacting %d ops to apply isolation ACLs to portGroup=%s", len(ops), pgName)
 	_, err = libovsdbops.TransactAndCheck(oc.nbClient, ops)
+	if err != nil {
+		klog.Errorf("[UDN-DEBUG] setupUDNACLs: TransactAndCheck FAILED: %v", err)
+	} else {
+		klog.Infof("[UDN-DEBUG] setupUDNACLs: TransactAndCheck succeeded for portGroup=%s", pgName)
+	}
 	return err
 }
 
@@ -219,6 +232,7 @@ func (oc *DefaultNetworkController) setUDNPodOpenPortsOps(podNamespacedName stri
 	udnPGName := libovsdbutil.GetPortGroupName(oc.getSecondaryPodsPortGroupDbIDs())
 
 	ingressMatch, egressMatch, parseErr := getPortsMatches(podAnnotations, lspName)
+	klog.Infof("[UDN-DEBUG] setUDNPodOpenPortsOps: pod=%s lspName=%q ingressMatch=%q egressMatch=%q parseErr=%v", podNamespacedName, lspName, ingressMatch, egressMatch, parseErr)
 	// don't return on parseErr, as we need to cleanup potentially present ACLs from the previous config
 	ingressIDs := oc.getUDNOpenPortDbIDs(podNamespacedName, libovsdbutil.ACLIngress)
 	ingressACL := libovsdbutil.BuildACL(ingressIDs, types.PrimaryUDNAllowPriority,
@@ -322,6 +336,7 @@ func BuildAdvertisedNetworkSubnetsDropACL(advertisedNetworkSubnetsAddressSet add
 // pass   "(ip[4|6].src == <UDN_SUBNET> && ip[4|6].dst == <UDN_SUBNET>)"                1100
 // drop   "(ip[4|6].src == $<ALL_ADV_SUBNETS> && ip[4|6].dst == $<ALL_ADV_SUBNETS>)"    1050
 func (bnc *BaseNetworkController) addAdvertisedNetworkIsolation(nodeName string) error {
+	klog.Infof("[UDN-DEBUG] addAdvertisedNetworkIsolation: entry for node=%s network=%s topology=%s", nodeName, bnc.GetNetworkName(), bnc.TopologyType())
 	var passMatches, cidrs []string
 	var ops []ovsdb.Operation
 
@@ -392,15 +407,20 @@ func (bnc *BaseNetworkController) addAdvertisedNetworkIsolation(nodeName string)
 		return fmt.Errorf("failed to add network isolation drop ACL to switch %s for network %s: %w", bnc.GetNetworkScopedSwitchName(nodeName), bnc.GetNetworkName(), err)
 	}
 
+	klog.Infof("[UDN-DEBUG] addAdvertisedNetworkIsolation: transacting %d ops for node=%s network=%s switchName=%s cidrs=%v passMatches=%v",
+		len(ops), nodeName, bnc.GetNetworkName(), bnc.GetNetworkScopedSwitchName(nodeName), cidrs, passMatches)
 	if _, err = libovsdbops.TransactAndCheck(bnc.nbClient, ops); err != nil {
+		klog.Errorf("[UDN-DEBUG] addAdvertisedNetworkIsolation: TransactAndCheck FAILED for node=%s network=%s: %v", nodeName, bnc.GetNetworkName(), err)
 		return fmt.Errorf("failed to configure network isolation OVN rules for network %s: %w", bnc.GetNetworkName(), err)
 	}
+	klog.Infof("[UDN-DEBUG] addAdvertisedNetworkIsolation: TransactAndCheck succeeded for node=%s network=%s", nodeName, bnc.GetNetworkName())
 	return nil
 }
 
 // deleteAdvertisedNetworkIsolation deletes advertised network isolation rules from the given node switch.
 // It removes the network CIDRs from the global advertised networks addresset together with the ACLs on the node switch.
 func (bnc *BaseNetworkController) deleteAdvertisedNetworkIsolation(nodeName string) error {
+	klog.Infof("[UDN-DEBUG] deleteAdvertisedNetworkIsolation: entry for node=%s network=%s topology=%s", nodeName, bnc.GetNetworkName(), bnc.TopologyType())
 	addrSet, err := bnc.addressSetFactory.GetAddressSet(GetAdvertisedNetworkSubnetsAddressSetDBIDs())
 	if err != nil && !errors.Is(err, libovsdbclient.ErrNotFound) {
 		return fmt.Errorf("failed to get advertised subnets addresset %s for network %s: %w", GetAdvertisedNetworkSubnetsAddressSetDBIDs(), bnc.GetNetworkName(), err)
@@ -443,11 +463,102 @@ func (bnc *BaseNetworkController) deleteAdvertisedNetworkIsolation(nodeName stri
 		}
 	}
 
+	klog.Infof("[UDN-DEBUG] deleteAdvertisedNetworkIsolation: transacting %d ops for node=%s network=%s, ACLsToRemove=%d",
+		len(ops), nodeName, bnc.GetNetworkName(), len(allACLsToRemove))
 	_, err = libovsdbops.TransactAndCheck(bnc.nbClient, ops)
+	if err != nil {
+		klog.Errorf("[UDN-DEBUG] deleteAdvertisedNetworkIsolation: TransactAndCheck FAILED for node=%s network=%s: %v", nodeName, bnc.GetNetworkName(), err)
+	} else {
+		klog.Infof("[UDN-DEBUG] deleteAdvertisedNetworkIsolation: TransactAndCheck succeeded for node=%s network=%s", nodeName, bnc.GetNetworkName())
+	}
 	return err
 }
 
+// debugVerifyUDNIsolationState is a diagnostic function that verifies the
+// SecondaryPods port group has ACLs and ports present in NBDB. It reads
+// the port group state and logs it, including full ACL details (match, action,
+// direction, priority), LSP details (name, addresses, up status), and UDN
+// service route status. This provides a complete "why is communication broken"
+// snapshot when the failure is permanent.
+func (oc *DefaultNetworkController) debugVerifyUDNIsolationState() {
+	if !util.IsNetworkSegmentationSupportEnabled() {
+		return
+	}
+	pgIDs := oc.getSecondaryPodsPortGroupDbIDs()
+	pgName := libovsdbutil.GetPortGroupName(pgIDs)
+	pg := &nbdb.PortGroup{Name: pgName}
+	pg, err := libovsdbops.GetPortGroup(oc.nbClient, pg)
+	if err != nil {
+		klog.Errorf("[UDN-DEBUG] PERIODIC-CHECK: cannot read SecondaryPods portGroup=%s: %v", pgName, err)
+		return
+	}
+
+	// Check that the port group has ACLs attached — 5 is expected
+	if len(pg.ACLs) == 0 {
+		klog.Errorf("[UDN-DEBUG] PERIODIC-CHECK: SecondaryPods portGroup=%s has ZERO ACLs! Isolation rules are missing.", pgName)
+	} else if len(pg.ACLs) != 5 {
+		klog.Warningf("[UDN-DEBUG] PERIODIC-CHECK: SecondaryPods portGroup=%s has unexpected aclCount=%d (expected 5) portCount=%d",
+			pgName, len(pg.ACLs), len(pg.Ports))
+	} else {
+		klog.Infof("[UDN-DEBUG] PERIODIC-CHECK: SecondaryPods portGroup=%s aclCount=%d portCount=%d portUUIDs=%v",
+			pgName, len(pg.ACLs), len(pg.Ports), pg.Ports)
+	}
+
+	// Dump full ACL details for each ACL in the port group
+	for i, aclUUID := range pg.ACLs {
+		aclLookup := &nbdb.ACL{UUID: aclUUID}
+		foundACLs, aclErr := libovsdbops.FindACLs(oc.nbClient, []*nbdb.ACL{aclLookup})
+		if aclErr != nil || len(foundACLs) == 0 {
+			klog.Errorf("[UDN-DEBUG] PERIODIC-CHECK: ACL[%d] uuid=%s LOOKUP FAILED: %v", i, aclUUID, aclErr)
+			continue
+		}
+		a := foundACLs[0]
+		aclName := ""
+		if a.Name != nil {
+			aclName = *a.Name
+		}
+		klog.Infof("[UDN-DEBUG] PERIODIC-CHECK: ACL[%d] uuid=%s name=%q direction=%s action=%s priority=%d tier=%d match=%q",
+			i, a.UUID, aclName, a.Direction, a.Action, a.Priority, a.Tier, a.Match)
+	}
+
+	// Dump LSP details for each port in the port group
+	for i, portUUID := range pg.Ports {
+		lsp := &nbdb.LogicalSwitchPort{UUID: portUUID}
+		lsp, lspErr := libovsdbops.GetLogicalSwitchPort(oc.nbClient, lsp)
+		if lspErr != nil {
+			klog.Errorf("[UDN-DEBUG] PERIODIC-CHECK: PORT[%d] uuid=%s LOOKUP FAILED: %v", i, portUUID, lspErr)
+			continue
+		}
+		upStr := "nil"
+		if lsp.Up != nil {
+			upStr = fmt.Sprintf("%v", *lsp.Up)
+		}
+		klog.Infof("[UDN-DEBUG] PERIODIC-CHECK: PORT[%d] uuid=%s name=%s up=%s addresses=%v portSecurity=%v pod=%s",
+			i, lsp.UUID, lsp.Name, upStr, lsp.Addresses, lsp.PortSecurity, lsp.ExternalIDs["pod"])
+	}
+
+	// Check UDN service routes — look for static routes with UDN-enabled-service external IDs
+	udnRoutes, routeErr := libovsdbops.FindLogicalRouterStaticRoutesWithPredicate(oc.nbClient, func(route *nbdb.LogicalRouterStaticRoute) bool {
+		_, hasUDNService := route.ExternalIDs[types.UDNEnabledServiceExternalID]
+		return hasUDNService
+	})
+	if routeErr != nil {
+		klog.Errorf("[UDN-DEBUG] PERIODIC-CHECK: failed to look up UDN service routes: %v", routeErr)
+	} else if len(udnRoutes) == 0 {
+		klog.Warningf("[UDN-DEBUG] PERIODIC-CHECK: NO UDN-enabled service routes found in NBDB — KAPI access may be broken for UDN pods")
+	} else {
+		for i, route := range udnRoutes {
+			klog.Infof("[UDN-DEBUG] PERIODIC-CHECK: UDN-ROUTE[%d] uuid=%s prefix=%s nexthop=%s network=%s topology=%s service=%s",
+				i, route.UUID, route.IPPrefix, route.Nexthop,
+				route.ExternalIDs[types.NetworkExternalID],
+				route.ExternalIDs[types.TopologyExternalID],
+				route.ExternalIDs[types.UDNEnabledServiceExternalID])
+		}
+	}
+}
+
 func (oc *DefaultNetworkController) syncUDNIsolation() error {
+	klog.Infof("[UDN-DEBUG] syncUDNIsolation: starting legacy ACL rename sync")
 	// Find ACLs with old "secondary" naming IDs, update them
 	type aclUpdate struct {
 		old *libovsdbops.DbObjectIDs


### PR DESCRIPTION
…n failures

Add targeted klog.Infof debug logging with [UDN-DEBUG] prefix to trace UDN pod isolation enforcement during CI runs. This addresses a flaky test where network isolation between a default-network pod and a UDN pod transiently breaks after ~64 seconds of correct behavior (IPv6 only).

Instrumented code paths:
- setupUDNACLs: log all ACL match/action details and transaction results
- setUDNPodOpenPortsOps: log open port ACL creation/removal per pod
- addAdvertisedNetworkIsolation / deleteAdvertisedNetworkIsolation: log entry, transaction ops count, and success/failure for network isolation ACLs on node switches
- syncUDNIsolation: log when legacy ACL rename sync starts
- configureUDNEnabledServiceRoute: log per-node iteration details and warn about the nil-ops bug where each loop iteration overwrites previous operations
- RequestFullSync: log call timing, nodeInfos count, startupDone state, and number of services requeued
- nodeTracker.updateNode: log L2/L3 subnet parsing results, mgmtIPs, and node removal decisions
- addLogicalPort / deleteLogicalPort: log LSP creation, port group membership, and UDN isolation setup for pods with primary UDN

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced internal debugging and diagnostic logging across network controller operations, including pod/port lifecycle management, node tracking, and UDN isolation verification. Added periodic isolation state verification to improve troubleshooting capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->