### PR TITLE
OTE: Add ipvlan and VXLAN overlay network support for metal infra provider

### DIFF
--- a/openshift/go.mod
+++ b/openshift/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/ovn-kubernetes/ovn-kubernetes/go-controller v1.0.0
 	github.com/ovn-kubernetes/ovn-kubernetes/test/e2e v0.0.0-00010101000000-000000000000
 	github.com/spf13/cobra v1.10.2
+	github.com/stretchr/testify v1.11.1
 	k8s.io/api v0.36.2
 	k8s.io/apimachinery v0.36.2
 	k8s.io/client-go v0.36.2
@@ -151,7 +152,6 @@ require (
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/stoewer/go-strcase v1.3.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
-	github.com/stretchr/testify v1.11.1 // indirect
 	github.com/urfave/cli/v2 v2.27.2 // indirect
 	github.com/vishvananda/netlink v1.3.2-0.20260320193013-72a8cd7e0a73 // indirect
 	github.com/vishvananda/netns v0.0.5 // indirect

--- a/openshift/test/allocator/ip_allocator.go
+++ b/openshift/test/allocator/ip_allocator.go
@@ -1,0 +1,439 @@
+// SPDX-FileCopyrightText: Copyright The OVN-Kubernetes Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package allocator
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"math/big"
+	"net"
+	"strconv"
+	"time"
+
+	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/allocators"
+	infraapi "github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/infraprovider/api"
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/retry"
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+const (
+	// ipAllocatorPrefix is used as the ConfigMap key prefix for IP allocations
+	ipAllocatorPrefix = "ip-allocator"
+)
+
+// AllocateIP allocates a unique IP address from the given subnet CIDR for parallel
+// test isolation. The allocation is backed by a ConfigMap using the AllocateInt API.
+// The first usable IP (network address + 1) and broadcast address are excluded from
+// allocation. Deallocation is registered as a cleanup function.
+//
+// Subnet size limits: The subnet must provide no more than 1024 IPs (e.g., /24 to /32 for IPv4,
+// /120 to /128 for IPv6). This prevents excessive ConfigMap sizes in E2E tests.
+//
+// Example:
+//
+//	ip, err := AllocateIP(f, cleanup, "192.168.1.0/24")
+//	// Returns an IP like "192.168.1.5" (skipping .0 and .255)
+func AllocateIP(kubeClient kubernetes.Interface, cleanup infraapi.ContextCleanUp, cidr string) (string, error) {
+	return allocateIPFromCIDR(kubeClient, cleanup, cidr, false, nil)
+}
+
+// AllocateIPv6 allocates a unique IPv6 address from the given subnet CIDR.
+// Subnet size limits: The subnet must provide no more than 1024 IPs (e.g., /120 to /128).
+func AllocateIPv6(kubeClient kubernetes.Interface, cleanup infraapi.ContextCleanUp, cidr string) (string, error) {
+	return allocateIPFromCIDR(kubeClient, cleanup, cidr, true, nil)
+}
+
+// AllocateIPWithReserved allocates a unique IP address from the given subnet CIDR,
+// excluding the specified reserved IPs from allocation. Reserved IPs are skipped
+// during the allocation process and never allocated.
+//
+// Example:
+//
+//	reserved := []string{"192.168.1.1", "192.168.1.254"}
+//	ip, err := AllocateIPWithReserved(f, cleanup, "192.168.1.0/24", reserved)
+//	// Returns an IP like "192.168.1.5" (skipping .0, .1, .254, and .255)
+func AllocateIPWithReserved(kubeClient kubernetes.Interface, cleanup infraapi.ContextCleanUp, cidr string, reservedIPs []string) (string, error) {
+	return allocateIPFromCIDR(kubeClient, cleanup, cidr, false, reservedIPs)
+}
+
+// AllocateIPv6WithReserved allocates a unique IPv6 address from the given subnet CIDR,
+// excluding the specified reserved IPs from allocation.
+func AllocateIPv6WithReserved(kubeClient kubernetes.Interface, cleanup infraapi.ContextCleanUp, cidr string, reservedIPs []string) (string, error) {
+	return allocateIPFromCIDR(kubeClient, cleanup, cidr, true, reservedIPs)
+}
+
+// AllocateSpecificIP allocates a specific IP address from the given subnet CIDR.
+// The IP is validated to be within the subnet and then reserved through the allocator.
+// Deallocation is registered as a cleanup function.
+//
+// Example:
+//
+//	ip, err := AllocateSpecificIP(f, cleanup, "192.168.1.0/24", "192.168.1.10")
+//	// Reserves 192.168.1.10 if it's valid and not already allocated
+func AllocateSpecificIP(kubeClient kubernetes.Interface, cleanup infraapi.ContextCleanUp, cidr string, requestedIP string) (string, error) {
+	return allocateSpecificIPFromCIDR(kubeClient, cleanup, cidr, false, requestedIP)
+}
+
+// AllocateSpecificIPv6 allocates a specific IPv6 address from the given subnet CIDR.
+// The IP is validated to be within the subnet and then reserved through the allocator.
+func AllocateSpecificIPv6(kubeClient kubernetes.Interface, cleanup infraapi.ContextCleanUp, cidr string, requestedIP string) (string, error) {
+	return allocateSpecificIPFromCIDR(kubeClient, cleanup, cidr, true, requestedIP)
+}
+
+// allocateSpecificInt attempts to allocate a specific integer index in the allocator ConfigMap.
+// Returns nil on success, or an error if the index is already allocated or on other failures.
+func allocateSpecificInt(kubeClient kubernetes.Interface, key string, index int) error {
+	ctx := context.Background()
+
+	const configMapNamespace = "ovn-kubernetes-e2e-allocators"
+
+	// Ensure namespace exists
+	ns := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: configMapNamespace}}
+	_, err := kubeClient.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		return fmt.Errorf("failed to ensure allocator namespace: %w", err)
+	}
+
+	// Ensure ConfigMap exists
+	cm := &v1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: key}}
+	client := kubeClient.CoreV1().ConfigMaps(configMapNamespace)
+	_, err = client.Create(ctx, cm, metav1.CreateOptions{})
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		return fmt.Errorf("failed to ensure allocator config map: %w", err)
+	}
+
+	allocatorBackoff := wait.Backoff{
+		Steps:    50,
+		Duration: 100 * time.Millisecond,
+	}
+
+	return retry.RetryOnConflict(allocatorBackoff, func() error {
+		cm, err := client.Get(ctx, key, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		if cm.Data == nil {
+			cm.Data = map[string]string{}
+		}
+
+		// Check if the specific index is already allocated
+		idxStr := strconv.Itoa(index)
+		if _, exists := cm.Data[idxStr]; exists {
+			return fmt.Errorf("index %d already allocated", index)
+		}
+
+		// Allocate the specific index
+		cm.Data[idxStr] = ""
+		_, err = client.Update(ctx, cm, metav1.UpdateOptions{})
+		return err
+	})
+}
+
+// allocateIPFromCIDR allocates an IP address from the given CIDR.
+// If reservedIPs is provided, those IPs are excluded from the allocation pool.
+func allocateIPFromCIDR(kubeClient kubernetes.Interface, cleanup infraapi.ContextCleanUp, cidr string, isIPv6 bool, reservedIPs []string) (string, error) {
+	ip, ipNet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse CIDR %q: %w", cidr, err)
+	}
+
+	// Validate IP family
+	if isIPv6 {
+		if ip.To4() != nil {
+			return "", fmt.Errorf("expected IPv6 CIDR, got IPv4: %s", cidr)
+		}
+	} else {
+		if ip.To4() == nil {
+			return "", fmt.Errorf("expected IPv4 CIDR, got IPv6: %s", cidr)
+		}
+	}
+
+	// Calculate number of usable IPs in the subnet
+	ones, bits := ipNet.Mask.Size()
+	hostBits := bits - ones
+
+	// Cap allocation pool to avoid huge ConfigMaps and integer overflow.
+	// For large subnets (e.g., /52), we allocate sparse IPs from the first 1024 addresses.
+	// ConfigMap only tracks allocated IPs, not the entire address space.
+	const maxAllocationPoolSize = 1024
+
+	var usableIPs int
+	if hostBits > 10 {
+		// Large subnet: cap to 1024 IPs (sparse allocation from beginning of subnet)
+		usableIPs = maxAllocationPoolSize
+	} else {
+		// Small subnet: use actual address space size
+		totalIPs := 1 << hostBits
+		// For IPv4, exclude network address (first IP) and broadcast (last IP)
+		// For IPv6, exclude network address (first IP) only
+		usableIPs = totalIPs - 1
+		if !isIPv6 {
+			usableIPs = totalIPs - 2 // Exclude both network and broadcast
+		}
+	}
+
+	if usableIPs <= 0 {
+		return "", fmt.Errorf("no usable IPs in subnet %s", cidr)
+	}
+
+	// Use a canonical, Kubernetes-safe key so equivalent CIDRs share the same allocator state.
+	normalizedCIDR := ipNet.String()
+	sum := sha256.Sum256([]byte(normalizedCIDR))
+	key := fmt.Sprintf("%s-%s", ipAllocatorPrefix, hex.EncodeToString(sum[:]))
+
+	// Build a map of reserved IP indices for quick lookup
+	reservedIndices := make(map[int]bool)
+	if len(reservedIPs) > 0 {
+		for _, reservedIP := range reservedIPs {
+			ip := net.ParseIP(reservedIP)
+			if ip == nil {
+				return "", fmt.Errorf("invalid reserved IP: %s", reservedIP)
+			}
+
+			// Verify the IP is within the subnet
+			if !ipNet.Contains(ip) {
+				return "", fmt.Errorf("reserved IP %s is not within subnet %s", reservedIP, ipNet)
+			}
+
+			// Convert IP to index
+			index, err := ipToIndex(ipNet.IP, ip)
+			if err != nil {
+				return "", fmt.Errorf("failed to convert reserved IP %s to index: %w", reservedIP, err)
+			}
+
+			// Verify index is within usable range
+			if index < 1 || index > usableIPs {
+				return "", fmt.Errorf("reserved IP %s index %d is outside usable range [1, %d]", reservedIP, index, usableIPs)
+			}
+
+			reservedIndices[index] = true
+			framework.Logf("Marked IP %s (index %d) as reserved in subnet %s", reservedIP, index, ipNet)
+		}
+	}
+
+	// Allocate a unique index within the usable range, skipping reserved indices.
+	// Try to allocate each non-reserved candidate index in order until one succeeds.
+	var index int
+	for candidate := 1; candidate <= usableIPs; candidate++ {
+		// Skip reserved indices during selection
+		if reservedIndices[candidate] {
+			framework.Logf("Skipping reserved index %d in subnet %s", candidate, ipNet)
+			continue
+		}
+
+		// Try to allocate this specific non-reserved index
+		if err := allocateSpecificInt(kubeClient, key, candidate); err == nil {
+			// Successfully allocated this index
+			index = candidate
+			break
+		}
+		// If already allocated by another test, try the next candidate
+	}
+
+	if index == 0 {
+		return "", fmt.Errorf("failed to allocate any non-reserved IP from subnet %s (all %d usable IPs exhausted or reserved)", cidr, usableIPs)
+	}
+
+	// Register cleanup to deallocate the allocated index
+	cleanup.AddCleanUpFn(func() error {
+		if err := allocators.DeallocateInt(kubeClient, key, index); err != nil {
+			return fmt.Errorf("failed to deallocate IP index %d: %w", index, err)
+		}
+		return nil
+	})
+
+	// Convert index to IP address
+	// For IPv4: start from network address + 1 (skip .0)
+	// For IPv6: start from network address + 1
+	allocatedIP := indexToIP(ipNet.IP, index, bits)
+
+	framework.Logf("AllocateIP: allocated %s from subnet %s (index %d)", allocatedIP, cidr, index)
+
+	return allocatedIP, nil
+}
+
+// allocateSpecificIPFromCIDR allocates a specific IP address from the given CIDR.
+// It validates the IP is within the subnet and reserves it through the allocator.
+func allocateSpecificIPFromCIDR(kubeClient kubernetes.Interface, cleanup infraapi.ContextCleanUp, cidr string, isIPv6 bool, requestedIP string) (string, error) {
+	ip, ipNet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse CIDR %q: %w", cidr, err)
+	}
+
+	// Validate IP family
+	if isIPv6 {
+		if ip.To4() != nil {
+			return "", fmt.Errorf("expected IPv6 CIDR, got IPv4: %s", cidr)
+		}
+	} else {
+		if ip.To4() == nil {
+			return "", fmt.Errorf("expected IPv4 CIDR, got IPv6: %s", cidr)
+		}
+	}
+
+	// Parse and validate requested IP
+	parsedIP := net.ParseIP(requestedIP)
+	if parsedIP == nil {
+		return "", fmt.Errorf("invalid requested IP: %s", requestedIP)
+	}
+
+	// Validate IP family matches
+	if isIPv6 {
+		if parsedIP.To4() != nil {
+			return "", fmt.Errorf("expected IPv6 address, got IPv4: %s", requestedIP)
+		}
+	} else {
+		if parsedIP.To4() == nil {
+			return "", fmt.Errorf("expected IPv4 address, got IPv6: %s", requestedIP)
+		}
+	}
+
+	// Verify the IP is within the subnet
+	if !ipNet.Contains(parsedIP) {
+		return "", fmt.Errorf("requested IP %s is not within subnet %s", requestedIP, ipNet)
+	}
+
+	// Check subnet size and determine tracking limits
+	ones, bits := ipNet.Mask.Size()
+	hostBits := bits - ones
+
+	// For very large subnets (hostBits > 62), index calculation would overflow.
+	// We only track allocations for the first 1024 IPs to avoid ConfigMap bloat.
+	const maxTrackedIndex = 1024
+
+	// Calculate index using big.Int to avoid overflow
+	baseInt := new(big.Int).SetBytes(ipNet.IP.To16())
+	targetInt := new(big.Int).SetBytes(parsedIP.To16())
+	diff := new(big.Int).Sub(targetInt, baseInt)
+
+	// Check if difference is negative (should not happen if ipNet.Contains passed)
+	if diff.Sign() < 0 {
+		return "", fmt.Errorf("requested IP %s is before subnet base %s", requestedIP, ipNet.IP)
+	}
+
+	// Check if difference is zero (network address itself)
+	if diff.Sign() == 0 {
+		return "", fmt.Errorf("requested IP %s is the network address (index 0)", requestedIP)
+	}
+
+	// For large subnets (> 1024 IPs tracked), check if requested IP is within tracked range
+	if hostBits > 10 {
+		// Large subnet: only track first 1024 IPs
+		maxTracked := big.NewInt(int64(maxTrackedIndex))
+		if diff.Cmp(maxTracked) > 0 {
+			// Beyond tracking limit - skip ConfigMap, return IP without conflict detection
+			framework.Logf("AllocateSpecificIP: allocated %s from subnet %s (beyond tracking limit %d, no ConfigMap tracking)",
+				requestedIP, cidr, maxTrackedIndex)
+			return requestedIP, nil
+		}
+	}
+
+	// Convert to int now that we know it's within trackable range
+	if !diff.IsInt64() {
+		return "", fmt.Errorf("requested IP %s offset too large to track (index overflow)", requestedIP)
+	}
+
+	index := int(diff.Int64())
+
+	// Validate index is within usable range (not broadcast for IPv4)
+	if hostBits <= 10 {
+		// Small subnet: validate against actual bounds
+		totalIPs := 1 << hostBits
+		maxUsableIndex := totalIPs - 1
+		if !isIPv6 {
+			maxUsableIndex = totalIPs - 2 // Exclude broadcast
+		}
+		if index > maxUsableIndex {
+			return "", fmt.Errorf("requested IP %s (index %d) is outside usable range [1, %d]", requestedIP, index, maxUsableIndex)
+		}
+	}
+
+	// Use a canonical, Kubernetes-safe key
+	normalizedCIDR := ipNet.String()
+	sum := sha256.Sum256([]byte(normalizedCIDR))
+	key := fmt.Sprintf("%s-%s", ipAllocatorPrefix, hex.EncodeToString(sum[:]))
+
+	// Allocate the specific index in ConfigMap
+	if err := allocateSpecificInt(kubeClient, key, index); err != nil {
+		return "", fmt.Errorf("failed to allocate specific IP %s from subnet %s: %w", requestedIP, cidr, err)
+	}
+
+	// Register cleanup to deallocate the allocated index
+	cleanup.AddCleanUpFn(func() error {
+		if err := allocators.DeallocateInt(kubeClient, key, index); err != nil {
+			return fmt.Errorf("failed to deallocate IP index %d: %w", index, err)
+		}
+		return nil
+	})
+
+	framework.Logf("AllocateSpecificIP: allocated %s from subnet %s (index %d)", requestedIP, cidr, index)
+
+	return requestedIP, nil
+}
+
+// ipToIndex converts an IP address to its index within the subnet.
+// The network address corresponds to index 0, the first usable IP to index 1, etc.
+func ipToIndex(baseIP, targetIP net.IP) (int, error) {
+	baseInt := new(big.Int).SetBytes(baseIP.To16())
+	targetInt := new(big.Int).SetBytes(targetIP.To16())
+
+	// Calculate the difference
+	diff := new(big.Int).Sub(targetInt, baseInt)
+
+	// Convert to int64 and return as index
+	index := diff.Int64()
+	if index < 0 {
+		return 0, fmt.Errorf("target IP is before base IP")
+	}
+
+	return int(index), nil
+}
+
+// indexToIP converts an allocation index to an IP address within the subnet.
+// index is 1-based (AllocateInt returns values starting from 1).
+// The first usable IP corresponds to index 1.
+func indexToIP(baseIP net.IP, index int, bits int) string {
+	// Convert base IP to big.Int
+	baseInt := new(big.Int).SetBytes(baseIP.To16())
+
+	// Calculate offset: index is 1-based, so actual offset is index
+	// (first usable IP is network + 1, which corresponds to index 1)
+	offset := big.NewInt(int64(index))
+
+	// Add offset to base IP
+	resultInt := new(big.Int).Add(baseInt, offset)
+
+	// Convert back to IP
+	ipBytes := resultInt.Bytes()
+
+	// Pad to 16 bytes for IPv6 or 4 bytes for IPv4
+	var ip net.IP
+	if bits == 32 {
+		// IPv4
+		ip = make(net.IP, 4)
+		if len(ipBytes) > 4 {
+			copy(ip, ipBytes[len(ipBytes)-4:])
+		} else {
+			copy(ip[4-len(ipBytes):], ipBytes)
+		}
+	} else {
+		// IPv6
+		ip = make(net.IP, 16)
+		if len(ipBytes) > 16 {
+			copy(ip, ipBytes[len(ipBytes)-16:])
+		} else {
+			copy(ip[16-len(ipBytes):], ipBytes)
+		}
+	}
+
+	return ip.String()
+}

