### PR TITLE
[WIP] CORENET-7073: Run OTE tests against KIND cluster

### DIFF
--- a/openshift/cmd/ovn-kubernetes-tests-ext/main.go
+++ b/openshift/cmd/ovn-kubernetes-tests-ext/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"strings"
 
@@ -21,6 +22,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/rest"
 
 	// ensure providers are initialised for configuring infra
 	_ "k8s.io/kubernetes/test/e2e/framework/providers/aws"
@@ -54,7 +56,7 @@ func shouldIncludeTest(spec *extensiontests.ExtensionTestSpec) bool {
 		return false
 	}
 
-	// Without cluster access, include all eligible tests
+	// Without cluster access (or) kind cluster, include all eligible tests
 	if ocpInfra == nil {
 		return true
 	}
@@ -72,6 +74,29 @@ func shouldIncludeTest(spec *extensiontests.ExtensionTestSpec) bool {
 	// suites
 
 	return true
+}
+
+// initializeInfraProvider initializes the infrastructure provider based on cluster type.
+// For kind clusters, it uses SSH-based command execution for OTE mode.
+// For OpenShift clusters, it uses the standard OpenShift infrastructure provider.
+func initializeInfraProvider(cfg *rest.Config) error {
+	if infraprovider.IsKind() {
+		infra, err := ocpinfraprovider.InitializeKindInfra()
+		if err != nil {
+			return fmt.Errorf("failed to initialize kind infrastructure: %w", err)
+		}
+		infraprovider.Set(infra)
+	} else {
+		infra, err := ocpinfraprovider.New(cfg)
+		if err != nil {
+			return fmt.Errorf("failed to initialize OpenShift infrastructure: %w", err)
+		}
+		infraprovider.Set(infra)
+		// Set ocpInfra only for OpenShift clusters (not for kind)
+		ocpInfra = infra
+	}
+	deploymentconfig.Set(ocpdeploymentconfig.New())
+	return nil
 }
 
 func main() {
@@ -109,14 +134,7 @@ func main() {
 	cfg, cfgErr := getKubeConfig()
 	var infraErr error
 	if cfgErr == nil {
-		infra, err := ocpinfraprovider.New(cfg)
-		if err != nil {
-			infraErr = err
-		} else {
-			ocpInfra = infra
-			infraprovider.Set(ocpInfra)
-			deploymentconfig.Set(ocpdeploymentconfig.New())
-		}
+		infraErr = initializeInfraProvider(cfg)
 	}
 
 	// Initialization for kube ginkgo test framework needs to run before all tests execute

--- a/openshift/test/infraprovider/kind.go
+++ b/openshift/test/infraprovider/kind.go
@@ -1,0 +1,85 @@
+package infraprovider
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/infraprovider/api"
+	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/infraprovider/engine/runner"
+	infraproviderkind "github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/infraprovider/providers/kind"
+)
+
+const (
+	kindHostUser      = "root"
+	kindHostSshport   = "22"
+	envKindHost       = "KIND_HOST"
+	envKindHostSSHKey = "KIND_HOST_SSH_KEY"
+)
+
+// InitializeKindInfra initializes a kind infrastructure provider with SSH-based command execution.
+// Used when OTE binary runs in a container and needs to interact with a kind cluster on a remote host.
+// Requires KIND_HOST, KIND_HOST_SSH_KEY, and CONTAINER_RUNTIME environment variables.
+func InitializeKindInfra() (api.Provider, error) {
+	// Initialize command runner for executing commands on the host
+	ce := infraproviderkind.GetContainerRuntime()
+	sshRunner, err := hostSshCmdRunner()
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize SSH runner: %w", err)
+	}
+
+	// Validate SSH connectivity before proceeding
+	if err := validateSSHConnection(sshRunner); err != nil {
+		return nil, fmt.Errorf("SSH connection validation failed: %w", err)
+	}
+
+	return infraproviderkind.New(ce, sshRunner), nil
+}
+
+func hostSshCmdRunner() (api.Runner, error) {
+	// Read host IP from env variable
+	ip := os.Getenv(envKindHost)
+	if ip == "" {
+		return nil, fmt.Errorf("%s environment variable is not set", envKindHost)
+	}
+
+	// Find SSH key for host access
+	sshKeyPath, err := findKindHostSSHKeyPath()
+	if err != nil {
+		return nil, fmt.Errorf("SSH key configuration failed: %w", err)
+	}
+
+	sshRunner, err := runner.NewSSHRunner(ip, kindHostUser, kindHostSshport, sshKeyPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create SSH runner for kind host: %w", err)
+	}
+
+	return sshRunner, nil
+}
+
+// findKindHostSSHKeyPath locates the SSH private key file for host access.
+func findKindHostSSHKeyPath() (string, error) {
+	sshKeyPath := os.Getenv(envKindHostSSHKey)
+	if sshKeyPath == "" {
+		return "", fmt.Errorf("%s environment variable is not set", envKindHostSSHKey)
+	}
+
+	exists, err := fileExists(sshKeyPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to check SSH key file %q: %w", sshKeyPath, err)
+	}
+	if !exists {
+		return "", fmt.Errorf("SSH key file %q does not exist", sshKeyPath)
+	}
+
+	return sshKeyPath, nil
+}
+
+// validateSSHConnection tests if the SSH runner can successfully execute commands.
+func validateSSHConnection(runner api.Runner) error {
+	// Quick connectivity test
+	_, err := runner.Run("echo", "test")
+	if err != nil {
+		return fmt.Errorf("cannot execute commands on kind host: %w", err)
+	}
+	return nil
+}

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/label"
 
 	deploymentkind "github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/deploymentconfig/configs/kind"
