### PR TITLE
OCPBUGS-41830: add ability to skip tests that require root

### DIFF
--- a/go-controller/pkg/node/default_node_network_controller_test.go
+++ b/go-controller/pkg/node/default_node_network_controller_test.go
@@ -1596,7 +1596,7 @@ add element inet ovn-kubernetes remote-node-ips-v6 { 2002:db8:1::4 }
 			})
 
 			Context("when gateway interface is set to derive-from-mgmt-port", func() {
-				It("should resolve gateway interface from PCI address successfully", func() {
+				ovntest.OnSupportedPlatformsIt("should resolve gateway interface from PCI address successfully", func() {
 					// Mock getManagementPortNetDev to return the management port device
 					netlinkOpsMock.On("LinkByName", mgmtPortNetdev).Return(netlinkLinkMock, nil)
 					netlinkLinkMock.On("Attrs").Return(&netlink.LinkAttrs{
@@ -1636,7 +1636,7 @@ add element inet ovn-kubernetes remote-node-ips-v6 { 2002:db8:1::4 }
 					Expect(selectedNetdev).To(Equal(expectedGatewayIntf))
 				})
 
-				It("should return error when no network devices found for PCI address", func() {
+				ovntest.OnSupportedPlatformsIt("should return error when no network devices found for PCI address", func() {
 					// Mock getManagementPortNetDev to return the management port device
 					netlinkOpsMock.On("LinkByName", mgmtPortNetdev).Return(netlinkLinkMock, nil)
 					netlinkLinkMock.On("Attrs").Return(&netlink.LinkAttrs{
@@ -1670,7 +1670,7 @@ add element inet ovn-kubernetes remote-node-ips-v6 { 2002:db8:1::4 }
 					Expect(netdevs).To(BeEmpty())
 				})
 
-				It("should return error when GetPciFromNetDevice fails", func() {
+				ovntest.OnSupportedPlatformsIt("should return error when GetPciFromNetDevice fails", func() {
 					// Mock getManagementPortNetDev to return the management port device
 					netlinkOpsMock.On("LinkByName", mgmtPortNetdev).Return(netlinkLinkMock, nil)
 					netlinkLinkMock.On("Attrs").Return(&netlink.LinkAttrs{
@@ -1689,7 +1689,7 @@ add element inet ovn-kubernetes remote-node-ips-v6 { 2002:db8:1::4 }
 					Expect(err.Error()).To(ContainSubstring("failed to get PCI address"))
 				})
 
-				It("should return error when GetPfPciFromVfPci fails", func() {
+				ovntest.OnSupportedPlatformsIt("should return error when GetPfPciFromVfPci fails", func() {
 					// Mock getManagementPortNetDev to return the management port device
 					netlinkOpsMock.On("LinkByName", mgmtPortNetdev).Return(netlinkLinkMock, nil)
 					netlinkLinkMock.On("Attrs").Return(&netlink.LinkAttrs{
@@ -1714,7 +1714,7 @@ add element inet ovn-kubernetes remote-node-ips-v6 { 2002:db8:1::4 }
 					Expect(err.Error()).To(ContainSubstring("failed to get PF PCI address"))
 				})
 
-				It("should return error when GetNetDevicesFromPci fails", func() {
+				ovntest.OnSupportedPlatformsIt("should return error when GetNetDevicesFromPci fails", func() {
 					// Mock getManagementPortNetDev to return the management port device
 					netlinkOpsMock.On("LinkByName", mgmtPortNetdev).Return(netlinkLinkMock, nil)
 					netlinkLinkMock.On("Attrs").Return(&netlink.LinkAttrs{

--- a/go-controller/pkg/node/gateway_udn_test.go
+++ b/go-controller/pkg/node/gateway_udn_test.go
@@ -1474,7 +1474,7 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 		Expect(fexec.CalledMatchesExpected()).To(BeTrue(), fexec.ErrorDesc)
 	})
 
-	It("should sync node port watcher successfully if a namespaces network is invalid", func() {
+	ovntest.OnSupportedPlatformsIt("should sync node port watcher successfully if a namespaces network is invalid", func() {
 		// create new gateway, add ns with primary UDN, pod, expose pod via Node port service, delete pod, delete udn, ensure sync should succeeds
 		namespace := util.NewNamespace("udn")
 		config.OVNKubernetesFeature.EnableMultiNetwork = true
@@ -1504,6 +1504,9 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 })
 
 func TestConstructUDNVRFIPRules(t *testing.T) {
+	if ovntest.NoRoot() {
+		t.Skip("Test requires root privileges")
+	}
 	type testRule struct {
 		priority int
 		family   int
@@ -1694,6 +1697,9 @@ func TestConstructUDNVRFIPRules(t *testing.T) {
 }
 
 func TestConstructUDNVRFIPRulesPodNetworkAdvertisedToDefaultVRF(t *testing.T) {
+	if ovntest.NoRoot() {
+		t.Skip("Test requires root privileges")
+	}
 	type testRule struct {
 		priority int
 		family   int
@@ -1877,6 +1883,9 @@ func TestConstructUDNVRFIPRulesPodNetworkAdvertisedToDefaultVRF(t *testing.T) {
 }
 
 func TestConstructUDNVRFIPRulesPodNetworkAdvertisedToNonDefaultVRF(t *testing.T) {
+	if ovntest.NoRoot() {
+		t.Skip("Test requires root privileges")
+	}
 	type testRule struct {
 		priority int
 		family   int

--- a/go-controller/pkg/node/user_defined_node_network_controller_test.go
+++ b/go-controller/pkg/node/user_defined_node_network_controller_test.go
@@ -66,7 +66,7 @@ var _ = Describe("UserDefinedNodeNetworkController", func() {
 		ovntest.DelLink("breth0")
 	})
 
-	It("ensure UDNGateway is not invoked when feature gate is OFF", func() {
+	ovntest.OnSupportedPlatformsIt("ensure UDNGateway is not invoked when feature gate is OFF", func() {
 		config.OVNKubernetesFeature.EnableNetworkSegmentation = false
 		config.OVNKubernetesFeature.EnableMultiNetwork = true
 		factoryMock := factoryMocks.NodeWatchFactory{}
@@ -91,7 +91,7 @@ var _ = Describe("UserDefinedNodeNetworkController", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(controller.gateway).To(BeNil())
 	})
-	It("ensure UDNGateway is invoked for Primary UDNs when feature gate is ON", func() {
+	ovntest.OnSupportedPlatformsIt("ensure UDNGateway is invoked for Primary UDNs when feature gate is ON", func() {
 		config.OVNKubernetesFeature.EnableNetworkSegmentation = true
 		config.OVNKubernetesFeature.EnableMultiNetwork = true
 		factoryMock := factoryMocks.NodeWatchFactory{}
@@ -123,7 +123,7 @@ var _ = Describe("UserDefinedNodeNetworkController", func() {
 		Expect(err.Error()).To(ContainSubstring("could not create management port"), err.Error())
 		Expect(controller.gateway).To(Not(BeNil()))
 	})
-	It("ensure UDNGateway is not invoked for Primary UDNs when feature gate is ON but network is not Primary", func() {
+	ovntest.OnSupportedPlatformsIt("ensure UDNGateway is not invoked for Primary UDNs when feature gate is ON but network is not Primary", func() {
 		config.OVNKubernetesFeature.EnableNetworkSegmentation = true
 		config.OVNKubernetesFeature.EnableMultiNetwork = true
 		factoryMock := factoryMocks.NodeWatchFactory{}


### PR DESCRIPTION
12 tests were found to need root and did not have the ability to be skipped when running UTs with NOROOT=TRUE. this adds the logic to skip those.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code does not require changes to the documentation
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] My code does not require tests
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
