### PR TITLE
OCPBUGS-74711: [release-4.20] EgressIP annotation corruption causes stale IPs on br-ex after failover

### DIFF
--- a/go-controller/pkg/node/controllers/egressip/egressip.go
+++ b/go-controller/pkg/node/controllers/egressip/egressip.go
@@ -1142,8 +1142,12 @@ func (c *Controller) migrateFromAddrLabelToAnnotation() error {
 		if err != nil {
 			return err
 		}
-		node.Annotations[util.OVNNodeSecondaryHostEgressIPs] = string(patch)
-		return c.kube.UpdateNodeStatus(node)
+		nodeToUpdate := node.DeepCopy()
+		if nodeToUpdate.Annotations == nil {
+			nodeToUpdate.Annotations = map[string]string{}
+		}
+		nodeToUpdate.Annotations[util.OVNNodeSecondaryHostEgressIPs] = string(patch)
+		return c.kube.UpdateNodeStatus(nodeToUpdate)
 	})
 }
 
@@ -1174,8 +1178,12 @@ func (c *Controller) addIPToAnnotation(ip string) error {
 		if err != nil {
 			return err
 		}
-		node.Annotations[util.OVNNodeSecondaryHostEgressIPs] = string(patch)
-		return c.kube.UpdateNodeStatus(node)
+		nodeToUpdate := node.DeepCopy()
+		if nodeToUpdate.Annotations == nil {
+			nodeToUpdate.Annotations = map[string]string{}
+		}
+		nodeToUpdate.Annotations[util.OVNNodeSecondaryHostEgressIPs] = string(patch)
+		return c.kube.UpdateNodeStatus(nodeToUpdate)
 	})
 }
 
@@ -1206,8 +1214,12 @@ func (c *Controller) deleteIPFromAnnotation(ip string) error {
 		if err != nil {
 			return err
 		}
-		node.Annotations[util.OVNNodeSecondaryHostEgressIPs] = string(patch)
-		return c.kube.UpdateNodeStatus(node)
+		nodeToUpdate := node.DeepCopy()
+		if nodeToUpdate.Annotations == nil {
+			nodeToUpdate.Annotations = map[string]string{}
+		}
+		nodeToUpdate.Annotations[util.OVNNodeSecondaryHostEgressIPs] = string(patch)
+		return c.kube.UpdateNodeStatus(nodeToUpdate)
 	})
 }
 

