### PR TITLE
[DNM]OCPBUGS-87249 - clustermanager: re-evaluate egress IPs when cloud egress IP config changes

### DIFF
--- a/go-controller/pkg/clustermanager/egressip_event_handler.go
+++ b/go-controller/pkg/clustermanager/egressip_event_handler.go
@@ -128,6 +128,7 @@ func (h *egressIPClusterControllerEventHandler) UpdateResource(oldObj, newObj in
 		isNewReady := h.eIPC.isEgressNodeReady(newNode)
 		isNewReachable := h.eIPC.isEgressNodeReachable(newNode)
 		isHostCIDRsAltered := util.NodeHostCIDRsAnnotationChanged(oldNode, newNode)
+		isCloudEgressIPConfigAltered := util.CloudEgressIPConfigAnnotationChanged(oldNode, newNode)
 		h.eIPC.setNodeEgressReady(newNode.Name, isNewReady)
 		if !oldHadEgressLabel && newHasEgressLabel {
 			klog.Infof("Node: %s has been labeled, adding it for egress assignment", newNode.Name)
@@ -142,7 +143,7 @@ func (h *egressIPClusterControllerEventHandler) UpdateResource(oldObj, newObj in
 			}
 			return nil
 		}
-		if isOldReady == isNewReady && !isHostCIDRsAltered {
+		if isOldReady == isNewReady && !isHostCIDRsAltered && !isCloudEgressIPConfigAltered {
 			return nil
 		}
 		if !isNewReady {
@@ -151,7 +152,16 @@ func (h *egressIPClusterControllerEventHandler) UpdateResource(oldObj, newObj in
 				return err
 			}
 		} else if isNewReady && isNewReachable {
-			klog.Infof("Node: %s is ready and reachable, adding it for egress assignment", newNode.Name)
+			if isCloudEgressIPConfigAltered {
+				// When cloud-network-config-controller updates the egress IP config
+				// annotation (e.g., adding an IPv6 subnet that was previously missing
+				// because the subnet's IPv6 CIDR was not yet in "associated" state),
+				// the node's egress IP capacity may have changed. Log this explicitly
+				// so operators can correlate annotation changes with re-assignments.
+				klog.Infof("Node: %s cloud egress IP config annotation changed, re-evaluating egress IP assignments", newNode.Name)
+			} else {
+				klog.Infof("Node: %s is ready and reachable, adding it for egress assignment", newNode.Name)
+			}
 			h.eIPC.setNodeEgressReachable(newNode.Name, isNewReachable)
 			if err := h.eIPC.addEgressNode(newNode.Name); err != nil {
 				return err

--- a/go-controller/pkg/util/node_annotations.go
+++ b/go-controller/pkg/util/node_annotations.go
@@ -886,6 +886,14 @@ func NodeHostCIDRsAnnotationChanged(oldNode, newNode *corev1.Node) bool {
 	return oldNode.Annotations[OVNNodeHostCIDRs] != newNode.Annotations[OVNNodeHostCIDRs]
 }
 
+// CloudEgressIPConfigAnnotationChanged returns true if the cloud egress IP
+// configuration annotation changed between oldNode and newNode. This annotation
+// is managed by cloud-network-config-controller and carries the IPv4/IPv6
+// subnets and capacity for egress IP assignment on cloud platforms.
+func CloudEgressIPConfigAnnotationChanged(oldNode, newNode *corev1.Node) bool {
+	return oldNode.Annotations[cloudEgressIPConfigAnnotationKey] != newNode.Annotations[cloudEgressIPConfigAnnotationKey]
+}
+
 // ParseNodeHostCIDRs returns the parsed host CIDRS living on a node
 func ParseNodeHostCIDRs(node *corev1.Node) (sets.Set[string], error) {
 	addrAnnotation, ok := node.Annotations[OVNNodeHostCIDRs]


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

Problem
On dualstack AWS clusters, egressIPv6 was never assigned even though nodes correctly report IPv6 subnet and capacity in the cloud.network.openshift.io/egress-ipconfig annotation.

The underlying cause lives in two places. The primary cause is in cloud-network-config-controller (CNCC): a bug in getSubnet could cause it to initially write the annotation with no IPv6 subnet (or the wrong one) by unconditionally picking the first entry in Ipv6CidrBlockAssociationSet regardless of its state. This is fixed in a companion CNCC [PR](https://github.com/openshift/cloud-network-config-controller/pull/228).

However, even with the CNCC fix in place, there is a secondary failure mode in OVN-K's node UpdateResource handler. Consider this sequence:

A node comes up; CNCC has not yet annotated it, so initEgressIPAllocator fails. The node's egressIPConfig in the allocator cache has V6.Net == nil.
CNCC annotates the node (possibly with no IPv6 subnet initially, due to the CNCC bug).
OVN-K receives the node UPDATE, calls initEgressIPAllocator (cache updated), then hits the early-return guard:
if isOldReady == isNewReady && !isHostCIDRsAltered {
    return nil  // ← exits here; addEgressNode() is never called
}
Because only the CNCC annotation changed — not readiness and not host-cidrs — the handler returns early without calling addEgressNode().
Any EgressIPs whose IPv6 address could not be placed (no node had a matching V6.Net) remain permanently unassigned — addEgressNode() is the only code path that re-evaluates them.
Later, CNCC corrects the annotation (adding the IPv6 subnet). OVN-K again receives the UPDATE and again exits early, never reconsidering the unassigned IPv6 EgressIPs.
The net effect: even after both nodes report i.e. "ipv6":"2600:1f18:1816:ac01::/64" with capacity 14 in their annotation, the EgressIP status shows the IPv6 address as permanently unassigned.

Fix
pkg/util/node_annotations.go
Add CloudEgressIPConfigAnnotationChanged(), analogous to the existing NodeHostCIDRsAnnotationChanged()


pkg/clustermanager/egressip_event_handler.go
Add isCloudEgressIPConfigAltered to the early-return guard so that annotation changes from CNCC trigger addEgressNode(), giving previously-unassigned EgressIPs another chance to be reconciled with the updated node cache. A distinct log line is emitted when the trigger is an annotation change rather than a readiness transition.


Impact
Cloud platforms only (PlatformTypeIsEgressIPCloudProvider()): CloudEgressIPConfigAnnotationChanged only fires on nodes that CNCC manages, so bare-metal is unaffected.
Low frequency: CNCC typically writes the annotation once at node startup and rarely updates it, so addEgressNode() is not called more often than necessary.
No functional regression for IPv4: The change is additive — it only allows addEgressNode() to run in a case where it previously did not.


Related
Companion CNCC fix: [[openshift/cloud-network-config-controller#<PR>](https://github.com/openshift/cloud-network-config-controller) ](https://github.com/openshift/cloud-network-config-controller/pull/228) — fixes the root cause where getSubnet picks a stale disassociated IPv6 CIDR block association instead of the current associated one.

Testing
Pre-merge testing was performed with https://github.com/openshift/cloud-network-config-controller/pull/228 on dualstack AWS IPv4 primary and dualstack AWS IPv6 primary cluster
Regression testing with https://github.com/openshift/cloud-network-config-controller/pull/228 was performed on dualstack BM cluster

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of node updates so changes to cloud egress IP configuration are now recognized and reprocessed correctly.
  * Prevented updates from being skipped when only the cloud egress IP annotation changes.
  * Added clearer status logging during node re-evaluation, making it easier to understand why egress behavior is being recalculated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->