### PR TITLE
OCPBUGS-86429: Unpin libreswan version for IPsec scaling fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN INSTALL_PKGS=" \
 	openssl firewalld-filesystem \
 	libpcap iproute iproute-tc strace \
 	tcpdump iputils \
-	libreswan-4.6-3.el9_0.3 \
+	libreswan \
 	ethtool conntrack-tools \
 	openshift-clients \
 	" && \


### PR DESCRIPTION
## Summary
- Unpin libreswan from `4.6-3.el9_0.3` to latest available version in Dockerfile
- This allows RHCOS to pick up libreswan 5.x which fixes a pluto segfault in `set_larval_v2_transition()` that causes IPsec mesh tunnel failures at 75+ node scale

## Background
Large clusters (75+ nodes) with IPsec enabled hit a race condition in libreswan's pluto daemon during concurrent Child SA negotiation. The fix is in libreswan 5.x but OCP 4.18 pins to an older version. This PR removes the pin so the latest packaged version is installed.

## Related PRs
- openshift/ovn-kubernetes#2498 (master - already merged)
- openshift/machine-config-operator#6310 (release-4.18 - companion PR)
- openshift/cluster-network-operator#3056 (release-4.18 - companion PR)

## Test plan
- [ ] Bring up a 75+ node cluster with IPsec enabled
- [ ] Verify `ipsec --version` shows libreswan 5.x on nodes
- [ ] Verify all IPsec tunnels establish successfully
- [ ] Check no pluto segfaults in journal logs