--- a/openshift/test/allocator/ip_allocator_test.go
+++ b/openshift/test/allocator/ip_allocator_test.go
@@ -1,0 +1,395 @@
+// SPDX-FileCopyrightText: Copyright The OVN-Kubernetes Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package allocator
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+// fakeCleanup is a test stub for ContextCleanUp interface
+type fakeCleanup struct {
+	cleanupFns []func() error
+}
+
+func (f *fakeCleanup) AddCleanUpFn(fn func() error) {
+	f.cleanupFns = append(f.cleanupFns, fn)
+}
+
+func TestIndexToIP(t *testing.T) {
+	tests := []struct {
+		name     string
+		baseIP   string
+		index    int
+		bits     int
+		expected string
+	}{
+		{
+			name:     "IPv4 first usable IP",
+			baseIP:   "192.168.1.0",
+			index:    1,
+			bits:     32,
+			expected: "192.168.1.1",
+		},
+		{
+			name:     "IPv4 10th IP",
+			baseIP:   "192.168.1.0",
+			index:    10,
+			bits:     32,
+			expected: "192.168.1.10",
+		},
+		{
+			name:     "IPv4 254th IP (last usable in /24)",
+			baseIP:   "192.168.1.0",
+			index:    254,
+			bits:     32,
+			expected: "192.168.1.254",
+		},
+		{
+			name:     "IPv4 /16 subnet",
+			baseIP:   "10.0.0.0",
+			index:    256,
+			bits:     32,
+			expected: "10.0.1.0",
+		},
+		{
+			name:     "IPv4 /16 subnet higher index",
+			baseIP:   "10.0.0.0",
+			index:    1000,
+			bits:     32,
+			expected: "10.0.3.232",
+		},
+		{
+			name:     "IPv6 first usable IP",
+			baseIP:   "fd00::",
+			index:    1,
+			bits:     128,
+			expected: "fd00::1",
+		},
+		{
+			name:     "IPv6 10th IP",
+			baseIP:   "fd00::",
+			index:    10,
+			bits:     128,
+			expected: "fd00::a",
+		},
+		{
+			name:     "IPv6 256th IP",
+			baseIP:   "fd00::",
+			index:    256,
+			bits:     128,
+			expected: "fd00::100",
+		},
+		{
+			name:     "IPv6 large index",
+			baseIP:   "2001:db8::",
+			index:    65536,
+			bits:     128,
+			expected: "2001:db8::1:0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			baseIP := net.ParseIP(tt.baseIP)
+			require.NotNil(t, baseIP, "invalid base IP: %s", tt.baseIP)
+
+			result := indexToIP(baseIP, tt.index, tt.bits)
+			assert.Equal(t, tt.expected, result)
+
+			// Verify the result is a valid IP
+			resultIP := net.ParseIP(result)
+			require.NotNil(t, resultIP, "result is not a valid IP: %s", result)
+		})
+	}
+}
+
+func TestAllocateIPValidation(t *testing.T) {
+	tests := []struct {
+		name        string
+		cidr        string
+		isIPv6      bool
+		shouldError bool
+		errorMsg    string
+	}{
+		{
+			name:        "valid IPv4",
+			cidr:        "192.168.1.0/24",
+			isIPv6:      false,
+			shouldError: false,
+		},
+		{
+			name:        "valid IPv6",
+			cidr:        "fd00::/120",
+			isIPv6:      true,
+			shouldError: false,
+		},
+		{
+			name:        "invalid CIDR",
+			cidr:        "not-a-cidr",
+			isIPv6:      false,
+			shouldError: true,
+			errorMsg:    "failed to parse CIDR",
+		},
+		{
+			name:        "IPv4 when expecting IPv6",
+			cidr:        "192.168.1.0/24",
+			isIPv6:      true,
+			shouldError: true,
+			errorMsg:    "expected IPv6 CIDR, got IPv4",
+		},
+		{
+			name:        "IPv6 when expecting IPv4",
+			cidr:        "fd00::/64",
+			isIPv6:      false,
+			shouldError: true,
+			errorMsg:    "expected IPv4 CIDR, got IPv6",
+		},
+		{
+			name:        "IPv4 /32 (no usable IPs)",
+			cidr:        "192.168.1.1/32",
+			isIPv6:      false,
+			shouldError: true,
+			errorMsg:    "no usable IPs",
+		},
+		{
+			name:        "IPv4 /31 (1 usable after excluding network and broadcast)",
+			cidr:        "192.168.1.0/31",
+			isIPv6:      false,
+			shouldError: true,
+			errorMsg:    "no usable IPs",
+		},
+		{
+			name:        "IPv4 /16 (large subnet, capped at 1024 IPs)",
+			cidr:        "10.0.0.0/16",
+			isIPv6:      false,
+			shouldError: false,
+		},
+		{
+			name:        "IPv6 /64 (large subnet, capped at 1024 IPs)",
+			cidr:        "fd00::/64",
+			isIPv6:      true,
+			shouldError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Call the real allocateIPFromCIDR with test stubs
+			fakeClient := fake.NewSimpleClientset()
+			cleanup := &fakeCleanup{}
+
+			ip, err := allocateIPFromCIDR(fakeClient, cleanup, tt.cidr, tt.isIPv6, nil)
+
+			if tt.shouldError {
+				require.Error(t, err)
+				if tt.errorMsg != "" {
+					assert.Contains(t, err.Error(), tt.errorMsg)
+				}
+			} else {
+				require.NoError(t, err)
+				// Verify allocated IP is valid
+				parsedIP := net.ParseIP(ip)
+				require.NotNil(t, parsedIP, "allocated IP should be valid")
+
+				// Verify cleanup function was registered
+				assert.NotEmpty(t, cleanup.cleanupFns, "cleanup function should be registered")
+			}
+		})
+	}
+}
+
+func TestIPAllocation(t *testing.T) {
+	t.Run("IPv4 allocation math", func(t *testing.T) {
+		// For 192.168.1.0/24:
+		// - Total IPs: 256
+		// - Usable IPs: 254 (excluding .0 and .255)
+		// - Index 1 -> 192.168.1.1
+		// - Index 254 -> 192.168.1.254
+
+		_, ipNet, err := net.ParseCIDR("192.168.1.0/24")
+		require.NoError(t, err)
+
+		ones, bits := ipNet.Mask.Size()
+		totalIPs := 1 << (bits - ones)
+		usableIPs := totalIPs - 2 // IPv4 excludes network and broadcast
+
+		assert.Equal(t, 256, totalIPs)
+		assert.Equal(t, 254, usableIPs)
+
+		// Verify first and last usable IPs
+		firstIP := indexToIP(ipNet.IP, 1, 32)
+		assert.Equal(t, "192.168.1.1", firstIP)
+
+		lastIP := indexToIP(ipNet.IP, 254, 32)
+		assert.Equal(t, "192.168.1.254", lastIP)
+	})
+
+	t.Run("IPv6 allocation math", func(t *testing.T) {
+		// For fd00::/120:
+		// - Total IPs: 256
+		// - Usable IPs: 255 (excluding network address only)
+		// - Index 1 -> fd00::1
+		// - Index 255 -> fd00::ff
+
+		_, ipNet, err := net.ParseCIDR("fd00::/120")
+		require.NoError(t, err)
+
+		ones, bits := ipNet.Mask.Size()
+		totalIPs := 1 << (bits - ones)
+		usableIPs := totalIPs - 1 // IPv6 excludes only network address
+
+		assert.Equal(t, 256, totalIPs)
+		assert.Equal(t, 255, usableIPs)
+
+		// Verify first and last usable IPs
+		firstIP := indexToIP(ipNet.IP, 1, 128)
+		assert.Equal(t, "fd00::1", firstIP)
+
+		lastIP := indexToIP(ipNet.IP, 255, 128)
+		assert.Equal(t, "fd00::ff", lastIP)
+	})
+}
+
+func TestIPToIndex(t *testing.T) {
+	tests := []struct {
+		name          string
+		baseIP        string
+		targetIP      string
+		expectedIndex int
+		shouldError   bool
+	}{
+		{
+			name:          "IPv4 first usable IP",
+			baseIP:        "192.168.1.0",
+			targetIP:      "192.168.1.1",
+			expectedIndex: 1,
+		},
+		{
+			name:          "IPv4 10th IP",
+			baseIP:        "192.168.1.0",
+			targetIP:      "192.168.1.10",
+			expectedIndex: 10,
+		},
+		{
+			name:          "IPv4 network address",
+			baseIP:        "192.168.1.0",
+			targetIP:      "192.168.1.0",
+			expectedIndex: 0,
+		},
+		{
+			name:          "IPv4 broadcast",
+			baseIP:        "192.168.1.0",
+			targetIP:      "192.168.1.255",
+			expectedIndex: 255,
+		},
+		{
+			name:          "IPv6 first usable IP",
+			baseIP:        "fd00::",
+			targetIP:      "fd00::1",
+			expectedIndex: 1,
+		},
+		{
+			name:          "IPv6 256th IP",
+			baseIP:        "fd00::",
+			targetIP:      "fd00::100",
+			expectedIndex: 256,
+		},
+		{
+			name:          "IPv6 network address",
+			baseIP:        "2001:db8::",
+			targetIP:      "2001:db8::",
+			expectedIndex: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			baseIP := net.ParseIP(tt.baseIP)
+			require.NotNil(t, baseIP, "invalid base IP: %s", tt.baseIP)
+
+			targetIP := net.ParseIP(tt.targetIP)
+			require.NotNil(t, targetIP, "invalid target IP: %s", tt.targetIP)
+
+			index, err := ipToIndex(baseIP, targetIP)
+
+			if tt.shouldError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expectedIndex, index)
+
+				// Verify round-trip: index -> IP should give us back the target
+				// Use 32 bits for IPv4, 128 for IPv6
+				bits := 32
+				if baseIP.To4() == nil {
+					bits = 128
+				}
+				resultIP := indexToIP(baseIP, index, bits)
+				assert.Equal(t, tt.targetIP, resultIP)
+			}
+		})
+	}
+}
+
+func TestReservedIPValidation(t *testing.T) {
+	const testCIDR = "192.168.1.0/24"
+
+	tests := []struct {
+		name        string
+		reservedIPs []string
+		shouldError bool
+		errorMsg    string
+	}{
+		{
+			name:        "valid reserved IPs",
+			reservedIPs: []string{"192.168.1.1", "192.168.1.10", "192.168.1.254"},
+			shouldError: false,
+		},
+		{
+			name:        "invalid IP format",
+			reservedIPs: []string{"not-an-ip"},
+			shouldError: true,
+			errorMsg:    "invalid reserved IP",
+		},
+		{
+			name:        "IP outside subnet",
+			reservedIPs: []string{"192.168.2.1"},
+			shouldError: true,
+			errorMsg:    "not within subnet",
+		},
+		{
+			name:        "empty reserved list",
+			reservedIPs: []string{},
+			shouldError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Call the real allocateIPFromCIDR with reserved IPs
+			fakeClient := fake.NewSimpleClientset()
+			cleanup := &fakeCleanup{}
+
+			ip, err := allocateIPFromCIDR(fakeClient, cleanup, testCIDR, false, tt.reservedIPs)
+
+			if tt.shouldError {
+				require.Error(t, err)
+				if tt.errorMsg != "" {
+					assert.Contains(t, err.Error(), tt.errorMsg)
+				}
+			} else {
+				require.NoError(t, err)
+				// Verify allocated IP is valid and not in reserved list
+				parsedIP := net.ParseIP(ip)
+				require.NotNil(t, parsedIP, "allocated IP should be valid")
+				assert.NotContains(t, tt.reservedIPs, ip, "allocated IP should not be in reserved list")
+			}
+		})
+	}
+}

