### PR TITLE
Ovnkube objretry

### DIFF
--- a/go-controller/pkg/controller/controller.go
+++ b/go-controller/pkg/controller/controller.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/klog/v2"
 
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/factory"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
 )
 
@@ -275,7 +276,11 @@ func (c *controller[T]) processNextQueueItem() bool {
 	if err != nil {
 		retry := c.config.MaxAttempts == InfiniteAttempts || c.queue.NumRequeues(key) < c.config.MaxAttempts
 		if retry {
-			klog.Errorf("Controller %s: error found while processing %s: %v", c.name, key, err)
+			if types.IsSuppressedError(err) {
+				klog.V(5).Infof("Controller %s: suppressed error while processing %s: %v", c.name, key, err)
+			} else {
+				klog.Errorf("Controller %s: error found while processing %s: %v", c.name, key, err)
+			}
 			c.queue.AddRateLimited(key)
 			return true
 		}

--- a/go-controller/pkg/node/default_node_network_controller.go
+++ b/go-controller/pkg/node/default_node_network_controller.go
@@ -1369,7 +1369,7 @@ func (nc *DefaultNodeNetworkController) addOrUpdateNode(node *corev1.Node) error
 	// Process IPv4 addresses
 	for _, nodeIP := range ipsv4 {
 		addrs = append(addrs, nodeIP.String())
-		klog.Infof("Adding remote node %q, IP: %s to PMTUD blocking rules", node.Name, nodeIP)
+		klog.V(5).Infof("Adding remote node %q, IP: %s to PMTUD blocking rules", node.Name, nodeIP)
 		// Only add to nftables if this is remote node
 		if (config.IsModeDPUHost() || config.IsModeFull()) && node.Name != nc.name {
 			nftElems = append(nftElems, &knftables.Element{
@@ -1382,7 +1382,7 @@ func (nc *DefaultNodeNetworkController) addOrUpdateNode(node *corev1.Node) error
 	// Process IPv6 addresses
 	for _, nodeIP := range ipsv6 {
 		addrs = append(addrs, nodeIP.String())
-		klog.Infof("Adding remote node %q, IP: %s to PMTUD blocking rules", node.Name, nodeIP)
+		klog.V(5).Infof("Adding remote node %q, IP: %s to PMTUD blocking rules", node.Name, nodeIP)
 		// Only add to nftables if this is remote node
 		if (config.IsModeDPUHost() || config.IsModeFull()) && node.Name != nc.name {
 			nftElems = append(nftElems, &knftables.Element{

--- a/go-controller/pkg/node/linkmanager/link_network_manager.go
+++ b/go-controller/pkg/node/linkmanager/link_network_manager.go
@@ -175,21 +175,25 @@ func (c *Controller) syncLinkLocked(link netlink.Link) error {
 // syncLink handles link updates
 // It MUST be called with the controller locked
 func (c *Controller) syncLink(link netlink.Link) error {
+	linkName := link.Attrs().Name
+	wantedAddresses, found := c.store[linkName]
+	if !found {
+		return nil
+	}
 	if c.linkHandlerFunc != nil {
 		if err := c.linkHandlerFunc(link); err != nil {
-			klog.Errorf("Failed to execute link handler function on link: %s, error: %v", link.Attrs().Name, err)
+			klog.Errorf("Failed to execute link handler function on link: %s, error: %v", linkName, err)
 		}
 	}
-	linkName := link.Attrs().Name
 	// get all addresses associated with the link depending on which IP families we support
 	foundAddresses, err := util.GetFilteredInterfaceAddrs(link, c.ipv4Enabled, c.ipv6Enabled)
 	if err != nil {
+		if errors.Is(err, unix.ENODEV) {
+			klog.V(5).Infof("Link manager: link %q was removed, cleaning up store entry", linkName)
+			delete(c.store, linkName)
+			return nil
+		}
 		return fmt.Errorf("failed to get address from link %q: %w", linkName, err)
-	}
-	wantedAddresses, found := c.store[linkName]
-	// we don't manage this link therefore we don't need to add any addresses
-	if !found {
-		return nil
 	}
 	// add addresses we want that are not found on the link
 	for _, addressWanted := range wantedAddresses {

--- a/go-controller/pkg/ovn/base_network_controller_pods.go
+++ b/go-controller/pkg/ovn/base_network_controller_pods.go
@@ -487,7 +487,7 @@ func (bnc *BaseNetworkController) addLogicalPortToNetwork(pod *corev1.Pod, nadKe
 	}
 
 	portName := bnc.GetLogicalPortName(pod, nadKey)
-	klog.Infof("[%s] creating logical port %s for pod on switch %s", podDesc, portName, switchName)
+	klog.V(5).Infof("[%s] creating logical port %s for pod on switch %s", podDesc, portName, switchName)
 
 	var addresses []string
 	lspExist := false

--- a/go-controller/pkg/ovn/base_network_controller_policy.go
+++ b/go-controller/pkg/ovn/base_network_controller_policy.go
@@ -648,7 +648,7 @@ func (bnc *BaseNetworkController) getNewLocalPolicyPorts(np *networkPolicy,
 // getExistingLocalPolicyPorts will find and return port info for every given pod obj, that is present in np.localPods.
 func (bnc *BaseNetworkController) getExistingLocalPolicyPorts(np *networkPolicy,
 	objs ...interface{}) (policyPortsToUUIDs map[string]string, policyPortUUIDs []string, err error) {
-	klog.Infof("Processing NetworkPolicy %s/%s to delete %d local pods...", np.namespace, np.name, len(objs))
+	klog.V(5).Infof("Processing NetworkPolicy %s/%s to delete %d local pods...", np.namespace, np.name, len(objs))
 
 	policyPortUUIDs = []string{}
 	policyPortsToUUIDs = map[string]string{}
@@ -1082,7 +1082,7 @@ func (bnc *BaseNetworkController) createNetworkPolicy(policy *knet.NetworkPolicy
 				}
 			}
 		}
-		klog.Infof("Policy %s added to peer address sets %v", npKey, np.peerAddressSets)
+		klog.V(5).Infof("Policy %s added to peer address sets %v", npKey, np.peerAddressSets)
 
 		// 3. Add policy to default deny port group
 		// Pods are not added to default deny port groups yet, this is just a preparation step
@@ -1187,7 +1187,7 @@ func (bnc *BaseNetworkController) setupGressPolicy(np *networkPolicy, gp *gressP
 // ports from Kubernetes NetworkPolicy objects using OVN Port Groups
 // if addNetworkPolicy fails, create or delete operation can be retried
 func (bnc *BaseNetworkController) addNetworkPolicy(policy *knet.NetworkPolicy) error {
-	klog.Infof("Adding network policy %s for network %s", getPolicyKey(policy), bnc.GetNetworkName())
+	klog.V(5).Infof("Adding network policy %s for network %s", getPolicyKey(policy), bnc.GetNetworkName())
 	if !bnc.IsUserDefinedNetwork() && config.Metrics.EnableScaleMetrics {
 		start := time.Now()
 		defer func() {
@@ -1240,7 +1240,7 @@ func (bnc *BaseNetworkController) addNetworkPolicy(policy *knet.NetworkPolicy) e
 	if err != nil {
 		return fmt.Errorf("failed to create Network Policy %s: %v", npKey, err)
 	}
-	klog.Infof("Create network policy %s resources completed, update namespace loglevel", npKey)
+	klog.V(5).Infof("Create network policy %s resources completed, update namespace loglevel", npKey)
 
 	// 3. lock namespace
 	nsInfo, nsUnlock = bnc.getNamespaceLocked(policy.Namespace, false)
@@ -1338,7 +1338,7 @@ func (bnc *BaseNetworkController) deleteNetworkPolicy(policy *knet.NetworkPolicy
 // that information.
 func (bnc *BaseNetworkController) cleanupNetworkPolicy(np *networkPolicy) error {
 	npKey := np.getKey()
-	klog.Infof("Cleaning up network policy %s", npKey)
+	klog.V(5).Infof("Cleaning up network policy %s", npKey)
 	np.Lock()
 	defer np.Unlock()
 

--- a/go-controller/pkg/ovn/base_network_controller_policy.go
+++ b/go-controller/pkg/ovn/base_network_controller_policy.go
@@ -1299,6 +1299,9 @@ func (bnc *BaseNetworkController) buildNetworkPolicyACLs(np *networkPolicy, aclL
 // It only uses Namespace and Name from given network policy
 func (bnc *BaseNetworkController) deleteNetworkPolicy(policy *knet.NetworkPolicy) error {
 	npKey := getPolicyKey(policy)
+	if _, ok := bnc.networkPolicies.Load(npKey); !ok {
+		return nil
+	}
 	klog.Infof("Deleting network policy %s", npKey)
 	if config.Metrics.EnableScaleMetrics {
 		start := time.Now()

--- a/go-controller/pkg/ovn/base_network_controller_user_defined.go
+++ b/go-controller/pkg/ovn/base_network_controller_user_defined.go
@@ -333,7 +333,7 @@ func (bsnc *BaseUserDefinedNetworkController) addLogicalPortToNetworkForNAD(pod 
 
 	start := time.Now()
 	defer func() {
-		klog.Infof("[%s/%s] addLogicalPort for NAD key %s took %v, libovsdb time %v",
+		klog.V(5).Infof("[%s/%s] addLogicalPort for NAD key %s took %v, libovsdb time %v",
 			pod.Namespace, pod.Name, nadKey, time.Since(start), libovsdbExecuteTime)
 	}()
 
@@ -479,7 +479,7 @@ func (bsnc *BaseUserDefinedNetworkController) removePodForUserDefinedNetwork(pod
 		}
 
 		// pod has a network managed by this controller
-		klog.Infof("Deleting pod: %s for network %s, NAD key: %s", podDesc, bsnc.GetNetworkName(), nadKey)
+		klog.V(5).Infof("Deleting pod: %s for network %s, NAD key: %s", podDesc, bsnc.GetNetworkName(), nadKey)
 
 		// handle remote pod clean up but only do this one time
 		if !bsnc.hasPodLogicalPort(pod) && !alreadyProcessed {
@@ -709,11 +709,11 @@ func (bsnc *BaseUserDefinedNetworkController) addPodToNamespaceForUserDefinedNet
 
 // AddNamespaceForUserDefinedNetwork creates corresponding addressset in ovn db for User Defined Network
 func (bsnc *BaseUserDefinedNetworkController) AddNamespaceForUserDefinedNetwork(ns *corev1.Namespace) error {
-	klog.Infof("[%s] adding namespace for network %s", ns.Name, bsnc.GetNetworkName())
+	klog.V(5).Infof("[%s] adding namespace for network %s", ns.Name, bsnc.GetNetworkName())
 	// Keep track of how long syncs take.
 	start := time.Now()
 	defer func() {
-		klog.Infof("[%s] adding namespace took %v for network %s", ns.Name, time.Since(start), bsnc.GetNetworkName())
+		klog.V(5).Infof("[%s] adding namespace took %v for network %s", ns.Name, time.Since(start), bsnc.GetNetworkName())
 	}()
 
 	_, nsUnlock, err := bsnc.ensureNamespaceLockedForUserDefinedNetwork(ns.Name, false, ns)
@@ -733,11 +733,11 @@ func (bsnc *BaseUserDefinedNetworkController) ensureNamespaceLockedForUserDefine
 
 func (bsnc *BaseUserDefinedNetworkController) updateNamespaceForUserDefinedNetwork(old, newer *corev1.Namespace) error {
 	var errors []error
-	klog.Infof("[%s] updating namespace for network %s", old.Name, bsnc.GetNetworkName())
+	klog.V(5).Infof("[%s] updating namespace for network %s", old.Name, bsnc.GetNetworkName())
 
 	nsInfo, nsUnlock := bsnc.getNamespaceLocked(old.Name, false)
 	if nsInfo == nil {
-		klog.Warningf("Update event for unknown namespace %q", old.Name)
+		klog.V(5).Infof("Update event for unknown namespace %q", old.Name)
 		return nil
 	}
 	defer nsUnlock()

--- a/go-controller/pkg/ovn/controller/services/services_controller.go
+++ b/go-controller/pkg/ovn/controller/services/services_controller.go
@@ -1273,7 +1273,7 @@ func (c *Controller) cleanupUDNEnabledServiceRoute(state *networkState, key stri
 }
 
 func (c *Controller) configureUDNEnabledServiceRoute(state *networkState, service *corev1.Service) error {
-	klog.Infof("Configuring UDN enabled service route for service %s/%s in network: %s", service.Namespace, service.Name, state.netInfo.GetNetworkName())
+	klog.V(5).Infof("Configuring UDN enabled service route for service %s/%s in network: %s", service.Namespace, service.Name, state.netInfo.GetNetworkName())
 
 	extIDs := map[string]string{
 		types.NetworkExternalID:           state.netInfo.GetNetworkName(),

--- a/go-controller/pkg/ovn/namespace.go
+++ b/go-controller/pkg/ovn/namespace.go
@@ -130,7 +130,7 @@ func (oc *DefaultNetworkController) configureNamespace(nsInfo *namespaceInfo, ns
 
 func (oc *DefaultNetworkController) updateNamespace(old, newer *corev1.Namespace) error {
 	var errors []error
-	klog.Infof("[%s] updating namespace", old.Name)
+	klog.V(5).Infof("[%s] updating namespace", old.Name)
 
 	nsInfo, nsUnlock := oc.getNamespaceLocked(old.Name, false)
 	if nsInfo == nil {

--- a/go-controller/pkg/retry/obj_retry.go
+++ b/go-controller/pkg/retry/obj_retry.go
@@ -475,20 +475,12 @@ func (r *RetryFramework) iterateRetryResources() {
 		return
 	}
 	now := time.Now()
-	wg := &sync.WaitGroup{}
 
-	// Process the above list of objects that need retry by holding the lock for each one of them.
 	klog.V(5).Infof("%s: going to retry %v resource setup for %d objects: %s", r.name, r.ResourceHandler.ObjType, len(entriesKeys), entriesKeys)
 
 	for _, entryKey := range entriesKeys {
-		wg.Add(1)
-		go func(entryKey string) {
-			defer wg.Done()
-			r.resourceRetry(entryKey, now)
-		}(entryKey)
+		r.resourceRetry(entryKey, now)
 	}
-	klog.V(5).Infof("%s: waiting for all the %s retry setup to complete in iterateRetryResources", r.name, r.ResourceHandler.ObjType)
-	wg.Wait()
 	klog.V(5).Infof("%s: function iterateRetryResources for %s ended (in %v)", r.name, r.ResourceHandler.ObjType, time.Since(now))
 }
 

--- a/go-controller/pkg/retry/obj_retry.go
+++ b/go-controller/pkg/retry/obj_retry.go
@@ -365,7 +365,9 @@ func (r *RetryFramework) resourceRetry(objKey string, now time.Time) {
 			initObj = entry.oldObj
 		}
 
-		klog.Infof("%s: retry object setup: %s %s", r.name, r.ResourceHandler.ObjType, objKey)
+		if entry.failedAttempts > 0 {
+			klog.Infof("%s: retry object setup: %s %s (failed attempts: %d)", r.name, r.ResourceHandler.ObjType, objKey, entry.failedAttempts)
+		}
 
 		if entry.newObj != nil {
 			// get the latest version of the object from the informer;
@@ -429,7 +431,9 @@ func (r *RetryFramework) resourceRetry(objKey string, now time.Time) {
 
 			// create new object if needed
 			if entry.newObj != nil {
-				klog.Infof("%s: adding new object: %s %s", r.name, r.ResourceHandler.ObjType, objKey)
+				if entry.failedAttempts > 0 {
+					klog.Infof("%s: adding new object: %s %s (failed attempts: %d)", r.name, r.ResourceHandler.ObjType, objKey, entry.failedAttempts)
+				}
 				if !r.ResourceHandler.IsResourceScheduled(entry.newObj) {
 					// unscheduled resources (pods) will be retried again later we do not track these as failures, and should not retry.
 					// we should avoid queuing objects to the retry handler that are not scheduled. Thus treat this as an error.

--- a/go-controller/pkg/retry/obj_retry.go
+++ b/go-controller/pkg/retry/obj_retry.go
@@ -151,14 +151,16 @@ func (r *RetryFramework) DoWithLock(key string, f func(key string)) {
 
 func (r *RetryFramework) initRetryObjWithAddBackoff(obj interface{}, lockedKey string, backoff time.Duration) *retryObjEntry {
 	// even if the object was loaded and changed before with the same lock, LoadOrStore will return reference to the same object
-	entry, _ := r.retryEntries.LoadOrStore(lockedKey, &retryObjEntry{backoff: backoff})
+	entry, loaded := r.retryEntries.LoadOrStore(lockedKey, &retryObjEntry{backoff: backoff})
 	entry.timeStamp = time.Now()
 	entry.newObj = obj
 	if _, isPod := obj.(*corev1.Pod); isPod {
 		// for pods we want to retry indefinitely
 		entry.infiniteRetry = true
 	}
-	entry.failedAttempts = 0
+	if !loaded {
+		entry.failedAttempts = 0
+	}
 	entry.backoff = backoff
 	return entry
 }
@@ -171,7 +173,7 @@ func (r *RetryFramework) initRetryObjWithAdd(obj interface{}, lockedKey string) 
 
 // initRetryObjWithUpdate tracks objects that failed to be updated to potentially retry later
 func (r *RetryFramework) initRetryObjWithUpdate(oldObj, newObj interface{}, lockedKey string) *retryObjEntry {
-	entry, _ := r.retryEntries.LoadOrStore(lockedKey, &retryObjEntry{config: oldObj, backoff: initialBackoff})
+	entry, loaded := r.retryEntries.LoadOrStore(lockedKey, &retryObjEntry{config: oldObj, backoff: initialBackoff})
 	// even if the object was loaded and changed before with the same lock, LoadOrStore will return reference to the same object
 	entry.timeStamp = time.Now()
 	entry.newObj = newObj
@@ -180,7 +182,9 @@ func (r *RetryFramework) initRetryObjWithUpdate(oldObj, newObj interface{}, lock
 		entry.infiniteRetry = true
 	}
 	entry.config = oldObj
-	entry.failedAttempts = 0
+	if !loaded {
+		entry.failedAttempts = 0
+	}
 	return entry
 }
 
@@ -195,7 +199,7 @@ func (r *RetryFramework) initRetryObjWithDelete(obj interface{}, lockedKey strin
 
 func (r *RetryFramework) initRetryObjWithDeleteBackoff(obj interface{}, lockedKey string, config interface{}, noRetryAdd bool, backoff time.Duration) *retryObjEntry {
 	// even if the object was loaded and changed before with the same lock, LoadOrStore will return reference to the same object
-	entry, _ := r.retryEntries.LoadOrStore(lockedKey, &retryObjEntry{config: config, backoff: initialBackoff})
+	entry, loaded := r.retryEntries.LoadOrStore(lockedKey, &retryObjEntry{config: config, backoff: initialBackoff})
 	entry.timeStamp = time.Now()
 	entry.oldObj = obj
 	if _, isPod := obj.(*corev1.Pod); isPod {
@@ -205,7 +209,9 @@ func (r *RetryFramework) initRetryObjWithDeleteBackoff(obj interface{}, lockedKe
 	if entry.config == nil {
 		entry.config = config
 	}
-	entry.failedAttempts = 0
+	if !loaded {
+		entry.failedAttempts = 0
+	}
 	if noRetryAdd {
 		// will not be retried for addition
 		entry.newObj = nil

--- a/go-controller/pkg/retry/obj_retry.go
+++ b/go-controller/pkg/retry/obj_retry.go
@@ -801,7 +801,7 @@ func (r *RetryFramework) WatchResourceFiltered(namespaceForFilteredHandler strin
 					// See: https://github.com/ovn-kubernetes/ovn-kubernetes/pull/3318#issuecomment-1349804450
 					if _, loaded := r.terminatedObjects.LoadAndDelete(key); loaded {
 						// object was already terminated
-						klog.Infof("%s: ignoring delete event for resource in terminal state %s %s",
+						klog.V(5).Infof("%s: ignoring delete event for resource in terminal state %s %s",
 							r.name, r.ResourceHandler.ObjType, key)
 						return
 					}

--- a/go-controller/pkg/retry/obj_retry_storm_test.go
+++ b/go-controller/pkg/retry/obj_retry_storm_test.go
@@ -70,11 +70,11 @@ func newTestService() *corev1.Service {
 	}
 }
 
-// TestFailedAttemptsResetOnReAdd demonstrates the retry storm bug:
-// when an informer update event fires for a service that is already failing,
-// initRetryObjWithAdd resets failedAttempts to 0, preventing MaxFailedAttempts
-// from ever being reached. The service retries indefinitely.
-func TestFailedAttemptsResetOnReAdd(t *testing.T) {
+// TestFailedAttemptsPreservedOnReAdd verifies that when an informer update
+// event fires for a service that is already failing, initRetryObjWithAdd
+// preserves the existing failedAttempts counter. The entry is correctly
+// dropped after MaxFailedAttempts even with update events between retries.
+func TestFailedAttemptsPreservedOnReAdd(t *testing.T) {
 	svc := newTestService()
 	handler := &alwaysFailHandler{
 		obj: svc,
@@ -102,51 +102,42 @@ func TestFailedAttemptsResetOnReAdd(t *testing.T) {
 		t.Fatalf("expected failedAttempts=1 after first retry, got %d", entry.failedAttempts)
 	}
 
-	// Simulate an informer update event: this calls initRetryObjWithAdd,
-	// which resets failedAttempts to 0. This is the bug.
+	// Simulate an informer update event: initRetryObjWithAdd must preserve
+	// failedAttempts for an already-existing entry.
 	rf.DoWithLock(key, func(k string) {
 		rf.initRetryObjWithAdd(svc, k)
 	})
 
 	entry, _ = GetRetryObj(key, rf)
-	if entry.failedAttempts != 0 {
-		t.Fatalf("expected failedAttempts=0 after re-add (demonstrating the bug), got %d",
+	if entry.failedAttempts != 1 {
+		t.Fatalf("expected failedAttempts=1 preserved after re-add, got %d",
 			entry.failedAttempts)
 	}
 
-	// Now simulate the full storm: retry + re-add in a loop, well past MaxFailedAttempts.
-	// The entry should never be dropped because each re-add resets the counter.
-	totalCycles := MaxFailedAttempts + 5
-	for i := 0; i < totalCycles; i++ {
-		// Clear backoff so resourceRetry doesn't skip due to timer.
+	// Simulate retry + update event cycles past MaxFailedAttempts.
+	// The entry should be dropped once MaxFailedAttempts is reached.
+	for i := 1; i < MaxFailedAttempts+5; i++ {
+		if !CheckRetryObj(key, rf) {
+			t.Logf("Fix confirmed: entry dropped after %d total failed attempts "+
+				"(MaxFailedAttempts=%d) despite update events between retries",
+				i, MaxFailedAttempts)
+			return
+		}
 		SetRetryObjWithNoBackoff(key, rf)
-
 		rf.resourceRetry(key, time.Now())
 
-		// Simulate the update event that arrives between retry sweeps.
-		rf.DoWithLock(key, func(k string) {
-			rf.initRetryObjWithAdd(svc, k)
-		})
+		// Simulate update event between retry sweeps.
+		if CheckRetryObj(key, rf) {
+			rf.DoWithLock(key, func(k string) {
+				rf.initRetryObjWithAdd(svc, k)
+			})
+		}
 	}
 
-	// The entry should still exist — MaxFailedAttempts was never reached
-	// because every update event reset failedAttempts to 0.
-	if !CheckRetryObj(key, rf) {
-		t.Fatalf("retry entry was dropped after %d cycles, but should have survived "+
-			"indefinitely due to failedAttempts reset (the retry storm bug)", totalCycles)
+	if CheckRetryObj(key, rf) {
+		t.Fatalf("entry should have been dropped after MaxFailedAttempts=%d "+
+			"even with update events between retries", MaxFailedAttempts)
 	}
-
-	// Verify AddResource was called on every cycle (no retries were skipped).
-	// 1 initial + totalCycles = total calls.
-	expectedCalls := 1 + totalCycles
-	if handler.addCalls != expectedCalls {
-		t.Fatalf("expected AddResource to be called %d times, got %d",
-			expectedCalls, handler.addCalls)
-	}
-
-	t.Logf("Bug confirmed: entry survived %d retry cycles (MaxFailedAttempts=%d) "+
-		"because update events reset failedAttempts to 0 each time",
-		totalCycles, MaxFailedAttempts)
 }
 
 // TestFailedAttemptsNotResetReachesMax is the control case: without update

--- a/go-controller/pkg/retry/obj_retry_storm_test.go
+++ b/go-controller/pkg/retry/obj_retry_storm_test.go
@@ -1,0 +1,191 @@
+// SPDX-FileCopyrightText: Copyright The OVN-Kubernetes Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package retry
+
+import (
+	"fmt"
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// alwaysFailHandler is a mock EventHandler where AddResource always returns
+// an error, simulating the "invalid primary network state" condition seen
+// during UDN namespace teardown.
+type alwaysFailHandler struct {
+	DefaultEventHandler
+
+	obj      interface{}
+	addCalls int
+	addErr   error
+}
+
+func (h *alwaysFailHandler) AddResource(_ interface{}, _ bool) error {
+	h.addCalls++
+	return h.addErr
+}
+
+func (h *alwaysFailHandler) UpdateResource(_, _ interface{}, _ bool) error {
+	return nil
+}
+
+func (h *alwaysFailHandler) DeleteResource(_, _ interface{}) error {
+	return nil
+}
+
+func (h *alwaysFailHandler) GetResourceFromInformerCache(_ string) (interface{}, error) {
+	return h.obj, nil
+}
+
+func (h *alwaysFailHandler) FilterOutResource(_ interface{}) bool {
+	return false
+}
+
+func newTestFramework(handler *alwaysFailHandler) *RetryFramework {
+	return NewRetryFramework(
+		"test",
+		make(chan struct{}),
+		&sync.WaitGroup{},
+		nil,
+		&ResourceHandler{
+			HasUpdateFunc:          false,
+			NeedsUpdateDuringRetry: false,
+			ObjType:                reflect.TypeOf(&corev1.Service{}),
+			EventHandler:           handler,
+		},
+	)
+}
+
+func newTestService() *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-svc",
+			Namespace: "test-ns",
+		},
+	}
+}
+
+// TestFailedAttemptsResetOnReAdd demonstrates the retry storm bug:
+// when an informer update event fires for a service that is already failing,
+// initRetryObjWithAdd resets failedAttempts to 0, preventing MaxFailedAttempts
+// from ever being reached. The service retries indefinitely.
+func TestFailedAttemptsResetOnReAdd(t *testing.T) {
+	svc := newTestService()
+	handler := &alwaysFailHandler{
+		obj: svc,
+		addErr: fmt.Errorf("invalid primary network state for namespace %q: "+
+			"a valid primary user defined network or network attachment definition "+
+			"custom resource, and required namespace label must both be present",
+			svc.Namespace),
+	}
+	rf := newTestFramework(handler)
+	key := "test-ns/test-svc"
+
+	// Seed the retry entry (simulates initial add event).
+	rf.DoWithLock(key, func(k string) {
+		rf.initRetryObjWithAddBackoff(svc, k, noBackoff)
+	})
+
+	// Run one retry cycle — AddResource fails, failedAttempts should be 1.
+	rf.resourceRetry(key, time.Now())
+
+	entry, found := GetRetryObj(key, rf)
+	if !found {
+		t.Fatal("retry entry should exist after first failed attempt")
+	}
+	if entry.failedAttempts != 1 {
+		t.Fatalf("expected failedAttempts=1 after first retry, got %d", entry.failedAttempts)
+	}
+
+	// Simulate an informer update event: this calls initRetryObjWithAdd,
+	// which resets failedAttempts to 0. This is the bug.
+	rf.DoWithLock(key, func(k string) {
+		rf.initRetryObjWithAdd(svc, k)
+	})
+
+	entry, _ = GetRetryObj(key, rf)
+	if entry.failedAttempts != 0 {
+		t.Fatalf("expected failedAttempts=0 after re-add (demonstrating the bug), got %d",
+			entry.failedAttempts)
+	}
+
+	// Now simulate the full storm: retry + re-add in a loop, well past MaxFailedAttempts.
+	// The entry should never be dropped because each re-add resets the counter.
+	totalCycles := MaxFailedAttempts + 5
+	for i := 0; i < totalCycles; i++ {
+		// Clear backoff so resourceRetry doesn't skip due to timer.
+		SetRetryObjWithNoBackoff(key, rf)
+
+		rf.resourceRetry(key, time.Now())
+
+		// Simulate the update event that arrives between retry sweeps.
+		rf.DoWithLock(key, func(k string) {
+			rf.initRetryObjWithAdd(svc, k)
+		})
+	}
+
+	// The entry should still exist — MaxFailedAttempts was never reached
+	// because every update event reset failedAttempts to 0.
+	if !CheckRetryObj(key, rf) {
+		t.Fatalf("retry entry was dropped after %d cycles, but should have survived "+
+			"indefinitely due to failedAttempts reset (the retry storm bug)", totalCycles)
+	}
+
+	// Verify AddResource was called on every cycle (no retries were skipped).
+	// 1 initial + totalCycles = total calls.
+	expectedCalls := 1 + totalCycles
+	if handler.addCalls != expectedCalls {
+		t.Fatalf("expected AddResource to be called %d times, got %d",
+			expectedCalls, handler.addCalls)
+	}
+
+	t.Logf("Bug confirmed: entry survived %d retry cycles (MaxFailedAttempts=%d) "+
+		"because update events reset failedAttempts to 0 each time",
+		totalCycles, MaxFailedAttempts)
+}
+
+// TestFailedAttemptsNotResetReachesMax is the control case: without update
+// events resetting the counter, MaxFailedAttempts is reached and the entry
+// is correctly dropped from the retry cache.
+func TestFailedAttemptsNotResetReachesMax(t *testing.T) {
+	svc := newTestService()
+	handler := &alwaysFailHandler{
+		obj:    svc,
+		addErr: fmt.Errorf("permanent failure"),
+	}
+	rf := newTestFramework(handler)
+	key := "test-ns/test-svc"
+
+	// Seed the retry entry.
+	rf.DoWithLock(key, func(k string) {
+		rf.initRetryObjWithAddBackoff(svc, k, noBackoff)
+	})
+
+	// Retry without any update events in between.
+	for i := 0; i < MaxFailedAttempts+1; i++ {
+		if !CheckRetryObj(key, rf) {
+			// Entry was dropped — verify it happened at the right time.
+			if i < MaxFailedAttempts {
+				t.Fatalf("entry dropped after %d attempts, expected %d",
+					i, MaxFailedAttempts)
+			}
+			t.Logf("Control confirmed: entry correctly dropped after %d failed attempts "+
+				"(MaxFailedAttempts=%d)", i, MaxFailedAttempts)
+			return
+		}
+		SetRetryObjWithNoBackoff(key, rf)
+		rf.resourceRetry(key, time.Now())
+	}
+
+	if CheckRetryObj(key, rf) {
+		t.Fatalf("entry should have been dropped after %d attempts", MaxFailedAttempts)
+	}
+
+	t.Logf("Control confirmed: entry correctly dropped at MaxFailedAttempts=%d",
+		MaxFailedAttempts)
+}

--- a/go-controller/pkg/retry/run-tests.sh
+++ b/go-controller/pkg/retry/run-tests.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# OVN-Kubernetes retry package requires linux (OVS metrics have //go:build linux).
+# On macOS, run tests in a container via podman.
+#
+# Usage:
+#   ./run-tests.sh                          # run all retry tests
+#   ./run-tests.sh TestFailedAttempts       # run matching tests only
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+RUN_FLAG=""
+if [ -n "$1" ]; then
+    RUN_FLAG="-run $1"
+fi
+
+podman run --rm \
+    -v "$REPO_ROOT:/workspace:Z" \
+    -w /workspace/go-controller \
+    golang:1.25 \
+    go test ./pkg/retry/ $RUN_FLAG -v -count=1

--- a/go-controller/pkg/util/net_linux.go
+++ b/go-controller/pkg/util/net_linux.go
@@ -824,7 +824,7 @@ func GetFilteredInterfaceAddrs(link netlink.Link, v4, v6 bool) ([]netlink.Addr, 
 	}
 	addrs, err := netLinkOps.AddrList(link, ipFamily)
 	if err != nil {
-		return nil, fmt.Errorf("failed to list addresses for %q: %v", link.Attrs().Name, err)
+		return nil, fmt.Errorf("failed to list addresses for %q: %w", link.Attrs().Name, err)
 	}
 	validAddrs := make([]netlink.Addr, 0)
 	for _, addr := range addrs {


### PR DESCRIPTION
## 📑 Description

Adds a test that proves the obj_retry storm and code that fixes it.

Mainly opening this PR downstream to run rehearse tests.

Full RCA from log analysis at: https://gist.github.com/afcollins/1b7f47b1396268c614ff606adddcdaba

## Additional Information for reviewers

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI

## How to verify it
`go test ./...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserve retry failure counters when retry entries are re-initialized; failedAttempts persist across re-add/update events.
  * Reduce log noise by gating many informational messages (ignored deletes, port/node/namespace/events, policy/pod progress) behind verbose logging.
  * Make network policy deletion idempotent and skip unmanaged link handling cleanly.
  * Retry sweeps now process entries sequentially to avoid concurrent retry runs.

* **Tests**
  * Added unit tests verifying preserved failure counts and correct removal once max failures are reached.

* **Chores**
  * Added a package test runner script to simplify running retry tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->