### PR TITLE
 [release-4.18] OCPBUGS-95088: prevent duplicate logical_router_static_route

### DIFF
--- a/go-controller/pkg/ovn/zone_interconnect/zone_ic_handler.go
+++ b/go-controller/pkg/ovn/zone_interconnect/zone_ic_handler.go
@@ -586,9 +586,7 @@ func (zic *ZoneInterconnectHandler) addRemoteNodeStaticRoutes(node *corev1.Node,
 		// external-ids, skip types.NetworkExternalID check in the predicate function to replace existing static route
 		// with correct external-ids on an upgrade scenario.
 		p := func(lrsr *nbdb.LogicalRouterStaticRoute) bool {
-			return lrsr.IPPrefix == prefix &&
-				lrsr.Nexthop == nexthop &&
-				lrsr.ExternalIDs["ic-node"] == node.Name
+			return lrsr.IPPrefix == prefix
 		}
 		var err error
 		ops, err = libovsdbops.CreateOrReplaceLogicalRouterStaticRouteWithPredicateOps(zic.nbClient, ops, zic.networkClusterRouterName, &logicalRouterStaticRoute, p)


### PR DESCRIPTION
## Description
  Backport of upstream commit 09cf494 (PR #6510) for [release-4.18].
Cherry-picked from c23bc7660 (#3276, release-4.19 backport).

  
  Fixes duplicate logical_router_static_route entries left behind when nodes are deleted, causing traffic loss between nodes.
  
  Original upstream PR: ovn-kubernetes/ovn-kubernetes#6510
  Prior branch PRs: #3273 (release-4.22), #3274 (release-4.21), #3275 (release-4.20), #3276 (release-4.19)
  
  cc: @jcaamano @pperiyasamy