### PR TITLE
OCPBUGS-87020: fix non-atomic NorthDB port-group writes causing persistent NodePort traffic loss

### DIFF
--- a/go-controller/pkg/libovsdb/ops/model.go
+++ b/go-controller/pkg/libovsdb/ops/model.go
@@ -597,7 +597,16 @@ func getAllUpdatableFields(model model.Model) []interface{} {
 	case *nbdb.LogicalSwitchPort:
 		return []interface{}{&t.Addresses, &t.Type, &t.TagRequest, &t.Options, &t.PortSecurity}
 	case *nbdb.PortGroup:
-		return []interface{}{&t.ACLs, &t.Ports, &t.ExternalIDs}
+		fields := []interface{}{&t.ACLs, &t.ExternalIDs}
+		// Only include Ports when explicitly set (non-nil). Callers like
+		// createNetworkPolicy pass nil Ports via BuildPortGroup and rely on
+		// a separate local-pod handler to populate them. Including a nil
+		// Ports here would generate an OVSDB Update that clears existing
+		// port membership, breaking traffic until pods are re-added.
+		if t.Ports != nil {
+			fields = append(fields, &t.Ports)
+		}
+		return fields
 	default:
 		panic(fmt.Sprintf("getAllUpdatableFields: unknown model %T", t))
 	}