--- a/go-controller/pkg/node/egressip/gateway_egressip.go
+++ b/go-controller/pkg/node/egressip/gateway_egressip.go
@@ -174,6 +174,7 @@ type BridgeEIPAddrManager struct {
 	nodeName         string
 	bridgeName       string
 	nodeAnnotationMu sync.Mutex
+	annotationIPs    sets.Set[string]
 	eIPLister        egressiplisters.EgressIPLister
 	eIPInformer      cache.SharedIndexInformer
 	nodeLister       corev1listers.NodeLister
@@ -194,6 +195,7 @@ func NewBridgeEIPAddrManager(nodeName, bridgeName string, linkManager *linkmanag
 		nodeName:         nodeName,     // k8 node name
 		bridgeName:       bridgeName,   // bridge name for which EIP IPs are managed
 		nodeAnnotationMu: sync.Mutex{}, // mu for updating Node annotation
+		annotationIPs:    sets.New[string](),
 		eIPLister:        eIPInformer.Lister(),
 		eIPInformer:      eIPInformer.Informer(),
 		nodeLister:       nodeInformer.Lister(),
@@ -304,6 +306,9 @@ func (g *BridgeEIPAddrManager) SyncEgressIP(objs []interface{}) error {
 	if err != nil {
 		return fmt.Errorf("failed to sync EgressIP gateway config because unable to get Node annotation: %v", err)
 	}
+	g.nodeAnnotationMu.Lock()
+	g.annotationIPs = sets.New[string](getIPsStr(annotIPs...)...)
+	g.nodeAnnotationMu.Unlock()
 	configs := markIPs{v4: map[int]string{}, v6: map[int]string{}}
 	for _, obj := range objs {
 		eip, ok := obj.(*egressipv1.EgressIP)
@@ -348,30 +353,15 @@ func (g *BridgeEIPAddrManager) SyncEgressIP(objs []interface{}) error {
 	return nil
 }
 
-// addIPToAnnotation adds an address to the collection of existing addresses stored in the nodes annotation. Caller
-// may repeat addition of addresses without care for duplicate addresses being added.
-func (g *BridgeEIPAddrManager) addIPToAnnotation(candidateIP net.IP) error {
-	g.nodeAnnotationMu.Lock()
-	defer g.nodeAnnotationMu.Unlock()
+// updateAnnotationLocked updates the node's egress IPs
+// Must be called with nodeAnnotationMu locked
+func (g *BridgeEIPAddrManager) updateAnnotationLocked(updatedIPs sets.Set[string]) error {
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		node, err := g.nodeLister.Get(g.nodeName)
 		if err != nil {
 			return err
 		}
-		existingIPsStr, err := util.ParseNodeBridgeEgressIPsAnnotation(node)
-		if err != nil {
-			if util.IsAnnotationNotSetError(err) {
-				existingIPsStr = make([]string, 0)
-			} else {
-				return fmt.Errorf("failed to parse annotation key %q from node object: %v", util.OVNNodeBridgeEgressIPs, err)
-			}
-		}
-		existingIPsSet := sets.New[string](existingIPsStr...)
-		candidateIPStr := candidateIP.String()
-		if existingIPsSet.Has(candidateIPStr) {
-			return nil
-		}
-		patch, err := json.Marshal(existingIPsSet.Insert(candidateIPStr).UnsortedList())
+		patch, err := json.Marshal(updatedIPs.UnsortedList())
 		if err != nil {
 			return err
 		}
@@ -384,44 +374,39 @@ func (g *BridgeEIPAddrManager) addIPToAnnotation(candidateIP net.IP) error {
 	})
 }
 
+// addIPToAnnotation adds an address to the collection of existing addresses stored in the nodes annotation. Caller
+// may repeat addition of addresses without care for duplicate addresses being added.
+func (g *BridgeEIPAddrManager) addIPToAnnotation(candidateIP net.IP) error {
+	g.nodeAnnotationMu.Lock()
+	defer g.nodeAnnotationMu.Unlock()
+	updatedIPs := sets.New[string](g.annotationIPs.UnsortedList()...)
+	updatedIPs.Insert(candidateIP.String())
+	if updatedIPs.Equal(g.annotationIPs) {
+		return nil
+	}
+	if err := g.updateAnnotationLocked(updatedIPs); err != nil {
+		return err
+	}
+	g.annotationIPs = updatedIPs
+	return nil
+}
+
 // deleteIPsFromAnnotation deletes address from annotation. If multiple users, callers must synchronise.
 // deletion of address that doesn't exist will not cause an error.
 func (g *BridgeEIPAddrManager) deleteIPsFromAnnotation(candidateIPs ...net.IP) error {
 	g.nodeAnnotationMu.Lock()
 	defer g.nodeAnnotationMu.Unlock()
-	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		node, err := g.nodeLister.Get(g.nodeName)
-		if err != nil {
-			return err
-		}
-		existingIPsStr, err := util.ParseNodeBridgeEgressIPsAnnotation(node)
-		if err != nil {
-			if util.IsAnnotationNotSetError(err) {
-				existingIPsStr = make([]string, 0)
-			} else {
-				return fmt.Errorf("failed to parse annotation key %q from node object: %v", util.OVNNodeBridgeEgressIPs, err)
-			}
-		}
-		if len(existingIPsStr) == 0 {
-			return nil
-		}
-		existingIPsSet := sets.New[string](existingIPsStr...)
-		candidateIPsStr := getIPsStr(candidateIPs...)
-		if !existingIPsSet.HasAny(candidateIPsStr...) {
-			return nil
-		}
-		existingIPsSet.Delete(candidateIPsStr...)
-		patch, err := json.Marshal(existingIPsSet.UnsortedList())
-		if err != nil {
-			return err
-		}
-		nodeToUpdate := node.DeepCopy()
-		if nodeToUpdate.Annotations == nil {
-			nodeToUpdate.Annotations = map[string]string{}
-		}
-		nodeToUpdate.Annotations[util.OVNNodeBridgeEgressIPs] = string(patch)
-		return g.kube.UpdateNodeStatus(nodeToUpdate)
-	})
+	candidateIPsStr := getIPsStr(candidateIPs...)
+	updatedIPs := sets.New[string](g.annotationIPs.UnsortedList()...)
+	updatedIPs.Delete(candidateIPsStr...)
+	if updatedIPs.Equal(g.annotationIPs) {
+		return nil
+	}
+	if err := g.updateAnnotationLocked(updatedIPs); err != nil {
+		return err
+	}
+	g.annotationIPs = updatedIPs
+	return nil
 }
 
 func (g *BridgeEIPAddrManager) addIPBridge(ip net.IP) error {

--- a/go-controller/pkg/node/egressip/gateway_egressip.go
+++ b/go-controller/pkg/node/egressip/gateway_egressip.go
@@ -375,8 +375,12 @@ func (g *BridgeEIPAddrManager) addIPToAnnotation(candidateIP net.IP) error {
 		if err != nil {
 			return err
 		}
-		node.Annotations[util.OVNNodeBridgeEgressIPs] = string(patch)
-		return g.kube.UpdateNodeStatus(node)
+		nodeToUpdate := node.DeepCopy()
+		if nodeToUpdate.Annotations == nil {
+			nodeToUpdate.Annotations = map[string]string{}
+		}
+		nodeToUpdate.Annotations[util.OVNNodeBridgeEgressIPs] = string(patch)
+		return g.kube.UpdateNodeStatus(nodeToUpdate)
 	})
 }
 
@@ -411,8 +415,12 @@ func (g *BridgeEIPAddrManager) deleteIPsFromAnnotation(candidateIPs ...net.IP) e
 		if err != nil {
 			return err
 		}
-		node.Annotations[util.OVNNodeBridgeEgressIPs] = string(patch)
-		return g.kube.UpdateNodeStatus(node)
+		nodeToUpdate := node.DeepCopy()
+		if nodeToUpdate.Annotations == nil {
+			nodeToUpdate.Annotations = map[string]string{}
+		}
+		nodeToUpdate.Annotations[util.OVNNodeBridgeEgressIPs] = string(patch)
+		return g.kube.UpdateNodeStatus(nodeToUpdate)
 	})
 }
 

