### PR TITLE
NO-JIRA: Revert "OCPBUGS-61065: Adding ovndb-raft-functions.sh to ovnk image"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,6 @@ COPY --from=builder /go/src/github.com/openshift/ovn-kubernetes/go-controller/_o
 COPY --from=builder /go/src/github.com/openshift/ovn-kubernetes/go-controller/_output/go/bin/ovn-kube-util /usr/bin/
 COPY --from=builder /go/src/github.com/openshift/ovn-kubernetes/go-controller/_output/go/bin/ovn-k8s-cni-overlay /usr/libexec/cni/
 COPY --from=builder /go/src/github.com/openshift/ovn-kubernetes/go-controller/_output/go/bin/windows/hybrid-overlay-node.exe /root/windows/
-COPY --from=builder /go/src/github.com/openshift/ovn-kubernetes/go-controller/_output/go/bin/ovndbchecker /usr/bin/
 COPY --from=builder /go/src/github.com/openshift/ovn-kubernetes/go-controller/_output/go/bin/ovnkube-trace /usr/bin/
 COPY --from=builder /go/src/github.com/openshift/ovn-kubernetes/go-controller/_output/go/bin/hybrid-overlay-node /usr/bin/
 COPY --from=builder /go/src/github.com/openshift/ovn-kubernetes/go-controller/_output/go/bin/ovnkube-observ /usr/bin/

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -42,9 +42,7 @@ COPY .git/refs/heads/ /root/.git/refs/heads/
 
 # ovnkube.sh is the entry point. This script examines environment
 # variables to direct operation and configure ovn
-# ovndb-raft-functions.sh is a dependency of ovnkube.sh
-COPY dist/images/ovnkube.sh dist/images/ovndb-raft-functions.sh /root/
-
+COPY dist/images/ovnkube.sh /root/
 
 WORKDIR /root
 ENTRYPOINT /root/ovnkube.sh

--- a/Dockerfile.microshift
+++ b/Dockerfile.microshift
@@ -10,7 +10,7 @@
 # from this image, for example:
 #
 # openvswitch-devel, openvswitch-ipsec, libpcap, iproute etc
-# ovn-kube-util, hybrid-overlay-node.exe, ovndbchecker and ovnkube-trace
+# ovn-kube-util, hybrid-overlay-node.exe and ovnkube-trace
 
 FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22 AS builder
 


### PR DESCRIPTION
Reverts openshift/ovn-kubernetes#2740 and also removes the `ovndbchecker` binary

This change shouldn't have merged w/o enhancement - its not a bug fix, we don't want to depend on any upstream "dist/image" script files for entry point. Whatever is required should be done via CNO.

What I don't understand is we don't even deploy nonIC raft mode in OCP - its not a supported config.
Also upstream this file is gone now because IC supported is removed: https://github.com/ovn-kubernetes/ovn-kubernetes/pull/6303 and its causing build issues downstream - we shouldn't have any dependencies on RAFT logic


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized Docker multi-stage build configuration to improve image composition
  * Adjusted binary packaging in the final container image
  * Refined base layer copy operations for improved image structure
  * Updated build documentation to reflect current image configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->