### PR TITLE
inconsistent managementPortRepresentor state

### DIFF
--- a/go-controller/pkg/node/managementport/port_dpu_linux.go
+++ b/go-controller/pkg/node/managementport/port_dpu_linux.go
@@ -84,7 +84,7 @@ func (mp *managementPortRepresentor) checkRepresentorPortHealth() error {
 		// Get management port representor by name
 		link, err := util.GetNetLinkOps().LinkByName(mp.repDevName)
 		if err != nil {
-			return fmt.Errorf("failed to get link device %s: %w", mp.repDevName, err)
+			klog.Fatalf("Can't find neither renamed management port %s nor original representor device %s: %v, inconsistent state, crashing to recover with fresh start", mp.ifName, mp.repDevName, err)
 		}
 		err = bringupManagementPortLink(types.DefaultNetworkName, link, nil, mp.ifName, config.Default.MTU)
 		if err != nil {

--- a/go-controller/pkg/node/managementport/port_linux_test.go
+++ b/go-controller/pkg/node/managementport/port_linux_test.go
@@ -716,6 +716,7 @@ var _ = Describe("Management Port tests", func() {
 
 				// Return error here, so we know that function didn't returned earlier
 				netlinkOpsMock.On("LinkByName", mgmtPortName).Return(nil, netlinkMockErr)
+				netlinkOpsMock.On("IsLinkNotFoundError", mock.Anything).Return(false)
 				err := syncMgmtPortInterface(mgmtPortName, false)
 				Expect(err).To(HaveOccurred())
 			})
@@ -730,9 +731,26 @@ var _ = Describe("Management Port tests", func() {
 					"ovs-vsctl --timeout=15 --if-exists del-port br-int " + mgmtPortName,
 				})
 				netlinkOpsMock.On("LinkByName", mgmtPortName).Return(nil, netlinkMockErr)
+				netlinkOpsMock.On("IsLinkNotFoundError", mock.Anything).Return(false)
 
 				err := syncMgmtPortInterface(mgmtPortName, false)
 				Expect(err).To(HaveOccurred())
+			})
+
+			It("Succeeds when representor link is already removed", func() {
+				execMock.AddFakeCmd(&ovntest.ExpectedCmd{
+					Cmd:    "ovs-vsctl --timeout=15 --no-headings --data bare --format csv --columns type,name find Interface name=" + mgmtPortName,
+					Output: "," + mgmtPortName,
+				})
+				execMock.AddFakeCmdsNoOutputNoError([]string{
+					"ovs-vsctl --timeout=15 --if-exists get Interface " + mgmtPortName + " external-ids:ovn-orig-mgmt-port-rep-name",
+					"ovs-vsctl --timeout=15 --if-exists del-port br-int " + mgmtPortName,
+				})
+				netlinkOpsMock.On("LinkByName", mgmtPortName).Return(nil, netlinkMockErr)
+				netlinkOpsMock.On("IsLinkNotFoundError", mock.Anything).Return(true)
+
+				err := syncMgmtPortInterface(mgmtPortName, false)
+				Expect(err).ToNot(HaveOccurred())
 			})
 
 			It("Fails to set representor link down", func() {

--- a/go-controller/pkg/node/managementport/utils_linux.go
+++ b/go-controller/pkg/node/managementport/utils_linux.go
@@ -197,7 +197,13 @@ func DeleteManagementPortRepInterface(network, repDevice, savedName string) erro
 
 	link, err := util.GetNetLinkOps().LinkByName(repDevice)
 	if err != nil {
-		return fmt.Errorf("failed to lookup management port representor interface %s for network %s: %v", repDevice, network, err)
+		if !util.GetNetLinkOps().IsLinkNotFoundError(err) {
+			return fmt.Errorf("failed to lookup management port representor interface %s for network %s: %v", repDevice, network, err)
+		}
+
+		klog.V(5).Infof("Management port representor interface %s is already removed for network %s", repDevice, network)
+
+		return nil
 	}
 
 	err = TearDownManagementPortLink(network, link, savedName)


### PR DESCRIPTION
Ignore, created accidentally here, meant to do it upstream