### PR TITLE
DNM: Revert upstream PRs

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -42,9 +42,7 @@ COPY .git/refs/heads/ /root/.git/refs/heads/
 
 # ovnkube.sh is the entry point. This script examines environment
 # variables to direct operation and configure ovn
-# ovndb-raft-functions.sh is a dependency of ovnkube.sh
-COPY dist/images/ovnkube.sh dist/images/ovndb-raft-functions.sh /root/
-
+COPY dist/images/ovnkube.sh /root/
 
 WORKDIR /root
 ENTRYPOINT /root/ovnkube.sh

--- a/go-controller/pkg/ovn/address_set/address_set.go
+++ b/go-controller/pkg/ovn/address_set/address_set.go
@@ -551,11 +551,6 @@ func (as *ovnAddressSets) Destroy() error {
 // given addresses, disregarding existing state.
 func (as *ovnAddressSet) setAddresses(addresses []string) error {
 	uniqAddresses := getUniqueAddresses(addresses)
-
-	if as.hasOnlyAddresses(uniqAddresses...) {
-		return nil
-	}
-
 	addrset := nbdb.AddressSet{
 		UUID:      as.uuid,
 		Name:      as.hashName,
@@ -617,33 +612,6 @@ func (as *ovnAddressSet) hasAddresses(addresses ...string) bool {
 	}
 
 	if len(existingAddresses) == 0 {
-		return false
-	}
-
-	for _, address := range addresses {
-		found := false
-		for _, existingAddress := range existingAddresses {
-			if existingAddress == address {
-				found = true
-				break
-			}
-		}
-		if !found {
-			return false
-		}
-	}
-
-	return true
-}
-
-// hasOnlyAddresses returns true if an address set contains only the given Addresses and no more
-func (as *ovnAddressSet) hasOnlyAddresses(addresses ...string) bool {
-	existingAddresses, err := as.getAddresses()
-	if err != nil {
-		return false
-	}
-
-	if len(existingAddresses) != len(addresses) {
 		return false
 	}
 

--- a/go-controller/pkg/ovn/addresssetmanager/addressset_manager_test.go
+++ b/go-controller/pkg/ovn/addresssetmanager/addressset_manager_test.go
@@ -6,10 +6,8 @@ package addresssetmanager
 import (
 	"context"
 	"fmt"
-	"sync/atomic"
 	"time"
 
-	cnitypes "github.com/containernetworking/cni/pkg/types"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 
@@ -19,8 +17,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	libovsdbclient "github.com/ovn-kubernetes/libovsdb/client"
-	"github.com/ovn-kubernetes/libovsdb/ovsdb"
 
+	cnitypes "github.com/containernetworking/cni/pkg/types"
 	ovncnitypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/cni/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/factory"
@@ -54,17 +52,6 @@ func eventuallyExpectEmptyAddressSetsExist(nbClient libovsdbclient.Client, peer 
 		expectedAS, _ := addressset.GetTestDbAddrSets(dbIDs, []string{})
 		gomega.Eventually(nbClient).Should(libovsdbtest.HaveData([]libovsdbtest.TestData{expectedAS}))
 	}
-}
-
-// this is a test wrapper to count db transactions
-type countingClient struct {
-	libovsdbclient.Client
-	transactCount atomic.Int64
-}
-
-func (c *countingClient) Transact(ctx context.Context, ops ...ovsdb.Operation) ([]ovsdb.OperationResult, error) {
-	c.transactCount.Add(1)
-	return c.Client.Transact(ctx, ops...)
 }
 
 func newNetInfo(networkName, topology, role, subnets string) util.NetInfo {
@@ -104,7 +91,6 @@ var _ = ginkgo.Describe("OVN podSelectorAddressSet", func() {
 		initialDB          libovsdbtest.TestSetup
 		libovsdbCleanup    *libovsdbtest.Context
 		libovsdbNBClient   libovsdbclient.Client
-		countingNBClient   *countingClient
 		fakeNetworkManager *networkmanager.FakeNetworkManager
 	)
 
@@ -144,9 +130,7 @@ var _ = ginkgo.Describe("OVN podSelectorAddressSet", func() {
 		gomega.Expect(wf.Start()).To(gomega.Succeed())
 		libovsdbNBClient, _, libovsdbCleanup, err = libovsdbtest.NewNBSBTestHarness(dbSetup)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		// this is only used for "saves db transactions when IPs don't change" test
-		countingNBClient = &countingClient{Client: libovsdbNBClient}
-		addressSetManager = NewAddressSetManager(wf.PodCoreInformer(), wf.NamespaceInformer(), wf.NodeCoreInformer(), countingNBClient,
+		addressSetManager = NewAddressSetManager(wf.PodCoreInformer(), wf.NamespaceInformer(), wf.NodeCoreInformer(), libovsdbNBClient,
 			fakeNetworkManager.Interface().GetNetworkNameForNADKey)
 		err = addressSetManager.Start()
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -583,30 +567,6 @@ var _ = ginkgo.Describe("OVN podSelectorAddressSet", func() {
 		// IP should be deleted from the address set on delete event, since the new pod with the same ip
 		// should not be present in given address set
 		eventuallyExpectEmptyAddressSetsExist(addressSetManager.nbClient, peer, namespace1.Name)
-	})
-	ginkgo.It("saves db transactions when IPs don't change", func() {
-		namespace1 := *testing.NewNamespace(namespaceName1)
-		ns1pod1 := testing.NewPod(namespace1.Name, "ns1pod1", nodeName, ip1)
-
-		startAddrSetManager(initialDB, []corev1.Namespace{namespace1}, []corev1.Pod{*ns1pod1})
-
-		_, _, _, err := addressSetManager.EnsureAddressSet(
-			&metav1.LabelSelector{}, nil, nil, namespace1.Name, "backRef", controllerName, &util.DefaultNetInfo{}, false)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-		dbIDs := GetPodSelectorAddrSetDbIDs(&metav1.LabelSelector{}, nil, nil, namespace1.Name, controllerName, false)
-		expectedAS, _ := addressset.GetTestDbAddrSets(dbIDs, []string{ip1})
-		gomega.Eventually(addressSetManager.nbClient).Should(libovsdbtest.HaveData([]libovsdbtest.TestData{expectedAS}))
-		// expect 2 transactions: 1 to create addr set and 1 to set IPs
-		gomega.Expect(countingNBClient.transactCount.Load()).To(gomega.Equal(int64(2)))
-
-		// Now update pod labels, which will cause the address set reconciliation
-		ns1pod1.Labels["newLabel"] = "newValue"
-		_, err = clientSet.KubeClient.CoreV1().Pods(namespace1.Name).Update(context.TODO(), ns1pod1, metav1.UpdateOptions{})
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		gomega.Consistently(addressSetManager.nbClient, 200*time.Millisecond, 50*time.Millisecond).Should(libovsdbtest.HaveData([]libovsdbtest.TestData{expectedAS}))
-		// no new transactions should happen since IPs don't change
-		gomega.Expect(countingNBClient.transactCount.Load()).To(gomega.Equal(int64(2)))
 	})
 
 	ginkgo.It("CleanupForController removes controller entries", func() {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated address set update behavior to ensure consistent handling of address changes.

* **Chores**
  * Refactored test infrastructure for improved validation of address set state.
  * Updated container build configuration to streamline image contents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->