### PR TITLE
OCPBUGS-86330: Revert upstream PR #6264 - Remove ns addrset

### DIFF
--- a/go-controller/.golangci.yml
+++ b/go-controller/.golangci.yml
@@ -37,12 +37,6 @@ linters:
           alias: nodeutil
         - pkg: github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/types
           alias: nodetypes
-        - pkg: github.com/ovn-kubernetes/ovn-kubernetes/go-controller/hybrid-overlay/pkg/types
-          alias: hotypes
-        - pkg: github.com/containernetworking/cni/pkg/types
-          alias: cnitypes
-        - pkg: github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/cni/types
-          alias: ovncnitypes
       no-unaliased: true
     revive:
       rules:

--- a/go-controller/cmd/ovn-k8s-cni-overlay/ovn-k8s-cni-overlay.go
+++ b/go-controller/cmd/ovn-k8s-cni-overlay/ovn-k8s-cni-overlay.go
@@ -7,7 +7,7 @@ import (
 	"os"
 
 	"github.com/containernetworking/cni/pkg/skel"
-	cnitypes "github.com/containernetworking/cni/pkg/types"
+	"github.com/containernetworking/cni/pkg/types"
 	"github.com/containernetworking/cni/pkg/version"
 	bv "github.com/containernetworking/plugins/pkg/utils/buildversion"
 	"github.com/urfave/cli/v2"
@@ -38,9 +38,9 @@ func main() {
 
 	if err := c.Run(os.Args); err != nil {
 		// Print the error to stdout in conformance with the CNI spec
-		e, ok := err.(*cnitypes.Error)
+		e, ok := err.(*types.Error)
 		if !ok {
-			e = &cnitypes.Error{Code: 100, Msg: err.Error()}
+			e = &types.Error{Code: 100, Msg: err.Error()}
 		}
 		e.Print()
 	}

--- a/go-controller/hybrid-overlay/pkg/controller/ho_node_linux.go
+++ b/go-controller/hybrid-overlay/pkg/controller/ho_node_linux.go
@@ -12,9 +12,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
 
-	hotypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/hybrid-overlay/pkg/types"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/hybrid-overlay/pkg/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/kube"
-	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
 )
 
@@ -72,7 +71,7 @@ func (n *HONodeController) AddNode(node *corev1.Node) error {
 
 	klog.Infof("Set hybrid overlay DRMAC annotation: %s", drMAC)
 	if err := n.kube.SetAnnotationsOnNode(node.Name, map[string]interface{}{
-		hotypes.HybridOverlayDRMAC: drMAC,
+		types.HybridOverlayDRMAC: drMAC,
 	}); err != nil {
 		return fmt.Errorf("failed to set DRMAC annotation on node: %v", err)
 	}
@@ -90,11 +89,11 @@ func (n *HONodeController) AddPod(pod *corev1.Pod) error {
 		return nil
 	}
 
-	_, ok := pod.Annotations[types.OvnPodAnnotationName]
+	_, ok := pod.Annotations[util.OvnPodAnnotationName]
 	if ok {
 		klog.Infof("Remove the ovnkube pod annotation from pod %s", pod.Name)
 		podToUpdate := pod.DeepCopy()
-		delete(podToUpdate.Annotations, types.OvnPodAnnotationName)
+		delete(podToUpdate.Annotations, util.OvnPodAnnotationName)
 		if err := n.kube.PatchPodStatusAnnotations(pod, podToUpdate); err != nil {
 			return fmt.Errorf("failed to remove ovnkube pod annotation from pod %s: %v", pod.Name, err)
 		}

--- a/go-controller/hybrid-overlay/pkg/controller/ho_node_linux_test.go
+++ b/go-controller/hybrid-overlay/pkg/controller/ho_node_linux_test.go
@@ -15,12 +15,11 @@ import (
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
 
-	hotypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/hybrid-overlay/pkg/types"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/hybrid-overlay/pkg/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/informer"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/kube"
 	ovntest "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing"
-	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util/mocks"
 
@@ -110,7 +109,7 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 			addHybridOverlayAddNodeMocks(nlMock)
 
 			testNode := createNode(hoNodeName, "linux", hoNodeIP, map[string]string{
-				hotypes.HybridOverlayNodeSubnet: hoNodeSubnet,
+				types.HybridOverlayNodeSubnet: hoNodeSubnet,
 			})
 
 			fakeClient := fake.NewSimpleClientset(&corev1.NodeList{
@@ -141,7 +140,7 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 					return nil, err
 				}
 				return updatedNode.Annotations, nil
-			}, 2).Should(HaveKeyWithValue(hotypes.HybridOverlayDRMAC, hoNodeDRMAC))
+			}, 2).Should(HaveKeyWithValue(types.HybridOverlayDRMAC, hoNodeDRMAC))
 			return nil
 		}
 		appHONRun(app)
@@ -157,7 +156,7 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 			testPod1 := createPod("default", "testpod-1", hoNodeName, "2.2.3.5/24", "aa:bb:cc:dd:ee:ff")
 			testPod2 := createPod("default", "testpod-2", "other-worker", "2.2.3.6/24", "ab:bb:cc:dd:ee:ff")
 			testNode := createNode(hoNodeName, "linux", hoNodeIP, map[string]string{
-				hotypes.HybridOverlayNodeSubnet: hoNodeSubnet,
+				types.HybridOverlayNodeSubnet: hoNodeSubnet,
 			})
 
 			fakeClient := fake.NewSimpleClientset(&corev1.PodList{
@@ -197,7 +196,7 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 					return nil, err
 				}
 				return updatedPod.Annotations, nil
-			}, 2).ShouldNot(HaveKey(types.OvnPodAnnotationName))
+			}, 2).ShouldNot(HaveKey(util.OvnPodAnnotationName))
 
 			Eventually(func() (map[string]string, error) {
 				updatedPod, err := fakeClient.CoreV1().Pods("default").Get(context.TODO(), "testpod-2", metav1.GetOptions{})
@@ -205,7 +204,7 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 					return nil, err
 				}
 				return updatedPod.Annotations, nil
-			}, 2).Should(HaveKey(types.OvnPodAnnotationName))
+			}, 2).Should(HaveKey(util.OvnPodAnnotationName))
 			return nil
 		}
 		appHONRun(app)

--- a/go-controller/hybrid-overlay/pkg/controller/ho_node_windows.go
+++ b/go-controller/hybrid-overlay/pkg/controller/ho_node_windows.go
@@ -17,7 +17,7 @@ import (
 	listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/klog/v2"
 
-	hotypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/hybrid-overlay/pkg/types"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/hybrid-overlay/pkg/types"
 	houtil "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/hybrid-overlay/pkg/util"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/kube"
@@ -98,7 +98,7 @@ func ensureBaseNetwork() error {
 
 	const (
 		baseNetworkName = "BaseOVNKubernetesHybridOverlayNetwork"
-		fakeSubnetVNI   = hotypes.HybridOverlayVNI + 1
+		fakeSubnetVNI   = types.HybridOverlayVNI + 1
 	)
 
 	// Unused subnet and gateway IP required to create the base overlay network.
@@ -202,10 +202,10 @@ func (n *NodeController) AddNode(node *corev1.Node) error {
 	}
 
 	klog.Infof("Adding a remote subnet route for CIDR '%s' (node: '%s', remote node address: %s, distributed router MAC: %s, VNI: %v).",
-		cidr.String(), node.Name, nodeIP.String(), drMAC.String(), hotypes.HybridOverlayVNI)
+		cidr.String(), node.Name, nodeIP.String(), drMAC.String(), types.HybridOverlayVNI)
 	networkPolicySettings := hcn.RemoteSubnetRoutePolicySetting{
 		// VXLAN virtual network Identifier. Is expected to be 4097 or higher on Windows
-		IsolationId: hotypes.HybridOverlayVNI,
+		IsolationId: types.HybridOverlayVNI,
 		// Distributed router/gateway MAC address
 		DistributedRouterMacAddress: drMAC.String(),
 		// Host IP address of the node
@@ -286,7 +286,7 @@ func (n *NodeController) initSelf(node *corev1.Node, nodeSubnet *net.IPNet) erro
 			Subnets: []SubnetInfo{{
 				AddressPrefix:  nodeSubnet,
 				GatewayAddress: gatewayAddress,
-				VSID:           hotypes.HybridOverlayVNI,
+				VSID:           types.HybridOverlayVNI,
 			}},
 			VXLANPort: uint16(config.HybridOverlay.VXLANPort),
 		}
@@ -339,7 +339,7 @@ func (n *NodeController) initSelf(node *corev1.Node, nodeSubnet *net.IPNet) erro
 				return fmt.Errorf("error creating the network: no DRMAC address")
 			}
 			if err := n.kube.SetAnnotationsOnNode(node.Name, map[string]interface{}{
-				hotypes.HybridOverlayDRMAC: policySettings.Address,
+				types.HybridOverlayDRMAC: policySettings.Address,
 			}); err != nil {
 				klog.Errorf("Failed to set DRMAC annotation on node: %v", err)
 			}

--- a/go-controller/hybrid-overlay/pkg/controller/ovn_node_linux_test.go
+++ b/go-controller/hybrid-overlay/pkg/controller/ovn_node_linux_test.go
@@ -158,7 +158,7 @@ func createPod(namespace, name, node, podIP, podMAC string) *corev1.Pod {
 	if podIP != "" || podMAC != "" {
 		ipn := ovntest.MustParseIPNet(podIP)
 		gatewayIP := iputils.NextIP(ipn.IP)
-		annotations[types.OvnPodAnnotationName] = `{"default": {"ip_address":"` + podIP + `", "mac_address":"` + podMAC + `", "gateway_ip": "` + gatewayIP.String() + `"}}`
+		annotations[util.OvnPodAnnotationName] = `{"default": {"ip_address":"` + podIP + `", "mac_address":"` + podMAC + `", "gateway_ip": "` + gatewayIP.String() + `"}}`
 	}
 
 	return &corev1.Pod{

--- a/go-controller/hybrid-overlay/pkg/util/util.go
+++ b/go-controller/hybrid-overlay/pkg/util/util.go
@@ -10,21 +10,21 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	utilnet "k8s.io/utils/net"
 
-	hotypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/hybrid-overlay/pkg/types"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/hybrid-overlay/pkg/types"
 )
 
 // ParseHybridOverlayHostSubnet returns the parsed hybrid overlay hostsubnet if
 // the annotations included a valid one, or nil if they did not include one. If
 // one was included, but it is invalid, an error is returned.
 func ParseHybridOverlayHostSubnet(node *corev1.Node) (*net.IPNet, error) {
-	sub, ok := node.Annotations[hotypes.HybridOverlayNodeSubnet]
+	sub, ok := node.Annotations[types.HybridOverlayNodeSubnet]
 	if !ok {
 		return nil, nil
 	}
 	_, subnet, err := net.ParseCIDR(sub)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing node %s annotation %s value %q: %v",
-			node.Name, hotypes.HybridOverlayNodeSubnet, sub, err)
+			node.Name, types.HybridOverlayNodeSubnet, sub, err)
 	}
 	return subnet, nil
 }