--- a/openshift/test/infraprovider/baremetal.go
+++ b/openshift/test/infraprovider/baremetal.go
@@ -150,6 +150,11 @@ func initializeClusterInfra(config *rest.Config) (*baremetalInfra, error) {
 		return nil, fmt.Errorf("failed to retrieve hypervisor node interface for machine network: %w", err)
 	}
 
+	// Configure firewall on hypervisor to allow VXLAN traffic (port 5789/udp)
+	if err := configureFirewallForVXLAN(sshRunner, ci.machineNetworkGwInfo.InfName); err != nil {
+		framework.Logf("Warning: failed to configure firewall for VXLAN: %v", err)
+	}
+
 	// Create ipvlan network based on IP family configuration
 	if ci.machineNetworkGwInfo.IPv4 != "" && ci.machineNetworkGwInfo.IPv6 != "" {
 		// Dual-stack configuration
@@ -180,6 +185,28 @@ func initializeClusterInfra(config *rest.Config) (*baremetalInfra, error) {
 			Configs: []network.ContainerEngineNetworkConfig{{Subnet: ipvlanPrimaryNetIPv4, Gateway: ipvlanPrimaryNetIPv4Gateway}}}
 	}
 	return ci, nil
+}
+
+// configureFirewallForVXLAN configures firewall on hypervisor to allow VXLAN traffic.
+func configureFirewallForVXLAN(runner api.Runner, interfaceName string) error {
+	// Get the firewall zone of the interface
+	zone, err := runner.Run("firewall-cmd", "--get-zone-of-interface="+interfaceName)
+	if err != nil {
+		return fmt.Errorf("failed to get firewall zone for interface %s: %w", interfaceName, err)
+	}
+	zone = strings.TrimSpace(zone)
+
+	// Add port 5789/udp to the interface's zone
+	if _, err := runner.Run("firewall-cmd", "--zone="+zone, "--add-port=5789/udp", "--permanent"); err != nil {
+		return fmt.Errorf("failed to add firewall port 5789/udp to zone %s: %w", zone, err)
+	}
+
+	// Reload firewall to apply changes
+	if _, err := runner.Run("firewall-cmd", "--reload"); err != nil {
+		return fmt.Errorf("failed to reload firewall: %w", err)
+	}
+
+	return nil
 }
 
 // createIpvlanNetwork creates an ipvlan L3 network with the specified configuration.

--- a/openshift/test/infraprovider/baremetal.go
+++ b/openshift/test/infraprovider/baremetal.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	configv1 "github.com/openshift/api/config/v1"
@@ -33,10 +34,25 @@ const (
 	externalFRRContainerName   = "frr"
 )
 
