### PR TITLE
[DNM] Testing fix for OCPBUGS-55741

### DIFF
--- a/go-controller/pkg/controllermanager/controller_manager.go
+++ b/go-controller/pkg/controllermanager/controller_manager.go
@@ -5,7 +5,6 @@ package controllermanager
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"slices"
 	"sync"
@@ -237,27 +236,11 @@ func (cm *ControllerManager) CleanupStaleNetworks(validNetworks ...util.NetInfo)
 		}
 	}
 
-	// Remove stale subnets from the advertised networks address set used for isolation
-	// NOTE: network reconciliation will take care of removing the subnets for existing networks that are no longer
+	// Remove stale subnets from the advertised networks address set used for isolation.
+	// Network reconciliation will take care of removing the subnets for existing networks that are no longer
 	// advertised.
-	addressSetFactory := addressset.NewOvnAddressSetFactory(cm.nbClient, config.IPv4Mode, config.IPv6Mode)
-	advertisedSubnets, err := addressSetFactory.GetAddressSet(ovn.GetAdvertisedNetworkSubnetsAddressSetDBIDs())
-	if err != nil && !errors.Is(err, libovsdbclient.ErrNotFound) {
-		return fmt.Errorf("failed to get advertised subnets addresset %s: %w", ovn.GetAdvertisedNetworkSubnetsAddressSetDBIDs(), err)
-	}
-	if advertisedSubnets != nil {
-		v4AdvertisedSubnets, v6AdvertisedSubnets := advertisedSubnets.GetAddresses()
-		var invalidSubnets []string
-		for _, subnet := range append(v4AdvertisedSubnets, v6AdvertisedSubnets...) {
-			if !validNetworksSubnets.Has(subnet) {
-				klog.Infof("Cleanup stale advertised subnet: %q", subnet)
-				invalidSubnets = append(invalidSubnets, subnet)
-			}
-		}
-
-		if err := advertisedSubnets.DeleteAddresses(invalidSubnets); err != nil {
-			klog.Errorf("Failed to delete stale advertised subnets: %v", invalidSubnets)
-		}
+	if err := ovn.CleanupStaleAdvertisedNetworkSubnets(cm.nbClient, validNetworksSubnets); err != nil {
+		klog.Errorf("Failed to cleanup stale advertised subnets: %v", err)
 	}
 	return nil
 }
