### PR TITLE
test/e2e: fix UDN services test for cloud platforms

### DIFF
--- a/test/e2e/network_segmentation_services.go
+++ b/test/e2e/network_segmentation_services.go
@@ -30,6 +30,7 @@ import (
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	e2eservice "k8s.io/kubernetes/test/e2e/framework/service"
+	admissionapi "k8s.io/pod-security-admission/api"
 	utilnet "k8s.io/utils/net"
 )
 
@@ -122,6 +123,10 @@ var _ = Describe("Network Segmentation: services", feature.NetworkSegmentation, 
 				)
 				Expect(err).NotTo(HaveOccurred())
 
+				// On cloud platforms (e.g. AWS), UDP LoadBalancer services are not supported and
+				// external containers (frr) are unavailable. Gate all such checks on KinD.
+				isKindCluster := infraprovider.IsKind()
+
 				By(fmt.Sprintf("Creating a UDN LoadBalancer service"))
 				policy := v1.IPFamilyPolicyPreferDualStack
 				udnService, err := jig.CreateUDPService(context.TODO(), func(s *v1.Service) {
@@ -138,9 +143,11 @@ var _ = Describe("Network Segmentation: services", feature.NetworkSegmentation, 
 				})
 				framework.ExpectNoError(err)
 
-				By("Wait for UDN LoadBalancer Ingress to pop up")
-				udnService, err = jig.WaitForLoadBalancer(context.TODO(), 180*time.Second)
-				framework.ExpectNoError(err)
+				if isKindCluster {
+					By("Wait for UDN LoadBalancer Ingress to pop up")
+					udnService, err = jig.WaitForLoadBalancer(context.TODO(), 180*time.Second)
+					framework.ExpectNoError(err)
+				}
 
 				By("Creating a UDN backend pod")
 				udnServerPod := e2epod.NewAgnhostPod(
@@ -169,7 +176,9 @@ ips=$(ip -o addr show dev $iface| grep global |awk '{print $4}' | cut -d/ -f1 | 
 				By("Connect to the UDN service cluster IP from the UDN client pod on the same node")
 				checkConnectionToClusterIPs(f, udnClientPod, udnService, udnServerPod.Name)
 				By("Connect to the UDN service nodePort on all 3 nodes from the UDN client pod")
-				checkConnectionToLoadBalancers(f, udnClientPod, udnService, udnServerPod.Name)
+				if isKindCluster {
+					checkConnectionToLoadBalancers(f, udnClientPod, udnService, udnServerPod.Name)
+				}
 				checkConnectionToNodePort(f, udnClientPod, udnService, &nodes.Items[0], "endpoint node", udnServerPod.Name)
 				if !dynamicUDNEnabled {
 					checkConnectionToNodePort(f, udnClientPod, udnService, &nodes.Items[1], "other node", udnServerPod.Name)
@@ -182,7 +191,9 @@ ips=$(ip -o addr show dev $iface| grep global |awk '{print $4}' | cut -d/ -f1 | 
 
 				By("Connect to the UDN service from the UDN client pod on a different node")
 				checkConnectionToClusterIPs(f, udnClientPod2, udnService, udnServerPod.Name)
-				checkConnectionToLoadBalancers(f, udnClientPod2, udnService, udnServerPod.Name)
+				if isKindCluster {
+					checkConnectionToLoadBalancers(f, udnClientPod2, udnService, udnServerPod.Name)
+				}
 				checkConnectionToNodePort(f, udnClientPod2, udnService, &nodes.Items[1], "local node", udnServerPod.Name)
 				checkConnectionToNodePort(f, udnClientPod2, udnService, &nodes.Items[0], "server node", udnServerPod.Name)
 				if !dynamicUDNEnabled {
@@ -191,13 +202,15 @@ ips=$(ip -o addr show dev $iface| grep global |awk '{print $4}' | cut -d/ -f1 | 
 
 				By("Connect to the UDN service from the UDN client external container")
 				externalContainer := infraapi.ExternalContainer{Name: "frr"}
-				if !dynamicUDNEnabled {
-					checkConnectionToLoadBalancersFromExternalContainer(f, externalContainer, udnService, udnServerPod.Name)
-				}
-				checkConnectionToNodePortFromExternalContainer(externalContainer, udnService, &nodes.Items[0], "server node", udnServerPod.Name)
-				if !dynamicUDNEnabled {
-					checkConnectionToNodePortFromExternalContainer(externalContainer, udnService, &nodes.Items[1], "other node", udnServerPod.Name)
-					checkConnectionToNodePortFromExternalContainer(externalContainer, udnService, &nodes.Items[2], "other node", udnServerPod.Name)
+				if isKindCluster {
+					if !dynamicUDNEnabled {
+						checkConnectionToLoadBalancersFromExternalContainer(f, externalContainer, udnService, udnServerPod.Name)
+					}
+					checkConnectionToNodePortFromExternalContainer(externalContainer, udnService, &nodes.Items[0], "server node", udnServerPod.Name)
+					if !dynamicUDNEnabled {
+						checkConnectionToNodePortFromExternalContainer(externalContainer, udnService, &nodes.Items[1], "other node", udnServerPod.Name)
+						checkConnectionToNodePortFromExternalContainer(externalContainer, udnService, &nodes.Items[2], "other node", udnServerPod.Name)
+					}
 				}
 
 				// Default network -> UDN
@@ -206,6 +219,13 @@ ips=$(ip -o addr show dev $iface| grep global |awk '{print $4}' | cut -d/ -f1 | 
 				defaultNetNamespace := &v1.Namespace{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: f.Namespace.Name + "-default",
+						Labels: map[string]string{
+							// Match the PodSecurity level that wrappedTestFramework sets via f.CreateNamespace
+							// so that pods created in this namespace are not rejected by PSA on cloud clusters.
+							admissionapi.EnforceLevelLabel: string(admissionapi.LevelPrivileged),
+							admissionapi.WarnLevelLabel:    string(admissionapi.LevelPrivileged),
+							admissionapi.AuditLevelLabel:   string(admissionapi.LevelPrivileged),
+						},
 					},
 				}
 				f.AddNamespacesToDelete(defaultNetNamespace)


### PR DESCRIPTION
The **[Feature:NetworkSegmentation] Network Segmentation: services … should be reachable through their cluster IP, node port and load balancer** test was failing on dualstack AWS clusters due to three cloud-platform incompatibilities. This PR fixes all three.

Problem 1 — UDP LoadBalancer not supported on AWS

Cloud load balancers (e.g. AWS ELB) do not support UDP protocol. The test unconditionally created a UDP LoadBalancer service and called WaitForLoadBalancer, which timed out after 3 minutes on AWS.

Fix: Gate WaitForLoadBalancer and all checkConnectionToLoadBalancers calls behind isKindCluster (infraprovider.IsKind()), since UDP LoadBalancer is only available in KinD environments.

Problem 2 — External container (frr) not available on cloud clusters

The OpenShift infra provider's ExecExternalContainerCommand panics with "not implemented" when no baremetal cluster infrastructure is present (i.e. clusterInfra == nil). The test called checkConnectionToNodePortFromExternalContainer unconditionally, causing a panic.

Fix: Wrap the entire external container section — both LB and NodePort checks — inside the same isKindCluster guard.

Problem 3 — PodSecurity admission rejects pods in manually-created namespace

The test creates a secondary namespace (<ns>-default) using the raw API, without the pod-security.kubernetes.io/enforce=privileged labels that f.CreateNamespace sets automatically (via f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged). On OpenShift AWS clusters, the default enforcement level is restricted, so pods without an explicit security context are rejected.

Fix: Add pod-security.kubernetes.io/enforce/warn/audit=privileged labels to the manually-created namespace at creation time, matching what the framework does for test namespaces.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Adjusted network segmentation end-to-end checks to run LoadBalancer-related assertions only in supported KinD environments.
  * Kept NodePort connectivity validation active while skipping unsupported LoadBalancer checks on other cluster types.
  * Updated the default test namespace labels to align with the expected Pod Security settings for negative connectivity validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->