+	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/infraprovider/engine/runner"
 	infraproviderkind "github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/infraprovider/providers/kind"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
@@ -67,7 +68,9 @@ func TestMain(m *testing.M) {
 	// Set up infrastructure provider and deployment config
 	// Upstream currently uses KinD as its preferred platform infra
 	// So TestMain is expected to run only there.
-	infraprovider.Set(infraproviderkind.New())
+	ce := infraproviderkind.GetContainerRuntime()
+	cmdRunner := runner.NewDirectRunner()
+	infraprovider.Set(infraproviderkind.New(ce, cmdRunner))
 	deploymentconfig.Set(deploymentkind.New())
 
 	os.Exit(m.Run())

--- a/test/e2e/infraprovider/providers/kind/kind.go
+++ b/test/e2e/infraprovider/providers/kind/kind.go
@@ -17,7 +17,6 @@ import (
 	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/infraprovider/api"
 	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/infraprovider/engine/container"
 	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/infraprovider/engine/portalloc"
-	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/infraprovider/engine/runner"
 	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/infraprovider/engine/testcontext"
 
 	corev1 "k8s.io/api/core/v1"
@@ -27,19 +26,21 @@ import (
 )
 
 type kind struct {
-	engine   *container.Engine
-	HostPort *portalloc.PortAllocator
+	containerRuntime ContainerRuntime
+	engine           *container.Engine
+	cmdRunner        api.Runner
+	HostPort         *portalloc.PortAllocator
 }
 
-func New() api.Provider {
+func New(ce ContainerRuntime, cmdRunner api.Runner) api.Provider {
 	if !infraprovider.IsKind() {
 		panic("Cluster provider must be KinD type")
 	}
-	ce := getContainerRuntime()
-	cmdRunner := runner.NewDirectRunner()
 	kind := &kind{
-		engine:   container.NewEngine(ce.String(), cmdRunner),
-		HostPort: portalloc.New(1024, 65535)}
+		containerRuntime: ce,
+		cmdRunner:        cmdRunner,
+		engine:           container.NewEngine(ce.String(), cmdRunner),
+		HostPort:         portalloc.New(1024, 65535)}
 	return kind
 }
 
@@ -104,10 +105,10 @@ func (k *kind) PreloadImages(imgs []string) {
 	pullBackoff := wait.Backoff{Duration: 5 * time.Second, Factor: 2, Steps: 5}
 	for _, img := range imgs {
 		framework.Logf("Preloading image %s into KIND cluster %s", img, clusterName)
-		var out []byte
+		var out string
 		err := wait.ExponentialBackoff(pullBackoff, func() (bool, error) {
 			var pullErr error
-			out, pullErr = exec.Command(engine.String(), "pull", img).CombinedOutput()
+			out, pullErr = k.cmdRunner.Run(k.containerRuntime.String(), "pull", img)
 			if pullErr != nil {
 				framework.Logf("Retrying pull for image %s: %v (%s)", img, pullErr, out)
 				return false, nil
@@ -118,16 +119,16 @@ func (k *kind) PreloadImages(imgs []string) {
 			framework.Logf("Warning: failed to pull image %s after retries: %v (%s)", img, err, out)
 			continue
 		}
-		if engine == podman {
+		if k.containerRuntime == podman {
 			os.Remove("/tmp/image.tar")
-			out, err = exec.Command(engine.String(), "save", "-o", "/tmp/image.tar", img).CombinedOutput()
+			out, err = k.cmdRunner.Run(k.containerRuntime.String(), "save", "-o", "/tmp/image.tar", img)
 			if err != nil {
 				framework.Logf("Warning: failed to save image %s: %v (%s)", img, err, out)
 				continue
 			}
-			out, err = exec.Command("kind", "load", "image-archive", "/tmp/image.tar", "--name", clusterName).CombinedOutput()
+			out, err = k.cmdRunner.Run("kind", "load", "image-archive", "/tmp/image.tar", "--name", clusterName)
 		} else {
-			out, err = exec.Command("kind", "load", "docker-image", img, "--name", clusterName).CombinedOutput()
+			out, err = k.cmdRunner.Run("kind", "load", "docker-image", img, "--name", clusterName)
 		}
 		if err != nil {
 			framework.Logf("Warning: failed to load image %s into KIND cluster %s: %v (%s)", img, clusterName, err, out)

--- a/test/e2e/infraprovider/providers/kind/runtime.go
+++ b/test/e2e/infraprovider/providers/kind/runtime.go
@@ -9,18 +9,18 @@ import (
 	"strings"
 )
 
-type containerRuntime string
+type ContainerRuntime string
 
-func (ce containerRuntime) String() string {
+func (ce ContainerRuntime) String() string {
 	return string(ce)
 }
 
 const (
-	docker containerRuntime = "docker"
-	podman containerRuntime = "podman"
+	docker ContainerRuntime = "docker"
+	podman ContainerRuntime = "podman"
 )
 
-var engine containerRuntime
+var engine ContainerRuntime
 
 func init() {
 	if cr, found := os.LookupEnv("CONTAINER_RUNTIME"); found {
@@ -37,7 +37,7 @@ func init() {
 	}
 }
 
-func getContainerRuntime() containerRuntime {
+func GetContainerRuntime() ContainerRuntime {
 	if engine.String() == "" {
 		panic("container engine is not set")
 	}


### PR DESCRIPTION
This PR enables the OTE binary to run E2E tests against kind cluster using SSH-based remote execution. It parameterizes the kind infrastructure provider to accept a `Runner` interface, allowing commands to be executed either locally (DirectRunner) or remotely via SSH (SSHRunner).

TODO: Run a test container that includes the OTE binary, SSH configuration, and necessary environment variables set, E2E tests against a remote kind cluster.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized cluster infrastructure initialization logic into a dedicated helper function for improved maintainability.
  * Refactored kind provider construction to use dependency injection for better testability and flexibility.
  * Updated container runtime type exports for improved accessibility across test infrastructure modules.

* **New Features**
  * Added SSH-based support for remote kind cluster operations, including validation of connectivity and configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->