### PR TITLE
OCPBUGS-79408: Revert upstream #6429 and #6467 — bisect ovnCPU-nbdb regression

### DIFF
--- a/go-controller/pkg/controllermanager/controller_manager.go
+++ b/go-controller/pkg/controllermanager/controller_manager.go
@@ -477,8 +477,7 @@ func (cm *ControllerManager) Start(ctx context.Context) error {
 
 	if config.OVNKubernetesFeature.EnableEgressIP {
 		cm.eIPController = ovn.NewEIPController(cm.nbClient, cm.kube, cm.watchFactory, cm.recorder, cm.portCache, cm.networkManager.Interface(),
-			addressset.NewOvnAddressSetFactory(cm.nbClient, config.IPv4Mode, config.IPv6Mode), cm.addressSetManager,
-			config.IPv4Mode, config.IPv6Mode, zone, ovntypes.DefaultNetworkControllerName)
+			addressset.NewOvnAddressSetFactory(cm.nbClient, config.IPv4Mode, config.IPv6Mode), config.IPv4Mode, config.IPv6Mode, zone, ovntypes.DefaultNetworkControllerName)
 		// FIXME(martinkennelly): remove when EIP controller is fully extracted from from DNC and started here. Ensure SyncLocalNodeZonesCache is re-enabled in EIP controller.
 		if err = cm.eIPController.SyncLocalNodeZonesCache(); err != nil {
 			klog.Warningf("Failed to sync EgressIP controllers local node node cache: %v", err)

--- a/go-controller/pkg/libovsdb/ops/db_object_types.go
+++ b/go-controller/pkg/libovsdb/ops/db_object_types.go
@@ -35,7 +35,6 @@ const (
 	HybridNodeRouteOwnerType    ownerType = "HybridNodeRoute"
 	EgressIPOwnerType           ownerType = "EgressIP"
 	EgressServiceOwnerType      ownerType = "EgressService"
-	ClusterNodeIPsOwnerType     ownerType = "ClusterNodeIPs"
 	MulticastNamespaceOwnerType ownerType = "MulticastNS"
 	MulticastClusterOwnerType   ownerType = "MulticastCluster"
 	NetpolNodeOwnerType         ownerType = "NetpolNode"
@@ -142,12 +141,6 @@ var AddressSetEgressIP = newObjectIDsType(addressSet, EgressIPOwnerType, []Exter
 	ObjectNameKey,
 	IPFamilyKey,
 	NetworkKey,
-})
-
-var AddressSetClusterNodeIPs = newObjectIDsType(addressSet, ClusterNodeIPsOwnerType, []ExternalIDKey{
-	// cluster-wide address set name
-	ObjectNameKey,
-	IPFamilyKey,
 })
 
 var AddressSetEgressService = newObjectIDsType(addressSet, EgressServiceOwnerType, []ExternalIDKey{

--- a/go-controller/pkg/libovsdb/util/address_set.go
+++ b/go-controller/pkg/libovsdb/util/address_set.go
@@ -7,8 +7,6 @@ import (
 	"fmt"
 	"strings"
 
-	"k8s.io/apimachinery/pkg/util/sets"
-
 	libovsdbclient "github.com/ovn-kubernetes/libovsdb/client"
 	"github.com/ovn-kubernetes/libovsdb/ovsdb"
 
@@ -23,81 +21,6 @@ func DeleteAddrSetsWithoutACLRef(predicateIDs *libovsdbops.DbObjectIDs, nbClient
 
 func DeleteAddrSetsWithoutACLRefAnyController(dbOwnerType *libovsdbops.ObjectIDsType, nbClient libovsdbclient.Client) error {
 	return deleteAddrSetsWithoutACLRef(nil, dbOwnerType, nbClient)
-}
-
-// DeleteAddrSetsWithoutMatchRef deletes address sets related to predicateIDs
-// when they are not referenced from ACL, NAT, or logical router policy matches.
-func DeleteAddrSetsWithoutMatchRef(predicateIDs *libovsdbops.DbObjectIDs, nbClient libovsdbclient.Client) error {
-	addrSets, err := libovsdbops.FindAddressSetsWithPredicate(
-		nbClient,
-		libovsdbops.GetPredicate[*nbdb.AddressSet](predicateIDs, nil),
-	)
-	if err != nil {
-		return fmt.Errorf("failed to find address sets with predicate: %w", err)
-	}
-	if len(addrSets) == 0 {
-		return nil
-	}
-
-	addrSetNames := sets.New[string]()
-	for _, addrSet := range addrSets {
-		addrSetNames.Insert(addrSet.Name)
-	}
-	referencedNames, err := addressSetNamesReferencedInMatches(nbClient, addrSetNames)
-	if err != nil {
-		return err
-	}
-
-	staleAddressSets := make([]*nbdb.AddressSet, 0, len(addrSets))
-	for _, addrSet := range addrSets {
-		if !referencedNames.Has(addrSet.Name) {
-			staleAddressSets = append(staleAddressSets, addrSet)
-		}
-	}
-	if len(staleAddressSets) == 0 {
-		return nil
-	}
-	if err := libovsdbops.DeleteAddressSets(nbClient, staleAddressSets...); err != nil {
-		return fmt.Errorf("failed to delete address sets without match references: %w", err)
-	}
-	return nil
-}
-
-func addressSetNamesReferencedInMatches(nbClient libovsdbclient.Client, addressSetNames sets.Set[string]) (sets.Set[string], error) {
-	referencedNames := sets.New[string]()
-	recordReferences := func(match string) {
-		for addressSetName := range addressSetNames {
-			if strings.Contains(match, addressSetName) {
-				referencedNames.Insert(addressSetName)
-			}
-		}
-	}
-
-	_, err := libovsdbops.FindACLsWithPredicate(nbClient, func(acl *nbdb.ACL) bool {
-		recordReferences(acl.Match)
-		return false
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to find ACLs referencing address sets: %w", err)
-	}
-
-	_, err = libovsdbops.FindNATsWithPredicate(nbClient, func(nat *nbdb.NAT) bool {
-		recordReferences(nat.Match)
-		return false
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to find NATs referencing address sets: %w", err)
-	}
-
-	_, err = libovsdbops.FindLogicalRouterPoliciesWithPredicate(nbClient, func(policy *nbdb.LogicalRouterPolicy) bool {
-		recordReferences(policy.Match)
-		return false
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to find logical router policies referencing address sets: %w", err)
-	}
-
-	return referencedNames, nil
 }
 
 func deleteAddrSetsWithoutACLRef(predicateIDs *libovsdbops.DbObjectIDs, dbOwnerType *libovsdbops.ObjectIDsType, nbClient libovsdbclient.Client) error {

--- a/go-controller/pkg/node/linkmanager/link_network_manager.go
+++ b/go-controller/pkg/node/linkmanager/link_network_manager.go
@@ -181,15 +181,15 @@ func (c *Controller) syncLink(link netlink.Link) error {
 		}
 	}
 	linkName := link.Attrs().Name
-	wantedAddresses, found := c.store[linkName]
-	// we don't manage this link therefore we don't need to add any addresses
-	if !found {
-		return nil
-	}
 	// get all addresses associated with the link depending on which IP families we support
 	foundAddresses, err := util.GetFilteredInterfaceAddrs(link, c.ipv4Enabled, c.ipv6Enabled)
 	if err != nil {
 		return fmt.Errorf("failed to get address from link %q: %w", linkName, err)
+	}
+	wantedAddresses, found := c.store[linkName]
+	// we don't manage this link therefore we don't need to add any addresses
+	if !found {
+		return nil
 	}
 	// add addresses we want that are not found on the link
 	for _, addressWanted := range wantedAddresses {

--- a/go-controller/pkg/node/node_ip_handler_linux.go
+++ b/go-controller/pkg/node/node_ip_handler_linux.go
@@ -550,11 +550,18 @@ func (c *addressManager) sync() {
 	var addrs []netlink.Addr
 
 	if c.useNetlink {
-		var err error
-		addrs, err = util.GetNetLinkOps().AddrList(nil, getSupportedIPFamily())
+		links, err := netlink.LinkList()
 		if err != nil {
-			klog.Errorf("Failed to sync node addresses: unable to list all interface addresses: %v", err)
+			klog.Errorf("Failed sync due to being unable to list links: %v", err)
 			return
+		}
+		for _, link := range links {
+			foundAddrs, err := util.GetNetLinkOps().AddrList(link, getSupportedIPFamily())
+			if err != nil {
+				klog.Errorf("Failed sync due to being unable to list addresses for %q: %v", link.Attrs().Name, err)
+				return
+			}
+			addrs = append(addrs, foundAddrs...)
 		}
 	}
 

--- a/go-controller/pkg/ovn/addresssetmanager/addressset_manager.go
+++ b/go-controller/pkg/ovn/addresssetmanager/addressset_manager.go
@@ -70,13 +70,6 @@ type podSelectorAddressSet struct {
 	legacyNetpolMode bool
 }
 
-const (
-	ClusterNodeIPsAddrSetName                = "node-ips"
-	ClusterNodeIPsEgressIPBackRef            = "egressip"
-	ClusterNodeIPsEgressServiceBackRef       = "egressservice"
-	ClusterNodeIPsRouteAdvertisementsBackRef = "route-advertisements"
-)
-
 // AddressSetManager manages shared address sets with pod IPs based on provided pod and namespace selectors.
 // It shared across network controllers.
 type AddressSetManager struct {
@@ -112,9 +105,6 @@ type AddressSetManager struct {
 	hostNetworkNamespaceIPsPerNode map[string][]string
 	// local cache of address sets that select HostNetworkNamespace
 	hostNetworkSelectingAddrSets sets.Set[string]
-
-	clusterNodeIPsLock     sync.RWMutex
-	clusterNodeIPsBackRefs sets.Set[string]
 }
 
 func NewAddressSetManager(podInformer coreinformers.PodInformer, namespaceInformer coreinformers.NamespaceInformer,
@@ -132,7 +122,6 @@ func NewAddressSetManager(podInformer coreinformers.PodInformer, namespaceInform
 		getNetworkNameForNADKey:        getNetworkNameForNADKey,
 		hostNetworkSelectingAddrSets:   sets.New[string](),
 		hostNetworkNamespaceIPsPerNode: make(map[string][]string),
-		clusterNodeIPsBackRefs:         sets.New[string](),
 	}
 	podCfg := &controller.ControllerConfig[corev1.Pod]{
 		RateLimiter:    workqueue.DefaultTypedControllerRateLimiter[string](),
@@ -204,79 +193,6 @@ func (m *AddressSetManager) initialSync() error {
 		}
 	}
 	return libovsdbutil.DeleteAddrSetsWithoutACLRefAnyController(libovsdbops.AddressSetPodSelector, m.nbClient)
-}
-
-// getClusterNodeIPsAddrSetDbIDs returns the DB IDs for the shared cluster node IP address set.
-func getClusterNodeIPsAddrSetDbIDs() *libovsdbops.DbObjectIDs {
-	return libovsdbops.NewDbObjectIDs(libovsdbops.AddressSetClusterNodeIPs, ovntypes.DefaultNetworkControllerName,
-		map[libovsdbops.ExternalIDKey]string{
-			libovsdbops.ObjectNameKey: ClusterNodeIPsAddrSetName,
-		})
-}
-
-// EnsureClusterNodeIPsAddressSet registers a controller-lifetime user of the
-// shared cluster node IP address set and returns its DB IDs. The address set is
-// populated from node k8s.ovn.org/host-cidrs annotations through
-// util.GetNodeAddresses. Users do not deregister because each backref
-// represents a feature controller, not an individual object.
-func (m *AddressSetManager) EnsureClusterNodeIPsAddressSet(backRef string) (*libovsdbops.DbObjectIDs, error) {
-	dbIDs := getClusterNodeIPsAddrSetDbIDs()
-	if backRef == "" {
-		return nil, fmt.Errorf("cluster node IP address set backref is empty")
-	}
-	m.clusterNodeIPsLock.Lock()
-	defer m.clusterNodeIPsLock.Unlock()
-
-	if m.clusterNodeIPsBackRefs.Has(backRef) {
-		return dbIDs, nil
-	}
-
-	m.clusterNodeIPsBackRefs.Insert(backRef)
-	if err := m.syncClusterNodeIPsAddressSetLocked(); err != nil {
-		m.clusterNodeIPsBackRefs.Delete(backRef)
-		return nil, err
-	}
-	return dbIDs, nil
-}
-
-func (m *AddressSetManager) clusterNodeIPsAddressSetInUse() bool {
-	m.clusterNodeIPsLock.RLock()
-	defer m.clusterNodeIPsLock.RUnlock()
-	return m.clusterNodeIPsBackRefs.Len() > 0
-}
-
-func (m *AddressSetManager) syncClusterNodeIPsAddressSet() error {
-	m.clusterNodeIPsLock.Lock()
-	defer m.clusterNodeIPsLock.Unlock()
-
-	return m.syncClusterNodeIPsAddressSetLocked()
-}
-
-func (m *AddressSetManager) syncClusterNodeIPsAddressSetLocked() error {
-	if m.clusterNodeIPsBackRefs.Len() == 0 {
-		return nil
-	}
-
-	as, err := addressset.NewOvnAddressSetFactory(m.nbClient, config.IPv4Mode, config.IPv6Mode).EnsureAddressSet(getClusterNodeIPsAddrSetDbIDs())
-	if err != nil {
-		return fmt.Errorf("cannot ensure address set %s exists: %w", ClusterNodeIPsAddrSetName, err)
-	}
-
-	nodes, err := m.nodeLister.List(labels.Everything())
-	if err != nil {
-		return fmt.Errorf("failed to list nodes: %w", err)
-	}
-	v4NodeAddrs, v6NodeAddrs, err := util.GetNodeAddresses(config.IPv4Mode, config.IPv6Mode, nodes...)
-	if err != nil {
-		return fmt.Errorf("failed to get node addresses: %w", err)
-	}
-	allAddresses := make([]net.IP, 0, len(v4NodeAddrs)+len(v6NodeAddrs))
-	allAddresses = append(allAddresses, v4NodeAddrs...)
-	allAddresses = append(allAddresses, v6NodeAddrs...)
-	if err := as.SetAddresses(util.StringSlice(allAddresses)); err != nil {
-		return fmt.Errorf("failed to set node IP address set addresses: %w", err)
-	}
-	return nil
 }
 
 // EnsureAddressSet returns address set for requested (podSelector, namespaceSelector, namespace, nodeSelector).
@@ -595,9 +511,6 @@ func (m *AddressSetManager) nodeNeedUpdate(old, new *corev1.Node) bool {
 		// if node labels change, we need to reconcile address sets that use a node selector
 		return true
 	}
-	if util.NodeHostCIDRsAnnotationChanged(old, new) && m.clusterNodeIPsAddressSetInUse() {
-		return true
-	}
 	// only check annotations that are used in getHostNamespaceAddressesForNode
 	if util.NodeSubnetAnnotationChangedForNetwork(old, new, ovntypes.DefaultNetworkName) || util.NodeIDAnnotationChanged(old, new) ||
 		old.Annotations[util.OvnNodeIfAddr] != new.Annotations[util.OvnNodeIfAddr] {
@@ -614,7 +527,6 @@ func (m *AddressSetManager) reconcileNode(nodeKey string) error {
 	// update host network IPs first to have fresh info for addr set reconcile
 	// don't return error immediately to let other changes like node selector be propagated
 	hostNetworkErr := m.updateHostNetworkIPs(nodeKey)
-	clusterNodeIPsErr := m.syncClusterNodeIPsAddressSet()
 
 	// find address sets that could be affected by this node event
 	// Get all existing keys, then lock address sets per key and check if they are affected.
@@ -648,11 +560,10 @@ func (m *AddressSetManager) reconcileNode(nodeKey string) error {
 			return nil
 		})
 		if err != nil {
-			return utilerrors.Join(hostNetworkErr, clusterNodeIPsErr,
-				fmt.Errorf("failed to reconcile address set %s for node %s: %v", addrSetKey, nodeKey, err))
+			return fmt.Errorf("failed to reconcile address set %s for node %s: %v", addrSetKey, nodeKey, err)
 		}
 	}
-	return utilerrors.Join(hostNetworkErr, clusterNodeIPsErr)
+	return hostNetworkErr
 }
 
 func (m *AddressSetManager) updateHostNetworkIPs(nodeName string) error {

--- a/go-controller/pkg/ovn/addresssetmanager/addressset_manager_test.go
+++ b/go-controller/pkg/ovn/addresssetmanager/addressset_manager_test.go
@@ -196,49 +196,6 @@ var _ = ginkgo.Describe("OVN podSelectorAddressSet", func() {
 		// address set will not be created
 		gomega.Consistently(addressSetManager.nbClient, 100*time.Millisecond, 20*time.Millisecond).Should(libovsdbtest.HaveData([]libovsdbtest.TestData{}))
 	})
-
-	ginkgo.It("reconciles the registered cluster node IP address set on node events", func() {
-		node1 := corev1.Node{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:        "node1",
-				Annotations: map[string]string{util.OVNNodeHostCIDRs: `["10.0.0.1/24"]`},
-			},
-		}
-		node2 := corev1.Node{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:        "node2",
-				Annotations: map[string]string{util.OVNNodeHostCIDRs: `["10.0.0.2/24"]`},
-			},
-		}
-		startAddrSetManagerWithNodes(initialDB, nil, nil, []corev1.Node{node1, node2})
-
-		addressSetFactory := addressset.NewOvnAddressSetFactory(libovsdbNBClient, config.IPv4Mode, config.IPv6Mode)
-		expectNodeIPs := func(expected ...string) {
-			gomega.Eventually(func() []string {
-				as, err := addressSetFactory.GetAddressSet(getClusterNodeIPsAddrSetDbIDs())
-				if err != nil {
-					return nil
-				}
-				v4Addresses, v6Addresses := as.GetAddresses()
-				return append(v4Addresses, v6Addresses...)
-			}).Should(gomega.ConsistOf(expected))
-		}
-
-		_, err := addressSetManager.EnsureClusterNodeIPsAddressSet(ClusterNodeIPsRouteAdvertisementsBackRef)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		expectNodeIPs("10.0.0.1", "10.0.0.2")
-
-		node2Copy := node2.DeepCopy()
-		node2Copy.Annotations[util.OVNNodeHostCIDRs] = `["10.0.0.2/24","10.0.0.20/24"]`
-		_, err = clientSet.KubeClient.CoreV1().Nodes().Update(context.TODO(), node2Copy, metav1.UpdateOptions{})
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		expectNodeIPs("10.0.0.1", "10.0.0.2", "10.0.0.20")
-
-		err = clientSet.KubeClient.CoreV1().Nodes().Delete(context.TODO(), node1.Name, metav1.DeleteOptions{})
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		expectNodeIPs("10.0.0.2", "10.0.0.20")
-	})
-
 	ginkgo.It("creates one address set for multiple users with the same selector", func() {
 		namespace1 := *testing.NewNamespace(namespaceName1)
 		podSelector := &metav1.LabelSelector{

--- a/go-controller/pkg/ovn/base_network_controller_user_defined.go
+++ b/go-controller/pkg/ovn/base_network_controller_user_defined.go
@@ -33,7 +33,6 @@ import (
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/metrics"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/nbdb"
 	addressset "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/address_set"
-	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/addresssetmanager"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/controller/udnenabledsvc"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/persistentips"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
@@ -940,12 +939,10 @@ func (bsnc *BaseUserDefinedNetworkController) buildUDNEgressSNAT(localPodSubnets
 		// For advertised networks, we need to SNAT any traffic leaving the
 		// pods from these networks towards the node IPs in the cluster. In
 		// order to do such a conditional SNAT, we need an address set that
-		// contains the node IPs in the cluster. Re-use the shared cluster node
-		// IP address set owned by the address set manager.
-		nodeIPsASIDs, err := bsnc.addressSetManager.EnsureClusterNodeIPsAddressSet(addresssetmanager.ClusterNodeIPsRouteAdvertisementsBackRef)
-		if err != nil {
-			return nil, fmt.Errorf("failed to ensure cluster node IP address set for route advertisements: %w", err)
-		}
+		// contains the node IPs in the cluster. Given that egressIP feature
+		// already has an address set containing these nodeIPs owned by the
+		// default network controller, let's re-use it.
+		nodeIPsASIDs := getEgressIPAddrSetDbIDs(NodeIPAddrSetName, types.DefaultNetworkName, types.DefaultNetworkControllerName)
 		nodeIPsAS, err = bsnc.addressSetFactory.GetAddressSet(nodeIPsASIDs)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get address set with IDs %v: %w", nodeIPsASIDs, err)

--- a/go-controller/pkg/ovn/default_network_controller.go
+++ b/go-controller/pkg/ovn/default_network_controller.go
@@ -786,9 +786,6 @@ func (oc *DefaultNetworkController) run(_ context.Context) error {
 			return err
 		}
 	}
-	if err := cleanupDeprecatedClusterNodeIPsAddressSet(oc.nbClient); err != nil {
-		return err
-	}
 
 	if config.OVNKubernetesFeature.EnableMultiExternalGateway {
 		if err = oc.apbExternalRouteController.Run(oc.wg, 1); err != nil {

--- a/go-controller/pkg/ovn/egressip.go
+++ b/go-controller/pkg/ovn/egressip.go
@@ -48,7 +48,6 @@ import (
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/nbdb"
 	networkmanager "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/networkmanager"
 	addressset "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/address_set"
-	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/addresssetmanager"
 	egresssvc "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/controller/egressservice"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/controller/udnenabledsvc"
 	ovnretry "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/retry"
@@ -64,7 +63,7 @@ type egressIPNoReroutePolicyName string
 type egressIPQoSRuleName string
 
 const (
-	NodeIPAddrSetName             egressIPAddrSetName = addresssetmanager.ClusterNodeIPsAddrSetName
+	NodeIPAddrSetName             egressIPAddrSetName = "node-ips"
 	EgressIPServedPodsAddrSetName egressIPAddrSetName = "egressip-served-pods"
 	// the possible values for LRP DB objects for EIPs
 	IPFamilyValueV4         egressIPFamilyValue         = "ip4"
@@ -171,17 +170,6 @@ func getEgressIPNATDbIDs(eIPName, podNamespace, podName string, ipFamily egressI
 	})
 }
 
-func getDeprecatedEgressIPClusterNodeIPsAddrSetDbIDs() *libovsdbops.DbObjectIDs {
-	return libovsdbops.NewDbObjectIDs(libovsdbops.AddressSetEgressIP, types.DefaultNetworkControllerName,
-		map[libovsdbops.ExternalIDKey]string{
-			libovsdbops.ObjectNameKey: addresssetmanager.ClusterNodeIPsAddrSetName,
-		})
-}
-
-func cleanupDeprecatedClusterNodeIPsAddressSet(nbClient libovsdbclient.Client) error {
-	return libovsdbutil.DeleteAddrSetsWithoutMatchRef(getDeprecatedEgressIPClusterNodeIPsAddrSetDbIDs(), nbClient)
-}
-
 // EgressIPController configures OVN to support EgressIP
 type EgressIPController struct {
 	// libovsdb northbound client interface
@@ -219,8 +207,6 @@ type EgressIPController struct {
 	retryEgressIPPods *ovnretry.RetryFramework
 	// An address set factory that creates address sets
 	addressSetFactory addressset.AddressSetFactory
-	// Shared address set manager that owns cluster-wide node IP address sets.
-	addressSetManager *addresssetmanager.AddressSetManager
 	// Northbound database zone name to which this Controller is connected to - aka local zone
 	zone string
 	v4   bool
@@ -237,7 +223,6 @@ func NewEIPController(
 	portCache *PortCache,
 	networkmanager networkmanager.Interface,
 	addressSetFactor addressset.AddressSetFactory,
-	addressSetManager *addresssetmanager.AddressSetManager,
 	v4 bool,
 	v6 bool,
 	zone string,
@@ -256,7 +241,6 @@ func NewEIPController(
 		controllerName:    controllerName,
 		networkManager:    networkmanager,
 		addressSetFactory: addressSetFactor,
-		addressSetManager: addressSetManager,
 		zone:              zone,
 		v4:                v4,
 		v6:                v6,
@@ -2420,11 +2404,7 @@ func (e *EgressIPController) initClusterEgressPolicies(_ []interface{}) error {
 		klog.Warningf("Failed to get a local zone node name: %v", err)
 	}
 	subnets := util.GetAllClusterSubnetsFromEntries(defaultNetInfo.Subnets())
-	clusterNodeIPsAddrSetDbIDs, err := e.addressSetManager.EnsureClusterNodeIPsAddressSet(addresssetmanager.ClusterNodeIPsEgressIPBackRef)
-	if err != nil {
-		return fmt.Errorf("failed to ensure cluster node IP address set for EgressIP: %w", err)
-	}
-	if err := InitClusterEgressPolicies(e.nbClient, e.addressSetFactory, defaultNetInfo, subnets, e.controllerName, defaultNetInfo.GetNetworkScopedClusterRouterName(), clusterNodeIPsAddrSetDbIDs); err != nil {
+	if err := InitClusterEgressPolicies(e.nbClient, e.addressSetFactory, defaultNetInfo, subnets, e.controllerName, defaultNetInfo.GetNetworkScopedClusterRouterName()); err != nil {
 		return fmt.Errorf("failed to initialize networks cluster logical router egress policies for the default network: %v", err)
 	}
 
@@ -2440,7 +2420,7 @@ func (e *EgressIPController) initClusterEgressPolicies(_ []interface{}) error {
 		if err != nil {
 			return err
 		}
-		if err = InitClusterEgressPolicies(e.nbClient, e.addressSetFactory, network, subnets, e.controllerName, routerName, clusterNodeIPsAddrSetDbIDs); err != nil {
+		if err = InitClusterEgressPolicies(e.nbClient, e.addressSetFactory, network, subnets, e.controllerName, routerName); err != nil {
 			return fmt.Errorf("failed to initialize networks cluster logical router egress policies for network %s: %v", network.GetNetworkName(), err)
 		}
 		return nil
@@ -2450,7 +2430,7 @@ func (e *EgressIPController) initClusterEgressPolicies(_ []interface{}) error {
 // InitClusterEgressPolicies creates the global no reroute policies and address-sets
 // required by the egressIP and egressServices features.
 func InitClusterEgressPolicies(nbClient libovsdbclient.Client, addressSetFactory addressset.AddressSetFactory, ni util.NetInfo,
-	clusterSubnets []*net.IPNet, controllerName, routerName string, clusterNodeIPsAddrSetDbIDs *libovsdbops.DbObjectIDs) error {
+	clusterSubnets []*net.IPNet, controllerName, routerName string) error {
 	if len(clusterSubnets) == 0 {
 		return nil
 	}
@@ -2495,15 +2475,13 @@ func InitClusterEgressPolicies(nbClient libovsdbclient.Client, addressSetFactory
 
 	// ensure the address-set for storing nodeIPs exists
 	// The address set with controller name 'default' is shared with all networks
-	if clusterNodeIPsAddrSetDbIDs == nil {
-		return fmt.Errorf("cluster node IP address set DB IDs are required")
-	}
-	if _, err = addressSetFactory.EnsureAddressSet(clusterNodeIPsAddrSetDbIDs); err != nil {
+	dbIDs := getEgressIPAddrSetDbIDs(NodeIPAddrSetName, types.DefaultNetworkName, types.DefaultNetworkControllerName)
+	if _, err = addressSetFactory.EnsureAddressSet(dbIDs); err != nil {
 		return fmt.Errorf("cannot ensure that addressSet %s exists %v", NodeIPAddrSetName, err)
 	}
 
 	// ensure the address-set for storing egressIP pods exists
-	dbIDs := getEgressIPAddrSetDbIDs(EgressIPServedPodsAddrSetName, ni.GetNetworkName(), controllerName)
+	dbIDs = getEgressIPAddrSetDbIDs(EgressIPServedPodsAddrSetName, ni.GetNetworkName(), controllerName)
 	_, err = addressSetFactory.EnsureAddressSet(dbIDs)
 	if err != nil {
 		return fmt.Errorf("cannot ensure that addressSet for egressIP pods %s exists for network %s: %v", EgressIPServedPodsAddrSetName, ni.GetNetworkName(), err)
@@ -2943,21 +2921,13 @@ func (e *EgressIPController) addExternalGWPodSNATOps(ni util.NetInfo, ops []ovsd
 				return nil, err
 			}
 
-			isNetworkAdvertised := util.IsPodNetworkAdvertisedAtNode(ni, pod.Spec.NodeName)
-			var clusterNodeIPsAddrSetDbIDs *libovsdbops.DbObjectIDs
-			if isNetworkAdvertised && !util.IsNoOverlaySNATExemptionNeeded(ni) {
-				clusterNodeIPsAddrSetDbIDs, err = e.addressSetManager.EnsureClusterNodeIPsAddressSet(addresssetmanager.ClusterNodeIPsEgressIPBackRef)
-				if err != nil {
-					return nil, fmt.Errorf("failed to ensure cluster node IP address set for EgressIP: %w", err)
-				}
-			}
 			// Handle each pod IP individually since each IP family needs its own SNAT match
 			for _, podIP := range podIPs {
 				ipFamily := utilnet.IPv4
 				if utilnet.IsIPv6CIDR(podIP) {
 					ipFamily = utilnet.IPv6
 				}
-				snatMatch, err := GetNetworkScopedClusterSubnetSNATMatch(e.nbClient, ni, pod.Spec.NodeName, isNetworkAdvertised, ipFamily, clusterNodeIPsAddrSetDbIDs)
+				snatMatch, err := GetNetworkScopedClusterSubnetSNATMatch(e.nbClient, ni, pod.Spec.NodeName, util.IsPodNetworkAdvertisedAtNode(ni, pod.Spec.NodeName), ipFamily)
 				if err != nil {
 					return nil, fmt.Errorf("failed to get SNAT match for node %s for network %s: %w", pod.Spec.NodeName, ni.GetNetworkName(), err)
 				}
@@ -3576,15 +3546,11 @@ func (e *EgressIPController) ensureRouterPoliciesForNetwork(ni util.NetInfo, nod
 	if err != nil {
 		return err
 	}
-	clusterNodeIPsAddrSetDbIDs, err := e.addressSetManager.EnsureClusterNodeIPsAddressSet(addresssetmanager.ClusterNodeIPsEgressIPBackRef)
-	if err != nil {
-		return fmt.Errorf("failed to ensure cluster node IP address set for EgressIP: %w", err)
-	}
-	if err := InitClusterEgressPolicies(e.nbClient, e.addressSetFactory, ni, subnets, e.controllerName, routerName, clusterNodeIPsAddrSetDbIDs); err != nil {
+	if err := InitClusterEgressPolicies(e.nbClient, e.addressSetFactory, ni, subnets, e.controllerName, routerName); err != nil {
 		return fmt.Errorf("failed to initialize networks cluster logical router egress policies for the default network: %v", err)
 	}
 	err = ensureDefaultNoRerouteNodePolicies(e.nbClient, e.addressSetFactory, ni.GetNetworkName(), routerName,
-		e.controllerName, listers.NewNodeLister(e.watchFactory.NodeInformer().GetIndexer()), e.v4, e.v6, clusterNodeIPsAddrSetDbIDs)
+		e.controllerName, listers.NewNodeLister(e.watchFactory.NodeInformer().GetIndexer()), e.v4, e.v6)
 	if err != nil {
 		return fmt.Errorf("failed to ensure no reroute node policies for network %s: %v", ni.GetNetworkName(), err)
 	}
@@ -3857,14 +3823,10 @@ func (e *EgressIPController) ensureDefaultNoRerouteNodePolicies() error {
 	e.nodeUpdateMutex.Lock()
 	defer e.nodeUpdateMutex.Unlock()
 	nodeLister := listers.NewNodeLister(e.watchFactory.NodeInformer().GetIndexer())
-	clusterNodeIPsAddrSetDbIDs, err := e.addressSetManager.EnsureClusterNodeIPsAddressSet(addresssetmanager.ClusterNodeIPsEgressIPBackRef)
-	if err != nil {
-		return fmt.Errorf("failed to ensure cluster node IP address set for EgressIP: %w", err)
-	}
 	// ensure default network is processed
 	defaultNetInfo := e.networkManager.GetNetwork(types.DefaultNetworkName)
-	err = ensureDefaultNoRerouteNodePolicies(e.nbClient, e.addressSetFactory, defaultNetInfo.GetNetworkName(), defaultNetInfo.GetNetworkScopedClusterRouterName(),
-		e.controllerName, nodeLister, e.v4, e.v6, clusterNodeIPsAddrSetDbIDs)
+	err := ensureDefaultNoRerouteNodePolicies(e.nbClient, e.addressSetFactory, defaultNetInfo.GetNetworkName(), defaultNetInfo.GetNetworkScopedClusterRouterName(),
+		e.controllerName, nodeLister, e.v4, e.v6)
 	if err != nil {
 		return fmt.Errorf("failed to ensure default no reroute policies for nodes for default network: %v", err)
 	}
@@ -3880,7 +3842,7 @@ func (e *EgressIPController) ensureDefaultNoRerouteNodePolicies() error {
 			return err
 		}
 		err = ensureDefaultNoRerouteNodePolicies(e.nbClient, e.addressSetFactory, network.GetNetworkName(), routerName,
-			e.controllerName, nodeLister, e.v4, e.v6, clusterNodeIPsAddrSetDbIDs)
+			e.controllerName, nodeLister, e.v4, e.v6)
 		if err != nil {
 			return fmt.Errorf("failed to ensure default no reroute policies for nodes for network %s: %v", network.GetNetworkName(), err)
 		}
@@ -3895,10 +3857,11 @@ func (e *EgressIPController) ensureDefaultNoRerouteNodePolicies() error {
 // i.e: ensuring that an egress pod can still communicate with a hostNetwork pod / service backed by hostNetwork pods
 // without using egressIPs.
 // sample: 101 ip4.src == $a12749576804119081385 && ip4.dst == $a11079093880111560446 allow pkt_mark=1008
-// All node addresses are listed here to decide which IP family policies are required.
+// All the cluster node's addresses are considered. This is to avoid race conditions after a VIP moves from one node
+// to another where we might process events out of order. For the same reason this function needs to be called under
+// lock.
 func ensureDefaultNoRerouteNodePolicies(nbClient libovsdbclient.Client, addressSetFactory addressset.AddressSetFactory,
-	network, router, controller string, nodeLister listers.NodeLister, v4, v6 bool,
-	clusterNodeIPsAddrSetDbIDs *libovsdbops.DbObjectIDs) error {
+	network, router, controller string, nodeLister listers.NodeLister, v4, v6 bool) error {
 	nodes, err := nodeLister.List(labels.Everything())
 	if err != nil {
 		return fmt.Errorf("failed to list nodes: %v", err)
@@ -3907,19 +3870,24 @@ func ensureDefaultNoRerouteNodePolicies(nbClient libovsdbclient.Client, addressS
 	if err != nil {
 		return fmt.Errorf("failed to get node addresses: %v", err)
 	}
+	allAddresses := make([]net.IP, 0, len(v4NodeAddrs)+len(v6NodeAddrs))
+	allAddresses = append(allAddresses, v4NodeAddrs...)
+	allAddresses = append(allAddresses, v6NodeAddrs...)
 
+	var as addressset.AddressSet
 	// all networks reference the same node IP address set
-	if clusterNodeIPsAddrSetDbIDs == nil {
-		return fmt.Errorf("cluster node IP address set DB IDs are required")
-	}
-	as, err := addressSetFactory.GetAddressSet(clusterNodeIPsAddrSetDbIDs)
-	if err != nil {
+	dbIDs := getEgressIPAddrSetDbIDs(NodeIPAddrSetName, types.DefaultNetworkName, types.DefaultNetworkControllerName)
+	if as, err = addressSetFactory.GetAddressSet(dbIDs); err != nil {
 		return fmt.Errorf("cannot ensure that addressSet %s exists %v", NodeIPAddrSetName, err)
+	}
+
+	if err = as.SetAddresses(util.StringSlice(allAddresses)); err != nil {
+		return fmt.Errorf("unable to set IPs to no re-route address set %s: %w", NodeIPAddrSetName, err)
 	}
 
 	ipv4ClusterNodeIPAS, ipv6ClusterNodeIPAS := as.GetASHashNames()
 	// fetch the egressIP pods address-set
-	dbIDs := getEgressIPAddrSetDbIDs(EgressIPServedPodsAddrSetName, network, controller)
+	dbIDs = getEgressIPAddrSetDbIDs(EgressIPServedPodsAddrSetName, network, controller)
 	if as, err = addressSetFactory.GetAddressSet(dbIDs); err != nil {
 		return fmt.Errorf("cannot ensure that addressSet %s exists %v", EgressIPServedPodsAddrSetName, err)
 	}

--- a/go-controller/pkg/ovn/egressip_test.go
+++ b/go-controller/pkg/ovn/egressip_test.go
@@ -27,7 +27,6 @@ import (
 	libovsdbops "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/libovsdb/ops"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/nbdb"
 	addressset "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/address_set"
-	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/addresssetmanager"
 	egresssvc "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/controller/egressservice"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/retry"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/syncmap"
@@ -93,98 +92,6 @@ type nodeInfo struct {
 }
 
 var egressPodLabel = map[string]string{"egress": "needed"}
-
-var _ = ginkgo.Describe("Deprecated cluster node IP address set cleanup", func() {
-	var fakeOvn *FakeOVN
-
-	ginkgo.AfterEach(func() {
-		fakeOvn.shutdown()
-	})
-
-	ginkgo.It("cleans up unreferenced deprecated cluster node IP address sets", func() {
-		oldDefaultV4AS, oldDefaultV6AS := addressset.GetTestDbAddrSets(
-			getDeprecatedEgressIPClusterNodeIPsAddrSetDbIDsForNetwork(types.DefaultNetworkName),
-			[]string{"10.0.0.1", "fd00::1"},
-		)
-		oldBlueV4AS, oldBlueV6AS := addressset.GetTestDbAddrSets(
-			getDeprecatedEgressIPClusterNodeIPsAddrSetDbIDsForNetwork("blue"),
-			[]string{"10.0.0.2", "fd00::2"},
-		)
-		fakeOvn = NewFakeOVN(false)
-		fakeOvn.startWithDBSetup(libovsdbtest.TestSetup{
-			NBData: []libovsdbtest.TestData{oldDefaultV4AS, oldDefaultV6AS, oldBlueV4AS, oldBlueV6AS},
-		})
-
-		gomega.Expect(cleanupDeprecatedClusterNodeIPsAddressSet(fakeOvn.nbClient)).To(gomega.Succeed())
-
-		gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveEmptyData())
-	})
-
-	ginkgo.It("keeps deprecated cluster node IP address sets while referenced by matches", func() {
-		oldDefaultV4AS, oldDefaultV6AS := addressset.GetTestDbAddrSets(
-			getDeprecatedEgressIPClusterNodeIPsAddrSetDbIDsForNetwork(types.DefaultNetworkName),
-			[]string{"10.0.0.1", "fd00::1"},
-		)
-		oldBlueV4AS, oldBlueV6AS := addressset.GetTestDbAddrSets(
-			getDeprecatedEgressIPClusterNodeIPsAddrSetDbIDsForNetwork("blue"),
-			[]string{"10.0.0.2", "fd00::2"},
-		)
-		nat := &nbdb.NAT{
-			UUID:       "nat-UUID",
-			Type:       nbdb.NATTypeSNAT,
-			LogicalIP:  "10.128.0.0/14",
-			ExternalIP: "172.18.0.2",
-			Match:      fmt.Sprintf("ip4.dst == $%s", oldBlueV4AS.Name),
-		}
-		lrp := &nbdb.LogicalRouterPolicy{
-			UUID:     "lrp-UUID",
-			Priority: types.DefaultNoRereoutePriority,
-			Action:   nbdb.LogicalRouterPolicyActionAllow,
-			Match:    fmt.Sprintf("ip6.dst == $%s", oldDefaultV6AS.Name),
-		}
-		acl := libovsdbops.BuildACL(
-			"acl",
-			nbdb.ACLDirectionFromLport,
-			types.DefaultAllowPriority,
-			fmt.Sprintf("ip4.src == $%s || ip6.src == $%s", oldDefaultV4AS.Name, oldBlueV6AS.Name),
-			nbdb.ACLActionAllow,
-			types.OvnACLLoggingMeter,
-			"",
-			false,
-			nil,
-			nil,
-			types.DefaultACLTier,
-		)
-		acl.UUID = "acl-UUID"
-		router := &nbdb.LogicalRouter{
-			UUID:     "router-UUID",
-			Name:     "router",
-			Nat:      []string{nat.UUID},
-			Policies: []string{lrp.UUID},
-		}
-		logicalSwitch := &nbdb.LogicalSwitch{
-			UUID: "switch-UUID",
-			ACLs: []string{acl.UUID},
-		}
-		expectedDB := []libovsdbtest.TestData{
-			oldDefaultV4AS,
-			oldDefaultV6AS,
-			oldBlueV4AS,
-			oldBlueV6AS,
-			nat,
-			lrp,
-			acl,
-			router,
-			logicalSwitch,
-		}
-		fakeOvn = NewFakeOVN(false)
-		fakeOvn.startWithDBSetup(libovsdbtest.TestSetup{NBData: expectedDB})
-
-		gomega.Expect(cleanupDeprecatedClusterNodeIPsAddressSet(fakeOvn.nbClient)).To(gomega.Succeed())
-
-		gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedDB))
-	})
-})
 
 var _ = ginkgo.Describe("OVN EgressIP Operations cluster default network", func() {
 	var (
@@ -478,7 +385,7 @@ var _ = ginkgo.Describe("OVN EgressIP Operations cluster default network", func(
 				},
 				&nbdb.LogicalRouterPolicy{
 					Priority:    types.DefaultNoRereoutePriority,
-					Match:       "(ip4.src == $a8519615025667110816 || ip4.src == $a13607449821398607916) && ip4.dst == $a1042611113178530741",
+					Match:       "(ip4.src == $a8519615025667110816 || ip4.src == $a13607449821398607916) && ip4.dst == $a712973235162149816",
 					Action:      nbdb.LogicalRouterPolicyActionAllow,
 					Options:     map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 					UUID:        "no-reroute-node-UUID",
@@ -690,7 +597,7 @@ var _ = ginkgo.Describe("OVN EgressIP Operations cluster default network", func(
 				},
 				&nbdb.LogicalRouterPolicy{
 					Priority:    types.DefaultNoRereoutePriority,
-					Match:       "(ip4.src == $a8519615025667110816 || ip4.src == $a13607449821398607916) && ip4.dst == $a1042611113178530741",
+					Match:       "(ip4.src == $a8519615025667110816 || ip4.src == $a13607449821398607916) && ip4.dst == $a712973235162149816",
 					Action:      nbdb.LogicalRouterPolicyActionAllow,
 					Options:     map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 					UUID:        "no-reroute-node-UUID",
@@ -950,7 +857,7 @@ var _ = ginkgo.Describe("OVN EgressIP Operations cluster default network", func(
 						},
 						&nbdb.LogicalRouterPolicy{
 							Priority:    types.DefaultNoRereoutePriority,
-							Match:       "(ip4.src == $a8519615025667110816 || ip4.src == $a13607449821398607916) && ip4.dst == $a1042611113178530741",
+							Match:       "(ip4.src == $a8519615025667110816 || ip4.src == $a13607449821398607916) && ip4.dst == $a712973235162149816",
 							Action:      nbdb.LogicalRouterPolicyActionAllow,
 							Options:     map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 							UUID:        "no-reroute-node-UUID",
@@ -1315,7 +1222,7 @@ var _ = ginkgo.Describe("OVN EgressIP Operations cluster default network", func(
 						},
 						&nbdb.LogicalRouterPolicy{
 							Priority:    types.DefaultNoRereoutePriority,
-							Match:       "(ip4.src == $a8519615025667110816 || ip4.src == $a13607449821398607916) && ip4.dst == $a1042611113178530741",
+							Match:       "(ip4.src == $a8519615025667110816 || ip4.src == $a13607449821398607916) && ip4.dst == $a712973235162149816",
 							Action:      nbdb.LogicalRouterPolicyActionAllow,
 							Options:     map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 							UUID:        "no-reroute-node-UUID",
@@ -1731,7 +1638,7 @@ var _ = ginkgo.Describe("OVN EgressIP Operations cluster default network", func(
 						},
 						&nbdb.LogicalRouterPolicy{
 							Priority:    types.DefaultNoRereoutePriority,
-							Match:       "(ip4.src == $a8519615025667110816 || ip4.src == $a13607449821398607916) && ip4.dst == $a1042611113178530741",
+							Match:       "(ip4.src == $a8519615025667110816 || ip4.src == $a13607449821398607916) && ip4.dst == $a712973235162149816",
 							Action:      nbdb.LogicalRouterPolicyActionAllow,
 							Options:     map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 							UUID:        "no-reroute-node-UUID",
@@ -2075,7 +1982,7 @@ var _ = ginkgo.Describe("OVN EgressIP Operations cluster default network", func(
 						},
 						&nbdb.LogicalRouterPolicy{
 							Priority:    types.DefaultNoRereoutePriority,
-							Match:       "(ip4.src == $a8519615025667110816 || ip4.src == $a13607449821398607916) && ip4.dst == $a1042611113178530741",
+							Match:       "(ip4.src == $a8519615025667110816 || ip4.src == $a13607449821398607916) && ip4.dst == $a712973235162149816",
 							Action:      nbdb.LogicalRouterPolicyActionAllow,
 							Options:     map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 							UUID:        "no-reroute-node-UUID",
@@ -2513,7 +2420,7 @@ var _ = ginkgo.Describe("OVN EgressIP Operations cluster default network", func(
 						},
 						&nbdb.LogicalRouterPolicy{
 							Priority:    types.DefaultNoRereoutePriority,
-							Match:       "(ip4.src == $a8519615025667110816 || ip4.src == $a13607449821398607916) && ip4.dst == $a1042611113178530741",
+							Match:       "(ip4.src == $a8519615025667110816 || ip4.src == $a13607449821398607916) && ip4.dst == $a712973235162149816",
 							Action:      nbdb.LogicalRouterPolicyActionAllow,
 							Options:     map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 							UUID:        "no-reroute-node-UUID",
@@ -2855,7 +2762,7 @@ var _ = ginkgo.Describe("OVN EgressIP Operations cluster default network", func(
 						primarySNAT,
 						&nbdb.LogicalRouterPolicy{
 							Priority:    types.DefaultNoRereoutePriority,
-							Match:       "(ip4.src == $a8519615025667110816 || ip4.src == $a13607449821398607916) && ip4.dst == $a1042611113178530741",
+							Match:       "(ip4.src == $a8519615025667110816 || ip4.src == $a13607449821398607916) && ip4.dst == $a712973235162149816",
 							Action:      nbdb.LogicalRouterPolicyActionAllow,
 							Options:     map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 							UUID:        "no-reroute-node-UUID",
@@ -3009,7 +2916,7 @@ var _ = ginkgo.Describe("OVN EgressIP Operations cluster default network", func(
 							getEgressIPLRPReRouteDbIDs(eIP.Name, egressPod.Namespace, egressPod.Name, IPFamilyValueV4, types.DefaultNetworkName, fakeOvn.controller.eIPC.controllerName).GetExternalIDs()),
 						&nbdb.LogicalRouterPolicy{
 							Priority:    types.DefaultNoRereoutePriority,
-							Match:       "(ip4.src == $a8519615025667110816 || ip4.src == $a13607449821398607916) && ip4.dst == $a1042611113178530741",
+							Match:       "(ip4.src == $a8519615025667110816 || ip4.src == $a13607449821398607916) && ip4.dst == $a712973235162149816",
 							Action:      nbdb.LogicalRouterPolicyActionAllow,
 							Options:     map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 							UUID:        "no-reroute-node-UUID",
@@ -3316,7 +3223,7 @@ var _ = ginkgo.Describe("OVN EgressIP Operations cluster default network", func(
 							getEgressIPLRPReRouteDbIDs(eIP.Name, egressPod.Namespace, egressPod.Name, IPFamilyValueV4, types.DefaultNetworkName, fakeOvn.controller.eIPC.controllerName).GetExternalIDs()),
 						&nbdb.LogicalRouterPolicy{
 							Priority:    types.DefaultNoRereoutePriority,
-							Match:       "(ip4.src == $a8519615025667110816 || ip4.src == $a13607449821398607916) && ip4.dst == $a1042611113178530741",
+							Match:       "(ip4.src == $a8519615025667110816 || ip4.src == $a13607449821398607916) && ip4.dst == $a712973235162149816",
 							Action:      nbdb.LogicalRouterPolicyActionAllow,
 							Options:     map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 							UUID:        "no-reroute-node-UUID",
@@ -12333,7 +12240,7 @@ var _ = ginkgo.Describe("OVN EgressIP Operations cluster default network", func(
 						},
 						&nbdb.LogicalRouterPolicy{
 							Priority:    types.DefaultNoRereoutePriority,
-							Match:       "(ip4.src == $a8519615025667110816 || ip4.src == $a13607449821398607916) && ip4.dst == $a1042611113178530741",
+							Match:       "(ip4.src == $a8519615025667110816 || ip4.src == $a13607449821398607916) && ip4.dst == $a712973235162149816",
 							Action:      nbdb.LogicalRouterPolicyActionAllow,
 							Options:     map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 							UUID:        "no-reroute-node-UUID",
@@ -12466,7 +12373,7 @@ var _ = ginkgo.Describe("OVN EgressIP Operations cluster default network", func(
 						},
 						&nbdb.LogicalRouterPolicy{
 							Priority:    types.DefaultNoRereoutePriority,
-							Match:       "(ip4.src == $a8519615025667110816 || ip4.src == $a13607449821398607916) && ip4.dst == $a1042611113178530741",
+							Match:       "(ip4.src == $a8519615025667110816 || ip4.src == $a13607449821398607916) && ip4.dst == $a712973235162149816",
 							Action:      nbdb.LogicalRouterPolicyActionAllow,
 							Options:     map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 							UUID:        "no-reroute-node-UUID",
@@ -15702,20 +15609,6 @@ func buildEgressIPServedPodsAddressSets(ips []string, network, controller string
 
 // returns the address set with externalID "k8s.ovn.org/name": "node-ips"
 func buildEgressIPNodeAddressSets(ips []string) (*nbdb.AddressSet, *nbdb.AddressSet) {
-	return addressset.GetTestDbAddrSets(getClusterNodeIPsAddrSetDbIDsForTest(), ips)
-}
-
-func getDeprecatedEgressIPClusterNodeIPsAddrSetDbIDsForNetwork(network string) *libovsdbops.DbObjectIDs {
-	return libovsdbops.NewDbObjectIDs(libovsdbops.AddressSetEgressIP, types.DefaultNetworkControllerName,
-		map[libovsdbops.ExternalIDKey]string{
-			libovsdbops.ObjectNameKey: addresssetmanager.ClusterNodeIPsAddrSetName,
-			libovsdbops.NetworkKey:    network,
-		})
-}
-
-func getClusterNodeIPsAddrSetDbIDsForTest() *libovsdbops.DbObjectIDs {
-	return libovsdbops.NewDbObjectIDs(libovsdbops.AddressSetClusterNodeIPs, types.DefaultNetworkControllerName,
-		map[libovsdbops.ExternalIDKey]string{
-			libovsdbops.ObjectNameKey: addresssetmanager.ClusterNodeIPsAddrSetName,
-		})
+	dbIDs := getEgressIPAddrSetDbIDs(NodeIPAddrSetName, types.DefaultNetworkName, types.DefaultNetworkControllerName)
+	return addressset.GetTestDbAddrSets(dbIDs, ips)
 }

--- a/go-controller/pkg/ovn/egressservices_test.go
+++ b/go-controller/pkg/ovn/egressservices_test.go
@@ -698,7 +698,11 @@ var _ = ginkgo.Describe("OVN Egress Service Operations", func() {
 					v6lrsr,
 				}
 				expectedEgressSvcAddrSet := []string{"10.128.1.5", "fe00:10:128:1::5"}
-				expectedDatabaseState = appendDefaultNoRerouteData(expectedDatabaseState, clusterRouter, controllerName, []string{node1IPv4, node2IPv4, node1IPv6, node2IPv6})
+
+				for _, lrp := range getDefaultNoReroutePolicies(controllerName) {
+					expectedDatabaseState = append(expectedDatabaseState, lrp)
+					clusterRouter.Policies = append(clusterRouter.Policies, lrp.UUID)
+				}
 				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 				fakeOVN.asf.ExpectAddressSetWithAddresses(egresssvc.GetEgressServiceAddrSetDbIDs(controllerName), expectedEgressSvcAddrSet)
 
@@ -717,7 +721,11 @@ var _ = ginkgo.Describe("OVN Egress Service Operations", func() {
 					v4lrp1,
 					v6lrp1,
 				}
-				expectedDatabaseState = appendDefaultNoRerouteData(expectedDatabaseState, clusterRouter, controllerName, []string{node1IPv4, node2IPv4, node1IPv6, node2IPv6})
+
+				for _, lrp := range getDefaultNoReroutePolicies(controllerName) {
+					expectedDatabaseState = append(expectedDatabaseState, lrp)
+					clusterRouter.Policies = append(clusterRouter.Policies, lrp.UUID)
+				}
 				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 
 				ginkgo.By("removing the EgressService its lrps will be removed")
@@ -726,7 +734,10 @@ var _ = ginkgo.Describe("OVN Egress Service Operations", func() {
 
 				clusterRouter.Policies = []string{}
 				expectedDatabaseState = []libovsdbtest.TestData{clusterRouter}
-				expectedDatabaseState = appendDefaultNoRerouteData(expectedDatabaseState, clusterRouter, controllerName, []string{node1IPv4, node2IPv4, node1IPv6, node2IPv6})
+				for _, lrp := range getDefaultNoReroutePolicies(controllerName) {
+					expectedDatabaseState = append(expectedDatabaseState, lrp)
+					clusterRouter.Policies = append(clusterRouter.Policies, lrp.UUID)
+				}
 				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 				fakeOVN.asf.ExpectAddressSetWithAddresses(egresssvc.GetEgressServiceAddrSetDbIDs(controllerName), []string{})
 
@@ -855,7 +866,11 @@ var _ = ginkgo.Describe("OVN Egress Service Operations", func() {
 					v6lrpic,
 				}
 				expectedEgressSvcAddrSet := []string{"10.128.1.5", "fe00:10:128:1::5"}
-				expectedDatabaseState = appendDefaultNoRerouteData(expectedDatabaseState, clusterRouter, controllerName, []string{node1IPv4, node2IPv4, node1IPv6, node2IPv6})
+
+				for _, lrp := range getDefaultNoReroutePolicies(controllerName) {
+					expectedDatabaseState = append(expectedDatabaseState, lrp)
+					clusterRouter.Policies = append(clusterRouter.Policies, lrp.UUID)
+				}
 				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 				fakeOVN.asf.ExpectAddressSetWithAddresses(egresssvc.GetEgressServiceAddrSetDbIDs(controllerName), expectedEgressSvcAddrSet)
 
@@ -867,7 +882,10 @@ var _ = ginkgo.Describe("OVN Egress Service Operations", func() {
 
 				clusterRouter.Policies = []string{}
 				expectedDatabaseState = []libovsdbtest.TestData{clusterRouter}
-				expectedDatabaseState = appendDefaultNoRerouteData(expectedDatabaseState, clusterRouter, controllerName, []string{node1IPv4, node2IPv4, node1IPv6, node2IPv6})
+				for _, lrp := range getDefaultNoReroutePolicies(controllerName) {
+					expectedDatabaseState = append(expectedDatabaseState, lrp)
+					clusterRouter.Policies = append(clusterRouter.Policies, lrp.UUID)
+				}
 				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 				fakeOVN.asf.ExpectAddressSetWithAddresses(egresssvc.GetEgressServiceAddrSetDbIDs(controllerName), []string{})
 				return nil
@@ -1016,7 +1034,11 @@ var _ = ginkgo.Describe("OVN Egress Service Operations", func() {
 				}
 				expectedEgressSvcAddrSet := []string{"10.128.1.5"}
 				expectedDatabaseState[0].(*nbdb.LogicalRouter).StaticRoutes = []string{"reroute-static-route-UUID", "reroute-static-route-UUID-v6"}
-				expectedDatabaseState = appendDefaultNoRerouteData(expectedDatabaseState, clusterRouter, controllerName, []string{node1IPv4, node2IPv4, node1IPv6, node2IPv6})
+
+				for _, lrp := range getDefaultNoReroutePolicies(controllerName) {
+					expectedDatabaseState = append(expectedDatabaseState, lrp)
+					clusterRouter.Policies = append(clusterRouter.Policies, lrp.UUID)
+				}
 				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 				fakeOVN.asf.ExpectAddressSetWithAddresses(egresssvc.GetEgressServiceAddrSetDbIDs(controllerName), expectedEgressSvcAddrSet)
 
@@ -1041,7 +1063,10 @@ var _ = ginkgo.Describe("OVN Egress Service Operations", func() {
 				}
 				expectedEgressSvcAddrSet = []string{"10.128.1.5", "fe00:10:128:1::5"}
 				expectedDatabaseState[0].(*nbdb.LogicalRouter).StaticRoutes = []string{"reroute-static-route-UUID", "reroute-static-route-UUID-v6"}
-				expectedDatabaseState = appendDefaultNoRerouteData(expectedDatabaseState, clusterRouter, controllerName, []string{node1IPv4, node2IPv4, node1IPv6, node2IPv6})
+				for _, lrp := range getDefaultNoReroutePolicies(controllerName) {
+					expectedDatabaseState = append(expectedDatabaseState, lrp)
+					clusterRouter.Policies = append(clusterRouter.Policies, lrp.UUID)
+				}
 				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 				fakeOVN.asf.ExpectAddressSetWithAddresses(egresssvc.GetEgressServiceAddrSetDbIDs(controllerName), expectedEgressSvcAddrSet)
 
@@ -1071,7 +1096,11 @@ var _ = ginkgo.Describe("OVN Egress Service Operations", func() {
 				}
 				expectedEgressSvcAddrSet = []string{"10.128.1.5", "10.128.1.7"}
 				expectedDatabaseState[0].(*nbdb.LogicalRouter).StaticRoutes = []string{"reroute-static-route-UUID", "reroute-static-route-UUID-v6"}
-				expectedDatabaseState = appendDefaultNoRerouteData(expectedDatabaseState, clusterRouter, controllerName, []string{node1IPv4, node2IPv4, node1IPv6, node2IPv6})
+
+				for _, lrp := range getDefaultNoReroutePolicies(controllerName) {
+					expectedDatabaseState = append(expectedDatabaseState, lrp)
+					clusterRouter.Policies = append(clusterRouter.Policies, lrp.UUID)
+				}
 				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 				fakeOVN.asf.ExpectAddressSetWithAddresses(egresssvc.GetEgressServiceAddrSetDbIDs(controllerName), expectedEgressSvcAddrSet)
 
@@ -1089,7 +1118,11 @@ var _ = ginkgo.Describe("OVN Egress Service Operations", func() {
 				}
 				expectedEgressSvcAddrSet = []string{}
 				expectedDatabaseState[0].(*nbdb.LogicalRouter).StaticRoutes = []string{"reroute-static-route-UUID", "reroute-static-route-UUID-v6"}
-				expectedDatabaseState = appendDefaultNoRerouteData(expectedDatabaseState, clusterRouter, controllerName, []string{node1IPv4, node2IPv4, node1IPv6, node2IPv6})
+
+				for _, lrp := range getDefaultNoReroutePolicies(controllerName) {
+					expectedDatabaseState = append(expectedDatabaseState, lrp)
+					clusterRouter.Policies = append(clusterRouter.Policies, lrp.UUID)
+				}
 				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 				fakeOVN.asf.ExpectAddressSetWithAddresses(egresssvc.GetEgressServiceAddrSetDbIDs(controllerName), expectedEgressSvcAddrSet)
 
@@ -1104,7 +1137,11 @@ var _ = ginkgo.Describe("OVN Egress Service Operations", func() {
 				}
 				expectedDatabaseState = append(expectedDatabaseState, v4DefaultReRoute)
 				expectedDatabaseState = append(expectedDatabaseState, v6DefaultReRoute)
-				expectedDatabaseState = appendDefaultNoRerouteData(expectedDatabaseState, clusterRouter, controllerName, []string{node1IPv4, node2IPv4, node1IPv6, node2IPv6})
+
+				for _, lrp := range getDefaultNoReroutePolicies(controllerName) {
+					expectedDatabaseState = append(expectedDatabaseState, lrp)
+					clusterRouter.Policies = append(clusterRouter.Policies, lrp.UUID)
+				}
 				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 
 				return nil
@@ -1269,7 +1306,11 @@ var _ = ginkgo.Describe("OVN Egress Service Operations", func() {
 					svc1v6iclrp1,
 				}
 				var expectedEgressSvcAddrSet []string
-				expectedDatabaseState = appendDefaultNoRerouteData(expectedDatabaseState, clusterRouter, controllerName, []string{node1IPv4, node2IPv4, node1IPv6, node2IPv6})
+
+				for _, lrp := range getDefaultNoReroutePolicies(controllerName) {
+					expectedDatabaseState = append(expectedDatabaseState, lrp)
+					clusterRouter.Policies = append(clusterRouter.Policies, lrp.UUID)
+				}
 				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 				fakeOVN.asf.ExpectAddressSetWithAddresses(egresssvc.GetEgressServiceAddrSetDbIDs(controllerName), expectedEgressSvcAddrSet)
 
@@ -1304,25 +1345,23 @@ var _ = ginkgo.Describe("OVN Egress Service Operations", func() {
 					svc2v6lrp1remote,
 				}
 				expectedEgressSvcAddrSet = []string{"10.128.1.6", "fe00:10:128:1::6"}
-				expectedDatabaseState = appendDefaultNoRerouteData(expectedDatabaseState, clusterRouter, controllerName, []string{node1IPv4, node2IPv4, node1IPv6, node2IPv6})
+				for _, lrp := range getDefaultNoReroutePolicies(controllerName) {
+					expectedDatabaseState = append(expectedDatabaseState, lrp)
+					clusterRouter.Policies = append(clusterRouter.Policies, lrp.UUID)
+				}
 				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 				fakeOVN.asf.ExpectAddressSetWithAddresses(egresssvc.GetEgressServiceAddrSetDbIDs(controllerName), expectedEgressSvcAddrSet)
 
 				ginkgo.By("updating the second node host cidr the node ip no re-route address set will be updated")
+				nodeIPsASdbIDs := getEgressIPAddrSetDbIDs(NodeIPAddrSetName, ovntypes.DefaultNetworkName, ovntypes.DefaultNetworkControllerName)
+				fakeOVN.asf.EventuallyExpectAddressSetWithAddresses(nodeIPsASdbIDs, []string{node1IPv4, node2IPv4, node1IPv6, node2IPv6})
+
 				node2.ObjectMeta.Annotations[util.OVNNodeHostCIDRs] = fmt.Sprintf("[\"%s\", \"%s\", \"%s\", \"%s\"]", node2IPv4+"/24", node2IPv6+"/64", vipIPv4+"/24", vipIPv6+"/64")
 				node2.ResourceVersion = "3"
 				_, err = fakeOVN.fakeClient.KubeClient.CoreV1().Nodes().Update(context.TODO(), node2, metav1.UpdateOptions{})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-				clusterRouter.Policies = []string{"svc2v4lrp1remote-UUID", "svc2v6lrp1remote-UUID", "svc1v4lrsr1-UUID", "svc1v6lrsr1-UUID"}
-				expectedDatabaseState = []libovsdbtest.TestData{
-					clusterRouter,
-					svc1v4iclrp1,
-					svc1v6iclrp1,
-					svc2v4lrp1remote,
-					svc2v6lrp1remote,
-				}
-				expectedDatabaseState = appendDefaultNoRerouteData(expectedDatabaseState, clusterRouter, controllerName, []string{node1IPv4, node2IPv4, node1IPv6, node2IPv6, vipIPv4, vipIPv6})
+				fakeOVN.asf.EventuallyExpectAddressSetWithAddresses(nodeIPsASdbIDs, []string{node1IPv4, node2IPv4, node1IPv6, node2IPv6, vipIPv4, vipIPv6})
 				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 
 				node2.ObjectMeta.Annotations[util.OVNNodeHostCIDRs] = fmt.Sprintf("[\"%s\", \"%s\"]", node2IPv4+"/24", node2IPv6+"/64")
@@ -1330,20 +1369,14 @@ var _ = ginkgo.Describe("OVN Egress Service Operations", func() {
 				_, err = fakeOVN.fakeClient.KubeClient.CoreV1().Nodes().Update(context.TODO(), node2, metav1.UpdateOptions{})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-				clusterRouter.Policies = []string{"svc2v4lrp1remote-UUID", "svc2v6lrp1remote-UUID", "svc1v4lrsr1-UUID", "svc1v6lrsr1-UUID"}
-				expectedDatabaseState = []libovsdbtest.TestData{
-					clusterRouter,
-					svc1v4iclrp1,
-					svc1v6iclrp1,
-					svc2v4lrp1remote,
-					svc2v6lrp1remote,
-				}
-				expectedDatabaseState = appendDefaultNoRerouteData(expectedDatabaseState, clusterRouter, controllerName, []string{node1IPv4, node2IPv4, node1IPv6, node2IPv6})
+				fakeOVN.asf.EventuallyExpectAddressSetWithAddresses(nodeIPsASdbIDs, []string{node1IPv4, node2IPv4, node1IPv6, node2IPv6})
 				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 
 				ginkgo.By("deleting the first node, the node ip no re-route address set will be updated and service resources will be deleted")
 				err = fakeOVN.fakeClient.KubeClient.CoreV1().Nodes().Delete(context.TODO(), node1.Name, metav1.DeleteOptions{})
 				gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+				fakeOVN.asf.EventuallyExpectAddressSetWithAddresses(nodeIPsASdbIDs, []string{node2IPv4, node2IPv6})
 
 				clusterRouter.Policies = []string{"svc2v4lrp1remote-UUID", "svc2v6lrp1remote-UUID"}
 				expectedDatabaseState = []libovsdbtest.TestData{
@@ -1352,7 +1385,10 @@ var _ = ginkgo.Describe("OVN Egress Service Operations", func() {
 					svc2v6lrp1remote,
 				}
 				expectedEgressSvcAddrSet = []string{"10.128.1.6", "fe00:10:128:1::6"}
-				expectedDatabaseState = appendDefaultNoRerouteData(expectedDatabaseState, clusterRouter, controllerName, []string{node2IPv4, node2IPv6})
+				for _, lrp := range getDefaultNoReroutePolicies(controllerName) {
+					expectedDatabaseState = append(expectedDatabaseState, lrp)
+					clusterRouter.Policies = append(clusterRouter.Policies, lrp.UUID)
+				}
 				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 				fakeOVN.asf.ExpectAddressSetWithAddresses(egresssvc.GetEgressServiceAddrSetDbIDs(controllerName), expectedEgressSvcAddrSet)
 
@@ -1364,8 +1400,12 @@ var _ = ginkgo.Describe("OVN Egress Service Operations", func() {
 				expectedDatabaseState = []libovsdbtest.TestData{
 					clusterRouter,
 				}
-				expectedDatabaseState = appendDefaultNoRerouteData(expectedDatabaseState, clusterRouter, controllerName, nil)
+				for _, lrp := range getDefaultNoReroutePolicies(controllerName) {
+					expectedDatabaseState = append(expectedDatabaseState, lrp)
+					clusterRouter.Policies = append(clusterRouter.Policies, lrp.UUID)
+				}
 				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+				fakeOVN.asf.EventuallyExpectEmptyAddressSetExist(nodeIPsASdbIDs)
 				fakeOVN.asf.ExpectAddressSetWithAddresses(egresssvc.GetEgressServiceAddrSetDbIDs(controllerName), []string{})
 				return nil
 			}
@@ -1403,26 +1443,11 @@ func egressServiceRouterPolicy(uuid, key, addr, nexthop string) *nbdb.LogicalRou
 	}
 }
 
-func appendDefaultNoRerouteData(expected []libovsdbtest.TestData, clusterRouter *nbdb.LogicalRouter, controllerName string, nodeIPs []string) []libovsdbtest.TestData {
-	for _, lrp := range getDefaultNoReroutePolicies(controllerName) {
-		expected = append(expected, lrp)
-		clusterRouter.Policies = append(clusterRouter.Policies, lrp.UUID)
-	}
-	nodeIPsASv4, nodeIPsASv6 := addressset.GetTestDbAddrSets(getClusterNodeIPsAddrSetDbIDsForTest(), nodeIPs)
-	if config.IPv4Mode {
-		expected = append(expected, nodeIPsASv4)
-	}
-	if config.IPv6Mode {
-		expected = append(expected, nodeIPsASv6)
-	}
-	return expected
-}
-
 func getDefaultNoReroutePolicies(controllerName string) []*nbdb.LogicalRouterPolicy {
 	allLRPS := []*nbdb.LogicalRouterPolicy{}
 	egressSvcPodsV4, egressSvcPodsV6 := addressset.GetHashNamesForAS(egresssvc.GetEgressServiceAddrSetDbIDs(controllerName))
 	egressipPodsV4, egressipPodsV6 := addressset.GetHashNamesForAS(getEgressIPAddrSetDbIDs(EgressIPServedPodsAddrSetName, ovntypes.DefaultNetworkName, controllerName))
-	nodeIPsV4, nodeIPsV6 := addressset.GetHashNamesForAS(getClusterNodeIPsAddrSetDbIDsForTest())
+	nodeIPsV4, nodeIPsV6 := addressset.GetHashNamesForAS(getEgressIPAddrSetDbIDs(NodeIPAddrSetName, ovntypes.DefaultNetworkName, controllerName))
 	v4ExtIDs := getEgressIPLRPNoReRoutePodToNodeDbIDs(IPFamilyValueV4, ovntypes.DefaultNetworkName, controllerName).GetExternalIDs()
 	v6ExtIDs := getEgressIPLRPNoReRoutePodToNodeDbIDs(IPFamilyValueV6, ovntypes.DefaultNetworkName, controllerName).GetExternalIDs()
 

--- a/go-controller/pkg/ovn/gateway.go
+++ b/go-controller/pkg/ovn/gateway.go
@@ -32,7 +32,6 @@ import (
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/nbdb"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node"
 	addressset "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/address_set"
-	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/addresssetmanager"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/gateway"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/gatewayrouter"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
@@ -52,7 +51,6 @@ type GatewayManager struct {
 	watchFactory            *factory.WatchFactory
 	getNetworkNameForNADKey func(nadKey string) string
 	nodeAnnotationCache     *nodecontroller.NodeAnnotationCache
-	addressSetManager       *addresssetmanager.AddressSetManager
 	// Cluster wide Load_Balancer_Group UUID.
 	// Includes all node switches and node gateway routers.
 	clusterLoadBalancerGroupUUID string
@@ -78,7 +76,6 @@ func NewGatewayManagerForLayer2Topology(
 	netInfo util.NetInfo,
 	watchFactory *factory.WatchFactory,
 	nodeAnnotationCache *nodecontroller.NodeAnnotationCache,
-	addressSetManager *addresssetmanager.AddressSetManager,
 	useTransitRouter bool,
 	opts ...GatewayOption,
 ) *GatewayManager {
@@ -97,7 +94,6 @@ func NewGatewayManagerForLayer2Topology(
 		netInfo,
 		watchFactory,
 		nodeAnnotationCache,
-		addressSetManager,
 		opts...,
 	)
 }
@@ -110,7 +106,6 @@ func NewGatewayManager(
 	netInfo util.NetInfo,
 	watchFactory *factory.WatchFactory,
 	nodeAnnotationCache *nodecontroller.NodeAnnotationCache,
-	addressSetManager *addresssetmanager.AddressSetManager,
 	opts ...GatewayOption,
 ) *GatewayManager {
 	return newGWManager(
@@ -124,7 +119,6 @@ func NewGatewayManager(
 		netInfo,
 		watchFactory,
 		nodeAnnotationCache,
-		addressSetManager,
 		opts...,
 	)
 }
@@ -137,7 +131,6 @@ func newGWManager(
 	netInfo util.NetInfo,
 	watchFactory *factory.WatchFactory,
 	nodeAnnotationCache *nodecontroller.NodeAnnotationCache,
-	addressSetManager *addresssetmanager.AddressSetManager,
 	opts ...GatewayOption) *GatewayManager {
 	gwManager := &GatewayManager{
 		nodeName:            nodeName,
@@ -151,7 +144,6 @@ func newGWManager(
 		netInfo:             netInfo,
 		watchFactory:        watchFactory,
 		nodeAnnotationCache: nodeAnnotationCache,
-		addressSetManager:   addressSetManager,
 	}
 
 	for _, opt := range opts {
@@ -905,15 +897,6 @@ func (gw *GatewayManager) updateGWRouterNAT(nodeName string, gwConfig *GatewayCo
 			}
 		}
 
-		isNetworkAdvertised := gw.isRoutingAdvertised(nodeName)
-		var clusterNodeIPsAddrSetDbIDs *libovsdbops.DbObjectIDs
-		if isNetworkAdvertised && !util.IsNoOverlaySNATExemptionNeeded(gw.netInfo) {
-			clusterNodeIPsAddrSetDbIDs, err = gw.addressSetManager.EnsureClusterNodeIPsAddressSet(addresssetmanager.ClusterNodeIPsRouteAdvertisementsBackRef)
-			if err != nil {
-				return fmt.Errorf("failed to ensure cluster node IP address set for route advertisements: %w", err)
-			}
-		}
-
 		// Default SNAT rules. DisableSNATMultipleGWs=false in LGW (traffic egresses via mp0) always.
 		// We are not checking for gateway mode to be shared explicitly to reduce topology differences.
 		for _, entry := range gwConfig.clusterSubnets {
@@ -929,7 +912,7 @@ func (gw *GatewayManager) updateGWRouterNAT(nodeName string, gwConfig *GatewayCo
 				ipFamily = utilnet.IPv6
 			}
 			snatMatch, err := GetNetworkScopedClusterSubnetSNATMatch(gw.nbClient, gw.netInfo, nodeName,
-				isNetworkAdvertised, ipFamily, clusterNodeIPsAddrSetDbIDs)
+				gw.isRoutingAdvertised(nodeName), ipFamily)
 			if err != nil {
 				return fmt.Errorf("failed to get SNAT match for node %s for network %s: %w", nodeName, gw.netInfo.GetNetworkName(), err)
 			}
@@ -1097,7 +1080,7 @@ func (gw *GatewayManager) gatewayInit(
 // - For Layer2 topology, the match is the output port of the GR to the join switch and the destination must be a nodeIP in the cluster.
 // - For Layer3 topology, the match is the destination must be a nodeIP in the cluster.
 func GetNetworkScopedClusterSubnetSNATMatch(nbClient libovsdbclient.Client, netInfo util.NetInfo, nodeName string,
-	isNetworkAdvertised bool, ipFamily utilnet.IPFamily, clusterNodeIPsAddrSetDbIDs *libovsdbops.DbObjectIDs) (string, error) {
+	isNetworkAdvertised bool, ipFamily utilnet.IPFamily) (string, error) {
 	layer2OldTopo := netInfo.TopologyType() == types.Layer2Topology && !config.Layer2UsesTransitRouter
 	if !isNetworkAdvertised {
 		if !layer2OldTopo {
@@ -1109,17 +1092,15 @@ func GetNetworkScopedClusterSubnetSNATMatch(nbClient libovsdbclient.Client, netI
 	}
 
 	// if the network is advertised, we need to ensure that the SNAT exists with the correct conditional destination match
-	if clusterNodeIPsAddrSetDbIDs == nil {
-		return "", fmt.Errorf("cluster node IP address set DB IDs are required for advertised network %s", netInfo.GetNetworkName())
-	}
+	dbIDs := getEgressIPAddrSetDbIDs(NodeIPAddrSetName, types.DefaultNetworkName, types.DefaultNetworkControllerName)
 	addressSetFactory := addressset.NewOvnAddressSetFactory(nbClient, config.IPv4Mode, config.IPv6Mode)
-	addrSet, err := addressSetFactory.GetAddressSet(clusterNodeIPsAddrSetDbIDs)
+	addrSet, err := addressSetFactory.GetAddressSet(dbIDs)
 	if err != nil {
-		return "", fmt.Errorf("cannot ensure that addressSet %v exists: %w", clusterNodeIPsAddrSetDbIDs, err)
+		return "", fmt.Errorf("cannot ensure that addressSet %v exists: %w", dbIDs, err)
 	}
 	destinationMatch := getClusterNodesDestinationBasedSNATMatch(ipFamily, addrSet)
 	if destinationMatch == "" {
-		return "", fmt.Errorf("could not build a destination based SNAT match because no addressSet %v exists for IP family %v", clusterNodeIPsAddrSetDbIDs, ipFamily)
+		return "", fmt.Errorf("could not build a destination based SNAT match because no addressSet %v exists for IP family %v", dbIDs, ipFamily)
 	}
 	if !layer2OldTopo {
 		return destinationMatch, nil
@@ -1718,18 +1699,12 @@ func (oc *DefaultNetworkController) AddPodSNATOps(
 
 	isNetworkAdvertised := oc.isPodNetworkAdvertisedAtNode(nodeName)
 	gwRouterName := oc.GetNetworkScopedGWRouterName(nodeName)
-	var clusterNodeIPsAddrSetDbIDs *libovsdbops.DbObjectIDs
 
 	if util.IsNoOverlaySNATExemptionNeeded(oc.GetNetInfo()) {
 		// Get the no-overlay SNAT exemption address set UUIDs
 		v4UUID, v6UUID, err = getNoOverlaySNATExemptionAsUUID(oc.addressSetFactory, oc.GetNetInfo(), oc.controllerName)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get no-overlay SNAT exemption address set UUID: %w", err)
-		}
-	} else if isNetworkAdvertised {
-		clusterNodeIPsAddrSetDbIDs, err = oc.addressSetManager.EnsureClusterNodeIPsAddressSet(addresssetmanager.ClusterNodeIPsRouteAdvertisementsBackRef)
-		if err != nil {
-			return nil, fmt.Errorf("failed to ensure cluster node IP address set for route advertisements: %w", err)
 		}
 	}
 
@@ -1747,7 +1722,7 @@ func (oc *DefaultNetworkController) AddPodSNATOps(
 			exemptedExtIPs = v4UUID
 		}
 
-		snatMatch, err := GetNetworkScopedClusterSubnetSNATMatch(oc.nbClient, oc.GetNetInfo(), nodeName, isNetworkAdvertised, ipFamily, clusterNodeIPsAddrSetDbIDs)
+		snatMatch, err := GetNetworkScopedClusterSubnetSNATMatch(oc.nbClient, oc.GetNetInfo(), nodeName, isNetworkAdvertised, ipFamily)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get SNAT match for node %s for network %s: %w", nodeName, oc.GetNetInfo().GetNetworkName(), err)
 		}

--- a/go-controller/pkg/ovn/gateway_test.go
+++ b/go-controller/pkg/ovn/gateway_test.go
@@ -69,16 +69,16 @@ func generateAdvertisedUDNIsolationExpectedNB(testData []libovsdbtest.TestData, 
 func generateGatewayInitExpectedNB(testData []libovsdbtest.TestData, expectedOVNClusterRouter *nbdb.LogicalRouter,
 	expectedNodeSwitch *nbdb.LogicalSwitch, nodeName string, clusterIPSubnets []*net.IPNet, hostSubnets []*net.IPNet,
 	l3GatewayConfig *util.L3GatewayConfig, joinLRPIPs, defLRPIPs []*net.IPNet, skipSnat bool, nodeMgmtPortIP,
-	gatewayMTU string, nodeIPsForClusterNodeIPAS ...string) []libovsdbtest.TestData {
+	gatewayMTU string) []libovsdbtest.TestData {
 	return generateGatewayInitExpectedNBWithPodNetworkAdvertised(testData, expectedOVNClusterRouter, expectedNodeSwitch,
 		nodeName, clusterIPSubnets, hostSubnets, l3GatewayConfig, joinLRPIPs, defLRPIPs, skipSnat, nodeMgmtPortIP,
-		gatewayMTU, false, nodeIPsForClusterNodeIPAS...) // Default to no pod network advertised
+		gatewayMTU, false) // Default to no pod network advertised
 }
 
 func generateGatewayInitExpectedNBWithPodNetworkAdvertised(testData []libovsdbtest.TestData, expectedOVNClusterRouter *nbdb.LogicalRouter,
 	expectedNodeSwitch *nbdb.LogicalSwitch, nodeName string, clusterIPSubnets []*net.IPNet, hostSubnets []*net.IPNet,
 	l3GatewayConfig *util.L3GatewayConfig, joinLRPIPs, defLRPIPs []*net.IPNet, skipSnat bool, nodeMgmtPortIP,
-	gatewayMTU string, isPodNetworkAdvertised bool, nodeIPsForClusterNodeIPAS ...string) []libovsdbtest.TestData {
+	gatewayMTU string, isPodNetworkAdvertised bool) []libovsdbtest.TestData {
 
 	GRName := "GR_" + nodeName
 	gwSwitchPort := types.JoinSwitchToGWRouterPrefix + GRName
@@ -230,11 +230,7 @@ func generateGatewayInitExpectedNBWithPodNetworkAdvertised(testData []libovsdbte
 	})
 	var egressNodeIPsASv4, egressNodeIPsASv6 *nbdb.AddressSet
 	if config.OVNKubernetesFeature.EnableEgressIP {
-		nodeIPs := physicalIPs
-		if len(nodeIPsForClusterNodeIPAS) > 0 {
-			nodeIPs = nodeIPsForClusterNodeIPAS
-		}
-		egressNodeIPsASv4, egressNodeIPsASv6 = buildEgressIPNodeAddressSets(nodeIPs)
+		egressNodeIPsASv4, egressNodeIPsASv6 = buildEgressIPNodeAddressSets(physicalIPs)
 		if config.IPv4Mode {
 			testData = append(testData, egressNodeIPsASv4)
 		}
@@ -2114,7 +2110,6 @@ func newGatewayManager(ovn *FakeOVN, nodeName string) *GatewayManager {
 		controller.GetNetInfo(),
 		ovn.watcher,
 		nodecontroller.NewNodeAnnotationCache(),
-		ovn.addressSetManager,
 		WithLoadBalancerGroups(
 			controller.routerLoadBalancerGroupUUID,
 			controller.clusterLoadBalancerGroupUUID,
@@ -2155,7 +2150,7 @@ var _ = ginkgo.Describe("GetNetworkScopedClusterSubnetSNATMatch", func() {
 	ginkgo.Context("when network is not advertised", func() {
 		ginkgo.It("returns empty match for Layer3 topology", func() {
 			netInfo.topology = types.Layer3Topology
-			match, err := GetNetworkScopedClusterSubnetSNATMatch(fakeOvn.nbClient, netInfo, nodeName, false, utilnet.IPv4, nil)
+			match, err := GetNetworkScopedClusterSubnetSNATMatch(fakeOvn.nbClient, netInfo, nodeName, false, utilnet.IPv4)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			gomega.Expect(match).To(gomega.BeEmpty())
 		})
@@ -2165,7 +2160,7 @@ var _ = ginkgo.Describe("GetNetworkScopedClusterSubnetSNATMatch", func() {
 			defer func() { config.Layer2UsesTransitRouter = originalValue }()
 			config.Layer2UsesTransitRouter = true
 			netInfo.topology = types.Layer2Topology
-			match, err := GetNetworkScopedClusterSubnetSNATMatch(fakeOvn.nbClient, netInfo, nodeName, false, utilnet.IPv4, nil)
+			match, err := GetNetworkScopedClusterSubnetSNATMatch(fakeOvn.nbClient, netInfo, nodeName, false, utilnet.IPv4)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			gomega.Expect(match).To(gomega.BeEmpty())
 		})
@@ -2175,7 +2170,7 @@ var _ = ginkgo.Describe("GetNetworkScopedClusterSubnetSNATMatch", func() {
 			defer func() { config.Layer2UsesTransitRouter = originalValue }()
 			config.Layer2UsesTransitRouter = false
 			netInfo.topology = types.Layer2Topology
-			match, err := GetNetworkScopedClusterSubnetSNATMatch(fakeOvn.nbClient, netInfo, nodeName, false, utilnet.IPv4, nil)
+			match, err := GetNetworkScopedClusterSubnetSNATMatch(fakeOvn.nbClient, netInfo, nodeName, false, utilnet.IPv4)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			expectedMatch := fmt.Sprintf("outport == %q", types.GWRouterToExtSwitchPrefix+netInfo.GetNetworkScopedGWRouterName(nodeName))
 			gomega.Expect(match).To(gomega.Equal(expectedMatch))
@@ -2196,7 +2191,7 @@ var _ = ginkgo.Describe("GetNetworkScopedClusterSubnetSNATMatch", func() {
 
 				ginkgo.It("returns empty match for Layer3 topology", func() {
 					netInfo.topology = types.Layer3Topology
-					match, err := GetNetworkScopedClusterSubnetSNATMatch(fakeOvn.nbClient, netInfo, nodeName, true, utilnet.IPv4, nil)
+					match, err := GetNetworkScopedClusterSubnetSNATMatch(fakeOvn.nbClient, netInfo, nodeName, true, utilnet.IPv4)
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 					gomega.Expect(match).To(gomega.BeEmpty())
 				})
@@ -2206,7 +2201,7 @@ var _ = ginkgo.Describe("GetNetworkScopedClusterSubnetSNATMatch", func() {
 				ginkgo.BeforeEach(func() {
 					config.Gateway.Mode = config.GatewayModeLocal
 					addressSetFactory = addressset.NewOvnAddressSetFactory(fakeOvn.nbClient, config.IPv4Mode, config.IPv6Mode)
-					dbIDs := getClusterNodeIPsAddrSetDbIDsForTest()
+					dbIDs := getEgressIPAddrSetDbIDs(NodeIPAddrSetName, types.DefaultNetworkName, types.DefaultNetworkControllerName)
 					as, err := addressSetFactory.EnsureAddressSet(dbIDs)
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 					err = as.AddAddresses([]string{"10.0.0.1"})
@@ -2215,10 +2210,9 @@ var _ = ginkgo.Describe("GetNetworkScopedClusterSubnetSNATMatch", func() {
 
 				ginkgo.It("returns destination match for Layer3 topology", func() {
 					netInfo.topology = types.Layer3Topology
-					dbIDs := getClusterNodeIPsAddrSetDbIDsForTest()
-					match, err := GetNetworkScopedClusterSubnetSNATMatch(fakeOvn.nbClient, netInfo, nodeName, true, utilnet.IPv4, dbIDs)
+					match, err := GetNetworkScopedClusterSubnetSNATMatch(fakeOvn.nbClient, netInfo, nodeName, true, utilnet.IPv4)
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
-					as, err := addressSetFactory.GetAddressSet(dbIDs)
+					as, err := addressSetFactory.GetAddressSet(getEgressIPAddrSetDbIDs(NodeIPAddrSetName, types.DefaultNetworkName, types.DefaultNetworkControllerName))
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 					v4Hash, _ := as.GetASHashNames()
 					expectedMatch := fmt.Sprintf("ip4.dst == $%s", v4Hash)
@@ -2230,7 +2224,7 @@ var _ = ginkgo.Describe("GetNetworkScopedClusterSubnetSNATMatch", func() {
 		ginkgo.Context("when outbound SNAT is disabled", func() {
 			ginkgo.BeforeEach(func() {
 				addressSetFactory = addressset.NewOvnAddressSetFactory(fakeOvn.nbClient, config.IPv4Mode, config.IPv6Mode)
-				dbIDs := getClusterNodeIPsAddrSetDbIDsForTest()
+				dbIDs := getEgressIPAddrSetDbIDs(NodeIPAddrSetName, types.DefaultNetworkName, types.DefaultNetworkControllerName)
 				as, err := addressSetFactory.EnsureAddressSet(dbIDs)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				err = as.AddAddresses([]string{"10.0.0.1"})
@@ -2239,10 +2233,9 @@ var _ = ginkgo.Describe("GetNetworkScopedClusterSubnetSNATMatch", func() {
 
 			ginkgo.It("returns destination match for Layer3 topology", func() {
 				netInfo.topology = types.Layer3Topology
-				dbIDs := getClusterNodeIPsAddrSetDbIDsForTest()
-				match, err := GetNetworkScopedClusterSubnetSNATMatch(fakeOvn.nbClient, netInfo, nodeName, true, utilnet.IPv4, dbIDs)
+				match, err := GetNetworkScopedClusterSubnetSNATMatch(fakeOvn.nbClient, netInfo, nodeName, true, utilnet.IPv4)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				as, err := addressSetFactory.GetAddressSet(dbIDs)
+				as, err := addressSetFactory.GetAddressSet(getEgressIPAddrSetDbIDs(NodeIPAddrSetName, types.DefaultNetworkName, types.DefaultNetworkControllerName))
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				v4Hash, _ := as.GetASHashNames()
 				expectedMatch := fmt.Sprintf("ip4.dst == $%s", v4Hash)
@@ -2254,10 +2247,9 @@ var _ = ginkgo.Describe("GetNetworkScopedClusterSubnetSNATMatch", func() {
 				defer func() { config.Layer2UsesTransitRouter = originalValue }()
 				config.Layer2UsesTransitRouter = true
 				netInfo.topology = types.Layer2Topology
-				dbIDs := getClusterNodeIPsAddrSetDbIDsForTest()
-				match, err := GetNetworkScopedClusterSubnetSNATMatch(fakeOvn.nbClient, netInfo, nodeName, true, utilnet.IPv4, dbIDs)
+				match, err := GetNetworkScopedClusterSubnetSNATMatch(fakeOvn.nbClient, netInfo, nodeName, true, utilnet.IPv4)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				as, err := addressSetFactory.GetAddressSet(dbIDs)
+				as, err := addressSetFactory.GetAddressSet(getEgressIPAddrSetDbIDs(NodeIPAddrSetName, types.DefaultNetworkName, types.DefaultNetworkControllerName))
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				v4Hash, _ := as.GetASHashNames()
 				expectedMatch := fmt.Sprintf("ip4.dst == $%s", v4Hash)
@@ -2269,10 +2261,9 @@ var _ = ginkgo.Describe("GetNetworkScopedClusterSubnetSNATMatch", func() {
 				defer func() { config.Layer2UsesTransitRouter = originalValue }()
 				config.Layer2UsesTransitRouter = false
 				netInfo.topology = types.Layer2Topology
-				dbIDs := getClusterNodeIPsAddrSetDbIDsForTest()
-				match, err := GetNetworkScopedClusterSubnetSNATMatch(fakeOvn.nbClient, netInfo, nodeName, true, utilnet.IPv4, dbIDs)
+				match, err := GetNetworkScopedClusterSubnetSNATMatch(fakeOvn.nbClient, netInfo, nodeName, true, utilnet.IPv4)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				as, err := addressSetFactory.GetAddressSet(dbIDs)
+				as, err := addressSetFactory.GetAddressSet(getEgressIPAddrSetDbIDs(NodeIPAddrSetName, types.DefaultNetworkName, types.DefaultNetworkControllerName))
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				v4Hash, _ := as.GetASHashNames()
 				expectedMatch := fmt.Sprintf("outport == %q && ip4.dst == $%s", types.GWRouterToExtSwitchPrefix+netInfo.GetNetworkScopedGWRouterName(nodeName), v4Hash)
@@ -2333,7 +2324,7 @@ var _ = ginkgo.Describe("AddPodSNATOps", func() {
 		controller = fakeOvn.controller
 
 		// Create address set for node IPs (required for SNAT match)
-		dbIDs := getClusterNodeIPsAddrSetDbIDsForTest()
+		dbIDs := getEgressIPAddrSetDbIDs(NodeIPAddrSetName, types.DefaultNetworkName, types.DefaultNetworkControllerName)
 		nodeIPAddrSet, asErr := controller.addressSetFactory.EnsureAddressSet(dbIDs)
 		gomega.Expect(asErr).NotTo(gomega.HaveOccurred())
 		asErr = nodeIPAddrSet.AddAddresses([]string{nodeIP, nodeIPv6})

--- a/go-controller/pkg/ovn/layer2_user_defined_network_controller.go
+++ b/go-controller/pkg/ovn/layer2_user_defined_network_controller.go
@@ -1212,7 +1212,6 @@ func (oc *Layer2UserDefinedNetworkController) newGatewayManager(nodeName string)
 		oc.GetNetInfo(),
 		oc.watchFactory,
 		oc.nodeAnnotationCache,
-		oc.addressSetManager,
 		config.Layer2UsesTransitRouter,
 		oc.gatewayOptions()...,
 	)

--- a/go-controller/pkg/ovn/layer3_user_defined_network_controller.go
+++ b/go-controller/pkg/ovn/layer3_user_defined_network_controller.go
@@ -1226,7 +1226,6 @@ func (oc *Layer3UserDefinedNetworkController) newGatewayManager(nodeName string)
 		oc.GetNetInfo(),
 		oc.watchFactory,
 		oc.nodeAnnotationCache,
-		oc.addressSetManager,
 		oc.gatewayOptions()...,
 	)
 }

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -874,7 +874,6 @@ func (oc *DefaultNetworkController) newGatewayManager(nodeName string) *GatewayM
 		oc.GetNetInfo(),
 		oc.watchFactory,
 		nodecontroller.NewNodeAnnotationCache(),
-		oc.addressSetManager,
 		oc.gatewayOptions()...,
 	)
 	return gatewayManager

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -41,7 +41,6 @@ import (
 	libovsdbutil "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/libovsdb/util"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/nbdb"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/networkmanager"
-	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/addresssetmanager"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/sbdb"
 	ovntest "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing"
 	libovsdbtest "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
@@ -568,7 +567,11 @@ var _ = ginkgo.Describe("Default network controller operations", func() {
 		err = util.SetL3GatewayConfig(nodeAnnotator, l3GatewayConfig)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		if config.OVNKubernetesFeature.EnableEgressIP {
-			egressNodeIPsASv4, egressNodeIPsASv6 := buildEgressIPNodeAddressSets([]string{node1.NodeIP})
+			physicalIPs := []string{}
+			for _, ip := range l3GatewayConfig.IPAddresses {
+				physicalIPs = append(physicalIPs, ip.IP.String())
+			}
+			egressNodeIPsASv4, egressNodeIPsASv6 := buildEgressIPNodeAddressSets(physicalIPs)
 			if config.IPv4Mode {
 				dbSetup.NBData = append(dbSetup.NBData, egressNodeIPsASv4)
 			}
@@ -596,22 +599,19 @@ var _ = ginkgo.Describe("Default network controller operations", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		recorder = record.NewFakeRecorder(10)
-		netManager := networkmanager.Default()
-		addressSetManager := addresssetmanager.NewAddressSetManager(f.PodCoreInformer(), f.NamespaceInformer(),
-			f.NodeCoreInformer(), nbClient, netManager.Interface().GetNetworkNameForNADKey)
 		oc, err = NewOvnController(
 			fakeClient,
 			f,
 			stopChan,
 			nil,
-			netManager.Interface(),
+			networkmanager.Default().Interface(),
 			nbClient,
 			sbClient,
 			recorder,
 			wg,
 			nil,
 			NewPortCache(stopChan),
-			addressSetManager,
+			nil,
 		)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		gomega.Expect(oc).NotTo(gomega.BeNil())
@@ -667,7 +667,7 @@ var _ = ginkgo.Describe("Default network controller operations", func() {
 			expectedNBDatabaseState = generateGatewayInitExpectedNB(expectedNBDatabaseState, expectedOVNClusterRouter,
 				expectedNodeSwitch, node1.Name, clusterSubnets, []*net.IPNet{subnet}, l3GatewayConfig,
 				[]*net.IPNet{classBIPAddress(node1.LrpIP)}, []*net.IPNet{classBIPAddress(node1.DrLrpIP)},
-				skipSnat, node1.NodeMgmtPortIP, "1400", node1.NodeIP)
+				skipSnat, node1.NodeMgmtPortIP, "1400")
 			expectedNBDatabaseState = append(expectedNBDatabaseState, expectedTransitSwitch())
 			gomega.Eventually(oc.nbClient).Should(libovsdbtest.HaveData(expectedNBDatabaseState))
 
@@ -717,7 +717,7 @@ var _ = ginkgo.Describe("Default network controller operations", func() {
 			expectedNBDatabaseState = generateGatewayInitExpectedNB(expectedNBDatabaseState, expectedOVNClusterRouter,
 				expectedNodeSwitch, node1.Name, clusterSubnets, []*net.IPNet{subnet}, l3GatewayConfig,
 				[]*net.IPNet{classBIPAddress(node1.LrpIP)}, []*net.IPNet{classBIPAddress(node1.DrLrpIP)},
-				skipSnat, node1.NodeMgmtPortIP, "1400", node1.NodeIP)
+				skipSnat, node1.NodeMgmtPortIP, "1400")
 			expectedNBDatabaseState = append(expectedNBDatabaseState, expectedTransitSwitch())
 			gomega.Eventually(oc.nbClient).Should(libovsdbtest.HaveData(expectedNBDatabaseState))
 
@@ -753,7 +753,7 @@ var _ = ginkgo.Describe("Default network controller operations", func() {
 			expectedNBDatabaseState = generateGatewayInitExpectedNB(expectedNBDatabaseState, expectedOVNClusterRouter,
 				expectedNodeSwitch, node1.Name, clusterSubnets, []*net.IPNet{subnet}, l3GatewayConfig,
 				[]*net.IPNet{classBIPAddress(node1.LrpIP)}, []*net.IPNet{classBIPAddress(node1.DrLrpIP)},
-				skipSnat, node1.NodeMgmtPortIP, "1400", node1.NodeIP)
+				skipSnat, node1.NodeMgmtPortIP, "1400")
 			expectedNBDatabaseState = append(expectedNBDatabaseState, expectedTransitSwitch())
 			gomega.Eventually(oc.nbClient).Should(libovsdbtest.HaveData(expectedNBDatabaseState))
 
@@ -776,10 +776,10 @@ var _ = ginkgo.Describe("Default network controller operations", func() {
 		newNodeSNAT("stale-nodeNAT-UUID-4", "10.0.0.3", "172.16.16.3"),
 	}
 	extraNatsWithMatch := []*nbdb.NAT{ // used for pod network advertised test
-		newNodeSNATWithMatch("stale-nodeNAT-UUID-1", "10.1.0.3", Node1GatewayRouterIP, "ip4.dst == $a1042611113178530741"),
-		newNodeSNATWithMatch("stale-nodeNAT-UUID-2", "10.2.0.3", Node1GatewayRouterIP, "ip4.dst == $a1042611113178530741"),
-		newNodeSNATWithMatch("stale-nodeNAT-UUID-3", "10.0.0.3", Node1GatewayRouterIP, "ip4.dst == $a1042611113178530741"),
-		newNodeSNATWithMatch("stale-nodeNAT-UUID-4", "10.0.0.3", "172.16.16.3", "ip4.dst == $a1042611113178530741"),
+		newNodeSNATWithMatch("stale-nodeNAT-UUID-1", "10.1.0.3", Node1GatewayRouterIP, "ip4.dst == $a712973235162149816"),
+		newNodeSNATWithMatch("stale-nodeNAT-UUID-2", "10.2.0.3", Node1GatewayRouterIP, "ip4.dst == $a712973235162149816"),
+		newNodeSNATWithMatch("stale-nodeNAT-UUID-3", "10.0.0.3", Node1GatewayRouterIP, "ip4.dst == $a712973235162149816"),
+		newNodeSNATWithMatch("stale-nodeNAT-UUID-4", "10.0.0.3", "172.16.16.3", "ip4.dst == $a712973235162149816"),
 	}
 	ginkgo.DescribeTable(
 		"reconciles pod network SNATs from syncGateway",
@@ -839,12 +839,12 @@ var _ = ginkgo.Describe("Default network controller operations", func() {
 					expectedNBDatabaseState = generateGatewayInitExpectedNB(expectedNBDatabaseState, expectedOVNClusterRouter,
 						expectedNodeSwitch, node1.Name, clusterSubnets, []*net.IPNet{subnet}, l3GatewayConfig,
 						[]*net.IPNet{classBIPAddress(node1.LrpIP)}, []*net.IPNet{classBIPAddress(node1.DrLrpIP)},
-						skipSnat, node1.NodeMgmtPortIP, "1400", node1.NodeIP)
+						skipSnat, node1.NodeMgmtPortIP, "1400")
 				} else {
 					expectedNBDatabaseState = generateGatewayInitExpectedNBWithPodNetworkAdvertised(expectedNBDatabaseState, expectedOVNClusterRouter,
 						expectedNodeSwitch, node1.Name, clusterSubnets, []*net.IPNet{subnet}, l3GatewayConfig,
 						[]*net.IPNet{classBIPAddress(node1.LrpIP)}, []*net.IPNet{classBIPAddress(node1.DrLrpIP)},
-						skipSnat, node1.NodeMgmtPortIP, "1400", true, node1.NodeIP)
+						skipSnat, node1.NodeMgmtPortIP, "1400", true)
 					addrSet, err := oc.addressSetFactory.GetAddressSet(GetAdvertisedNetworkSubnetsAddressSetDBIDs())
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 					expectedNBDatabaseState = generateAdvertisedUDNIsolationExpectedNB(expectedNBDatabaseState, oc.GetNetworkName(), oc.GetNetworkID(), clusterSubnets, expectedNodeSwitch, addrSet)
@@ -900,9 +900,9 @@ var _ = ginkgo.Describe("Default network controller operations", func() {
 				return oc.Reconcile(mutableNetInfo)
 			},
 			// won't be deleted on this node since this pod belongs to node-1 and is advertised so we keep this SNAT
-			newNodeSNATWithMatch("stale-nodeNAT-UUID-3", "10.0.0.3", Node1GatewayRouterIP, "ip4.dst == $a1042611113178530741"),
+			newNodeSNATWithMatch("stale-nodeNAT-UUID-3", "10.0.0.3", Node1GatewayRouterIP, "ip4.dst == $a712973235162149816"),
 			// won't be deleted on this node but will be deleted on the node whose IP is 172.16.16.3 since this pod belongs to node-1
-			newNodeSNATWithMatch("stale-nodeNAT-UUID-4", "10.0.0.3", "172.16.16.3", "ip4.dst == $a1042611113178530741"),
+			newNodeSNATWithMatch("stale-nodeNAT-UUID-4", "10.0.0.3", "172.16.16.3", "ip4.dst == $a712973235162149816"),
 		),
 		ginkgo.Entry(
 			"When pod network is advertised and DisableSNATMultipleGWs is false",
@@ -913,7 +913,7 @@ var _ = ginkgo.Describe("Default network controller operations", func() {
 				mutableNetInfo.SetPodNetworkAdvertisedVRFs(map[string][]string{"node1": {"vrf"}})
 				return oc.Reconcile(mutableNetInfo)
 			},
-			newNodeSNATWithMatch("stale-nodeNAT-UUID-4", "10.0.0.3", "172.16.16.3", "ip4.dst == $a1042611113178530741"), // won't be deleted on this node but will be deleted on the node whose IP is 172.16.16.3 since this pod belongs to this node
+			newNodeSNATWithMatch("stale-nodeNAT-UUID-4", "10.0.0.3", "172.16.16.3", "ip4.dst == $a712973235162149816"), // won't be deleted on this node but will be deleted on the node whose IP is 172.16.16.3 since this pod belongs to this node
 		),
 	)
 
@@ -930,7 +930,7 @@ var _ = ginkgo.Describe("Default network controller operations", func() {
 			expectedNBDatabaseState = generateGatewayInitExpectedNB(expectedNBDatabaseState, expectedOVNClusterRouter,
 				expectedNodeSwitch, node1.Name, clusterSubnets, []*net.IPNet{subnet}, l3GatewayConfig,
 				[]*net.IPNet{classBIPAddress(node1.LrpIP)}, []*net.IPNet{classBIPAddress(node1.DrLrpIP)},
-				skipSnat, node1.NodeMgmtPortIP, "1400", node1.NodeIP)
+				skipSnat, node1.NodeMgmtPortIP, "1400")
 			expectedNBDatabaseState = append(expectedNBDatabaseState, expectedTransitSwitch())
 			gomega.Eventually(oc.nbClient).Should(libovsdbtest.HaveData(expectedNBDatabaseState))
 

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -27,7 +27,6 @@ import (
 	libovsdbutil "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/libovsdb/util"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/metrics"
 	addressset "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/address_set"
-	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/addresssetmanager"
 	anpcontroller "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/controller/admin_network_policy"
 	egresssvc_zone "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/controller/egressservice"
 	networkconnectcontroller "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/controller/networkconnect"
@@ -447,22 +446,8 @@ func (oc *DefaultNetworkController) InitEgressServiceZoneController() (*egresssv
 	}
 
 	if !config.OVNKubernetesFeature.EnableEgressIP {
-		initClusterEgressPolicies = func(nbClient libovsdbclient.Client, addressSetFactory addressset.AddressSetFactory,
-			ni util.NetInfo, clusterSubnets []*net.IPNet, controllerName, routerName string) error {
-			clusterNodeIPsAddrSetDbIDs, err := oc.addressSetManager.EnsureClusterNodeIPsAddressSet(addresssetmanager.ClusterNodeIPsEgressServiceBackRef)
-			if err != nil {
-				return fmt.Errorf("failed to ensure cluster node IP address set for EgressService: %w", err)
-			}
-			return InitClusterEgressPolicies(nbClient, addressSetFactory, ni, clusterSubnets, controllerName, routerName, clusterNodeIPsAddrSetDbIDs)
-		}
-		ensureNodeNoReroutePolicies = func(nbClient libovsdbclient.Client, addressSetFactory addressset.AddressSetFactory,
-			network, router, controller string, nodeLister listers.NodeLister, v4, v6 bool) error {
-			clusterNodeIPsAddrSetDbIDs, err := oc.addressSetManager.EnsureClusterNodeIPsAddressSet(addresssetmanager.ClusterNodeIPsEgressServiceBackRef)
-			if err != nil {
-				return fmt.Errorf("failed to ensure cluster node IP address set for EgressService: %w", err)
-			}
-			return ensureDefaultNoRerouteNodePolicies(nbClient, addressSetFactory, network, router, controller, nodeLister, v4, v6, clusterNodeIPsAddrSetDbIDs)
-		}
+		initClusterEgressPolicies = InitClusterEgressPolicies
+		ensureNodeNoReroutePolicies = ensureDefaultNoRerouteNodePolicies
 		createDefaultNodeRouteToExternal = libovsdbutil.CreateDefaultRouteToExternal
 	}
 

--- a/go-controller/pkg/ovn/ovn_test.go
+++ b/go-controller/pkg/ovn/ovn_test.go
@@ -278,9 +278,6 @@ func (o *FakeOVN) init(nadList []nettypes.NetworkAttachmentDefinition) {
 	}
 
 	o.portCache = NewPortCache(o.stopChan)
-	o.addressSetManager = addresssetmanager.NewAddressSetManager(o.watcher.PodCoreInformer(),
-		o.watcher.NamespaceInformer(), o.watcher.NodeCoreInformer(), o.nbClient, o.networkManager.Interface().GetNetworkNameForNADKey)
-
 	kubeOVN := &kube.KubeOVN{
 		Kube:      kube.Kube{KClient: o.fakeClient.KubeClient},
 		EIPClient: o.fakeClient.EgressIPClient,
@@ -293,12 +290,13 @@ func (o *FakeOVN) init(nadList []nettypes.NetworkAttachmentDefinition) {
 		o.portCache,
 		o.networkManager.Interface(),
 		o.asf,
-		o.addressSetManager,
 		config.IPv4Mode,
 		config.IPv6Mode,
 		"",
 		types.DefaultNetworkControllerName,
 	)
+	o.addressSetManager = addresssetmanager.NewAddressSetManager(o.watcher.PodCoreInformer(),
+		o.watcher.NamespaceInformer(), o.watcher.NodeCoreInformer(), o.nbClient, o.networkManager.Interface().GetNetworkNameForNADKey)
 
 	if o.asf == nil {
 		o.eIPController.addressSetFactory = addressset.NewOvnAddressSetFactory(o.nbClient, config.IPv4Mode, config.IPv6Mode)


### PR DESCRIPTION
## Summary
Reverts two upstream PRs from downstream merge #3247 to bisect the `ovnCPU-nbdb_avg +22.50%` regression detected in the `payload-udn-density-l2-pods` workload.

### Reverted PRs

1. **[ovn-org/ovn-kubernetes#6429](https://github.com/ovn-kubernetes/ovn-kubernetes/pull/6429)** — "Ensure node IP address set for advertised SNAT"
   - Adds a new `ClusterNodeIPs` address set in NBDB that syncs on every node update
   - Net-new NBDB write load: creates/updates address set objects on node add/update/delete events
   - Primary suspect for NBDB CPU increase

2. **[ovn-org/ovn-kubernetes#6467](https://github.com/ovn-kubernetes/ovn-kubernetes/pull/6467)** — "Optimize addressManager sync and linkmanager syncLink"
   - Changes `addressManager.sync()` from per-link `AddrList` calls to a single `AddrList(nil, ...)` call
   - Moves `GetFilteredInterfaceAddrs` after the managed-link check in `syncLink()`
   - In L2 UDN density with many pods/veths, this changes the cadence of node IP reconciliation

### Context
- Regression: `ovnCPU-nbdb_avg` increased from ~0.586 to 0.717 cores (+22.50%)
- Workload: `payload-udn-density-l2-pods` — creates L2 Primary UDNs with NetworkPolicies, Services, and pods
- Other upstream PRs in #3247 (#6435 OutboundSNAT, #5433 P-UDN multi-subnet) were ruled out as they only affect CUDN or L3 topology code paths not exercised by this L2 workload

## Test plan
- [ ] Run `payload-udn-density-l2-pods` perfscale test and compare `ovnCPU-nbdb_avg` against baseline
- [ ] If regression resolves, create individual revert PRs to isolate which of the two changes is the root cause

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multicast support with new multicast namespace and cluster owner types.

* **Refactor**
  * Removed deprecated cluster node IP address set functionality.
  * Improved address set cleanup logic to focus on ACL references.
  * Restructured EgressIP controller initialization and gateway manager dependencies.
  * Updated address set management and SNAT routing logic for advertised networks.

* **Tests**
  * Updated test cases to align with refactored address set handling and controller initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->