--- a/go-controller/pkg/clustermanager/endpointslicemirror/endpointslice_mirror_controller_test.go
+++ b/go-controller/pkg/clustermanager/endpointslicemirror/endpointslice_mirror_controller_test.go
@@ -84,7 +84,14 @@ var _ = ginkgo.Describe("Cluster manager EndpointSlice mirror controller", func(
 			app.Action = func(*cli.Context) error {
 				namespaceT := *util.NewNamespace("testns")
 				namespaceT.Labels[types.RequiredUDNNamespaceLabel] = ""
-				pod := *testing.NewPodWithPrimaryNADIP(namespaceT.Name, "test-pod", "", "10.244.2.3", "l3-network", "10.132.2.4")
+				pod := corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "test-pod",
+						Namespace:   namespaceT.Name,
+						Annotations: map[string]string{util.OvnPodAnnotationName: `{"default":{"mac_address":"0a:58:0a:f4:02:03","ip_address":"10.244.2.3/24","role":"infrastructure-locked"},"testns/l3-network":{"mac_address":"0a:58:0a:84:02:04","ip_address":"10.132.2.4/24","role":"primary"}}`},
+					},
+					Status: corev1.PodStatus{Phase: corev1.PodRunning},
+				}
 
 				defaultEndpointSlice := discovery.EndpointSlice{
 					ObjectMeta: metav1.ObjectMeta{
@@ -184,7 +191,15 @@ var _ = ginkgo.Describe("Cluster manager EndpointSlice mirror controller", func(
 		ginkgo.It("should not create mirrored EndpointSlices in namespaces that are not using user defined networks as primary", func() {
 			app.Action = func(*cli.Context) error {
 				namespaceT := *util.NewNamespace("testns")
-				pod := *testing.NewPodWithPrimaryNADIP(namespaceT.Name, "test-pod", "", "10.244.2.3", "l3-network", "10.132.2.4")
+
+				pod := corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "test-pod",
+						Namespace:   namespaceT.Name,
+						Annotations: map[string]string{util.OvnPodAnnotationName: `{"default":{"mac_address":"0a:58:0a:f4:02:03","ip_address":"10.244.2.3/24","role":"primary"},"testns/l3-network":{"mac_address":"0a:58:0a:84:02:04","ip_address":"10.132.2.4/24","role":"secondary}}`},
+					},
+					Status: corev1.PodStatus{Phase: corev1.PodRunning},
+				}
 
 				defaultEndpointSlice := discovery.EndpointSlice{
 					ObjectMeta: metav1.ObjectMeta{
@@ -270,7 +285,14 @@ var _ = ginkgo.Describe("Cluster manager EndpointSlice mirror controller", func(
 				namespaceT := *util.NewNamespace("testns")
 				namespaceT.Labels[types.RequiredUDNNamespaceLabel] = ""
 
-				pod := *testing.NewPodWithPrimaryNADIP(namespaceT.Name, "test-pod", "", "10.244.2.3", "l3-network", "10.132.2.4")
+				pod := corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "test-pod",
+						Namespace:   namespaceT.Name,
+						Annotations: map[string]string{util.OvnPodAnnotationName: `{"default":{"mac_address":"0a:58:0a:f4:02:03","ip_address":"10.244.2.3/24","role":"infrastructure-locked"},"testns/l3-network":{"mac_address":"0a:58:0a:84:02:04","ip_address":"10.132.2.4/24","role":"primary"}}`},
+					},
+					Status: corev1.PodStatus{Phase: corev1.PodRunning},
+				}
 
 				defaultEndpointSlice := discovery.EndpointSlice{
 					ObjectMeta: metav1.ObjectMeta{
@@ -353,8 +375,14 @@ var _ = ginkgo.Describe("Cluster manager EndpointSlice mirror controller", func(
 				gomega.Expect(mirroredEndpointSlices[0].Endpoints[0].Addresses).To(gomega.BeEquivalentTo([]string{"10.132.2.4"}))
 
 				ginkgo.By("when the EndpointSlice changes the mirrored one gets updated")
-				newPod := *testing.NewPodWithPrimaryNADIP(namespaceT.Name, "test-pod-new", "", "10.244.2.4", "l3-network", "10.132.2.5")
-
+				newPod := corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "test-pod-new",
+						Namespace:   namespaceT.Name,
+						Annotations: map[string]string{util.OvnPodAnnotationName: `{"default":{"mac_address":"0a:58:0a:f4:02:04","ip_address":"10.244.2.4/24","primary":false},"testns/l3-network":{"mac_address":"0a:58:0a:84:02:05","ip_address":"10.132.2.5/24","primary":true}}`},
+					},
+					Status: corev1.PodStatus{Phase: corev1.PodRunning},
+				}
 				_, err = fakeClient.KubeClient.CoreV1().Pods(newPod.Namespace).Create(context.TODO(), &newPod, metav1.CreateOptions{})
 				gomega.Expect(err).ToNot(gomega.HaveOccurred())
 				gomega.Eventually(func() error {
@@ -426,7 +454,14 @@ var _ = ginkgo.Describe("Cluster manager EndpointSlice mirror controller", func(
 				namespaceT := *util.NewNamespace("testns")
 				namespaceT.Labels[types.RequiredUDNNamespaceLabel] = ""
 
-				pod := *testing.NewPodWithPrimaryNADIP(namespaceT.Name, "test-pod", "", "10.244.2.3", "l3-network", "10.132.2.4")
+				pod := corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "test-pod",
+						Namespace:   namespaceT.Name,
+						Annotations: map[string]string{util.OvnPodAnnotationName: `{"default":{"mac_address":"0a:58:0a:f4:02:03","ip_address":"10.244.2.3/24","role":"infrastructure-locked"},"testns/l3-network":{"mac_address":"0a:58:0a:84:02:04","ip_address":"10.132.2.4/24","role":"primary"}}`},
+					},
+					Status: corev1.PodStatus{Phase: corev1.PodRunning},
+				}
 				longName := strings.Repeat("a", 253)
 
 				defaultEndpointSlice := discovery.EndpointSlice{

--- a/go-controller/pkg/clustermanager/status_manager/status_manager_test.go
+++ b/go-controller/pkg/clustermanager/status_manager/status_manager_test.go
@@ -23,7 +23,7 @@ import (
 	anpfake "sigs.k8s.io/network-policy-api/pkg/client/clientset/versioned/fake"
 
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/clustermanager/status_manager/zone_tracker"
-	ovncnitypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/cni/types"
+	ovnkcnitypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/cni/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
 	adminpolicybasedrouteapi "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/adminpolicybasedroute/v1"
 	egressfirewallapi "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/egressfirewall/v1"
@@ -93,7 +93,7 @@ func newEgressFirewall(namespace string) *egressfirewallapi.EgressFirewall {
 }
 
 func newPrimaryL3NetInfo(name string) util.NetInfo {
-	netInfo, err := util.NewNetInfo(&ovncnitypes.NetConf{
+	netInfo, err := util.NewNetInfo(&ovnkcnitypes.NetConf{
 		NetConf:  cnitypes.NetConf{Name: name},
 		Topology: types.Layer3Topology,
 		Subnets:  "10.1.130.0/16/24",

--- a/go-controller/pkg/clustermanager/user_defined_network_cluster_manager.go
+++ b/go-controller/pkg/clustermanager/user_defined_network_cluster_manager.go
@@ -4,7 +4,7 @@
 package clustermanager
 
 import (
-	cnitypes "github.com/containernetworking/cni/pkg/types"
+	"github.com/containernetworking/cni/pkg/types"
 
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
@@ -178,7 +178,7 @@ func (sncm *userDefinedNetworkClusterManager) CleanupStaleNetworks(validNetworks
 // clean up stale node annotations for the given network. It skips the full
 // init() path and only sets up what Cleanup() requires: a nodeAllocator.
 func (sncm *userDefinedNetworkClusterManager) newDummyNetworkController(topoType, netName string) (networkmanager.NetworkController, error) {
-	netInfo, _ := util.NewNetInfo(&ovncnitypes.NetConf{NetConf: cnitypes.NetConf{Name: netName}, Topology: topoType})
+	netInfo, _ := util.NewNetInfo(&ovncnitypes.NetConf{NetConf: types.NetConf{Name: netName}, Topology: topoType})
 	nc := newNetworkClusterController(
 		netInfo,
 		sncm.ovnClient,

--- a/go-controller/pkg/clustermanager/user_defined_network_unit_test.go
+++ b/go-controller/pkg/clustermanager/user_defined_network_unit_test.go
@@ -9,7 +9,7 @@ import (
 	"net"
 	"sync"
 
-	cnitypes "github.com/containernetworking/cni/pkg/types"
+	"github.com/containernetworking/cni/pkg/types"
 	ipamclaimsapi "github.com/k8snetworkplumbingwg/ipamclaims/pkg/crd/ipamclaims/v1alpha1"
 	fakeipamclaimclient "github.com/k8snetworkplumbingwg/ipamclaims/pkg/crd/ipamclaims/v1alpha1/apis/clientset/versioned/fake"
 	fakenadclient "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/clientset/versioned/fake"
@@ -87,7 +87,7 @@ var _ = ginkgo.Describe("Cluster Controller Manager", func() {
 
 				sncm, err := newUserDefinedNetworkClusterManager(fakeClient, f, networkmanager.Default().Interface(), recorder, nodeController)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				netInfo, err := util.NewNetInfo(&ovncnitypes.NetConf{NetConf: cnitypes.NetConf{Name: "blue"}, Topology: ovntypes.Layer3Topology, Subnets: "192.168.0.0/16/24"})
+				netInfo, err := util.NewNetInfo(&ovncnitypes.NetConf{NetConf: types.NetConf{Name: "blue"}, Topology: ovntypes.Layer3Topology, Subnets: "192.168.0.0/16/24"})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				nc, err := sncm.NewNetworkController(netInfo)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -134,7 +134,7 @@ var _ = ginkgo.Describe("Cluster Controller Manager", func() {
 				var err error
 				netInfo, err = util.NewNetInfo(
 					&ovncnitypes.NetConf{
-						NetConf:  cnitypes.NetConf{Name: "blue"},
+						NetConf:  types.NetConf{Name: "blue"},
 						Topology: ovntypes.Layer2Topology,
 						Subnets:  subnets,
 					})
@@ -277,14 +277,14 @@ var _ = ginkgo.Describe("Cluster Controller Manager", func() {
 				},
 				ginkgo.Entry(
 					"does not manage localnet topologies on IC deployments for networks without subnets",
-					&ovncnitypes.NetConf{NetConf: cnitypes.NetConf{Name: "blue"}, Topology: ovntypes.LocalnetTopology},
+					&ovncnitypes.NetConf{NetConf: types.NetConf{Name: "blue"}, Topology: ovntypes.LocalnetTopology},
 					config.OVNKubernetesFeatureConfig{EnableInterconnect: true, EnableMultiNetwork: true},
 					networkmanager.ErrNetworkControllerTopologyNotManaged,
 				),
 				ginkgo.Entry(
 					"manages localnet topologies on IC deployments for networks with subnets",
 					&ovncnitypes.NetConf{
-						NetConf:  cnitypes.NetConf{Name: "blue"},
+						NetConf:  types.NetConf{Name: "blue"},
 						Topology: ovntypes.LocalnetTopology,
 						Subnets:  subnets,
 					},
@@ -293,14 +293,14 @@ var _ = ginkgo.Describe("Cluster Controller Manager", func() {
 				),
 				ginkgo.Entry(
 					"does not manage localnet topologies on non-IC deployments without subnets",
-					&ovncnitypes.NetConf{NetConf: cnitypes.NetConf{Name: "blue"}, Topology: ovntypes.LocalnetTopology},
+					&ovncnitypes.NetConf{NetConf: types.NetConf{Name: "blue"}, Topology: ovntypes.LocalnetTopology},
 					config.OVNKubernetesFeatureConfig{EnableMultiNetwork: true},
 					networkmanager.ErrNetworkControllerTopologyNotManaged,
 				),
 				ginkgo.Entry(
 					"does not manage localnet topologies on non-IC deployments with subnets",
 					&ovncnitypes.NetConf{
-						NetConf:  cnitypes.NetConf{Name: "blue"},
+						NetConf:  types.NetConf{Name: "blue"},
 						Topology: ovntypes.LocalnetTopology,
 						Subnets:  subnets,
 					},
@@ -409,7 +409,7 @@ var _ = ginkgo.Describe("Cluster Controller Manager", func() {
 				// there could be a race in updating the node annotations with the fakeclient.
 				// fakeclient will not return an error in such cases to trigger retry by RetryOnConflict.
 				// So testing the cleanup one at a time.
-				netInfo, err := util.NewNetInfo(&ovncnitypes.NetConf{NetConf: cnitypes.NetConf{Name: "blue"}, Topology: ovntypes.Layer3Topology})
+				netInfo, err := util.NewNetInfo(&ovncnitypes.NetConf{NetConf: types.NetConf{Name: "blue"}, Topology: ovntypes.Layer3Topology})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				oc := newNetworkClusterController(
@@ -550,7 +550,7 @@ var _ = ginkgo.Describe("Cluster Controller Manager", func() {
 
 				netInfo, err = util.NewNetInfo(
 					&ovncnitypes.NetConf{
-						NetConf:            cnitypes.NetConf{Name: networkName},
+						NetConf:            types.NetConf{Name: networkName},
 						Topology:           ovntypes.Layer2Topology,
 						Subnets:            subnetCIDR,
 						AllowPersistentIPs: true,
@@ -815,7 +815,7 @@ var _ = ginkgo.Describe("Cluster Controller Manager", func() {
 						var err error
 						netInfo, err = util.NewNetInfo(
 							&ovncnitypes.NetConf{
-								NetConf:  cnitypes.NetConf{Name: networkName},
+								NetConf:  types.NetConf{Name: networkName},
 								Topology: ovntypes.Layer2Topology,
 								Subnets:  subnetCIDR,
 							})
@@ -894,7 +894,7 @@ var _ = ginkgo.Describe("Cluster Controller Manager", func() {
 					var err error
 					netInfo, err = util.NewNetInfo(
 						&ovncnitypes.NetConf{
-							NetConf:  cnitypes.NetConf{Name: "blue"},
+							NetConf:  types.NetConf{Name: "blue"},
 							Role:     ovntypes.NetworkRolePrimary,
 							Subnets:  subnets,
 							Topology: ovntypes.Layer2Topology,

--- a/go-controller/pkg/clustermanager/userdefinednetwork/controller_test.go
+++ b/go-controller/pkg/clustermanager/userdefinednetwork/controller_test.go
@@ -416,7 +416,7 @@ var _ = Describe("User Defined Network Controller", func() {
 				udn := testPrimaryUDN()
 				udn.SetDeletionTimestamp(&metav1.Time{Time: time.Now()})
 
-				testOVNPodAnnot := map[string]string{ovntypes.OvnPodAnnotationName: `{"default": {"role":"primary"}, "test/test": {"role": "secondary"}}`}
+				testOVNPodAnnot := map[string]string{util.OvnPodAnnotationName: `{"default": {"role":"primary"}, "test/test": {"role": "secondary"}}`}
 				pod1 := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-1", Namespace: udn.Namespace, Annotations: testOVNPodAnnot}}
 				pod2 := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-2", Namespace: udn.Namespace, Annotations: testOVNPodAnnot}}
 
@@ -1584,7 +1584,7 @@ var _ = Describe("User Defined Network Controller", func() {
 						pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
 							Name:        "pod-0",
 							Namespace:   nsName,
-							Annotations: map[string]string{ovntypes.OvnPodAnnotationName: `{"default": {"role":"primary"}, "` + nsName + `/` + cudnName + `": {"role": "secondary"}}`}},
+							Annotations: map[string]string{util.OvnPodAnnotationName: `{"default": {"role":"primary"}, "` + nsName + `/` + cudnName + `": {"role": "secondary"}}`}},
 						}
 						pod, err := cs.KubeClient.CoreV1().Pods(nsName).Create(context.Background(), pod, metav1.CreateOptions{})
 						Expect(err).NotTo(HaveOccurred())
@@ -1915,7 +1915,7 @@ var _ = Describe("User Defined Network Controller", func() {
 			pod := &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "pod1", Namespace: udn.Namespace,
-					Annotations: map[string]string{ovntypes.OvnPodAnnotationName: `{ 
+					Annotations: map[string]string{util.OvnPodAnnotationName: `{ 
                           "default": {"role":"primary", "mac_address":"0a:58:0a:f4:02:03"},
 						  "test/another-network": {"role": "secondary","mac_address":"0a:58:0a:f4:02:01"} 
                          }`,
@@ -1942,7 +1942,7 @@ var _ = Describe("User Defined Network Controller", func() {
 				for podName, ovnAnnotValue := range podOvnAnnotations {
 					objs = append(objs, &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
 						Name: podName, Namespace: udn.Namespace,
-						Annotations: map[string]string{ovntypes.OvnPodAnnotationName: ovnAnnotValue},
+						Annotations: map[string]string{util.OvnPodAnnotationName: ovnAnnotValue},
 					}})
 				}
 				objs = append(objs, udn, nad)

--- a/go-controller/pkg/clustermanager/userdefinednetwork/nad.go
+++ b/go-controller/pkg/clustermanager/userdefinednetwork/nad.go
@@ -13,7 +13,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/clustermanager/userdefinednetwork/template"
-	ovncnitypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/cni/types"
+	cnitypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/cni/types"
 	ovntypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
 )
@@ -45,7 +45,7 @@ func NetAttachDefNotInUse(nad *netv1.NetworkAttachmentDefinition, pods []*corev1
 // PrimaryNetAttachDefNotExist checks no OVN-K primary network NAD exist in the given slice.
 func PrimaryNetAttachDefNotExist(nads []*netv1.NetworkAttachmentDefinition) error {
 	for _, nad := range nads {
-		var netConf *ovncnitypes.NetConf
+		var netConf *cnitypes.NetConf
 		if err := json.Unmarshal([]byte(nad.Spec.Config), &netConf); err != nil {
 			return fmt.Errorf("failed to validate no primary network exist: unmarshal failed [%s/%s]: %w",
 				nad.Namespace, nad.Name, err)

--- a/go-controller/pkg/cni/cni_dpu_test.go
+++ b/go-controller/pkg/cni/cni_dpu_test.go
@@ -13,7 +13,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	ovncnitypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/cni/types"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/cni/types"
 	kubeMocks "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/kube/mocks"
 	v1mocks "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing/mocks/k8s.io/client-go/listers/core/v1"
 	ovntypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
@@ -43,7 +43,7 @@ var _ = Describe("cni_dpu tests", func() {
 			SandboxID:    "824bceff24af3",
 			Netns:        "ns",
 			IfName:       "eth0",
-			CNIConf: &ovncnitypes.NetConf{
+			CNIConf: &types.NetConf{
 				NetConf:  cnitypes.NetConf{},
 				DeviceID: "",
 			},

--- a/go-controller/pkg/cni/cni_test.go
+++ b/go-controller/pkg/cni/cni_test.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/ovn-kubernetes/libovsdb/client"
 
-	ovncnitypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/cni/types"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/cni/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/networkmanager"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing"
@@ -88,7 +88,7 @@ var _ = Describe("Network Segmentation", func() {
 			SandboxID:    "824bceff24af3",
 			Netns:        "ns",
 			IfName:       "eth0",
-			CNIConf: &ovncnitypes.NetConf{
+			CNIConf: &types.NetConf{
 				NetConf:  cnitypes.NetConf{},
 				DeviceID: "",
 			},

--- a/go-controller/pkg/cni/cnishim.go
+++ b/go-controller/pkg/cni/cnishim.go
@@ -22,7 +22,7 @@ import (
 	"time"
 
 	"github.com/containernetworking/cni/pkg/skel"
-	cnitypes "github.com/containernetworking/cni/pkg/types"
+	"github.com/containernetworking/cni/pkg/types"
 	current "github.com/containernetworking/cni/pkg/types/100"
 	nadapi "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	lumberjack "gopkg.in/natefinch/lumberjack.v2"
@@ -33,7 +33,7 @@ import (
 	"k8s.io/klog/v2"
 	kexec "k8s.io/utils/exec"
 
-	ovncnitypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/cni/types"
+	ovntypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/cni/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
 )
@@ -101,7 +101,7 @@ func (p *Plugin) doCNI(url string, req interface{}) ([]byte, error) {
 	}
 
 	if resp.StatusCode != 200 {
-		var cniErr cnitypes.Error
+		var cniErr types.Error
 		if err := json.Unmarshal(body, &cniErr); err == nil && cniErr.Code != 0 {
 			return nil, &cniErr
 		}
@@ -111,7 +111,7 @@ func (p *Plugin) doCNI(url string, req interface{}) ([]byte, error) {
 	return body, nil
 }
 
-func setupLogging(conf *ovncnitypes.NetConf) {
+func setupLogging(conf *ovntypes.NetConf) {
 	var err error
 	var level klog.Level
 
@@ -284,7 +284,7 @@ func (p *Plugin) CmdAdd(args *skel.CmdArgs) error {
 		}
 	}
 
-	return cnitypes.PrintResult(result, conf.CNIVersion)
+	return types.PrintResult(result, conf.CNIVersion)
 }
 
 // CmdDel is the callback for 'teardown' cni calls from skel
@@ -292,7 +292,7 @@ func (p *Plugin) CmdDel(args *skel.CmdArgs) error {
 	var err error
 	var body []byte
 	var pr *PodRequest
-	var conf *ovncnitypes.NetConf
+	var conf *ovntypes.NetConf
 
 	startTime := time.Now()
 	defer func() {

--- a/go-controller/pkg/cni/helper_linux_test.go
+++ b/go-controller/pkg/cni/helper_linux_test.go
@@ -27,7 +27,7 @@ import (
 	"sigs.k8s.io/knftables"
 
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/cni/mocks"
-	ovncnitypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/cni/types"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/cni/types"
 	ovntest "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing"
 	cni_type_mocks "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing/mocks/github.com/containernetworking/cni/pkg/types"
 	cni_ns_mocks "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing/mocks/github.com/containernetworking/plugins/pkg/ns"
@@ -1194,7 +1194,7 @@ func TestPodRequest_deletePodConntrack(t *testing.T) {
 		{
 			desc: "test code path when CNIConf.PrevResult == nil",
 			inpPodRequest: PodRequest{
-				CNIConf: &ovncnitypes.NetConf{
+				CNIConf: &types.NetConf{
 					NetConf: cnitypes.NetConf{
 						PrevResult: nil,
 					},
@@ -1204,7 +1204,7 @@ func TestPodRequest_deletePodConntrack(t *testing.T) {
 		{
 			desc: "test code path NewResultFromResult returns error",
 			inpPodRequest: PodRequest{
-				CNIConf: &ovncnitypes.NetConf{
+				CNIConf: &types.NetConf{
 					NetConf: cnitypes.NetConf{
 						PrevResult: mockTypeResult,
 					},
@@ -1217,7 +1217,7 @@ func TestPodRequest_deletePodConntrack(t *testing.T) {
 		{
 			desc: "test code path when ip.Interface != nil and path when Sandbox is empty value",
 			inpPodRequest: PodRequest{
-				CNIConf: &ovncnitypes.NetConf{
+				CNIConf: &types.NetConf{
 					NetConf: cnitypes.NetConf{
 						PrevResult: mockTypeResult,
 					},
@@ -1232,7 +1232,7 @@ func TestPodRequest_deletePodConntrack(t *testing.T) {
 		{
 			desc: "test code path when DeleteConntrack returns error",
 			inpPodRequest: PodRequest{
-				CNIConf: &ovncnitypes.NetConf{
+				CNIConf: &types.NetConf{
 					NetConf: cnitypes.NetConf{
 						PrevResult: mockTypeResult,
 					},

--- a/go-controller/pkg/cni/types.go
+++ b/go-controller/pkg/cni/types.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/ovn-kubernetes/libovsdb/client"
 
-	ovncnitypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/cni/types"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/cni/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/networkmanager"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
 )
@@ -163,7 +163,7 @@ type PodRequest struct {
 	// Interface name to be configured
 	IfName string
 	// CNI conf obtained from stdin conf
-	CNIConf *ovncnitypes.NetConf
+	CNIConf *types.NetConf
 	// Timestamp when the request was started
 	timestamp time.Time
 	// ctx is a context tracking this request's lifetime
@@ -173,7 +173,7 @@ type PodRequest struct {
 	// if CNIConf.DeviceID is present, then captures if the VF is of type VFIO or not
 	IsVFIO bool
 
-	// network name, for default network, this will be ovncnitypes.DefaultNetworkName
+	// network name, for default network, this will be types.DefaultNetworkName
 	netName string
 
 	// for ovs interfaces plumbed for UDNs, their iface-id's prefix is derived from the specific nadName;

--- a/go-controller/pkg/cni/types/types.go
+++ b/go-controller/pkg/cni/types/types.go
@@ -7,12 +7,12 @@ import (
 	"encoding/json"
 	"net"
 
-	cnitypes "github.com/containernetworking/cni/pkg/types"
+	"github.com/containernetworking/cni/pkg/types"
 )
 
 // NetConf is CNI NetConf with DeviceID
 type NetConf struct {
-	cnitypes.NetConf
+	types.NetConf
 	// Role is valid only on L3 / L2 topologies. Not on localnet.
 	// It allows for using this network to be either secondary or
 	// primary user defined network for the pod.
@@ -120,9 +120,9 @@ type NetConf struct {
 // v1.3.0 changed types.NetConf from a distinct type to a type alias for PluginConf,
 // causing PluginConf.MarshalJSON to be promoted into any struct embedding types.NetConf.
 func (n NetConf) MarshalJSON() ([]byte, error) {
-	// cniConf is a new type with the same layout as cnitypes.PluginConf but without
+	// cniConf is a new type with the same layout as types.PluginConf but without
 	// its MarshalJSON method, so embedding it uses standard struct marshaling.
-	type cniConf cnitypes.PluginConf
+	type cniConf types.PluginConf
 	type netConf struct {
 		cniConf
 		Role                  string      `json:"role,omitempty"`

--- a/go-controller/pkg/cni/utils_test.go
+++ b/go-controller/pkg/cni/utils_test.go
@@ -76,7 +76,7 @@ var _ = Describe("CNI Utils tests", func() {
 
 	Context("isOvnReady", func() {
 		It("Returns true if OVN pod network annotation exists", func() {
-			podAnnot := map[string]string{ovntypes.OvnPodAnnotationName: defaultPodAnnotation}
+			podAnnot := map[string]string{util.OvnPodAnnotationName: defaultPodAnnotation}
 			pod.Annotations = podAnnot
 			_, ready, _ := isOvnReady(pod, ovntypes.DefaultNetworkName)
 			Expect(ready).To(BeTrue())
@@ -93,7 +93,7 @@ var _ = Describe("CNI Utils tests", func() {
 	Context("isDPUReady", func() {
 		It("Returns true if dpu.connection-status is present and Status is Ready", func() {
 			podAnnot := map[string]string{
-				ovntypes.OvnPodAnnotationName: defaultPodAnnotation,
+				util.OvnPodAnnotationName:     defaultPodAnnotation,
 				util.DPUConnectionStatusAnnot: `{"Status":"Ready"}`}
 			pod.Annotations = podAnnot
 			_, ready, err := isDPUReady(nil, ovntypes.DefaultNetworkName)(pod, ovntypes.DefaultNetworkName)
@@ -103,7 +103,7 @@ var _ = Describe("CNI Utils tests", func() {
 
 		It("Returns false if dpu.connection-status is present and Status is not Ready", func() {
 			podAnnot := map[string]string{
-				ovntypes.OvnPodAnnotationName: defaultPodAnnotation,
+				util.OvnPodAnnotationName:     defaultPodAnnotation,
 				util.DPUConnectionStatusAnnot: `{"Status":"NotReady"}`}
 			pod.Annotations = podAnnot
 			_, ready, err := isDPUReady(nil, ovntypes.DefaultNetworkName)(pod, ovntypes.DefaultNetworkName)
@@ -113,7 +113,7 @@ var _ = Describe("CNI Utils tests", func() {
 
 		It("Returns false if dpu.connection-status Status is not present", func() {
 			podAnnot := map[string]string{
-				ovntypes.OvnPodAnnotationName: defaultPodAnnotation,
+				util.OvnPodAnnotationName:     defaultPodAnnotation,
 				util.DPUConnectionStatusAnnot: `{"Foo":"Bar"}`}
 			pod.Annotations = podAnnot
 			_, ready, err := isDPUReady(nil, ovntypes.DefaultNetworkName)(pod, ovntypes.DefaultNetworkName)
@@ -122,7 +122,7 @@ var _ = Describe("CNI Utils tests", func() {
 		})
 
 		It("Returns false if dpu.connection-status is not present", func() {
-			podAnnot := map[string]string{ovntypes.OvnPodAnnotationName: defaultPodAnnotation}
+			podAnnot := map[string]string{util.OvnPodAnnotationName: defaultPodAnnotation}
 			pod.Annotations = podAnnot
 			_, ready, err := isDPUReady(nil, ovntypes.DefaultNetworkName)(pod, ovntypes.DefaultNetworkName)
 			Expect(err).ToNot(HaveOccurred())
@@ -260,7 +260,7 @@ var _ = Describe("CNI Utils tests", func() {
 
 	Context("PodAnnotation2PodInfo", func() {
 		podAnnot := map[string]string{
-			ovntypes.OvnPodAnnotationName: `{
+			util.OvnPodAnnotationName: `{
 "default":{"ip_addresses":["192.168.2.3/24"],
 "mac_address":"0a:58:c0:a8:02:03",
 "gateway_ips":["192.168.2.1"],

--- a/go-controller/pkg/config/cni.go
+++ b/go-controller/pkg/config/cni.go
@@ -12,7 +12,7 @@ import (
 	"path/filepath"
 
 	"github.com/containernetworking/cni/libcni"
-	cnitypes "github.com/containernetworking/cni/pkg/types"
+	"github.com/containernetworking/cni/pkg/types"
 	"github.com/containernetworking/cni/pkg/version"
 
 	ovncnitypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/cni/types"
@@ -30,7 +30,7 @@ const CNISpecVersion = "1.1.0"
 // be written.
 func WriteCNIConfig() error {
 	netConf := &ovncnitypes.NetConf{
-		NetConf: cnitypes.NetConf{
+		NetConf: types.NetConf{
 			CNIVersion: CNISpecVersion,
 			Name:       "ovn-kubernetes",
 			Type:       CNI.Plugin,

--- a/go-controller/pkg/controllermanager/controller_manager.go
+++ b/go-controller/pkg/controllermanager/controller_manager.go
@@ -11,7 +11,7 @@ import (
 	"sync"
 	"time"
 
-	cnitypes "github.com/containernetworking/cni/pkg/types"
+	"github.com/containernetworking/cni/pkg/types"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -118,7 +118,7 @@ func (cm *ControllerManager) newDummyNetworkController(topoType, netName, role s
 	if err != nil {
 		return nil, fmt.Errorf("failed to create network controller info %w", err)
 	}
-	netInfo, _ := util.NewNetInfo(&ovncnitypes.NetConf{NetConf: cnitypes.NetConf{Name: netName}, Topology: topoType, Role: role})
+	netInfo, _ := util.NewNetInfo(&ovncnitypes.NetConf{NetConf: types.NetConf{Name: netName}, Topology: topoType, Role: role})
 	switch topoType {
 	case ovntypes.Layer3Topology:
 		return ovn.NewLayer3UserDefinedNetworkController(cnci, netInfo, cm.networkManager.Interface(), cm.routeImportManager,

--- a/go-controller/pkg/libovsdb/ops/db_object_types.go
+++ b/go-controller/pkg/libovsdb/ops/db_object_types.go
@@ -129,7 +129,6 @@ var AddressSetNetworkPolicy = newObjectIDsType(addressSet, NetworkPolicyOwnerTyp
 	IPFamilyKey,
 })
 
-// deprecated, should only be used for sync.
 var AddressSetNamespace = newObjectIDsType(addressSet, NamespaceOwnerType, []ExternalIDKey{
 	// namespace
 	ObjectNameKey,

--- a/go-controller/pkg/node/controllers/evpn/evpn_pod_controller.go
+++ b/go-controller/pkg/node/controllers/evpn/evpn_pod_controller.go
@@ -50,7 +50,7 @@ func (c *Controller) podNeedsUpdate(oldObj, newObj *corev1.Pod) bool {
 		if oldObj.Spec.NodeName != c.nodeName {
 			return false
 		}
-		oldAnnot = oldObj.Annotations[types.OvnPodAnnotationName]
+		oldAnnot = oldObj.Annotations[util.OvnPodAnnotationName]
 	}
 	if newObj != nil {
 		if newObj.Spec.NodeName != c.nodeName {
@@ -59,7 +59,7 @@ func (c *Controller) podNeedsUpdate(oldObj, newObj *corev1.Pod) bool {
 		if util.PodCompleted(newObj) {
 			return true
 		}
-		newAnnot = newObj.Annotations[types.OvnPodAnnotationName]
+		newAnnot = newObj.Annotations[util.OvnPodAnnotationName]
 	}
 	return oldAnnot != newAnnot
 }

--- a/go-controller/pkg/node/controllers/evpn/evpn_pod_controller_test.go
+++ b/go-controller/pkg/node/controllers/evpn/evpn_pod_controller_test.go
@@ -18,7 +18,6 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/networkmanager"
-	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
 	netlinkMocks "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util/mocks"
 	multinetworkmocks "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util/mocks/multinetwork"
@@ -90,7 +89,7 @@ var _ = Describe("EVPN pod controller", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-pod", Namespace: "test-ns",
 					UID:         "pod-uid-1",
-					Annotations: map[string]string{types.OvnPodAnnotationName: podAnnotation},
+					Annotations: map[string]string{util.OvnPodAnnotationName: podAnnotation},
 				},
 				Spec: corev1.PodSpec{NodeName: nodeName},
 			}
@@ -233,7 +232,7 @@ var _ = Describe("EVPN pod controller", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-pod", Namespace: "test-ns",
 					UID:         "pod-uid-1",
-					Annotations: map[string]string{types.OvnPodAnnotationName: `{"default":{"ip_addresses":["10.244.0.5/24"],"mac_address":"0a:58:0a:f4:00:05"}}`},
+					Annotations: map[string]string{util.OvnPodAnnotationName: `{"default":{"ip_addresses":["10.244.0.5/24"],"mac_address":"0a:58:0a:f4:00:05"}}`},
 				},
 				Spec: corev1.PodSpec{NodeName: nodeName},
 			}

--- a/go-controller/pkg/node/udn_isolation.go
+++ b/go-controller/pkg/node/udn_isolation.go
@@ -465,7 +465,7 @@ func podNeedsUpdate(oldObj, newObj *corev1.Pod) bool {
 	}
 	// react to pod IP changes
 	return !reflect.DeepEqual(oldObj.Status, newObj.Status) ||
-		oldObj.Annotations[types.OvnPodAnnotationName] != newObj.Annotations[types.OvnPodAnnotationName] ||
+		oldObj.Annotations[util.OvnPodAnnotationName] != newObj.Annotations[util.OvnPodAnnotationName] ||
 		oldObj.Annotations[util.UDNOpenPortsAnnotationName] != newObj.Annotations[util.UDNOpenPortsAnnotationName]
 }
 

--- a/go-controller/pkg/node/udn_isolation_test.go
+++ b/go-controller/pkg/node/udn_isolation_test.go
@@ -551,7 +551,7 @@ func newPodWithIPs(namespace, name string, primaryUDN bool, ips []string, openPo
 	if primaryUDN {
 		role = types.NetworkRoleInfrastructure
 	}
-	annotations[types.OvnPodAnnotationName] = fmt.Sprintf(`{"default": {"role": "%s", "ip_addresses":[%s], "mac_address":"0a:58:0a:f4:02:03"}}`,
+	annotations[util.OvnPodAnnotationName] = fmt.Sprintf(`{"default": {"role": "%s", "ip_addresses":[%s], "mac_address":"0a:58:0a:f4:02:03"}}`,
 		role, strings.Join(annoPodIPs, ","))
 
 	return &corev1.Pod{

--- a/go-controller/pkg/ovn/address_set/address_set_test.go
+++ b/go-controller/pkg/ovn/address_set/address_set_test.go
@@ -38,9 +38,10 @@ func getDbAsWithUUID(dbIDs *libovsdbops.DbObjectIDs, ips []string, UUID string, 
 	return as
 }
 
-func getEgressServiceAddrSetDbIDs(serviceName, controller string) *libovsdbops.DbObjectIDs {
-	return libovsdbops.NewDbObjectIDs(libovsdbops.AddressSetEgressService, controller, map[libovsdbops.ExternalIDKey]string{
-		libovsdbops.ObjectNameKey: serviceName,
+func getNamespaceAddrSetDbIDs(namespaceName, controller string) *libovsdbops.DbObjectIDs {
+	return libovsdbops.NewDbObjectIDs(libovsdbops.AddressSetNamespace, controller, map[libovsdbops.ExternalIDKey]string{
+		// namespace has only 1 address set, no additional ids are required
+		libovsdbops.ObjectNameKey: namespaceName,
 	})
 }
 
@@ -61,7 +62,7 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 		asFactory    AddressSetFactory
 		testdbCtx    *libovsdbtest.Context
 		nbClient     libovsdbclient.Client
-		addrsetDbIDs = getEgressServiceAddrSetDbIDs(addrsetName, controllerName)
+		addrsetDbIDs = getNamespaceAddrSetDbIDs(addrsetName, controllerName)
 	)
 
 	ginkgo.BeforeEach(func() {
@@ -89,14 +90,14 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 						Name: "1",
 						ExternalIDs: map[string]string{
 							libovsdbops.OwnerControllerKey.String(): controllerName,
-							libovsdbops.OwnerTypeKey.String():       string(libovsdbops.EgressServiceOwnerType),
+							libovsdbops.OwnerTypeKey.String():       string(libovsdbops.NamespaceOwnerType),
 						},
 					},
 					&nbdb.AddressSet{
 						Name: "2",
 						ExternalIDs: map[string]string{
 							libovsdbops.OwnerControllerKey.String(): controllerName,
-							libovsdbops.OwnerTypeKey.String():       string(libovsdbops.EgressServiceOwnerType),
+							libovsdbops.OwnerTypeKey.String():       string(libovsdbops.NamespaceOwnerType),
 							libovsdbops.ObjectNameKey.String():      "ns",
 						},
 					},
@@ -121,11 +122,11 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 				asFactory = NewOvnAddressSetFactory(nbClient, config.IPv4Mode, config.IPv6Mode)
 
 				expectedIndexes := map[string]*libovsdbops.DbObjectIDs{
-					"":   libovsdbops.NewDbObjectIDs(libovsdbops.AddressSetEgressService, controllerName, nil),
-					"ns": getEgressServiceAddrSetDbIDs("ns", controllerName),
+					"":   libovsdbops.NewDbObjectIDs(libovsdbops.AddressSetNamespace, controllerName, nil),
+					"ns": getNamespaceAddrSetDbIDs("ns", controllerName),
 				}
 				handledIndexes := map[string]*libovsdbops.DbObjectIDs{}
-				_ = asFactory.ProcessEachAddressSet(controllerName, libovsdbops.AddressSetEgressService,
+				_ = asFactory.ProcessEachAddressSet(controllerName, libovsdbops.AddressSetNamespace,
 					func(dbIDs *libovsdbops.DbObjectIDs) error {
 						handledIndexes[dbIDs.GetObjectID(libovsdbops.ObjectNameKey)] = dbIDs
 						return nil

--- a/go-controller/pkg/ovn/address_set/fake_address_set.go
+++ b/go-controller/pkg/ovn/address_set/fake_address_set.go
@@ -227,29 +227,47 @@ func (f *FakeAddressSetFactory) expectAddressSetWithAddresses(g gomega.Gomega, d
 	g.Expect(lenAddressSet).To(gomega.Equal(len(addresses)))
 }
 
+func (f *FakeAddressSetFactory) getDbIDsFromNsNameOrDbIDs(dbIDsOrNsName any) *libovsdbops.DbObjectIDs {
+	var dbIDs *libovsdbops.DbObjectIDs
+	if nsName, ok := dbIDsOrNsName.(string); ok {
+		dbIDs = libovsdbops.NewDbObjectIDs(libovsdbops.AddressSetNamespace, f.ControllerName, map[libovsdbops.ExternalIDKey]string{
+			libovsdbops.ObjectNameKey: nsName,
+		})
+	} else if dbIDs, ok = dbIDsOrNsName.(*libovsdbops.DbObjectIDs); !ok {
+		panic("unexpected type of argument passed to ExpectAddressSetWithAddresses")
+	}
+	return dbIDs
+}
+
 // ExpectAddressSetWithAddresses ensure address set exists with the given set of ips.
-func (f *FakeAddressSetFactory) ExpectAddressSetWithAddresses(dbIDs *libovsdbops.DbObjectIDs, addresses []string) {
+// Address set is identified by dbIDsOrNsName, which may be a namespace name (string) or a *libovsdbops.DbObjectIDs.
+func (f *FakeAddressSetFactory) ExpectAddressSetWithAddresses(dbIDsOrNsName any, addresses []string) {
+	dbIDs := f.getDbIDsFromNsNameOrDbIDs(dbIDsOrNsName)
 	g := gomega.Default
 	f.expectAddressSetWithAddresses(g, dbIDs, addresses)
 }
 
-func (f *FakeAddressSetFactory) EventuallyExpectAddressSetWithAddresses(dbIDs *libovsdbops.DbObjectIDs, addresses []string) {
+func (f *FakeAddressSetFactory) EventuallyExpectAddressSetWithAddresses(dbIDsOrNsName any, addresses []string) {
+	dbIDs := f.getDbIDsFromNsNameOrDbIDs(dbIDsOrNsName)
 	gomega.Eventually(func(g gomega.Gomega) {
 		f.expectAddressSetWithAddresses(g, dbIDs, addresses)
 	}).Should(gomega.Succeed())
 }
 
-// ExpectEmptyAddressSet ensures the address set owned by dbIDs exists with no Addresses
-func (f *FakeAddressSetFactory) ExpectEmptyAddressSet(dbIDs *libovsdbops.DbObjectIDs) {
+// ExpectEmptyAddressSet ensures the address set owned by dbIDsOrNsName exists with no Addresses
+func (f *FakeAddressSetFactory) ExpectEmptyAddressSet(dbIDsOrNsName any) {
+	dbIDs := f.getDbIDsFromNsNameOrDbIDs(dbIDsOrNsName)
 	f.ExpectAddressSetWithAddresses(dbIDs, nil)
 }
 
 // EventuallyExpectEmptyAddressSetExist ensures the named address set eventually exists with no Addresses
-func (f *FakeAddressSetFactory) EventuallyExpectEmptyAddressSetExist(dbIDs *libovsdbops.DbObjectIDs) {
+func (f *FakeAddressSetFactory) EventuallyExpectEmptyAddressSetExist(dbIDsOrNsName any) {
+	dbIDs := f.getDbIDsFromNsNameOrDbIDs(dbIDsOrNsName)
 	f.EventuallyExpectAddressSetWithAddresses(dbIDs, nil)
 }
 
-func (f *FakeAddressSetFactory) AddressSetExists(dbIDs *libovsdbops.DbObjectIDs) bool {
+func (f *FakeAddressSetFactory) AddressSetExists(dbIDsOrNsName any) bool {
+	dbIDs := f.getDbIDsFromNsNameOrDbIDs(dbIDsOrNsName)
 	name := getOvnAddressSetsName(dbIDs)
 	f.Lock()
 	defer f.Unlock()
@@ -258,17 +276,21 @@ func (f *FakeAddressSetFactory) AddressSetExists(dbIDs *libovsdbops.DbObjectIDs)
 }
 
 // EventuallyExpectAddressSet ensures the named address set eventually exists
-func (f *FakeAddressSetFactory) EventuallyExpectAddressSet(dbIDs *libovsdbops.DbObjectIDs) {
+func (f *FakeAddressSetFactory) EventuallyExpectAddressSet(dbIDsOrNsName any) {
+	dbIDs := f.getDbIDsFromNsNameOrDbIDs(dbIDsOrNsName)
 	gomega.Eventually(func() bool {
 		return f.AddressSetExists(dbIDs)
 	}).Should(gomega.BeTrue())
 }
 
-// EventuallyExpectNoAddressSet ensures the address set eventually does not exist
-func (f *FakeAddressSetFactory) EventuallyExpectNoAddressSet(dbIDs *libovsdbops.DbObjectIDs) {
+// EventuallyExpectNoAddressSet ensures the named address set eventually does not exist
+// For namespaces address set deletion is delayed by 20 seconds, it is only tested once in namespace_test
+// to not slow down tests. Don't use for namespace-owned address sets
+func (f *FakeAddressSetFactory) EventuallyExpectNoAddressSet(dbIDsOrNsName any) {
+	dbIDs := f.getDbIDsFromNsNameOrDbIDs(dbIDsOrNsName)
 	gomega.Eventually(func() bool {
 		return f.AddressSetExists(dbIDs)
-	}).Should(gomega.BeFalse(), "expected address set %s to eventually not exist", dbIDs.String())
+	}).Should(gomega.BeFalse())
 }
 
 // ExpectNumberOfAddressSets ensures the number of created address sets equals given number

--- a/go-controller/pkg/ovn/addresssetmanager/addressset_manager.go
+++ b/go-controller/pkg/ovn/addresssetmanager/addressset_manager.go
@@ -344,9 +344,9 @@ func (m *AddressSetManager) podNeedUpdate(old, new *corev1.Pod) bool {
 	}
 	if old == nil {
 		// new pod, check if it has IPs already, if not, wait for update event when IPs are assigned
-		return new.Annotations[ovntypes.OvnPodAnnotationName] != "" || len(new.Status.PodIPs) > 0
+		return new.Annotations[util.OvnPodAnnotationName] != "" || len(new.Status.PodIPs) > 0
 	}
-	if new.Annotations[ovntypes.OvnPodAnnotationName] != old.Annotations[ovntypes.OvnPodAnnotationName] {
+	if new.Annotations[util.OvnPodAnnotationName] != old.Annotations[util.OvnPodAnnotationName] {
 		// this annotation is set when pod gets its IPs, so if it changes, we need to reconcile to update address set with new IPs
 		return true
 	}
@@ -838,7 +838,7 @@ func (m *AddressSetManager) getPodIPs(pods []*corev1.Pod, netInfo util.NetInfo, 
 			// skip hostNetwork pods if requested, since they are not selected in legacyNetpolMode
 			continue
 		}
-		if pod.Annotations[ovntypes.OvnPodAnnotationName] == "" && len(pod.Status.PodIPs) == 0 {
+		if pod.Annotations[util.OvnPodAnnotationName] == "" && len(pod.Status.PodIPs) == 0 {
 			// pod doesn't have IPs yet, skip it
 			continue
 		}

--- a/go-controller/pkg/ovn/addresssetmanager/addressset_manager_test.go
+++ b/go-controller/pkg/ovn/addresssetmanager/addressset_manager_test.go
@@ -259,7 +259,7 @@ var _ = ginkgo.Describe("OVN podSelectorAddressSet", func() {
 		if netInfo.GetNetworkName() == types.DefaultNetworkName {
 			return testing.NewPod(namespace, name, node, podIP)
 		} else {
-			return testing.NewPodWithSecondaryNADIP(namespace, name, node, "10.244.0.2", netInfo.GetNetworkName(), podIP)
+			return testing.NewPodWithSecondaryNADIP(namespace, name, node, "10.244.0.2", netInfo.GetNetworkName(), netInfo.GetNetworkName(), podIP)
 		}
 	}
 

--- a/go-controller/pkg/ovn/addresssetmanager/addressset_manager_test.go
+++ b/go-controller/pkg/ovn/addresssetmanager/addressset_manager_test.go
@@ -9,24 +9,20 @@ import (
 	"sync/atomic"
 	"time"
 
-	cnitypes "github.com/containernetworking/cni/pkg/types"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 
 	corev1 "k8s.io/api/core/v1"
 	knet "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/sets"
 
 	libovsdbclient "github.com/ovn-kubernetes/libovsdb/client"
 	"github.com/ovn-kubernetes/libovsdb/ovsdb"
 
-	ovncnitypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/cni/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/factory"
 	libovsdbops "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/libovsdb/ops"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/nbdb"
-	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/networkmanager"
 	addressset "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/address_set"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing"
 	libovsdbtest "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
@@ -67,21 +63,6 @@ func (c *countingClient) Transact(ctx context.Context, ops ...ovsdb.Operation) (
 	return c.Client.Transact(ctx, ops...)
 }
 
-func newNetInfo(networkName, topology, role, subnets string) util.NetInfo {
-	netconf := ovncnitypes.NetConf{
-		NetConf: cnitypes.NetConf{
-			Name: networkName,
-			Type: "ovn-k8s-cni-overlay",
-		},
-		Role:     role,
-		Topology: topology,
-		Subnets:  subnets,
-	}
-	netInfo, err := util.NewNetInfo(&netconf)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-	return netInfo
-}
-
 var _ = ginkgo.Describe("OVN podSelectorAddressSet", func() {
 	const (
 		namespaceName1 = "namespace1"
@@ -98,14 +79,13 @@ var _ = ginkgo.Describe("OVN podSelectorAddressSet", func() {
 		node1MgmtIP    = "10.244.0.2"
 	)
 	var (
-		addressSetManager  *AddressSetManager
-		wf                 *factory.WatchFactory
-		clientSet          *util.OVNKubeControllerClientset
-		initialDB          libovsdbtest.TestSetup
-		libovsdbCleanup    *libovsdbtest.Context
-		libovsdbNBClient   libovsdbclient.Client
-		countingNBClient   *countingClient
-		fakeNetworkManager *networkmanager.FakeNetworkManager
+		addressSetManager *AddressSetManager
+		wf                *factory.WatchFactory
+		clientSet         *util.OVNKubeControllerClientset
+		initialDB         libovsdbtest.TestSetup
+		libovsdbCleanup   *libovsdbtest.Context
+		libovsdbNBClient  libovsdbclient.Client
+		countingNBClient  *countingClient
 	)
 
 	ginkgo.BeforeEach(func() {
@@ -113,9 +93,6 @@ var _ = ginkgo.Describe("OVN podSelectorAddressSet", func() {
 		gomega.Expect(config.PrepareTestConfig()).To(gomega.Succeed())
 		initialDB = libovsdbtest.TestSetup{
 			NBData: []libovsdbtest.TestData{},
-		}
-		fakeNetworkManager = &networkmanager.FakeNetworkManager{
-			NADNetworks: map[string]util.NetInfo{},
 		}
 	})
 
@@ -147,7 +124,7 @@ var _ = ginkgo.Describe("OVN podSelectorAddressSet", func() {
 		// this is only used for "saves db transactions when IPs don't change" test
 		countingNBClient = &countingClient{Client: libovsdbNBClient}
 		addressSetManager = NewAddressSetManager(wf.PodCoreInformer(), wf.NamespaceInformer(), wf.NodeCoreInformer(), countingNBClient,
-			fakeNetworkManager.Interface().GetNetworkNameForNADKey)
+			func(_ string) string { return "" })
 		err = addressSetManager.Start()
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	}
@@ -247,168 +224,131 @@ var _ = ginkgo.Describe("OVN podSelectorAddressSet", func() {
 		// expect 2 peer address sets only
 		gomega.Eventually(addressSetManager.nbClient).Should(libovsdbtest.HaveData([]libovsdbtest.TestData{peerAS, peerASLegacy}))
 	})
-	// this is run during ginkgo tree construction, so env is not set yet
-	config.IPv4Mode = true
-	config.IPv6Mode = false
-	primaryNetInfo := newNetInfo("primarynet", types.Layer3Topology, types.NetworkRolePrimary, "10.128.1.0/24/27")
-	secondaryNetInfo := newNetInfo("secondarynet", types.Layer2Topology, types.NetworkRoleSecondary, "10.128.1.0/24")
-
-	newPod := func(namespace, name, node, podIP string, netInfo util.NetInfo) *corev1.Pod {
-		nadKey := fmt.Sprintf("%s/%s", namespace, netInfo.GetNetworkName())
-		fakeNetworkManager.NADNetworks[nadKey] = netInfo
-		if netInfo.GetNetworkName() == types.DefaultNetworkName {
-			return testing.NewPod(namespace, name, node, podIP)
-		} else {
-			return testing.NewPodWithSecondaryNADIP(namespace, name, node, "10.244.0.2", netInfo.GetNetworkName(), netInfo.GetNetworkName(), podIP)
-		}
-	}
-
-	for _, netInfo := range []util.NetInfo{&util.DefaultNetInfo{}, primaryNetInfo, secondaryNetInfo} {
-		netInfo := netInfo
-		ginkgo.DescribeTable(fmt.Sprintf("[%s] adds selected pod ips to the address set and removes on delete", netInfo.GetNetworkName()),
-			func(peer knet.NetworkPolicyPeer, staticNamespace string, addrSetIPsList []string, legacyMode bool, netInfo util.NetInfo) {
-				addrSetIPs := sets.New(addrSetIPsList...)
-				namespace1 := *testing.NewNamespace(namespaceName1)
-				namespace2 := *testing.NewNamespace(namespaceName2)
-				config.Kubernetes.HostNetworkNamespace = "ovn-host-network"
-				hostNetNamespace := *testing.NewNamespace(config.Kubernetes.HostNetworkNamespace)
-				ns1pod1 := newPod(namespace1.Name, "ns1pod1", nodeName, ip1, netInfo)
-				ns1pod2 := newPod(namespace1.Name, "ns1pod2", nodeName, ip2, netInfo)
-				ns1pod3 := newPod(namespace1.Name, "ns1pod3", nodeName, hostNetPodIP, netInfo)
-				ns1pod3.Spec.HostNetwork = true
-				ns2pod1 := newPod(namespace2.Name, "ns2pod1", nodeName, ip3, netInfo)
-				ns2pod2 := newPod(namespace2.Name, "ns2pod2", nodeName, ip4, netInfo)
-				podsList := []corev1.Pod{}
-				for _, pod := range []*corev1.Pod{ns1pod1, ns1pod2, ns1pod3, ns2pod1, ns2pod2} {
-					pod.Labels = map[string]string{podLabelKey: pod.Name}
-					podsList = append(podsList, *pod)
-				}
-				testNode := corev1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: nodeName,
-						Annotations: map[string]string{
-							"k8s.ovn.org/node-subnets": fmt.Sprintf("{\"default\":\"%s\"}", node1Subnet),
-						},
+	ginkgo.DescribeTable("adds selected pod ips to the address set",
+		func(peer knet.NetworkPolicyPeer, staticNamespace string, addrSetIPs []string, legacyMode bool) {
+			namespace1 := *testing.NewNamespace(namespaceName1)
+			namespace2 := *testing.NewNamespace(namespaceName2)
+			config.Kubernetes.HostNetworkNamespace = "ovn-host-network"
+			hostNetNamespace := *testing.NewNamespace(config.Kubernetes.HostNetworkNamespace)
+			ns1pod1 := testing.NewPod(namespace1.Name, "ns1pod1", nodeName, ip1)
+			ns1pod2 := testing.NewPod(namespace1.Name, "ns1pod2", nodeName, ip2)
+			ns1pod3 := testing.NewPod(namespace1.Name, "ns1pod3", nodeName, hostNetPodIP)
+			ns1pod3.Spec.HostNetwork = true
+			ns2pod1 := testing.NewPod(namespace2.Name, "ns2pod1", nodeName, ip3)
+			ns2pod2 := testing.NewPod(namespace2.Name, "ns2pod2", nodeName, ip4)
+			podsList := []corev1.Pod{}
+			for _, pod := range []*corev1.Pod{ns1pod1, ns1pod2, ns1pod3, ns2pod1, ns2pod2} {
+				pod.Labels = map[string]string{podLabelKey: pod.Name}
+				podsList = append(podsList, *pod)
+			}
+			testNode := corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: nodeName,
+					Annotations: map[string]string{
+						"k8s.ovn.org/node-subnets": fmt.Sprintf("{\"default\":\"%s\"}", node1Subnet),
 					},
-				}
-				startAddrSetManagerWithNodes(initialDB, []corev1.Namespace{namespace1, namespace2, hostNetNamespace}, podsList,
-					[]corev1.Node{testNode})
+				},
+			}
+			startAddrSetManagerWithNodes(initialDB, []corev1.Namespace{namespace1, namespace2, hostNetNamespace}, podsList,
+				[]corev1.Node{testNode})
 
-				_, _, _, err := addressSetManager.EnsureAddressSet(
-					peer.PodSelector, peer.NamespaceSelector, nil, staticNamespace, "backRef", controllerName, netInfo, legacyMode)
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				// address set should be created and pod ips added
-				peerASIDs := GetPodSelectorAddrSetDbIDs(peer.PodSelector, peer.NamespaceSelector, nil, staticNamespace, controllerName, legacyMode)
-				// non-default networks don't match hostNetwork namespace remove node1MgmtIP if present
-				if !netInfo.IsDefault() {
-					addrSetIPs.Delete(node1MgmtIP)
-					// secondary networks don't match hostNetwork pods, remove hostNetPodIP if present
-					if !netInfo.IsPrimaryNetwork() {
-						addrSetIPs.Delete(hostNetPodIP)
-					}
-				}
-				peerAS, _ := addressset.GetTestDbAddrSets(peerASIDs, addrSetIPs.UnsortedList())
-				gomega.Eventually(addressSetManager.nbClient).Should(libovsdbtest.HaveData([]libovsdbtest.TestData{peerAS}))
-				// now delete ns1pod1 and ns1pod3 to test both overlay and hostnet pod IP cleanup
-				err = clientSet.KubeClient.CoreV1().Pods(namespace1.Name).Delete(context.TODO(), ns1pod1.Name, metav1.DeleteOptions{})
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				err = clientSet.KubeClient.CoreV1().Pods(namespace1.Name).Delete(context.TODO(), ns1pod3.Name, metav1.DeleteOptions{})
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				// deleted pod IPs should be removed from address set
-				addrSetIPs.Delete(ip1, hostNetPodIP)
-				peerAS, _ = addressset.GetTestDbAddrSets(peerASIDs, addrSetIPs.UnsortedList())
-				gomega.Eventually(addressSetManager.nbClient).Should(libovsdbtest.HaveData([]libovsdbtest.TestData{peerAS}))
+			_, _, _, err := addressSetManager.EnsureAddressSet(
+				peer.PodSelector, peer.NamespaceSelector, nil, staticNamespace, "backRef", controllerName, &util.DefaultNetInfo{}, legacyMode)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			// address set should be created and pod ips added
+			peerASIDs := GetPodSelectorAddrSetDbIDs(peer.PodSelector, peer.NamespaceSelector, nil, staticNamespace, controllerName, legacyMode)
+			peerAS, _ := addressset.GetTestDbAddrSets(peerASIDs, addrSetIPs)
+			gomega.Eventually(addressSetManager.nbClient).Should(libovsdbtest.HaveData([]libovsdbtest.TestData{peerAS}))
+		},
+		ginkgo.Entry("all pods from a static namespace", knet.NetworkPolicyPeer{
+			PodSelector:       &metav1.LabelSelector{},
+			NamespaceSelector: nil,
+		}, namespaceName1, []string{ip1, ip2, hostNetPodIP}, false),
+		ginkgo.Entry("selected pods from a static namespace", knet.NetworkPolicyPeer{
+			PodSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{podLabelKey: "ns1pod1"},
 			},
-			ginkgo.Entry("all pods from a static namespace", knet.NetworkPolicyPeer{
-				PodSelector:       &metav1.LabelSelector{},
-				NamespaceSelector: nil,
-			}, namespaceName1, []string{ip1, ip2, hostNetPodIP}, false, netInfo),
-			ginkgo.Entry("selected pods from a static namespace", knet.NetworkPolicyPeer{
-				PodSelector: &metav1.LabelSelector{
-					MatchLabels: map[string]string{podLabelKey: "ns1pod1"},
-				},
-				NamespaceSelector: nil,
-			}, namespaceName1, []string{ip1}, false, netInfo),
-			ginkgo.Entry("all pods from all namespaces", knet.NetworkPolicyPeer{
-				PodSelector:       &metav1.LabelSelector{},
-				NamespaceSelector: &metav1.LabelSelector{},
-			}, namespaceName1, []string{ip1, ip2, hostNetPodIP, ip3, ip4}, false, netInfo),
-			ginkgo.Entry("selected pods from all namespaces", knet.NetworkPolicyPeer{
-				PodSelector: &metav1.LabelSelector{
-					MatchExpressions: []metav1.LabelSelectorRequirement{
-						{
-							Key:      podLabelKey,
-							Operator: metav1.LabelSelectorOpIn,
-							Values:   []string{"ns1pod1", "ns2pod1"},
-						},
+			NamespaceSelector: nil,
+		}, namespaceName1, []string{ip1}, false),
+		ginkgo.Entry("all pods from all namespaces", knet.NetworkPolicyPeer{
+			PodSelector:       &metav1.LabelSelector{},
+			NamespaceSelector: &metav1.LabelSelector{},
+		}, namespaceName1, []string{ip1, ip2, hostNetPodIP, ip3, ip4}, false),
+		ginkgo.Entry("selected pods from all namespaces", knet.NetworkPolicyPeer{
+			PodSelector: &metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{
+						Key:      podLabelKey,
+						Operator: metav1.LabelSelectorOpIn,
+						Values:   []string{"ns1pod1", "ns2pod1"},
 					},
 				},
-				NamespaceSelector: &metav1.LabelSelector{},
-			}, namespaceName1, []string{ip1, ip3}, false, netInfo),
-			ginkgo.Entry("all pods from selected namespaces", knet.NetworkPolicyPeer{
-				PodSelector: &metav1.LabelSelector{},
-				NamespaceSelector: &metav1.LabelSelector{
-					MatchLabels: map[string]string{
-						"name": namespaceName2,
+			},
+			NamespaceSelector: &metav1.LabelSelector{},
+		}, namespaceName1, []string{ip1, ip3}, false),
+		ginkgo.Entry("all pods from selected namespaces", knet.NetworkPolicyPeer{
+			PodSelector: &metav1.LabelSelector{},
+			NamespaceSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"name": namespaceName2,
+				},
+			},
+		}, namespaceName1, []string{ip3, ip4}, false),
+		ginkgo.Entry("selected pods from selected namespaces", knet.NetworkPolicyPeer{
+			PodSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{podLabelKey: "ns2pod1"},
+			},
+			NamespaceSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"name": namespaceName2,
+				},
+			},
+		}, namespaceName1, []string{ip3}, false),
+		ginkgo.Entry("all pods from a static namespace, legacyNetpolMode", knet.NetworkPolicyPeer{
+			PodSelector:       &metav1.LabelSelector{},
+			NamespaceSelector: nil,
+		}, namespaceName1, []string{ip1, ip2}, true),
+		ginkgo.Entry("selected pods from a static namespace, legacyNetpolMode", knet.NetworkPolicyPeer{
+			PodSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{podLabelKey: "ns1pod1"},
+			},
+			NamespaceSelector: nil,
+		}, namespaceName1, []string{ip1}, true),
+		ginkgo.Entry("all pods from all namespaces, legacyNetpolMode", knet.NetworkPolicyPeer{
+			PodSelector:       &metav1.LabelSelector{},
+			NamespaceSelector: &metav1.LabelSelector{},
+		}, namespaceName1, []string{ip1, ip2, ip3, ip4, node1MgmtIP}, true),
+		ginkgo.Entry("selected pods from all namespaces, legacyNetpolMode", knet.NetworkPolicyPeer{
+			PodSelector: &metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{
+						Key:      podLabelKey,
+						Operator: metav1.LabelSelectorOpIn,
+						Values:   []string{"ns1pod1", "ns2pod1"},
 					},
 				},
-			}, namespaceName1, []string{ip3, ip4}, false, netInfo),
-			ginkgo.Entry("selected pods from selected namespaces", knet.NetworkPolicyPeer{
-				PodSelector: &metav1.LabelSelector{
-					MatchLabels: map[string]string{podLabelKey: "ns2pod1"},
+			},
+			NamespaceSelector: &metav1.LabelSelector{},
+		}, namespaceName1, []string{ip1, ip3}, true),
+		ginkgo.Entry("all pods from selected namespaces, legacyNetpolMode", knet.NetworkPolicyPeer{
+			PodSelector: &metav1.LabelSelector{},
+			NamespaceSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"name": namespaceName2,
 				},
-				NamespaceSelector: &metav1.LabelSelector{
-					MatchLabels: map[string]string{
-						"name": namespaceName2,
-					},
+			},
+		}, namespaceName1, []string{ip3, ip4}, true),
+		ginkgo.Entry("selected pods from selected namespaces, legacyNetpolMode", knet.NetworkPolicyPeer{
+			PodSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{podLabelKey: "ns2pod1"},
+			},
+			NamespaceSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"name": namespaceName2,
 				},
-			}, namespaceName1, []string{ip3}, false, netInfo),
-			ginkgo.Entry("all pods from a static namespace, legacyNetpolMode", knet.NetworkPolicyPeer{
-				PodSelector:       &metav1.LabelSelector{},
-				NamespaceSelector: nil,
-			}, namespaceName1, []string{ip1, ip2}, true, netInfo),
-			ginkgo.Entry("selected pods from a static namespace, legacyNetpolMode", knet.NetworkPolicyPeer{
-				PodSelector: &metav1.LabelSelector{
-					MatchLabels: map[string]string{podLabelKey: "ns1pod1"},
-				},
-				NamespaceSelector: nil,
-			}, namespaceName1, []string{ip1}, true, netInfo),
-			ginkgo.Entry("all pods from all namespaces, legacyNetpolMode", knet.NetworkPolicyPeer{
-				PodSelector:       &metav1.LabelSelector{},
-				NamespaceSelector: &metav1.LabelSelector{},
-			}, namespaceName1, []string{ip1, ip2, ip3, ip4, node1MgmtIP}, true, netInfo),
-			ginkgo.Entry("selected pods from all namespaces, legacyNetpolMode", knet.NetworkPolicyPeer{
-				PodSelector: &metav1.LabelSelector{
-					MatchExpressions: []metav1.LabelSelectorRequirement{
-						{
-							Key:      podLabelKey,
-							Operator: metav1.LabelSelectorOpIn,
-							Values:   []string{"ns1pod1", "ns2pod1"},
-						},
-					},
-				},
-				NamespaceSelector: &metav1.LabelSelector{},
-			}, namespaceName1, []string{ip1, ip3}, true, netInfo),
-			ginkgo.Entry("all pods from selected namespaces, legacyNetpolMode", knet.NetworkPolicyPeer{
-				PodSelector: &metav1.LabelSelector{},
-				NamespaceSelector: &metav1.LabelSelector{
-					MatchLabels: map[string]string{
-						"name": namespaceName2,
-					},
-				},
-			}, namespaceName1, []string{ip3, ip4}, true, netInfo),
-			ginkgo.Entry("selected pods from selected namespaces, legacyNetpolMode", knet.NetworkPolicyPeer{
-				PodSelector: &metav1.LabelSelector{
-					MatchLabels: map[string]string{podLabelKey: "ns2pod1"},
-				},
-				NamespaceSelector: &metav1.LabelSelector{
-					MatchLabels: map[string]string{
-						"name": namespaceName2,
-					},
-				},
-			}, namespaceName1, []string{ip3}, true, netInfo),
-		)
-	}
+			},
+		}, namespaceName1, []string{ip3}, true),
+	)
 	ginkgo.It("on initial sync deletes unreferenced and updates referenced address sets", func() {
 		unusedPodSelIDs := GetPodSelectorAddrSetDbIDs(&metav1.LabelSelector{}, nil, nil, "nsName", controllerName, false)
 		unusedPodSelAS, _ := addressset.GetTestDbAddrSets(unusedPodSelIDs, []string{"1.1.1.2"})

--- a/go-controller/pkg/ovn/admin_network_policy_test.go
+++ b/go-controller/pkg/ovn/admin_network_policy_test.go
@@ -324,9 +324,15 @@ var _ = ginkgo.Describe("OVN ANP Operations", func() {
 					Name: node1Name,
 					UUID: node1Name + "-UUID",
 				}
+				subjectNSASIPv4, subjectNSASIPv6 := buildNamespaceAddressSets(anpSubjectNamespaceName, []string{})
+				peerNSASIPv4, peerNSASIPv6 := buildNamespaceAddressSets(anpPeerNamespaceName, []string{})
 				dbSetup := libovsdbtest.TestSetup{
 					NBData: []libovsdbtest.TestData{
 						node1Switch,
+						subjectNSASIPv4,
+						subjectNSASIPv6,
+						peerNSASIPv4,
+						peerNSASIPv6,
 					},
 				}
 				fakeOVN.startWithDBSetup(dbSetup,
@@ -376,7 +382,7 @@ var _ = ginkgo.Describe("OVN ANP Operations", func() {
 				anp, err = fakeOVN.fakeClient.ANPClient.PolicyV1alpha1().AdminNetworkPolicies().Create(context.TODO(), anp, metav1.CreateOptions{})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				pg := getDefaultPGForANPSubject(anp.Name, nil, nil, false)
-				expectedDatabaseState := []libovsdbtest.TestData{node1Switch, pg}
+				expectedDatabaseState := []libovsdbtest.TestData{node1Switch, subjectNSASIPv4, subjectNSASIPv6, peerNSASIPv4, peerNSASIPv6, pg}
 				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 
 				ginkgo.By("2. creating a pod that will act as subject of admin network policy; check if lsp is added to port-group after retries")
@@ -406,8 +412,9 @@ var _ = ginkgo.Describe("OVN ANP Operations", func() {
 				anpSubjectPod.Labels["rv"] = "resourceVersionUTHack"
 				_, err = fakeOVN.fakeClient.KubeClient.CoreV1().Pods(anpSubjectPod.Namespace).Update(context.TODO(), &anpSubjectPod, metav1.UpdateOptions{})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				subjectNSASIPv4, subjectNSASIPv6 = buildNamespaceAddressSets(anpSubjectNamespaceName, []string{t.podIP})
 				pg = getDefaultPGForANPSubject(anp.Name, []string{t.portUUID}, nil, false)
-				expectedDatabaseState = []libovsdbtest.TestData{pg}
+				expectedDatabaseState = []libovsdbtest.TestData{pg, subjectNSASIPv4, subjectNSASIPv6, peerNSASIPv4, peerNSASIPv6}
 				expectedDatabaseState = append(expectedDatabaseState, getDefaultNetExpectedPodsAndSwitches([]testPod{t}, []string{node1Name})...)
 				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 
@@ -468,7 +475,8 @@ var _ = ginkgo.Describe("OVN ANP Operations", func() {
 				anpPeerPod.Labels["rv"] = "resourceVersionUTHack"
 				_, err = fakeOVN.fakeClient.KubeClient.CoreV1().Pods(anpPeerPod.Namespace).Update(context.TODO(), &anpPeerPod, metav1.UpdateOptions{})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				expectedDatabaseState = []libovsdbtest.TestData{pg}
+				peerNSASIPv4, peerNSASIPv6 = buildNamespaceAddressSets(anpPeerNamespaceName, []string{t2.podIP})
+				expectedDatabaseState = []libovsdbtest.TestData{pg, subjectNSASIPv4, subjectNSASIPv6, peerNSASIPv4, peerNSASIPv6}
 				for _, acl := range acls {
 					acl := acl
 					expectedDatabaseState = append(expectedDatabaseState, acl)
@@ -535,7 +543,7 @@ var _ = ginkgo.Describe("OVN ANP Operations", func() {
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				acls = getACLsForANPRules(anp)
 				pg = getDefaultPGForANPSubject(anp.Name, []string{t.portUUID}, acls, false)
-				expectedDatabaseState = []libovsdbtest.TestData{pg}
+				expectedDatabaseState = []libovsdbtest.TestData{pg, subjectNSASIPv4, subjectNSASIPv6, peerNSASIPv4, peerNSASIPv6}
 				for _, acl := range acls {
 					acl := acl
 					expectedDatabaseState = append(expectedDatabaseState, acl)
@@ -630,7 +638,7 @@ var _ = ginkgo.Describe("OVN ANP Operations", func() {
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				acls = getACLsForANPRules(anp)
 				pg = getDefaultPGForANPSubject(anp.Name, []string{t.portUUID}, acls, false)
-				expectedDatabaseState = []libovsdbtest.TestData{pg}
+				expectedDatabaseState = []libovsdbtest.TestData{pg, subjectNSASIPv4, subjectNSASIPv6, peerNSASIPv4, peerNSASIPv6}
 				for _, acl := range acls {
 					acl := acl
 					expectedDatabaseState = append(expectedDatabaseState, acl)
@@ -748,7 +756,7 @@ var _ = ginkgo.Describe("OVN ANP Operations", func() {
 
 				newACLs := getACLsForANPRules(anp)
 				pg = getDefaultPGForANPSubject(anp.Name, []string{t.portUUID}, newACLs, false) // only newACLs are hosted
-				expectedDatabaseState = []libovsdbtest.TestData{pg}
+				expectedDatabaseState = []libovsdbtest.TestData{pg, subjectNSASIPv4, subjectNSASIPv6, peerNSASIPv4, peerNSASIPv6}
 				for _, acl := range newACLs {
 					acl := acl
 					expectedDatabaseState = append(expectedDatabaseState, acl)
@@ -778,8 +786,9 @@ var _ = ginkgo.Describe("OVN ANP Operations", func() {
 				anpPeerPod.ResourceVersion = "3"
 				err = fakeOVN.fakeClient.KubeClient.CoreV1().Pods(anpPeerPod.Namespace).Delete(context.TODO(), anpPeerPod.Name, metav1.DeleteOptions{})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				pg = getDefaultPGForANPSubject(anp.Name, []string{t.portUUID}, newACLs, false) // only newACLs are hosted
-				expectedDatabaseState = []libovsdbtest.TestData{pg}
+				pg = getDefaultPGForANPSubject(anp.Name, []string{t.portUUID}, newACLs, false)           // only newACLs are hosted
+				peerNSASIPv4, peerNSASIPv6 = buildNamespaceAddressSets(anpPeerNamespaceName, []string{}) // pod is gone from peer namespace address-set
+				expectedDatabaseState = []libovsdbtest.TestData{pg, subjectNSASIPv4, subjectNSASIPv6, peerNSASIPv4, peerNSASIPv6}
 				for _, acl := range newACLs {
 					acl := acl
 					expectedDatabaseState = append(expectedDatabaseState, acl)
@@ -809,7 +818,8 @@ var _ = ginkgo.Describe("OVN ANP Operations", func() {
 				_, err = fakeOVN.fakeClient.KubeClient.CoreV1().Pods(anpSubjectPod.Namespace).Update(context.TODO(), &anpSubjectPod, metav1.UpdateOptions{})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				pg = getDefaultPGForANPSubject(anp.Name, nil, newACLs, false) // no ports in PG
-				expectedDatabaseState = []libovsdbtest.TestData{pg}
+				subjectNSASIPv4, subjectNSASIPv6 = buildNamespaceAddressSets(anpSubjectNamespaceName, []string{})
+				expectedDatabaseState = []libovsdbtest.TestData{pg, subjectNSASIPv4, subjectNSASIPv6, peerNSASIPv4, peerNSASIPv6}
 				for _, acl := range newACLs {
 					acl := acl
 					expectedDatabaseState = append(expectedDatabaseState, acl)
@@ -840,7 +850,8 @@ var _ = ginkgo.Describe("OVN ANP Operations", func() {
 				t.podIP = "10.128.1.5"
 				t.podMAC = "0a:58:0a:80:01:05"
 				pg = getDefaultPGForANPSubject(anp.Name, []string{t.portUUID}, newACLs, false)
-				expectedDatabaseState = []libovsdbtest.TestData{pg}
+				subjectNSASIPv4, subjectNSASIPv6 = buildNamespaceAddressSets(anpSubjectNamespaceName, []string{t.podIP})
+				expectedDatabaseState = []libovsdbtest.TestData{pg, subjectNSASIPv4, subjectNSASIPv6, peerNSASIPv4, peerNSASIPv6}
 				for _, acl := range newACLs {
 					acl := acl
 					expectedDatabaseState = append(expectedDatabaseState, acl)
@@ -865,7 +876,8 @@ var _ = ginkgo.Describe("OVN ANP Operations", func() {
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				t2.podIP = "10.128.1.6"
 				t2.podMAC = "0a:58:0a:80:01:06"
-				expectedDatabaseState = []libovsdbtest.TestData{pg}
+				peerNSASIPv4, peerNSASIPv6 = buildNamespaceAddressSets(anpPeerNamespaceName, []string{t2.podIP})
+				expectedDatabaseState = []libovsdbtest.TestData{pg, subjectNSASIPv4, subjectNSASIPv6, peerNSASIPv4, peerNSASIPv6}
 				for _, acl := range newACLs {
 					acl := acl
 					expectedDatabaseState = append(expectedDatabaseState, acl)
@@ -1286,7 +1298,10 @@ var _ = ginkgo.Describe("OVN ANP Operations", func() {
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				acls := getACLsForANPRulesWithNamedPorts(anp, namedIPorts, namedEPorts)
 				pg := getDefaultPGForANPSubject(anp.Name, []string{}, acls, false)
-				baseExpectedDatabaseState := []libovsdbtest.TestData{}
+				subjectNSASIPv4, subjectNSASIPv6 := buildNamespaceAddressSets(anpSubjectNamespaceName, []string{})
+				peerNSASIPv4, peerNSASIPv6 := buildNamespaceAddressSets(anpPeerNamespaceName, []string{anpPodV4IP2, anpPodV6IP2})
+				peerNS2ASIPv4, peerNS2ASIPv6 := buildNamespaceAddressSets(anpPeerNamespaceName+"2", []string{})
+				baseExpectedDatabaseState := []libovsdbtest.TestData{subjectNSASIPv4, subjectNSASIPv6, peerNSASIPv4, peerNSASIPv6, peerNS2ASIPv4, peerNS2ASIPv6}
 				peerASIngressRule0v4, peerASIngressRule0v6 := buildANPAddressSets(anp, 0, []string{}, libovsdbutil.ACLIngress)
 				baseExpectedDatabaseState = append(baseExpectedDatabaseState, peerASIngressRule0v4)
 				baseExpectedDatabaseState = append(baseExpectedDatabaseState, peerASIngressRule0v6)
@@ -1327,6 +1342,9 @@ var _ = ginkgo.Describe("OVN ANP Operations", func() {
 					{L4Protocol: "udp", L3PodIP: anpPodV6IP, L3PodIPFamily: "ip6", L4PodPort: "5353"},
 				}
 
+				subjectNSASIPv4, subjectNSASIPv6 = buildNamespaceAddressSets(anpSubjectNamespaceName, []string{anpPodV4IP, anpPodV6IP})
+				baseExpectedDatabaseState[0] = subjectNSASIPv4
+				baseExpectedDatabaseState[1] = subjectNSASIPv6
 				acls = getACLsForANPRulesWithNamedPorts(anp, namedIPorts, namedEPorts)
 				pg = getDefaultPGForANPSubject(anp.Name, []string{t2.portUUID}, acls, false)
 				expectedDatabaseState = append(baseExpectedDatabaseState, pg)
@@ -1370,9 +1388,12 @@ var _ = ginkgo.Describe("OVN ANP Operations", func() {
 				delete(namedEPorts, "web123")
 				acls = getACLsForANPRulesWithNamedPorts(anp, namedIPorts, namedEPorts)
 				pg = getDefaultPGForANPSubject(anp.Name, []string{t2.portUUID}, acls, false)
+				peerNSASIPv4, peerNSASIPv6 = buildNamespaceAddressSets(anpPeerNamespaceName, []string{}) // pod is gone from peer namespace address-set
+				baseExpectedDatabaseState[2] = peerNSASIPv4
+				baseExpectedDatabaseState[3] = peerNSASIPv6
 				peerASEgressRule0v4, peerASEgressRule0v6 = buildANPAddressSets(anp, 0, []string{}, libovsdbutil.ACLEgress)
-				baseExpectedDatabaseState[2] = peerASEgressRule0v4
-				baseExpectedDatabaseState[3] = peerASEgressRule0v6
+				baseExpectedDatabaseState[8] = peerASEgressRule0v4
+				baseExpectedDatabaseState[9] = peerASEgressRule0v6
 				expectedDatabaseState = append(baseExpectedDatabaseState, pg)
 				expectedDatabaseState = append(expectedDatabaseState, getDefaultNetExpectedPodsAndSwitches([]testPod{t2}, []string{node1Name})...)
 				for _, acl := range acls {
@@ -1400,9 +1421,12 @@ var _ = ginkgo.Describe("OVN ANP Operations", func() {
 				}
 				acls = getACLsForANPRulesWithNamedPorts(anp, namedIPorts, namedEPorts)
 				pg = getDefaultPGForANPSubject(anp.Name, []string{t2.portUUID}, acls, false)
+				peerNSASIPv4, peerNSASIPv6 = buildNamespaceAddressSets(anpPeerNamespaceName, []string{"fe00:10:128:1::4", "10.128.1.4"}) // pod is re-added to peer namespace address-set
+				baseExpectedDatabaseState[2] = peerNSASIPv4
+				baseExpectedDatabaseState[3] = peerNSASIPv6
 				peerASEgressRule0v4, peerASEgressRule0v6 = buildANPAddressSets(anp, 0, []string{"fe00:10:128:1::4", "10.128.1.4"}, libovsdbutil.ACLEgress)
-				baseExpectedDatabaseState[2] = peerASEgressRule0v4
-				baseExpectedDatabaseState[3] = peerASEgressRule0v6
+				baseExpectedDatabaseState[8] = peerASEgressRule0v4
+				baseExpectedDatabaseState[9] = peerASEgressRule0v6
 				expectedDatabaseState = append(baseExpectedDatabaseState, pg)
 				expectedDatabaseState = append(expectedDatabaseState, getDefaultNetExpectedPodsAndSwitches([]testPod{t1, t2}, []string{node1Name})...)
 				for _, acl := range acls {
@@ -1425,7 +1449,7 @@ var _ = ginkgo.Describe("OVN ANP Operations", func() {
 				delete(namedEPorts, "web")
 				acls = getACLsForANPRulesWithNamedPorts(anp, namedIPorts, namedEPorts)
 				pg = getDefaultPGForANPSubject(anp.Name, []string{t2.portUUID}, acls, false)
-				expectedDatabaseState = []libovsdbtest.TestData{pg}
+				expectedDatabaseState = []libovsdbtest.TestData{pg, subjectNSASIPv4, subjectNSASIPv6, peerNSASIPv4, peerNSASIPv6, peerNS2ASIPv4, peerNS2ASIPv6}
 				expectedDatabaseState = append(expectedDatabaseState, getDefaultNetExpectedPodsAndSwitches([]testPod{t1, t2}, []string{node1Name})...)
 				expectedDatabaseState = append(expectedDatabaseState, peerASIngressRule0v4)
 				expectedDatabaseState = append(expectedDatabaseState, peerASIngressRule0v6)
@@ -1451,7 +1475,7 @@ var _ = ginkgo.Describe("OVN ANP Operations", func() {
 				delete(namedEPorts, "web123")
 				acls = getACLsForANPRulesWithNamedPorts(anp, namedIPorts, namedEPorts)
 				pg = getDefaultPGForANPSubject(anp.Name, []string{t2.portUUID}, acls, false)
-				expectedDatabaseState = []libovsdbtest.TestData{pg}
+				expectedDatabaseState = []libovsdbtest.TestData{pg, subjectNSASIPv4, subjectNSASIPv6, peerNSASIPv4, peerNSASIPv6, peerNS2ASIPv4, peerNS2ASIPv6}
 				expectedDatabaseState = append(expectedDatabaseState, getDefaultNetExpectedPodsAndSwitches([]testPod{t1, t2}, []string{node1Name})...)
 				expectedDatabaseState = append(expectedDatabaseState, peerASIngressRule0v4)
 				expectedDatabaseState = append(expectedDatabaseState, peerASIngressRule0v6)
@@ -1808,7 +1832,9 @@ var _ = ginkgo.Describe("OVN ANP Operations", func() {
 
 				acls := getACLsForANPRules(anp)
 				pg := getDefaultPGForANPSubject(anp.Name, []string{t.portUUID}, acls, false)
-				expectedDatabaseState := []libovsdbtest.TestData{pg}
+				subjectNSASIPv4, subjectNSASIPv6 := buildNamespaceAddressSets(anpSubjectNamespaceName, []string{anpPodV4IP, anpPodV6IP})
+				peerNSASIPv4, peerNSASIPv6 := buildNamespaceAddressSets(anpPeerNamespaceName, []string{anpPodV4IP2, anpPodV6IP2})
+				expectedDatabaseState := []libovsdbtest.TestData{pg, subjectNSASIPv4, subjectNSASIPv6, peerNSASIPv4, peerNSASIPv6}
 				expectedDatabaseState = append(expectedDatabaseState, getDefaultNetExpectedPodsAndSwitches([]testPod{t, t2}, []string{node1Name})...)
 				for _, acl := range acls {
 					acl := acl
@@ -1906,7 +1932,7 @@ var _ = ginkgo.Describe("OVN ANP Operations", func() {
 				anp, err = fakeOVN.fakeClient.ANPClient.PolicyV1alpha1().AdminNetworkPolicies().Update(context.TODO(), anp, metav1.UpdateOptions{})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				pg = getDefaultPGForANPSubject(anp.Name, []string{t.portUUID}, nil, false)
-				expectedDatabaseState = []libovsdbtest.TestData{pg}
+				expectedDatabaseState = []libovsdbtest.TestData{pg, subjectNSASIPv4, subjectNSASIPv6, peerNSASIPv4, peerNSASIPv6}
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				expectedDatabaseState = append(expectedDatabaseState, getDefaultNetExpectedPodsAndSwitches([]testPod{t, t2}, []string{node1Name})...)
 				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
@@ -1915,7 +1941,7 @@ var _ = ginkgo.Describe("OVN ANP Operations", func() {
 				anp.ResourceVersion = "20"
 				err = fakeOVN.fakeClient.ANPClient.PolicyV1alpha1().AdminNetworkPolicies().Delete(context.TODO(), anp.Name, metav1.DeleteOptions{})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				expectedDatabaseState = []libovsdbtest.TestData{} // port group should be deleted
+				expectedDatabaseState = []libovsdbtest.TestData{subjectNSASIPv4, subjectNSASIPv6, peerNSASIPv4, peerNSASIPv6} // port group should be deleted
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				expectedDatabaseState = append(expectedDatabaseState, getDefaultNetExpectedPodsAndSwitches([]testPod{t, t2}, []string{node1Name})...)
 				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))

--- a/go-controller/pkg/ovn/base_network_controller.go
+++ b/go-controller/pkg/ovn/base_network_controller.go
@@ -766,6 +766,60 @@ func (bnc *BaseNetworkController) deleteNamespaceLocked(ns string) (*namespaceIn
 		nsInfo.Unlock()
 		return nil, nil
 	}
+	if nsInfo.addressSet != nil {
+		// Empty the address set, then delete it after an interval.
+		if err := nsInfo.addressSet.SetAddresses(nil); err != nil {
+			klog.Errorf("Warning: failed to empty address set for deleted NS %s: %v", ns, err)
+		}
+
+		// Delete the address set after a short delay.
+		// This is to avoid OVN warnings while the address set is still
+		// referenced from NBDB ACLs until the NetworkPolicy handlers remove
+		// them.
+		addressSet := nsInfo.addressSet
+		go func() {
+			select {
+			case <-bnc.stopChan:
+				return
+			case <-time.After(20 * time.Second):
+				maybeDeleteAddressSet := func() bool {
+					bnc.namespacesMutex.Lock()
+					nsInfo := bnc.namespaces[ns]
+					if nsInfo == nil {
+						defer bnc.namespacesMutex.Unlock()
+					} else {
+						bnc.namespacesMutex.Unlock()
+						nsInfo.Lock()
+						defer nsInfo.Unlock()
+						bnc.namespacesMutex.Lock()
+						defer bnc.namespacesMutex.Unlock()
+						if nsInfo != bnc.namespaces[ns] {
+							// somebody deleted the namespace while waiting for
+							// its lock, check again in case it was added back
+							return false
+						}
+						// if somebody recreated the namespace during the delay,
+						// check if it has an address set
+						if nsInfo.addressSet != nil {
+							klog.V(5).Infof("Skipping deferred deletion of AddressSet for NS %s: recreated", ns)
+							return true
+						}
+					}
+					klog.V(5).Infof("Finishing deferred deletion of AddressSet for NS %s", ns)
+					if err := addressSet.Destroy(); err != nil {
+						klog.Errorf("Failed to delete AddressSet for NS %s: %v", ns, err.Error())
+					}
+					return true
+				}
+				for {
+					done := maybeDeleteAddressSet()
+					if done {
+						break
+					}
+				}
+			}
+		}()
+	}
 	if nsInfo.portGroupName != "" {
 		err := libovsdbops.DeletePortGroups(bnc.nbClient, nsInfo.portGroupName)
 		if err != nil {
@@ -867,9 +921,14 @@ func (bnc *BaseNetworkController) syncNodeManagementPort(node *corev1.Node, swit
 // addLocalPodToNamespaceLocked returns the ops needed to add the pod's IP to the namespace
 // address set and the port UUID (if applicable) to the namespace port group.
 // This function must be called with the nsInfo lock taken.
-func (bnc *BaseNetworkController) addLocalPodToNamespaceLocked(nsInfo *namespaceInfo, portUUID string) ([]ovsdb.Operation, error) {
+func (bnc *BaseNetworkController) addLocalPodToNamespaceLocked(nsInfo *namespaceInfo, ips []*net.IPNet, portUUID string) ([]ovsdb.Operation, error) {
 	var ops []ovsdb.Operation
 	var err error
+
+	if ops, err = nsInfo.addressSet.AddAddressesReturnOps(util.IPNetsIPToStringSlice(ips)); err != nil {
+		return nil, err
+	}
+
 	if portUUID != "" && nsInfo.portGroupName != "" {
 		if ops, err = libovsdbops.AddPortsToPortGroupOps(bnc.nbClient, ops, nsInfo.portGroupName, portUUID); err != nil {
 			return nil, err

--- a/go-controller/pkg/ovn/base_network_controller_multicast.go
+++ b/go-controller/pkg/ovn/base_network_controller_multicast.go
@@ -6,7 +6,6 @@ package ovn
 import (
 	"fmt"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
 
@@ -59,14 +58,11 @@ func getMulticastACLIgrMatchV6(addrSetName string) string {
 	return "(mldv1 || mldv2 || (ip6.src == $" + addrSetName + " && " + ipv6DynamicMulticastMatch + "))"
 }
 
-func getMulticastAddrsetBackref(namespace string) string {
-	return fmt.Sprintf("%v/%v", "Multicast", namespace)
-}
-
 // Creates the match string used for ACLs allowing incoming multicast into a
 // namespace, that is, from IPs that are in the namespace's address set.
-func (bnc *BaseNetworkController) getMulticastACLIgrMatch(addrSetNameV4, addrSetNameV6 string) string {
+func (bnc *BaseNetworkController) getMulticastACLIgrMatch(nsInfo *namespaceInfo) string {
 	var ipv4Match, ipv6Match string
+	addrSetNameV4, addrSetNameV6 := nsInfo.addressSet.GetASHashNames()
 	ipv4Mode, ipv6Mode := bnc.IPMode()
 	if ipv4Mode {
 		ipv4Match = getMulticastACLIgrMatchV4(addrSetNameV4)
@@ -121,20 +117,6 @@ func getNamespaceMcastACLDbIDs(ns string, aclDir libovsdbutil.ACLDirection, cont
 //     namespace address set).
 func (bnc *BaseNetworkController) createMulticastAllowPolicy(ns string, nsInfo *namespaceInfo) error {
 	portGroupName := bnc.getNamespacePortGroupName(ns)
-	// we use legacyNetpolMode to avoid adding hostNetwork pods (aka node) IPs.
-	// Another side-effect of using legacyNetpolMode is that HostNetworkNamespace could be matched,
-	// but since we are using static namespace and not a selector, this will never happen
-	// (unless multicast is enabled on HostNetworkNamespace, which should never happen)
-	asKey, addrSetNameV4, addrSetNameV6, err := bnc.addressSetManager.EnsureAddressSet(
-		&metav1.LabelSelector{}, nil, nil, ns, getMulticastAddrsetBackref(ns),
-		bnc.controllerName, bnc.GetNetInfo(), true)
-	// even if EnsureAddressSet failed, add key for future cleanup or retry.
-	nsInfo.addrSetOwnerBackref = asKey
-	nsInfo.addrSetNameV4 = addrSetNameV4
-	nsInfo.addrSetNameV6 = addrSetNameV6
-	if err != nil {
-		return fmt.Errorf("unable to ensure address set for namespace %s: %v", ns, err)
-	}
 
 	aclDir := libovsdbutil.ACLEgress
 	egressMatch := libovsdbutil.GetACLMatch(portGroupName, bnc.getMulticastACLEgrMatch(), aclDir)
@@ -143,7 +125,7 @@ func (bnc *BaseNetworkController) createMulticastAllowPolicy(ns string, nsInfo *
 	egressACL := libovsdbutil.BuildACLWithDefaultTier(dbIDs, types.DefaultMcastAllowPriority, egressMatch, nbdb.ACLActionAllow, nil, aclPipeline)
 
 	aclDir = libovsdbutil.ACLIngress
-	ingressMatch := libovsdbutil.GetACLMatch(portGroupName, bnc.getMulticastACLIgrMatch(addrSetNameV4, addrSetNameV6), aclDir)
+	ingressMatch := libovsdbutil.GetACLMatch(portGroupName, bnc.getMulticastACLIgrMatch(nsInfo), aclDir)
 	dbIDs = getNamespaceMcastACLDbIDs(ns, aclDir, bnc.controllerName)
 	aclPipeline = libovsdbutil.ACLDirectionToACLPipeline(aclDir)
 	ingressACL := libovsdbutil.BuildACLWithDefaultTier(dbIDs, types.DefaultMcastAllowPriority, ingressMatch, nbdb.ACLActionAllow, nil, aclPipeline)
@@ -167,7 +149,7 @@ func (bnc *BaseNetworkController) createMulticastAllowPolicy(ns string, nsInfo *
 	return nil
 }
 
-func (bnc *BaseNetworkController) deleteMulticastAllowPolicy(ns string, nsInfo *namespaceInfo) error {
+func (bnc *BaseNetworkController) deleteMulticastAllowPolicy(ns string) error {
 	portGroupName := bnc.getNamespacePortGroupName(ns)
 
 	// mcast acls have ACLMulticastNamespace owner
@@ -187,16 +169,6 @@ func (bnc *BaseNetworkController) deleteMulticastAllowPolicy(ns string, nsInfo *
 	if err != nil {
 		return fmt.Errorf("unable to delete multicast acls for namespace %s: %w", ns, err)
 	}
-	// nsInfo is nil on initial sync, there is no need to cleanup address set in that case
-	if nsInfo != nil {
-		if err := bnc.addressSetManager.DeleteAddressSet(nsInfo.addrSetOwnerBackref, getMulticastAddrsetBackref(ns)); err != nil {
-			return fmt.Errorf("unable to delete address set for namespace %s: %v", ns, err)
-		}
-		nsInfo.addrSetOwnerBackref = ""
-		nsInfo.addrSetNameV4 = ""
-		nsInfo.addrSetNameV6 = ""
-	}
-
 	return nil
 }
 
@@ -301,9 +273,6 @@ func (bnc *BaseNetworkController) disableMulticast() error {
 	if err != nil {
 		return fmt.Errorf("unable to delete namespaced multicast objects: %v", err)
 	}
-	// disableMulticast is only called on controller creation to clean up stale db entries.
-	// there is no need to call cleanups on the addresssetManager, because no calls to EnsureAddressSet
-	// were done if multicast is disabled.
 	return nil
 }
 
@@ -348,7 +317,7 @@ func (bnc *BaseNetworkController) syncNsMulticast(k8sNamespaces map[string]bool)
 	}
 
 	for _, staleNs := range staleNamespaces {
-		if err = bnc.deleteMulticastAllowPolicy(staleNs, nil); err != nil {
+		if err = bnc.deleteMulticastAllowPolicy(staleNs); err != nil {
 			return fmt.Errorf("unable to delete multicast allow policy for stale ns %s: %v", staleNs, err)
 		}
 	}

--- a/go-controller/pkg/ovn/base_network_controller_namespace.go
+++ b/go-controller/pkg/ovn/base_network_controller_namespace.go
@@ -6,7 +6,9 @@ package ovn
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"net"
 	"sync"
 
 	corev1 "k8s.io/api/core/v1"
@@ -15,9 +17,11 @@ import (
 	"k8s.io/klog/v2"
 
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/kubevirt"
 	libovsdbops "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/libovsdb/ops"
 	libovsdbutil "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/libovsdb/util"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/nbdb"
+	addressset "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/address_set"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
 	utilerrors "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util/errors"
 )
@@ -28,11 +32,10 @@ import (
 // manages the oc.namespaces map is ever allowed to hold an unlocked namespaceInfo.)
 type namespaceInfo struct {
 	sync.RWMutex
-	// we don't create namespace from the namespace handler anymore, instead using addressset_manager
-	// only multicast uses and manages this address set
-	addrSetOwnerBackref          string
-	addrSetNameV4, addrSetNameV6 string
 
+	// addressSet is an address set object that holds the IP addresses
+	// of all pods in the namespace.
+	addressSet addressset.AddressSet
 	// portGroupName is a name of a port group, that stores all local zone ports for a given namespace.
 	// May be empty if the port group wasn't created.
 	portGroupName string
@@ -59,6 +62,13 @@ type namespaceInfo struct {
 
 	// If not empty, then it has to be set to a logging a severity level, e.g. "notice", "alert", etc
 	aclLogging libovsdbutil.ACLLoggingLevels
+}
+
+func getNamespaceAddrSetDbIDs(namespaceName, controller string) *libovsdbops.DbObjectIDs {
+	return libovsdbops.NewDbObjectIDs(libovsdbops.AddressSetNamespace, controller, map[libovsdbops.ExternalIDKey]string{
+		// namespace has only 1 address set, no additional ids are required
+		libovsdbops.ObjectNameKey: namespaceName,
+	})
 }
 
 func (bnc *BaseNetworkController) shouldWatchNamespaces() bool {
@@ -165,6 +175,20 @@ func (bnc *BaseNetworkController) syncNamespaces(namespaces []interface{}) error
 		}
 	}
 
+	err := bnc.addressSetFactory.ProcessEachAddressSet(bnc.controllerName, libovsdbops.AddressSetNamespace,
+		func(dbIDs *libovsdbops.DbObjectIDs) error {
+			if !expectedNs[dbIDs.GetObjectID(libovsdbops.ObjectNameKey)] {
+				if err := bnc.addressSetFactory.DestroyAddressSet(dbIDs); err != nil {
+					return err
+				}
+			}
+
+			return nil
+		})
+	if err != nil {
+		return fmt.Errorf("error in syncing namespaces: %v", err)
+	}
+
 	// remove stale port groups
 	predicateIDs := libovsdbops.NewDbObjectIDs(libovsdbops.PortGroupNamespace, bnc.controllerName, nil)
 	p := libovsdbops.GetPredicate[*nbdb.PortGroup](predicateIDs, func(item *nbdb.PortGroup) bool {
@@ -172,7 +196,7 @@ func (bnc *BaseNetworkController) syncNamespaces(namespaces []interface{}) error
 		return !bnc.needNamespacedPortGroup() || !expectedNs[namespaceName]
 	})
 
-	err := libovsdbops.DeletePortGroupsWithPredicate(bnc.nbClient, p)
+	err = libovsdbops.DeletePortGroupsWithPredicate(bnc.nbClient, p)
 	if err != nil {
 		return fmt.Errorf("unable to delete stale namespace port groups: %v", err)
 	}
@@ -182,9 +206,7 @@ func (bnc *BaseNetworkController) syncNamespaces(namespaces []interface{}) error
 			return fmt.Errorf("error in syncing multicast for namespaces: %v", err)
 		}
 	}
-	// clean up deprecated namespace-owned address sets
-	predicateIDs = libovsdbops.NewDbObjectIDs(libovsdbops.AddressSetNamespace, bnc.controllerName, nil)
-	return libovsdbutil.DeleteAddrSetsWithoutACLRef(predicateIDs, bnc.nbClient)
+	return nil
 }
 
 // Creates an explicit "allow" policy for multicast traffic within the
@@ -206,7 +228,7 @@ func (bnc *BaseNetworkController) multicastUpdateNamespace(ns *corev1.Namespace,
 	if enabled {
 		err = bnc.createMulticastAllowPolicy(ns.Name, nsInfo)
 	} else {
-		err = bnc.deleteMulticastAllowPolicy(ns.Name, nsInfo)
+		err = bnc.deleteMulticastAllowPolicy(ns.Name)
 	}
 	if err != nil {
 		return err
@@ -219,7 +241,7 @@ func (bnc *BaseNetworkController) multicastUpdateNamespace(ns *corev1.Namespace,
 func (bnc *BaseNetworkController) multicastDeleteNamespace(ns *corev1.Namespace, nsInfo *namespaceInfo) error {
 	if nsInfo.multicastEnabled {
 		nsInfo.multicastEnabled = false
-		if err := bnc.deleteMulticastAllowPolicy(ns.Name, nsInfo); err != nil {
+		if err := bnc.deleteMulticastAllowPolicy(ns.Name); err != nil {
 			return err
 		}
 	}
@@ -245,6 +267,14 @@ func (bnc *BaseNetworkController) ensureNamespaceLockedCommon(ns string, readOnl
 		// we are creating nsInfo and going to set it in namespaces map
 		// so safe to hold the lock while we create and add it
 		defer bnc.namespacesMutex.Unlock()
+		// create the adddress set for the new namespace
+		var err error
+		ips := bnc.getAllNamespacePodAddresses(ns)
+		nsInfo.addressSet, err = bnc.createNamespaceAddrSetAllPods(ns, ips)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to create address set for namespace: %s, error: %v", ns, err)
+		}
+
 		// namespace port groups are only used by egress firewall and multicast for now
 		if bnc.needNamespacedPortGroup() {
 			portGroupName, err := bnc.createNamespacePortGroup(ns)
@@ -363,6 +393,39 @@ func (bnc *BaseNetworkController) updateNamespaceAclLogging(ns, aclAnnotation st
 	return nil
 }
 
+func (bnc *BaseNetworkController) getAllNamespacePodAddresses(ns string) []net.IP {
+	if !bnc.doesNetworkRequireIPAM() {
+		return nil
+	}
+
+	var ips []net.IP
+	resolver := bnc.getNetworkNameForNADKeyFunc()
+	// Get all the pods in the namespace and append their IP to the address_set
+	existingPods, err := bnc.watchFactory.GetPods(ns)
+	if err != nil {
+		klog.Errorf("Failed to get all the pods (%v)", err)
+	} else {
+		ips = make([]net.IP, 0, len(existingPods))
+		for _, pod := range existingPods {
+			if !util.PodWantsHostNetwork(pod) && !util.PodCompleted(pod) && util.PodScheduled(pod) {
+				podIPs, err := util.GetPodIPsOfNetwork(pod, bnc.GetNetInfo(), resolver)
+				if err != nil {
+					klog.Warningf("Failed to get IPs for pod %s/%s: %v", pod.Namespace, pod.Name, err)
+					continue
+				}
+				ips = append(ips, podIPs...)
+			}
+		}
+	}
+	return ips
+}
+
+func (bnc *BaseNetworkController) createNamespaceAddrSetAllPods(ns string, ips []net.IP) (addressset.AddressSet, error) {
+	dbIDs := getNamespaceAddrSetDbIDs(ns, bnc.controllerName)
+	ipSet := util.StringSlice(ips)
+	return bnc.addressSetFactory.NewAddressSet(dbIDs, ipSet)
+}
+
 // createNamespacePortGroup should only create a port group if it doesn't exist already,
 // all ports and acls will be added by pod/multicast/egressfirewall/etc handlers.
 func (bnc *BaseNetworkController) createNamespacePortGroup(ns string) (string, error) {
@@ -383,4 +446,56 @@ func getNamespacePortGroupDbIDs(ns string, controller string) *libovsdbops.DbObj
 
 func (bnc *BaseNetworkController) getNamespacePortGroupName(namespace string) string {
 	return libovsdbutil.GetPortGroupName(getNamespacePortGroupDbIDs(namespace, bnc.controllerName))
+}
+
+// removeRemoteZonePodFromNamespaceAddressset tries to remove the remote zone pod ips from the pod namespace address set.
+// failure indicates it should be retried later.
+func (bsnc *BaseNetworkController) removeRemoteZonePodFromNamespaceAddressSet(pod *corev1.Pod) error {
+	podDesc := fmt.Sprintf("pod %s/%s/%s", bsnc.GetNetworkName(), pod.Namespace, pod.Name)
+	podIfAddrs, err := util.GetPodCIDRsWithFullMask(pod, bsnc.GetNetInfo(), bsnc.getNetworkNameForNADKeyFunc())
+	if err != nil {
+		// maybe the pod is not scheduled yet or addLSP has not happened yet, so it doesn't have IPs.
+		// let us ignore deletion failures for podIPs not found because
+		// there is nothing more we can do here.
+		if errors.Is(err, util.ErrNoPodIPFound) {
+			klog.Warningf("Unable to remove remote zone pod's %s/%s IP address from the "+
+				"namespace address-set, err: %v", pod.Namespace, pod.Name, err)
+			return nil
+		}
+		return fmt.Errorf("failed to get pod ips for the pod  %s/%s : %w", pod.Namespace, pod.Name, err)
+	}
+
+	// If this pod applies to live migration it could have migrated so get the
+	// correct node name corresponding with the subnet. If the subnet is not
+	// tracked within the zone, nodeName will be empty which will force
+	// canReleasePodIPs to lookup all nodes.
+	nodeName := pod.Spec.NodeName
+	if !bsnc.IsUserDefinedNetwork() && kubevirt.IsPodLiveMigratable(pod) {
+		nodeName, _ = bsnc.lsManager.GetSubnetName(podIfAddrs)
+	}
+
+	// Remove the pod ips from the namespace address set. Before that check if its a completed pod and
+	// make sure that the ips are not colliding with other pod.
+	shouldRelease, err := bsnc.canReleasePodIPs(podIfAddrs, nodeName)
+	if err != nil {
+		return err
+	}
+
+	if !shouldRelease {
+		klog.Infof("Cannot release IP address: %s for %s/%s from namespace address set. Detected another pod"+
+			" using this IP", util.JoinIPNetIPs(podIfAddrs, " "), pod.Namespace, pod.Name)
+		return nil
+	}
+
+	ops, err := bsnc.deletePodFromNamespace(pod.Namespace, podIfAddrs, "")
+	if err != nil {
+		return fmt.Errorf("failed to delete remote pod %s's IP from namespace: %w", podDesc, err)
+	}
+
+	_, err = libovsdbops.TransactAndCheck(bsnc.nbClient, ops)
+	if err != nil {
+		return fmt.Errorf("could not delete remote pod IPs from the namespace address set - %w", err)
+	}
+
+	return nil
 }

--- a/go-controller/pkg/ovn/base_network_controller_namespace_test.go
+++ b/go-controller/pkg/ovn/base_network_controller_namespace_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	ovncnitypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/cni/types"
+	ovntypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/cni/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
@@ -19,19 +19,19 @@ import (
 func TestBaseNetworkController_shouldWatchNamespaces(t *testing.T) {
 	tests := []struct {
 		name                                                 string
-		netCfg                                               *ovncnitypes.NetConf
+		netCfg                                               *ovntypes.NetConf
 		enableNetSeg, enableMultiNetPolicies, expectedReturn bool
 	}{
 		{
 			name: "should watch namespaces for default network",
-			netCfg: &ovncnitypes.NetConf{
+			netCfg: &ovntypes.NetConf{
 				NetConf: cnitypes.NetConf{Name: types.DefaultNetworkName},
 			},
 			expectedReturn: true,
 		},
 		{
 			name: "should watch namespaces for primary network when network segmentation is enabled",
-			netCfg: &ovncnitypes.NetConf{
+			netCfg: &ovntypes.NetConf{
 				NetConf:  cnitypes.NetConf{Name: "primary"},
 				Topology: types.Layer3Topology,
 				Role:     types.NetworkRolePrimary,
@@ -41,7 +41,7 @@ func TestBaseNetworkController_shouldWatchNamespaces(t *testing.T) {
 		},
 		{
 			name: "should watch namespaces for secondary network when multi NetworkPolicies are enabled",
-			netCfg: &ovncnitypes.NetConf{
+			netCfg: &ovntypes.NetConf{
 				NetConf:  cnitypes.NetConf{Name: "secondary"},
 				Topology: types.Layer3Topology,
 				Role:     types.NetworkRoleSecondary,
@@ -51,7 +51,7 @@ func TestBaseNetworkController_shouldWatchNamespaces(t *testing.T) {
 		},
 		{
 			name: "should not watch namespaces for primary network when network segmentation is disabled",
-			netCfg: &ovncnitypes.NetConf{
+			netCfg: &ovntypes.NetConf{
 				NetConf:  cnitypes.NetConf{Name: "primary"},
 				Topology: types.Layer3Topology,
 				Role:     types.NetworkRolePrimary,
@@ -60,7 +60,7 @@ func TestBaseNetworkController_shouldWatchNamespaces(t *testing.T) {
 		},
 		{
 			name: "should not watch namespaces for secondary network when multi NetworkPolicies is disabled",
-			netCfg: &ovncnitypes.NetConf{
+			netCfg: &ovntypes.NetConf{
 				NetConf:  cnitypes.NetConf{Name: "secondary"},
 				Topology: types.Layer3Topology,
 				Role:     types.NetworkRoleSecondary,

--- a/go-controller/pkg/ovn/base_network_controller_pods.go
+++ b/go-controller/pkg/ovn/base_network_controller_pods.go
@@ -254,12 +254,14 @@ func (bnc *BaseNetworkController) deletePodLogicalPort(pod *corev1.Pod, portInfo
 
 	var allOps, ops []ovsdb.Operation
 
-	if ops, err = bnc.deletePodFromNamespace(pod.Namespace,
-		portUUID); err != nil {
-		return nil, fmt.Errorf("unable to delete pod %s from namespace: %w", podDesc, err)
+	// if the ip is in use by another pod we should not try to remove it from the address set
+	if shouldRelease {
+		if ops, err = bnc.deletePodFromNamespace(pod.Namespace,
+			podIfAddrs, portUUID); err != nil {
+			return nil, fmt.Errorf("unable to delete pod %s from namespace: %w", podDesc, err)
+		}
+		allOps = append(allOps, ops...)
 	}
-	allOps = append(allOps, ops...)
-
 	ops, err = bnc.delLSPOps(logicalPort, switchName, portUUID)
 	// Tolerate cases where logical switch of the logical port no longer exist in OVN.
 	if err != nil && !errors.Is(err, libovsdbclient.ErrNotFound) {
@@ -731,7 +733,7 @@ func (bnc *BaseNetworkController) delLSPOps(logicalPort, switchName,
 	return ops, nil
 }
 
-func (bnc *BaseNetworkController) deletePodFromNamespace(ns string, portUUID string) ([]ovsdb.Operation, error) {
+func (bnc *BaseNetworkController) deletePodFromNamespace(ns string, podIfAddrs []*net.IPNet, portUUID string) ([]ovsdb.Operation, error) {
 	// for UDN, namespace may be not managed
 	nsInfo, nsUnlock := bnc.getNamespaceLocked(ns, true)
 	if nsInfo == nil {
@@ -740,6 +742,11 @@ func (bnc *BaseNetworkController) deletePodFromNamespace(ns string, portUUID str
 	defer nsUnlock()
 	var ops []ovsdb.Operation
 	var err error
+	if nsInfo.addressSet != nil {
+		if ops, err = nsInfo.addressSet.DeleteAddressesReturnOps(util.IPNetsIPToStringSlice(podIfAddrs)); err != nil {
+			return nil, err
+		}
+	}
 
 	if nsInfo.portGroupName != "" && len(portUUID) > 0 {
 		if ops, err = libovsdbops.DeletePortsFromPortGroupOps(bnc.nbClient, ops, nsInfo.portGroupName, portUUID); err != nil {

--- a/go-controller/pkg/ovn/base_network_controller_user_defined.go
+++ b/go-controller/pkg/ovn/base_network_controller_user_defined.go
@@ -410,7 +410,7 @@ func (bsnc *BaseUserDefinedNetworkController) addLogicalPortToNetworkForNAD(pod 
 		if lsp != nil {
 			portUUID = lsp.UUID
 		}
-		addOps, err := bsnc.addPodToNamespaceForUserDefinedNetwork(pod.Namespace, portUUID)
+		addOps, err := bsnc.addPodToNamespaceForUserDefinedNetwork(pod.Namespace, podAnnotation.IPs, portUUID)
 		if err != nil {
 			return err
 		}
@@ -491,6 +491,13 @@ func (bsnc *BaseUserDefinedNetworkController) removePodForUserDefinedNetwork(pod
 
 		// handle remote pod clean up but only do this one time
 		if !hasLogicalPort && !alreadyProcessed {
+			if bsnc.doesNetworkRequireIPAM() &&
+				// address set is for network policy only. So either multi network policy is enabled or network
+				// segmentation, and it is a primary UDN (regular netpol)
+				(util.IsMultiNetworkPoliciesSupportEnabled() || (util.IsNetworkSegmentationSupportEnabled() && bsnc.IsPrimaryNetwork())) {
+				return bsnc.removeRemoteZonePodFromNamespaceAddressSet(pod)
+			}
+
 			// except for localnet networks, continue the delete flow in case a node just
 			// became remote where we might still need to cleanup. On L3 networks
 			// the node switch is removed so there is no need to do this.
@@ -703,7 +710,7 @@ func (bsnc *BaseUserDefinedNetworkController) syncPodsForUserDefinedNetwork(pods
 }
 
 // addPodToNamespaceForUserDefinedNetwork returns the ops needed to add pod's IP to the namespace's address set.
-func (bsnc *BaseUserDefinedNetworkController) addPodToNamespaceForUserDefinedNetwork(ns string, portUUID string) ([]ovsdb.Operation, error) {
+func (bsnc *BaseUserDefinedNetworkController) addPodToNamespaceForUserDefinedNetwork(ns string, ips []*net.IPNet, portUUID string) ([]ovsdb.Operation, error) {
 	var err error
 	nsInfo, nsUnlock, err := bsnc.ensureNamespaceLockedForUserDefinedNetwork(ns, true, nil)
 	if err != nil {
@@ -712,7 +719,7 @@ func (bsnc *BaseUserDefinedNetworkController) addPodToNamespaceForUserDefinedNet
 
 	defer nsUnlock()
 
-	return bsnc.addLocalPodToNamespaceLocked(nsInfo, portUUID)
+	return bsnc.addLocalPodToNamespaceLocked(nsInfo, ips, portUUID)
 }
 
 // AddNamespaceForUserDefinedNetwork creates corresponding addressset in ovn db for User Defined Network

--- a/go-controller/pkg/ovn/baseline_admin_network_policy_test.go
+++ b/go-controller/pkg/ovn/baseline_admin_network_policy_test.go
@@ -150,9 +150,15 @@ var _ = ginkgo.Describe("OVN BANP Operations", func() {
 					Name: node1Name,
 					UUID: node1Name + "-UUID",
 				}
+				subjectNSASIPv4, subjectNSASIPv6 := buildNamespaceAddressSets(banpSubjectNamespaceName, []string{})
+				peerNSASIPv4, peerNSASIPv6 := buildNamespaceAddressSets(banpPeerNamespaceName, []string{})
 				dbSetup := libovsdbtest.TestSetup{
 					NBData: []libovsdbtest.TestData{
 						node1Switch,
+						subjectNSASIPv4,
+						subjectNSASIPv6,
+						peerNSASIPv4,
+						peerNSASIPv6,
 					},
 				}
 				fakeOVN.startWithDBSetup(dbSetup,
@@ -202,7 +208,7 @@ var _ = ginkgo.Describe("OVN BANP Operations", func() {
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				// TODO: Check if clone methods did the right thing - do the test in the admin_network_policy_package
 				pg := getDefaultPGForANPSubject(banp.Name, nil, nil, true)
-				expectedDatabaseState := []libovsdbtest.TestData{node1Switch, pg}
+				expectedDatabaseState := []libovsdbtest.TestData{node1Switch, subjectNSASIPv4, subjectNSASIPv6, peerNSASIPv4, peerNSASIPv6, pg}
 				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 
 				ginkgo.By("2. creating a pod that will act as subject of baseline admin network policy; check if lsp is added to port-group after retries")
@@ -232,8 +238,9 @@ var _ = ginkgo.Describe("OVN BANP Operations", func() {
 				banpSubjectPod.Labels["rv"] = "resourceVersionUTHack"
 				_, err = fakeOVN.fakeClient.KubeClient.CoreV1().Pods(banpSubjectPod.Namespace).Update(context.TODO(), &banpSubjectPod, metav1.UpdateOptions{})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				subjectNSASIPv4, subjectNSASIPv6 = buildNamespaceAddressSets(banpSubjectNamespaceName, []string{t.podIP})
 				pg = getDefaultPGForANPSubject(banp.Name, []string{t.portUUID}, nil, true)
-				expectedDatabaseState = []libovsdbtest.TestData{pg}
+				expectedDatabaseState = []libovsdbtest.TestData{pg, subjectNSASIPv4, subjectNSASIPv6, peerNSASIPv4, peerNSASIPv6}
 				expectedDatabaseState = append(expectedDatabaseState, getDefaultNetExpectedPodsAndSwitches([]testPod{t}, []string{node1Name})...)
 				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 
@@ -293,7 +300,8 @@ var _ = ginkgo.Describe("OVN BANP Operations", func() {
 				banpPeerPod.Labels["rv"] = "resourceVersionUTHack"
 				_, err = fakeOVN.fakeClient.KubeClient.CoreV1().Pods(banpPeerPod.Namespace).Update(context.TODO(), &banpPeerPod, metav1.UpdateOptions{})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				expectedDatabaseState = []libovsdbtest.TestData{pg}
+				peerNSASIPv4, peerNSASIPv6 = buildNamespaceAddressSets(banpPeerNamespaceName, []string{t2.podIP})
+				expectedDatabaseState = []libovsdbtest.TestData{pg, subjectNSASIPv4, subjectNSASIPv6, peerNSASIPv4, peerNSASIPv6}
 				for _, acl := range acls {
 					acl := acl
 					expectedDatabaseState = append(expectedDatabaseState, acl)
@@ -360,7 +368,7 @@ var _ = ginkgo.Describe("OVN BANP Operations", func() {
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				acls = getACLsForBANPRules(banp)
 				pg = getDefaultPGForANPSubject(banp.Name, []string{t.portUUID}, acls, true)
-				expectedDatabaseState = []libovsdbtest.TestData{pg}
+				expectedDatabaseState = []libovsdbtest.TestData{pg, subjectNSASIPv4, subjectNSASIPv6, peerNSASIPv4, peerNSASIPv6}
 				for _, acl := range acls {
 					acl := acl
 					expectedDatabaseState = append(expectedDatabaseState, acl)
@@ -453,7 +461,7 @@ var _ = ginkgo.Describe("OVN BANP Operations", func() {
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				acls = getACLsForBANPRules(banp)
 				pg = getDefaultPGForANPSubject(banp.Name, []string{t.portUUID}, acls, true)
-				expectedDatabaseState = []libovsdbtest.TestData{pg}
+				expectedDatabaseState = []libovsdbtest.TestData{pg, subjectNSASIPv4, subjectNSASIPv6, peerNSASIPv4, peerNSASIPv6}
 				for _, acl := range acls {
 					acl := acl
 					expectedDatabaseState = append(expectedDatabaseState, acl)
@@ -572,7 +580,7 @@ var _ = ginkgo.Describe("OVN BANP Operations", func() {
 				// Both oldACLs and newACLs will be found in test server.
 				newACLs := getACLsForBANPRules(banp)
 				pg = getDefaultPGForANPSubject(banp.Name, []string{t.portUUID}, newACLs, true) // only newACLs are hosted
-				expectedDatabaseState = []libovsdbtest.TestData{pg}
+				expectedDatabaseState = []libovsdbtest.TestData{pg, subjectNSASIPv4, subjectNSASIPv6, peerNSASIPv4, peerNSASIPv6}
 				for _, acl := range newACLs {
 					acl := acl
 					expectedDatabaseState = append(expectedDatabaseState, acl)
@@ -602,8 +610,9 @@ var _ = ginkgo.Describe("OVN BANP Operations", func() {
 				banpPeerPod.ResourceVersion = "3"
 				err = fakeOVN.fakeClient.KubeClient.CoreV1().Pods(banpPeerPod.Namespace).Delete(context.TODO(), banpPeerPod.Name, metav1.DeleteOptions{})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				pg = getDefaultPGForANPSubject(banp.Name, []string{t.portUUID}, newACLs, true) // only newACLs are hosted
-				expectedDatabaseState = []libovsdbtest.TestData{pg}
+				pg = getDefaultPGForANPSubject(banp.Name, []string{t.portUUID}, newACLs, true)            // only newACLs are hosted
+				peerNSASIPv4, peerNSASIPv6 = buildNamespaceAddressSets(banpPeerNamespaceName, []string{}) // pod is gone from peer namespace address-set
+				expectedDatabaseState = []libovsdbtest.TestData{pg, subjectNSASIPv4, subjectNSASIPv6, peerNSASIPv4, peerNSASIPv6}
 				for _, acl := range newACLs {
 					acl := acl
 					expectedDatabaseState = append(expectedDatabaseState, acl)
@@ -623,7 +632,8 @@ var _ = ginkgo.Describe("OVN BANP Operations", func() {
 				_, err = fakeOVN.fakeClient.KubeClient.CoreV1().Pods(banpSubjectPod.Namespace).Update(context.TODO(), &banpSubjectPod, metav1.UpdateOptions{})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				pg = getDefaultPGForANPSubject(banp.Name, nil, newACLs, true) // no ports in PG
-				expectedDatabaseState = []libovsdbtest.TestData{pg}
+				subjectNSASIPv4, subjectNSASIPv6 = buildNamespaceAddressSets(banpSubjectNamespaceName, []string{})
+				expectedDatabaseState = []libovsdbtest.TestData{pg, subjectNSASIPv4, subjectNSASIPv6, peerNSASIPv4, peerNSASIPv6}
 				for _, acl := range newACLs {
 					acl := acl
 					expectedDatabaseState = append(expectedDatabaseState, acl)
@@ -654,7 +664,8 @@ var _ = ginkgo.Describe("OVN BANP Operations", func() {
 				t.podIP = "10.128.1.5"
 				t.podMAC = "0a:58:0a:80:01:05"
 				pg = getDefaultPGForANPSubject(banp.Name, []string{t.portUUID}, newACLs, true)
-				expectedDatabaseState = []libovsdbtest.TestData{pg}
+				subjectNSASIPv4, subjectNSASIPv6 = buildNamespaceAddressSets(banpSubjectNamespaceName, []string{t.podIP})
+				expectedDatabaseState = []libovsdbtest.TestData{pg, subjectNSASIPv4, subjectNSASIPv6, peerNSASIPv4, peerNSASIPv6}
 				for _, acl := range newACLs {
 					acl := acl
 					expectedDatabaseState = append(expectedDatabaseState, acl)
@@ -678,7 +689,8 @@ var _ = ginkgo.Describe("OVN BANP Operations", func() {
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				t2.podIP = "10.128.1.6"
 				t2.podMAC = "0a:58:0a:80:01:06"
-				expectedDatabaseState = []libovsdbtest.TestData{pg}
+				peerNSASIPv4, peerNSASIPv6 = buildNamespaceAddressSets(banpPeerNamespaceName, []string{t2.podIP})
+				expectedDatabaseState = []libovsdbtest.TestData{pg, subjectNSASIPv4, subjectNSASIPv6, peerNSASIPv4, peerNSASIPv6}
 				for _, acl := range newACLs {
 					acl := acl
 					expectedDatabaseState = append(expectedDatabaseState, acl)
@@ -1047,7 +1059,9 @@ var _ = ginkgo.Describe("OVN BANP Operations", func() {
 
 				acls := getACLsForBANPRules(banp)
 				pg := getDefaultPGForANPSubject(banp.Name, []string{t.portUUID}, acls, true)
-				expectedDatabaseState := []libovsdbtest.TestData{pg}
+				subjectNSASIPv4, subjectNSASIPv6 := buildNamespaceAddressSets(banpSubjectNamespaceName, []string{banpPodV4IP, banpPodV6IP})
+				peerNSASIPv4, peerNSASIPv6 := buildNamespaceAddressSets(banpPeerNamespaceName, []string{banpPodV4IP2, banpPodV6IP2})
+				expectedDatabaseState := []libovsdbtest.TestData{pg, subjectNSASIPv4, subjectNSASIPv6, peerNSASIPv4, peerNSASIPv6}
 				expectedDatabaseState = append(expectedDatabaseState, getDefaultNetExpectedPodsAndSwitches([]testPod{t, t2}, []string{node1Name})...)
 				for _, acl := range acls {
 					acl := acl
@@ -1141,7 +1155,7 @@ var _ = ginkgo.Describe("OVN BANP Operations", func() {
 				banp, err = fakeOVN.fakeClient.ANPClient.PolicyV1alpha1().BaselineAdminNetworkPolicies().Update(context.TODO(), banp, metav1.UpdateOptions{})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				pg = getDefaultPGForANPSubject(banp.Name, []string{t.portUUID}, nil, true)
-				expectedDatabaseState = []libovsdbtest.TestData{pg}
+				expectedDatabaseState = []libovsdbtest.TestData{pg, subjectNSASIPv4, subjectNSASIPv6, peerNSASIPv4, peerNSASIPv6}
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				expectedDatabaseState = append(expectedDatabaseState, getDefaultNetExpectedPodsAndSwitches([]testPod{t, t2}, []string{node1Name})...)
 				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
@@ -1150,7 +1164,7 @@ var _ = ginkgo.Describe("OVN BANP Operations", func() {
 				banp.ResourceVersion = "8"
 				err = fakeOVN.fakeClient.ANPClient.PolicyV1alpha1().BaselineAdminNetworkPolicies().Delete(context.TODO(), banp.Name, metav1.DeleteOptions{})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				expectedDatabaseState = []libovsdbtest.TestData{} // port group should be deleted
+				expectedDatabaseState = []libovsdbtest.TestData{subjectNSASIPv4, subjectNSASIPv6, peerNSASIPv4, peerNSASIPv6} // port group should be deleted
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				expectedDatabaseState = append(expectedDatabaseState, getDefaultNetExpectedPodsAndSwitches([]testPod{t, t2}, []string{node1Name})...)
 				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
@@ -1357,7 +1371,10 @@ var _ = ginkgo.Describe("OVN BANP Operations", func() {
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				acls := getACLsForBANPRulesWithNamedPorts(banp, namedIPorts, namedEPorts)
 				pg := getDefaultPGForANPSubject(banp.Name, []string{}, acls, true)
-				baseExpectedDatabaseState := []libovsdbtest.TestData{}
+				subjectNSASIPv4, subjectNSASIPv6 := buildNamespaceAddressSets(banpSubjectNamespaceName, []string{})
+				peerNSASIPv4, peerNSASIPv6 := buildNamespaceAddressSets(banpPeerNamespaceName, []string{banpPodV4IP2, banpPodV6IP2})
+				peerNS2ASIPv4, peerNS2ASIPv6 := buildNamespaceAddressSets(banpPeerNamespaceName+"2", []string{})
+				baseExpectedDatabaseState := []libovsdbtest.TestData{subjectNSASIPv4, subjectNSASIPv6, peerNSASIPv4, peerNSASIPv6, peerNS2ASIPv4, peerNS2ASIPv6}
 				peerASIngressRule0v4, peerASIngressRule0v6 := buildBANPAddressSets(banp, 0, []string{}, libovsdbutil.ACLIngress)
 				baseExpectedDatabaseState = append(baseExpectedDatabaseState, peerASIngressRule0v4)
 				baseExpectedDatabaseState = append(baseExpectedDatabaseState, peerASIngressRule0v6)
@@ -1393,8 +1410,11 @@ var _ = ginkgo.Describe("OVN BANP Operations", func() {
 					{L4Protocol: "udp", L3PodIP: banpPodV4IP, L3PodIPFamily: "ip4", L4PodPort: "5353"},
 					{L4Protocol: "udp", L3PodIP: banpPodV6IP, L3PodIPFamily: "ip6", L4PodPort: "5353"}}
 
+				subjectNSASIPv4, subjectNSASIPv6 = buildNamespaceAddressSets(banpSubjectNamespaceName, []string{banpPodV4IP, banpPodV6IP})
 				acls = getACLsForBANPRulesWithNamedPorts(banp, namedIPorts, namedEPorts)
 				pg = getDefaultPGForANPSubject(banp.Name, []string{t2.portUUID}, acls, true)
+				baseExpectedDatabaseState[0] = subjectNSASIPv4
+				baseExpectedDatabaseState[1] = subjectNSASIPv6
 				expectedDatabaseState = append(baseExpectedDatabaseState, pg)
 				expectedDatabaseState = append(expectedDatabaseState, getDefaultNetExpectedPodsAndSwitches([]testPod{t1, t2}, []string{node1Name})...)
 				for _, acl := range acls {
@@ -1434,9 +1454,12 @@ var _ = ginkgo.Describe("OVN BANP Operations", func() {
 				delete(namedEPorts, "web123")
 				acls = getACLsForBANPRulesWithNamedPorts(banp, namedIPorts, namedEPorts)
 				pg = getDefaultPGForANPSubject(banp.Name, []string{t2.portUUID}, acls, true)
+				peerNSASIPv4, peerNSASIPv6 = buildNamespaceAddressSets(banpPeerNamespaceName, []string{}) // pod is gone from peer namespace address-set
+				baseExpectedDatabaseState[2] = peerNSASIPv4
+				baseExpectedDatabaseState[3] = peerNSASIPv6
 				peerASEgressRule0v4, peerASEgressRule0v6 = buildBANPAddressSets(banp, 0, []string{}, libovsdbutil.ACLEgress)
-				baseExpectedDatabaseState[2] = peerASEgressRule0v4
-				baseExpectedDatabaseState[3] = peerASEgressRule0v6
+				baseExpectedDatabaseState[8] = peerASEgressRule0v4
+				baseExpectedDatabaseState[9] = peerASEgressRule0v6
 				expectedDatabaseState = append(baseExpectedDatabaseState, pg)
 				expectedDatabaseState = append(expectedDatabaseState, getDefaultNetExpectedPodsAndSwitches([]testPod{t2}, []string{node1Name})...)
 				for _, acl := range acls {
@@ -1461,9 +1484,12 @@ var _ = ginkgo.Describe("OVN BANP Operations", func() {
 					{L4Protocol: "sctp", L3PodIP: banpPodV6IP2, L3PodIPFamily: "ip6", L4PodPort: "35356"}}
 				acls = getACLsForBANPRulesWithNamedPorts(banp, namedIPorts, namedEPorts)
 				pg = getDefaultPGForANPSubject(banp.Name, []string{t2.portUUID}, acls, true)
+				peerNSASIPv4, peerNSASIPv6 = buildNamespaceAddressSets(banpPeerNamespaceName, []string{"fe00:10:128:1::4", "10.128.1.4"}) // pod is gone from peer namespace address-set
+				baseExpectedDatabaseState[2] = peerNSASIPv4
+				baseExpectedDatabaseState[3] = peerNSASIPv6
 				peerASEgressRule0v4, peerASEgressRule0v6 = buildBANPAddressSets(banp, 0, []string{"fe00:10:128:1::4", "10.128.1.4"}, libovsdbutil.ACLEgress)
-				baseExpectedDatabaseState[2] = peerASEgressRule0v4
-				baseExpectedDatabaseState[3] = peerASEgressRule0v6
+				baseExpectedDatabaseState[8] = peerASEgressRule0v4
+				baseExpectedDatabaseState[9] = peerASEgressRule0v6
 				expectedDatabaseState = append(baseExpectedDatabaseState, pg)
 				expectedDatabaseState = append(expectedDatabaseState, getDefaultNetExpectedPodsAndSwitches([]testPod{t1, t2}, []string{node1Name})...)
 				for _, acl := range acls {
@@ -1504,7 +1530,7 @@ var _ = ginkgo.Describe("OVN BANP Operations", func() {
 				delete(namedEPorts, "web123")
 				acls = getACLsForBANPRulesWithNamedPorts(banp, namedIPorts, namedEPorts)
 				pg = getDefaultPGForANPSubject(banp.Name, []string{t2.portUUID}, acls, true)
-				expectedDatabaseState = []libovsdbtest.TestData{pg}
+				expectedDatabaseState = []libovsdbtest.TestData{pg, subjectNSASIPv4, subjectNSASIPv6, peerNSASIPv4, peerNSASIPv6, peerNS2ASIPv4, peerNS2ASIPv6}
 				expectedDatabaseState = append(expectedDatabaseState, getDefaultNetExpectedPodsAndSwitches([]testPod{t1, t2}, []string{node1Name})...)
 				expectedDatabaseState = append(expectedDatabaseState, peerASIngressRule0v4)
 				expectedDatabaseState = append(expectedDatabaseState, peerASIngressRule0v6)

--- a/go-controller/pkg/ovn/controller/network_qos/utils.go
+++ b/go-controller/pkg/ovn/controller/network_qos/utils.go
@@ -10,7 +10,6 @@ import (
 
 	libovsdbops "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/libovsdb/ops"
 	addressset "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/address_set"
-	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
 	ovnkutil "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
 )
 
@@ -39,7 +38,7 @@ func getPodAddresses(pod *corev1.Pod, networkInfo ovnkutil.NetInfo, resolver fun
 	// check annotation "k8s.ovn.org/pod-networks" before calling GetPodIPsOfNetwork,
 	// as it's no easy to check if the error is caused by missing annotation, while
 	// we don't want to return error for such case as it will trigger retry
-	_, ok := pod.Annotations[types.OvnPodAnnotationName]
+	_, ok := pod.Annotations[ovnkutil.OvnPodAnnotationName]
 	if !ok {
 		// pod hasn't been annotated yet, return nil to avoid retry
 		return nil, nil

--- a/go-controller/pkg/ovn/egressfirewall_test.go
+++ b/go-controller/pkg/ovn/egressfirewall_test.go
@@ -286,6 +286,16 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		err = fakeOVN.controller.efController.Start()
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		for _, namespace := range namespaces {
+			namespaceASip4, namespaceASip6 := buildNamespaceAddressSets(namespace.Name, []string{})
+			if config.IPv4Mode {
+				initialData = append(initialData, namespaceASip4)
+			}
+			if config.IPv6Mode {
+				initialData = append(initialData, namespaceASip6)
+			}
+		}
 	}
 
 	startOvn := func(dbSetup libovsdb.TestSetup, namespaces []corev1.Namespace, egressFirewalls []egressfirewallapi.EgressFirewall, oldDNS bool) {
@@ -371,6 +381,8 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 					purgeACL2.UUID = "purgeACL2-UUID"
 
 					namespace1 := *ovntest.NewNamespace("namespace1")
+					namespace1ASip4, _ := buildNamespaceAddressSets(namespace1.Name, []string{})
+
 					egressFirewall := newEgressFirewallObject("default", namespace1.Name, []egressfirewallapi.EgressFirewallRule{
 						{
 							Type: "Allow",
@@ -425,6 +437,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 							joinSwitch,
 							clusterRouter,
 							clusterPortGroup,
+							namespace1ASip4,
 						},
 					}
 
@@ -454,6 +467,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 						joinSwitch,
 						clusterRouter,
 						clusterPortGroup,
+						namespace1ASip4,
 						namespacePG,
 					}
 
@@ -1385,8 +1399,9 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 					addrSet, _ := addressset.GetTestDbAddrSets(
 						dnsnameresolver.GetEgressFirewallDNSAddrSetDbIDs(dnsNameForAddrSet, fakeOVN.controller.controllerName),
 						[]string{resolvedIP})
+					namespace1ASip4, _ := buildNamespaceAddressSets(namespace1.Name, []string{})
 					addrSetUUID := strings.TrimSuffix(addrSet.UUID, "-UUID")
-					expectedDatabaseState := getEFExpectedDb(append(initialData, addrSet), fakeOVN, namespace1.Name, "(ip4.dst == $"+addrSetUUID+")", "", nbdb.ACLActionDrop)
+					expectedDatabaseState := getEFExpectedDb(append(initialData, addrSet, namespace1ASip4), fakeOVN, namespace1.Name, "(ip4.dst == $"+addrSetUUID+")", "", nbdb.ACLActionDrop)
 					gomega.Eventually(fakeOVN.nbClient).Should(libovsdb.HaveData(expectedDatabaseState))
 
 					ginkgo.By("deleting egress firewall, DNS, and namespace")
@@ -1408,7 +1423,8 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 
 					ginkgo.By("NBDB should be in a clean state")
 					// check dns address set is cleaned up on delete
-					gomega.Eventually(fakeOVN.nbClient).Should(libovsdb.HaveData(initialData))
+					// namespace delete takes 20 seconds to remove address set, so expect it to still be there
+					gomega.Eventually(fakeOVN.nbClient).Should(libovsdb.HaveData(append(initialData, namespace1ASip4)))
 					return nil
 				}
 				err := app.Run([]string{app.Name})

--- a/go-controller/pkg/ovn/egressip_test.go
+++ b/go-controller/pkg/ovn/egressip_test.go
@@ -6942,6 +6942,8 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 
 				nodeSwitch.QOSRules = []string{"default-QoS-UUID"}
 
+				namespaceAddressSetv4, _ := buildNamespaceAddressSets(eipNamespace, []string{egressPodIP.String()})
+
 				egressSVCServedPodsASv4, _ := buildEgressServiceAddressSets(nil)
 				egressIPServedPodsASv4, _ := buildEgressIPServedPodsAddressSets([]string{egressPodIP.String()}, types.DefaultNetworkName, fakeOvn.controller.eIPC.controllerName)
 				egressNodeIPsASv4, _ := buildEgressIPNodeAddressSets([]string{node1IPv4})
@@ -7033,6 +7035,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 					egressSVCServedPodsASv4,
 					egressIPServedPodsASv4,
 					egressNodeIPsASv4,
+					namespaceAddressSetv4,
 				}
 				podLSP := &nbdb.LogicalSwitchPort{
 					UUID:      util.GetLogicalPortName(egressPod1.Namespace, egressPod1.Name) + "-UUID",
@@ -7062,6 +7065,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				nodeSwitch.Ports = []string{"k8s-" + node1.Name + "-UUID"} // remove the pod port
 				egressIPServedPodsASv4.Addresses = nil
+				namespaceAddressSetv4.Addresses = nil
 				expectedDatabaseStateWithoutPod := []libovsdbtest.TestData{
 					&nbdb.LogicalRouterPolicy{
 						Priority: types.DefaultNoRereoutePriority,
@@ -7129,6 +7133,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 					egressSVCServedPodsASv4,
 					egressIPServedPodsASv4,
 					egressNodeIPsASv4,
+					namespaceAddressSetv4,
 				}
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseStateWithoutPod))
 				// recreate pod with same name immediately; simulating handler race (pods v/s egressip) condition,
@@ -7317,6 +7322,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 				egressSVCServedPodsASv4, _ := buildEgressServiceAddressSets(nil)
 				egressIPServedPodsASv4, _ := buildEgressIPServedPodsAddressSets([]string{oldEgressPodIP}, types.DefaultNetworkName, fakeOvn.controller.eIPC.controllerName)
 				egressNodeIPsASv4, _ := buildEgressIPNodeAddressSets([]string{node1IPv4})
+				namespaceAddressSetv4, _ := buildNamespaceAddressSets(eipNamespace, []string{egressPodIP.String()})
 
 				expectedDatabaseStatewithPod := []libovsdbtest.TestData{
 					podEIPSNAT,
@@ -7381,6 +7387,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 					getDefaultQoSRule(false, types.DefaultNetworkName, fakeOvn.controller.eIPC.controllerName),
 					egressSVCServedPodsASv4,
 					egressNodeIPsASv4,
+					namespaceAddressSetv4,
 					egressIPServedPodsASv4,
 				}
 				podLSP := &nbdb.LogicalSwitchPort{
@@ -7462,6 +7469,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 				podAddr = fmt.Sprintf("%s %s", podPortInfo.mac.String(), egressPodIP)
 				podLSP.Addresses = []string{podAddr}
 				podLSP.PortSecurity = []string{podAddr}
+				namespaceAddressSetv4.Addresses = []string{egressPodIP.String()}
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(finalDatabaseStatewithPod))
 				return nil
 			}
@@ -7738,6 +7746,8 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 					egressIPServedPodsASv4, _ := buildEgressIPServedPodsAddressSets([]string{egressPodIP[0].String()}, types.DefaultNetworkName, fakeOvn.controller.eIPC.controllerName)
 					egressNodeIPsASv4, _ := buildEgressIPNodeAddressSets([]string{node1IPv4, node2IPv4})
 
+					namespaceAddressSetv4, _ := buildNamespaceAddressSets(eipNamespace, []string{egressPodIP[0].String()})
+
 					expectedDatabaseStatewithPod := []libovsdbtest.TestData{
 						podEIPSNAT,
 						podReRoutePolicy,
@@ -7799,6 +7809,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 						egressSVCServedPodsASv4,
 						egressIPServedPodsASv4,
 						egressNodeIPsASv4,
+						namespaceAddressSetv4,
 					}
 					podLSP := &nbdb.LogicalSwitchPort{
 						UUID:      util.GetLogicalPortName(egressPod1.Namespace, egressPod1.Name) + "-UUID",

--- a/go-controller/pkg/ovn/gatewayrouter/policybasedroutes_test.go
+++ b/go-controller/pkg/ovn/gatewayrouter/policybasedroutes_test.go
@@ -15,7 +15,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilnet "k8s.io/utils/net"
 
-	ovncnitypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/cni/types"
+	types2 "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/cni/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/nbdb"
 	libovsdbtest "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
@@ -134,7 +134,7 @@ func TestAddSameNodeIPPolicy(t *testing.T) {
 			mgntIPv4:    node1CDNMgntIPv4Str,
 			mgntIPv6:    node1CDNMgntIPv6Str,
 		}
-		l3NetInfo, _ = util.NewNetInfo(&ovncnitypes.NetConf{
+		l3NetInfo, _ = util.NewNetInfo(&types2.NetConf{
 			NetConf:    cnitypes.NetConf{Name: udnNetworkName},
 			Topology:   types.Layer3Topology,
 			JoinSubnet: joinSubnetIPv4Str,    // not required, but adding so NewNetInfo doesn't fail
@@ -538,7 +538,7 @@ func TestAddHostCIDRPolicy(t *testing.T) {
 		hostCIDRPolicyPrio, _ = strconv.Atoi(types.UDNHostCIDRPolicyPriority)
 		_, hostCIDRV4Range, _ = net.ParseCIDR(hostCIDRV4RangeStr)
 		_, hostCIDRV6Range, _ = net.ParseCIDR(hostCIDRV6RangeStr)
-		l2NetInfo, _          = util.NewNetInfo(&ovncnitypes.NetConf{
+		l2NetInfo, _          = util.NewNetInfo(&types2.NetConf{
 			NetConf:    cnitypes.NetConf{Name: udnNetworkName},
 			Topology:   types.Layer2Topology,
 			JoinSubnet: joinSubnetIPv4Str,                                 // not required, but adding so NewNetInfo doesn't fail

--- a/go-controller/pkg/ovn/layer2_user_defined_network_controller_test.go
+++ b/go-controller/pkg/ovn/layer2_user_defined_network_controller_test.go
@@ -24,7 +24,7 @@ import (
 	knet "k8s.io/utils/net"
 	"k8s.io/utils/ptr"
 
-	ovncnitypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/cni/types"
+	ovnkcnitypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/cni/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/kubevirt"
@@ -465,7 +465,7 @@ var _ = Describe("OVN Multi-Homed pod operations for layer 2 network", func() {
 				// clustermanager to annotate the pod.
 				if !config.OVNKubernetesFeature.EnableInterconnect {
 					// pod exists, networks annotations don't
-					_, ok := pod.Annotations[ovntypes.OvnPodAnnotationName]
+					_, ok := pod.Annotations[util.OvnPodAnnotationName]
 					Expect(ok).To(BeFalse())
 				}
 
@@ -825,7 +825,7 @@ var _ = Describe("OVN Multi-Homed pod operations for layer 2 network", func() {
 		controller := &Layer2UserDefinedNetworkController{}
 		controller.watchFactory = fakeOvn.watcher
 		// this network won't invoke nodeID check, so it should pass
-		netInfo, err := util.NewNetInfo(&ovncnitypes.NetConf{
+		netInfo, err := util.NewNetInfo(&ovnkcnitypes.NetConf{
 			NetConf:    cnitypes.NetConf{Name: "test"},
 			Topology:   ovntypes.Layer2Topology,
 			JoinSubnet: "100.65.0.0/16,fd99::/64",
@@ -841,7 +841,7 @@ var _ = Describe("OVN Multi-Homed pod operations for layer 2 network", func() {
 		}))
 		// this network has a small subnet, it will do the nodeID check
 		// it will fail if there is a node with nodeID 1022, which doesn't exist for now
-		netInfo, err = util.NewNetInfo(&ovncnitypes.NetConf{
+		netInfo, err = util.NewNetInfo(&ovnkcnitypes.NetConf{
 			NetConf:    cnitypes.NetConf{Name: "test"},
 			Topology:   ovntypes.Layer2Topology,
 			JoinSubnet: "100.65.0.0/22",

--- a/go-controller/pkg/ovn/layer3_user_defined_network_controller_test.go
+++ b/go-controller/pkg/ovn/layer3_user_defined_network_controller_test.go
@@ -174,7 +174,7 @@ var _ = Describe("OVN Multi-Homed pod operations for layer 3 network", func() {
 				// pod exists, networks annotations don't
 				pod, err := fakeOvn.fakeClient.KubeClient.CoreV1().Pods(podInfo.namespace).Get(context.Background(), podInfo.podName, metav1.GetOptions{})
 				Expect(err).NotTo(HaveOccurred())
-				_, ok := pod.Annotations[types.OvnPodAnnotationName]
+				_, ok := pod.Annotations[util.OvnPodAnnotationName]
 				Expect(ok).To(BeFalse())
 
 				// succeed the check for Load_Balancer_Group support
@@ -416,7 +416,7 @@ var _ = Describe("OVN Multi-Homed pod operations for layer 3 network", func() {
 				// pod exists, networks annotations don't
 				pod, err := fakeOvn.fakeClient.KubeClient.CoreV1().Pods(podInfo.namespace).Get(context.Background(), podInfo.podName, metav1.GetOptions{})
 				Expect(err).NotTo(HaveOccurred())
-				_, ok := pod.Annotations[types.OvnPodAnnotationName]
+				_, ok := pod.Annotations[util.OvnPodAnnotationName]
 				Expect(ok).To(BeFalse())
 
 				// succeed the check for Load_Balancer_Group support

--- a/go-controller/pkg/ovn/multicast_test.go
+++ b/go-controller/pkg/ovn/multicast_test.go
@@ -20,7 +20,6 @@ import (
 	libovsdbutil "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/libovsdb/util"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/nbdb"
 	addressset "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/address_set"
-	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/addresssetmanager"
 	ovntest "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
@@ -118,20 +117,45 @@ func getMulticastExpectedData(netInfo util.NetInfo, clusterPortGroup, clusterRtr
 	}
 }
 
-func getMulticastPolicyExpectedData(netInfo util.NetInfo, ns string, ports []string) []libovsdb.TestData {
-	return getMulticastPolicyExpectedDataWithPodIPs(netInfo, ns, ports, nil)
+func getMulticastStaleData(netInfo util.NetInfo, clusterPortGroup, clusterRtrPortGroup *nbdb.PortGroup) []libovsdb.TestData {
+	testData := getMulticastExpectedData(netInfo, clusterPortGroup, clusterRtrPortGroup)
+	defaultDenyIngressACL := testData[0].(*nbdb.ACL)
+	newName := libovsdbutil.JoinACLName(types.ClusterPortGroupNameBase, "DefaultDenyMulticastIngress")
+	defaultDenyIngressACL.Name = &newName
+	defaultDenyIngressACL.Options = nil
+
+	defaultDenyEgressACL := testData[1].(*nbdb.ACL)
+	newName1 := libovsdbutil.JoinACLName(types.ClusterPortGroupNameBase, "DefaultDenyMulticastEgress")
+	defaultDenyEgressACL.Name = &newName1
+	defaultDenyEgressACL.Options = nil
+
+	defaultAllowEgressACL := testData[2].(*nbdb.ACL)
+	newName2 := libovsdbutil.JoinACLName(types.ClusterRtrPortGroupNameBase, "DefaultAllowMulticastEgress")
+	defaultAllowEgressACL.Name = &newName2
+	defaultAllowEgressACL.Options = nil
+
+	defaultAllowIngressACL := testData[3].(*nbdb.ACL)
+	newName3 := libovsdbutil.JoinACLName(types.ClusterRtrPortGroupNameBase, "DefaultAllowMulticastIngress")
+	defaultAllowIngressACL.Name = &newName3
+	defaultAllowIngressACL.Options = nil
+
+	return []libovsdb.TestData{
+		defaultDenyIngressACL,
+		defaultDenyEgressACL,
+		defaultAllowEgressACL,
+		defaultAllowIngressACL,
+		testData[4],
+		testData[5],
+	}
 }
 
-func getMulticastPolicyExpectedDataWithPodIPs(netInfo util.NetInfo, ns string, ports, podIPs []string) []libovsdb.TestData {
+func getMulticastPolicyExpectedData(netInfo util.NetInfo, ns string, ports []string) []libovsdb.TestData {
 	netControllerName := getNetworkControllerName(netInfo.GetNetworkName())
 	fakeController := getFakeController(netControllerName)
 	pg_hash := fakeController.getNamespacePortGroupName(ns)
 	egressMatch := libovsdbutil.GetACLMatch(pg_hash, fakeController.getMulticastACLEgrMatch(), libovsdbutil.ACLEgress)
 
-	peerIndex := addresssetmanager.GetPodSelectorAddrSetDbIDs(&metav1.LabelSelector{}, nil, nil,
-		ns, netControllerName, true)
-	nsASv4, nsASv6 := addressset.GetTestDbAddrSets(peerIndex, podIPs)
-	ip4AddressSet, ip6AddressSet := addressset.GetHashNamesForAS(peerIndex)
+	ip4AddressSet, ip6AddressSet := getNsAddrSetHashNames(netControllerName, ns)
 	mcastMatch := getACLMatchAF(getMulticastACLIgrMatchV4(ip4AddressSet), getMulticastACLIgrMatchV6(ip6AddressSet), config.IPv4Mode, config.IPv6Mode)
 	ingressMatch := libovsdbutil.GetACLMatch(pg_hash, mcastMatch, libovsdbutil.ACLIngress)
 
@@ -184,19 +208,11 @@ func getMulticastPolicyExpectedDataWithPodIPs(netInfo util.NetInfo, ns string, p
 	)
 	pg.UUID = pg.Name + "-UUID"
 
-	data := []libovsdb.TestData{}
-	if config.IPv4Mode {
-		data = append(data, nsASv4)
-	}
-	if config.IPv6Mode {
-		data = append(data, nsASv6)
-	}
-
-	return append(data,
+	return []libovsdb.TestData{
 		egressACL,
 		ingressACL,
 		pg,
-	)
+	}
 }
 
 func getNamespacePG(ns, controllerName string) *nbdb.PortGroup {
@@ -206,13 +222,24 @@ func getNamespacePG(ns, controllerName string) *nbdb.PortGroup {
 	return pg
 }
 
-func getMulticastPolicyStaleData(netInfo util.NetInfo, ns string) []libovsdb.TestData {
-	testData := getMulticastPolicyExpectedData(netInfo, ns, nil)
-	// remove address sets
-	result := testData[len(testData)-3:]
-	// get ingress ACL and spoil the match (just to make sure it will be updated)
-	result[1].(*nbdb.ACL).Match = "stale-match"
-	return result
+func getMulticastPolicyStaleData(netInfo util.NetInfo, ns string, ports []string) []libovsdb.TestData {
+	testData := getMulticastPolicyExpectedData(netInfo, ns, ports)
+
+	egressACL := testData[0].(*nbdb.ACL)
+	newName := libovsdbutil.JoinACLName(ns, "MulticastAllowEgress")
+	egressACL.Name = &newName
+	egressACL.Options = nil
+
+	ingressACL := testData[1].(*nbdb.ACL)
+	newName1 := libovsdbutil.JoinACLName(ns, "MulticastAllowIngress")
+	ingressACL.Name = &newName1
+	ingressACL.Options = nil
+
+	return []libovsdb.TestData{
+		egressACL,
+		ingressACL,
+		testData[2],
+	}
 }
 
 func getNetInfoFromNAD(nad *nadapi.NetworkAttachmentDefinition) util.NetInfo {
@@ -292,16 +319,16 @@ func updateMulticast(fakeOvn *FakeOVN, ns *corev1.Namespace, enable bool) {
 	Expect(err).NotTo(HaveOccurred())
 }
 
-func startBaseNetworkController(fakeOvn *FakeOVN, nad *nadapi.NetworkAttachmentDefinition) *BaseNetworkController {
+func startBaseNetworkController(fakeOvn *FakeOVN, nad *nadapi.NetworkAttachmentDefinition) (*BaseNetworkController, *addressset.FakeAddressSetFactory) {
 	if nad != nil {
 		netInfo, err := util.ParseNADInfo(nad)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(fakeOvn.NewUserDefinedNetworkController(nad)).To(Succeed())
 		controller, ok := fakeOvn.userDefinedNetworkControllers[netInfo.GetNetworkName()]
 		Expect(ok).To(BeTrue())
-		return &controller.bnc.BaseNetworkController
+		return &controller.bnc.BaseNetworkController, controller.asf
 	} else {
-		return &fakeOvn.controller.BaseNetworkController
+		return &fakeOvn.controller.BaseNetworkController, fakeOvn.asf
 	}
 }
 
@@ -354,7 +381,7 @@ var _ = Describe("OVN Multicast with IP Address Family", func() {
 		// alternative approach is to give this flag to app.Run, but that require more changes.
 		//app.Flags = config.Flags
 
-		fakeOvn = NewFakeOVN(false)
+		fakeOvn = NewFakeOVN(true)
 		gomegaFormatMaxLength = format.MaxLength
 		format.MaxLength = 0
 	})
@@ -379,11 +406,43 @@ var _ = Describe("OVN Multicast with IP Address Family", func() {
 						clusterRtrPortGroup,
 					},
 				})
-				bnc := startBaseNetworkController(fakeOvn, nad)
+				bnc, _ := startBaseNetworkController(fakeOvn, nad)
 
 				Expect(bnc.createDefaultDenyMulticastPolicy()).To(Succeed())
 				Expect(bnc.createDefaultAllowMulticastPolicy()).To(Succeed())
 
+				Eventually(fakeOvn.nbClient).Should(libovsdb.HaveData(
+					getMulticastExpectedData(netInfo, clusterPortGroup, clusterRtrPortGroup)))
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			Expect(err).NotTo(HaveOccurred())
+		},
+			Entry("IPv4", true, false, nil),
+			Entry("IPv6", false, true, nil),
+			Entry("[Network Segmentation] IPv4", true, false, nadFromIPMode(namespaceName1, true, false)),
+			Entry("[Network Segmentation] IPv6", false, true, nadFromIPMode(namespaceName1, false, true)),
+		)
+
+		DescribeTable("updates stale default Multicast ACLs", func(useIPv4, useIPv6 bool, nad *nadapi.NetworkAttachmentDefinition) {
+			app.Action = func(*cli.Context) error {
+				config.IPv4Mode = useIPv4
+				config.IPv6Mode = useIPv6
+
+				// start with stale ACLs
+				netInfo := getNetInfoFromNAD(nad)
+				clusterPortGroup := newNetworkClusterPortGroup(netInfo)
+				clusterRtrPortGroup := newNetworkRouterPortGroup(netInfo)
+				fakeOvn.startWithDBSetup(libovsdb.TestSetup{
+					NBData: getMulticastStaleData(netInfo, clusterPortGroup, clusterRtrPortGroup),
+				})
+				bnc, _ := startBaseNetworkController(fakeOvn, nad)
+
+				Expect(bnc.createDefaultDenyMulticastPolicy()).To(Succeed())
+				Expect(bnc.createDefaultAllowMulticastPolicy()).To(Succeed())
+
+				// check acls are updated
 				Eventually(fakeOvn.nbClient).Should(libovsdb.HaveData(
 					getMulticastExpectedData(netInfo, clusterPortGroup, clusterRtrPortGroup)))
 				return nil
@@ -409,9 +468,6 @@ var _ = Describe("OVN Multicast with IP Address Family", func() {
 				initialData := getMulticastExpectedData(netInfo, clusterPortGroup, clusterRtrPortGroup)
 
 				nsData := getMulticastPolicyExpectedData(netInfo, namespaceName1, nil)
-				// preserve address set because it will only be cleaned up on the next restart by the addresssetManager as unreferenced
-				// we never use dualstack mode in tests, so it will always be 1 address set
-				addrSet := nsData[0]
 				initialData = append(initialData, nsData...)
 				// namespace is still present, but multicast support is disabled
 				namespace1 := *ovntest.NewNamespace(namespaceName1)
@@ -422,7 +478,7 @@ var _ = Describe("OVN Multicast with IP Address Family", func() {
 						},
 					},
 				)
-				bnc := startBaseNetworkController(fakeOvn, nad)
+				bnc, _ := startBaseNetworkController(fakeOvn, nad)
 
 				// this "if !oc.multicastSupport" part of SetupMaster
 				Expect(bnc.disableMulticast()).To(Succeed())
@@ -434,7 +490,6 @@ var _ = Describe("OVN Multicast with IP Address Family", func() {
 					clusterPortGroup,
 					clusterRtrPortGroup,
 					namespacePortGroup,
-					addrSet,
 				}
 				Eventually(fakeOvn.nbClient).Should(libovsdb.HaveData(expectedData))
 				return nil
@@ -477,7 +532,7 @@ var _ = Describe("OVN Multicast with IP Address Family", func() {
 					Expect(fakeOvn.networkManager.Start()).To(Succeed())
 					defer fakeOvn.networkManager.Stop()
 				}
-				bnc := startBaseNetworkController(fakeOvn, nad)
+				bnc, _ := startBaseNetworkController(fakeOvn, nad)
 
 				Expect(bnc.WatchNamespaces()).To(Succeed())
 				expectedData = append(expectedData, getMulticastPolicyExpectedData(netInfo, namespaceName1, nil)...)
@@ -504,7 +559,7 @@ var _ = Describe("OVN Multicast with IP Address Family", func() {
 				clusterPortGroup := newNetworkClusterPortGroup(netInfo)
 				clusterRtrPortGroup := newNetworkRouterPortGroup(netInfo)
 				expectedData := getMulticastExpectedData(netInfo, clusterPortGroup, clusterRtrPortGroup)
-				expectedData = append(expectedData, getMulticastPolicyStaleData(netInfo, namespaceName1)...)
+				expectedData = append(expectedData, getMulticastPolicyStaleData(netInfo, namespaceName1, nil)...)
 				namespace1 := *ovntest.NewNamespace(namespaceName1)
 				namespace1.Annotations[util.NsMulticastAnnotation] = "true"
 
@@ -523,7 +578,7 @@ var _ = Describe("OVN Multicast with IP Address Family", func() {
 					Expect(fakeOvn.networkManager.Start()).To(Succeed())
 					defer fakeOvn.networkManager.Stop()
 				}
-				bnc := startBaseNetworkController(fakeOvn, nad)
+				bnc, _ := startBaseNetworkController(fakeOvn, nad)
 
 				Expect(bnc.WatchNamespaces()).To(Succeed())
 				expectedData = getMulticastExpectedData(netInfo, clusterPortGroup, clusterRtrPortGroup)
@@ -552,9 +607,6 @@ var _ = Describe("OVN Multicast with IP Address Family", func() {
 				clusterRtrPortGroup := newNetworkRouterPortGroup(netInfo)
 				defaultMulticastData := getMulticastExpectedData(netInfo, clusterPortGroup, clusterRtrPortGroup)
 				namespaceMulticastData := getMulticastPolicyExpectedData(netInfo, namespaceName1, nil)
-				// preserve address set because it will only be cleaned up on the next restart by the addresssetManager as unreferenced
-				// we never use dualstack mode in tests, so it will always be 1 address set
-				addrSet := namespaceMulticastData[0]
 				namespace1 := *ovntest.NewNamespace(namespaceName1)
 
 				objs := []runtime.Object{&corev1.NamespaceList{
@@ -572,12 +624,12 @@ var _ = Describe("OVN Multicast with IP Address Family", func() {
 					Expect(fakeOvn.networkManager.Start()).To(Succeed())
 					defer fakeOvn.networkManager.Stop()
 				}
-				bnc := startBaseNetworkController(fakeOvn, nad)
+				bnc, _ := startBaseNetworkController(fakeOvn, nad)
 
 				Expect(bnc.WatchNamespaces()).To(Succeed())
 				// only namespaced acls should be dereferenced, default acls will stay
 				namespacePortGroup := getNamespacePG(namespaceName1, getNetworkControllerName(netInfo.GetNetworkName()))
-				expectedData := append(defaultMulticastData, namespacePortGroup, addrSet)
+				expectedData := append(defaultMulticastData, namespacePortGroup)
 				Eventually(fakeOvn.nbClient).Should(libovsdb.HaveData(expectedData))
 				return nil
 			}
@@ -619,7 +671,7 @@ var _ = Describe("OVN Multicast with IP Address Family", func() {
 					defer fakeOvn.networkManager.Stop()
 				}
 
-				bnc := startBaseNetworkController(fakeOvn, nad)
+				bnc, _ := startBaseNetworkController(fakeOvn, nad)
 				Expect(bnc.WatchNamespaces()).To(Succeed())
 
 				ns, err := fakeOvn.fakeClient.KubeClient.CoreV1().Namespaces().Get(context.TODO(), namespace1.Name, metav1.GetOptions{})
@@ -688,7 +740,7 @@ var _ = Describe("OVN Multicast with IP Address Family", func() {
 				}
 
 				fakeOvn.startWithDBSetup(libovsdb.TestSetup{NBData: getNodeData(netInfo, nodeName)}, objs...)
-				bnc := startBaseNetworkController(fakeOvn, nad)
+				bnc, asf := startBaseNetworkController(fakeOvn, nad)
 
 				for _, tPod := range tPods {
 					tPod.populateControllerLogicalSwitchCache(bnc)
@@ -711,13 +763,14 @@ var _ = Describe("OVN Multicast with IP Address Family", func() {
 				for _, tPod := range tPods {
 					ports = append(ports, tPod.portUUID)
 				}
-				expectedData := getMulticastPolicyExpectedDataWithPodIPs(netInfo, namespace1.Name, ports, tPodIPs)
+				expectedData := getMulticastPolicyExpectedData(netInfo, namespace1.Name, ports)
 				nadKey := ""
 				if nad != nil {
 					nadKey = util.GetNADName(nad.Namespace, nad.Name)
 				}
 				expectedData = append(expectedData, getExpectedPodsAndSwitches(bnc.GetNetInfo(), tPods, []string{nodeName}, nadKey)...)
 				Eventually(fakeOvn.nbClient).Should(libovsdb.HaveData(expectedData...))
+				asf.ExpectAddressSetWithAddresses(namespace1.Name, tPodIPs)
 				return nil
 			}
 
@@ -761,7 +814,7 @@ var _ = Describe("OVN Multicast with IP Address Family", func() {
 				}
 
 				fakeOvn.startWithDBSetup(libovsdb.TestSetup{NBData: getNodeData(netInfo, nodeName)}, objs...)
-				bnc := startBaseNetworkController(fakeOvn, nad)
+				bnc, _ := startBaseNetworkController(fakeOvn, nad)
 
 				if nad != nil {
 					Expect(fakeOvn.networkManager.Start()).To(Succeed())
@@ -777,8 +830,9 @@ var _ = Describe("OVN Multicast with IP Address Family", func() {
 				Expect(err).To(Succeed())
 				Expect(ns2).NotTo(BeNil())
 
-				expectedData := getMulticastPolicyExpectedData(netInfo, longnamespaceName1Name, nil)
-				acl := expectedData[1].(*nbdb.ACL)
+				portsns1 := []string{}
+				expectedData := getMulticastPolicyExpectedData(netInfo, longnamespaceName1Name, portsns1)
+				acl := expectedData[0].(*nbdb.ACL)
 				// Post ACL indexing work, multicast ACL's don't have names
 				// We use externalIDs instead; so we can check if the expected IDs exist for the long namespace so that
 				// isEquivalent logic will be correct
@@ -789,7 +843,7 @@ var _ = Describe("OVN Multicast with IP Address Family", func() {
 				// longNameSpace2Name
 				if nad == nil {
 					expectedData = append(expectedData, getMulticastPolicyExpectedData(netInfo, longNameSpace2Name, nil)...)
-					acl = expectedData[5].(*nbdb.ACL)
+					acl = expectedData[3].(*nbdb.ACL)
 					Expect(acl.Name).To(BeNil())
 					Expect(acl.ExternalIDs[libovsdbops.ObjectNameKey.String()]).To(Equal(longNameSpace2Name))
 				}
@@ -852,7 +906,7 @@ var _ = Describe("OVN Multicast with IP Address Family", func() {
 				}
 
 				fakeOvn.startWithDBSetup(libovsdb.TestSetup{NBData: getNodeData(netInfo, nodeName)}, objs...)
-				bnc := startBaseNetworkController(fakeOvn, nad)
+				bnc, asf := startBaseNetworkController(fakeOvn, nad)
 
 				for _, tPod := range tPods {
 					tPod.populateControllerLogicalSwitchCache(bnc)
@@ -884,7 +938,8 @@ var _ = Describe("OVN Multicast with IP Address Family", func() {
 				}
 
 				// Check pods were added
-				expectedDataWithPods := getMulticastPolicyExpectedDataWithPodIPs(netInfo, namespace1.Name, ports, tPodIPs)
+				asf.EventuallyExpectAddressSetWithAddresses(namespace1.Name, tPodIPs)
+				expectedDataWithPods := getMulticastPolicyExpectedData(netInfo, namespace1.Name, ports)
 				nadKey := ""
 				if nad != nil {
 					nadKey = util.GetNADName(nad.Namespace, nad.Name)
@@ -898,6 +953,7 @@ var _ = Describe("OVN Multicast with IP Address Family", func() {
 						tPod.podName, *metav1.NewDeleteOptions(0))
 					Expect(err).NotTo(HaveOccurred())
 				}
+				asf.EventuallyExpectEmptyAddressSetExist(namespace1.Name)
 				Eventually(fakeOvn.nbClient).Should(libovsdb.HaveData(expectedDataWithoutPods))
 
 				return nil

--- a/go-controller/pkg/ovn/multipolicy_test.go
+++ b/go-controller/pkg/ovn/multipolicy_test.go
@@ -222,7 +222,7 @@ var _ = ginkgo.Describe("OVN MultiNetworkPolicy Operations", func() {
 		app.Name = "test"
 		app.Flags = config.Flags
 
-		fakeOvn = NewFakeOVN(false)
+		fakeOvn = NewFakeOVN(true)
 
 		gomegaFormatMaxLength = format.MaxLength
 		format.MaxLength = 0
@@ -360,6 +360,12 @@ var _ = ginkgo.Describe("OVN MultiNetworkPolicy Operations", func() {
 		err = fakeOvn.controller.WatchNetworkPolicy()
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
+		ocInfo, ok := fakeOvn.userDefinedNetworkControllers[userDefinedNetworkName]
+		gomega.Expect(ok).To(gomega.BeTrue())
+		asf := ocInfo.asf
+		gomega.Expect(asf).NotTo(gomega.BeNil())
+		gomega.Expect(asf.ControllerName).To(gomega.Equal(getNetworkControllerName(userDefinedNetworkName)))
+
 		for _, ocInfo := range fakeOvn.userDefinedNetworkControllers {
 			if watchNodes {
 				if ocInfo.bnc.TopologyType() == ovntypes.Layer3Topology && config.OVNKubernetesFeature.EnableInterconnect {
@@ -431,6 +437,10 @@ var _ = ginkgo.Describe("OVN MultiNetworkPolicy Operations", func() {
 					Get(context.TODO(), mpolicy.Name, metav1.GetOptions{})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
+				ocInfo := fakeOvn.userDefinedNetworkControllers[userDefinedNetworkName]
+				ocInfo.asf.EventuallyExpectEmptyAddressSetExist(namespaceName1)
+				ocInfo.asf.EventuallyExpectEmptyAddressSetExist(namespaceName2)
+
 				expectedData := getNamespaceWithSinglePolicyExpectedData(
 					newNetpolDataParams(policy).
 						withNetInfo(netInfo),
@@ -472,6 +482,7 @@ var _ = ginkgo.Describe("OVN MultiNetworkPolicy Operations", func() {
 					_, err = fakeOvn.fakeClient.KubeClient.NetworkingV1().NetworkPolicies(networkPolicy.Namespace).
 						Get(context.TODO(), networkPolicy.Name, metav1.GetOptions{})
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					fakeOvn.asf.ExpectAddressSetWithAddresses(namespaceName1, []string{nPodTest.podIP})
 
 					dataParams := newNetpolDataParams(networkPolicy).
 						withLocalPortUUIDs(nPodTest.portUUID).
@@ -495,8 +506,10 @@ var _ = ginkgo.Describe("OVN MultiNetworkPolicy Operations", func() {
 						Get(context.TODO(), mpolicy.Name, metav1.GetOptions{})
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
+					ocInfo := fakeOvn.userDefinedNetworkControllers[userDefinedNetworkName]
 					portInfo := nPodTest.getNetworkPortInfo(userDefinedNetworkName, nadNamespacedName)
 					gomega.Expect(portInfo).NotTo(gomega.BeNil())
+					ocInfo.asf.ExpectAddressSetWithAddresses(namespaceName1, []string{portInfo.podIP})
 
 					dataParams2 := newNetpolDataParams(networkPolicy).
 						withLocalPortUUIDs(portInfo.portUUID).
@@ -662,14 +675,15 @@ var _ = ginkgo.Describe("OVN MultiNetworkPolicy Operations", func() {
 					Get(context.TODO(), mpolicy.Name, metav1.GetOptions{})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
+				ocInfo := fakeOvn.userDefinedNetworkControllers[userDefinedNetworkName]
 				portInfo := nPodTest.getNetworkPortInfo(userDefinedNetworkName, nadNamespacedName)
 				gomega.Expect(portInfo).NotTo(gomega.BeNil())
+				ocInfo.asf.ExpectAddressSetWithAddresses(namespaceName1, []string{portInfo.podIP})
 
 				dataParams2 := newNetpolDataParams(networkPolicy).
 					withLocalPortUUIDs(portInfo.portUUID).
 					withTCPPeerPorts(portNum).
-					withNetInfo(netInfo).
-					withPeerIPs(portInfo.podIP)
+					withNetInfo(netInfo)
 				gressPolicyExpectedData2 := getPolicyData(dataParams2)
 				defaultDenyExpectedData2 := getDefaultDenyData(dataParams2)
 				initData := getUpdatedInitialDB([]testPod{nPodTest})

--- a/go-controller/pkg/ovn/multipolicy_test.go
+++ b/go-controller/pkg/ovn/multipolicy_test.go
@@ -531,6 +531,104 @@ var _ = ginkgo.Describe("OVN MultiNetworkPolicy Operations", func() {
 			ginkgo.Entry("with allow ICMP network policy enabled", true),
 		)
 
+		ginkgo.DescribeTable("correctly adds and deletes pod IPs from secondary network namespace address set",
+			func(topology string, remote bool) {
+				app.Action = func(*cli.Context) error {
+					var err error
+
+					subnets := "10.1.0.0/16"
+					nodeSubnet := ""
+					if topology == ovntypes.Layer3Topology {
+						subnets = subnets + "/24"
+						nodeSubnet = "10.1.1.0/24"
+					}
+
+					setUserDefinedNetworkTestData(topology, subnets) // here I set network role if layer2
+
+					watchNodes := true
+					node := *newNode(nodeName, "192.168.126.202/24")
+
+					// set L3 specific node annotations
+					if topology == ovntypes.Layer3Topology {
+						node.Annotations, err = util.UpdateNodeHostSubnetAnnotation(
+							node.Annotations,
+							ovntest.MustParseIPNets(nodeSubnet),
+							userDefinedNetworkName,
+						)
+						gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					}
+
+					// flag node as remote and set IC specific annotations
+					if remote {
+						config.OVNKubernetesFeature.EnableInterconnect = true
+						node.Annotations["k8s.ovn.org/zone-name"] = "remote"
+						node.Annotations, err = util.UpdateNetworkIDAnnotation(node.Annotations, ovntypes.DefaultNetworkName, 0)
+						gomega.Expect(err).NotTo(gomega.HaveOccurred())
+						if topology != ovntypes.LocalnetTopology {
+							node.Annotations, err = util.UpdateNetworkIDAnnotation(node.Annotations, userDefinedNetworkName, 2)
+							gomega.Expect(err).NotTo(gomega.HaveOccurred())
+						}
+					}
+
+					namespace1 := *ovntest.NewNamespace(namespaceName1)
+
+					config.EnableMulticast = false
+					startOvn(initialDB, watchNodes, []corev1.Node{node}, []corev1.Namespace{namespace1}, nil, nil,
+						[]nettypes.NetworkAttachmentDefinition{*nad}, []testPod{}, map[string]string{labelName: labelVal})
+
+					ocInfo := fakeOvn.userDefinedNetworkControllers[userDefinedNetworkName]
+
+					// check that the node zone is tracked as expected
+					if topology != ovntypes.LocalnetTopology {
+						_, isLocal := ocInfo.bnc.localZoneNodes.Load(node.Name)
+						gomega.Expect(isLocal).NotTo(gomega.Equal(remote))
+					}
+
+					ocInfo.asf.EventuallyExpectEmptyAddressSetExist(namespaceName1)
+
+					nPodTest := getTestPod(namespace1.Name, nodeName)
+					nPodTest.addNetwork(userDefinedNetworkName, nadNamespacedName, nodeSubnet, "", "", "10.1.1.1", "0a:58:0a:01:01:01", "secondary", 1, nil)
+					knetPod := ovntest.NewPod(nPodTest.namespace, nPodTest.podName, nPodTest.nodeName, nPodTest.podIP)
+					addPodNetwork(knetPod, nPodTest.udnPodInfos)
+					setPodAnnotations(knetPod, nPodTest)
+					nPodTest.populateLogicalSwitchCache(fakeOvn)
+					nPodTest.populateUserDefinedNetworkLogicalSwitchCache(ocInfo)
+
+					ginkgo.By("Creating a pod attached to the secondary network")
+					_, err = fakeOvn.fakeClient.KubeClient.CoreV1().Pods(nPodTest.namespace).Create(context.TODO(), knetPod, metav1.CreateOptions{})
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+					if topology == ovntypes.Layer2Topology && remote {
+						// add the transit switch port bindings on behalf of ovn-controller
+						// so that the added pod is eventually processed successfully
+						transistSwitchPortName := util.GetUserDefinedNetworkLogicalPortName(nPodTest.namespace, nPodTest.podName, nadNamespacedName)
+						transistSwitchName := netInfo.GetNetworkScopedName(ovntypes.OVNLayer2Switch)
+						err = libovsdb.CreateTransitSwitchPortBindings(fakeOvn.sbClient, transistSwitchName, transistSwitchPortName)
+						gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					}
+
+					ocInfo.asf.EventuallyExpectAddressSetWithAddresses(namespaceName1, []string{"10.1.1.1"})
+
+					// Delete the pod
+					ginkgo.By("Deleting the pod")
+					err = fakeOvn.fakeClient.KubeClient.CoreV1().Pods(nPodTest.namespace).Delete(context.TODO(), nPodTest.podName, metav1.DeleteOptions{})
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					ocInfo.asf.EventuallyExpectEmptyAddressSetExist(namespaceName1)
+
+					return nil
+				}
+
+				err := app.Run([]string{app.Name})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			},
+			ginkgo.Entry("on local zone for layer3 topology", ovntypes.Layer3Topology, false),
+			ginkgo.Entry("on remote zone for layer3 topology", ovntypes.Layer3Topology, true),
+			ginkgo.Entry("on local zone for layer2 topology", ovntypes.Layer2Topology, false),
+			ginkgo.Entry("on remote zone for layer2 topology", ovntypes.Layer2Topology, true),
+			ginkgo.Entry("on local zone for localnet topology", ovntypes.LocalnetTopology, false),
+			ginkgo.Entry("on remote zone for localnet topology", ovntypes.LocalnetTopology, true),
+		)
+
 		ginkgo.It("correctly creates, updates and deletes multi network policies", func() {
 			app.Action = func(*cli.Context) error {
 				config.OVNKubernetesFeature.EnableStatelessNetPol = true

--- a/go-controller/pkg/ovn/namespace.go
+++ b/go-controller/pkg/ovn/namespace.go
@@ -64,7 +64,7 @@ func (oc *DefaultNetworkController) getRoutingPodGWs(nsInfo *namespaceInfo) map[
 
 // addLocalPodToNamespace returns pod's routing gateway info and the ops needed
 // to add pod's IP to the namespace's address set and port group.
-func (oc *DefaultNetworkController) addLocalPodToNamespace(ns string, portUUID string) (*gatewayInfo, map[string]gatewayInfo, []ovsdb.Operation, error) {
+func (oc *DefaultNetworkController) addLocalPodToNamespace(ns string, ips []*net.IPNet, portUUID string) (*gatewayInfo, map[string]gatewayInfo, []ovsdb.Operation, error) {
 	var err error
 	nsInfo, nsUnlock, err := oc.ensureNamespaceLocked(ns, true, nil)
 	if err != nil {
@@ -73,11 +73,21 @@ func (oc *DefaultNetworkController) addLocalPodToNamespace(ns string, portUUID s
 
 	defer nsUnlock()
 
-	ops, err := oc.addLocalPodToNamespaceLocked(nsInfo, portUUID)
+	ops, err := oc.addLocalPodToNamespaceLocked(nsInfo, ips, portUUID)
 	if err != nil {
 		return nil, nil, nil, err
 	}
 	return oc.getRoutingExternalGWs(nsInfo), oc.getRoutingPodGWs(nsInfo), ops, nil
+}
+
+func (oc *DefaultNetworkController) addRemotePodToNamespace(ns string, ips []*net.IPNet) error {
+	nsInfo, nsUnlock, err := oc.ensureNamespaceLocked(ns, true, nil)
+	if err != nil {
+		return fmt.Errorf("failed to ensure namespace locked: %v", err)
+	}
+
+	defer nsUnlock()
+	return nsInfo.addressSet.AddAddresses(util.IPNetsIPToStringSlice(ips))
 }
 
 func isNamespaceMulticastEnabled(annotations map[string]string) bool {

--- a/go-controller/pkg/ovn/namespace_test.go
+++ b/go-controller/pkg/ovn/namespace_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"net"
 	"sync"
+	"time"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
@@ -16,7 +17,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
-	libovsdbops "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/libovsdb/ops"
 	libovsdbutil "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/libovsdb/util"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/nbdb"
 	addressset "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/address_set"
@@ -52,21 +52,20 @@ func newUDNNamespace(namespace string) *corev1.Namespace {
 	}
 }
 
-func getStaleNamespaceAddrSetDbIDs(namespaceName, controller string) *libovsdbops.DbObjectIDs {
-	return libovsdbops.NewDbObjectIDs(libovsdbops.AddressSetNamespace, controller, map[libovsdbops.ExternalIDKey]string{
-		// namespace has only 1 address set, no additional ids are required
-		libovsdbops.ObjectNameKey: namespaceName,
-	})
+func getNsAddrSetHashNames(netControllerName, ns string) (string, string) {
+	return addressset.GetHashNamesForAS(getNamespaceAddrSetDbIDs(ns, netControllerName))
 }
 
-func buildStaleNamespaceAddressSets(namespace string, ips []string) (*nbdb.AddressSet, *nbdb.AddressSet) {
-	return addressset.GetTestDbAddrSets(getStaleNamespaceAddrSetDbIDs(namespace, "default-network-controller"), ips)
+func buildNamespaceAddressSets(namespace string, ips []string) (*nbdb.AddressSet, *nbdb.AddressSet) {
+	return addressset.GetTestDbAddrSets(getNamespaceAddrSetDbIDs(namespace, "default-network-controller"), ips)
 }
 
 var _ = ginkgo.Describe("OVN Namespace Operations", func() {
 	const (
-		namespaceName  = "namespace1"
-		controllerName = ovntypes.DefaultNetworkControllerName
+		namespaceName         = "namespace1"
+		clusterIPNet   string = "10.1.0.0"
+		clusterCIDR    string = clusterIPNet + "/16"
+		controllerName        = ovntypes.DefaultNetworkControllerName
 	)
 	var (
 		fakeOvn *FakeOVN
@@ -78,7 +77,7 @@ var _ = ginkgo.Describe("OVN Namespace Operations", func() {
 		err := config.PrepareTestConfig()
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-		fakeOvn = NewFakeOVN(false)
+		fakeOvn = NewFakeOVN(true)
 		wg = &sync.WaitGroup{}
 	})
 
@@ -89,33 +88,42 @@ var _ = ginkgo.Describe("OVN Namespace Operations", func() {
 
 	ginkgo.Context("on startup", func() {
 		ginkgo.It("only cleans up address sets owned by namespace", func() {
-			// namespace address sets are now deprecated and should all be removed on startup
 			namespace1 := ovntest.NewNamespace(namespaceName)
-			// namespace-owned address set for existing namespace, should be deleted
-			ns1, _ := buildStaleNamespaceAddressSets(namespaceName, []string{"1.1.1.1"})
+			// namespace-owned address set for existing namespace, should stay
+			ns1 := getNamespaceAddrSetDbIDs(namespaceName, ovntypes.DefaultNetworkControllerName)
+			_, err := fakeOvn.asf.NewAddressSet(ns1, []string{"1.1.1.1"})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			// namespace-owned address set for stale namespace, should be deleted
-			ns2, _ := buildStaleNamespaceAddressSets("namespace2", []string{"1.1.1.2"})
-			// netpol peer address set will be removed by the addresssetManager as unreferenced
+			ns2 := getNamespaceAddrSetDbIDs("namespace2", ovntypes.DefaultNetworkControllerName)
+			_, err = fakeOvn.asf.NewAddressSet(ns2, []string{"1.1.1.2"})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			// netpol peer address set for existing netpol, should stay
 			netpol := addresssetmanager.GetPodSelectorAddrSetDbIDs(&metav1.LabelSelector{}, nil, nil, "nsName", ovntypes.DefaultNetworkControllerName, false)
-			netpolAS, _ := addressset.GetTestDbAddrSets(netpol, []string{"1.1.1.3"})
+			_, err = fakeOvn.asf.NewAddressSet(netpol, []string{"1.1.1.3"})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			// egressQoS-owned address set, should stay
 			qos := getEgressQosAddrSetDbIDs("namespace", "0", controllerName)
-			qosAS, _ := addressset.GetTestDbAddrSets(qos, []string{"1.1.1.4"})
+			_, err = fakeOvn.asf.NewAddressSet(qos, []string{"1.1.1.4"})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			// hybridNode-owned address set, should stay
 			hybridNode := apbroute.GetHybridRouteAddrSetDbIDs("node", ovntypes.DefaultNetworkControllerName)
-			hybridNodeAS, _ := addressset.GetTestDbAddrSets(hybridNode, []string{"1.1.1.5"})
+			_, err = fakeOvn.asf.NewAddressSet(hybridNode, []string{"1.1.1.5"})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			// egress firewall-owned address set, should stay
 			ef := dnsnameresolver.GetEgressFirewallDNSAddrSetDbIDs("dnsname", controllerName)
-			efAS, _ := addressset.GetTestDbAddrSets(ef, []string{"1.1.1.6"})
-
-			fakeOvn.startWithDBSetup(libovsdb.TestSetup{NBData: []libovsdb.TestData{ns1, ns2, netpolAS, qosAS, hybridNodeAS, efAS}})
-			gomega.Eventually(fakeOvn.nbClient).Should(libovsdb.HaveData([]libovsdb.TestData{ns1, ns2, qosAS, hybridNodeAS, efAS}))
-
-			// now namespace address sets will be cleaned up
-			err := fakeOvn.controller.syncNamespaces([]interface{}{namespace1})
+			_, err = fakeOvn.asf.NewAddressSet(ef, []string{"1.1.1.6"})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			gomega.Eventually(fakeOvn.nbClient).Should(libovsdb.HaveData([]libovsdb.TestData{qosAS, hybridNodeAS, efAS}))
+			fakeOvn.startWithDBSetup(libovsdb.TestSetup{NBData: []libovsdb.TestData{}})
+			err = fakeOvn.controller.syncNamespaces([]interface{}{namespace1})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			fakeOvn.asf.ExpectAddressSetWithAddresses(ns1, []string{"1.1.1.1"})
+			fakeOvn.asf.EventuallyExpectNoAddressSet(ns2)
+			fakeOvn.asf.ExpectAddressSetWithAddresses(netpol, []string{"1.1.1.3"})
+			fakeOvn.asf.ExpectAddressSetWithAddresses(qos, []string{"1.1.1.4"})
+			fakeOvn.asf.ExpectAddressSetWithAddresses(hybridNode, []string{"1.1.1.5"})
+			fakeOvn.asf.ExpectAddressSetWithAddresses(ef, []string{"1.1.1.6"})
 		})
 
 		ginkgo.It("reconciles an existing namespace with pods", func() {
@@ -160,6 +168,8 @@ var _ = ginkgo.Describe("OVN Namespace Operations", func() {
 			_, err = fakeOvn.fakeClient.KubeClient.CoreV1().Namespaces().Get(context.TODO(), namespaceT.Name, metav1.GetOptions{})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
+			fakeOvn.asf.EventuallyExpectAddressSetWithAddresses(namespaceName, []string{tP.podIP})
+
 			// port group is empty, because it will be filled by pod add logic
 			pgIDs := getNamespacePortGroupDbIDs(namespaceName, ovntypes.DefaultNetworkControllerName)
 			pg := libovsdbutil.BuildPortGroup(pgIDs, nil, nil)
@@ -180,6 +190,8 @@ var _ = ginkgo.Describe("OVN Namespace Operations", func() {
 
 			_, err = fakeOvn.fakeClient.KubeClient.CoreV1().Namespaces().Get(context.TODO(), namespaceName, metav1.GetOptions{})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			fakeOvn.asf.ExpectEmptyAddressSet(namespaceName)
 
 			pgIDs := getNamespacePortGroupDbIDs(namespaceName, ovntypes.DefaultNetworkControllerName)
 			pg := libovsdbutil.BuildPortGroup(pgIDs, nil, nil)
@@ -211,6 +223,8 @@ var _ = ginkgo.Describe("OVN Namespace Operations", func() {
 
 			err := fakeOvn.controller.WatchNamespaces()
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			fakeOvn.asf.EventuallyExpectAddressSetWithAddresses(namespaceName, []string{})
 			gomega.Eventually(fakeOvn.nbClient).Should(libovsdb.HaveData(initialData))
 		})
 		ginkgo.It("deletes an existing namespace port group when egress firewall and multicast are disabled", func() {
@@ -256,6 +270,27 @@ var _ = ginkgo.Describe("OVN Namespace Operations", func() {
 			err := fakeOvn.controller.WatchNamespaces()
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			gomega.Eventually(fakeOvn.nbClient).Should(libovsdb.HaveData([]libovsdb.TestData{}))
+		})
+	})
+
+	ginkgo.Context("during execution", func() {
+		ginkgo.It("deletes an empty namespace's resources", func() {
+			fakeOvn.start(&corev1.NamespaceList{
+				Items: []corev1.Namespace{
+					*ovntest.NewNamespace(namespaceName),
+				},
+			})
+			err := fakeOvn.controller.WatchNamespaces()
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			fakeOvn.asf.ExpectEmptyAddressSet(namespaceName)
+
+			err = fakeOvn.fakeClient.KubeClient.CoreV1().Namespaces().Delete(context.TODO(), namespaceName, *metav1.NewDeleteOptions(1))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			// namespace's address set deletion is delayed by 20 second to let other handlers cleanup
+			gomega.Eventually(func() bool {
+				return fakeOvn.asf.AddressSetExists(namespaceName)
+			}, 21*time.Second).Should(gomega.BeFalse())
 		})
 	})
 })

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -123,6 +123,12 @@ func (oc *DefaultNetworkController) ensurePod(oldPod, pod *corev1.Pod, addPort b
 		return nil
 	}
 
+	// Add podIPs on no host subnet Nodes to the namespace address_set
+	switchName := pod.Spec.NodeName
+	if oc.lsManager.IsNonHostSubnetSwitch(switchName) {
+		return oc.ensureRemotePodIP(oldPod, pod, addPort)
+	}
+
 	// If an external gateway pod is in terminating or not ready state then remove the
 	// routes for the external gateway pod
 	if util.PodTerminating(pod) || !v1pod.IsPodReadyConditionTrue(pod.Status) {
@@ -137,7 +143,7 @@ func (oc *DefaultNetworkController) ensurePod(oldPod, pod *corev1.Pod, addPort b
 	}
 
 	klog.V(5).Infof("Ensuring zone remote for Pod %s/%s in node %s", pod.Namespace, pod.Name, pod.Spec.NodeName)
-	return oc.ensureRemoteZonePod(oldPod, pod)
+	return oc.ensureRemoteZonePod(oldPod, pod, addPort)
 }
 
 // ensureLocalZonePod tries to set up a local zone pod. It returns nil on success and error on failure; failure
@@ -203,12 +209,30 @@ func (oc *DefaultNetworkController) ensureLocalZonePod(oldPod, pod *corev1.Pod, 
 	return nil
 }
 
+func (oc *DefaultNetworkController) ensureRemotePodIP(oldPod, pod *corev1.Pod, addPort bool) error {
+	if (addPort || (oldPod != nil && len(pod.Status.PodIPs) != len(oldPod.Status.PodIPs))) && !util.PodWantsHostNetwork(pod) {
+		podIfAddrs, err := util.GetPodCIDRsWithFullMask(pod, oc.GetNetInfo(), nil)
+		if err != nil {
+			// not finding pod IPs on a remote pod is common until the other node wires the pod, suppress it
+			return fmt.Errorf("failed to obtain IPs to add remote pod %s/%s: %w",
+				pod.Namespace, pod.Name, ovntypes.NewSuppressedError(err))
+		}
+		if err := oc.addRemotePodToNamespace(pod.Namespace, podIfAddrs); err != nil {
+			return fmt.Errorf("failed to add remote pod %s/%s to namespace: %w", pod.Namespace, pod.Name, err)
+		}
+	}
+	return nil
+}
+
 // ensureRemoteZonePod tries to set up remote zone pod bits required to interconnect it.
-//   - Reconciles external-gateway annotations on the remote pod
-//   - For live-migratable VMs, ensures remote-zone pod-to-node routes
+//   - Adds the remote pod ips to the pod namespace address set for network policy and egress gw
 //
 // It returns nil on success and error on failure; failure indicates the pod set up should be retried later.
-func (oc *DefaultNetworkController) ensureRemoteZonePod(oldPod, pod *corev1.Pod) error {
+func (oc *DefaultNetworkController) ensureRemoteZonePod(oldPod, pod *corev1.Pod, addPort bool) error {
+	if err := oc.ensureRemotePodIP(oldPod, pod, addPort); err != nil {
+		return err
+	}
+
 	//FIXME: Update comments & reduce code duplication.
 	// check if this remote pod is serving as an external GW.
 	if oldPod != nil && (exGatewayAnnotationsChanged(oldPod, pod) || networkStatusAnnotationsChanged(oldPod, pod)) {
@@ -300,6 +324,10 @@ func (oc *DefaultNetworkController) removeRemoteZonePod(pod *corev1.Pod) error {
 			pod.Name,
 		)
 		return nil
+	}
+
+	if err := oc.removeRemoteZonePodFromNamespaceAddressSet(pod); err != nil {
+		return fmt.Errorf("failed to remove the remote zone pod: %w", err)
 	}
 
 	// FIXME: there are other things we are probably leaving behind and should

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -300,7 +300,7 @@ func (oc *DefaultNetworkController) addLogicalPort(pod *corev1.Pod) (err error) 
 	}
 
 	// Ensure the namespace/nsInfo exists
-	routingExternalGWs, routingPodGWs, addOps, err := oc.addLocalPodToNamespace(pod.Namespace, lsp.UUID)
+	routingExternalGWs, routingPodGWs, addOps, err := oc.addLocalPodToNamespace(pod.Namespace, podAnnotation.IPs, lsp.UUID)
 	if err != nil {
 		return err
 	}

--- a/go-controller/pkg/ovn/pods_test.go
+++ b/go-controller/pkg/ovn/pods_test.go
@@ -952,6 +952,7 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 
 				expectedData := []libovsdbtest.TestData{getDefaultNetExpectedPodsAndSwitches([]testPod{}, []string{"node1"})}
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedData...))
+				fakeOvn.asf.ExpectAddressSetWithAddresses(namespaceT.Name, []string{})
 				return nil
 			}
 
@@ -1068,6 +1069,7 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 				podTest.populateLogicalSwitchCache(fakeOvn)
 				err = fakeOvn.controller.WatchNamespaces()
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				fakeOvn.asf.ExpectAddressSetWithAddresses(podTest.namespace, []string{podTest.podIP})
 				gomega.Eventually(fakeOvn.controller.nbClient).Should(
 					libovsdbtest.HaveData(getDefaultNetExpectedPodsAndSwitches([]testPod{}, []string{"node1"})...))
 
@@ -1095,6 +1097,7 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 
 				_, err = fakeOvn.fakeClient.KubeClient.CoreV1().Pods(podTest.namespace).Get(context.TODO(), podTest.podName, metav1.GetOptions{})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				fakeOvn.asf.ExpectAddressSetWithAddresses(podTest.namespace, []string{podTest.podIP})
 				gomega.Eventually(fakeOvn.controller.nbClient).Should(
 					libovsdbtest.HaveData(getDefaultNetExpectedPodsAndSwitches([]testPod{podTest}, []string{"node1"})...))
 				// check the retry cache no longer has the entry
@@ -1148,6 +1151,7 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 				_, err = fakeOvn.fakeClient.KubeClient.CoreV1().Pods(podTest.namespace).Get(context.TODO(), podTest.podName, metav1.GetOptions{})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedData...))
+				fakeOvn.asf.ExpectAddressSetWithAddresses(podTest.namespace, []string{podTest.podIP})
 
 				// inject transient problem, nbdb is down
 				fakeOvn.controller.nbClient.Close()
@@ -1170,6 +1174,7 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 				retry.SetRetryObjWithNoBackoff(key, fakeOvn.controller.retryPods)
 				fakeOvn.controller.retryPods.RequestRetryObjs() // retry the failed entry
 
+				fakeOvn.asf.ExpectEmptyAddressSet(podTest.namespace)
 				gomega.Eventually(fakeOvn.controller.nbClient).Should(
 					libovsdbtest.HaveData(getDefaultNetExpectedPodsAndSwitches([]testPod{}, []string{"node1"})...))
 				// check the retry cache no longer has the entry
@@ -1220,6 +1225,7 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 				err = fakeOvn.controller.WatchNamespaces()
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
+				fakeOvn.asf.ExpectAddressSetWithAddresses(podTest.namespace, []string{podTest.podIP})
 				gomega.Eventually(fakeOvn.controller.nbClient).Should(
 					libovsdbtest.HaveData(getDefaultNetExpectedPodsAndSwitches([]testPod{}, []string{"node1"})...))
 
@@ -1338,6 +1344,7 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 					context.TODO(), podTest.podName, metav1.GetOptions{})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedData...))
+				fakeOvn.asf.ExpectAddressSetWithAddresses(podTest.namespace, []string{podTest.podIP})
 
 				// inject transient problem, nbdb is down
 				fakeOvn.controller.nbClient.Close()
@@ -1446,6 +1453,7 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedData...))
+				fakeOvn.asf.ExpectAddressSetWithAddresses(podTest.namespace, []string{podTest.podIP})
 
 				// Get pod from api with its metadata filled in
 				pod, err = fakeOvn.fakeClient.KubeClient.CoreV1().Pods(podTest.namespace).Get(context.TODO(), podTest.podName, metav1.GetOptions{})
@@ -1459,6 +1467,7 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				// OVN db should be empty now
+				fakeOvn.asf.ExpectEmptyAddressSet(podTest.namespace)
 				gomega.Eventually(fakeOvn.controller.nbClient).Should(
 					libovsdbtest.HaveData(getDefaultNetExpectedPodsAndSwitches([]testPod{}, []string{"node1"})...))
 
@@ -2401,12 +2410,10 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 				err = fakeOvn.controller.WatchPods()
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-				// use conditional IP Release, it will run given predicate if IP is already allocated otherwise returns false
-				podIP, podNet, _ := net.ParseCIDR("10.128.1.30/24")
-				podNet.IP = podIP
-				ok, _ := fakeOvn.controller.lsManager.ConditionalIPRelease(fakeOvn.controller.GetNetworkScopedSwitchName(node1Name),
-					[]*net.IPNet{podNet}, func() (bool, error) { return true, nil })
-				gomega.Expect(ok).To(gomega.BeTrue())
+				// use the namespace address set to verify that the IP was not
+				// released
+				fakeOvn.asf.ExpectAddressSetWithAddresses(runningTPod.namespace, []string{runningTPod.podIP})
+
 				return nil
 			}
 
@@ -2464,6 +2471,10 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 				podKey, err := retry.GetResourceKey(myPod)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				gomega.Expect(retry.CheckRetryObj(podKey, fakeOvn.controller.retryPods)).To(gomega.BeFalse())
+
+				// check that the namespace AS is kept empty
+				fakeOvn.asf.ExpectAddressSetWithAddresses(namespaceT.Name, []string{})
+
 				return nil
 			}
 
@@ -2588,6 +2599,9 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				err = fakeOvn.controller.WatchPods()
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				// check that the pod IP is added to the namespace AS
+				fakeOvn.asf.ExpectAddressSetWithAddresses(testNs, []string{testPodIP})
 
 				return nil
 			}

--- a/go-controller/pkg/ovn/pods_test.go
+++ b/go-controller/pkg/ovn/pods_test.go
@@ -39,7 +39,7 @@ import (
 func getPodAnnotations(fakeClient kubernetes.Interface, namespace, name string) string {
 	pod, err := fakeClient.CoreV1().Pods(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-	return pod.Annotations[ovntypes.OvnPodAnnotationName]
+	return pod.Annotations[util.OvnPodAnnotationName]
 }
 
 func newNode(nodeName, nodeIPv4CIDR string) *corev1.Node {
@@ -367,7 +367,7 @@ func setPodAnnotations(podObj *corev1.Pod, testPod testPod) {
 	if podObj.Annotations == nil {
 		podObj.Annotations = map[string]string{}
 	}
-	podObj.Annotations[ovntypes.OvnPodAnnotationName] = testPod.getAnnotationsJson()
+	podObj.Annotations[util.OvnPodAnnotationName] = testPod.getAnnotationsJson()
 }
 
 func getDefaultNetExpectedPodsAndSwitches(pods []testPod, nodes []string) []libovsdbtest.TestData {
@@ -544,7 +544,7 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 				pod, err := fakeOvn.fakeClient.KubeClient.CoreV1().Pods(t.namespace).Get(context.TODO(), t.podName, metav1.GetOptions{})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-				_, ok := pod.Annotations[ovntypes.OvnPodAnnotationName]
+				_, ok := pod.Annotations[util.OvnPodAnnotationName]
 				gomega.Expect(ok).To(gomega.BeFalse())
 
 				// Assign it and perform the update
@@ -1748,7 +1748,7 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 				pod, err := fakeOvn.fakeClient.KubeClient.CoreV1().Pods(t.namespace).Get(context.TODO(), t.podName, metav1.GetOptions{})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-				_, ok := pod.Annotations[ovntypes.OvnPodAnnotationName]
+				_, ok := pod.Annotations[util.OvnPodAnnotationName]
 				gomega.Expect(ok).To(gomega.BeFalse())
 
 				err = fakeOvn.controller.WatchNamespaces()
@@ -2249,7 +2249,7 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 				pod, err := fakeOvn.fakeClient.KubeClient.CoreV1().Pods(t.namespace).Get(context.TODO(), t.podName, metav1.GetOptions{})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-				_, ok := pod.Annotations[ovntypes.OvnPodAnnotationName]
+				_, ok := pod.Annotations[util.OvnPodAnnotationName]
 				gomega.Expect(ok).To(gomega.BeFalse())
 
 				err = fakeOvn.controller.WatchNamespaces()

--- a/go-controller/pkg/ovn/policy_stale_test.go
+++ b/go-controller/pkg/ovn/policy_stale_test.go
@@ -126,10 +126,6 @@ func getStaleDefaultDenyDataWithICMP(networkPolicy *knet.NetworkPolicy, includeI
 	return append(testData, egressDenyPG, ingressDenyPG)
 }
 
-func getMultinetNsAddrSetHashNames(ns, controllerName string) (string, string) {
-	return addressset.GetHashNamesForAS(getStaleNamespaceAddrSetDbIDs(ns, controllerName))
-}
-
 // getStalePolicyACLs builds stale ACLs for given peers
 func getStalePolicyACLs(gressIdx int, namespace, policyName string, peerNamespaces []string,
 	peers []knet.NetworkPolicyPeer, policyType knet.PolicyType, netInfo util.NetInfo) []*nbdb.ACL {
@@ -297,9 +293,12 @@ var _ = ginkgo.Describe("OVN Stale NetworkPolicy Operations", func() {
 					Get(context.TODO(), networkPolicy.Name, metav1.GetOptions{})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				// make sure stale ACLs were updated
+				namespace1AddressSetv4, _ := buildNamespaceAddressSets(namespace1.Name, nil)
+				namespace2AddressSetv4, _ := buildNamespaceAddressSets(namespace2.Name, nil)
 				expectedData := getNamespaceWithSinglePolicyExpectedData(
 					newNetpolDataParams(networkPolicy),
 					initialDB.NBData)
+				expectedData = append(expectedData, namespace1AddressSetv4, namespace2AddressSetv4)
 
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedData...))
 			},
@@ -329,6 +328,9 @@ var _ = ginkgo.Describe("OVN Stale NetworkPolicy Operations", func() {
 			expectedData := getNamespaceWithSinglePolicyExpectedData(
 				newNetpolDataParams(networkPolicy),
 				initialDB.NBData)
+			namespace1AddressSetv4, _ := buildNamespaceAddressSets(namespace1.Name, nil)
+			namespace2AddressSetv4, _ := buildNamespaceAddressSets(namespace2.Name, nil)
+			expectedData = append(expectedData, namespace1AddressSetv4, namespace2AddressSetv4)
 
 			gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedData...))
 		})
@@ -355,6 +357,9 @@ var _ = ginkgo.Describe("OVN Stale NetworkPolicy Operations", func() {
 			expectedData := getNamespaceWithSinglePolicyExpectedData(
 				newNetpolDataParams(networkPolicy),
 				initialDB.NBData)
+			namespace1AddressSetv4, _ := buildNamespaceAddressSets(longNamespaceName63, nil)
+			namespace2AddressSetv4, _ := buildNamespaceAddressSets(namespace2.Name, nil)
+			expectedData = append(expectedData, namespace1AddressSetv4, namespace2AddressSetv4)
 			gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedData...))
 		})
 	})

--- a/go-controller/pkg/ovn/policy_test.go
+++ b/go-controller/pkg/ovn/policy_test.go
@@ -236,6 +236,10 @@ func getDefaultDenyDataMultiplePolicies(networkPolicies []*knet.NetworkPolicy) [
 	return getDefaultDenyDataHelper(policyTypeIngress, policyTypeEgress, newNetpolDataParams(networkPolicies[0]))
 }
 
+func getMultinetNsAddrSetHashNames(ns, controllerName string) (string, string) {
+	return addressset.GetHashNamesForAS(getNamespaceAddrSetDbIDs(ns, controllerName))
+}
+
 // getGressACLsAndAddrSets can only handle tcpPeerPorts for policies built with getPortNetworkPolicy, i.e. peer should only
 // have `Ports` filled, but no `To`/`From`.
 func getGressACLsAndAddrSets(gressIdx int, peers []knet.NetworkPolicyPeer, policyType knet.PolicyType,
@@ -797,7 +801,10 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 					config.OVNKubernetesFeature.AllowICMPNetworkPolicy = allowICMPNetworkPolicy
 					namespace1 := *ovntest.NewNamespace(namespaceName1)
 					namespace2 := *ovntest.NewNamespace(namespaceName2)
+					namespace1AddressSetv4, _ := buildNamespaceAddressSets(namespace1.Name, nil)
+					namespace2AddressSetv4, _ := buildNamespaceAddressSets(namespace2.Name, nil)
 					// add namespaces to initial Database
+					initialDB.NBData = append(initialDB.NBData, namespace1AddressSetv4, namespace2AddressSetv4)
 
 					networkPolicy := ovntest.NewMatchLabelsNetworkPolicy(netPolicyName1, namespace1.Name,
 						namespace2.Name, "", true, true)
@@ -826,7 +833,10 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 
 				namespace1 := *ovntest.NewNamespace(namespaceName1)
 				namespace2 := *ovntest.NewNamespace(namespaceName2)
+				namespace1AddressSetv4, _ := buildNamespaceAddressSets(namespace1.Name, nil)
+				namespace2AddressSetv4, _ := buildNamespaceAddressSets(namespace2.Name, nil)
 				// add namespaces to initial Database
+				initialDB.NBData = append(initialDB.NBData, namespace1AddressSetv4, namespace2AddressSetv4)
 
 				networkPolicy := ovntest.NewMatchLabelsNetworkPolicy(netPolicyName1, namespace1.Name,
 					namespace2.Name, "", true, true)
@@ -863,6 +873,8 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				startOvn(initialDB, []corev1.Namespace{namespace1}, []knet.NetworkPolicy{*networkPolicy},
 					[]testPod{nPodTest}, nil)
 
+				namespace1AddressSetv4, _ := buildNamespaceAddressSets(namespace1.Name, []string{nPodTest.podIP})
+
 				_, err := fakeOvn.fakeClient.KubeClient.NetworkingV1().NetworkPolicies(networkPolicy.Namespace).
 					Get(context.TODO(), networkPolicy.Name, metav1.GetOptions{})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -870,6 +882,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				expectedData := getNamespaceWithSinglePolicyExpectedData(
 					newNetpolDataParams(networkPolicy).withLocalPortUUIDs(nPodTest.portUUID).withPeerIPs(nPodTest.podIP),
 					getUpdatedInitialDB([]testPod{nPodTest}))
+				expectedData = append(expectedData, namespace1AddressSetv4)
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedData...))
 
 				return nil
@@ -889,6 +902,9 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				startOvn(initialDB, []corev1.Namespace{namespace1, namespace2}, []knet.NetworkPolicy{*networkPolicy},
 					[]testPod{nPodTest}, nil)
 
+				namespace1AddressSetv4, _ := buildNamespaceAddressSets(namespace1.Name, nil)
+				namespace2AddressSetv4, _ := buildNamespaceAddressSets(namespace2.Name, []string{nPodTest.podIP})
+
 				_, err := fakeOvn.fakeClient.KubeClient.NetworkingV1().NetworkPolicies(networkPolicy.Namespace).
 					Get(context.TODO(), networkPolicy.Name, metav1.GetOptions{})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -896,6 +912,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				expectedData := getNamespaceWithSinglePolicyExpectedData(
 					newNetpolDataParams(networkPolicy).withPeerIPs(nPodTest.podIP),
 					getUpdatedInitialDB([]testPod{nPodTest}))
+				expectedData = append(expectedData, namespace1AddressSetv4, namespace2AddressSetv4)
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedData))
 
 				return nil
@@ -907,6 +924,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 		ginkgo.It("reconciles existing networkPolicies with equivalent rules", func() {
 			app.Action = func(*cli.Context) error {
 				namespace1 := *ovntest.NewNamespace(namespaceName1)
+				namespace1AddressSetv4, _ := buildNamespaceAddressSets(namespace1.Name, nil)
 				peer := knet.NetworkPolicyPeer{
 					IPBlock: &knet.IPBlock{
 						CIDR: "1.1.1.1",
@@ -928,6 +946,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 						},
 					}, nil)
 				initialData := initialDB.NBData
+				initialData = append(initialData, namespace1AddressSetv4)
 				gressPolicy1ExpectedData := getPolicyData(newNetpolDataParams(networkPolicy1))
 				gressPolicy2ExpectedData := getPolicyData(newNetpolDataParams(networkPolicy2))
 				defaultDenyExpectedData := getDefaultDenyDataMultiplePolicies([]*knet.NetworkPolicy{networkPolicy1, networkPolicy2})
@@ -948,6 +967,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				// check the initial data is updated, one acl should be removed
 				gressUpdatedPolicy1ExpectedData := getPolicyData(newNetpolDataParams(networkPolicy1Updated))
 				finalData := initialDB.NBData
+				finalData = append(finalData, namespace1AddressSetv4)
 				finalData = append(finalData, gressUpdatedPolicy1ExpectedData...)
 				finalData = append(finalData, gressPolicy2ExpectedData...)
 				finalData = append(finalData, defaultDenyExpectedData...)
@@ -961,6 +981,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 		ginkgo.It("reconciles existing networkPolicies with has legacy ipBlock ACLs", func() {
 			app.Action = func(*cli.Context) error {
 				namespace1 := *ovntest.NewNamespace(namespaceName1)
+				namespace1AddressSetv4, _ := buildNamespaceAddressSets(namespace1.Name, nil)
 				peer := knet.NetworkPolicyPeer{
 					IPBlock: &knet.IPBlock{
 						CIDR: "1.1.1.1",
@@ -982,6 +1003,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 						},
 					}, nil)
 				initialData := initialDB.NBData
+				initialData = append(initialData, namespace1AddressSetv4)
 				defaultDenyExpectedData := getDefaultDenyDataMultiplePolicies([]*knet.NetworkPolicy{networkPolicy1, networkPolicy2})
 				initialData = append(initialData, defaultDenyExpectedData...)
 
@@ -1088,6 +1110,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				gressPolicy1ExpectedData := getPolicyData(newNetpolDataParams(networkPolicy1))
 				gressPolicy2ExpectedData := getPolicyData(newNetpolDataParams(networkPolicy2))
 				finalData := initialDB.NBData
+				finalData = append(finalData, namespace1AddressSetv4)
 				finalData = append(finalData, gressPolicy1ExpectedData...)
 				finalData = append(finalData, gressPolicy2ExpectedData...)
 				finalData = append(finalData, defaultDenyExpectedData...)
@@ -1121,9 +1144,14 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				startOvn(initialDB, []corev1.Namespace{namespace1, namespace2, hostNetNamespace}, []knet.NetworkPolicy{*netpol},
 					[]testPod{ns1Pod, ns1HosnetPod, ns2Pod}, nil)
 
+				namespace1AddressSetv4, _ := buildNamespaceAddressSets(namespace1.Name, []string{ns1Pod.podIP})
+				namespace2AddressSetv4, _ := buildNamespaceAddressSets(namespace2.Name, []string{ns2Pod.podIP})
+				hostNamespaceAddressSetV4, _ := buildNamespaceAddressSets(config.Kubernetes.HostNetworkNamespace, []string{})
+
 				expectedData := getNamespaceWithSinglePolicyExpectedData(
 					newNetpolDataParams(netpol).withPeerIPs(peerIPs...).withLocalPortUUIDs(ns1Pod.portUUID),
 					getUpdatedInitialDB([]testPod{ns1Pod, ns2Pod}))
+				expectedData = append(expectedData, namespace1AddressSetv4, namespace2AddressSetv4, hostNamespaceAddressSetV4)
 
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedData...))
 			},
@@ -1180,6 +1208,8 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 			app.Action = func(*cli.Context) error {
 				namespace1 := *ovntest.NewNamespace(namespaceName1)
 				nPodTest := getTestPod(namespace1.Name, nodeName)
+				namespace1AddressSetv4, _ := buildNamespaceAddressSets(namespace1.Name, []string{nPodTest.podIP})
+				initialDB.NBData = append(initialDB.NBData, namespace1AddressSetv4)
 				networkPolicy := getPortNetworkPolicy(netPolicyName1, namespace1.Name, labelName, labelVal, portNum)
 				startOvn(initialDB, []corev1.Namespace{namespace1}, []knet.NetworkPolicy{*networkPolicy},
 					[]testPod{nPodTest}, map[string]string{labelName: labelVal})
@@ -1197,6 +1227,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				expectedData := getUpdatedInitialDB([]testPod{nPodTest})
 				expectedData = append(expectedData, gressPolicy1ExpectedData...)
 				expectedData = append(expectedData, defaultDenyExpectedData...)
+				expectedData = append(expectedData, namespace1AddressSetv4)
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedData...))
 
 				// Create a second NP
@@ -1225,6 +1256,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				expectedData = getUpdatedInitialDB([]testPod{nPodTest})
+				expectedData = append(expectedData, namespace1AddressSetv4)
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedData))
 
 				return nil
@@ -1252,6 +1284,8 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 						withTCPPeerPorts(portNum),
 					getUpdatedInitialDB([]testPod{nPodTest}))
 
+				namespace1AddressSetv4, _ := buildNamespaceAddressSets(namespace1.Name, []string{nPodTest.podIP})
+				expectedData = append(expectedData, namespace1AddressSetv4)
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedData...))
 
 				ginkgo.By("Bringing down NBDB")
@@ -1310,6 +1344,8 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 						withLocalPortUUIDs(nPodTest.portUUID).
 						withTCPPeerPorts(portNum),
 					getUpdatedInitialDB([]testPod{nPodTest}))
+				namespace1AddressSetv4, _ := buildNamespaceAddressSets(namespace1.Name, []string{nPodTest.podIP})
+				expectedData = append(expectedData, namespace1AddressSetv4)
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedData...))
 
 				ginkgo.By("Bringing down NBDB")
@@ -1353,6 +1389,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 						withLocalPortUUIDs(nPodTest.portUUID).
 						withTCPPeerPorts(portNum+1),
 					getUpdatedInitialDB([]testPod{nPodTest}))
+				expectedData = append(expectedData, namespace1AddressSetv4)
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedData...))
 				// check the cache no longer has the entry
 				key, err = retry.GetResourceKey(networkPolicy)
@@ -1385,6 +1422,9 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				expectedData = append(expectedData, gressPolicyExpectedData...)
 				expectedData = append(expectedData, defaultDenyExpectedData...)
 
+				namespace1AddressSetv4, _ := buildNamespaceAddressSets(namespace1.Name, []string{nPodTest.podIP})
+				namespace2AddressSetv4, _ := buildNamespaceAddressSets(namespace2.Name, nil)
+				expectedData = append(expectedData, namespace1AddressSetv4, namespace2AddressSetv4)
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedData...))
 
 				// Delete peer namespace2
@@ -1396,6 +1436,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				updatedGressPolicyExpectedData := getPolicyData(newNetpolDataParams(networkPolicy).withLocalPortUUIDs(nPodTest.portUUID))
 				expectedData = append(expectedData, updatedGressPolicyExpectedData...)
 				expectedData = append(expectedData, defaultDenyExpectedData...)
+				expectedData = append(expectedData, namespace1AddressSetv4, namespace2AddressSetv4)
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedData...))
 
 				return nil
@@ -1421,6 +1462,9 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				defaultDenyExpectedData := getDefaultDenyData(dataParams)
 				expectedData := initialDB.NBData
 
+				namespace1AddressSetv4, _ := buildNamespaceAddressSets(namespace1.Name, nil)
+				namespace2AddressSetv4, _ := buildNamespaceAddressSets(namespace2.Name, nil)
+				expectedData = append(expectedData, namespace1AddressSetv4, namespace2AddressSetv4)
 				expectedData = append(expectedData, gressPolicyExpectedData...)
 				expectedData = append(expectedData, defaultDenyExpectedData...)
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedData...))
@@ -1432,6 +1476,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 
 				// acls will be deleted, since no namespaces are selected at this point.
 				expectedData = initialDB.NBData
+				expectedData = append(expectedData, namespace1AddressSetv4, namespace2AddressSetv4)
 				updatedGressPolicyExpectedData := getPolicyData(newNetpolDataParams(networkPolicy))
 				expectedData = append(expectedData, updatedGressPolicyExpectedData...)
 				expectedData = append(expectedData, defaultDenyExpectedData...)
@@ -1460,6 +1505,8 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 						withLocalPortUUIDs(nPodTest.portUUID).withPeerIPs(nPodTest.podIP),
 					getUpdatedInitialDB([]testPod{nPodTest}))
 
+				namespace1AddressSetv4, _ := buildNamespaceAddressSets(namespace1.Name, []string{nPodTest.podIP})
+				expectedData = append(expectedData, namespace1AddressSetv4)
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedData...))
 
 				// Delete pod
@@ -1470,6 +1517,8 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				expectedData = getNamespaceWithSinglePolicyExpectedData(
 					newNetpolDataParams(networkPolicy),
 					initialDB.NBData)
+				namespace1AddressSetv4.Addresses = nil
+				expectedData = append(expectedData, namespace1AddressSetv4)
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedData...))
 
 				return nil
@@ -1495,6 +1544,9 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				expectedData := getNamespaceWithSinglePolicyExpectedData(
 					newNetpolDataParams(networkPolicy).withPeerIPs(nPodTest.podIP),
 					getUpdatedInitialDB([]testPod{nPodTest}))
+				namespace1AddressSetv4, _ := buildNamespaceAddressSets(namespace1.Name, nil)
+				namespace2AddressSetv4, _ := buildNamespaceAddressSets(namespace2.Name, []string{nPodTest.podIP})
+				expectedData = append(expectedData, namespace1AddressSetv4, namespace2AddressSetv4)
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedData...))
 
 				// Delete pod
@@ -1505,6 +1557,8 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 					newNetpolDataParams(networkPolicy),
 					getUpdatedInitialDB([]testPod{}))
 				// After deleting the pod all address sets should be empty
+				namespace2AddressSetv4.Addresses = nil
+				expectedData = append(expectedData, namespace1AddressSetv4, namespace2AddressSetv4)
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedData...))
 
 				return nil
@@ -1528,6 +1582,9 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				expectedData := getNamespaceWithSinglePolicyExpectedData(
 					newNetpolDataParams(networkPolicy).withPeerIPs(nPodTest.podIP),
 					getUpdatedInitialDB([]testPod{nPodTest}))
+				namespace1AddressSetv4, _ := buildNamespaceAddressSets(namespace1.Name, nil)
+				namespace2AddressSetv4, _ := buildNamespaceAddressSets(namespace2.Name, []string{nPodTest.podIP})
+				expectedData = append(expectedData, namespace1AddressSetv4, namespace2AddressSetv4)
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedData...))
 
 				// Update namespace labels
@@ -1540,6 +1597,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				expectedData = getNamespaceWithSinglePolicyExpectedData(
 					newNetpolDataParams(networkPolicy),
 					getUpdatedInitialDB([]testPod{nPodTest}))
+				expectedData = append(expectedData, namespace1AddressSetv4, namespace2AddressSetv4)
 				// db data should reflect the empty addressets
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedData...))
 
@@ -1568,6 +1626,8 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				expectedData := getUpdatedInitialDB([]testPod{nPodTest})
 				expectedData = append(expectedData, gressPolicyExpectedData...)
 				expectedData = append(expectedData, defaultDenyExpectedData...)
+				namespace1AddressSetv4, _ := buildNamespaceAddressSets(namespace1.Name, []string{nPodTest.podIP})
+				expectedData = append(expectedData, namespace1AddressSetv4)
 
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedData...))
 
@@ -1577,6 +1637,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				expectedData = getUpdatedInitialDB([]testPod{nPodTest})
+				expectedData = append(expectedData, namespace1AddressSetv4)
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedData))
 
 				return nil
@@ -1606,6 +1667,8 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				expectedData := getUpdatedInitialDB([]testPod{nPodTest})
 				expectedData = append(expectedData, gressPolicyExpectedData...)
 				expectedData = append(expectedData, defaultDenyExpectedData...)
+				namespace1AddressSetv4, _ := buildNamespaceAddressSets(namespace1.Name, []string{nPodTest.podIP})
+				expectedData = append(expectedData, namespace1AddressSetv4)
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedData...))
 
 				// inject transient problem, nbdb is down
@@ -1633,6 +1696,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				fakeOvn.controller.retryNetworkPolicies.RequestRetryObjs()
 
 				expectedData = getUpdatedInitialDB([]testPod{nPodTest})
+				expectedData = append(expectedData, namespace1AddressSetv4)
 				gomega.Eventually(fakeOvn.controller.nbClient).Should(libovsdbtest.HaveData(expectedData))
 
 				// check the cache no longer has the entry
@@ -1682,6 +1746,8 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				expectedData := getUpdatedInitialDB([]testPod{nPodTest})
 				expectedData = append(expectedData, gressPolicy1ExpectedData...)
 				expectedData = append(expectedData, defaultDenyExpectedData...)
+				namespace1AddressSetv4, _ := buildNamespaceAddressSets(namespace1.Name, []string{nPodTest.podIP})
+				expectedData = append(expectedData, namespace1AddressSetv4)
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedData...))
 
 				// Delete the network policy
@@ -1690,6 +1756,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				expectedData = getUpdatedInitialDB([]testPod{nPodTest})
+				expectedData = append(expectedData, namespace1AddressSetv4)
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedData))
 
 				return nil
@@ -1737,6 +1804,8 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				expectedData := getUpdatedInitialDB([]testPod{nPodTest})
 				expectedData = append(expectedData, gressPolicy1ExpectedData...)
 				expectedData = append(expectedData, defaultDenyExpectedData...)
+				namespace1AddressSetv4, _ := buildNamespaceAddressSets(namespace1.Name, []string{nPodTest.podIP})
+				expectedData = append(expectedData, namespace1AddressSetv4)
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedData...))
 
 				// Delete the network policy
@@ -1746,6 +1815,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				expectedData = getUpdatedInitialDB([]testPod{nPodTest})
+				expectedData = append(expectedData, namespace1AddressSetv4)
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedData))
 
 				return nil
@@ -1818,6 +1888,8 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				// check db
 				expectedData := getNamespaceWithMultiplePoliciesExpectedData(
 					[]*knet.NetworkPolicy{networkPolicy1}, initialDB.NBData)
+				namespace1AddressSetv4, _ := buildNamespaceAddressSets(namespace1.Name, nil)
+				expectedData = append(expectedData, namespace1AddressSetv4)
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedData))
 				// create second netpol
 				_, err = fakeOvn.fakeClient.KubeClient.NetworkingV1().NetworkPolicies(networkPolicy2.Namespace).
@@ -1826,6 +1898,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				// check db
 				expectedData = getNamespaceWithMultiplePoliciesExpectedData(
 					[]*knet.NetworkPolicy{networkPolicy1, networkPolicy2}, initialDB.NBData)
+				expectedData = append(expectedData, namespace1AddressSetv4)
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedData))
 
 				return nil
@@ -1861,6 +1934,10 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 						// this is added via HostNetworkNamespace
 						withPeerIPs(nPodTest.podIP, node1MgmtIP),
 					getUpdatedInitialDB([]testPod{nPodTest}))
+				namespace1AddressSetv4, _ := buildNamespaceAddressSets(namespace1.Name, []string{nPodTest.podIP})
+				hostNamespaceAddressSetV4, _ := buildNamespaceAddressSets(config.Kubernetes.HostNetworkNamespace, []string{})
+
+				expectedData = append(expectedData, namespace1AddressSetv4, hostNamespaceAddressSetV4)
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedData...))
 
 				return nil
@@ -2012,6 +2089,8 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				expectedData := getNamespaceWithSinglePolicyExpectedData(
 					newNetpolDataParams(networkPolicy).withPeerIPs(nPodTest.podIP),
 					initialDB.NBData)
+				namespace1AddressSetv4, _ := buildNamespaceAddressSets(namespace1.Name, nil)
+				expectedData = append(expectedData, namespace1AddressSetv4)
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedData...))
 
 				return nil
@@ -2051,6 +2130,8 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				expectedData := getNamespaceWithSinglePolicyExpectedData(
 					newNetpolDataParams(networkPolicy),
 					initialDB.NBData)
+				namespace1AddressSetv4, _ := buildNamespaceAddressSets(namespace1.Name, nil)
+				expectedData = append(expectedData, namespace1AddressSetv4)
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedData...))
 
 				return nil
@@ -2075,6 +2156,8 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 					newNetpolDataParams(networkPolicy).
 						withTCPPeerPorts(portNum),
 					initialDB.NBData)
+				namespace1AddressSetv4, _ := buildNamespaceAddressSets(namespace1.Name, nil)
+				expectedData = append(expectedData, namespace1AddressSetv4)
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedData...))
 				gomega.Consistently(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedData...))
 
@@ -2101,6 +2184,8 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				expectedData = getNamespaceWithSinglePolicyExpectedData(
 					newNetpolDataParams(networkPolicy),
 					initialDB.NBData)
+				namespace1AddressSetv4, _ = buildNamespaceAddressSets(namespace1.Name, nil)
+				expectedData = append(expectedData, namespace1AddressSetv4)
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedData...))
 
 				ginkgo.By("Updating network policy labels")
@@ -2129,6 +2214,8 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 					newNetpolDataParams(networkPolicy).
 						withStateless(true),
 					initialDB.NBData)
+				namespace1AddressSetv4, _ = buildNamespaceAddressSets(namespace1.Name, nil)
+				expectedData = append(expectedData, namespace1AddressSetv4)
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedData...))
 
 				ginkgo.By("Updating network policy with IPBlock when stateless OVN ACLs annotation is set to true")
@@ -2146,6 +2233,8 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 					newNetpolDataParams(networkPolicy).
 						withStateless(true),
 					initialDB.NBData)
+				namespace1AddressSetv4, _ = buildNamespaceAddressSets(namespace1.Name, nil)
+				expectedData = append(expectedData, namespace1AddressSetv4)
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedData...))
 
 				ginkgo.By("Updating network policy stateless OVN ACLs annotation to false")
@@ -2158,6 +2247,8 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 					newNetpolDataParams(networkPolicy).
 						withStateless(false),
 					initialDB.NBData)
+				namespace1AddressSetv4, _ = buildNamespaceAddressSets(namespace1.Name, nil)
+				expectedData = append(expectedData, namespace1AddressSetv4)
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedData...))
 
 				ginkgo.By("Deleting network policy")
@@ -2165,7 +2256,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 					Delete(context.TODO(), networkPolicy.Name, metav1.DeleteOptions{})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-				expectedData = initialDB.NBData
+				expectedData = append(initialDB.NBData, namespace1AddressSetv4)
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedData))
 
 				return nil
@@ -2208,6 +2299,8 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 			app.Action = func(*cli.Context) error {
 				startOvn(initialDB, []corev1.Namespace{originalNamespace}, []knet.NetworkPolicy{*initialDenyAllPolicy},
 					nil, nil)
+				namespace1AddressSetv4, _ := buildNamespaceAddressSets(originalNamespace.Name, nil)
+				initialExpectedData = append(initialExpectedData, namespace1AddressSetv4)
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(initialExpectedData...))
 
 				var createsPoliciesData []libovsdbtest.TestData
@@ -2245,6 +2338,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				}
 				expectedData = append(expectedData, initialDB.NBData...)
 
+				expectedData = append(expectedData, namespace1AddressSetv4)
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedData...))
 				return nil
 			}
@@ -2279,6 +2373,8 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				expectedData = append(expectedData, getDefaultDenyData(newNetpolDataParams(newPolicy).
 					withDenyLogSeverity(desiredLogSeverity))...)
 
+				namespace1AddressSetv4, _ := buildNamespaceAddressSets(namespaceName1, nil)
+				expectedData = append(expectedData, namespace1AddressSetv4)
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedData...))
 				return nil
 			}
@@ -2307,6 +2403,8 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 						withTCPPeerPorts(portNum).
 						withStateless(true),
 					getUpdatedInitialDB([]testPod{nPodTest}))
+				namespace1AddressSetv4, _ := buildNamespaceAddressSets(namespaceName1, []string{nPodTest.podIP})
+				expectedData = append(expectedData, namespace1AddressSetv4)
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedData...))
 
 				return nil

--- a/go-controller/pkg/ovn/policy_test.go
+++ b/go-controller/pkg/ovn/policy_test.go
@@ -678,7 +678,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 			if len(podLabels) > 0 {
 				knetPod.Labels = podLabels
 			}
-			knetPod.Annotations = map[string]string{types.OvnPodAnnotationName: fmt.Sprintf(`{"default":{"mac_address":"%s","ip_address":"%s/24","role":"infrastructure-locked"}}`, testPod.podMAC, testPod.podIP)}
+			knetPod.Annotations = map[string]string{util.OvnPodAnnotationName: fmt.Sprintf(`{"default":{"mac_address":"%s","ip_address":"%s/24","role":"infrastructure-locked"}}`, testPod.podMAC, testPod.podIP)}
 			if testPod.hostNetwork {
 				knetPod.Spec.HostNetwork = true
 			}

--- a/go-controller/pkg/ovnwebhook/podadmission.go
+++ b/go-controller/pkg/ovnwebhook/podadmission.go
@@ -27,7 +27,7 @@ type checkPodAnnot func(nodeLister listers.NodeLister, v annotationChange, pod *
 
 // interconnectPodAnnotationChecks holds annotations allowed for ovnkube-node:<nodeName> users in IC environments
 var interconnectPodAnnotations = map[string]checkPodAnnot{
-	types.OvnPodAnnotationName: func(nodeLister listers.NodeLister, v annotationChange, pod *corev1.Pod, nodeName string) error {
+	util.OvnPodAnnotationName: func(nodeLister listers.NodeLister, v annotationChange, pod *corev1.Pod, nodeName string) error {
 		// Ignore kubevirt pods with live migration, the IP can cross node-subnet boundaries
 		if kubevirt.IsPodLiveMigratable(pod) {
 			return nil
@@ -37,7 +37,7 @@ var interconnectPodAnnotations = map[string]checkPodAnnot{
 			return fmt.Errorf("the annotation is not allowed on host networked pods")
 		}
 
-		podAnnot, err := util.UnmarshalPodAnnotation(map[string]string{types.OvnPodAnnotationName: v.value}, types.DefaultNetworkName)
+		podAnnot, err := util.UnmarshalPodAnnotation(map[string]string{util.OvnPodAnnotationName: v.value}, types.DefaultNetworkName)
 		if err != nil {
 			if util.IsAnnotationNotSetError(err) {
 				return nil

--- a/go-controller/pkg/ovnwebhook/podadmission_test.go
+++ b/go-controller/pkg/ovnwebhook/podadmission_test.go
@@ -20,7 +20,6 @@ import (
 	listersv1 "k8s.io/client-go/listers/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
-	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
 )
 
@@ -86,16 +85,16 @@ func TestPodAdmission_ValidateUpdate(t *testing.T) {
 			oldObj: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        podName,
-					Annotations: map[string]string{types.OvnPodAnnotationName: "old"},
+					Annotations: map[string]string{util.OvnPodAnnotationName: "old"},
 				},
 			},
 			newObj: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        podName,
-					Annotations: map[string]string{types.OvnPodAnnotationName: "new"},
+					Annotations: map[string]string{util.OvnPodAnnotationName: "new"},
 				},
 			},
-			expectedErr: fmt.Errorf("user %q is not allowed to set the following annotations on pod: %q: %v", "system:nodes:node", podName, []string{types.OvnPodAnnotationName}),
+			expectedErr: fmt.Errorf("user %q is not allowed to set the following annotations on pod: %q: %v", "system:nodes:node", podName, []string{util.OvnPodAnnotationName}),
 		},
 		{
 			name: "error out if the request is not in context",
@@ -128,14 +127,14 @@ func TestPodAdmission_ValidateUpdate(t *testing.T) {
 			oldObj: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        podName,
-					Annotations: map[string]string{types.OvnPodAnnotationName: `{"default":{"ip_addresses":["192.168.0.5/24"],"mac_address":"0a:58:0a:80:00:05"}}`},
+					Annotations: map[string]string{util.OvnPodAnnotationName: `{"default":{"ip_addresses":["192.168.0.5/24"],"mac_address":"0a:58:0a:80:00:05"}}`},
 				},
 				Spec: corev1.PodSpec{NodeName: nodeName},
 			},
 			newObj: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        podName,
-					Annotations: map[string]string{types.OvnPodAnnotationName: `{"default":{"ip_addresses":["192.168.0.10/24"],"mac_address":"0a:58:0a:80:00:05"}}`},
+					Annotations: map[string]string{util.OvnPodAnnotationName: `{"default":{"ip_addresses":["192.168.0.10/24"],"mac_address":"0a:58:0a:80:00:05"}}`},
 				},
 				Spec: corev1.PodSpec{NodeName: nodeName},
 			},
@@ -152,18 +151,18 @@ func TestPodAdmission_ValidateUpdate(t *testing.T) {
 			oldObj: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        podName,
-					Annotations: map[string]string{types.OvnPodAnnotationName + "bad": "old"},
+					Annotations: map[string]string{util.OvnPodAnnotationName + "bad": "old"},
 				},
 				Spec: corev1.PodSpec{NodeName: nodeName},
 			},
 			newObj: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        podName,
-					Annotations: map[string]string{types.OvnPodAnnotationName + "bad": "new"},
+					Annotations: map[string]string{util.OvnPodAnnotationName + "bad": "new"},
 				},
 				Spec: corev1.PodSpec{NodeName: nodeName},
 			},
-			expectedErr: fmt.Errorf("ovnkube-node on node: %q is not allowed to set the following annotations on pod: %q: %v", nodeName, podName, []string{types.OvnPodAnnotationName + "bad"}),
+			expectedErr: fmt.Errorf("ovnkube-node on node: %q is not allowed to set the following annotations on pod: %q: %v", nodeName, podName, []string{util.OvnPodAnnotationName + "bad"}),
 		},
 		{
 			name: "ovnkube-node can modify OvnPodAnnotationName annotation on a pod",
@@ -181,14 +180,14 @@ func TestPodAdmission_ValidateUpdate(t *testing.T) {
 			oldObj: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        podName,
-					Annotations: map[string]string{types.OvnPodAnnotationName: `{"default":{"ip_addresses":["192.168.0.5/24"],"mac_address":"0a:58:0a:80:00:05"}}`},
+					Annotations: map[string]string{util.OvnPodAnnotationName: `{"default":{"ip_addresses":["192.168.0.5/24"],"mac_address":"0a:58:0a:80:00:05"}}`},
 				},
 				Spec: corev1.PodSpec{NodeName: nodeName},
 			},
 			newObj: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        podName,
-					Annotations: map[string]string{types.OvnPodAnnotationName: `{"default":{"ip_addresses":["192.168.0.10/24"],"mac_address":"0a:58:0a:80:00:05"}}`},
+					Annotations: map[string]string{util.OvnPodAnnotationName: `{"default":{"ip_addresses":["192.168.0.10/24"],"mac_address":"0a:58:0a:80:00:05"}}`},
 				},
 				Spec: corev1.PodSpec{NodeName: nodeName},
 			},
@@ -209,18 +208,18 @@ func TestPodAdmission_ValidateUpdate(t *testing.T) {
 			oldObj: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        podName,
-					Annotations: map[string]string{types.OvnPodAnnotationName: `{"default":{"ip_addresses":["192.168.0.5/24"],"mac_address":"0a:58:0a:80:00:05"}}`},
+					Annotations: map[string]string{util.OvnPodAnnotationName: `{"default":{"ip_addresses":["192.168.0.5/24"],"mac_address":"0a:58:0a:80:00:05"}}`},
 				},
 				Spec: corev1.PodSpec{NodeName: nodeName},
 			},
 			newObj: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        podName,
-					Annotations: map[string]string{types.OvnPodAnnotationName: `{"default":{"ip_addresses":["10.10.10.10/24"],"mac_address":"0a:58:0a:80:00:05"}}`},
+					Annotations: map[string]string{util.OvnPodAnnotationName: `{"default":{"ip_addresses":["10.10.10.10/24"],"mac_address":"0a:58:0a:80:00:05"}}`},
 				},
 				Spec: corev1.PodSpec{NodeName: nodeName},
 			},
-			expectedErr: fmt.Errorf("user: %q is not allowed to set %s on pod %q: 10.10.10.10/24 does not belong to %s node", userName, types.OvnPodAnnotationName, podName, nodeName),
+			expectedErr: fmt.Errorf("user: %q is not allowed to set %s on pod %q: 10.10.10.10/24 does not belong to %s node", userName, util.OvnPodAnnotationName, podName, nodeName),
 		},
 		{
 			name: "ovnkube-node cannot set an IP in the OvnPodAnnotationName annotation on host-networked pods",
@@ -244,11 +243,11 @@ func TestPodAdmission_ValidateUpdate(t *testing.T) {
 			newObj: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        podName,
-					Annotations: map[string]string{types.OvnPodAnnotationName: `{"default":{"ip_addresses":["192.168.0.5/24"],"mac_address":"0a:58:0a:80:00:05"}}`},
+					Annotations: map[string]string{util.OvnPodAnnotationName: `{"default":{"ip_addresses":["192.168.0.5/24"],"mac_address":"0a:58:0a:80:00:05"}}`},
 				},
 				Spec: corev1.PodSpec{NodeName: nodeName, HostNetwork: true},
 			},
-			expectedErr: fmt.Errorf("user: %q is not allowed to set %s on pod %q: the annotation is not allowed on host networked pods", userName, types.OvnPodAnnotationName, podName),
+			expectedErr: fmt.Errorf("user: %q is not allowed to set %s on pod %q: the annotation is not allowed on host networked pods", userName, util.OvnPodAnnotationName, podName),
 		},
 		{
 			name: "ovnkube-node can use an IP in OvnPodAnnotationName annotation that belongs to a different node in kubevirt live-migration",
@@ -273,7 +272,7 @@ func TestPodAdmission_ValidateUpdate(t *testing.T) {
 			newObj: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: podName,
-					Annotations: map[string]string{types.OvnPodAnnotationName: `{"default":{"ip_addresses":["10.10.10.10/24"],"mac_address":"0a:58:0a:80:00:05"}}`,
+					Annotations: map[string]string{util.OvnPodAnnotationName: `{"default":{"ip_addresses":["10.10.10.10/24"],"mac_address":"0a:58:0a:80:00:05"}}`,
 						kubevirtv1.AllowPodBridgeNetworkLiveMigrationAnnotation: ""},
 				},
 				Spec: corev1.PodSpec{NodeName: nodeName},
@@ -351,7 +350,7 @@ func TestPodAdmission_ValidateUpdate(t *testing.T) {
 			oldObj: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        podName,
-					Annotations: map[string]string{types.OvnPodAnnotationName: `{"default":{"ip_addresses":["192.168.0.5/24"],"mac_address":"0a:58:0a:80:00:05"}}`},
+					Annotations: map[string]string{util.OvnPodAnnotationName: `{"default":{"ip_addresses":["192.168.0.5/24"],"mac_address":"0a:58:0a:80:00:05"}}`},
 					Labels:      map[string]string{"key": "old"},
 				},
 				Spec: corev1.PodSpec{NodeName: nodeName},
@@ -359,7 +358,7 @@ func TestPodAdmission_ValidateUpdate(t *testing.T) {
 			newObj: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        podName,
-					Annotations: map[string]string{types.OvnPodAnnotationName: `{"default":{"ip_addresses":["192.168.0.10/24"],"mac_address":"0a:58:0a:80:00:05"}}`},
+					Annotations: map[string]string{util.OvnPodAnnotationName: `{"default":{"ip_addresses":["192.168.0.10/24"],"mac_address":"0a:58:0a:80:00:05"}}`},
 					Labels:      map[string]string{"key": "new"},
 				},
 				Spec: corev1.PodSpec{NodeName: nodeName},
@@ -472,14 +471,14 @@ func TestPodAdmission_ValidateUpdateExtraUsers(t *testing.T) {
 			oldObj: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        podName,
-					Annotations: map[string]string{types.OvnPodAnnotationName: `{"default":{"ip_addresses":["192.168.0.5/24"],"mac_address":"0a:58:0a:80:00:05"}}`},
+					Annotations: map[string]string{util.OvnPodAnnotationName: `{"default":{"ip_addresses":["192.168.0.5/24"],"mac_address":"0a:58:0a:80:00:05"}}`},
 				},
 				Spec: corev1.PodSpec{NodeName: nodeName},
 			},
 			newObj: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        podName,
-					Annotations: map[string]string{types.OvnPodAnnotationName: `{"default":{"ip_addresses":["192.168.0.10/24"],"mac_address":"0a:58:0a:80:00:05"}}`},
+					Annotations: map[string]string{util.OvnPodAnnotationName: `{"default":{"ip_addresses":["192.168.0.10/24"],"mac_address":"0a:58:0a:80:00:05"}}`},
 				},
 				Spec: corev1.PodSpec{NodeName: nodeName},
 			},
@@ -506,11 +505,11 @@ func TestPodAdmission_ValidateUpdateExtraUsers(t *testing.T) {
 			newObj: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        podName,
-					Annotations: map[string]string{types.OvnPodAnnotationName: `{"default":{"ip_addresses":["192.168.0.5/24"],"mac_address":"0a:58:0a:80:00:05"}}`},
+					Annotations: map[string]string{util.OvnPodAnnotationName: `{"default":{"ip_addresses":["192.168.0.5/24"],"mac_address":"0a:58:0a:80:00:05"}}`},
 				},
 				Spec: corev1.PodSpec{NodeName: nodeName, HostNetwork: true},
 			},
-			expectedErr: fmt.Errorf("user: %q is not allowed to set %s on pod %q: the annotation is not allowed on host networked pods", extraUser, types.OvnPodAnnotationName, podName),
+			expectedErr: fmt.Errorf("user: %q is not allowed to set %s on pod %q: the annotation is not allowed on host networked pods", extraUser, util.OvnPodAnnotationName, podName),
 		},
 	}
 

--- a/go-controller/pkg/persistentips/allocator_test.go
+++ b/go-controller/pkg/persistentips/allocator_test.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"testing"
 
-	cnitypes "github.com/containernetworking/cni/pkg/types"
+	"github.com/containernetworking/cni/pkg/types"
 	ipamclaimsapi "github.com/k8snetworkplumbingwg/ipamclaims/pkg/crd/ipamclaims/v1alpha1"
 	fakeipamclaimclient "github.com/k8snetworkplumbingwg/ipamclaims/pkg/crd/ipamclaims/v1alpha1/apis/clientset/versioned/fake"
 	ipamclaimsfactory "github.com/k8snetworkplumbingwg/ipamclaims/pkg/crd/ipamclaims/v1alpha1/apis/informers/externalversions"
@@ -55,7 +55,7 @@ var _ = Describe("Persistent IP allocator operations", func() {
 
 		BeforeEach(func() {
 			netConf := &ovncnitypes.NetConf{
-				NetConf:  cnitypes.NetConf{Name: networkName},
+				NetConf:  types.NetConf{Name: networkName},
 				Topology: ovnktypes.Layer2Topology,
 				Subnets:  "192.10.10.0/24",
 			}
@@ -416,7 +416,7 @@ func generateIPAMClaimsListerAndTeardownFunc(stopChannel <-chan struct{}, ipamCl
 
 func dummyNetconf(networkName string) *ovncnitypes.NetConf {
 	return &ovncnitypes.NetConf{
-		NetConf:  cnitypes.NetConf{Name: networkName},
+		NetConf:  types.NetConf{Name: networkName},
 		Topology: ovnktypes.Layer2Topology,
 		Subnets:  "192.10.10.0/24",
 	}

--- a/go-controller/pkg/testing/testobj.go
+++ b/go-controller/pkg/testing/testobj.go
@@ -157,14 +157,14 @@ func getPodAnnotationSecondary(namespace, nadName, ip string) string {
 
 func NewPodWithPrimaryNADIP(namespace, name, node, defaultNetworkIP, nadName, nadIP string) *corev1.Pod {
 	pod := NewPod(namespace, name, node, defaultNetworkIP)
-	pod.Annotations = map[string]string{types.OvnPodAnnotationName: fmt.Sprintf(`{%s,%s}`, getPodAnnotationDefault(defaultNetworkIP, true), getPodAnnotationPrimary(namespace, nadName, nadIP))}
+	pod.Annotations = map[string]string{util.OvnPodAnnotationName: fmt.Sprintf(`{%s,%s}`, getPodAnnotationDefault(defaultNetworkIP, true), getPodAnnotationPrimary(namespace, nadName, nadIP))}
 	return pod
 }
 
 func NewPodWithSecondaryNADIP(namespace, name, node, defaultNetworkIP, nadAndNetworkName, nadIP string) *corev1.Pod {
 	pod := NewPod(namespace, name, node, defaultNetworkIP)
 	pod.Annotations = map[string]string{
-		types.OvnPodAnnotationName:   fmt.Sprintf(`{%s,%s}`, getPodAnnotationDefault(defaultNetworkIP, false), getPodAnnotationSecondary(namespace, nadAndNetworkName, nadIP)),
+		util.OvnPodAnnotationName:    fmt.Sprintf(`{%s,%s}`, getPodAnnotationDefault(defaultNetworkIP, false), getPodAnnotationSecondary(namespace, nadAndNetworkName, nadIP)),
 		nadv1.NetworkAttachmentAnnot: nadAndNetworkName,
 	}
 	return pod

--- a/go-controller/pkg/testing/testobj.go
+++ b/go-controller/pkg/testing/testobj.go
@@ -4,19 +4,12 @@
 package testing
 
 import (
-	"crypto/sha256"
-	"fmt"
-	"net"
 	"strings"
-
-	nadv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	apimachinerytypes "k8s.io/apimachinery/pkg/types"
-
-	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 func NewPodMeta(namespace, name string, additionalLabels map[string]string) metav1.ObjectMeta {
@@ -28,7 +21,7 @@ func NewPodMeta(namespace, name string, additionalLabels map[string]string) meta
 	}
 	return metav1.ObjectMeta{
 		Name:      name,
-		UID:       apimachinerytypes.UID(name),
+		UID:       types.UID(name),
 		Namespace: namespace,
 		Labels:    labels,
 	}
@@ -116,60 +109,6 @@ func NewPod(namespace, name, node, podIP string) *corev1.Pod {
 	}
 }
 
-// ipAddrToHWAddr takes the four octets of IPv4 address (aa.bb.cc.dd, for example) and uses them in creating
-// a MAC address (0A:58:AA:BB:CC:DD).  For IPv6, create a hash from the IPv6 string and use that for MAC Address.
-// Assumption: the caller will ensure that an empty net.IP{} will NOT be passed.
-func ipAddrToHWAddr(ip net.IP) net.HardwareAddr {
-	// Ensure that for IPv4, we are always working with the IP in 4-byte form.
-	ip4 := ip.To4()
-	if ip4 != nil {
-		// safe to use private MAC prefix: 0A:58
-		return net.HardwareAddr{0x0A, 0x58, ip4[0], ip4[1], ip4[2], ip4[3]}
-	}
-
-	hash := sha256.Sum256([]byte(ip.String()))
-	return net.HardwareAddr{0x0A, 0x58, hash[0], hash[1], hash[2], hash[3]}
-}
-
-func getPodAnnotationDefault(ip string, hasPrimaryUDN bool) string {
-	role := "primary"
-	if hasPrimaryUDN {
-		role = "infrastructure-locked"
-	}
-	netip := net.ParseIP(ip)
-	mac := ipAddrToHWAddr(netip)
-	return fmt.Sprintf(`"default":{"mac_address":"%s","ip_address":"%s/24","role":"%s"}`, mac.String(), ip, role)
-}
-
-func getPodAnnotationPrimary(namespace, nadName, ip string) string {
-	netip := net.ParseIP(ip)
-	mac := ipAddrToHWAddr(netip)
-	return fmt.Sprintf(`"%s/%s":{"mac_address":"%s","ip_address":"%s/24","role":"primary"}`,
-		namespace, nadName, mac, ip)
-}
-
-func getPodAnnotationSecondary(namespace, nadName, ip string) string {
-	netip := net.ParseIP(ip)
-	mac := ipAddrToHWAddr(netip)
-	return fmt.Sprintf(`"%s/%s":{"mac_address":"%s","ip_address":"%s/24","role":"secondary"}`,
-		namespace, nadName, mac, ip)
-}
-
-func NewPodWithPrimaryNADIP(namespace, name, node, defaultNetworkIP, nadName, nadIP string) *corev1.Pod {
-	pod := NewPod(namespace, name, node, defaultNetworkIP)
-	pod.Annotations = map[string]string{util.OvnPodAnnotationName: fmt.Sprintf(`{%s,%s}`, getPodAnnotationDefault(defaultNetworkIP, true), getPodAnnotationPrimary(namespace, nadName, nadIP))}
-	return pod
-}
-
-func NewPodWithSecondaryNADIP(namespace, name, node, defaultNetworkIP, nadName, networkName, nadIP string) *corev1.Pod {
-	pod := NewPod(namespace, name, node, defaultNetworkIP)
-	pod.Annotations = map[string]string{
-		util.OvnPodAnnotationName:    fmt.Sprintf(`{%s,%s}`, getPodAnnotationDefault(defaultNetworkIP, false), getPodAnnotationSecondary(namespace, nadName, nadIP)),
-		nadv1.NetworkAttachmentAnnot: networkName,
-	}
-	return pod
-}
-
 func NewNamespaceMeta(namespace string, additionalLabels map[string]string) metav1.ObjectMeta {
 	labels := map[string]string{
 		"name": namespace,
@@ -178,7 +117,7 @@ func NewNamespaceMeta(namespace string, additionalLabels map[string]string) meta
 		labels[k] = v
 	}
 	return metav1.ObjectMeta{
-		UID:         apimachinerytypes.UID(namespace),
+		UID:         types.UID(namespace),
 		Name:        namespace,
 		Labels:      labels,
 		Annotations: map[string]string{},
@@ -205,7 +144,7 @@ func NewTestNetworkPolicy(name, namespace string, podSelector metav1.LabelSelect
 	egress []networkingv1.NetworkPolicyEgressRule, policyTypes ...networkingv1.PolicyType) *networkingv1.NetworkPolicy {
 	policy := &networkingv1.NetworkPolicy{
 		ObjectMeta: metav1.ObjectMeta{
-			UID:       apimachinerytypes.UID(namespace),
+			UID:       types.UID(namespace),
 			Name:      name,
 			Namespace: namespace,
 			Labels: map[string]string{

--- a/go-controller/pkg/testing/testobj.go
+++ b/go-controller/pkg/testing/testobj.go
@@ -161,11 +161,11 @@ func NewPodWithPrimaryNADIP(namespace, name, node, defaultNetworkIP, nadName, na
 	return pod
 }
 
-func NewPodWithSecondaryNADIP(namespace, name, node, defaultNetworkIP, nadAndNetworkName, nadIP string) *corev1.Pod {
+func NewPodWithSecondaryNADIP(namespace, name, node, defaultNetworkIP, nadName, networkName, nadIP string) *corev1.Pod {
 	pod := NewPod(namespace, name, node, defaultNetworkIP)
 	pod.Annotations = map[string]string{
-		util.OvnPodAnnotationName:    fmt.Sprintf(`{%s,%s}`, getPodAnnotationDefault(defaultNetworkIP, false), getPodAnnotationSecondary(namespace, nadAndNetworkName, nadIP)),
-		nadv1.NetworkAttachmentAnnot: nadAndNetworkName,
+		util.OvnPodAnnotationName:    fmt.Sprintf(`{%s,%s}`, getPodAnnotationDefault(defaultNetworkIP, false), getPodAnnotationSecondary(namespace, nadName, nadIP)),
+		nadv1.NetworkAttachmentAnnot: networkName,
 	}
 	return pod
 }

--- a/go-controller/pkg/types/const.go
+++ b/go-controller/pkg/types/const.go
@@ -263,8 +263,6 @@ const (
 	//		"l2-network-b":"10"}
 	// }",
 	UDNLayer2NodeGRLRPTunnelIDAnnotation = "k8s.ovn.org/udn-layer2-node-gateway-router-lrp-tunnel-ids"
-	// OvnPodAnnotationName is the constant string representing the POD annotation key
-	OvnPodAnnotationName = OvnK8sPrefix + "/pod-networks"
 
 	// different user-defined network topology types defined in CNI netconf
 	Layer3Topology   = "layer3"

--- a/go-controller/pkg/util/pod_annotation.go
+++ b/go-controller/pkg/util/pod_annotation.go
@@ -52,6 +52,8 @@ import (
 // values.)
 
 const (
+	// OvnPodAnnotationName is the constant string representing the POD annotation key
+	OvnPodAnnotationName = "k8s.ovn.org/pod-networks"
 	// DefNetworkAnnotation is the pod annotation for the cluster-wide active network
 	DefNetworkAnnotation = "v1.multus-cni.io/default-network"
 	// UDNOpenPortsAnnotationName is the pod annotation to open default network pods on UDN pods.
@@ -210,14 +212,14 @@ func MarshalPodAnnotation(annotations map[string]string, podInfo *PodAnnotation,
 	if err != nil {
 		return nil, fmt.Errorf("failed marshaling podNetworks map %v", podNetworks)
 	}
-	annotations[types.OvnPodAnnotationName] = string(bytes)
+	annotations[OvnPodAnnotationName] = string(bytes)
 	return annotations, nil
 }
 
 // UnmarshalPodAnnotation returns the Pod's network info of the given network from pod.Annotations
 func UnmarshalPodAnnotation(annotations map[string]string, nadKey string) (*PodAnnotation, error) {
 	var err error
-	ovnAnnotation, ok := annotations[types.OvnPodAnnotationName]
+	ovnAnnotation, ok := annotations[OvnPodAnnotationName]
 	if !ok {
 		return nil, newAnnotationNotSetError("could not find OVN pod annotation in %v", annotations)
 	}
@@ -308,7 +310,7 @@ func UnmarshalPodAnnotation(annotations map[string]string, nadKey string) (*PodA
 
 func UnmarshalPodAnnotationAllNetworks(annotations map[string]string) (map[string]podAnnotation, error) {
 	podNetworks := make(map[string]podAnnotation)
-	ovnAnnotation, ok := annotations[types.OvnPodAnnotationName]
+	ovnAnnotation, ok := annotations[OvnPodAnnotationName]
 	if ok {
 		if err := json.Unmarshal([]byte(ovnAnnotation), &podNetworks); err != nil {
 			return nil, fmt.Errorf("failed to unmarshal ovn pod annotation %q: %v",


### PR DESCRIPTION
## Summary
- Reverts upstream PR [ovn-org/ovn-kubernetes#6264](https://github.com/ovn-org/ovn-kubernetes/pull/6264) ("Remove ns addrset") which was included in downstream merge PR #3177
- This PR moved namespace address set management from the synchronous pod-creation path to the async `AddressSetManager`, which:
  - Replaced batched, incremental `AddAddressesReturnOps` (part of the same NBDB transaction as LSP creation) with async full-replace `SetAddresses` via a reconciler pipeline
  - Each pod event now triggers `reconcilePod` → iterates all address set keys → enqueues `reconcileAddressSet` for each matching one, which re-lists all pods and replaces the entire address set
  - Multicast now registers additional address sets in the manager (previously shared `nsInfo.addressSet`)
- Following 5.0.0-0.nightly-2026-05-19-152900, we observed performance degradation in `podReadyLatency_P99` and `containersStartedLatency_P99`, along with significant CPU increases: ovnk-controller CPU nearly doubled (14.8→25.4) and NBDB CPU tripled (0.52→1.56)

## Test plan
- [ ] Run `payload-node-density` perfscale test and compare `podReadyLatency_P99`, `containersStartedLatency_P99`, and CPU metrics against baseline and PR #3199 (full merge revert)
- [ ] This revert isolates the namespace address set change from other changes in the upstream merge to identify if it is the primary contributor to the latency regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Standardized import aliases and package references across the codebase for improved maintainability.
  * Consolidated pod annotation constant definitions for consistency.
  * Removed test helper functions for pod construction.

* **Bug Fixes**
  * Improved namespace address set lifecycle management with deferred cleanup to prevent data loss during namespace recreation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->