@@ -514,7 +497,7 @@ func (cm *ControllerManager) Start(ctx context.Context) error {
 	}
 
 	if util.IsRouteAdvertisementsEnabled() {
-		if err := cm.configureAdvertisedNetworkIsolation(); err != nil {
+		if err := ovn.ConfigureAdvertisedNetworkIsolation(cm.nbClient); err != nil {
 			return fmt.Errorf("failed to initialize advertised network isolation: %w", err)
 		}
 	}
@@ -574,12 +557,6 @@ func (cm *ControllerManager) Stop() {
 
 func (cm *ControllerManager) Reconcile(_ string, _, _ util.NetInfo) error {
 	return nil
-}
-
-func (cm *ControllerManager) configureAdvertisedNetworkIsolation() error {
-	addressSetFactory := addressset.NewOvnAddressSetFactory(cm.nbClient, config.IPv4Mode, config.IPv6Mode)
-	_, err := addressSetFactory.EnsureAddressSet(ovn.GetAdvertisedNetworkSubnetsAddressSetDBIDs())
-	return err
 }
 
 func (cm *ControllerManager) setTopologyType() error {

--- a/go-controller/pkg/libovsdb/ops/acl.go
+++ b/go-controller/pkg/libovsdb/ops/acl.go
@@ -28,6 +28,25 @@ func getACLMutableFields(acl *nbdb.ACL) []interface{} {
 		&acl.Name, &acl.Options, &acl.Priority, &acl.Severity, &acl.Tier, &acl.SampleNew, &acl.SampleEst}
 }
 
+// GetACL looks up an ACL from the cache
+func GetACL(nbClient libovsdbclient.Client, acl *nbdb.ACL) (*nbdb.ACL, error) {
+	found := []*nbdb.ACL{}
+	opModel := operationModel{
+		Model:          acl,
+		ExistingResult: &found,
+		ErrNotFound:    true,
+		BulkOp:         false,
+	}
+
+	m := newModelClient(nbClient)
+	err := m.Lookup(opModel)
+	if err != nil {
+		return nil, err
+	}
+
+	return found[0], nil
+}
+
 type aclPredicate func(*nbdb.ACL) bool
 
 // FindACLsWithPredicate looks up ACLs from the cache based on a given predicate

--- a/go-controller/pkg/libovsdb/ops/db_object_types.go
+++ b/go-controller/pkg/libovsdb/ops/db_object_types.go
@@ -368,6 +368,10 @@ var PortGroupCluster = newObjectIDsType(portGroup, ClusterOwnerType, []ExternalI
 	ObjectNameKey,
 })
 
+var PortGroupAdvertisedNetwork = newObjectIDsType(portGroup, AdvertisedNetworkOwnerType, []ExternalIDKey{
+	ObjectNameKey,
+})
+
 var PortGroupUDN = newObjectIDsType(portGroup, UDNIsolationOwnerType, []ExternalIDKey{
 	// name of a UDN port group
 	// currently uses:

--- a/go-controller/pkg/libovsdb/ops/mac_binding.go
+++ b/go-controller/pkg/libovsdb/ops/mac_binding.go
@@ -5,6 +5,7 @@ package ops
 
 import (
 	libovsdbclient "github.com/ovn-kubernetes/libovsdb/client"
+	"github.com/ovn-kubernetes/libovsdb/ovsdb"
 
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/nbdb"
 )
@@ -45,8 +46,8 @@ func DeleteStaticMacBindings(nbClient libovsdbclient.Client, smbs ...*nbdb.Stati
 
 type staticMACBindingPredicate func(*nbdb.StaticMACBinding) bool
 
-// DeleteStaticMACBindingWithPredicate deletes a Static MAC entry for a logical port from the cache
-func DeleteStaticMACBindingWithPredicate(nbClient libovsdbclient.Client, p staticMACBindingPredicate) error {
+// DeleteStaticMACBindingWithPredicateOps returns ops to delete Static MAC entries matching the predicate
+func DeleteStaticMACBindingWithPredicateOps(nbClient libovsdbclient.Client, ops []ovsdb.Operation, p staticMACBindingPredicate) ([]ovsdb.Operation, error) {
 	found := []*nbdb.StaticMACBinding{}
 	opModel := operationModel{
 		ModelPredicate: p,
@@ -56,9 +57,15 @@ func DeleteStaticMACBindingWithPredicate(nbClient libovsdbclient.Client, p stati
 	}
 
 	m := newModelClient(nbClient)
-	err := m.Delete(opModel)
+	return m.DeleteOps(ops, opModel)
+}
+
+// DeleteStaticMACBindingWithPredicate deletes a Static MAC entry for a logical port from the cache
+func DeleteStaticMACBindingWithPredicate(nbClient libovsdbclient.Client, p staticMACBindingPredicate) error {
+	ops, err := DeleteStaticMACBindingWithPredicateOps(nbClient, nil, p)
 	if err != nil {
 		return err
 	}
-	return nil
+	_, err = TransactAndCheck(nbClient, ops)
+	return err
 }

--- a/go-controller/pkg/libovsdb/ops/portgroup.go
+++ b/go-controller/pkg/libovsdb/ops/portgroup.go
@@ -55,8 +55,8 @@ func CreateOrUpdatePortGroups(nbClient libovsdbclient.Client, pgs ...*nbdb.PortG
 	return err
 }
 
-// CreatePortGroup creates the provided port group if it doesn't exist
-func CreatePortGroup(nbClient libovsdbclient.Client, portGroup *nbdb.PortGroup) error {
+// CreatePortGroupOps returns ops to create the provided port group if it doesn't exist
+func CreatePortGroupOps(nbClient libovsdbclient.Client, ops []ovsdb.Operation, portGroup *nbdb.PortGroup) ([]ovsdb.Operation, error) {
 	opModel := operationModel{
 		Model:          portGroup,
 		OnModelUpdates: onModelUpdatesNone(),
@@ -65,7 +65,17 @@ func CreatePortGroup(nbClient libovsdbclient.Client, portGroup *nbdb.PortGroup) 
 	}
 
 	m := newModelClient(nbClient)
-	_, err := m.CreateOrUpdate(opModel)
+	return m.CreateOrUpdateOps(ops, opModel)
+}
+
+// CreatePortGroup creates the provided port group if it doesn't exist
+func CreatePortGroup(nbClient libovsdbclient.Client, portGroup *nbdb.PortGroup) error {
+	ops, err := CreatePortGroupOps(nbClient, nil, portGroup)
+	if err != nil {
+		return err
+	}
+
+	_, err = TransactAndCheck(nbClient, ops)
 	return err
 }
 

--- a/go-controller/pkg/libovsdb/ops/switch.go
+++ b/go-controller/pkg/libovsdb/ops/switch.go
@@ -249,6 +249,28 @@ func AddACLsToLogicalSwitchOps(nbClient libovsdbclient.Client, ops []ovsdb.Opera
 	return m.CreateOrUpdateOps(ops, opModels)
 }
 
+// RemoveACLsFromLogicalSwitchOps removes the provided ACLs from the named logical switch
+// and returns the corresponding ops
+func RemoveACLsFromLogicalSwitchOps(nbClient libovsdbclient.Client, ops []ovsdb.Operation, name string, acls ...*nbdb.ACL) ([]ovsdb.Operation, error) {
+	sw := &nbdb.LogicalSwitch{
+		Name: name,
+		ACLs: make([]string, 0, len(acls)),
+	}
+	for _, acl := range acls {
+		sw.ACLs = append(sw.ACLs, acl.UUID)
+	}
+
+	opModel := operationModel{
+		Model:            sw,
+		OnModelMutations: []interface{}{&sw.ACLs},
+		ErrNotFound:      false,
+		BulkOp:           false,
+	}
+
+	m := newModelClient(nbClient)
+	return m.DeleteOps(ops, opModel)
+}
+
 // RemoveACLsFromLogicalSwitchesWithPredicateOps looks up logical switches from the cache
 // based on a given predicate, removes from them the provided ACLs, and returns the
 // corresponding ops

--- a/go-controller/pkg/ovn/gateway.go
+++ b/go-controller/pkg/ovn/gateway.go
@@ -1308,67 +1308,60 @@ func deleteStaleMasqueradeResources(nbClient libovsdbclient.Client, routerName, 
 // list of nextHopIPs. If nextHopIPs is empty, then an attempt will be made to detect the stale route and MAC bindings
 func deleteStaleMasqueradeRouteAndMACBinding(nbClient libovsdbclient.Client, routerName string, nextHopIPs []net.IP) error {
 	logicalport := types.GWRouterToExtSwitchPrefix + routerName
+
+	var matchNextHop func(nexthop string) bool
 	if len(nextHopIPs) == 0 {
-		// build valid values
-		validNextHops := []net.IP{config.Gateway.MasqueradeIPs.V4DummyNextHopMasqueradeIP, config.Gateway.MasqueradeIPs.V6DummyNextHopMasqueradeIP}
-		// lookup routes for external id that dont match currently configured masquerade subnets
-		for _, validNextHop := range validNextHops {
-			staticRoutePredicate := func(item *nbdb.LogicalRouterStaticRoute) bool {
-				if item.OutputPort != nil && *item.OutputPort == logicalport &&
-					item.Nexthop != validNextHop.String() && utilnet.IPFamilyOfString(item.Nexthop) == utilnet.IPFamilyOf(validNextHop) {
-					if _, ok := item.ExternalIDs[util.OvnNodeMasqCIDR]; ok {
-						return true
-					}
-				}
-				return false
-			}
-
-			staleRoutes, err := libovsdbops.FindLogicalRouterStaticRoutesWithPredicate(nbClient, staticRoutePredicate)
-			if err != nil {
-				return fmt.Errorf("failed to search for stale masquerade routes: %w", err)
-			}
-
-			for _, staleRoute := range staleRoutes {
-				klog.Infof("Stale masquerade route found: %#v", *staleRoute)
-				// found stale routes, derive nexthop and flush the route and mac binding if it exists
-				staleNextHop := staleRoute.Nexthop
-
-				macBindingPredicate := func(item *nbdb.StaticMACBinding) bool {
-					return item.LogicalPort == logicalport && item.IP == staleNextHop &&
-						utilnet.IPFamilyOfString(item.IP) == utilnet.IPFamilyOfString(staleNextHop)
-				}
-				if err := libovsdbops.DeleteStaticMACBindingWithPredicate(nbClient, macBindingPredicate); err != nil {
-					return fmt.Errorf("failed to delete static MAC binding for logical port %s: %v", logicalport, err)
-				}
-			}
-			if err := libovsdbops.DeleteLogicalRouterStaticRoutes(nbClient, routerName, staleRoutes...); err != nil {
-				return err
-			}
+		configuredNextHops := sets.New(
+			config.Gateway.MasqueradeIPs.V4DummyNextHopMasqueradeIP.String(),
+			config.Gateway.MasqueradeIPs.V6DummyNextHopMasqueradeIP.String(),
+		)
+		matchNextHop = func(nexthop string) bool {
+			return !configuredNextHops.Has(nexthop)
 		}
-		return nil
+	} else {
+		targetNextHops := sets.New[string]()
+		for _, ip := range nextHopIPs {
+			targetNextHops.Insert(ip.String())
+		}
+		matchNextHop = func(nexthop string) bool {
+			return targetNextHops.Has(nexthop)
+		}
 	}
 
-	for _, nextHop := range nextHopIPs {
-		staticRoutePredicate := func(item *nbdb.LogicalRouterStaticRoute) bool {
-			if item.OutputPort != nil && *item.OutputPort == logicalport &&
-				item.Nexthop == nextHop.String() && utilnet.IPFamilyOfString(item.Nexthop) == utilnet.IPFamilyOf(nextHop) {
-				if _, ok := item.ExternalIDs[util.OvnNodeMasqCIDR]; ok {
-					return true
-				}
-			}
+	var staleNextHops []string
+	staticRoutePredicate := func(item *nbdb.LogicalRouterStaticRoute) bool {
+		if item.OutputPort == nil || *item.OutputPort != logicalport {
 			return false
 		}
-		if err := libovsdbops.DeleteLogicalRouterStaticRoutesWithPredicate(nbClient, routerName, staticRoutePredicate); err != nil {
-			return fmt.Errorf("failed to delete static route from gateway router %s: %v", routerName, err)
+		if _, ok := item.ExternalIDs[util.OvnNodeMasqCIDR]; !ok {
+			return false
 		}
+		if matchNextHop(item.Nexthop) {
+			staleNextHops = append(staleNextHops, item.Nexthop)
+			return true
+		}
+		return false
+	}
 
+	var ops []ovsdb.Operation
+	ops, err := libovsdbops.DeleteLogicalRouterStaticRoutesWithPredicateOps(nbClient, ops, routerName, staticRoutePredicate)
+	if err != nil {
+		return fmt.Errorf("failed to build ops to delete stale masquerade routes from router %s: %w", routerName, err)
+	}
+
+	for _, staleNextHop := range staleNextHops {
+		klog.Infof("Stale masquerade route found on router %s with nexthop %s", routerName, staleNextHop)
 		macBindingPredicate := func(item *nbdb.StaticMACBinding) bool {
-			return item.LogicalPort == logicalport && item.IP == nextHop.String() &&
-				utilnet.IPFamilyOfString(item.IP) == utilnet.IPFamilyOf(nextHop)
+			return item.LogicalPort == logicalport && item.IP == staleNextHop
 		}
-		if err := libovsdbops.DeleteStaticMACBindingWithPredicate(nbClient, macBindingPredicate); err != nil {
-			return fmt.Errorf("failed to delete static MAC binding for logical port %s: %v", logicalport, err)
+		ops, err = libovsdbops.DeleteStaticMACBindingWithPredicateOps(nbClient, ops, macBindingPredicate)
+		if err != nil {
+			return fmt.Errorf("failed to build ops to delete static MAC binding for logical port %s: %w", logicalport, err)
 		}
+	}
+
+	if _, err := libovsdbops.TransactAndCheck(nbClient, ops); err != nil {
+		return fmt.Errorf("failed to delete stale masquerade routes and MAC bindings from router %s: %w", routerName, err)
 	}
 	return nil
 }

--- a/go-controller/pkg/ovn/gateway_test.go
+++ b/go-controller/pkg/ovn/gateway_test.go
@@ -60,8 +60,23 @@ func generateAdvertisedUDNIsolationExpectedNB(testData []libovsdbtest.TestData, 
 	passACL.UUID = "advertised-udn-isolation-pass-acl-UUID"
 	dropACL := BuildAdvertisedNetworkSubnetsDropACL(addrSet)
 	dropACL.UUID = "advertised-udn-isolation-drop-acl-UUID"
-	nodeSwitch.ACLs = append(nodeSwitch.ACLs, passACL.UUID, dropACL.UUID)
-	testData = append(testData, passACL, dropACL)
+	nodeSwitch.ACLs = append(nodeSwitch.ACLs, passACL.UUID)
+	pg := libovsdbutil.BuildPortGroup(GetAdvertisedNetworkSubnetsDropPGdbIDs(), nil, []*nbdb.ACL{dropACL})
+	pg.UUID = "advertised-udn-isolation-drop-pg-UUID"
+	pg.Ports = []string{types.SwitchToRouterPrefix + nodeSwitch.Name + "-UUID"}
+	testData = append(testData, passACL, dropACL, pg)
+
+	var cidrs []string
+	for _, subnet := range clusterIPSubnets {
+		cidrs = append(cidrs, subnet.String())
+	}
+	v4set, v6set := addressset.GetTestDbAddrSets(GetAdvertisedNetworkSubnetsAddressSetDBIDs(), cidrs)
+	if config.IPv4Mode {
+		testData = append(testData, v4set)
+	}
+	if config.IPv6Mode {
+		testData = append(testData, v6set)
+	}
 
 	return testData
 }

--- a/go-controller/pkg/ovn/layer3_user_defined_network_controller_test.go
+++ b/go-controller/pkg/ovn/layer3_user_defined_network_controller_test.go
@@ -1323,6 +1323,8 @@ var _ = Describe("Layer3 CUDN OutboundSNAT for no-overlay mode", func() {
 			userDefinedNetController.bnc.ovnClusterLRPToJoinIfAddrs = dummyJoinIPs()
 			podInfo.populateUserDefinedNetworkLogicalSwitchCache(userDefinedNetController)
 
+			Expect(ConfigureAdvertisedNetworkIsolation(fakeOvn.nbClient)).To(Succeed())
+
 			// Step 4: Start watching nodes to trigger addUpdateLocalNodeEvent()
 			By("Starting node watch on L3 UDN controller")
 			Expect(fakeOvn.registerUDNNodeHandler(userDefinedNetworkName)).To(Succeed())
@@ -1477,6 +1479,8 @@ var _ = Describe("Layer3 CUDN OutboundSNAT for no-overlay mode", func() {
 
 			userDefinedNetController.bnc.ovnClusterLRPToJoinIfAddrs = dummyJoinIPs()
 			podInfo.populateUserDefinedNetworkLogicalSwitchCache(userDefinedNetController)
+
+			Expect(ConfigureAdvertisedNetworkIsolation(fakeOvn.nbClient)).To(Succeed())
 
 			// Step 4: Create and advertise a pod on the CUDN to trigger gateway SNAT creation
 			By("Starting node watch on L3 UDN controller for shared gateway mode")

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -800,6 +800,9 @@ var _ = ginkgo.Describe("Default network controller operations", func() {
 				err = condition(oc)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
+				if oc.isPodNetworkAdvertisedAtNode(node1.Name) {
+					gomega.Expect(ConfigureAdvertisedNetworkIsolation(nbClient)).To(gomega.Succeed())
+				}
 				startDefaultNodeController(oc)
 				gomega.Eventually(func() error {
 					_, err := libovsdbops.GetLogicalRouter(nbClient, &nbdb.LogicalRouter{

--- a/go-controller/pkg/ovn/udn_isolation.go
+++ b/go-controller/pkg/ovn/udn_isolation.go
@@ -10,12 +10,14 @@ import (
 	"strconv"
 	"strings"
 
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
 	utilnet "k8s.io/utils/net"
 
 	libovsdbclient "github.com/ovn-kubernetes/libovsdb/client"
 	"github.com/ovn-kubernetes/libovsdb/ovsdb"
 
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
 	libovsdbops "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/libovsdb/ops"
 	libovsdbutil "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/libovsdb/util"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/nbdb"
@@ -288,6 +290,39 @@ func GetAdvertisedNetworkSubnetsPassACLdbIDs(controller, networkName string, net
 			libovsdbops.ObjectNameKey: networkName,
 			libovsdbops.NetworkKey:    strconv.Itoa(networkID),
 		})
+}
+
+// ConfigureAdvertisedNetworkIsolation ensures the global resources for advertised network isolation exist.
+func ConfigureAdvertisedNetworkIsolation(nbClient libovsdbclient.Client) error {
+	addressSetFactory := addressset.NewOvnAddressSetFactory(nbClient, config.IPv4Mode, config.IPv6Mode)
+	_, err := addressSetFactory.EnsureAddressSet(GetAdvertisedNetworkSubnetsAddressSetDBIDs())
+	return err
+}
+
+// CleanupStaleAdvertisedNetworkSubnets removes subnets from the advertised network subnets address set
+// that are not in validSubnets.
+func CleanupStaleAdvertisedNetworkSubnets(nbClient libovsdbclient.Client, validSubnets sets.Set[string]) error {
+	addressSetFactory := addressset.NewOvnAddressSetFactory(nbClient, config.IPv4Mode, config.IPv6Mode)
+	addrSet, err := addressSetFactory.GetAddressSet(GetAdvertisedNetworkSubnetsAddressSetDBIDs())
+	if err != nil && !errors.Is(err, libovsdbclient.ErrNotFound) {
+		return fmt.Errorf("failed to get advertised subnets address set: %w", err)
+	}
+	if addrSet == nil {
+		return nil
+	}
+	v4Addrs, v6Addrs := addrSet.GetAddresses()
+	var stale []string
+	for _, addr := range append(v4Addrs, v6Addrs...) {
+		if !validSubnets.Has(addr) {
+			stale = append(stale, addr)
+		}
+	}
+	if len(stale) > 0 {
+		if err := addrSet.DeleteAddresses(stale); err != nil {
+			return fmt.Errorf("failed to delete stale addresses %q from advertised network subnets address set: %w", stale, err)
+		}
+	}
+	return nil
 }
 
 // BuildAdvertisedNetworkSubnetsDropACL builds the advertised network subnets drop ACL:

--- a/go-controller/pkg/ovn/udn_isolation.go
+++ b/go-controller/pkg/ovn/udn_isolation.go
@@ -386,18 +386,22 @@ func BuildAdvertisedNetworkSubnetsDropACL(advertisedNetworkSubnetsAddressSet add
 }
 
 // addAdvertisedNetworkIsolation adds advertised network isolation rules to the given node.
-// It adds the following ACLs to the node switch:
+// We end up with the following ACLs:
 // action match                                                                       priority
 // ------ --------------------------------------------------------------------------- --------
 // pass   "(ip[4|6].src == <UDN_SUBNET> && ip[4|6].dst == <UDN_SUBNET>)"                1100
 // drop   "(ip[4|6].src == $<ALL_ADV_SUBNETS> && ip[4|6].dst == $<ALL_ADV_SUBNETS>)"    1050
+// The pass ACL is added to the node switch. The drop ACL is on a port group shared by all
+// advertised networks. The stor port of this network's switch is added to that port group
+// so the drop ACL applies to the whole switch.
+// On upgrade from switch-based drop ACL, stale switch references are removed in the same transaction.
 func (bnc *BaseNetworkController) addAdvertisedNetworkIsolation(nodeName string) error {
 	var passMatches, cidrs []string
 	var ops []ovsdb.Operation
 
 	addrSet, err := bnc.addressSetFactory.GetAddressSet(GetAdvertisedNetworkSubnetsAddressSetDBIDs())
 	if err != nil {
-		return fmt.Errorf("failed to get advertised subnets addresset %s for network %s: %w", GetAdvertisedNetworkSubnetsAddressSetDBIDs(), bnc.GetNetworkName(), err)
+		return fmt.Errorf("failed to get advertised subnets address set for network %s: %w", bnc.GetNetworkName(), err)
 	}
 	var ipv4Subnets, ipv6Subnets []*net.IPNet
 	for _, subnet := range bnc.Subnets() {
@@ -432,6 +436,8 @@ func (bnc *BaseNetworkController) addAdvertisedNetworkIsolation(nodeName string)
 	}
 	ops = append(ops, addrOps...)
 
+	switchName := bnc.GetNetworkScopedSwitchName(nodeName)
+
 	if len(passMatches) > 0 {
 		passACL := libovsdbutil.BuildACL(
 			GetAdvertisedNetworkSubnetsPassACLdbIDs(bnc.controllerName, bnc.GetNetworkName(), bnc.GetNetworkID()),
@@ -444,22 +450,24 @@ func (bnc *BaseNetworkController) addAdvertisedNetworkIsolation(nodeName string)
 
 		ops, err = libovsdbops.CreateOrUpdateACLsOps(bnc.nbClient, ops, nil, passACL)
 		if err != nil {
-			return fmt.Errorf("failed to create or update network isolation pass ACL %s for network %s: %w", GetAdvertisedNetworkSubnetsPassACLdbIDs(bnc.controllerName, bnc.GetNetworkName(), bnc.GetNetworkID()), bnc.GetNetworkName(), err)
+			return fmt.Errorf("failed to create or update network isolation pass ACL for network %s: %w", bnc.GetNetworkName(), err)
 		}
-		ops, err = libovsdbops.AddACLsToLogicalSwitchOps(bnc.nbClient, ops, bnc.GetNetworkScopedSwitchName(nodeName), passACL)
+		ops, err = libovsdbops.AddACLsToLogicalSwitchOps(bnc.nbClient, ops, switchName, passACL)
 		if err != nil {
-			return fmt.Errorf("failed to add network isolation pass ACL to switch %s for network %s: %w", bnc.GetNetworkScopedSwitchName(nodeName), bnc.GetNetworkName(), err)
+			return fmt.Errorf("failed to add network isolation pass ACL to switch %s for network %s: %w", switchName, bnc.GetNetworkName(), err)
 		}
 	}
 
-	dropACL := BuildAdvertisedNetworkSubnetsDropACL(addrSet)
-	ops, err = libovsdbops.CreateOrUpdateACLsOps(bnc.nbClient, ops, nil, dropACL)
+	// Add the stor port to the port group
+	pgName := GetAdvertisedNetworkSubnetsDropPGName()
+	storPortName := types.SwitchToRouterPrefix + switchName
+	storLSP, err := libovsdbops.GetLogicalSwitchPort(bnc.nbClient, &nbdb.LogicalSwitchPort{Name: storPortName})
 	if err != nil {
-		return fmt.Errorf("failed to create or update network isolation drop ACL %v", err)
+		return fmt.Errorf("failed to get stor port %s: %w", storPortName, err)
 	}
-	ops, err = libovsdbops.AddACLsToLogicalSwitchOps(bnc.nbClient, ops, bnc.GetNetworkScopedSwitchName(nodeName), dropACL)
+	ops, err = libovsdbops.AddPortsToPortGroupOps(bnc.nbClient, ops, pgName, storLSP.UUID)
 	if err != nil {
-		return fmt.Errorf("failed to add network isolation drop ACL to switch %s for network %s: %w", bnc.GetNetworkScopedSwitchName(nodeName), bnc.GetNetworkName(), err)
+		return fmt.Errorf("failed to add stor port %s to advertised network isolation port group: %w", storPortName, err)
 	}
 
 	if _, err = libovsdbops.TransactAndCheck(bnc.nbClient, ops); err != nil {
@@ -469,7 +477,8 @@ func (bnc *BaseNetworkController) addAdvertisedNetworkIsolation(nodeName string)
 }
 
 // deleteAdvertisedNetworkIsolation deletes advertised network isolation rules from the given node switch.
-// It removes the network CIDRs from the global advertised networks addresset together with the ACLs on the node switch.
+// It removes the network CIDRs from the global advertised networks address set, removes the pass ACL from
+// the node switch, and removes the stor port from the advertised network drop port group.
 func (bnc *BaseNetworkController) deleteAdvertisedNetworkIsolation(nodeName string) error {
 	addrSet, err := bnc.addressSetFactory.GetAddressSet(GetAdvertisedNetworkSubnetsAddressSetDBIDs())
 	if err != nil && !errors.Is(err, libovsdbclient.ErrNotFound) {
@@ -488,28 +497,31 @@ func (bnc *BaseNetworkController) deleteAdvertisedNetworkIsolation(nodeName stri
 		}
 	}
 
+	switchName := bnc.GetNetworkScopedSwitchName(nodeName)
+
+	// Remove the pass ACL from the switch
 	passACLIDs := GetAdvertisedNetworkSubnetsPassACLdbIDs(bnc.controllerName, bnc.GetNetworkName(), bnc.GetNetworkID())
-	dropACLIDs := GetAdvertisedNetworkSubnetsDropACLdbIDs()
-	passACLPredicate := libovsdbops.GetPredicate[*nbdb.ACL](passACLIDs, nil)
-	dropACLPredicate := libovsdbops.GetPredicate[*nbdb.ACL](dropACLIDs, nil)
-	// Create a combined predicate to find both ACLs in a single lookup
-	combinedACLPredicate := func(acl *nbdb.ACL) bool {
-		// Check if ACL matches either pass or drop ACL IDs
-		return passACLPredicate(acl) || dropACLPredicate(acl)
+	passACL, err := libovsdbops.GetACL(bnc.nbClient, &nbdb.ACL{ExternalIDs: passACLIDs.GetExternalIDs()})
+	if err != nil && !errors.Is(err, libovsdbclient.ErrNotFound) {
+		return fmt.Errorf("unable to find pass ACL for advertised network %s: %w", bnc.GetNetworkName(), err)
 	}
-
-	// Find both ACLs in a single lookup
-	allACLsToRemove, err := libovsdbops.FindACLsWithPredicate(bnc.nbClient, combinedACLPredicate)
-	if err != nil {
-		return fmt.Errorf("unable to find pass and/or drop ACLs for advertised network %s: %w", bnc.GetNetworkName(), err)
-	}
-
-	// ACLs referenced by the switch will be deleted by db if there are no other references
-	p := func(sw *nbdb.LogicalSwitch) bool { return sw.Name == bnc.GetNetworkScopedSwitchName(nodeName) }
-	if len(allACLsToRemove) > 0 {
-		ops, err = libovsdbops.RemoveACLsFromLogicalSwitchesWithPredicateOps(bnc.nbClient, ops, p, allACLsToRemove...)
+	if passACL != nil {
+		ops, err = libovsdbops.RemoveACLsFromLogicalSwitchOps(bnc.nbClient, ops, switchName, passACL)
 		if err != nil {
-			return fmt.Errorf("failed to create ovsdb ops for removing network isolation ACLs from the %s switch for network %s: %w", bnc.GetNetworkScopedSwitchName(nodeName), bnc.GetNetworkName(), err)
+			return fmt.Errorf("failed to remove pass ACL from switch %s for network %s: %w", switchName, bnc.GetNetworkName(), err)
+		}
+	}
+
+	// Remove the stor port from the port group
+	storPortName := types.SwitchToRouterPrefix + switchName
+	storLSP, err := libovsdbops.GetLogicalSwitchPort(bnc.nbClient, &nbdb.LogicalSwitchPort{Name: storPortName})
+	if err != nil && !errors.Is(err, libovsdbclient.ErrNotFound) {
+		return fmt.Errorf("failed to get stor port %s: %w", storPortName, err)
+	}
+	if storLSP != nil {
+		ops, err = libovsdbops.DeletePortsFromPortGroupOps(bnc.nbClient, ops, GetAdvertisedNetworkSubnetsDropPGName(), storLSP.UUID)
+		if err != nil {
+			return fmt.Errorf("failed to remove stor port %s from advertised network isolation port group: %w", storPortName, err)
 		}
 	}
 

--- a/go-controller/pkg/ovn/udn_isolation.go
+++ b/go-controller/pkg/ovn/udn_isolation.go
@@ -274,6 +274,19 @@ func GetAdvertisedNetworkSubnetsAddressSetDBIDs() *libovsdbops.DbObjectIDs {
 	})
 }
 
+// GetAdvertisedNetworkSubnetsDropPGdbIDs returns the DB IDs for the advertised network subnets drop port group
+func GetAdvertisedNetworkSubnetsDropPGdbIDs() *libovsdbops.DbObjectIDs {
+	return libovsdbops.NewDbObjectIDs(libovsdbops.PortGroupAdvertisedNetwork, types.DefaultNetworkControllerName,
+		map[libovsdbops.ExternalIDKey]string{
+			libovsdbops.ObjectNameKey: advertisedNetworkSubnetsKey,
+		})
+}
+
+// GetAdvertisedNetworkSubnetsDropPGName returns the hashed name for the advertised network subnets drop port group
+func GetAdvertisedNetworkSubnetsDropPGName() string {
+	return libovsdbutil.GetPortGroupName(GetAdvertisedNetworkSubnetsDropPGdbIDs())
+}
+
 // GetAdvertisedNetworkSubnetsDropACLdbIDs returns the DB IDs for the advertised network subnets drop ACL
 func GetAdvertisedNetworkSubnetsDropACLdbIDs() *libovsdbops.DbObjectIDs {
 	return libovsdbops.NewDbObjectIDs(libovsdbops.ACLAdvertisedNetwork, types.DefaultNetworkControllerName,
@@ -295,8 +308,30 @@ func GetAdvertisedNetworkSubnetsPassACLdbIDs(controller, networkName string, net
 // ConfigureAdvertisedNetworkIsolation ensures the global resources for advertised network isolation exist.
 func ConfigureAdvertisedNetworkIsolation(nbClient libovsdbclient.Client) error {
 	addressSetFactory := addressset.NewOvnAddressSetFactory(nbClient, config.IPv4Mode, config.IPv6Mode)
-	_, err := addressSetFactory.EnsureAddressSet(GetAdvertisedNetworkSubnetsAddressSetDBIDs())
-	return err
+	addrSet, err := addressSetFactory.EnsureAddressSet(GetAdvertisedNetworkSubnetsAddressSetDBIDs())
+	if err != nil {
+		return fmt.Errorf("failed to ensure advertised subnets address set: %w", err)
+	}
+
+	dropACL := BuildAdvertisedNetworkSubnetsDropACL(addrSet)
+	pg := libovsdbutil.BuildPortGroup(GetAdvertisedNetworkSubnetsDropPGdbIDs(), nil, nil)
+
+	ops, err := libovsdbops.CreateOrUpdateACLsOps(nbClient, nil, nil, dropACL)
+	if err != nil {
+		return fmt.Errorf("failed to create or update advertised network isolation drop ACL: %w", err)
+	}
+
+	pg.ACLs = []string{dropACL.UUID}
+
+	ops, err = libovsdbops.CreatePortGroupOps(nbClient, ops, pg)
+	if err != nil {
+		return fmt.Errorf("failed to create advertised network isolation port group: %w", err)
+	}
+
+	if _, err = libovsdbops.TransactAndCheck(nbClient, ops); err != nil {
+		return fmt.Errorf("failed to configure advertised network isolation: %w", err)
+	}
+	return nil
 }
 
 // CleanupStaleAdvertisedNetworkSubnets removes subnets from the advertised network subnets address set

--- a/go-controller/pkg/ovn/udn_isolation.go
+++ b/go-controller/pkg/ovn/udn_isolation.go
@@ -370,6 +370,10 @@ func migrateAdvertisedNetworkDropACLToPortGroup(nbClient libovsdbclient.Client, 
 			return nil, fmt.Errorf("failed to find advertised network drop ACLs: %w", err)
 		}
 	}
+	// shouldn't happen but safe-guard it
+	if len(existingDropACLs) == 0 {
+		return nil, nil
+	}
 
 	dropACL.UUID = existingDropACLs[0].UUID
 
@@ -395,6 +399,10 @@ func migrateAdvertisedNetworkDropACLToPortGroup(nbClient libovsdbclient.Client, 
 	for _, swName := range affectedSwitches {
 		storPortName := types.SwitchToRouterPrefix + swName
 		storLSP, err := libovsdbops.GetLogicalSwitchPort(nbClient, &nbdb.LogicalSwitchPort{Name: storPortName})
+		if errors.Is(err, libovsdbclient.ErrNotFound) {
+			klog.Warningf("Skipping advertised network isolation port group population for switch %s: stor port %s not found", swName, storPortName)
+			continue
+		}
 		if err != nil {
 			return nil, fmt.Errorf("failed to get stor port %s: %w", storPortName, err)
 		}

--- a/go-controller/pkg/ovn/udn_isolation.go
+++ b/go-controller/pkg/ovn/udn_isolation.go
@@ -613,22 +613,27 @@ func (oc *DefaultNetworkController) syncUDNIsolation() error {
 		{oc.getUDNACLDbIDs(allowHostSecondaryACL, libovsdbutil.ACLIngress), oc.getUDNACLDbIDs(allowHostPrimaryUDNACL, libovsdbutil.ACLIngress)},
 	}
 
-	aclsToUpdate := make([]*nbdb.ACL, 0)
-	for _, update := range updates {
-		legacyACLs, err := libovsdbops.FindACLsWithPredicate(oc.nbClient, libovsdbops.GetPredicate[*nbdb.ACL](update.old, nil))
-		if err != nil {
-			return fmt.Errorf("unable to find ACLs for UDN Isolation sync: %w", err)
+	var aclsToUpdate []*nbdb.ACL
+	_, err := libovsdbops.FindACLsWithPredicate(oc.nbClient, func(acl *nbdb.ACL) bool {
+		for _, update := range updates {
+			p := libovsdbops.GetPredicate[*nbdb.ACL](update.old, nil)
+			if p(acl) {
+				copy := *acl
+				copy.ExternalIDs = update.new.GetExternalIDs()
+				aclName := libovsdbutil.GetACLName(update.new)
+				copy.Name = &aclName
+				aclsToUpdate = append(aclsToUpdate, &copy)
+				return false
+			}
 		}
-		for _, acl := range legacyACLs {
-			externalIDs := update.new.GetExternalIDs()
-			acl.ExternalIDs = externalIDs
-			aclName := libovsdbutil.GetACLName(update.new)
-			acl.Name = &aclName
-			aclsToUpdate = append(aclsToUpdate, acl)
-		}
+		return false
+	})
+	if err != nil {
+		return fmt.Errorf("unable to find ACLs for UDN Isolation sync: %w", err)
 	}
+
 	if len(aclsToUpdate) > 0 {
-		err := batching.Batch[*nbdb.ACL](20000, aclsToUpdate, func(batchACLs []*nbdb.ACL) error {
+		err := batching.Batch(20000, aclsToUpdate, func(batchACLs []*nbdb.ACL) error {
 			return libovsdbops.CreateOrUpdateACLs(oc.nbClient, oc.GetSamplingConfig(), batchACLs...)
 		})
 		if err != nil {

--- a/go-controller/pkg/ovn/udn_isolation.go
+++ b/go-controller/pkg/ovn/udn_isolation.go
@@ -316,7 +316,12 @@ func ConfigureAdvertisedNetworkIsolation(nbClient libovsdbclient.Client) error {
 	dropACL := BuildAdvertisedNetworkSubnetsDropACL(addrSet)
 	pg := libovsdbutil.BuildPortGroup(GetAdvertisedNetworkSubnetsDropPGdbIDs(), nil, nil)
 
-	ops, err := libovsdbops.CreateOrUpdateACLsOps(nbClient, nil, nil, dropACL)
+	ops, err := migrateAdvertisedNetworkDropACLToPortGroup(nbClient, pg, dropACL)
+	if err != nil {
+		return err
+	}
+
+	ops, err = libovsdbops.CreateOrUpdateACLsOps(nbClient, ops, nil, dropACL)
 	if err != nil {
 		return fmt.Errorf("failed to create or update advertised network isolation drop ACL: %w", err)
 	}
@@ -332,6 +337,71 @@ func ConfigureAdvertisedNetworkIsolation(nbClient libovsdbclient.Client) error {
 		return fmt.Errorf("failed to configure advertised network isolation: %w", err)
 	}
 	return nil
+}
+
+// migrateAdvertisedNetworkDropACLToPortGroup handles upgrade from switch-based drop ACL.
+// If the port group already exists, migration was already done. Otherwise, it looks up
+// the existing drop ACL by index. If found, it removes it from switches and populates the
+// port group with the stor ports of affected switches. If the index lookup fails with
+// multiple results (the race condition this migration fixes), it falls back to a predicate
+// scan. It sets dropACL.UUID to the first existing ACL's UUID so the caller can update it
+// in place.
+func migrateAdvertisedNetworkDropACLToPortGroup(nbClient libovsdbclient.Client, pg *nbdb.PortGroup, dropACL *nbdb.ACL) ([]ovsdb.Operation, error) {
+	_, err := libovsdbops.GetPortGroup(nbClient, &nbdb.PortGroup{Name: pg.Name})
+	if err == nil {
+		return nil, nil
+	}
+	if !errors.Is(err, libovsdbclient.ErrNotFound) {
+		return nil, fmt.Errorf("failed to get advertised network isolation port group: %w", err)
+	}
+
+	var existingDropACLs []*nbdb.ACL
+	existingACL, err := libovsdbops.GetACL(nbClient, &nbdb.ACL{ExternalIDs: GetAdvertisedNetworkSubnetsDropACLdbIDs().GetExternalIDs()})
+	if errors.Is(err, libovsdbclient.ErrNotFound) {
+		return nil, nil
+	}
+	if err == nil {
+		existingDropACLs = []*nbdb.ACL{existingACL}
+	} else {
+		// multiple ACLs found (the race condition this migration fixes), fall back to predicate scan
+		existingDropACLs, err = libovsdbops.FindACLsWithPredicate(nbClient,
+			libovsdbops.GetPredicate[*nbdb.ACL](GetAdvertisedNetworkSubnetsDropACLdbIDs(), nil))
+		if err != nil {
+			return nil, fmt.Errorf("failed to find advertised network drop ACLs: %w", err)
+		}
+	}
+
+	dropACL.UUID = existingDropACLs[0].UUID
+
+	allDropACLUUIDs := sets.New[string]()
+	for _, acl := range existingDropACLs {
+		allDropACLUUIDs.Insert(acl.UUID)
+	}
+
+	var ops []ovsdb.Operation
+	var affectedSwitches []string
+	p := func(sw *nbdb.LogicalSwitch) bool {
+		if allDropACLUUIDs.HasAny(sw.ACLs...) {
+			affectedSwitches = append(affectedSwitches, sw.Name)
+			return true
+		}
+		return false
+	}
+	ops, err = libovsdbops.RemoveACLsFromLogicalSwitchesWithPredicateOps(nbClient, ops, p, existingDropACLs...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to remove stale drop ACLs from switches: %w", err)
+	}
+
+	for _, swName := range affectedSwitches {
+		storPortName := types.SwitchToRouterPrefix + swName
+		storLSP, err := libovsdbops.GetLogicalSwitchPort(nbClient, &nbdb.LogicalSwitchPort{Name: storPortName})
+		if err != nil {
+			return nil, fmt.Errorf("failed to get stor port %s: %w", storPortName, err)
+		}
+		pg.Ports = append(pg.Ports, storLSP.UUID)
+	}
+
+	return ops, nil
 }
 
 // CleanupStaleAdvertisedNetworkSubnets removes subnets from the advertised network subnets address set

--- a/go-controller/pkg/ovn/udn_isolation_test.go
+++ b/go-controller/pkg/ovn/udn_isolation_test.go
@@ -155,7 +155,7 @@ var _ = Describe("UDN Isolation", func() {
 		config.IPv4Mode = true
 		config.IPv6Mode = false
 
-		fakeOVN := NewFakeOVN(true)
+		fakeOVN := NewFakeOVN(false)
 
 		netInfoBefore := dummyPrimaryLayer3UserDefinedNetwork("192.168.0.0/16", "192.168.1.0/24")
 		nadBefore, err := newNetworkAttachmentDefinition(ns, nadName, *netInfoBefore.netconf())
@@ -177,11 +177,15 @@ var _ = Describe("UDN Isolation", func() {
 		mutableNetInfo.SetPodNetworkAdvertisedVRFs(map[string][]string{nodeName: {"vrf"}})
 		Expect(util.ReconcileNetInfo(l3Controller.ReconcilableNetInfo, mutableNetInfo)).To(Succeed())
 
-		_, err = l3Controller.addressSetFactory.EnsureAddressSet(GetAdvertisedNetworkSubnetsAddressSetDBIDs())
-		Expect(err).NotTo(HaveOccurred())
+		Expect(ConfigureAdvertisedNetworkIsolation(fakeOVN.nbClient)).To(Succeed())
+		switchName := l3Controller.GetNetworkScopedSwitchName(nodeName)
 		Expect(libovsdbops.CreateOrUpdateLogicalSwitch(fakeOVN.nbClient, &nbdb.LogicalSwitch{
-			Name: l3Controller.GetNetworkScopedSwitchName(nodeName),
+			Name: switchName,
 		})).To(Succeed())
+		Expect(libovsdbops.CreateOrUpdateLogicalSwitchPortsOnSwitch(fakeOVN.nbClient,
+			&nbdb.LogicalSwitch{Name: switchName},
+			&nbdb.LogicalSwitchPort{Name: types.SwitchToRouterPrefix + switchName, Type: "router"},
+		)).To(Succeed())
 
 		Expect(l3Controller.addAdvertisedNetworkIsolation(nodeName)).To(Succeed())
 		getPassACL := func() *nbdb.ACL {

--- a/go-controller/pkg/ovn/udn_isolation_test.go
+++ b/go-controller/pkg/ovn/udn_isolation_test.go
@@ -4,6 +4,7 @@
 package ovn
 
 import (
+	"fmt"
 	"strings"
 
 	nettypes "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
@@ -14,6 +15,7 @@ import (
 	libovsdbops "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/libovsdb/ops"
 	libovsdbutil "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/libovsdb/util"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/nbdb"
+	addressset "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/address_set"
 	libovsdbtest "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
@@ -98,6 +100,153 @@ var _ = Describe("UDN Isolation", func() {
 		Expect(acls[0].ExternalIDs).To(Equal(fakeController.getUDNACLDbIDs(denyPrimaryUDNACL, libovsdbutil.ACLEgress).GetExternalIDs()))
 		By("expect updated ACL with proper name")
 		Expect(*acls[0].Name).To(BeEmpty())
+	})
+
+	Describe("ConfigureAdvertisedNetworkIsolation", func() {
+		expectedDropACLMatch := func() string {
+			v4HashName, v6HashName := addressset.GetHashNamesForAS(GetAdvertisedNetworkSubnetsAddressSetDBIDs())
+			var matches []string
+			if config.IPv4Mode {
+				matches = append(matches, fmt.Sprintf("(ip4.src == $%s && ip4.dst == $%s)", v4HashName, v4HashName))
+			}
+			if config.IPv6Mode {
+				matches = append(matches, fmt.Sprintf("(ip6.src == $%s && ip6.dst == $%s)", v6HashName, v6HashName))
+			}
+			return strings.Join(matches, " || ")
+		}
+
+		expectedAddrSets := func() []libovsdbtest.TestData {
+			var data []libovsdbtest.TestData
+			v4set, v6set := addressset.GetTestDbAddrSets(GetAdvertisedNetworkSubnetsAddressSetDBIDs(), nil)
+			if config.IPv4Mode {
+				data = append(data, v4set)
+			}
+			if config.IPv6Mode {
+				data = append(data, v6set)
+			}
+			return data
+		}
+
+		It("creates the port group and drop ACL on fresh install", func() {
+			nbClient, nbCleanup, err := libovsdbtest.NewNBTestHarness(libovsdbtest.TestSetup{}, nil)
+			Expect(err).NotTo(HaveOccurred())
+			defer nbCleanup.Cleanup()
+
+			Expect(ConfigureAdvertisedNetworkIsolation(nbClient)).To(Succeed())
+
+			dropACL := libovsdbutil.BuildACL(GetAdvertisedNetworkSubnetsDropACLdbIDs(),
+				types.AdvertisedNetworkDenyPriority, expectedDropACLMatch(),
+				nbdb.ACLActionDrop, nil, libovsdbutil.LportEgressAfterLB, isolationTier)
+			dropACL.UUID = "drop-acl-UUID"
+			pg := libovsdbutil.BuildPortGroup(GetAdvertisedNetworkSubnetsDropPGdbIDs(), nil, []*nbdb.ACL{dropACL})
+			pg.UUID = "drop-pg-UUID"
+			expectedData := append([]libovsdbtest.TestData{dropACL, pg}, expectedAddrSets()...)
+			Expect(nbClient).To(libovsdbtest.HaveData(expectedData))
+		})
+
+		It("migrates a single drop ACL from a switch to the port group", func() {
+			dropACLdbIDs := GetAdvertisedNetworkSubnetsDropACLdbIDs()
+			dropACL := libovsdbutil.BuildACL(dropACLdbIDs, types.AdvertisedNetworkDenyPriority,
+				"(ip4.src == $fake && ip4.dst == $fake)", nbdb.ACLActionDrop, nil,
+				libovsdbutil.LportEgressAfterLB, isolationTier)
+			dropACL.UUID = "drop-acl-UUID"
+
+			storLSP := &nbdb.LogicalSwitchPort{UUID: "stor-sw1-UUID", Name: types.SwitchToRouterPrefix + "sw1", Type: "router"}
+			sw := &nbdb.LogicalSwitch{UUID: "sw1-UUID", Name: "sw1", Ports: []string{storLSP.UUID}, ACLs: []string{dropACL.UUID}}
+
+			nbClient, nbCleanup, err := libovsdbtest.NewNBTestHarness(libovsdbtest.TestSetup{
+				NBData: []libovsdbtest.TestData{dropACL, sw, storLSP},
+			}, nil)
+			Expect(err).NotTo(HaveOccurred())
+			defer nbCleanup.Cleanup()
+
+			Expect(ConfigureAdvertisedNetworkIsolation(nbClient)).To(Succeed())
+
+			expectedDropACL := libovsdbutil.BuildACL(dropACLdbIDs,
+				types.AdvertisedNetworkDenyPriority, expectedDropACLMatch(),
+				nbdb.ACLActionDrop, nil, libovsdbutil.LportEgressAfterLB, isolationTier)
+			expectedDropACL.UUID = "drop-acl-UUID"
+			expectedPG := libovsdbutil.BuildPortGroup(GetAdvertisedNetworkSubnetsDropPGdbIDs(), nil, []*nbdb.ACL{expectedDropACL})
+			expectedPG.UUID = "drop-pg-UUID"
+			expectedPG.Ports = []string{storLSP.UUID}
+			expectedData := append([]libovsdbtest.TestData{
+				expectedDropACL, expectedPG,
+				&nbdb.LogicalSwitch{UUID: "sw1-UUID", Name: "sw1", Ports: []string{storLSP.UUID}},
+				storLSP,
+			}, expectedAddrSets()...)
+			Expect(nbClient).To(libovsdbtest.HaveData(expectedData))
+		})
+
+		It("migrates duplicate drop ACLs from switches to the port group", func() {
+			dropACLdbIDs := GetAdvertisedNetworkSubnetsDropACLdbIDs()
+			dropACL1 := libovsdbutil.BuildACL(dropACLdbIDs, types.AdvertisedNetworkDenyPriority,
+				"(ip4.src == $fake && ip4.dst == $fake)", nbdb.ACLActionDrop, nil,
+				libovsdbutil.LportEgressAfterLB, isolationTier)
+			dropACL1.UUID = "drop-acl-1-UUID"
+			dropACL2 := libovsdbutil.BuildACL(dropACLdbIDs, types.AdvertisedNetworkDenyPriority,
+				"(ip4.src == $fake && ip4.dst == $fake)", nbdb.ACLActionDrop, nil,
+				libovsdbutil.LportEgressAfterLB, isolationTier)
+			dropACL2.UUID = "drop-acl-2-UUID"
+
+			sw1LSP := &nbdb.LogicalSwitchPort{UUID: "stor-sw1-UUID", Name: types.SwitchToRouterPrefix + "sw1", Type: "router"}
+			sw2LSP := &nbdb.LogicalSwitchPort{UUID: "stor-sw2-UUID", Name: types.SwitchToRouterPrefix + "sw2", Type: "router"}
+			sw1 := &nbdb.LogicalSwitch{UUID: "sw1-UUID", Name: "sw1", Ports: []string{sw1LSP.UUID}, ACLs: []string{dropACL1.UUID}}
+			sw2 := &nbdb.LogicalSwitch{UUID: "sw2-UUID", Name: "sw2", Ports: []string{sw2LSP.UUID}, ACLs: []string{dropACL2.UUID}}
+
+			nbClient, nbCleanup, err := libovsdbtest.NewNBTestHarness(libovsdbtest.TestSetup{
+				NBData: []libovsdbtest.TestData{dropACL1, dropACL2, sw1, sw2, sw1LSP, sw2LSP},
+			}, nil)
+			Expect(err).NotTo(HaveOccurred())
+			defer nbCleanup.Cleanup()
+
+			Expect(ConfigureAdvertisedNetworkIsolation(nbClient)).To(Succeed())
+
+			expectedDropACL := libovsdbutil.BuildACL(dropACLdbIDs,
+				types.AdvertisedNetworkDenyPriority, expectedDropACLMatch(),
+				nbdb.ACLActionDrop, nil, libovsdbutil.LportEgressAfterLB, isolationTier)
+			expectedDropACL.UUID = "drop-acl-1-UUID"
+			expectedPG := libovsdbutil.BuildPortGroup(GetAdvertisedNetworkSubnetsDropPGdbIDs(), nil, []*nbdb.ACL{expectedDropACL})
+			expectedPG.UUID = "drop-pg-UUID"
+			expectedPG.Ports = []string{sw1LSP.UUID, sw2LSP.UUID}
+			expectedData := append([]libovsdbtest.TestData{
+				expectedDropACL, expectedPG,
+				&nbdb.LogicalSwitch{UUID: "sw1-UUID", Name: "sw1", Ports: []string{sw1LSP.UUID}},
+				&nbdb.LogicalSwitch{UUID: "sw2-UUID", Name: "sw2", Ports: []string{sw2LSP.UUID}},
+				sw1LSP, sw2LSP,
+			}, expectedAddrSets()...)
+			Expect(nbClient).To(libovsdbtest.HaveData(expectedData))
+		})
+
+		It("skips migration but self-heals the drop ACL when the port group already exists", func() {
+			dropACLdbIDs := GetAdvertisedNetworkSubnetsDropACLdbIDs()
+			dropACL := libovsdbutil.BuildACL(dropACLdbIDs, types.AdvertisedNetworkDenyPriority,
+				"(ip4.src == $fake && ip4.dst == $fake)", nbdb.ACLActionDrop, nil,
+				libovsdbutil.LportEgressAfterLB, isolationTier)
+			dropACL.UUID = "drop-acl-UUID"
+			storLSP := &nbdb.LogicalSwitchPort{UUID: "stor-sw1-UUID", Name: types.SwitchToRouterPrefix + "sw1", Type: "router"}
+			sw := &nbdb.LogicalSwitch{UUID: "sw1-UUID", Name: "sw1", Ports: []string{storLSP.UUID}}
+			pg := libovsdbutil.BuildPortGroup(GetAdvertisedNetworkSubnetsDropPGdbIDs(), nil, []*nbdb.ACL{dropACL})
+			pg.UUID = "drop-pg-UUID"
+			pg.Ports = []string{storLSP.UUID}
+
+			nbClient, nbCleanup, err := libovsdbtest.NewNBTestHarness(libovsdbtest.TestSetup{
+				NBData: []libovsdbtest.TestData{dropACL, pg, sw, storLSP},
+			}, nil)
+			Expect(err).NotTo(HaveOccurred())
+			defer nbCleanup.Cleanup()
+
+			Expect(ConfigureAdvertisedNetworkIsolation(nbClient)).To(Succeed())
+
+			expectedDropACL := libovsdbutil.BuildACL(dropACLdbIDs,
+				types.AdvertisedNetworkDenyPriority, expectedDropACLMatch(),
+				nbdb.ACLActionDrop, nil, libovsdbutil.LportEgressAfterLB, isolationTier)
+			expectedDropACL.UUID = "drop-acl-UUID"
+			expectedPG := libovsdbutil.BuildPortGroup(GetAdvertisedNetworkSubnetsDropPGdbIDs(), nil, []*nbdb.ACL{expectedDropACL})
+			expectedPG.UUID = "drop-pg-UUID"
+			expectedPG.Ports = []string{storLSP.UUID}
+			expectedData := append([]libovsdbtest.TestData{expectedDropACL, expectedPG, sw, storLSP}, expectedAddrSets()...)
+			Expect(nbClient).To(libovsdbtest.HaveData(expectedData))
+		})
 	})
 
 	It("queues advertised local nodes when a primary Layer3 UDN adds a subnet", func() {

--- a/go-controller/pkg/ovn/udn_isolation_test.go
+++ b/go-controller/pkg/ovn/udn_isolation_test.go
@@ -68,20 +68,42 @@ var _ = Describe("UDN Isolation", func() {
 		config.OVNKubernetesFeature.EnableNetworkSegmentation = true
 		fakeController := getFakeController(types.DefaultNetworkControllerName)
 
-		By("initializing the database with legacy secondary IDs")
+		By("initializing the database with all legacy ACLs")
 		pgIDs := fakeController.getSecondaryPodsPortGroupDbIDs()
 		pgName := libovsdbutil.GetPortGroupName(pgIDs)
-		egressDenyIDs := fakeController.getUDNACLDbIDs(denySecondaryACL, libovsdbutil.ACLEgress)
-		match := libovsdbutil.GetACLMatch(pgName, "", libovsdbutil.ACLEgress)
-		egressDenyACL := libovsdbutil.BuildACL(egressDenyIDs, types.PrimaryUDNDenyPriority, match, nbdb.ACLActionDrop,
-			nil, libovsdbutil.LportEgress, isolationTier)
-		// required to make sure port group correctly references the ACL
-		egressDenyACL.UUID = egressDenyIDs.String() + "-UUID"
 
-		pg := libovsdbutil.BuildPortGroup(pgIDs, nil, []*nbdb.ACL{egressDenyACL})
+		type legacyACLDef struct {
+			oldName  string
+			newName  string
+			dir      libovsdbutil.ACLDirection
+			priority int
+			action   string
+			applyDir libovsdbutil.ACLPipelineType
+		}
+		legacyACLDefs := []legacyACLDef{
+			{denySecondaryACL, denyPrimaryUDNACL, libovsdbutil.ACLEgress, types.PrimaryUDNDenyPriority, nbdb.ACLActionDrop, libovsdbutil.LportEgress},
+			{legacyAllowHostARPACL, allowHostARPACL, libovsdbutil.ACLEgress, types.PrimaryUDNAllowPriority, nbdb.ACLActionAllow, libovsdbutil.LportEgress},
+			{denySecondaryACL, denyPrimaryUDNACL, libovsdbutil.ACLIngress, types.PrimaryUDNDenyPriority, nbdb.ACLActionDrop, libovsdbutil.LportIngress},
+			{legacyAllowHostARPACL, allowHostARPACL, libovsdbutil.ACLIngress, types.PrimaryUDNAllowPriority, nbdb.ACLActionAllow, libovsdbutil.LportIngress},
+			{allowHostSecondaryACL, allowHostPrimaryUDNACL, libovsdbutil.ACLIngress, types.PrimaryUDNAllowPriority, nbdb.ACLActionAllowRelated, libovsdbutil.LportIngress},
+		}
+
+		var legacyACLs []*nbdb.ACL
+		nbData := []libovsdbtest.TestData{}
+		for _, def := range legacyACLDefs {
+			oldIDs := fakeController.getUDNACLDbIDs(def.oldName, def.dir)
+			match := libovsdbutil.GetACLMatch(pgName, "", def.dir)
+			acl := libovsdbutil.BuildACL(oldIDs, def.priority, match, def.action, nil, def.applyDir, isolationTier)
+			acl.UUID = oldIDs.String() + "-UUID"
+			legacyACLs = append(legacyACLs, acl)
+			nbData = append(nbData, acl)
+		}
+
+		pg := libovsdbutil.BuildPortGroup(pgIDs, nil, legacyACLs)
+		nbData = append(nbData, pg)
 
 		nbClient, nbCleanup, err := libovsdbtest.NewNBTestHarness(libovsdbtest.TestSetup{
-			NBData: []libovsdbtest.TestData{egressDenyACL, pg},
+			NBData: nbData,
 		}, nil)
 		Expect(err).NotTo(HaveOccurred())
 		defer nbCleanup.Cleanup()
@@ -93,13 +115,25 @@ var _ = Describe("UDN Isolation", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(pgs).To(HaveLen(1))
 		Expect(pgs[0].ExternalIDs).To(Equal(fakeController.getSecondaryPodsPortGroupDbIDs().GetExternalIDs()))
-		By("expect updated ACL with proper external_ids")
+		By("expect all ACLs updated with proper external_ids and names")
 		acls, err := libovsdbops.FindACLsWithPredicate(nbClient, func(_ *nbdb.ACL) bool { return true })
 		Expect(err).NotTo(HaveOccurred())
-		Expect(acls).To(HaveLen(1))
-		Expect(acls[0].ExternalIDs).To(Equal(fakeController.getUDNACLDbIDs(denyPrimaryUDNACL, libovsdbutil.ACLEgress).GetExternalIDs()))
-		By("expect updated ACL with proper name")
-		Expect(*acls[0].Name).To(BeEmpty())
+		Expect(acls).To(HaveLen(len(legacyACLDefs)))
+		for _, def := range legacyACLDefs {
+			newIDs := fakeController.getUDNACLDbIDs(def.newName, def.dir)
+			expectedExtIDs := newIDs.GetExternalIDs()
+			found := false
+			for _, acl := range acls {
+				if acl.ExternalIDs[libovsdbops.ObjectNameKey.String()] == expectedExtIDs[libovsdbops.ObjectNameKey.String()] &&
+					acl.ExternalIDs[libovsdbops.PolicyDirectionKey.String()] == expectedExtIDs[libovsdbops.PolicyDirectionKey.String()] {
+					Expect(acl.ExternalIDs).To(Equal(expectedExtIDs))
+					Expect(*acl.Name).To(BeEmpty())
+					found = true
+					break
+				}
+			}
+			Expect(found).To(BeTrue(), "expected ACL with name=%s dir=%s not found", def.newName, def.dir)
+		}
 	})
 
 	Describe("ConfigureAdvertisedNetworkIsolation", func() {

--- a/go-controller/pkg/ovn/udn_isolation_test.go
+++ b/go-controller/pkg/ovn/udn_isolation_test.go
@@ -283,6 +283,153 @@ var _ = Describe("UDN Isolation", func() {
 		})
 	})
 
+	Describe("ConfigureAdvertisedNetworkIsolation", func() {
+		expectedDropACLMatch := func() string {
+			v4HashName, v6HashName := addressset.GetHashNamesForAS(GetAdvertisedNetworkSubnetsAddressSetDBIDs())
+			var matches []string
+			if config.IPv4Mode {
+				matches = append(matches, fmt.Sprintf("(ip4.src == $%s && ip4.dst == $%s)", v4HashName, v4HashName))
+			}
+			if config.IPv6Mode {
+				matches = append(matches, fmt.Sprintf("(ip6.src == $%s && ip6.dst == $%s)", v6HashName, v6HashName))
+			}
+			return strings.Join(matches, " || ")
+		}
+
+		expectedAddrSets := func() []libovsdbtest.TestData {
+			var data []libovsdbtest.TestData
+			v4set, v6set := addressset.GetTestDbAddrSets(GetAdvertisedNetworkSubnetsAddressSetDBIDs(), nil)
+			if config.IPv4Mode {
+				data = append(data, v4set)
+			}
+			if config.IPv6Mode {
+				data = append(data, v6set)
+			}
+			return data
+		}
+
+		It("creates the port group and drop ACL on fresh install", func() {
+			nbClient, nbCleanup, err := libovsdbtest.NewNBTestHarness(libovsdbtest.TestSetup{}, nil)
+			Expect(err).NotTo(HaveOccurred())
+			defer nbCleanup.Cleanup()
+
+			Expect(ConfigureAdvertisedNetworkIsolation(nbClient)).To(Succeed())
+
+			dropACL := libovsdbutil.BuildACL(GetAdvertisedNetworkSubnetsDropACLdbIDs(),
+				types.AdvertisedNetworkDenyPriority, expectedDropACLMatch(),
+				nbdb.ACLActionDrop, nil, libovsdbutil.LportEgressAfterLB, isolationTier)
+			dropACL.UUID = "drop-acl-UUID"
+			pg := libovsdbutil.BuildPortGroup(GetAdvertisedNetworkSubnetsDropPGdbIDs(), nil, []*nbdb.ACL{dropACL})
+			pg.UUID = "drop-pg-UUID"
+			expectedData := append([]libovsdbtest.TestData{dropACL, pg}, expectedAddrSets()...)
+			Expect(nbClient).To(libovsdbtest.HaveData(expectedData))
+		})
+
+		It("migrates a single drop ACL from a switch to the port group", func() {
+			dropACLdbIDs := GetAdvertisedNetworkSubnetsDropACLdbIDs()
+			dropACL := libovsdbutil.BuildACL(dropACLdbIDs, types.AdvertisedNetworkDenyPriority,
+				"(ip4.src == $fake && ip4.dst == $fake)", nbdb.ACLActionDrop, nil,
+				libovsdbutil.LportEgressAfterLB, isolationTier)
+			dropACL.UUID = "drop-acl-UUID"
+
+			storLSP := &nbdb.LogicalSwitchPort{UUID: "stor-sw1-UUID", Name: types.SwitchToRouterPrefix + "sw1", Type: "router"}
+			sw := &nbdb.LogicalSwitch{UUID: "sw1-UUID", Name: "sw1", Ports: []string{storLSP.UUID}, ACLs: []string{dropACL.UUID}}
+
+			nbClient, nbCleanup, err := libovsdbtest.NewNBTestHarness(libovsdbtest.TestSetup{
+				NBData: []libovsdbtest.TestData{dropACL, sw, storLSP},
+			}, nil)
+			Expect(err).NotTo(HaveOccurred())
+			defer nbCleanup.Cleanup()
+
+			Expect(ConfigureAdvertisedNetworkIsolation(nbClient)).To(Succeed())
+
+			expectedDropACL := libovsdbutil.BuildACL(dropACLdbIDs,
+				types.AdvertisedNetworkDenyPriority, expectedDropACLMatch(),
+				nbdb.ACLActionDrop, nil, libovsdbutil.LportEgressAfterLB, isolationTier)
+			expectedDropACL.UUID = "drop-acl-UUID"
+			expectedPG := libovsdbutil.BuildPortGroup(GetAdvertisedNetworkSubnetsDropPGdbIDs(), nil, []*nbdb.ACL{expectedDropACL})
+			expectedPG.UUID = "drop-pg-UUID"
+			expectedPG.Ports = []string{storLSP.UUID}
+			expectedData := append([]libovsdbtest.TestData{
+				expectedDropACL, expectedPG,
+				&nbdb.LogicalSwitch{UUID: "sw1-UUID", Name: "sw1", Ports: []string{storLSP.UUID}},
+				storLSP,
+			}, expectedAddrSets()...)
+			Expect(nbClient).To(libovsdbtest.HaveData(expectedData))
+		})
+
+		It("migrates duplicate drop ACLs from switches to the port group", func() {
+			dropACLdbIDs := GetAdvertisedNetworkSubnetsDropACLdbIDs()
+			dropACL1 := libovsdbutil.BuildACL(dropACLdbIDs, types.AdvertisedNetworkDenyPriority,
+				"(ip4.src == $fake && ip4.dst == $fake)", nbdb.ACLActionDrop, nil,
+				libovsdbutil.LportEgressAfterLB, isolationTier)
+			dropACL1.UUID = "drop-acl-1-UUID"
+			dropACL2 := libovsdbutil.BuildACL(dropACLdbIDs, types.AdvertisedNetworkDenyPriority,
+				"(ip4.src == $fake && ip4.dst == $fake)", nbdb.ACLActionDrop, nil,
+				libovsdbutil.LportEgressAfterLB, isolationTier)
+			dropACL2.UUID = "drop-acl-2-UUID"
+
+			sw1LSP := &nbdb.LogicalSwitchPort{UUID: "stor-sw1-UUID", Name: types.SwitchToRouterPrefix + "sw1", Type: "router"}
+			sw2LSP := &nbdb.LogicalSwitchPort{UUID: "stor-sw2-UUID", Name: types.SwitchToRouterPrefix + "sw2", Type: "router"}
+			sw1 := &nbdb.LogicalSwitch{UUID: "sw1-UUID", Name: "sw1", Ports: []string{sw1LSP.UUID}, ACLs: []string{dropACL1.UUID}}
+			sw2 := &nbdb.LogicalSwitch{UUID: "sw2-UUID", Name: "sw2", Ports: []string{sw2LSP.UUID}, ACLs: []string{dropACL2.UUID}}
+
+			nbClient, nbCleanup, err := libovsdbtest.NewNBTestHarness(libovsdbtest.TestSetup{
+				NBData: []libovsdbtest.TestData{dropACL1, dropACL2, sw1, sw2, sw1LSP, sw2LSP},
+			}, nil)
+			Expect(err).NotTo(HaveOccurred())
+			defer nbCleanup.Cleanup()
+
+			Expect(ConfigureAdvertisedNetworkIsolation(nbClient)).To(Succeed())
+
+			expectedDropACL := libovsdbutil.BuildACL(dropACLdbIDs,
+				types.AdvertisedNetworkDenyPriority, expectedDropACLMatch(),
+				nbdb.ACLActionDrop, nil, libovsdbutil.LportEgressAfterLB, isolationTier)
+			expectedDropACL.UUID = "drop-acl-1-UUID"
+			expectedPG := libovsdbutil.BuildPortGroup(GetAdvertisedNetworkSubnetsDropPGdbIDs(), nil, []*nbdb.ACL{expectedDropACL})
+			expectedPG.UUID = "drop-pg-UUID"
+			expectedPG.Ports = []string{sw1LSP.UUID, sw2LSP.UUID}
+			expectedData := append([]libovsdbtest.TestData{
+				expectedDropACL, expectedPG,
+				&nbdb.LogicalSwitch{UUID: "sw1-UUID", Name: "sw1", Ports: []string{sw1LSP.UUID}},
+				&nbdb.LogicalSwitch{UUID: "sw2-UUID", Name: "sw2", Ports: []string{sw2LSP.UUID}},
+				sw1LSP, sw2LSP,
+			}, expectedAddrSets()...)
+			Expect(nbClient).To(libovsdbtest.HaveData(expectedData))
+		})
+
+		It("skips migration but self-heals the drop ACL when the port group already exists", func() {
+			dropACLdbIDs := GetAdvertisedNetworkSubnetsDropACLdbIDs()
+			dropACL := libovsdbutil.BuildACL(dropACLdbIDs, types.AdvertisedNetworkDenyPriority,
+				"(ip4.src == $fake && ip4.dst == $fake)", nbdb.ACLActionDrop, nil,
+				libovsdbutil.LportEgressAfterLB, isolationTier)
+			dropACL.UUID = "drop-acl-UUID"
+			storLSP := &nbdb.LogicalSwitchPort{UUID: "stor-sw1-UUID", Name: types.SwitchToRouterPrefix + "sw1", Type: "router"}
+			sw := &nbdb.LogicalSwitch{UUID: "sw1-UUID", Name: "sw1", Ports: []string{storLSP.UUID}}
+			pg := libovsdbutil.BuildPortGroup(GetAdvertisedNetworkSubnetsDropPGdbIDs(), nil, []*nbdb.ACL{dropACL})
+			pg.UUID = "drop-pg-UUID"
+			pg.Ports = []string{storLSP.UUID}
+
+			nbClient, nbCleanup, err := libovsdbtest.NewNBTestHarness(libovsdbtest.TestSetup{
+				NBData: []libovsdbtest.TestData{dropACL, pg, sw, storLSP},
+			}, nil)
+			Expect(err).NotTo(HaveOccurred())
+			defer nbCleanup.Cleanup()
+
+			Expect(ConfigureAdvertisedNetworkIsolation(nbClient)).To(Succeed())
+
+			expectedDropACL := libovsdbutil.BuildACL(dropACLdbIDs,
+				types.AdvertisedNetworkDenyPriority, expectedDropACLMatch(),
+				nbdb.ACLActionDrop, nil, libovsdbutil.LportEgressAfterLB, isolationTier)
+			expectedDropACL.UUID = "drop-acl-UUID"
+			expectedPG := libovsdbutil.BuildPortGroup(GetAdvertisedNetworkSubnetsDropPGdbIDs(), nil, []*nbdb.ACL{expectedDropACL})
+			expectedPG.UUID = "drop-pg-UUID"
+			expectedPG.Ports = []string{storLSP.UUID}
+			expectedData := append([]libovsdbtest.TestData{expectedDropACL, expectedPG, sw, storLSP}, expectedAddrSets()...)
+			Expect(nbClient).To(libovsdbtest.HaveData(expectedData))
+		})
+	})
+
 	It("queues advertised local nodes when a primary Layer3 UDN adds a subnet", func() {
 		config.OVNKubernetesFeature.EnableMultiNetwork = true
 		config.OVNKubernetesFeature.EnableNetworkSegmentation = true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved advertised-network isolation using shared drop port groups and subnet address sets.
  * Added automatic migration and self-healing for existing isolation configuration.
  * Added support for cleaning up stale advertised-network subnets.

* **Bug Fixes**
  * Improved stale route and MAC-binding cleanup.
  * Missing ACL or switch entries are now handled safely during updates.

* **Tests**
  * Expanded coverage for isolation setup, migration, cleanup, and network address-family scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->