### PR TITLE
OCPBUGS-94111: Send release GARP before deleting EgressIP to prevent stale ARP cache

### DIFF
--- a/go-controller/pkg/node/linkmanager/link_network_manager.go
+++ b/go-controller/pkg/node/linkmanager/link_network_manager.go
@@ -148,7 +148,24 @@ func (c *Controller) DelAddress(address netlink.Addr) error {
 		}
 		return fmt.Errorf("no valid link associated with addresses %s: %v", address.String(), err)
 	}
-	klog.Infof("Link manager: deleting address %s from link %s", address.String(), link.Attrs().Name)
+	linkName := link.Attrs().Name
+	klog.Infof("Link manager: deleting address %s from link %s", address.String(), linkName)
+
+	// Send release GARP before deleting the address to signal that this node is
+	// releasing ownership of the IP. This prevents duplicate IP detection when
+	// the IP is being moved to another node (e.g., during EgressIP failover).
+	if utilnet.IsIPv4(address.IP) {
+		garp, err := util.NewGARP(address.IP, nil)
+		if err != nil {
+			klog.Warningf("Link manager: failed to create release GARP for %s: %v (continuing with deletion)", address.IP, err)
+		} else {
+			// Best effort - if release GARP fails, log but still proceed with deletion
+			if err := util.SendReleaseGARP(linkName, garp); err != nil {
+				klog.Warningf("Link manager: failed to send release GARP for %s on link %s: %v (continuing with deletion)", address.IP, linkName, err)
+			}
+		}
+	}
+
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if err := util.GetNetLinkOps().AddrDel(link, &address); err != nil {
@@ -156,7 +173,7 @@ func (c *Controller) DelAddress(address netlink.Addr) error {
 			return fmt.Errorf("failed to delete address %s: %v", address.String(), err)
 		}
 	}
-	c.delAddressFromStore(link.Attrs().Name, address)
+	c.delAddressFromStore(linkName, address)
 	return nil
 }
 

--- a/go-controller/pkg/util/arp.go
+++ b/go-controller/pkg/util/arp.go
@@ -103,3 +103,46 @@ func BroadcastGARP(interfaceName string, garp GARP) error {
 	klog.Infof("BroadcastGARP: completed GARP broadcast for IP %s on interface %s with MAC: %s", garp.IP().String(), interfaceName, mac.String())
 	return nil
 }
+
+// SendReleaseGARP sends a gratuitous ARP with zero MAC address to signal that
+// this node is releasing ownership of the IP. This helps prevent duplicate IP
+// detection when the IP is being moved to another node.
+//
+// The release GARP uses MAC address 00:00:00:00:00:00 as the source hardware
+// address, which is a well-known technique for releasing IP ownership on the
+// network layer. This proactively clears ARP caches on switches/routers and
+// prevents the old node from continuing to defend the IP after deletion.
+//
+// This function sends both ARP request and reply operations (similar to
+// BroadcastGARP) since some systems respond to request and others to reply.
+func SendReleaseGARP(interfaceName string, garp GARP) error {
+	iface, err := net.InterfaceByName(interfaceName)
+	if err != nil {
+		return fmt.Errorf("failed finding interface %s: %v", interfaceName, err)
+	}
+
+	srcIP := netip.AddrFrom4(garp.IPv4())
+	// Use zero MAC to signal IP release
+	zeroMAC := net.HardwareAddr{0, 0, 0, 0, 0, 0}
+
+	c, err := arp.Dial(iface)
+	if err != nil {
+		return fmt.Errorf("failed dialing %q: %v", interfaceName, err)
+	}
+	defer c.Close()
+
+	// Send both request and reply with zero MAC to ensure maximum compatibility
+	for _, op := range []arp.Operation{arp.OperationRequest, arp.OperationReply} {
+		p, err := arp.NewPacket(op, zeroMAC /* srcHw */, srcIP, net.HardwareAddr{0, 0, 0, 0, 0, 0}, srcIP)
+		if err != nil {
+			return fmt.Errorf("failed creating %q release GARP %+v: %w", op, garp, err)
+		}
+
+		if err := c.WriteTo(p, net.HardwareAddr{0xff, 0xff, 0xff, 0xff, 0xff, 0xff}); err != nil {
+			return fmt.Errorf("failed sending %q release GARP %+v: %w", op, garp, err)
+		}
+	}
+
+	klog.Infof("SendReleaseGARP: completed release GARP for IP %s on interface %s with zero MAC", garp.IP().String(), interfaceName)
+	return nil
+}