--- a/go-controller/pkg/libovsdb/ops/portgroup_test.go
+++ b/go-controller/pkg/libovsdb/ops/portgroup_test.go
@@ -1,0 +1,273 @@
+// SPDX-FileCopyrightText: Copyright The OVN-Kubernetes Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package ops
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/nbdb"
+	libovsdbtest "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
+)
+
+func TestCreateOrUpdatePortGroupsOps_NilPortsPreservesExisting(t *testing.T) {
+	aclUUID := buildNamedUUID()
+	lspUUID := buildNamedUUID()
+	lsUUID := buildNamedUUID()
+	pgUUID := buildNamedUUID()
+
+	initialNbdb := libovsdbtest.TestSetup{
+		NBData: []libovsdbtest.TestData{
+			&nbdb.ACL{
+				UUID:      aclUUID,
+				Action:    nbdb.ACLActionAllow,
+				Direction: nbdb.ACLDirectionToLport,
+				Match:     "ip4",
+				Priority:  1000,
+			},
+			&nbdb.LogicalSwitchPort{
+				UUID: lspUUID,
+				Name: "lsp1",
+			},
+			&nbdb.LogicalSwitch{
+				UUID:  lsUUID,
+				Name:  "sw1",
+				Ports: []string{lspUUID},
+			},
+			&nbdb.PortGroup{
+				UUID:  pgUUID,
+				Name:  "test-pg",
+				ACLs:  []string{aclUUID},
+				Ports: []string{lspUUID},
+				ExternalIDs: map[string]string{
+					"key": "old-value",
+				},
+			},
+		},
+	}
+
+	nbClient, cleanup, err := libovsdbtest.NewNBTestHarness(initialNbdb, nil)
+	if err != nil {
+		t.Fatalf("failed to set up test harness: %v", err)
+	}
+	t.Cleanup(cleanup.Cleanup)
+
+	// Look up real UUIDs from the client cache.
+	var acls []*nbdb.ACL
+	if err := nbClient.List(context.Background(), &acls); err != nil || len(acls) != 1 {
+		t.Fatalf("failed to list ACLs: %v (count: %d)", err, len(acls))
+	}
+	var pgs []*nbdb.PortGroup
+	if err := nbClient.List(context.Background(), &pgs); err != nil || len(pgs) != 1 {
+		t.Fatalf("failed to list PortGroups: %v (count: %d)", err, len(pgs))
+	}
+	var lsps []*nbdb.LogicalSwitchPort
+	if err := nbClient.List(context.Background(), &lsps); err != nil || len(lsps) != 1 {
+		t.Fatalf("failed to list LSPs: %v (count: %d)", err, len(lsps))
+	}
+
+	// Call CreateOrUpdatePortGroupsOps with nil Ports but updated ExternalIDs.
+	// This simulates what happens during re-sync when BuildPortGroup(ids, nil, acls)
+	// is called followed by CreateOrUpdatePortGroupsOps.
+	updatePG := &nbdb.PortGroup{
+		Name: "test-pg",
+		ACLs: []string{acls[0].UUID},
+		ExternalIDs: map[string]string{
+			"key": "new-value",
+		},
+		// Ports is nil — must NOT clear existing ports
+	}
+
+	ops, err := CreateOrUpdatePortGroupsOps(nbClient, nil, updatePG)
+	if err != nil {
+		t.Fatalf("CreateOrUpdatePortGroupsOps() error = %v", err)
+	}
+	_, err = TransactAndCheck(nbClient, ops)
+	if err != nil {
+		t.Fatalf("TransactAndCheck() error = %v", err)
+	}
+
+	// Verify ports are preserved.
+	var resultPGs []*nbdb.PortGroup
+	if err := nbClient.List(context.Background(), &resultPGs); err != nil || len(resultPGs) != 1 {
+		t.Fatalf("failed to list result PortGroups: %v (count: %d)", err, len(resultPGs))
+	}
+	pg := resultPGs[0]
+
+	if len(pg.Ports) != 1 || pg.Ports[0] != lsps[0].UUID {
+		t.Fatalf("expected ports to be preserved [%s], got %v", lsps[0].UUID, pg.Ports)
+	}
+	if pg.ExternalIDs["key"] != "new-value" {
+		t.Fatalf("expected ExternalIDs to be updated to 'new-value', got %v", pg.ExternalIDs)
+	}
+}
+
+func TestCreateOrUpdatePortGroupsOps_ExplicitPortsReplaceExisting(t *testing.T) {
+	aclUUID := buildNamedUUID()
+	lsp1UUID := buildNamedUUID()
+	lsp2UUID := buildNamedUUID()
+	lsUUID := buildNamedUUID()
+	pgUUID := buildNamedUUID()
+
+	initialNbdb := libovsdbtest.TestSetup{
+		NBData: []libovsdbtest.TestData{
+			&nbdb.ACL{
+				UUID:      aclUUID,
+				Action:    nbdb.ACLActionAllow,
+				Direction: nbdb.ACLDirectionToLport,
+				Match:     "ip4",
+				Priority:  1000,
+			},
+			&nbdb.LogicalSwitchPort{
+				UUID: lsp1UUID,
+				Name: "lsp1",
+			},
+			&nbdb.LogicalSwitchPort{
+				UUID: lsp2UUID,
+				Name: "lsp2",
+			},
+			&nbdb.LogicalSwitch{
+				UUID:  lsUUID,
+				Name:  "sw1",
+				Ports: []string{lsp1UUID, lsp2UUID},
+			},
+			&nbdb.PortGroup{
+				UUID:  pgUUID,
+				Name:  "test-pg",
+				ACLs:  []string{aclUUID},
+				Ports: []string{lsp1UUID},
+				ExternalIDs: map[string]string{
+					"key": "value",
+				},
+			},
+		},
+	}
+
+	nbClient, cleanup, err := libovsdbtest.NewNBTestHarness(initialNbdb, nil)
+	if err != nil {
+		t.Fatalf("failed to set up test harness: %v", err)
+	}
+	t.Cleanup(cleanup.Cleanup)
+
+	// Look up real UUIDs.
+	var acls []*nbdb.ACL
+	if err := nbClient.List(context.Background(), &acls); err != nil || len(acls) != 1 {
+		t.Fatalf("failed to list ACLs: %v (count: %d)", err, len(acls))
+	}
+	var lsps []*nbdb.LogicalSwitchPort
+	if err := nbClient.List(context.Background(), &lsps); err != nil || len(lsps) != 2 {
+		t.Fatalf("failed to list LSPs: %v (count: %d)", err, len(lsps))
+	}
+	// Find lsp2's real UUID.
+	var lsp2RealUUID string
+	for _, lsp := range lsps {
+		if lsp.Name == "lsp2" {
+			lsp2RealUUID = lsp.UUID
+		}
+	}
+	if lsp2RealUUID == "" {
+		t.Fatal("failed to find lsp2 UUID")
+	}
+
+	// Call CreateOrUpdatePortGroupsOps with explicit (non-nil) Ports pointing to lsp2.
+	// This should REPLACE existing ports (lsp1 -> lsp2).
+	updatePG := &nbdb.PortGroup{
+		Name:  "test-pg",
+		Ports: []string{lsp2RealUUID},
+		ACLs:  []string{acls[0].UUID},
+		ExternalIDs: map[string]string{
+			"key": "value",
+		},
+	}
+
+	ops, err := CreateOrUpdatePortGroupsOps(nbClient, nil, updatePG)
+	if err != nil {
+		t.Fatalf("CreateOrUpdatePortGroupsOps() error = %v", err)
+	}
+	_, err = TransactAndCheck(nbClient, ops)
+	if err != nil {
+		t.Fatalf("TransactAndCheck() error = %v", err)
+	}
+
+	// Verify ports were replaced.
+	var resultPGs []*nbdb.PortGroup
+	if err := nbClient.List(context.Background(), &resultPGs); err != nil || len(resultPGs) != 1 {
+		t.Fatalf("failed to list result PortGroups: %v (count: %d)", err, len(resultPGs))
+	}
+	pg := resultPGs[0]
+
+	if len(pg.Ports) != 1 || pg.Ports[0] != lsp2RealUUID {
+		t.Fatalf("expected ports to be replaced with [%s], got %v", lsp2RealUUID, pg.Ports)
+	}
+}
+
+func TestCreateOrUpdatePortGroupsOps_CreateWithNilPorts(t *testing.T) {
+	aclUUID := buildNamedUUID()
+	// Include a PG that references the ACL so the ACL isn't garbage-collected
+	// during setup (ACLs are non-root in OVN NB schema).
+	holderPGUUID := buildNamedUUID()
+
+	initialNbdb := libovsdbtest.TestSetup{
+		NBData: []libovsdbtest.TestData{
+			&nbdb.ACL{
+				UUID:      aclUUID,
+				Action:    nbdb.ACLActionAllow,
+				Direction: nbdb.ACLDirectionToLport,
+				Match:     "ip4",
+				Priority:  1000,
+			},
+			&nbdb.PortGroup{
+				UUID: holderPGUUID,
+				Name: "holder-pg",
+				ACLs: []string{aclUUID},
+			},
+		},
+	}
+
+	nbClient, cleanup, err := libovsdbtest.NewNBTestHarness(initialNbdb, nil)
+	if err != nil {
+		t.Fatalf("failed to set up test harness: %v", err)
+	}
+	t.Cleanup(cleanup.Cleanup)
+
+	// Look up real ACL UUID.
+	var acls []*nbdb.ACL
+	if err := nbClient.List(context.Background(), &acls); err != nil || len(acls) != 1 {
+		t.Fatalf("failed to list ACLs: %v (count: %d)", err, len(acls))
+	}
+
+	// Create a new PG with nil Ports (simulating BuildPortGroup(ids, nil, acls)).
+	newPG := &nbdb.PortGroup{
+		Name: "new-pg",
+		ACLs: []string{acls[0].UUID},
+		ExternalIDs: map[string]string{
+			"key": "value",
+		},
+		// Ports is nil — new PG should be created with empty ports
+	}
+
+	ops, err := CreateOrUpdatePortGroupsOps(nbClient, nil, newPG)
+	if err != nil {
+		t.Fatalf("CreateOrUpdatePortGroupsOps() error = %v", err)
+	}
+	_, err = TransactAndCheck(nbClient, ops)
+	if err != nil {
+		t.Fatalf("TransactAndCheck() error = %v", err)
+	}
+
+	// Verify the new PG was created.
+	pg, err := GetPortGroup(nbClient, &nbdb.PortGroup{Name: "new-pg"})
+	if err != nil {
+		t.Fatalf("GetPortGroup() error = %v", err)
+	}
+	if len(pg.Ports) != 0 {
+		t.Fatalf("expected new PG to have empty ports, got %v", pg.Ports)
+	}
+	if len(pg.ACLs) != 1 || pg.ACLs[0] != acls[0].UUID {
+		t.Fatalf("expected new PG to have ACL [%s], got %v", acls[0].UUID, pg.ACLs)
+	}
+	if pg.ExternalIDs["key"] != "value" {
+		t.Fatalf("expected ExternalIDs key=value, got %v", pg.ExternalIDs)
+	}
+}