--- a/go-controller/pkg/node/egressip/gateway_egressip_test.go
+++ b/go-controller/pkg/node/egressip/gateway_egressip_test.go
@@ -12,6 +12,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes/fake"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
@@ -72,9 +73,11 @@ var _ = ginkgo.Describe("Gateway EgressIP", func() {
 			isUpdated, err := addrMgr.AddEgressIP(eip)
 			gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "should process a valid EgressIP")
 			gomega.Expect(isUpdated).Should(gomega.BeTrue())
-			node, err := addrMgr.nodeLister.Get(nodeName)
-			gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "node should be present within kapi")
-			gomega.Expect(parseEIPsFromAnnotation(node)).Should(gomega.ConsistOf(ipV4Addr))
+			gomega.Eventually(func() []string {
+				node, err := addrMgr.nodeLister.Get(nodeName)
+				gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "node should be present within kapi")
+				return parseEIPsFromAnnotation(node)
+			}).Should(gomega.ConsistOf(ipV4Addr))
 			gomega.Expect(nlMock.AssertCalled(ginkgo.GinkgoT(), "AddrAdd", nlLinkMock,
 				egressip.GetNetlinkAddress(net.ParseIP(ipV4Addr), bridgeLinkIndex))).Should(gomega.BeTrue())
 		})
@@ -122,9 +125,11 @@ var _ = ginkgo.Describe("Gateway EgressIP", func() {
 			isUpdated, err := addrMgr.AddEgressIP(eip)
 			gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "should process a valid EgressIP")
 			gomega.Expect(isUpdated).Should(gomega.BeTrue())
-			node, err := addrMgr.nodeLister.Get(nodeName)
-			gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "node should be present within kapi")
-			gomega.Expect(parseEIPsFromAnnotation(node)).Should(gomega.ConsistOf(ipV4Addr, ipV4Addr2))
+			gomega.Eventually(func() []string {
+				node, err := addrMgr.nodeLister.Get(nodeName)
+				gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "node should be present within kapi")
+				return parseEIPsFromAnnotation(node)
+			}).Should(gomega.ConsistOf(ipV4Addr, ipV4Addr2))
 			gomega.Expect(nlMock.AssertCalled(ginkgo.GinkgoT(), "AddrAdd", nlLinkMock,
 				egressip.GetNetlinkAddress(net.ParseIP(ipV4Addr), bridgeLinkIndex))).Should(gomega.BeTrue())
 		})