--- a/go-controller/pkg/util/arp_test.go
+++ b/go-controller/pkg/util/arp_test.go
@@ -1,0 +1,63 @@
+package util
+
+import (
+	"net"
+	"testing"
+)
+
+// TestSendReleaseGARP_InterfaceNotFound verifies that SendReleaseGARP
+// returns an error when the interface doesn't exist
+func TestSendReleaseGARP_InterfaceNotFound(t *testing.T) {
+	nonExistentInterface := "nonexistent-iface-xyz"
+	garp := &garp{
+		ip: [4]byte{192, 168, 1, 1},
+	}
+
+	err := SendReleaseGARP(nonExistentInterface, garp)
+	if err == nil {
+		t.Errorf("SendReleaseGARP() should return error for non-existent interface, got nil")
+	}
+}
+
+// TestGARPStruct verifies the GARP interface implementation
+func TestGARPStruct(t *testing.T) {
+	expectedIP := net.IPv4(10, 0, 0, 1)
+	expectedMAC := net.HardwareAddr{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff}
+
+	g := &garp{
+		ip:  [4]byte{10, 0, 0, 1},
+		mac: &expectedMAC,
+	}
+
+	// Test IP() method
+	if !g.IP().Equal(expectedIP) {
+		t.Errorf("GARP.IP() = %v, want %v", g.IP(), expectedIP)
+	}
+
+	// Test IPv4() method
+	ipv4 := g.IPv4()
+	if ipv4[0] != 10 || ipv4[1] != 0 || ipv4[2] != 0 || ipv4[3] != 1 {
+		t.Errorf("GARP.IPv4() = %v, want [10 0 0 1]", ipv4)
+	}
+
+	// Test MAC() method
+	mac := g.MAC()
+	if mac == nil {
+		t.Error("GARP.MAC() returned nil, expected non-nil")
+	} else if mac.String() != expectedMAC.String() {
+		t.Errorf("GARP.MAC() = %v, want %v", mac, expectedMAC)
+	}
+}
+
+// TestGARPWithNilMAC verifies GARP behavior when MAC is nil
+func TestGARPWithNilMAC(t *testing.T) {
+	g := &garp{
+		ip:  [4]byte{10, 0, 0, 1},
+		mac: nil,
+	}
+
+	mac := g.MAC()
+	if mac != nil {
+		t.Errorf("GARP.MAC() = %v, want nil when not set", mac)
+	}
+}


### PR DESCRIPTION
## Summary

This PR fixes OCPBUGS-94111 where the stale egress node continues to respond with unicast GARP after EgressIP reassignment, causing duplicate IP detection and network connectivity issues.

**Root Cause:** When an EgressIP is deleted from a node (during failover), the kernel continues to defend the IP address on the external network interface (br-ex) by sending defensive unicast ARP replies to the new node's broadcast GARP announcements.

**Fix:** Send a release GARP with zero MAC address (00:00:00:00:00:00) before deleting the IP address. This proactively signals to the network that this node is releasing ownership of the IP.

## Changes

1. **`go-controller/pkg/util/arp.go`**: Added `SendReleaseGARP()` function that sends both ARP request and reply with zero MAC to signal IP release
2. **`go-controller/pkg/util/arp_test.go`**: Added basic tests for the new function
3. **`go-controller/pkg/node/linkmanager/link_network_manager.go`**: Modified `DelAddress()` to call `SendReleaseGARP()` before deleting IPv4 addresses

## Testing

**Before fix:** Packet capture showed 200+ defensive unicast ARP replies from old node after EgressIP failover:
```
00:50:56:b7:ed:aa > 00:50:56:b7:77:0c, ARP reply 10.37.205.200 is-at 00:50:56:b7:ed:aa
(old node MAC)      (new node MAC - UNICAST!)
```

**After fix (expected):** Should see release GARP with zero MAC, followed by NO defensive replies:
```
00:00:00:00:00:00 > ff:ff:ff:ff:ff:ff, ARP reply 10.37.205.200 is-at 00:00:00:00:00:00
(zero MAC = IP release signal)
```

## Related Issues

- OCPBUGS-84201: Fixed ovn-controller GARP by adding drop flows on patch port (different layer)
- OCPBUGS-86612: Uses `disable-garp-rarp` flag to suppress ovn-controller GARPs (different layer)
- **OCPBUGS-94111**: This fix - prevents kernel from defending stale IPs on external network (br-ex)

All three bugs are related but occur at different network layers and require separate fixes.

## Commits

- `484a731be`: feat(util): Add SendReleaseGARP function for IP ownership release
- `c35de1a76`: fix(linkmanager): Send release GARP before deleting IP address

Signed-off-by: Swati Mulje <smulje@redhat.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code) via `/jira:solve OCPBUGS-94111 fork`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Network address removal now sends a release notification over IPv4 when possible, helping connected devices promptly recognize that the address is no longer available.
  * Address deletion continues successfully even if the release notification cannot be sent or the network link is already missing.
  * Improved handling of network interface and ARP communication errors during address cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->