--- a/go-controller/pkg/ovn/base_network_controller_policy.go
+++ b/go-controller/pkg/ovn/base_network_controller_policy.go
@@ -894,9 +894,10 @@ func (bnc *BaseNetworkController) addLocalPodHandler(policy *knet.NetworkPolicy,
 
 	// Add all local pods in a syncFunction to minimize db ops.
 	syncFunc := func(objs []interface{}) error {
-		// ignore returned error, since any pod that wasn't properly handled will be retried individually.
-		_ = bnc.handleLocalPodSelectorAddFunc(np, objs...)
-		return nil
+		// Return error so WatchFactory retries the sync.
+		// handleLocalPodSelectorAddFunc is idempotent: pods already
+		// stored in np.localPods are skipped via getNewLocalPolicyPorts.
+		return bnc.handleLocalPodSelectorAddFunc(np, objs...)
 	}
 	retryLocalPods := bnc.newNetpolRetryFramework(
 		factory.LocalPodSelectorType,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
When ovnkube-controller reconnects to kube-apiserver after a transient outage (e.g. KAS revision rollout) and re-syncs NetworkPolicy state, two bugs combine to cause persistent NodePort/LB traffic loss:

1. CreateOrUpdatePortGroupsOps clears existing port membership during Update. getAllUpdatableFields() unconditionally returns Ports in the OnModelUpdates list. When BuildPortGroup() is called with nil ports (the normal path in createNetworkPolicy and createDefaultDenyPGAndACLs), and the port group already exists in NorthDB (during retry/re-sync), the OVSDB Update operation replaces existing ports with an empty set. The allow ACLs on the now-empty port group match no pods, while default-deny ACLs still apply — dropping all traffic.

2. The local pod sync function silently discards errors. In addLocalPodHandler, the syncFunc ignores the return value of handleLocalPodSelectorAddFunc. If the NorthDB transaction fails during sync (e.g. connection instability during API server recovery), ports are never added to the port group and no retry is triggered. Since resyncInterval=0, the stale state persists indefinitely.

Fix getAllUpdatableFields for PortGroup to skip nil fields — nil means "not specified" (preserve existing value), while non-nil means "set to this value". This is safe for all callers: NetworkPolicy code passes nil ports (preserved on update), ANP code passes explicit ports (replaced as before), and the Create path is unaffected (uses the full model, not OnModelUpdates).

Fix the syncFunc to return errors from handleLocalPodSelectorAddFunc. The function is idempotent (pods already in np.localPods are skipped), and the WatchFactory retries the sync for up to 60 seconds.

Both bugs were introduced in 2022 (commits 5d84deb81 and c973d615c) and are present in all release branches from 4.14 through 4.21.

Fixes: https://issues.redhat.com/browse/OCPBUGS-87020

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [x] My code requires tests
- [x] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Pod sync now surfaces sync errors so failed syncs are retried.
  * Port group updates now preserve existing ports when ports are unspecified; explicitly provided ports replace existing ones; creating with unspecified ports yields an empty ports list. ACLs and external IDs are consistently applied.

* **Tests**
  * Added tests covering port group create/update behaviors for nil, explicit, and create-with-nil ports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->