### PR TITLE
OCPBUGS-86018: Fix NodePort cleanup when allocateLoadBalancerNodePorts is disabled

### DIFF
--- a/go-controller/pkg/node/port_claim.go
+++ b/go-controller/pkg/node/port_claim.go
@@ -160,7 +160,16 @@ func (p *portClaimWatcher) AddService(svc *corev1.Service) error {
 }
 
 func (p *portClaimWatcher) UpdateService(old, new *corev1.Service) error {
-	if reflect.DeepEqual(old.Spec.ExternalIPs, new.Spec.ExternalIPs) && reflect.DeepEqual(old.Spec.Ports, new.Spec.Ports) {
+	// Check if anything changed that would affect port claims:
+	// - ExternalIPs changed
+	// - Ports changed
+	// - AllocateLoadBalancerNodePorts changed (affects whether NodePorts should be claimed)
+	oldAllocate := util.LoadBalancerServiceHasNodePortAllocation(old)
+	newAllocate := util.LoadBalancerServiceHasNodePortAllocation(new)
+
+	if reflect.DeepEqual(old.Spec.ExternalIPs, new.Spec.ExternalIPs) &&
+	   reflect.DeepEqual(old.Spec.Ports, new.Spec.Ports) &&
+	   oldAllocate == newAllocate {
 		return nil
 	}
 	var errors, raw_errors []error

--- a/go-controller/pkg/ovn/controller/services/lb_config.go
+++ b/go-controller/pkg/ovn/controller/services/lb_config.go
@@ -195,7 +195,20 @@ func buildServiceLBConfigs(service *corev1.Service, endpointSlices []*discovery.
 		// NodePort services get a per-node load balancer, but with the node's physical IP as the vip
 		// Thus, the vip "node" will be expanded later.
 		// This is NEVER influenced by InternalTrafficPolicy
-		if svcPort.NodePort != 0 {
+		//
+		// Only create NodePort load balancers if the service type requires NodePorts
+		// Note: We cannot rely on svcPort.NodePort != 0 because Kubernetes keeps the
+		// NodePort value internally even after it's removed from the spec when
+		// allocateLoadBalancerNodePorts=false. We must check the service type and
+		// allocation policy instead.
+		//
+		// Create NodePort LBs for:
+		// 1. NodePort services (always have NodePorts)
+		// 2. LoadBalancer services where allocateLoadBalancerNodePorts is not explicitly false
+		shouldCreateNodePortLB := service.Spec.Type == corev1.ServiceTypeNodePort ||
+			(service.Spec.Type == corev1.ServiceTypeLoadBalancer && util.LoadBalancerServiceHasNodePortAllocation(service))
+
+		if shouldCreateNodePortLB && svcPort.NodePort != 0 {
 			nodePortLBConfig := lbConfig{
 				protocol:             svcPort.Protocol,
 				inport:               svcPort.NodePort,

--- a/go-controller/pkg/ovn/controller/services/lb_config_test.go
+++ b/go-controller/pkg/ovn/controller/services/lb_config_test.go
@@ -1167,6 +1167,168 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "LB service with AllocateLoadBalancerNodePorts=false should not create NodePort LB",
+			args: args{
+				slices: makeV4SliceWithEndpoints(
+					corev1.ProtocolTCP,
+					kubetest.MakeReadyEndpoint(nodeA, "10.128.0.2"),
+					kubetest.MakeReadyEndpoint(nodeB, "10.128.1.2"),
+				),
+				service: &corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: ns},
+					Spec: corev1.ServiceSpec{
+						Type:                          corev1.ServiceTypeLoadBalancer,
+						ClusterIP:                     "192.168.1.1",
+						ClusterIPs:                    []string{"192.168.1.1"},
+						AllocateLoadBalancerNodePorts: ptr.To(false),
+						Ports: []corev1.ServicePort{{
+							Name:       portName,
+							Port:       inport,
+							Protocol:   corev1.ProtocolTCP,
+							TargetPort: outportstr,
+							NodePort:   5, // This should be ignored when AllocateLoadBalancerNodePorts=false
+						}},
+						ExternalIPs: []string{"4.2.2.2"},
+					},
+					Status: corev1.ServiceStatus{
+						LoadBalancer: corev1.LoadBalancerStatus{
+							Ingress: []corev1.LoadBalancerIngress{{
+								IP: "5.5.5.5",
+							}},
+						},
+					},
+				},
+			},
+			resultsSame: true,
+			resultSharedGatewayCluster: []lbConfig{
+				{
+					vips:     []string{"192.168.1.1", "4.2.2.2", "5.5.5.5"},
+					protocol: corev1.ProtocolTCP,
+					inport:   inport,
+					clusterEndpoints: util.LBEndpoints{
+						V4IPs: []string{"10.128.0.2", "10.128.1.2"},
+						Port:  outport,
+					},
+					nodeEndpoints: util.PortToLBEndpoints{},
+				},
+			},
+			// No NodePort LB should be created
+			resultSharedGatewayNode: nil,
+		},
+		{
+			name: "LB service with AllocateLoadBalancerNodePorts=true should create NodePort LB",
+			args: args{
+				slices: makeV4SliceWithEndpoints(
+					corev1.ProtocolTCP,
+					kubetest.MakeReadyEndpoint(nodeA, "10.128.0.2"),
+					kubetest.MakeReadyEndpoint(nodeB, "10.128.1.2"),
+				),
+				service: &corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: ns},
+					Spec: corev1.ServiceSpec{
+						Type:                          corev1.ServiceTypeLoadBalancer,
+						ClusterIP:                     "192.168.1.1",
+						ClusterIPs:                    []string{"192.168.1.1"},
+						AllocateLoadBalancerNodePorts: ptr.To(true),
+						Ports: []corev1.ServicePort{{
+							Name:       portName,
+							Port:       inport,
+							Protocol:   corev1.ProtocolTCP,
+							TargetPort: outportstr,
+							NodePort:   5,
+						}},
+						ExternalIPs: []string{"4.2.2.2"},
+					},
+					Status: corev1.ServiceStatus{
+						LoadBalancer: corev1.LoadBalancerStatus{
+							Ingress: []corev1.LoadBalancerIngress{{
+								IP: "5.5.5.5",
+							}},
+						},
+					},
+				},
+			},
+			resultsSame: true,
+			resultSharedGatewayCluster: []lbConfig{
+				{
+					vips:     []string{"192.168.1.1", "4.2.2.2", "5.5.5.5"},
+					protocol: corev1.ProtocolTCP,
+					inport:   inport,
+					clusterEndpoints: util.LBEndpoints{
+						V4IPs: []string{"10.128.0.2", "10.128.1.2"},
+						Port:  outport,
+					},
+					nodeEndpoints: util.PortToLBEndpoints{},
+				},
+			},
+			// NodePort LB should be created as a template config (since no ETP and no affinity timeout)
+			resultSharedGatewayTemplate: []lbConfig{
+				{
+					vips:        []string{"node"},
+					protocol:    corev1.ProtocolTCP,
+					inport:      5,
+					hasNodePort: true,
+					clusterEndpoints: util.LBEndpoints{
+						V4IPs: []string{"10.128.0.2", "10.128.1.2"},
+						Port:  outport,
+					},
+					nodeEndpoints: util.PortToLBEndpoints{},
+				},
+			},
+		},
+		{
+			name: "NodePort service should always create NodePort LB regardless of AllocateLoadBalancerNodePorts",
+			args: args{
+				slices: makeV4SliceWithEndpoints(
+					corev1.ProtocolTCP,
+					kubetest.MakeReadyEndpoint(nodeA, "10.128.0.2"),
+					kubetest.MakeReadyEndpoint(nodeB, "10.128.1.2"),
+				),
+				service: &corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: ns},
+					Spec: corev1.ServiceSpec{
+						Type:       corev1.ServiceTypeNodePort,
+						ClusterIP:  "192.168.1.1",
+						ClusterIPs: []string{"192.168.1.1"},
+						Ports: []corev1.ServicePort{{
+							Name:       portName,
+							Port:       inport,
+							Protocol:   corev1.ProtocolTCP,
+							TargetPort: outportstr,
+							NodePort:   5,
+						}},
+					},
+				},
+			},
+			resultsSame: true,
+			resultSharedGatewayCluster: []lbConfig{
+				{
+					vips:     []string{"192.168.1.1"},
+					protocol: corev1.ProtocolTCP,
+					inport:   inport,
+					clusterEndpoints: util.LBEndpoints{
+						V4IPs: []string{"10.128.0.2", "10.128.1.2"},
+						Port:  outport,
+					},
+					nodeEndpoints: util.PortToLBEndpoints{},
+				},
+			},
+			// NodePort LB should be created as a template config
+			resultSharedGatewayTemplate: []lbConfig{
+				{
+					vips:        []string{"node"},
+					protocol:    corev1.ProtocolTCP,
+					inport:      5,
+					hasNodePort: true,
+					clusterEndpoints: util.LBEndpoints{
+						V4IPs: []string{"10.128.0.2", "10.128.1.2"},
+						Port:  outport,
+					},
+					nodeEndpoints: util.PortToLBEndpoints{},
+				},
+			},
+		},
 	}
 
 	for i, tt := range tests {


### PR DESCRIPTION
## Summary

When a LoadBalancer service has `allocateLoadBalancerNodePorts` set to false, OVN-Kubernetes was still creating NodePort load balancers and keeping NodePort listeners open on nodes.

## Root Cause

Two issues prevented proper cleanup:

1. **lb_config.go**: `buildServiceLBConfigs()` only checked if `NodePort != 0`, but Kubernetes keeps this value internally even after removal from the spec, so the check always passed.

2. **port_claim.go**: `UpdateService()` didn't detect when `allocateLoadBalancerNodePorts` changed, so it never triggered cleanup of existing NodePort listeners.

## Solution

### Fix 1: lb_config.go (buildServiceLBConfigs)
Changed the logic to check service type and allocation policy instead of relying on the NodePort value:
- **NodePort services**: Always create NodePort LBs
- **LoadBalancer services**: Only create NodePort LBs if `allocateLoadBalancerNodePorts` is enabled (true or nil)

### Fix 2: port_claim.go (UpdateService)
Added detection for when `allocateLoadBalancerNodePorts` changes from true to false, triggering proper cleanup of NodePort listeners.

## Files Changed

- `go-controller/pkg/ovn/controller/services/lb_config.go` - Service LB config logic
- `go-controller/pkg/node/port_claim.go` - NodePort listener lifecycle management
- `go-controller/pkg/ovn/controller/services/lb_config_test.go` - Comprehensive test coverage

## Test Plan

- [x] LoadBalancer with `allocateLoadBalancerNodePorts=false` → no NodePort LB created
- [x] LoadBalancer with `allocateLoadBalancerNodePorts=true` → NodePort LB created  
- [x] NodePort service → NodePort LB always created (regardless of allocate field)
- [x] Transitioning from true→false closes existing NodePort listeners

## Verification Steps

Tested on OpenShift 4.18:
1. Create LoadBalancer service (NodePort auto-assigned, listener active on nodes)
2. Set `allocateLoadBalancerNodePorts: false` and remove `nodePort` from spec
3. **Result**: NodePort listener closes within seconds ✅

Before fix: Port remained open indefinitely (security issue)
After fix: Port closes immediately upon reconciliation

## Fixes

OCPBUGS-86018

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * NodePort load balancers now respect whether LoadBalancer services are configured to allocate NodePorts, preventing unnecessary NodePort exposure.
  * Services that change NodePort allocation settings now update port handling correctly, so stale port claims are avoided.
  * LoadBalancer services continue to get the expected cluster-wide load balancer behavior even when NodePort allocation is disabled.
* **Tests**
  * Expanded coverage for NodePort and LoadBalancer service combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->