### PR TITLE
[DNM] debug(CNV-90807): log shouldWatchNamespaces condition values when false

### DIFF
--- a/go-controller/pkg/ovn/base_network_controller_namespace.go
+++ b/go-controller/pkg/ovn/base_network_controller_namespace.go
@@ -66,9 +66,16 @@ func (bnc *BaseNetworkController) shouldWatchNamespaces() bool {
 	// - The network is the default network.
 	// - The network is primary, and network segmentation is enabled.
 	// - The network is secondary, and multi NetworkPolicies are enabled.
-	return bnc.IsDefault() ||
+	result := bnc.IsDefault() ||
 		bnc.IsPrimaryNetwork() && util.IsNetworkSegmentationSupportEnabled() ||
 		bnc.IsUserDefinedNetwork() && util.IsMultiNetworkPoliciesSupportEnabled()
+	if !result {
+		klog.Infof("shouldWatchNamespaces=false for network %s: IsDefault=%v IsPrimary=%v IsUDN=%v MNPEnabled=%v NetSegEnabled=%v",
+			bnc.GetNetworkName(), bnc.IsDefault(), bnc.IsPrimaryNetwork(),
+			bnc.IsUserDefinedNetwork(), util.IsMultiNetworkPoliciesSupportEnabled(),
+			util.IsNetworkSegmentationSupportEnabled())
+	}
+	return result
 }
 
 // WatchNamespaces starts the watching of namespace resource and calls


### PR DESCRIPTION
Add debug logging to shouldWatchNamespaces() to print each condition's value when the function returns false. This helps diagnose cases where MultiNetworkPolicy enforcement is silently disabled because the OVN-K process has EnableMultiNetworkPolicy=false in memory.

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