@@ -164,9 +169,11 @@ var _ = ginkgo.Describe("Gateway EgressIP", func() {
 			isUpdated, err := addrMgr.UpdateEgressIP(unassignedEIP, assignedEIP)
 			gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "should process a valid EgressIP")
 			gomega.Expect(isUpdated).Should(gomega.BeTrue())
-			node, err := addrMgr.nodeLister.Get(nodeName)
-			gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "node should be present within kapi")
-			gomega.Expect(parseEIPsFromAnnotation(node)).Should(gomega.ConsistOf(ipV4Addr))
+			gomega.Eventually(func() []string {
+				node, err := addrMgr.nodeLister.Get(nodeName)
+				gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "node should be present within kapi")
+				return parseEIPsFromAnnotation(node)
+			}).Should(gomega.ConsistOf(ipV4Addr))
 			gomega.Expect(nlMock.AssertCalled(ginkgo.GinkgoT(), "AddrAdd", nlLinkMock,
 				egressip.GetNetlinkAddress(net.ParseIP(ipV4Addr), bridgeLinkIndex))).Should(gomega.BeTrue())
 		})
@@ -189,9 +196,11 @@ var _ = ginkgo.Describe("Gateway EgressIP", func() {
 			isUpdated, err = addrMgr.UpdateEgressIP(assignedEIP, unassignedEIP)
 			gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "should process a valid EgressIP")
 			gomega.Expect(isUpdated).Should(gomega.BeTrue())
-			node, err := addrMgr.nodeLister.Get(nodeName)
-			gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "node should be present within kapi")
-			gomega.Expect(parseEIPsFromAnnotation(node)).ShouldNot(gomega.ConsistOf(ipV4Addr))
+			gomega.Eventually(func() []string {
+				node, err := addrMgr.nodeLister.Get(nodeName)
+				gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "node should be present within kapi")
+				return parseEIPsFromAnnotation(node)
+			}).ShouldNot(gomega.ConsistOf(ipV4Addr))
 			gomega.Expect(nlMock.AssertCalled(ginkgo.GinkgoT(), "AddrAdd", nlLinkMock,
 				egressip.GetNetlinkAddress(net.ParseIP(ipV4Addr), bridgeLinkIndex))).Should(gomega.BeTrue())
 			gomega.Expect(nlMock.AssertCalled(ginkgo.GinkgoT(), "AddrDel", nlLinkMock,
@@ -250,9 +259,11 @@ var _ = ginkgo.Describe("Gateway EgressIP", func() {
 			isUpdated, err = addrMgr.DeleteEgressIP(eip)
 			gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "should process a valid EgressIP")
 			gomega.Expect(isUpdated).Should(gomega.BeTrue())
-			node, err := addrMgr.nodeLister.Get(nodeName)
-			gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "node should be present within kapi")
-			gomega.Expect(parseEIPsFromAnnotation(node)).ShouldNot(gomega.ConsistOf(ipV4Addr))
+			gomega.Eventually(func() []string {
+				node, err := addrMgr.nodeLister.Get(nodeName)
+				gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "node should be present within kapi")
+				return parseEIPsFromAnnotation(node)
+			}).ShouldNot(gomega.ConsistOf(ipV4Addr))
 			gomega.Expect(nlMock.AssertCalled(ginkgo.GinkgoT(), "AddrAdd", nlLinkMock,
 				egressip.GetNetlinkAddress(net.ParseIP(ipV4Addr), bridgeLinkIndex))).Should(gomega.BeTrue())
 			gomega.Expect(nlMock.AssertCalled(ginkgo.GinkgoT(), "AddrDel", nlLinkMock,
@@ -290,9 +301,11 @@ var _ = ginkgo.Describe("Gateway EgressIP", func() {
 			eipUnassigned3 := getEIPNotAssignedToNode(mark3, ipV4Addr3)
 			err := addrMgr.SyncEgressIP([]interface{}{eipAssigned1, eipAssigned2, eipUnassigned3})
 			gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "should process valid EgressIPs")
-			node, err := addrMgr.nodeLister.Get(nodeName)
-			gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "node should be present within kapi")
-			gomega.Expect(parseEIPsFromAnnotation(node)).Should(gomega.ConsistOf(ipV4Addr, ipV4Addr2))
+			gomega.Eventually(func() []string {
+				node, err := addrMgr.nodeLister.Get(nodeName)
+				gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "node should be present within kapi")
+				return parseEIPsFromAnnotation(node)
+			}).Should(gomega.ConsistOf(ipV4Addr, ipV4Addr2))
 			gomega.Expect(nlMock.AssertCalled(ginkgo.GinkgoT(), "AddrAdd", nlLinkMock,
 				egressip.GetNetlinkAddress(net.ParseIP(ipV4Addr), bridgeLinkIndex))).Should(gomega.BeTrue())
 			gomega.Expect(nlMock.AssertCalled(ginkgo.GinkgoT(), "AddrAdd", nlLinkMock,
@@ -374,9 +387,11 @@ var _ = ginkgo.Describe("Gateway EgressIP", func() {
 
 			// Verify cleanup: secondary IP removed from cache, annotation, and bridge
 			gomega.Expect(addrMgr.cache.IsIPPresent(net.ParseIP(secondaryIP))).Should(gomega.BeFalse(), "secondary IP should be removed from cache")
-			node, err = addrMgr.nodeLister.Get(nodeName)
-			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
-			gomega.Expect(parseEIPsFromAnnotation(node)).Should(gomega.ConsistOf(ipV4Addr), "only valid OVN IP should be in annotation")
+			gomega.Eventually(func() []string {
+				node, err := addrMgr.nodeLister.Get(nodeName)
+				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+				return parseEIPsFromAnnotation(node)
+			}).Should(gomega.ConsistOf(ipV4Addr), "only valid OVN IP should be in annotation")
 			gomega.Expect(nlMock.AssertCalled(ginkgo.GinkgoT(), "AddrDel", nlLinkMock,
 				egressip.GetNetlinkAddress(net.ParseIP(secondaryIP), bridgeLinkIndex))).Should(gomega.BeTrue(), "should delete secondary IP from bridge")
 			gomega.Expect(nlMock.AssertCalled(ginkgo.GinkgoT(), "AddrAdd", nlLinkMock,
@@ -411,8 +426,17 @@ func initBridgeEIPAddrManagerWithHostCIDRs(nodeName, bridgeName string, bridgeEI
 	gomega.Expect(watchFactory.Start()).Should(gomega.Succeed(), "watch factory should start")
 	gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "watch factory creation must succeed")
 	linkManager := linkmanager.NewController(nodeName, true, true, nil)
-	return NewBridgeEIPAddrManager(nodeName, bridgeName, linkManager, &kube.Kube{KClient: client}, watchFactory.EgressIPInformer(), watchFactory.NodeCoreInformer()),
-		watchFactory.Shutdown
+	addrMgr := NewBridgeEIPAddrManager(nodeName, bridgeName, linkManager, &kube.Kube{KClient: client}, watchFactory.EgressIPInformer(), watchFactory.NodeCoreInformer())
+	initialAnnotIPs, err := util.ParseNodeBridgeEgressIPsAnnotation(node)
+	if err != nil {
+		if util.IsAnnotationNotSetError(err) {
+			initialAnnotIPs = make([]string, 0)
+		} else {
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "bridge EgressIP annotation should be parseable")
+		}
+	}
+	addrMgr.annotationIPs = sets.New[string](initialAnnotIPs...)
+	return addrMgr, watchFactory.Shutdown
 }
 
 func getEIPAssignedToNode(nodeName, mark, assignedIP string) *egressipv1.EgressIP {


### PR DESCRIPTION
## Summary

Backport of upstream [ovn-kubernetes/ovn-kubernetes#5951](https://github.com/ovn-kubernetes/ovn-kubernetes/pull/5951) to release-4.20.

Cherry-picked commits:
- `0e44890df` — EgressIP: Fix crash from mutating node informer object
- `b95fc8081` — Fixes gateway egress IP node update logic

## Problem

`addIPToAnnotation` and `deleteIPsFromAnnotation` in `gateway_egressip.go` read the node annotation from the informer cache and directly mutate the cached node object. With many EgressIPs (customer has 270), the rapid read-modify-write calls during `SyncEgressIP` overwrite each other due to stale informer reads. The annotation ends up tracking only ~7% of assigned IPs, preventing `SyncEgressIP` from cleaning up stale IPs on br-ex after failover. This causes duplicate IPs across nodes and service outages.

## Fix

1. Deep-copy the node object before mutation (stops corrupting the informer cache)
2. Replace informer reads with a local `annotationIPs` cache initialized at startup, eliminating the stale-read race

## Test plan

- [ ] Existing EgressIP unit tests pass
- [ ] CI green
- [ ] Verified fix is in 4.21+ and working

Fixes: https://redhat.atlassian.net/browse/OCPBUGS-74711

🤖 Generated with [Claude Code](https://claude.com/claude-code)