+const (
+	ipvlanPrimaryNetNameIPv4      = "ostestbm-ipvlan-v4"
+	ipvlanPrimaryNetNameIPv6      = "ostestbm-ipvlan-v6"
+	ipvlanPrimaryNetNameDualStack = "ostestbm-ipvlan-dual"
+	// Ipvlan uses separate subnet from machine network to avoid IP allocation conflicts
+	// Machine network: 192.168.111.0/24, Ipvlan network: 192.168.112.0/24
+	ipvlanPrimaryNetIPv4        = "192.168.112.0/24"
+	ipvlanPrimaryNetIPv4Gateway = "192.168.112.1"
+	// IPv6 subnet for ipvlan (fd2e:6f44:5dd8:c957::/120) is separate from
+	// machine network IPv6 subnet (fd2e:6f44:5dd8:c956::/120)
+	ipvlanPrimaryNetIPv6        = "fd2e:6f44:5dd8:c957::/120"
+	ipvlanPrimaryNetIPv6Gateway = "fd2e:6f44:5dd8:c957::1"
+)
+
 type baremetalInfra struct {
-	engine               *container.Engine
-	machineNetwork       api.Network           // contains subnet details about cluster machine network
-	machineNetworkGwInfo *api.NetworkInterface // contains interface info about hypervisor node machine network interface
+	engine                            *container.Engine
+	machineNetwork                    api.Network           // contains subnet details about cluster machine network
+	machineNetworkGwInfo              *api.NetworkInterface // contains interface info about hypervisor node machine network interface
+	primaryNetworkBackendForContainer api.Network           // ipvlan network which is a container network backend for cluster machine network
 }
 
 func initializeClusterInfra(config *rest.Config) (*baremetalInfra, error) {
@@ -88,7 +104,79 @@ func initializeClusterInfra(config *rest.Config) (*baremetalInfra, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve hypervisor node interface for machine network: %w", err)
 	}
+	// Create ipvlan network based on IP family configuration
+	if ci.machineNetworkGwInfo.IPv4 != "" && ci.machineNetworkGwInfo.IPv6 != "" {
+		// Dual-stack configuration
+		if err := createIpvlanNetwork(sshRunner, ipvlanPrimaryNetNameDualStack, ci.machineNetworkGwInfo.InfName,
+			ipvlanPrimaryNetIPv4, ipvlanPrimaryNetIPv4Gateway,
+			ipvlanPrimaryNetIPv6, ipvlanPrimaryNetIPv6Gateway); err != nil {
+			return nil, fmt.Errorf("failed to create dual-stack ipvlan container network for primary machine network: %w", err)
+		}
+		ci.primaryNetworkBackendForContainer = &network.ContainerEngineNetwork{NetName: ipvlanPrimaryNetNameDualStack,
+			Configs: []network.ContainerEngineNetworkConfig{
+				{Subnet: ipvlanPrimaryNetIPv4, Gateway: ipvlanPrimaryNetIPv4Gateway},
+				{Subnet: ipvlanPrimaryNetIPv6, Gateway: ipvlanPrimaryNetIPv6Gateway}}}
+	} else if ci.machineNetworkGwInfo.IPv6 != "" {
+		// IPv6-only configuration
+		if err := createIpvlanNetwork(sshRunner, ipvlanPrimaryNetNameIPv6, ci.machineNetworkGwInfo.InfName,
+			"", "", ipvlanPrimaryNetIPv6, ipvlanPrimaryNetIPv6Gateway); err != nil {
+			return nil, fmt.Errorf("failed to create IPv6 ipvlan container network for primary machine network: %w", err)
+		}
+		ci.primaryNetworkBackendForContainer = &network.ContainerEngineNetwork{NetName: ipvlanPrimaryNetNameIPv6,
+			Configs: []network.ContainerEngineNetworkConfig{{Subnet: ipvlanPrimaryNetIPv6, Gateway: ipvlanPrimaryNetIPv6Gateway}}}
+	} else if ci.machineNetworkGwInfo.IPv4 != "" {
+		// IPv4-only configuration
+		if err := createIpvlanNetwork(sshRunner, ipvlanPrimaryNetNameIPv4, ci.machineNetworkGwInfo.InfName,
+			ipvlanPrimaryNetIPv4, ipvlanPrimaryNetIPv4Gateway, "", ""); err != nil {
+			return nil, fmt.Errorf("failed to create IPv4 ipvlan container network for primary machine network: %w", err)
+		}
+		ci.primaryNetworkBackendForContainer = &network.ContainerEngineNetwork{NetName: ipvlanPrimaryNetNameIPv4,
+			Configs: []network.ContainerEngineNetworkConfig{{Subnet: ipvlanPrimaryNetIPv4, Gateway: ipvlanPrimaryNetIPv4Gateway}}}
+	}
 	return ci, nil
+}
+
+// createIpvlanNetwork creates an ipvlan L3 network with the specified configuration.
+// It checks if the network already exists to support idempotent initialization.
+// For IPv4-only, pass empty strings for v6Subnet and v6Gateway.
+// For IPv6-only, pass empty strings for v4Subnet and v4Gateway.
+func createIpvlanNetwork(runner api.Runner, networkName, parentInterface, v4Subnet, v4Gateway, v6Subnet, v6Gateway string) error {
+	// Check if network already exists (idempotency)
+	existingNets, err := runner.Run("podman", "network", "ls", "--format", "{{.Name}}")
+	if err != nil {
+		return fmt.Errorf("failed to list existing networks: %w", err)
+	}
+	if slices.Contains(strings.Split(strings.TrimSpace(existingNets), "\n"), networkName) {
+		return nil
+	}
+
+	// Build podman network create command
+	args := []string{"network", "create", "-d", "ipvlan"}
+
+	// Add IPv4 configuration if provided
+	if v4Subnet != "" {
+		args = append(args, fmt.Sprintf("--subnet=%s", v4Subnet))
+		args = append(args, fmt.Sprintf("--gateway=%s", v4Gateway))
+	}
+
+	// Add IPv6 configuration if provided
+	if v6Subnet != "" {
+		args = append(args, fmt.Sprintf("--subnet=%s", v6Subnet))
+		args = append(args, fmt.Sprintf("--gateway=%s", v6Gateway))
+		args = append(args, "--ipv6")
+	}
+
+	// Add ipvlan-specific options
+	args = append(args, "-o", fmt.Sprintf("parent=%s", parentInterface))
+	args = append(args, "-o", "mode=l3")
+	args = append(args, networkName)
+
+	// Create the network
+	if _, err := runner.Run("podman", args...); err != nil {
+		return fmt.Errorf("failed to create ipvlan network %s: %w", networkName, err)
+	}
+
+	return nil
 }
 
 func (ci *baremetalInfra) GetNetwork(name string) (api.Network, error) {
@@ -147,6 +235,8 @@ func (ci *baremetalInfra) GetExternalContainerNetworkInterface(container api.Ext
 				IPv4Prefix:  ci.machineNetworkGwInfo.IPv4Prefix,
 				IPv6Prefix:  ci.machineNetworkGwInfo.IPv6Prefix},
 			nil
+	} else if network.Name() == primaryNetworkName {
+		network = ci.primaryNetworkBackendForContainer
 	}
 	return ci.engine.GetNetworkInterface(container.Name, network.Name())
 }
@@ -158,6 +248,9 @@ func (ci *baremetalInfra) GetExternalContainerContextProvider(context *testconte
 }
 
 func (ci *baremetalInfra) CreateExternalContainer(container api.ExternalContainer) (api.ExternalContainer, error) {
+	if container.Network.Name() == primaryNetworkName {
+		container.Network = ci.primaryNetworkBackendForContainer
+	}
 	return ci.engine.CreateExternalContainer(container)
 }
 
@@ -170,10 +263,16 @@ func (ci *baremetalInfra) CreateNetwork(name string, subnets ...string) (api.Net
 }
 
 func (ci *baremetalInfra) AttachNetwork(network api.Network, container string) (api.NetworkInterface, error) {
+	if network.Name() == primaryNetworkName {
+		return ci.engine.AttachNetwork(ci.primaryNetworkBackendForContainer, container)
+	}
 	return ci.engine.AttachNetwork(network, container)
 }
 
 func (ci *baremetalInfra) DetachNetwork(network api.Network, container string) error {
+	if network.Name() == primaryNetworkName {
+		return ci.engine.DetachNetwork(ci.primaryNetworkBackendForContainer, container)
+	}
 	return ci.engine.DetachNetwork(network, container)
 }
 

--- a/openshift/test/infraprovider/baremetal.go
+++ b/openshift/test/infraprovider/baremetal.go
@@ -1,6 +1,7 @@
 package infraprovider
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
@@ -8,10 +9,12 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"slices"
 	"strings"
 	"sync"
+	"time"
 
 	configv1 "github.com/openshift/api/config/v1"
 	configclient "github.com/openshift/client-go/config/clientset/versioned"
@@ -22,6 +25,7 @@ import (
 	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/infraprovider/engine/container/network"
 	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/infraprovider/engine/runner"
 	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/infraprovider/engine/testcontext"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -509,20 +513,36 @@ func (ci *baremetalInfra) CreateNetwork(name string, subnets ...string) (api.Net
 	return vxlanNetwork, nil
 }
 
