### PR TITLE
Fix primary UDN race condition in CNI server

### DIFF
--- a/go-controller/pkg/cni/cniserver.go
+++ b/go-controller/pkg/cni/cniserver.go
@@ -333,6 +333,17 @@ func (s *Server) handleCNIRequest(r *http.Request) (result []byte, err error) {
 		}
 		if primaryPodRequest != nil {
 			klog.V(4).Infof("Pod %s/%s primaryUDN podRequest %v", primaryPodRequest.PodNamespace, primaryPodRequest.PodName, primaryPodRequest)
+
+			// Wait for the OVN controller to create the primary UDN annotation before proceeding.
+			// This prevents a race condition where the CNI tries to configure the OVS port
+			// before the logical port has been created by the OVN controller.
+			_, _, _, err = GetPodWithAnnotations(primaryPodRequest.ctx, s.clientSet,
+				primaryPodRequest.PodNamespace, primaryPodRequest.PodName,
+				primaryPodRequest.nadKey, isOvnReady)
+			if err != nil {
+				return nil, fmt.Errorf("failed to wait for primary UDN pod annotation: %v", err)
+			}
+
 			primaryResponse, err := primaryPodRequest.cmdAdd(s.kubeAuth, s.clientSet, s.ovsClient)
 			if err != nil {
 				return nil, fmt.Errorf("failed to add primary UDN pod request: %v", err)


### PR DESCRIPTION
## Summary

This PR fixes a critical race condition in primary UDN (User Defined Network) pod creation that was introduced in upstream commit 1826e9971.

## The Problem

All NetworkSegmentation e2e tests were failing with:
```
timed out waiting for OVS port binding (ovn-installed) for <MAC> [<IP>]
```

## Root Cause

Commit 1826e9971 ("Move primary UDN out of pod request") refactored primary UDN handling but inadvertently removed the annotation waiting logic. This created a race condition where the CNI tries to configure the OVS port before the OVN controller has created the logical port.

## The Fix

Add a single call to `GetPodWithAnnotations(isOvnReady)` to wait for the OVN controller to be ready before calling `cmdAdd()` on the primary UDN interface. This is a minimal 7-line fix that restores the original behavior.

## Testing

- Fixes 64 failing NetworkSegmentation tests in PR #3237
- Should be verified with: `/test e2e-aws-ovn`

## Related

- Fixes regression from upstream ovn-kubernetes/ovn-kubernetes commit 1826e9971
- Related to PR #3237 (downstream merge)
