### PR TITLE
Update openshift-tests-extension to latest

### DIFF
--- a/openshift/go.mod
+++ b/openshift/go.mod
@@ -7,7 +7,7 @@ toolchain go1.25.1
 require (
 	github.com/onsi/ginkgo/v2 v2.27.2
 	github.com/onsi/gomega v1.38.2
-	github.com/openshift-eng/openshift-tests-extension v0.0.0-20260127124016-0fed2b824818
+	github.com/openshift-eng/openshift-tests-extension v0.0.0-20260612102633-2fd5b2fa4221
 	github.com/openshift/api v0.0.0-20260311143357-f6ee4c095675
 	github.com/openshift/client-go v0.0.0-20260306160707-3935d929fc7d
 	github.com/ovn-kubernetes/ovn-kubernetes/go-controller v1.0.0

--- a/openshift/go.sum
+++ b/openshift/go.sum
@@ -400,8 +400,8 @@ github.com/opencontainers/runtime-spec v1.2.1 h1:S4k4ryNgEpxW1dzyqffOmhI1BHYcjzU
 github.com/opencontainers/runtime-spec v1.2.1/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/selinux v1.13.0 h1:Zza88GWezyT7RLql12URvoxsbLfjFx988+LGaWfbL84=
 github.com/opencontainers/selinux v1.13.0/go.mod h1:XxWTed+A/s5NNq4GmYScVy+9jzXhGBVEOAyucdRUY8s=
-github.com/openshift-eng/openshift-tests-extension v0.0.0-20260127124016-0fed2b824818 h1:jJLE/aCAqDf8U4wc3bE1IEKgIxbb0ICjCNVFA49x/8s=
-github.com/openshift-eng/openshift-tests-extension v0.0.0-20260127124016-0fed2b824818/go.mod h1:6gkP5f2HL0meusT0Aim8icAspcD1cG055xxBZ9yC68M=
+github.com/openshift-eng/openshift-tests-extension v0.0.0-20260612102633-2fd5b2fa4221 h1:k6W1oylHruGVhmnnW4t1IN/EPCIenUpnDKEpp+4bEZs=
+github.com/openshift-eng/openshift-tests-extension v0.0.0-20260612102633-2fd5b2fa4221/go.mod h1:pHOS9c6BjZv91OkkHyIHAOWnYhxwcxWQkyYGEvPyUCE=
 github.com/openshift-kni/k8sreporter v1.0.6 h1:aaxDzZx3s9bo1I3nopR63RGVZxcJgR94j5X87aDihYo=
 github.com/openshift-kni/k8sreporter v1.0.6/go.mod h1:tX6LOg0m0oXje7WNLFo8LKHC9Ix8VV0a7vUc6eyeFBQ=
 github.com/openshift/api v0.0.0-20260311143357-f6ee4c095675 h1:5yWWatBRhf5p1t0B+UGgWIAMNkz/YeoXyHqW6qm2GK0=


### PR DESCRIPTION
## Summary
- Update `openshift-tests-extension` from `v0.0.0-20260127` to `v0.0.0-20260612`
- This transitively pulls in `openshift/onsi-ginkgo` with the `ForwardingOutputInterceptor` fix (openshift/onsi-ginkgo#23)
- Fixes false OTP test failures in parallel CI jobs where test stdout output (STEP logs, kube framework output) contaminated the JSON result, causing deserialization errors

## Root cause
`RunSpec` in `openshift/onsi-ginkgo`'s `suite_patch.go` previously used `NoopOutputInterceptor`, so any direct `os.Stdout` writes from test code (kube e2e framework STEP logs, `exutil.CLI` output) leaked to process stdout alongside the JSON result. The harness then failed to parse the mixed output as JSON, reporting passing tests as failures with `Deserialization Error: invalid character 'S' looking for beginning of value`.

## Test plan
- [x] `go build` passes
- [ ] CI: OTP tests that previously showed false deserialization failures should now pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project dependencies to ensure stability and compatibility with latest upstream components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->