### PR TITLE
openshift: enable kubevirt Secondary/Layer2 e2e tests in virtualization suite

### DIFF
--- a/openshift/cmd/ovn-kubernetes-tests-ext/main.go
+++ b/openshift/cmd/ovn-kubernetes-tests-ext/main.go
@@ -80,9 +80,18 @@ func main() {
 	// CI (registered in openshift/origin test/extended/util/image) so kubevirt
 	// tests do not pull unmirrored images, which trips the openshift-tests
 	// known-image-checker monitor and does not work in disconnected environments.
-	// FEDORA_WITH_TEST_TOOLING_IMAGE still takes precedence when set.
+	// openshift-tests exports KUBE_TEST_REPO with the --from-repository value
+	// (e.g. the local dev-scripts registry on baremetalds jobs); the mirror tag
+	// is deterministic (see origin test/extended/util/image GetMappedImages), so
+	// only the repository part changes. FEDORA_WITH_TEST_TOOLING_IMAGE still
+	// takes precedence when set.
 	if os.Getenv("FEDORA_WITH_TEST_TOOLING_IMAGE") == "" {
-		kubevirttest.FedoraWithTestToolingContainerDiskImage = "quay.io/openshift/community-e2e-images:e2e-quay-io-kubevirt-fedora-with-test-tooling-container-disk-20241024_891122a6fc-IycYTh-87XrXse4E"
+		const mirroredFedoraTag = "e2e-quay-io-kubevirt-fedora-with-test-tooling-container-disk-20241024_891122a6fc-IycYTh-87XrXse4E"
+		repo := os.Getenv("KUBE_TEST_REPO")
+		if repo == "" {
+			repo = "quay.io/openshift/community-e2e-images"
+		}
+		kubevirttest.FedoraWithTestToolingContainerDiskImage = repo + ":" + mirroredFedoraTag
 	}
 
 	// Create our registry of openshift-tests extensions

--- a/openshift/cmd/ovn-kubernetes-tests-ext/main.go
+++ b/openshift/cmd/ovn-kubernetes-tests-ext/main.go
@@ -86,7 +86,7 @@ func main() {
 		Parents: []string{
 			"openshift/conformance/serial",
 		},
-		Qualifiers: []string{`labels.exists(l, l == "Serial")`},
+		Qualifiers: []string{`labels.exists(l, l == "Serial") && !labels.exists(l, l == "Feature:VirtualMachineSupport")`},
 	})
 
 	ovnTestsExtension.AddSuite(extension.Suite{
@@ -94,7 +94,19 @@ func main() {
 		Parents: []string{
 			"openshift/conformance/parallel",
 		},
-		Qualifiers: []string{`!labels.exists(l, l == "Serial")`},
+		Qualifiers: []string{`!labels.exists(l, l == "Serial") && !labels.exists(l, l == "Feature:VirtualMachineSupport")`},
+	})
+
+	// Kubevirt tests run in the virtualization suite (used by the
+	// baremetalds-e2e-ovn-bgp-virt-* jobs with TEST_SUITE=openshift/network/virtualization)
+	// instead of the conformance suites; live-migration tests are too heavy for
+	// openshift/conformance/parallel parallelism.
+	ovnTestsExtension.AddSuite(extension.Suite{
+		Name: "ovn-kubernetes/network/virtualization",
+		Parents: []string{
+			"openshift/network/virtualization",
+		},
+		Qualifiers: []string{`labels.exists(l, l == "Feature:VirtualMachineSupport")`},
 	})
 
 	specs, err := ginkgo.BuildExtensionTestSpecsFromOpenShiftGinkgoSuite(extensiontests.AllTestsIncludingVendored())

--- a/openshift/cmd/ovn-kubernetes-tests-ext/main.go
+++ b/openshift/cmd/ovn-kubernetes-tests-ext/main.go
@@ -13,6 +13,7 @@ import (
 	_ "github.com/ovn-kubernetes/ovn-kubernetes/test/e2e"
 	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/deploymentconfig"
 	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/infraprovider"
+	kubevirttest "github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/kubevirt"
 
 	"github.com/openshift-eng/openshift-tests-extension/pkg/cmd"
 	"github.com/openshift-eng/openshift-tests-extension/pkg/extension"
@@ -75,6 +76,15 @@ func shouldIncludeTest(spec *extensiontests.ExtensionTestSpec) bool {
 }
 
 func main() {
+	// Use the fedora-with-test-tooling containerdisk image mirrored for OpenShift
+	// CI (registered in openshift/origin test/extended/util/image) so kubevirt
+	// tests do not pull unmirrored images, which trips the openshift-tests
+	// known-image-checker monitor and does not work in disconnected environments.
+	// FEDORA_WITH_TEST_TOOLING_IMAGE still takes precedence when set.
+	if os.Getenv("FEDORA_WITH_TEST_TOOLING_IMAGE") == "" {
+		kubevirttest.FedoraWithTestToolingContainerDiskImage = "quay.io/openshift/community-e2e-images:e2e-quay-io-kubevirt-fedora-with-test-tooling-container-disk-20241024_891122a6fc-IycYTh-87XrXse4E"
+	}
+
 	// Create our registry of openshift-tests extensions
 	extensionRegistry := extension.NewRegistry()
 	ovnTestsExtension := extension.NewExtension("openshift", "payload", "ovn-kubernetes")

--- a/openshift/test/annotate/rules.go
+++ b/openshift/test/annotate/rules.go
@@ -9,6 +9,12 @@ var (
 	// LabelToLabelMaps label -> label (ginkgo label)
 	// E2E tests are written with the support of ginkgo. ginkgo tests may contain Labels.
 	LabelToLabelMaps = map[string][]string{
+		// Kubevirt tests run in the virtualization suite (parallelism 3)
+		// instead of openshift/conformance/parallel, matching the
+		// baremetalds-e2e-ovn-bgp-virt-* jobs (TEST_SUITE=openshift/network/virtualization).
+		"[Suite:openshift/network/virtualization]": {
+			`[Feature:VirtualMachineSupport]`,
+		},
 		"[Disabled:Unimplemented]": {
 			`[Feature:Service]`,
 			`[Feature:NetworkPolicy]`,
@@ -20,7 +26,6 @@ var (
 			`[Feature:EgressQos]`,
 			`[Feature:ExternalGateway]`,
 			`[Feature:DisablePacketMTUCheck]`,
-			`[Feature:VirtualMachineSupport]`,
 			`[Feature:Interconnect]`,
 			`[Feature:Multicast]`,
 			`[Feature:MultiHoming]`,
@@ -33,6 +38,8 @@ var (
 	// if a test name partially or fully contains one of the map value strings, then add the label to the test
 	// label -> partial or full test name or regex to match a test name
 	LabelToTestNameMatchMaps = map[string][]string{
+		// Kubevirt tests run in the virtualization suite, see LabelToLabelMaps.
+		"[Suite:openshift/network/virtualization]": {},
 		// alpha features that are not gated
 		"[Disabled:Alpha]": {},
 		// tests for features that are not implemented in openshift

--- a/openshift/test/generated/zz_generated.annotations.go
+++ b/openshift/test/generated/zz_generated.annotations.go
@@ -1177,69 +1177,69 @@ var AppendedAnnotations = map[string]string{
 
 	"External Gateway With Admin Policy Based External Route CRs e2e non-vxlan external gateway through a gateway pod Should validate TCP/UDP connectivity to an external gateway's loopback address via a gateway pod UDP ipv6": "[Disabled:Unimplemented]",
 
-	"Kubevirt Virtual Machines IP family validation for layer2 primary networks should fail when dual-stack network requests only IPv4": "[Disabled:Unimplemented]",
+	"Kubevirt Virtual Machines IP family validation for layer2 primary networks should fail when dual-stack network requests only IPv4": "[Suite:openshift/network/virtualization]",
 
-	"Kubevirt Virtual Machines IP family validation for layer2 primary networks should fail when dual-stack network requests only IPv6": "[Disabled:Unimplemented]",
+	"Kubevirt Virtual Machines IP family validation for layer2 primary networks should fail when dual-stack network requests only IPv6": "[Suite:openshift/network/virtualization]",
 
-	"Kubevirt Virtual Machines IP family validation for layer2 primary networks should fail when single-stack IPv4 network requests multiple IPv4 IPs": "[Disabled:Unimplemented]",
+	"Kubevirt Virtual Machines IP family validation for layer2 primary networks should fail when single-stack IPv4 network requests multiple IPv4 IPs": "[Suite:openshift/network/virtualization]",
 
-	"Kubevirt Virtual Machines IP family validation for layer2 primary networks should fail when single-stack IPv6 network requests multiple IPv6 IPs": "[Disabled:Unimplemented]",
+	"Kubevirt Virtual Machines IP family validation for layer2 primary networks should fail when single-stack IPv6 network requests multiple IPv6 IPs": "[Suite:openshift/network/virtualization]",
 
-	"Kubevirt Virtual Machines IP family validation for layer2 primary networks should succeed when dual-stack network requests correct IPs (1 IPv4 + 1 IPv6)": "[Disabled:Unimplemented]",
+	"Kubevirt Virtual Machines IP family validation for layer2 primary networks should succeed when dual-stack network requests correct IPs (1 IPv4 + 1 IPv6)": "[Suite:openshift/network/virtualization]",
 
-	"Kubevirt Virtual Machines duplicate addresses validation should fail when creating second VM with duplicate static IP": "[Disabled:Unimplemented]",
+	"Kubevirt Virtual Machines duplicate addresses validation should fail when creating second VM with duplicate static IP": "[Suite:openshift/network/virtualization]",
 
-	"Kubevirt Virtual Machines duplicate addresses validation should fail when creating second VM with duplicate user requested MAC": "[Disabled:Unimplemented]",
+	"Kubevirt Virtual Machines duplicate addresses validation should fail when creating second VM with duplicate user requested MAC": "[Suite:openshift/network/virtualization]",
 
-	"Kubevirt Virtual Machines ipv4 subnet exhaustion should fail when subnet is exhausted": "[Disabled:Unimplemented]",
+	"Kubevirt Virtual Machines ipv4 subnet exhaustion should fail when subnet is exhausted": "[Suite:openshift/network/virtualization]",
 
-	"Kubevirt Virtual Machines with default pod network when live migration with post-copy succeeds, should keep connectivity": "[Disabled:Unimplemented]",
+	"Kubevirt Virtual Machines with default pod network when live migration with post-copy succeeds, should keep connectivity": "[Suite:openshift/network/virtualization]",
 
-	"Kubevirt Virtual Machines with default pod network when live migration with pre-copy fails, should keep connectivity": "[Disabled:Unimplemented]",
+	"Kubevirt Virtual Machines with default pod network when live migration with pre-copy fails, should keep connectivity": "[Suite:openshift/network/virtualization]",
 
-	"Kubevirt Virtual Machines with default pod network when live migration with pre-copy succeeds, should keep connectivity": "[Disabled:Unimplemented]",
+	"Kubevirt Virtual Machines with default pod network when live migration with pre-copy succeeds, should keep connectivity": "[Suite:openshift/network/virtualization]",
 
-	"Kubevirt Virtual Machines with kubevirt VM using layer2 UDPN should configure IPv4 and IPv6 using DHCP and NDP": "[Disabled:Unimplemented]",
+	"Kubevirt Virtual Machines with kubevirt VM using layer2 UDPN should configure IPv4 and IPv6 using DHCP and NDP": "[Suite:openshift/network/virtualization]",
 
-	"Kubevirt Virtual Machines with user defined networks and persistent ips configured should keep ip after live migration failed of VirtualMachine with interface binding for UDN with Primary/Layer2 ingress routed over evpn": "[Disabled:Unimplemented]",
+	"Kubevirt Virtual Machines with user defined networks and persistent ips configured should keep ip after live migration failed of VirtualMachine with interface binding for UDN with Primary/Layer2 ingress routed over evpn": "[Suite:openshift/network/virtualization]",
 
-	"Kubevirt Virtual Machines with user defined networks and persistent ips configured should keep ip after live migration failed of VirtualMachineInstance with Secondary/Localnet ingress snat": "[Disabled:Unimplemented]",
+	"Kubevirt Virtual Machines with user defined networks and persistent ips configured should keep ip after live migration failed of VirtualMachineInstance with Secondary/Localnet ingress snat": "[Suite:openshift/network/virtualization]",
 
-	"Kubevirt Virtual Machines with user defined networks and persistent ips configured should keep ip after live migration failed of VirtualMachineInstance with interface binding for UDN with Primary/Layer2 ingress snat": "[Disabled:Unimplemented]",
+	"Kubevirt Virtual Machines with user defined networks and persistent ips configured should keep ip after live migration failed of VirtualMachineInstance with interface binding for UDN with Primary/Layer2 ingress snat": "[Suite:openshift/network/virtualization]",
 
-	"Kubevirt Virtual Machines with user defined networks and persistent ips configured should keep ip after live migration of VirtualMachine with Secondary/Layer2 ingress snat": "[Disabled:Unimplemented]",
+	"Kubevirt Virtual Machines with user defined networks and persistent ips configured should keep ip after live migration of VirtualMachine with Secondary/Layer2 ingress snat": "[Suite:openshift/network/virtualization]",
 
-	"Kubevirt Virtual Machines with user defined networks and persistent ips configured should keep ip after live migration of VirtualMachine with Secondary/Localnet ingress snat": "[Disabled:Unimplemented]",
+	"Kubevirt Virtual Machines with user defined networks and persistent ips configured should keep ip after live migration of VirtualMachine with Secondary/Localnet ingress snat": "[Suite:openshift/network/virtualization]",
 
-	"Kubevirt Virtual Machines with user defined networks and persistent ips configured should keep ip after live migration of VirtualMachine with interface binding for UDN and statics IPs and MAC with Primary/Layer2 ingress routed": "[Disabled:Unimplemented]",
+	"Kubevirt Virtual Machines with user defined networks and persistent ips configured should keep ip after live migration of VirtualMachine with interface binding for UDN and statics IPs and MAC with Primary/Layer2 ingress routed": "[Suite:openshift/network/virtualization]",
 
-	"Kubevirt Virtual Machines with user defined networks and persistent ips configured should keep ip after live migration of VirtualMachine with interface binding for UDN and statics IPs and MAC with Primary/Layer2 ingress snat": "[Disabled:Unimplemented]",
+	"Kubevirt Virtual Machines with user defined networks and persistent ips configured should keep ip after live migration of VirtualMachine with interface binding for UDN and statics IPs and MAC with Primary/Layer2 ingress snat": "[Suite:openshift/network/virtualization]",
 
-	"Kubevirt Virtual Machines with user defined networks and persistent ips configured should keep ip after live migration of VirtualMachine with interface binding for UDN with Primary/Layer2 ingress routed over evpn": "[Disabled:Unimplemented]",
+	"Kubevirt Virtual Machines with user defined networks and persistent ips configured should keep ip after live migration of VirtualMachine with interface binding for UDN with Primary/Layer2 ingress routed over evpn": "[Suite:openshift/network/virtualization]",
 
-	"Kubevirt Virtual Machines with user defined networks and persistent ips configured should keep ip after live migration of VirtualMachine with interface binding for UDN with Primary/Layer2 ingress routed": "[Disabled:Unimplemented]",
+	"Kubevirt Virtual Machines with user defined networks and persistent ips configured should keep ip after live migration of VirtualMachine with interface binding for UDN with Primary/Layer2 ingress routed": "[Suite:openshift/network/virtualization]",
 
-	"Kubevirt Virtual Machines with user defined networks and persistent ips configured should keep ip after live migration of VirtualMachine with interface binding for UDN with Primary/Layer2 ingress snat": "[Disabled:Unimplemented]",
+	"Kubevirt Virtual Machines with user defined networks and persistent ips configured should keep ip after live migration of VirtualMachine with interface binding for UDN with Primary/Layer2 ingress snat": "[Suite:openshift/network/virtualization]",
 
-	"Kubevirt Virtual Machines with user defined networks and persistent ips configured should keep ip after live migration of VirtualMachineInstance with Secondary/Layer2 ingress snat": "[Disabled:Unimplemented]",
+	"Kubevirt Virtual Machines with user defined networks and persistent ips configured should keep ip after live migration of VirtualMachineInstance with Secondary/Layer2 ingress snat": "[Suite:openshift/network/virtualization]",
 
-	"Kubevirt Virtual Machines with user defined networks and persistent ips configured should keep ip after live migration of VirtualMachineInstance with Secondary/Localnet ingress snat": "[Disabled:Unimplemented]",
+	"Kubevirt Virtual Machines with user defined networks and persistent ips configured should keep ip after live migration of VirtualMachineInstance with Secondary/Localnet ingress snat": "[Suite:openshift/network/virtualization]",
 
-	"Kubevirt Virtual Machines with user defined networks and persistent ips configured should keep ip after live migration of VirtualMachineInstance with interface binding for UDN with Primary/Layer2 ingress snat": "[Disabled:Unimplemented]",
+	"Kubevirt Virtual Machines with user defined networks and persistent ips configured should keep ip after live migration of VirtualMachineInstance with interface binding for UDN with Primary/Layer2 ingress snat": "[Suite:openshift/network/virtualization]",
 
-	"Kubevirt Virtual Machines with user defined networks and persistent ips configured should keep ip after restart of VirtualMachine with Secondary/Layer2 ingress snat": "[Disabled:Unimplemented]",
+	"Kubevirt Virtual Machines with user defined networks and persistent ips configured should keep ip after restart of VirtualMachine with Secondary/Layer2 ingress snat": "[Suite:openshift/network/virtualization]",
 
-	"Kubevirt Virtual Machines with user defined networks and persistent ips configured should keep ip after restart of VirtualMachine with Secondary/Localnet ingress snat": "[Disabled:Unimplemented]",
+	"Kubevirt Virtual Machines with user defined networks and persistent ips configured should keep ip after restart of VirtualMachine with Secondary/Localnet ingress snat": "[Suite:openshift/network/virtualization]",
 
-	"Kubevirt Virtual Machines with user defined networks and persistent ips configured should keep ip after restart of VirtualMachine with interface binding for UDN and statics IPs and MAC with Primary/Layer2 ingress snat": "[Disabled:Unimplemented]",
+	"Kubevirt Virtual Machines with user defined networks and persistent ips configured should keep ip after restart of VirtualMachine with interface binding for UDN and statics IPs and MAC with Primary/Layer2 ingress snat": "[Suite:openshift/network/virtualization]",
 
-	"Kubevirt Virtual Machines with user defined networks and persistent ips configured should keep ip after restart of VirtualMachine with interface binding for UDN with Primary/Layer2 ingress snat": "[Disabled:Unimplemented]",
+	"Kubevirt Virtual Machines with user defined networks and persistent ips configured should keep ip after restart of VirtualMachine with interface binding for UDN with Primary/Layer2 ingress snat": "[Suite:openshift/network/virtualization]",
 
-	"Kubevirt Virtual Machines with user defined networks with ipamless localnet topology should maintain tcp connection with minimal downtime after failed live migration": "[Disabled:Unimplemented]",
+	"Kubevirt Virtual Machines with user defined networks with ipamless localnet topology should maintain tcp connection with minimal downtime after failed live migration": "[Suite:openshift/network/virtualization]",
 
-	"Kubevirt Virtual Machines with user defined networks with ipamless localnet topology should maintain tcp connection with minimal downtime after succeeded live migration": "[Disabled:Unimplemented]",
+	"Kubevirt Virtual Machines with user defined networks with ipamless localnet topology should maintain tcp connection with minimal downtime after succeeded live migration": "[Suite:openshift/network/virtualization]",
 
-	"Kubevirt Virtual Machines with user defined networks with ipamless localnet topology should start multiple VMs with same hostname": "[Disabled:Unimplemented]",
+	"Kubevirt Virtual Machines with user defined networks with ipamless localnet topology should start multiple VMs with same hostname": "[Suite:openshift/network/virtualization]",
 
 	"Load Balancer Service Tests with MetalLB Should ensure connectivity works on an external service when mtu changes in intermediate node": "[Disabled:Unimplemented]",
 

--- a/openshift/test/tests.go
+++ b/openshift/test/tests.go
@@ -12,6 +12,9 @@ package test
 // InformingTests lists tests that generally pass but are not considered stable
 // and should not block CI jobs if they fail.
 var InformingTests = []string{
+	"[Feature:VirtualMachineSupport][ovn-kubernetes-ote][sig-network] Kubevirt Virtual Machines with user defined networks and persistent ips configured should keep ip after live migration of VirtualMachine with Secondary/Layer2 ingress snat [Suite:openshift/network/virtualization]",
+	"[Feature:VirtualMachineSupport][ovn-kubernetes-ote][sig-network] Kubevirt Virtual Machines with user defined networks and persistent ips configured should keep ip after live migration of VirtualMachineInstance with Secondary/Layer2 ingress snat [Suite:openshift/network/virtualization]",
+	"[Feature:VirtualMachineSupport][ovn-kubernetes-ote][sig-network] Kubevirt Virtual Machines with user defined networks and persistent ips configured should keep ip after restart of VirtualMachine with Secondary/Layer2 ingress snat [Suite:openshift/network/virtualization]",
 	"[Feature:NetworkSegmentation][ovn-kubernetes-ote][sig-network] Network Segmentation a user defined primary network created using ClusterUserDefinedNetwork can perform east/west traffic between nodes two pods connected over a L2 primary UDN [Suite:openshift/conformance/parallel]",
 	"[Feature:NetworkSegmentation][ovn-kubernetes-ote][sig-network] Network Segmentation a user defined primary network created using ClusterUserDefinedNetwork can perform east/west traffic between nodes two pods connected over a L2 primary UDN with custom network [Suite:openshift/conformance/parallel]",
 	"[Feature:NetworkSegmentation][ovn-kubernetes-ote][sig-network] Network Segmentation a user defined primary network created using ClusterUserDefinedNetwork can perform east/west traffic between nodes two pods connected over a L3 primary UDN [Suite:openshift/conformance/parallel]",

--- a/test/e2e/kubevirt.go
+++ b/test/e2e/kubevirt.go
@@ -2037,9 +2037,16 @@ ip route add %[3]s via %[4]s
 				WithPolling(time.Second).
 				Should(Succeed(), step)
 
-			// expect 2 addresses on dual-stack deployments; 1 on single-stack
+			// IPv6 is not supported for secondaries with IPAM since
+			// KubeVirt does not run a DHCPv6 server for bridge bindings,
+			// so the VMI status will only report IPv4 addresses.
+			// For primary UDNs, expect dual-stack (2 addresses); for
+			// secondaries, expect IPv4 only (1 address).
 			step = by(vmi.Name, "Wait for addresses at the virtual machine")
 			expectedNumberOfAddresses := len(dualCIDRs)
+			if td.role != udnv1.NetworkRolePrimary {
+				expectedNumberOfAddresses = 1
+			}
 			expectedAddreses := virtualMachineAddressesFromStatus(vmi, expectedNumberOfAddresses)
 			if _, hasIPRequests := vmi.Annotations[kubevirt.AddressesAnnotation]; hasIPRequests {
 				Expect(expectedAddreses).To(ConsistOf(filterIPs(fr.ClientSet, staticIPv4, staticIPv6)), "expected addresses should be consistent with the static IPs")

--- a/test/e2e/kubevirt/types.go
+++ b/test/e2e/kubevirt/types.go
@@ -3,8 +3,19 @@
 
 package kubevirt
 
+import "os"
+
 const (
-	FedoraCoreOSContainerDiskImage          = "quay.io/kubevirtci/fedora-coreos-kubevirt:v20230905-be4fa50"
-	FedoraWithTestToolingContainerDiskImage = "quay.io/kubevirtci/fedora-with-test-tooling:v20250416-e37573e"
-	FedoraContainerDiskImage                = "quay.io/containerdisks/fedora:39"
+	FedoraCoreOSContainerDiskImage = "quay.io/kubevirtci/fedora-coreos-kubevirt:v20230905-be4fa50"
+	FedoraContainerDiskImage       = "quay.io/containerdisks/fedora:39"
 )
+
+var (
+	FedoraWithTestToolingContainerDiskImage = "quay.io/kubevirtci/fedora-with-test-tooling:v20250416-e37573e"
+)
+
+func init() {
+	if override := os.Getenv("FEDORA_WITH_TEST_TOOLING_IMAGE"); override != "" {
+		FedoraWithTestToolingContainerDiskImage = override
+	}
+}


### PR DESCRIPTION
## 📑 Description

Enable the kubevirt live-migration/restart e2e tests for **secondary layer2** user defined networks in the downstream tests extension (OTE), running them in the `openshift/network/virtualization` suite instead of `openshift/conformance/parallel`:

- Stop mapping `[Feature:VirtualMachineSupport]` to `[Disabled:Unimplemented]`; kubevirt tests are now annotated `[Suite:openshift/network/virtualization]` (regenerated annotations).
- Add a new extension suite `ovn-kubernetes/network/virtualization` parented into `openshift/network/virtualization`, and exclude `Feature:VirtualMachineSupport` from the conformance suites. This matches the existing `baremetalds-e2e-ovn-bgp-virt-*` jobs (`TEST_SUITE=openshift/network/virtualization`, CNV installed via the `kubevirt-install` step, parallelism 3) — no openshift/release changes needed.
- List the three Secondary/Layer2 tests as **informing**:
  - `should keep ip after live migration of VirtualMachine with Secondary/Layer2 ingress snat`
  - `should keep ip after live migration of VirtualMachineInstance with Secondary/Layer2 ingress snat`
  - `should keep ip after restart of VirtualMachine with Secondary/Layer2 ingress snat`

Only the Secondary/Layer2 variants are enabled: Primary UDN and localnet kubevirt variants require infraprovider methods not implemented for OpenShift (`CreateExternalContainer`/`SetupUnderlay`).

## Additional Information for reviewers

Live-migration tests are too heavy for `openshift/conformance/parallel` (parallelism 30): each spawns a Fedora VM plus per-worker iperf server pods, and concurrent live migrations were observed to fail. The virtualization suite runs with parallelism 3 and origin serializes tests from the same Ordered ginkgo container, so they run sequentially there.

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [x] My code requires tests
- [x] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI

## How to verify it

Verified against an OCP 4.22.0-rc.4 + CNV 4.22 cluster (2 workers, nested virt) through origin's `openshift-tests` using the local extension override:

```
export EXTENSION_BINARY_OVERRIDE_OVN_KUBERNETES=<repo>/openshift/bin/ovn-kubernetes-tests-ext
export EXTENSION_BINARY_OVERRIDE_INCLUDE_TAGS=ovn-kubernetes
openshift-tests run openshift/network/virtualization --run ovn-kubernetes-ote
```

Result: `3 pass, 0 flaky, 0 skip (15m43s)`. Also verified with `--dry-run` that `openshift/network/virtualization` selects exactly these 3 tests and `openshift/conformance/parallel` no longer selects any kubevirt test (other OTE tests unaffected).

In CI: `/test e2e-metal-ipi-ovn-bgp-virt-dualstack` on this PR exercises the suite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a dedicated OpenShift conformance suite for virtualization tests labeled `Feature:VirtualMachineSupport`.
  - Expanded OpenShift informing tests to cover KubeVirt IP preservation for VirtualMachine live migration and restart scenarios.
- **Bug Fixes**
  - Improved conformance test routing by excluding `VirtualMachineSupport` from standard serial/parallel suites and mapping it to the new suite.
  - Updated persistent IP expectations for secondary UDNs with IPAM to require IPv4 only (no IPv6).
- **Chores**
  - Improved Fedora test-tooling image selection by honoring `FEDORA_WITH_TEST_TOOLING_IMAGE`, with a mirrored/disconnected-friendly default when unset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->