-func (ci *baremetalInfra) AttachNetwork(network api.Network, container string) (api.NetworkInterface, error) {
+func (ci *baremetalInfra) AttachNetwork(network api.Network, instance string) (api.NetworkInterface, error) {
 	if network.Name() == primaryNetworkName {
-		return ci.engine.AttachNetwork(ci.primaryNetworkBackendForContainer, container)
+		return ci.engine.AttachNetwork(ci.primaryNetworkBackendForContainer, instance)
 	}
-	// Attach VXLAN overlay network using veth pairs
-	return ci.attachVXLANNetwork(network, container, "", "")
+
+	// Try container attachment first by checking if we can get container PID
+	pidStr, err := ci.runner.Run("podman", "inspect", "-f", "{{.State.Pid}}", instance)
+	if err == nil && strings.TrimSpace(pidStr) != "" {
+		// It's a container (allocate IPs since none requested)
+		return ci.attachVXLANNetwork(network, instance, "", "")
+	}
+
+	// Fall back to node attachment
+	return ci.attachVXLANNetworkToNode(network, instance)
 }
 
-func (ci *baremetalInfra) DetachNetwork(network api.Network, container string) error {
+func (ci *baremetalInfra) DetachNetwork(network api.Network, instance string) error {
 	if network.Name() == primaryNetworkName {
-		return ci.engine.DetachNetwork(ci.primaryNetworkBackendForContainer, container)
+		return ci.engine.DetachNetwork(ci.primaryNetworkBackendForContainer, instance)
 	}
-	// Detach VXLAN overlay network
-	return ci.detachVXLANNetwork(network.Name(), container)
+
+	// Check if instance is a container by trying to get PID
+	_, err := ci.runner.Run("podman", "inspect", "-f", "{{.State.Pid}}", instance)
+	if err == nil {
+		// It's a container
+		return ci.detachVXLANNetwork(network.Name(), instance)
+	}
+
+	// Fall back to node detachment
+	return ci.detachVXLANNetworkFromNode(network.Name(), instance)
 }
 
 func (ci *baremetalInfra) DeleteNetwork(network api.Network) error {
@@ -1004,5 +1024,282 @@ func (ci *baremetalInfra) detachVXLANNetwork(networkName, containerName string) 
 	ci.networkState.Unlock()
 
 	framework.Logf("detached VXLAN network %s from container %s", networkName, containerName)
+	return nil
+}
+
+// execNodeCommand executes a command on a k8s node using oc debug.
+func (ci *baremetalInfra) execNodeCommand(nodeName string, cmd []string) (string, error) {
+	if len(cmd) == 0 {
+		return "", fmt.Errorf("insufficient command arguments")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+	cmd = append([]string{"debug", fmt.Sprintf("node/%s", nodeName), "--to-namespace=default",
+		"--", "chroot", "/host"}, cmd...)
+	ocDebugCmd := exec.CommandContext(ctx, "oc", cmd...)
+	var stdout, stderr bytes.Buffer
+	ocDebugCmd.Stdout = &stdout
+	ocDebugCmd.Stderr = &stderr
+
+	if err := ocDebugCmd.Run(); err != nil {
+		return "", fmt.Errorf("failed to run command on node %s: %w, stderr: %s", nodeName, err, stderr.String())
+	}
+
+	return stdout.String(), nil
+}
+
+// getNodeMachineNetworkIPs retrieves all node's internal IPs (IPv4 and IPv6).
+func (ci *baremetalInfra) getNodeMachineNetworkIPs(nodeName string) (ipv4, ipv6 string, err error) {
+	node, err := ci.kubeClient.CoreV1().Nodes().Get(context.Background(), nodeName, metav1.GetOptions{})
+	if err != nil {
+		return "", "", fmt.Errorf("failed to get node %s: %w", nodeName, err)
+	}
+
+	// Get node's internal IPs
+	for _, addr := range node.Status.Addresses {
+		if addr.Type == corev1.NodeInternalIP {
+			ip := net.ParseIP(addr.Address)
+			if ip == nil {
+				continue
+			}
+			if ip.To4() != nil {
+				ipv4 = addr.Address
+			} else {
+				ipv6 = addr.Address
+			}
+		}
+	}
+
+	if ipv4 == "" && ipv6 == "" {
+		return "", "", fmt.Errorf("no internal IP found for node %s", nodeName)
+	}
+
+	return ipv4, ipv6, nil
+}
+
+// attachVXLANNetworkToNode attaches a VXLAN overlay network to a k8s node.
+func (ci *baremetalInfra) attachVXLANNetworkToNode(network api.Network, nodeName string) (api.NetworkInterface, error) {
+	ci.networkState.Lock()
+	netInfo, ok := ci.networkState.overlayNetworks[network.Name()]
+	ci.networkState.Unlock()
+
+	if !ok {
+		return api.NetworkInterface{}, fmt.Errorf("overlay network info not found for network %s", network.Name())
+	}
+
+	vni := netInfo.vni
+	vxlanName := vxlanInterfaceName(vni)
+
+	// Get all node IPs
+	nodeIPv4, nodeIPv6, err := ci.getNodeMachineNetworkIPs(nodeName)
+	if err != nil {
+		return api.NetworkInterface{}, fmt.Errorf("failed to get node IPs for %s: %w", nodeName, err)
+	}
+
+	// Determine which IP family to use for VXLAN tunnel
+	// Prefer IPv4 if both hypervisor and node have it, otherwise use IPv6
+	var nodeIP, hypervisorVTEP string
+	if ci.machineNetworkGwInfo.IPv4 != "" && nodeIPv4 != "" {
+		// Use IPv4 for VXLAN tunnel
+		nodeIP = nodeIPv4
+		hypervisorVTEP = ci.machineNetworkGwInfo.IPv4
+	} else if ci.machineNetworkGwInfo.IPv6 != "" && nodeIPv6 != "" {
+		// Use IPv6 for VXLAN tunnel
+		nodeIP = nodeIPv6
+		hypervisorVTEP = ci.machineNetworkGwInfo.IPv6
+	} else {
+		return api.NetworkInterface{}, fmt.Errorf("no matching IP family between hypervisor and node %s (hypervisor: v4=%s v6=%s, node: v4=%s v6=%s)",
+			nodeName, ci.machineNetworkGwInfo.IPv4, ci.machineNetworkGwInfo.IPv6, nodeIPv4, nodeIPv6)
+	}
+
+	ipv4Subnet, ipv6Subnet, err := network.IPv4IPv6Subnets()
+	if err != nil {
+		return api.NetworkInterface{}, fmt.Errorf("failed to get network subnets for %s: %w", network.Name(), err)
+	}
+
+	netInterface := api.NetworkInterface{InfName: vxlanName}
+
+	// Allocate IPv4 if present
+	if ipv4Subnet != "" {
+		_, ipv4Net, err := net.ParseCIDR(ipv4Subnet)
+		if err != nil {
+			return api.NetworkInterface{}, fmt.Errorf("failed to parse IPv4 subnet %s: %w", ipv4Subnet, err)
+		}
+		gatewayIP := incrementIP(ipv4Net.IP).String()
+
+		allocatedIP, err := allocator.AllocateIPWithReserved(ci.kubeClient, ci.testContext, ipv4Subnet, []string{gatewayIP})
+		if err != nil {
+			return api.NetworkInterface{}, fmt.Errorf("failed to allocate IPv4 from %s: %w", ipv4Subnet, err)
+		}
+		netInterface.IPv4 = allocatedIP
+		netInterface.IPv4Gateway = gatewayIP
+		netInterface.IPv4Prefix = ipv4Subnet
+	}
+
+	// Allocate IPv6 if present
+	if ipv6Subnet != "" {
+		_, ipv6Net, err := net.ParseCIDR(ipv6Subnet)
+		if err != nil {
+			return api.NetworkInterface{}, fmt.Errorf("failed to parse IPv6 subnet %s: %w", ipv6Subnet, err)
+		}
+		gatewayIP := incrementIP(ipv6Net.IP).String()
+
+		allocatedIP, err := allocator.AllocateIPv6WithReserved(ci.kubeClient, ci.testContext, ipv6Subnet, []string{gatewayIP})
+		if err != nil {
+			return api.NetworkInterface{}, fmt.Errorf("failed to allocate IPv6 from %s: %w", ipv6Subnet, err)
+		}
+		netInterface.IPv6 = allocatedIP
+		netInterface.IPv6Gateway = gatewayIP
+		netInterface.IPv6Prefix = ipv6Subnet
+	}
+
+	// Add FDB entry on hypervisor
+	if _, err := ci.runner.Run("bridge", "fdb", "append", "00:00:00:00:00:00", "dev", vxlanName, "dst", nodeIP); err != nil {
+		return api.NetworkInterface{}, fmt.Errorf("failed to add FDB entry on hypervisor for node %s: %w", nodeName, err)
+	}
+
+	// Create VXLAN on node
+	createVxlanCmd := []string{"ip", "link", "add", vxlanName, "type", "vxlan",
+		"id", fmt.Sprintf("%d", vni),
+		"local", nodeIP,
+		"dstport", "5789",
+		"nolearning"}
+	if _, err := ci.execNodeCommand(nodeName, createVxlanCmd); err != nil {
+		ci.runner.Run("bridge", "fdb", "del", "00:00:00:00:00:00", "dev", vxlanName, "dst", nodeIP)
+		return api.NetworkInterface{}, fmt.Errorf("failed to create VXLAN interface on node %s: %w", nodeName, err)
+	}
+
+	// Add FDB entry on node
+	addFdbCmd := []string{"bridge", "fdb", "append", "00:00:00:00:00:00", "dev", vxlanName, "dst", hypervisorVTEP}
+	if _, err := ci.execNodeCommand(nodeName, addFdbCmd); err != nil {
+		ci.execNodeCommand(nodeName, []string{"ip", "link", "delete", vxlanName})
+		ci.runner.Run("bridge", "fdb", "del", "00:00:00:00:00:00", "dev", vxlanName, "dst", nodeIP)
+		return api.NetworkInterface{}, fmt.Errorf("failed to add FDB entry on node %s: %w", nodeName, err)
+	}
+
+	// Bring up VXLAN on node
+	bringUpCmd := []string{"ip", "link", "set", vxlanName, "up"}
+	if _, err := ci.execNodeCommand(nodeName, bringUpCmd); err != nil {
+		ci.execNodeCommand(nodeName, []string{"ip", "link", "delete", vxlanName})
+		ci.runner.Run("bridge", "fdb", "del", "00:00:00:00:00:00", "dev", vxlanName, "dst", nodeIP)
+		return api.NetworkInterface{}, fmt.Errorf("failed to bring up VXLAN on node %s: %w", nodeName, err)
+	}
+
+	// Get MAC address from the VXLAN interface on node
+	getMacCmd := []string{"cat", fmt.Sprintf("/sys/class/net/%s/address", vxlanName)}
+	macAddr, err := ci.execNodeCommand(nodeName, getMacCmd)
+	if err != nil {
+		ci.execNodeCommand(nodeName, []string{"ip", "link", "delete", vxlanName})
+		ci.runner.Run("bridge", "fdb", "del", "00:00:00:00:00:00", "dev", vxlanName, "dst", nodeIP)
+		return api.NetworkInterface{}, fmt.Errorf("failed to get MAC address for %s on node %s: %w", vxlanName, nodeName, err)
+	}
+	netInterface.MAC = strings.TrimSpace(macAddr)
+
+	// Configure IPv4 on node
+	if netInterface.IPv4 != "" {
+		_, ipv4Net, _ := net.ParseCIDR(ipv4Subnet)
+		prefixLen := maskBits(ipv4Net.Mask)
+		ipWithPrefix := fmt.Sprintf("%s/%d", netInterface.IPv4, prefixLen)
+		addIPCmd := []string{"ip", "addr", "add", ipWithPrefix, "dev", vxlanName}
+		if _, err := ci.execNodeCommand(nodeName, addIPCmd); err != nil {
+			ci.execNodeCommand(nodeName, []string{"ip", "link", "delete", vxlanName})
+			ci.runner.Run("bridge", "fdb", "del", "00:00:00:00:00:00", "dev", vxlanName, "dst", nodeIP)
+			return api.NetworkInterface{}, fmt.Errorf("failed to configure IPv4 on node %s: %w", nodeName, err)
+		}
+	}
+
+	// Configure IPv6 on node
+	if netInterface.IPv6 != "" {
+		_, ipv6Net, _ := net.ParseCIDR(ipv6Subnet)
+		prefixLen := maskBits(ipv6Net.Mask)
+		ipWithPrefix := fmt.Sprintf("%s/%d", netInterface.IPv6, prefixLen)
+		addIPCmd := []string{"ip", "addr", "add", ipWithPrefix, "dev", vxlanName}
+		if _, err := ci.execNodeCommand(nodeName, addIPCmd); err != nil {
+			ci.execNodeCommand(nodeName, []string{"ip", "link", "delete", vxlanName})
+			ci.runner.Run("bridge", "fdb", "del", "00:00:00:00:00:00", "dev", vxlanName, "dst", nodeIP)
+			return api.NetworkInterface{}, fmt.Errorf("failed to configure IPv6 on node %s: %w", nodeName, err)
+		}
+	}
+
+	// Store interface info
+	ci.networkState.Lock()
+	if ci.networkState.containerNetworkInterfaces[nodeName] == nil {
+		ci.networkState.containerNetworkInterfaces[nodeName] = make(map[string]api.NetworkInterface)
+	}
+	ci.networkState.containerNetworkInterfaces[nodeName][network.Name()] = netInterface
+	ci.networkState.Unlock()
+
+	// Add cleanup
+	ci.testContext.AddCleanUpFn(func() error {
+		ci.execNodeCommand(nodeName, []string{"ip", "link", "delete", vxlanName})
+		ci.runner.Run("bridge", "fdb", "del", "00:00:00:00:00:00", "dev", vxlanName, "dst", nodeIP)
+		ci.networkState.Lock()
+		if ci.networkState.containerNetworkInterfaces[nodeName] != nil {
+			delete(ci.networkState.containerNetworkInterfaces[nodeName], network.Name())
+			if len(ci.networkState.containerNetworkInterfaces[nodeName]) == 0 {
+				delete(ci.networkState.containerNetworkInterfaces, nodeName)
+			}
+		}
+		ci.networkState.Unlock()
+		return nil
+	})
+
+	framework.Logf("attached VXLAN network %s to node %s (vxlan: %s, MAC: %s, VTEP: %s<->%s, IPv4: %s, IPv6: %s)",
+		network.Name(), nodeName, vxlanName, netInterface.MAC, hypervisorVTEP, nodeIP, netInterface.IPv4, netInterface.IPv6)
+
+	return netInterface, nil
+}
+
+// detachVXLANNetworkFromNode detaches a VXLAN overlay network from a k8s node.
+func (ci *baremetalInfra) detachVXLANNetworkFromNode(networkName, nodeName string) error {
+	ci.networkState.Lock()
+	netInfo, ok := ci.networkState.overlayNetworks[networkName]
+	ci.networkState.Unlock()
+
+	if !ok {
+		return fmt.Errorf("overlay network info not found for network %s", networkName)
+	}
+
+	vni := netInfo.vni
+	vxlanName := vxlanInterfaceName(vni)
+
+	// Get node IPs to determine which was used for VXLAN tunnel
+	nodeIPv4, nodeIPv6, err := ci.getNodeMachineNetworkIPs(nodeName)
+	if err != nil {
+		framework.Logf("Warning: failed to get node IPs for %s: %v", nodeName, err)
+	}
+
+	// Determine which IP was used (same logic as attachment: prefer IPv4)
+	var nodeIP string
+	if ci.machineNetworkGwInfo.IPv4 != "" && nodeIPv4 != "" {
+		nodeIP = nodeIPv4
+	} else if ci.machineNetworkGwInfo.IPv6 != "" && nodeIPv6 != "" {
+		nodeIP = nodeIPv6
+	}
+
+	// Delete VXLAN on node
+	if _, err := ci.execNodeCommand(nodeName, []string{"ip", "link", "delete", vxlanName}); err != nil {
+		framework.Logf("Warning: failed to delete VXLAN on node %s: %v", nodeName, err)
+	}
+
+	// Delete FDB entry on hypervisor
+	if nodeIP != "" {
+		if _, err := ci.runner.Run("bridge", "fdb", "del", "00:00:00:00:00:00", "dev", vxlanName, "dst", nodeIP); err != nil {
+			framework.Logf("Warning: failed to delete FDB entry on hypervisor: %v", err)
+		}
+	}
+
+	// Clean up stored interface info
+	ci.networkState.Lock()
+	if ci.networkState.containerNetworkInterfaces[nodeName] != nil {
+		delete(ci.networkState.containerNetworkInterfaces[nodeName], networkName)
+		if len(ci.networkState.containerNetworkInterfaces[nodeName]) == 0 {
+			delete(ci.networkState.containerNetworkInterfaces, nodeName)
+		}
+	}
+	ci.networkState.Unlock()
+
+	framework.Logf("detached VXLAN network %s from node %s", networkName, nodeName)
 	return nil
 }

--- a/openshift/test/infraprovider/baremetal.go
+++ b/openshift/test/infraprovider/baremetal.go
@@ -2,6 +2,8 @@ package infraprovider
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"net"
@@ -9,15 +11,19 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"sync"
 
 	configv1 "github.com/openshift/api/config/v1"
 	configclient "github.com/openshift/client-go/config/clientset/versioned"
+	allocator "github.com/ovn-kubernetes/ovn-kubernetes/openshift/test/allocator"
+	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/allocators"
 	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/infraprovider/api"
 	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/infraprovider/engine/container"
 	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/infraprovider/engine/container/network"
 	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/infraprovider/engine/runner"
 	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/infraprovider/engine/testcontext"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/kubernetes/test/e2e/framework"
 )
@@ -48,11 +54,35 @@ const (
 	ipvlanPrimaryNetIPv6Gateway = "fd2e:6f44:5dd8:c957::1"
 )
 
+const (
+	// VNI valid range is 1-16777215 (24-bit)
+	vniMax          = 16777215
+	infraNetworkKey = "ocp-infra-network"
+)
+
+// overlayNetworkInfo holds VNI and network object for a VXLAN overlay network
+type overlayNetworkInfo struct {
+	vni     int
+	network api.Network
+}
+
+// networkState contains state shared across baremetalInfra clones created by GetExternalContainerContextProvider.
+// All map access must be protected by the mutex.
+type networkState struct {
+	sync.Mutex                                                            // protects overlayNetworks and containerNetworkInterfaces
+	overlayNetworks            map[string]*overlayNetworkInfo             // maps network name to VNI and network object for VXLAN overlay networks
+	containerNetworkInterfaces map[string]map[string]api.NetworkInterface // containerName -> networkName -> interface info
+}
+
 type baremetalInfra struct {
+	kubeClient                        kubernetes.Interface
+	testContext                       *testcontext.TestContext
 	engine                            *container.Engine
+	runner                            api.Runner            // SSH runner for executing commands on hypervisor
 	machineNetwork                    api.Network           // contains subnet details about cluster machine network
 	machineNetworkGwInfo              *api.NetworkInterface // contains interface info about hypervisor node machine network interface
 	primaryNetworkBackendForContainer api.Network           // ipvlan network which is a container network backend for cluster machine network
+	networkState                      *networkState         // shared state across clones
 }
 
 func initializeClusterInfra(config *rest.Config) (*baremetalInfra, error) {
@@ -64,6 +94,10 @@ func initializeClusterInfra(config *rest.Config) (*baremetalInfra, error) {
 	}
 	if sshRunner == nil {
 		return nil, nil
+	}
+	kubeClient, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve kubernetes client: %w", err)
 	}
 	configClient, err := configclient.NewForConfig(config)
 	if err != nil {
@@ -78,13 +112,20 @@ func initializeClusterInfra(config *rest.Config) (*baremetalInfra, error) {
 	if infra.Spec.PlatformSpec.Type != configv1.BareMetalPlatformType {
 		return nil, nil
 	}
-	ci := &baremetalInfra{}
+	ci := &baremetalInfra{
+		kubeClient: kubeClient,
+		networkState: &networkState{
+			overlayNetworks:            make(map[string]*overlayNetworkInfo),
+			containerNetworkInterfaces: make(map[string]map[string]api.NetworkInterface),
+		},
+	}
 	// Verify SSH connectivity works
 	if _, err := sshRunner.Run("echo", "connection test"); err != nil {
 		return nil, fmt.Errorf("failed to check frr container status, connectivity check failed with hypervisor: %w", err)
 	}
 	// Initialize podman container engine
 	ci.engine = container.NewEngine("podman", sshRunner)
+	ci.runner = sshRunner
 	// just mimic machine network with ContainerEngineNetwork to make it
 	// compatibile with api.Network API.
 	machineNetwork := &network.ContainerEngineNetwork{NetName: primaryNetworkName}
@@ -104,6 +145,7 @@ func initializeClusterInfra(config *rest.Config) (*baremetalInfra, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve hypervisor node interface for machine network: %w", err)
 	}
+
 	// Create ipvlan network based on IP family configuration
 	if ci.machineNetworkGwInfo.IPv4 != "" && ci.machineNetworkGwInfo.IPv6 != "" {
 		// Dual-stack configuration
@@ -194,6 +236,16 @@ func (ci *baremetalInfra) getNetwork(name string) (api.Network, error) {
 	if name == primaryNetworkName {
 		return ci.machineNetwork, nil
 	}
+
+	// check VXLAN overlay networks
+	ci.networkState.Lock()
+	netInfo, ok := ci.networkState.overlayNetworks[name]
+	ci.networkState.Unlock()
+
+	if ok {
+		return netInfo.network, nil
+	}
+
 	// fall back into container networks.
 	return ci.engine.GetNetwork(name)
 }
@@ -237,21 +289,75 @@ func (ci *baremetalInfra) GetExternalContainerNetworkInterface(container api.Ext
 			nil
 	} else if network.Name() == primaryNetworkName {
 		network = ci.primaryNetworkBackendForContainer
+		return ci.engine.GetNetworkInterface(container.Name, network.Name())
 	}
+
+	// Check if this is a VXLAN overlay network
+	ci.networkState.Lock()
+	netInterface, ok := ci.networkState.containerNetworkInterfaces[container.Name][network.Name()]
+	ci.networkState.Unlock()
+
+	if ok {
+		return netInterface, nil
+	}
+
+	// Fall back to engine for other networks
 	return ci.engine.GetNetworkInterface(container.Name, network.Name())
 }
 
 func (ci *baremetalInfra) GetExternalContainerContextProvider(context *testcontext.TestContext) api.ExternalContainerContextProvider {
 	ciWithTestContext := &baremetalInfra{
-		engine: ci.engine.WithTestContext(context)}
+		testContext:                       context,
+		engine:                            ci.engine.WithTestContext(context),
+		kubeClient:                        ci.kubeClient,
+		runner:                            ci.runner,
+		machineNetwork:                    ci.machineNetwork,
+		machineNetworkGwInfo:              ci.machineNetworkGwInfo,
+		primaryNetworkBackendForContainer: ci.primaryNetworkBackendForContainer,
+		networkState:                      ci.networkState, // Share the same state and mutex across clones
+	}
 	return ciWithTestContext
 }
 
 func (ci *baremetalInfra) CreateExternalContainer(container api.ExternalContainer) (api.ExternalContainer, error) {
-	if container.Network.Name() == primaryNetworkName {
+	var networkToBeAttached api.Network
+	var requestedIPv4, requestedIPv6 string
+	if container.Network != nil && container.Network.Name() == primaryNetworkName {
 		container.Network = ci.primaryNetworkBackendForContainer
+	} else if container.Network != nil {
+		networkToBeAttached = container.Network
+		// Save requested IPs before clearing (to use in network attachment)
+		requestedIPv4 = container.IPv4
+		requestedIPv6 = container.IPv6
+		// for other networks, let's create container first and plumb the network afterwards.
+		container.Network = nil
+		// Clear IPs temporarily (podman rejects --ip with --network none)
+		container.IPv4 = ""
+		container.IPv6 = ""
 	}
-	return ci.engine.CreateExternalContainer(container)
+	container, err := ci.engine.CreateExternalContainer(container)
+	if err != nil {
+		return container, err
+	}
+	if networkToBeAttached == nil {
+		return container, nil
+	}
+
+	// Attach VXLAN overlay network to container with requested IPs
+	netInterface, err := ci.attachVXLANNetwork(networkToBeAttached, container.Name, requestedIPv4, requestedIPv6)
+	if err != nil {
+		if delErr := ci.engine.DeleteExternalContainer(container); delErr != nil {
+			return container, fmt.Errorf("failed to attach network %s to container %s: %w (rollback delete failed: %v)",
+				networkToBeAttached.Name(), container.Name, err, delErr)
+		}
+		return container, fmt.Errorf("failed to attach network %s to container %s: %w", networkToBeAttached.Name(), container.Name, err)
+	}
+
+	// Assign allocated IPs to container
+	container.IPv4 = netInterface.IPv4
+	container.IPv6 = netInterface.IPv6
+
+	return container, nil
 }
 
 func (ci *baremetalInfra) DeleteExternalContainer(container api.ExternalContainer) error {
@@ -259,24 +365,199 @@ func (ci *baremetalInfra) DeleteExternalContainer(container api.ExternalContaine
 }
 
 func (ci *baremetalInfra) CreateNetwork(name string, subnets ...string) (api.Network, error) {
-	return ci.engine.CreateNetwork(name, subnets...)
+	vni, err := allocators.AllocateInt(ci.kubeClient, infraNetworkKey, vniMax)
+	if err != nil {
+		return nil, fmt.Errorf("VNI allocation failed for network %s: %w", name, err)
+	}
+	ci.testContext.AddCleanUpFn(func() error {
+		return allocators.DeallocateInt(ci.kubeClient, infraNetworkKey, vni)
+	})
+
+	// Parse subnets - expecting at most 2 subnets (IPv4 and/or IPv6)
+	var ipv4Subnet, ipv6Subnet string
+	var ipv4Gateway, ipv6Gateway string
+
+	for _, subnet := range subnets {
+		ip, ipNet, err := net.ParseCIDR(subnet)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse subnet %s: %w", subnet, err)
+		}
+		// Calculate gateway IP (first IP in subnet)
+		gateway := incrementIP(ipNet.IP)
+		prefixLen := maskBits(ipNet.Mask)
+		gatewayWithPrefix := fmt.Sprintf("%s/%d", gateway.String(), prefixLen)
+
+		if ip.To4() != nil {
+			ipv4Subnet = subnet
+			ipv4Gateway = gatewayWithPrefix
+		} else {
+			ipv6Subnet = subnet
+			ipv6Gateway = gatewayWithPrefix
+		}
+	}
+
+	// Get bridge and VXLAN interface names from VNI
+	bridgeName := vxlanBridgeName(vni)
+	vxlanName := vxlanInterfaceName(vni)
+
+	// Create Linux bridge
+	if _, err := ci.runner.Run("ip", "link", "add", bridgeName, "type", "bridge"); err != nil {
+		return nil, fmt.Errorf("failed to create bridge %s: %w", bridgeName, err)
+	}
+
+	// Configure IPv4 gateway on bridge if present
+	if ipv4Subnet != "" {
+		if _, err := ci.runner.Run("ip", "addr", "add", ipv4Gateway, "dev", bridgeName); err != nil {
+			ci.runner.Run("ip", "link", "delete", bridgeName)
+			return nil, fmt.Errorf("failed to add IPv4 address to bridge %s: %w", bridgeName, err)
+		}
+	}
+
+	// Configure IPv6 gateway on bridge if present
+	if ipv6Subnet != "" {
+		if _, err := ci.runner.Run("ip", "-6", "addr", "add", ipv6Gateway, "dev", bridgeName); err != nil {
+			ci.runner.Run("ip", "link", "delete", bridgeName)
+			return nil, fmt.Errorf("failed to add IPv6 address to bridge %s: %w", bridgeName, err)
+		}
+	}
+
+	// Bring up bridge
+	if _, err := ci.runner.Run("ip", "link", "set", bridgeName, "up"); err != nil {
+		ci.runner.Run("ip", "link", "delete", bridgeName)
+		return nil, fmt.Errorf("failed to bring up bridge %s: %w", bridgeName, err)
+	}
+
+	// Determine local VTEP IP (prefer IPv4 if available, otherwise IPv6)
+	localVTEP := ci.machineNetworkGwInfo.IPv4
+	if localVTEP == "" {
+		localVTEP = ci.machineNetworkGwInfo.IPv6
+	}
+
+	// Create VXLAN interface
+	vxlanArgs := []string{
+		"link", "add", vxlanName, "type", "vxlan",
+		"id", fmt.Sprintf("%d", vni),
+		"local", localVTEP,
+		"dstport", "5789",
+		"nolearning",
+		"dev", ci.machineNetworkGwInfo.InfName,
+	}
+	if _, err := ci.runner.Run("ip", vxlanArgs...); err != nil {
+		ci.runner.Run("ip", "link", "delete", bridgeName)
+		return nil, fmt.Errorf("failed to create VXLAN interface %s: %w", vxlanName, err)
+	}
+
+	// Attach VXLAN interface to bridge
+	if _, err := ci.runner.Run("ip", "link", "set", vxlanName, "master", bridgeName); err != nil {
+		ci.runner.Run("ip", "link", "delete", vxlanName)
+		ci.runner.Run("ip", "link", "delete", bridgeName)
+		return nil, fmt.Errorf("failed to attach VXLAN %s to bridge %s: %w", vxlanName, bridgeName, err)
+	}
+
+	// Bring up VXLAN interface
+	if _, err := ci.runner.Run("ip", "link", "set", vxlanName, "up"); err != nil {
+		ci.runner.Run("ip", "link", "delete", vxlanName)
+		ci.runner.Run("ip", "link", "delete", bridgeName)
+		return nil, fmt.Errorf("failed to bring up VXLAN interface %s: %w", vxlanName, err)
+	}
+
+	// Build network object
+	vxlanNetwork := &network.ContainerEngineNetwork{NetName: name}
+	var configs []network.ContainerEngineNetworkConfig
+
+	if ipv4Subnet != "" {
+		// Extract gateway IP without prefix for the config
+		gateway := strings.Split(ipv4Gateway, "/")[0]
+		configs = append(configs, network.ContainerEngineNetworkConfig{
+			Subnet:  ipv4Subnet,
+			Gateway: gateway,
+		})
+	}
+
+	if ipv6Subnet != "" {
+		// Extract gateway IP without prefix for the config
+		gateway := strings.Split(ipv6Gateway, "/")[0]
+		configs = append(configs, network.ContainerEngineNetworkConfig{
+			Subnet:  ipv6Subnet,
+			Gateway: gateway,
+		})
+	}
+
+	vxlanNetwork.Configs = configs
+
+	// Store VNI and network object for later use in network attachment and retrieval
+	ci.networkState.Lock()
+	ci.networkState.overlayNetworks[name] = &overlayNetworkInfo{
+		vni:     vni,
+		network: vxlanNetwork,
+	}
+	ci.networkState.Unlock()
+
+	// Add cleanup for VXLAN and bridge
+	ci.testContext.AddCleanUpFn(func() error {
+		ci.runner.Run("ip", "link", "delete", vxlanName)
+		ci.runner.Run("ip", "link", "delete", bridgeName)
+		ci.networkState.Lock()
+		delete(ci.networkState.overlayNetworks, name)
+		ci.networkState.Unlock()
+		return nil
+	})
+
+	framework.Logf("created VXLAN overlay network %s (bridge: %s, vxlan: %s, vni: %d, local: %s, dev: %s)",
+		name, bridgeName, vxlanName, vni, localVTEP, ci.machineNetworkGwInfo.InfName)
+
+	return vxlanNetwork, nil
 }
 
 func (ci *baremetalInfra) AttachNetwork(network api.Network, container string) (api.NetworkInterface, error) {
 	if network.Name() == primaryNetworkName {
 		return ci.engine.AttachNetwork(ci.primaryNetworkBackendForContainer, container)
 	}
-	return ci.engine.AttachNetwork(network, container)
+	// Attach VXLAN overlay network using veth pairs
+	return ci.attachVXLANNetwork(network, container, "", "")
 }
 
 func (ci *baremetalInfra) DetachNetwork(network api.Network, container string) error {
 	if network.Name() == primaryNetworkName {
 		return ci.engine.DetachNetwork(ci.primaryNetworkBackendForContainer, container)
 	}
-	return ci.engine.DetachNetwork(network, container)
+	// Detach VXLAN overlay network
+	return ci.detachVXLANNetwork(network.Name(), container)
 }
 
 func (ci *baremetalInfra) DeleteNetwork(network api.Network) error {
+	// Check if this is a VXLAN overlay network
+	ci.networkState.Lock()
+	netInfo, ok := ci.networkState.overlayNetworks[network.Name()]
+	ci.networkState.Unlock()
+
+	if ok {
+		// Delete VXLAN overlay infrastructure
+		vxlanName := vxlanInterfaceName(netInfo.vni)
+		bridgeName := vxlanBridgeName(netInfo.vni)
+
+		// Delete VXLAN interface
+		if _, err := ci.runner.Run("ip", "link", "delete", vxlanName); err != nil {
+			framework.Logf("Warning: failed to delete VXLAN interface %s: %v", vxlanName, err)
+		}
+
+		// Delete bridge
+		if _, err := ci.runner.Run("ip", "link", "delete", bridgeName); err != nil {
+			framework.Logf("Warning: failed to delete bridge %s: %v", bridgeName, err)
+		}
+
+		// Remove from overlay networks map
+		ci.networkState.Lock()
+		delete(ci.networkState.overlayNetworks, network.Name())
+		ci.networkState.Unlock()
+
+		framework.Logf("deleted VXLAN overlay network %s (bridge: %s, vxlan: %s, vni: %d)",
+			network.Name(), bridgeName, vxlanName, netInfo.vni)
+
+		return nil
+	}
+
+	// Not a VXLAN overlay network, delegate to engine
 	return ci.engine.DeleteNetwork(network)
 }
 
@@ -459,4 +740,269 @@ func ipInCIDR(ipStr, cidrStr string) (bool, error) {
 		return false, err
 	}
 	return ipNet.Contains(ip), nil
+}
+
+// incrementIP returns the next IP address by incrementing the given IP by 1.
+// This is used to calculate the gateway IP as the first usable IP in a subnet.
+func incrementIP(ip net.IP) net.IP {
+	result := make(net.IP, len(ip))
+	copy(result, ip)
+	for i := len(result) - 1; i >= 0; i-- {
+		result[i]++
+		if result[i] != 0 {
+			break
+		}
+	}
+	return result
+}
+
+// maskBits returns the number of bits set in the network mask.
+func maskBits(mask net.IPMask) int {
+	ones, _ := mask.Size()
+	return ones
+}
+
+// vxlanBridgeName returns the bridge name for a given VNI.
+// Bridge names are limited to 15 characters by Linux kernel.
+func vxlanBridgeName(vni int) string {
+	return fmt.Sprintf("tbr%d", vni)
+}
+
+// vxlanInterfaceName returns the VXLAN interface name for a given VNI.
+// Interface names are limited to 15 characters by Linux kernel.
+func vxlanInterfaceName(vni int) string {
+	return fmt.Sprintf("tvx%d", vni)
+}
+
+// vethHostName returns the host-side veth name (vh<hash><vni>, max 14 chars).
+func vethHostName(containerName string, vni int) string {
+	hash := containerNameHash(containerName)
+	return fmt.Sprintf("vh%s%d", hash, vni)
+}
+
+// vethContainerName returns the container-side veth name (vc<hash><vni>, max 14 chars).
+func vethContainerName(containerName string, vni int) string {
+	hash := containerNameHash(containerName)
+	return fmt.Sprintf("vc%s%d", hash, vni)
+}
+
+// containerNameHash returns a 4-character hex hash of the container name.
+func containerNameHash(name string) string {
+	h := sha256.Sum256([]byte(name))
+	return hex.EncodeToString(h[:])[:4]
+}
+
+// attachVXLANNetwork attaches a VXLAN overlay network to a container using veth pairs.
+// It uses requestedIPv4/requestedIPv6 if provided, otherwise allocates IPs from the network subnets.
+// Creates veth pair, attaches host-side to bridge, moves container-side into container namespace, and configures routing.
+func (ci *baremetalInfra) attachVXLANNetwork(network api.Network, containerName, requestedIPv4, requestedIPv6 string) (api.NetworkInterface, error) {
+	// Get VNI for this network
+	ci.networkState.Lock()
+	netInfo, ok := ci.networkState.overlayNetworks[network.Name()]
+	ci.networkState.Unlock()
+
+	if !ok {
+		return api.NetworkInterface{}, fmt.Errorf("overlay network info not found for network %s", network.Name())
+	}
+
+	vni := netInfo.vni
+
+	// Get bridge name for this VNI
+	bridgeName := vxlanBridgeName(vni)
+
+	// Get veth interface names
+	vethHost := vethHostName(containerName, vni)
+	vethCont := vethContainerName(containerName, vni)
+
+	// Get container PID
+	pidStr, err := ci.runner.Run("podman", "inspect", "-f", "{{.State.Pid}}", containerName)
+	if err != nil {
+		return api.NetworkInterface{}, fmt.Errorf("failed to get container PID for %s: %w", containerName, err)
+	}
+	containerPID := strings.TrimSpace(pidStr)
+
+	// Get network subnets
+	ipv4Subnet, ipv6Subnet, err := network.IPv4IPv6Subnets()
+	if err != nil {
+		return api.NetworkInterface{}, fmt.Errorf("failed to get network subnets for %s: %w", network.Name(), err)
+	}
+
+	netInterface := api.NetworkInterface{InfName: vethCont}
+
+	// Allocate or use requested IPv4 address if IPv4 subnet exists
+	if ipv4Subnet != "" {
+		// Get gateway IP
+		_, ipv4Net, err := net.ParseCIDR(ipv4Subnet)
+		if err != nil {
+			return api.NetworkInterface{}, fmt.Errorf("failed to parse IPv4 subnet %s: %w", ipv4Subnet, err)
+		}
+		gatewayIP := incrementIP(ipv4Net.IP).String()
+
+		if requestedIPv4 != "" {
+			// Validate and reserve the requested IP through the allocator
+			allocatedIP, err := allocator.AllocateSpecificIP(ci.kubeClient, ci.testContext, ipv4Subnet, requestedIPv4)
+			if err != nil {
+				return api.NetworkInterface{}, fmt.Errorf("failed to allocate requested IPv4 %s from %s: %w", requestedIPv4, ipv4Subnet, err)
+			}
+			netInterface.IPv4 = allocatedIP
+		} else {
+			// Allocate IP from subnet excluding gateway
+			allocatedIP, err := allocator.AllocateIPWithReserved(ci.kubeClient, ci.testContext, ipv4Subnet, []string{gatewayIP})
+			if err != nil {
+				return api.NetworkInterface{}, fmt.Errorf("failed to allocate IPv4 from %s: %w", ipv4Subnet, err)
+			}
+			netInterface.IPv4 = allocatedIP
+		}
+		netInterface.IPv4Gateway = gatewayIP
+		netInterface.IPv4Prefix = ipv4Subnet
+	}
+
+	// Allocate or use requested IPv6 address if IPv6 subnet exists
+	if ipv6Subnet != "" {
+		// Get gateway IP
+		_, ipv6Net, err := net.ParseCIDR(ipv6Subnet)
+		if err != nil {
+			return api.NetworkInterface{}, fmt.Errorf("failed to parse IPv6 subnet %s: %w", ipv6Subnet, err)
+		}
+		gatewayIP := incrementIP(ipv6Net.IP).String()
+
+		if requestedIPv6 != "" {
+			// Validate and reserve the requested IP through the allocator
+			allocatedIP, err := allocator.AllocateSpecificIPv6(ci.kubeClient, ci.testContext, ipv6Subnet, requestedIPv6)
+			if err != nil {
+				return api.NetworkInterface{}, fmt.Errorf("failed to allocate requested IPv6 %s from %s: %w", requestedIPv6, ipv6Subnet, err)
+			}
+			netInterface.IPv6 = allocatedIP
+		} else {
+			// Allocate IP from subnet excluding gateway
+			allocatedIP, err := allocator.AllocateIPv6WithReserved(ci.kubeClient, ci.testContext, ipv6Subnet, []string{gatewayIP})
+			if err != nil {
+				return api.NetworkInterface{}, fmt.Errorf("failed to allocate IPv6 from %s: %w", ipv6Subnet, err)
+			}
+			netInterface.IPv6 = allocatedIP
+		}
+		netInterface.IPv6Gateway = gatewayIP
+		netInterface.IPv6Prefix = ipv6Subnet
+	}
+
+	// Create veth pair
+	if _, err := ci.runner.Run("ip", "link", "add", vethHost, "type", "veth", "peer", "name", vethCont); err != nil {
+		return api.NetworkInterface{}, fmt.Errorf("failed to create veth pair %s/%s: %w", vethHost, vethCont, err)
+	}
+
+	// Attach host-side veth to bridge
+	if _, err := ci.runner.Run("ip", "link", "set", vethHost, "master", bridgeName); err != nil {
+		ci.runner.Run("ip", "link", "delete", vethHost)
+		return api.NetworkInterface{}, fmt.Errorf("failed to attach %s to bridge %s: %w", vethHost, bridgeName, err)
+	}
+
+	// Bring up host-side veth
+	if _, err := ci.runner.Run("ip", "link", "set", vethHost, "up"); err != nil {
+		ci.runner.Run("ip", "link", "delete", vethHost)
+		return api.NetworkInterface{}, fmt.Errorf("failed to bring up %s: %w", vethHost, err)
+	}
+
+	// Move container-side veth into container namespace
+	if _, err := ci.runner.Run("ip", "link", "set", vethCont, "netns", containerPID); err != nil {
+		ci.runner.Run("ip", "link", "delete", vethHost)
+		return api.NetworkInterface{}, fmt.Errorf("failed to move %s to container namespace: %w", vethCont, err)
+	}
+
+	// Configure IPv4 address in container if allocated
+	if netInterface.IPv4 != "" {
+		_, ipv4Net, _ := net.ParseCIDR(ipv4Subnet)
+		prefixLen := maskBits(ipv4Net.Mask)
+		ipWithPrefix := fmt.Sprintf("%s/%d", netInterface.IPv4, prefixLen)
+		if _, err := ci.runner.Run("nsenter", "-t", containerPID, "-n", "ip", "addr", "add", ipWithPrefix, "dev", vethCont); err != nil {
+			ci.runner.Run("ip", "link", "delete", vethHost)
+			return api.NetworkInterface{}, fmt.Errorf("failed to configure IPv4 %s on %s: %w", ipWithPrefix, vethCont, err)
+		}
+	}
+
+	// Configure IPv6 address in container if allocated
+	if netInterface.IPv6 != "" {
+		_, ipv6Net, _ := net.ParseCIDR(ipv6Subnet)
+		prefixLen := maskBits(ipv6Net.Mask)
+		ipWithPrefix := fmt.Sprintf("%s/%d", netInterface.IPv6, prefixLen)
+		if _, err := ci.runner.Run("nsenter", "-t", containerPID, "-n", "ip", "addr", "add", ipWithPrefix, "dev", vethCont); err != nil {
+			ci.runner.Run("ip", "link", "delete", vethHost)
+			return api.NetworkInterface{}, fmt.Errorf("failed to configure IPv6 %s on %s: %w", ipWithPrefix, vethCont, err)
+		}
+	}
+
+	// Bring up container-side veth
+	if _, err := ci.runner.Run("nsenter", "-t", containerPID, "-n", "ip", "link", "set", vethCont, "up"); err != nil {
+		ci.runner.Run("ip", "link", "delete", vethHost)
+		return api.NetworkInterface{}, fmt.Errorf("failed to bring up %s in container: %w", vethCont, err)
+	}
+
+	// Get MAC address from the veth interface in container
+	macAddr, err := ci.runner.Run("podman", "exec", containerName, "cat", fmt.Sprintf("/sys/class/net/%s/address", vethCont))
+	if err != nil {
+		ci.runner.Run("ip", "link", "delete", vethHost)
+		return api.NetworkInterface{}, fmt.Errorf("failed to get MAC address for %s: %w", vethCont, err)
+	}
+	netInterface.MAC = strings.TrimSpace(macAddr)
+
+	// Store network interface info for GetExternalContainerNetworkInterface
+	ci.networkState.Lock()
+	if ci.networkState.containerNetworkInterfaces[containerName] == nil {
+		ci.networkState.containerNetworkInterfaces[containerName] = make(map[string]api.NetworkInterface)
+	}
+	ci.networkState.containerNetworkInterfaces[containerName][network.Name()] = netInterface
+	ci.networkState.Unlock()
+
+	// Add cleanup to delete veth pair
+	ci.testContext.AddCleanUpFn(func() error {
+		if _, err := ci.runner.Run("ip", "link", "delete", vethHost); err != nil {
+			framework.Logf("Warning: failed to delete veth %s: %v", vethHost, err)
+		}
+		// Clean up stored interface info
+		ci.networkState.Lock()
+		if ci.networkState.containerNetworkInterfaces[containerName] != nil {
+			delete(ci.networkState.containerNetworkInterfaces[containerName], network.Name())
+			if len(ci.networkState.containerNetworkInterfaces[containerName]) == 0 {
+				delete(ci.networkState.containerNetworkInterfaces, containerName)
+			}
+		}
+		ci.networkState.Unlock()
+		return nil
+	})
+
+	framework.Logf("attached VXLAN network %s to container %s (veth: %s/%s, MAC: %s, IPv4: %s, IPv6: %s)",
+		network.Name(), containerName, vethHost, vethCont, netInterface.MAC, netInterface.IPv4, netInterface.IPv6)
+
+	return netInterface, nil
+}
+
+// detachVXLANNetwork detaches a VXLAN overlay network from a container by deleting the veth pair.
+func (ci *baremetalInfra) detachVXLANNetwork(networkName, containerName string) error {
+	ci.networkState.Lock()
+	netInfo, ok := ci.networkState.overlayNetworks[networkName]
+	ci.networkState.Unlock()
+
+	if !ok {
+		return fmt.Errorf("overlay network info not found for network %s", networkName)
+	}
+
+	vni := netInfo.vni
+
+	// Delete veth pair
+	vethHost := vethHostName(containerName, vni)
+	if _, err := ci.runner.Run("ip", "link", "delete", vethHost); err != nil {
+		framework.Logf("Warning: failed to delete veth %s: %v", vethHost, err)
+	}
+
+	// Clean up stored interface info
+	ci.networkState.Lock()
+	if ci.networkState.containerNetworkInterfaces[containerName] != nil {
+		delete(ci.networkState.containerNetworkInterfaces[containerName], networkName)
+		if len(ci.networkState.containerNetworkInterfaces[containerName]) == 0 {
+			delete(ci.networkState.containerNetworkInterfaces, containerName)
+		}
+	}
+	ci.networkState.Unlock()
+
+	framework.Logf("detached VXLAN network %s from container %s", networkName, containerName)
+	return nil
 }

--- a/openshift/test/infraprovider/openshift.go
+++ b/openshift/test/infraprovider/openshift.go
@@ -294,18 +294,18 @@ func (o *contextOpenshift) CreateNetwork(name string, subnets ...string) (api.Ne
 	return o.externalContainerContextProvider.CreateNetwork(name, subnets...)
 }
 
-func (o *contextOpenshift) AttachNetwork(network api.Network, container string) (api.NetworkInterface, error) {
+func (o *contextOpenshift) AttachNetwork(network api.Network, instance string) (api.NetworkInterface, error) {
 	if o.externalContainerContextProvider == nil {
 		panic("not implemented")
 	}
-	return o.externalContainerContextProvider.AttachNetwork(network, container)
+	return o.externalContainerContextProvider.AttachNetwork(network, instance)
 }
 
-func (o *contextOpenshift) DetachNetwork(network api.Network, container string) error {
+func (o *contextOpenshift) DetachNetwork(network api.Network, instance string) error {
 	if o.externalContainerContextProvider == nil {
 		panic("not implemented")
 	}
-	return o.externalContainerContextProvider.DetachNetwork(network, container)
+	return o.externalContainerContextProvider.DetachNetwork(network, instance)
 }
 
 func (o *contextOpenshift) DeleteNetwork(network api.Network) error {

--- a/test/e2e/allocators/bgp.go
+++ b/test/e2e/allocators/bgp.go
@@ -73,13 +73,13 @@ func AllocateBGP(f *framework.Framework, cleanup infraapi.ContextCleanUp) (BGPAl
 		(vniMax-vniOffset+1)/2,
 	)
 
-	n, err := AllocateInt(f, bgpKey, maxUsable)
+	n, err := AllocateInt(f.ClientSet, bgpKey, maxUsable)
 	if err != nil {
 		return BGPAllocation{}, err
 	}
 
 	cleanup.AddCleanUpFn(func() error {
-		return DeallocateInt(f, bgpKey, n)
+		return DeallocateInt(f.ClientSet, bgpKey, n)
 	})
 
 	bgpV4Idx := bgpPeer4.nthFree(n)

--- a/test/e2e/allocators/int.go
+++ b/test/e2e/allocators/int.go
@@ -15,6 +15,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/kubernetes/test/e2e/framework"
 )
@@ -38,7 +39,7 @@ const (
 // need to avoid collisions when running in parallel. This is useful when the
 // orchestration handling the parallelization does not provide any context where
 // this allocation can happen. De-allocate with DeallocateInt.
-func AllocateInt(f *framework.Framework, key string, max int) (int, error) {
+func AllocateInt(kubeClient kubernetes.Interface, key string, max int) (int, error) {
 	if max < 1 {
 		return 0, fmt.Errorf("max must be at least 1, got %d", max)
 	}
@@ -46,13 +47,13 @@ func AllocateInt(f *framework.Framework, key string, max int) (int, error) {
 	ctx := context.Background()
 
 	ns := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: configMapNamespace}}
-	_, err := f.ClientSet.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
+	_, err := kubeClient.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
 	if err != nil && !apierrors.IsAlreadyExists(err) {
 		return 0, fmt.Errorf("failed to ensure allocator namespace: %w", err)
 	}
 
 	cm := &v1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: key}}
-	client := f.ClientSet.CoreV1().ConfigMaps(configMapNamespace)
+	client := kubeClient.CoreV1().ConfigMaps(configMapNamespace)
 
 	_, err = client.Create(ctx, cm, metav1.CreateOptions{})
 	if err != nil && !apierrors.IsAlreadyExists(err) {
@@ -103,9 +104,9 @@ func AllocateInt(f *framework.Framework, key string, max int) (int, error) {
 }
 
 // DeallocateInt deallocates an integer previously allocated with AllocateInt.
-func DeallocateInt(f *framework.Framework, key string, index int) error {
+func DeallocateInt(kubeClient kubernetes.Interface, key string, index int) error {
 	ctx := context.Background()
-	client := f.ClientSet.CoreV1().ConfigMaps(configMapNamespace)
+	client := kubeClient.CoreV1().ConfigMaps(configMapNamespace)
 
 	return retry.RetryOnConflict(allocatorBackoff, func() error {
 		cm, err := client.Get(ctx, key, metav1.GetOptions{})

--- a/test/e2e/infraprovider/api/api.go
+++ b/test/e2e/infraprovider/api/api.go
@@ -277,7 +277,7 @@ func (ec ExternalContainer) IsValidPreCreateContainer() (bool, error) {
 	if ec.Image == "" {
 		errs = append(errs, errors.New("image is not set"))
 	}
-	if ec.Network.String() == "" {
+	if ec.Network != nil && ec.Network.String() == "" {
 		errs = append(errs, errors.New("network is not set"))
 	}
 	if len(errs) == 0 {
@@ -287,6 +287,9 @@ func (ec ExternalContainer) IsValidPreCreateContainer() (bool, error) {
 }
 
 func (ec ExternalContainer) IsValidPostCreate() (bool, error) {
+	if ec.Network == nil {
+		return true, nil
+	}
 	var errs []error
 	if ec.IPv4 == "" && ec.IPv6 == "" {
 		errs = append(errs, errors.New("provider did not populate an IPv4 or an IPv6 address"))

--- a/test/e2e/infraprovider/engine/container/ops/ops.go
+++ b/test/e2e/infraprovider/engine/container/ops/ops.go
@@ -420,7 +420,11 @@ func (o *ContainerOps) CreateExternalContainer(container api.ExternalContainer) 
 	if exists {
 		return container, fmt.Errorf("external container %s already exists", container.Name)
 	}
-	cmd := []string{"run", "-itd", "--privileged", "--name", container.Name, "--network", container.Network.Name(), "--hostname", container.Name}
+	network := "none"
+	if container.Network != nil {
+		network = container.Network.Name()
+	}
+	cmd := []string{"run", "-itd", "--privileged", "--name", container.Name, "--network", network, "--hostname", container.Name}
 	if container.IPv4 != "" {
 		cmd = append(cmd, "--ip", container.IPv4)
 	}
@@ -463,7 +467,6 @@ func (o *ContainerOps) CreateExternalContainer(container api.ExternalContainer) 
 			return container, fmt.Errorf("failed to get network interface information: %w", err)
 		}
 	}
-
 	if valid, err := container.IsValidPostCreate(); !valid {
 		return container, err
 	}


### PR DESCRIPTION
This PR implements network infrastructure for the OTE baremetal infra provider to enable external containers and cluster nodes to communicate with each other over both primary and overlay networks