### PR TITLE
[release-4.21] OCPBUGS-95075: prevent duplicate logical_router_static_route

### DIFF
--- a/go-controller/pkg/ovn/zone_interconnect/zone_ic_handler.go
+++ b/go-controller/pkg/ovn/zone_interconnect/zone_ic_handler.go
@@ -662,9 +662,7 @@ func (zic *ZoneInterconnectHandler) addRemoteNodeStaticRoutes(node *corev1.Node,
 		// external-ids, skip types.NetworkExternalID check in the predicate function to replace existing static route
 		// with correct external-ids on an upgrade scenario.
 		p := func(lrsr *nbdb.LogicalRouterStaticRoute) bool {
-			return lrsr.IPPrefix == prefix &&
-				lrsr.Nexthop == nexthop &&
-				lrsr.ExternalIDs["ic-node"] == node.Name
+			return lrsr.IPPrefix == prefix
 		}
 		var err error
 		ops, err = libovsdbops.CreateOrReplaceLogicalRouterStaticRouteWithPredicateOps(zic.nbClient, ops, zic.networkClusterRouterName, &logicalRouterStaticRoute, p)


### PR DESCRIPTION
## Description
Backport of upstream commit 09cf494 (PR #6510) for [release-4.21].
Cherry-picked from 3d9955fa5 (#3273, release-4.22 backport).
  
  Fixes duplicate logical_router_static_route entries left behind when nodes are deleted, causing traffic loss between nodes.
  jira : https://redhat.atlassian.net/browse/OCPBUGS-95075
  Original upstream PR: ovn-kubernetes/ovn-kubernetes#6510
  Prior branch PR: openshift/ovn-kubernetes#3273 (release-4.22)
  
  cc: @jcaamano @pperiyasamy