### PR TITLE
OCPBUGS-55179: CARRY: dns-default preferLocal for UDN router targets

### DIFF
--- a/go-controller/pkg/ovn/controller/services/lb_config.go
+++ b/go-controller/pkg/ovn/controller/services/lb_config.go
@@ -86,7 +86,7 @@ func makeNodeSwitchTargetIPs(service *corev1.Service, node string, clusterEntry 
 	return
 }
 
-func makeNodeRouterTargetIPs(service *corev1.Service, node *nodeInfo, clusterEntry util.LBEndpointEntry, c *lbConfig, hostMasqueradeIPV4, hostMasqueradeIPV6 string) (targetIPsV4, targetIPsV6 []string, v4Changed, v6Changed bool, zeroRouterLocalEndpointsV4, zeroRouterLocalEndpointsV6 bool) {
+func makeNodeRouterTargetIPs(service *corev1.Service, node *nodeInfo, clusterEntry util.LBEndpointEntry, c *lbConfig, hostMasqueradeIPV4, hostMasqueradeIPV6 string, preferLocal bool) (targetIPsV4, targetIPsV6 []string, v4Changed, v6Changed bool, zeroRouterLocalEndpointsV4, zeroRouterLocalEndpointsV6 bool) {
 	targetIPsV4 = clusterEntry.V4IPs
 	targetIPsV6 = clusterEntry.V6IPs
 
@@ -114,6 +114,29 @@ func makeNodeRouterTargetIPs(service *corev1.Service, node *nodeInfo, clusterEnt
 		}
 		if len(targetIPsV6) == 0 {
 			zeroRouterLocalEndpointsV6 = true
+			targetIPsV6 = clusterEntry.V6IPs
+		}
+	}
+	// OCP HACK END
+
+	// OCP HACK BEGIN
+	// Extend dns-default preferLocal to router targets so that UDN traffic arriving via
+	// management port → GWR (br-ex) path also prefers the local dns-default pod.
+	// Remove together with the switch-side hack above when ITP:preferLocal is implemented.
+	if preferLocal {
+		localV4 := util.FilterIPsSlice(targetIPsV4, node.podSubnets, true)
+		localV6 := util.FilterIPsSlice(targetIPsV6, node.podSubnets, true)
+		if len(localV4) > 0 {
+			targetIPsV4 = localV4
+		} else if len(targetIPsV4) == 0 && !c.externalTrafficLocal {
+			// No local endpoint and no prior ETP=Local filtering: restore from the full
+			// cluster entry so traffic is not dropped (tainted nodes, custom nodePlacement).
+			// When externalTrafficLocal is true the empty list is intentional — do not restore.
+			targetIPsV4 = clusterEntry.V4IPs
+		}
+		if len(localV6) > 0 {
+			targetIPsV6 = localV6
+		} else if len(targetIPsV6) == 0 && !c.externalTrafficLocal {
 			targetIPsV6 = clusterEntry.V6IPs
 		}
 	}
@@ -475,7 +498,8 @@ func buildTemplateLBs(service *corev1.Service, configs []lbConfig, nodes []nodeI
 						entry,
 						&cfg,
 						config.Gateway.MasqueradeIPs.V4HostMasqueradeIP.String(),
-						config.Gateway.MasqueradeIPs.V6HostMasqueradeIP.String())
+						config.Gateway.MasqueradeIPs.V6HostMasqueradeIP.String(),
+						false)
 
 					if v4Changed {
 						routerV4TargetNeedsTemplate = true
@@ -684,6 +708,7 @@ func buildPerNodeLBs(service *corev1.Service, configs []lbConfig, nodes []nodeIn
 				// OCP HACK begin
 				zeroRouterV4LocalEndpoints := true
 				zeroRouterV6LocalEndpoints := true
+				isDNSDefault := service.Namespace == "openshift-dns" && service.Name == "dns-default"
 				// OCP HACK end
 
 				for _, entry := range cfg.clusterEndpoints {
@@ -695,14 +720,15 @@ func buildPerNodeLBs(service *corev1.Service, configs []lbConfig, nodes []nodeIn
 						entry,
 						&cfg,
 						config.Gateway.MasqueradeIPs.V4HostMasqueradeIP.String(),
-						config.Gateway.MasqueradeIPs.V6HostMasqueradeIP.String())
+						config.Gateway.MasqueradeIPs.V6HostMasqueradeIP.String(),
+						isDNSDefault)
 
 					routerV4targets = append(routerV4targets, joinHostsPort(routerV4TargetIPs, entry.Port)...)
 					routerV6targets = append(routerV6targets, joinHostsPort(routerV6TargetIPs, entry.Port)...)
 
 					// OCP HACK begin
 					// TODO: Remove this hack once we add support for ITP:preferLocal and DNS operator starts using it.
-					if service.Namespace == "openshift-dns" && service.Name == "dns-default" {
+					if isDNSDefault {
 						// Select endpoints that are local to this node.
 						switchV4targetDNSips := util.FilterIPsSlice(entry.V4IPs, node.podSubnets, true)
 						switchV6targetDNSips := util.FilterIPsSlice(entry.V6IPs, node.podSubnets, true)

--- a/go-controller/pkg/ovn/controller/services/lb_config_ocphack_test.go
+++ b/go-controller/pkg/ovn/controller/services/lb_config_ocphack_test.go
@@ -98,21 +98,10 @@ func Test_buildPerNodeLBs_OCPHackForDNS(t *testing.T) {
 			},
 			expected: []LB{
 				{
-					Name:        "Service_openshift-dns/dns-default_TCP_node_router_node-a_merged",
+					// Router and switch have same local-only target per node — merged into one LB.
+					Name:        "Service_openshift-dns/dns-default_TCP_node_router+switch_node-a",
 					ExternalIDs: defaultExternalIDs,
-					Routers:     []string{"gr-node-a", "gr-node-b"},
-					Protocol:    "TCP",
-					Rules: []LBRule{
-						{
-							Source:  Addr{"192.168.1.1", 80, nil},
-							Targets: []Addr{{"10.128.0.2", 8080, nil}, {"10.128.1.2", 8080, nil}},
-						},
-					},
-					Opts: defaultOpts,
-				},
-				{
-					Name:        "Service_openshift-dns/dns-default_TCP_node_switch_node-a",
-					ExternalIDs: defaultExternalIDs,
+					Routers:     []string{"gr-node-a"},
 					Switches:    []string{"switch-node-a"},
 					Protocol:    "TCP",
 					Rules: []LBRule{
@@ -124,8 +113,61 @@ func Test_buildPerNodeLBs_OCPHackForDNS(t *testing.T) {
 					Opts: defaultOpts,
 				},
 				{
-					Name:        "Service_openshift-dns/dns-default_TCP_node_switch_node-b",
+					Name:        "Service_openshift-dns/dns-default_TCP_node_router+switch_node-b",
 					ExternalIDs: defaultExternalIDs,
+					Routers:     []string{"gr-node-b"},
+					Switches:    []string{"switch-node-b"},
+					Protocol:    "TCP",
+					Rules: []LBRule{
+						{
+							Source:  Addr{"192.168.1.1", 80, nil},
+							Targets: []Addr{{"10.128.1.2", 8080, nil}},
+						},
+					},
+					Opts: defaultOpts,
+				},
+			},
+		},
+		{
+			// dns-default with no local endpoint on node-a — uses two endpoints so node-a
+			// and node-b produce genuinely different targets, proving fallback returns all
+			// endpoints rather than empty. node-a has no local endpoint (neither is in
+			// 10.128.0.0/24); node-b has 10.128.1.2 locally.
+			name:    "dns-default service, no local endpoint on node-a, router fallback to all",
+			service: defaultService,
+			configs: []lbConfig{
+				{
+					vips:     []string{"192.168.1.1"},
+					protocol: corev1.ProtocolTCP,
+					inport:   80,
+					clusterEndpoints: util.LBEndpoints{{
+						V4IPs: []string{"10.128.1.2", "10.128.2.2"},
+						Port:  8080,
+					}},
+				},
+			},
+			expected: []LB{
+				{
+					// node-a: no local endpoint for either router or switch → both fall back
+					// to all endpoints and are merged into one router+switch LB.
+					Name:        "Service_openshift-dns/dns-default_TCP_node_router+switch_node-a",
+					ExternalIDs: defaultExternalIDs,
+					Routers:     []string{"gr-node-a"},
+					Switches:    []string{"switch-node-a"},
+					Protocol:    "TCP",
+					Rules: []LBRule{
+						{
+							Source:  Addr{"192.168.1.1", 80, nil},
+							Targets: []Addr{{"10.128.1.2", 8080, nil}, {"10.128.2.2", 8080, nil}},
+						},
+					},
+					Opts: defaultOpts,
+				},
+				{
+					// node-b: 10.128.1.2 is local → router+switch both get local target only.
+					Name:        "Service_openshift-dns/dns-default_TCP_node_router+switch_node-b",
+					ExternalIDs: defaultExternalIDs,
+					Routers:     []string{"gr-node-b"},
 					Switches:    []string{"switch-node-b"},
 					Protocol:    "TCP",
 					Rules: []LBRule{
@@ -484,6 +526,142 @@ func Test_buildPerNodeLBs_OCPHackForLocalWithFallback(t *testing.T) {
 			assert.Equal(t, tt.expected, actual, "local gateway mode not as expected")
 		})
 	}
+}
+
+// Test_buildPerNodeLBs_OCPHackForDNS_IPv6 verifies that the preferLocal router-target filtering
+// works for IPv6: local IPv6 endpoint is preferred per node; fallback to all when no local endpoint.
+func Test_buildPerNodeLBs_OCPHackForDNS_IPv6(t *testing.T) {
+	oldClusterSubnet := globalconfig.Default.ClusterSubnets
+	oldGwMode := globalconfig.Gateway.Mode
+	oldIPv4Mode := globalconfig.IPv4Mode
+	oldIPv6Mode := globalconfig.IPv6Mode
+	defer func() {
+		globalconfig.Gateway.Mode = oldGwMode
+		globalconfig.Default.ClusterSubnets = oldClusterSubnet
+		globalconfig.IPv4Mode = oldIPv4Mode
+		globalconfig.IPv6Mode = oldIPv6Mode
+	}()
+	_, cidr6, _ := net.ParseCIDR("fd00::/48")
+	globalconfig.Default.ClusterSubnets = []globalconfig.CIDRNetworkEntry{{CIDR: cidr6, HostSubnetLength: 64}}
+	globalconfig.IPv4Mode = false
+	globalconfig.IPv6Mode = true
+	globalconfig.Gateway.Mode = globalconfig.GatewayModeShared
+
+	nodes := []nodeInfo{
+		{
+			name:              nodeA,
+			hostAddresses:     []net.IP{net.ParseIP("fd00::1")},
+			gatewayRouterName: "gr-node-a",
+			switchName:        "switch-node-a",
+			podSubnets:        []net.IPNet{{IP: net.ParseIP("fd00::"), Mask: net.CIDRMask(64, 128)}},
+		},
+		{
+			name:              nodeB,
+			hostAddresses:     []net.IP{net.ParseIP("fd00:0:0:1::1")},
+			gatewayRouterName: "gr-node-b",
+			switchName:        "switch-node-b",
+			podSubnets:        []net.IPNet{{IP: net.ParseIP("fd00:0:0:1::"), Mask: net.CIDRMask(64, 128)}},
+		},
+		{
+			// node-c has no endpoint in its subnet — exercises the fallback path.
+			name:              "node-c",
+			hostAddresses:     []net.IP{net.ParseIP("fd00:0:0:2::1")},
+			gatewayRouterName: "gr-node-c",
+			switchName:        "switch-node-c",
+			podSubnets:        []net.IPNet{{IP: net.ParseIP("fd00:0:0:2::"), Mask: net.CIDRMask(64, 128)}},
+		},
+	}
+
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "dns-default", Namespace: "openshift-dns"},
+		Spec:       corev1.ServiceSpec{Type: corev1.ServiceTypeClusterIP},
+	}
+	configs := []lbConfig{
+		{
+			vips:     []string{"fd10::10"},
+			protocol: corev1.ProtocolTCP,
+			inport:   53,
+			clusterEndpoints: util.LBEndpoints{{
+				V6IPs: []string{"fd00::2", "fd00:0:0:1::2"},
+				Port:  5353,
+			}},
+		},
+	}
+
+	actual := buildPerNodeLBs(svc, configs, nodes, &util.DefaultNetInfo{})
+
+	// 3 per-node LBs: node-a and node-b get local-only targets; node-c has no local
+	// endpoint so both router and switch fall back to all endpoints.
+	assert.Len(t, actual, 3)
+	// node-a: local fd00::2 only.
+	assert.Equal(t, []string{"gr-node-a"}, actual[0].Routers)
+	assert.Equal(t, []Addr{{"fd00::2", 5353, nil}}, actual[0].Rules[0].Targets)
+	// node-b: local fd00:0:0:1::2 only.
+	assert.Equal(t, []string{"gr-node-b"}, actual[1].Routers)
+	assert.Equal(t, []Addr{{"fd00:0:0:1::2", 5353, nil}}, actual[1].Rules[0].Targets)
+	// node-c: no local endpoint — fallback returns all endpoints.
+	assert.Equal(t, []string{"gr-node-c"}, actual[2].Routers)
+	assert.ElementsMatch(t, []Addr{{"fd00::2", 5353, nil}, {"fd00:0:0:1::2", 5353, nil}}, actual[2].Rules[0].Targets)
+}
+
+// Test_buildPerNodeLBs_OCPHackForDNS_NonDNSService verifies that the router-target preferLocal
+// logic is scoped strictly to the dns-default service and does not affect other services in the
+// same namespace.
+func Test_buildPerNodeLBs_OCPHackForDNS_NonDNSService(t *testing.T) {
+	oldClusterSubnet := globalconfig.Default.ClusterSubnets
+	oldGwMode := globalconfig.Gateway.Mode
+	oldIPv4Mode := globalconfig.IPv4Mode
+	defer func() {
+		globalconfig.Gateway.Mode = oldGwMode
+		globalconfig.Default.ClusterSubnets = oldClusterSubnet
+		globalconfig.IPv4Mode = oldIPv4Mode
+	}()
+	_, cidr4, _ := net.ParseCIDR("10.128.0.0/16")
+	globalconfig.Default.ClusterSubnets = []globalconfig.CIDRNetworkEntry{{CIDR: cidr4, HostSubnetLength: 26}}
+	globalconfig.IPv4Mode = true
+	globalconfig.Gateway.Mode = globalconfig.GatewayModeShared
+
+	nodes := []nodeInfo{
+		{
+			name:              nodeA,
+			hostAddresses:     []net.IP{net.ParseIP("10.0.0.1")},
+			gatewayRouterName: "gr-node-a",
+			switchName:        "switch-node-a",
+			podSubnets:        []net.IPNet{{IP: net.ParseIP("10.128.0.0"), Mask: net.CIDRMask(24, 32)}},
+		},
+		{
+			name:              nodeB,
+			hostAddresses:     []net.IP{net.ParseIP("10.0.0.2")},
+			gatewayRouterName: "gr-node-b",
+			switchName:        "switch-node-b",
+			podSubnets:        []net.IPNet{{IP: net.ParseIP("10.128.1.0"), Mask: net.CIDRMask(24, 32)}},
+		},
+	}
+
+	// A non-dns service in openshift-dns: router preferLocal must not apply.
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "node-resolver", Namespace: "openshift-dns"},
+		Spec:       corev1.ServiceSpec{Type: corev1.ServiceTypeClusterIP},
+	}
+	configs := []lbConfig{
+		{
+			vips:     []string{"192.168.1.2"},
+			protocol: corev1.ProtocolTCP,
+			inport:   80,
+			clusterEndpoints: util.LBEndpoints{{
+				V4IPs: []string{"10.128.0.2", "10.128.1.2"},
+				Port:  8080,
+			}},
+		},
+	}
+
+	actual := buildPerNodeLBs(svc, configs, nodes, &util.DefaultNetInfo{})
+
+	// Expect one merged LB — router and switch both have all endpoints (no preferLocal).
+	assert.Len(t, actual, 1)
+	assert.Equal(t, []string{"gr-node-a", "gr-node-b"}, actual[0].Routers)
+	assert.Equal(t, []string{"switch-node-a", "switch-node-b"}, actual[0].Switches)
+	assert.Equal(t, []Addr{{"10.128.0.2", 8080, nil}, {"10.128.1.2", 8080, nil}}, actual[0].Rules[0].Targets)
 }
 
 // OCP hack end

--- a/go-controller/pkg/ovn/controller/services/lb_config_ocphack_test.go
+++ b/go-controller/pkg/ovn/controller/services/lb_config_ocphack_test.go
@@ -98,21 +98,10 @@ func Test_buildPerNodeLBs_OCPHackForDNS(t *testing.T) {
 			},
 			expected: []LB{
 				{
-					Name:        "Service_openshift-dns/dns-default_TCP_node_router_node-a_merged",
+					// Router and switch have same local-only target per node — merged into one LB.
+					Name:        "Service_openshift-dns/dns-default_TCP_node_router+switch_node-a",
 					ExternalIDs: defaultExternalIDs,
-					Routers:     []string{"gr-node-a", "gr-node-b"},
-					Protocol:    "TCP",
-					Rules: []LBRule{
-						{
-							Source:  Addr{"192.168.1.1", 80, nil},
-							Targets: []Addr{{"10.128.0.2", 8080, nil}, {"10.128.1.2", 8080, nil}},
-						},
-					},
-					Opts: defaultOpts,
-				},
-				{
-					Name:        "Service_openshift-dns/dns-default_TCP_node_switch_node-a",
-					ExternalIDs: defaultExternalIDs,
+					Routers:     []string{"gr-node-a"},
 					Switches:    []string{"switch-node-a"},
 					Protocol:    "TCP",
 					Rules: []LBRule{
@@ -124,8 +113,61 @@ func Test_buildPerNodeLBs_OCPHackForDNS(t *testing.T) {
 					Opts: defaultOpts,
 				},
 				{
-					Name:        "Service_openshift-dns/dns-default_TCP_node_switch_node-b",
+					Name:        "Service_openshift-dns/dns-default_TCP_node_router+switch_node-b",
 					ExternalIDs: defaultExternalIDs,
+					Routers:     []string{"gr-node-b"},
+					Switches:    []string{"switch-node-b"},
+					Protocol:    "TCP",
+					Rules: []LBRule{
+						{
+							Source:  Addr{"192.168.1.1", 80, nil},
+							Targets: []Addr{{"10.128.1.2", 8080, nil}},
+						},
+					},
+					Opts: defaultOpts,
+				},
+			},
+		},
+		{
+			// dns-default with no local endpoint on node-a — uses two endpoints so node-a
+			// and node-b produce genuinely different targets, proving fallback returns all
+			// endpoints rather than empty. node-a has no local endpoint (neither is in
+			// 10.128.0.0/24); node-b has 10.128.1.2 locally.
+			name:    "dns-default service, no local endpoint on node-a, router fallback to all",
+			service: defaultService,
+			configs: []lbConfig{
+				{
+					vips:     []string{"192.168.1.1"},
+					protocol: corev1.ProtocolTCP,
+					inport:   80,
+					clusterEndpoints: util.LBEndpoints{{
+						V4IPs: []string{"10.128.1.2", "10.128.2.2"},
+						Port:  8080,
+					}},
+				},
+			},
+			expected: []LB{
+				{
+					// node-a: no local endpoint for either router or switch → both fall back
+					// to all endpoints and are merged into one router+switch LB.
+					Name:        "Service_openshift-dns/dns-default_TCP_node_router+switch_node-a",
+					ExternalIDs: defaultExternalIDs,
+					Routers:     []string{"gr-node-a"},
+					Switches:    []string{"switch-node-a"},
+					Protocol:    "TCP",
+					Rules: []LBRule{
+						{
+							Source:  Addr{"192.168.1.1", 80, nil},
+							Targets: []Addr{{"10.128.1.2", 8080, nil}, {"10.128.2.2", 8080, nil}},
+						},
+					},
+					Opts: defaultOpts,
+				},
+				{
+					// node-b: 10.128.1.2 is local → router+switch both get local target only.
+					Name:        "Service_openshift-dns/dns-default_TCP_node_router+switch_node-b",
+					ExternalIDs: defaultExternalIDs,
+					Routers:     []string{"gr-node-b"},
 					Switches:    []string{"switch-node-b"},
 					Protocol:    "TCP",
 					Rules: []LBRule{
@@ -484,6 +526,145 @@ func Test_buildPerNodeLBs_OCPHackForLocalWithFallback(t *testing.T) {
 			assert.Equal(t, tt.expected, actual, "local gateway mode not as expected")
 		})
 	}
+}
+
+// Test_buildPerNodeLBs_OCPHackForDNS_IPv6 verifies that the preferLocal router-target filtering
+// works for IPv6: local IPv6 endpoint is preferred per node; fallback to all when no local endpoint.
+func Test_buildPerNodeLBs_OCPHackForDNS_IPv6(t *testing.T) {
+	oldClusterSubnet := globalconfig.Default.ClusterSubnets
+	oldGwMode := globalconfig.Gateway.Mode
+	oldIPv4Mode := globalconfig.IPv4Mode
+	oldIPv6Mode := globalconfig.IPv6Mode
+	defer func() {
+		globalconfig.Gateway.Mode = oldGwMode
+		globalconfig.Default.ClusterSubnets = oldClusterSubnet
+		globalconfig.IPv4Mode = oldIPv4Mode
+		globalconfig.IPv6Mode = oldIPv6Mode
+	}()
+	_, cidr6, _ := net.ParseCIDR("fd00::/48")
+	globalconfig.Default.ClusterSubnets = []globalconfig.CIDRNetworkEntry{{CIDR: cidr6, HostSubnetLength: 64}}
+	globalconfig.IPv4Mode = false
+	globalconfig.IPv6Mode = true
+	globalconfig.Gateway.Mode = globalconfig.GatewayModeShared
+
+	nodes := []nodeInfo{
+		{
+			name:              nodeA,
+			hostAddresses:     []net.IP{net.ParseIP("fd00::1")},
+			gatewayRouterName: "gr-node-a",
+			switchName:        "switch-node-a",
+			podSubnets:        []net.IPNet{{IP: net.ParseIP("fd00::"), Mask: net.CIDRMask(64, 128)}},
+		},
+		{
+			name:              nodeB,
+			hostAddresses:     []net.IP{net.ParseIP("fd00:0:0:1::1")},
+			gatewayRouterName: "gr-node-b",
+			switchName:        "switch-node-b",
+			podSubnets:        []net.IPNet{{IP: net.ParseIP("fd00:0:0:1::"), Mask: net.CIDRMask(64, 128)}},
+		},
+		{
+			// node-c has no endpoint in its subnet — exercises the fallback path.
+			name:              "node-c",
+			hostAddresses:     []net.IP{net.ParseIP("fd00:0:0:2::1")},
+			gatewayRouterName: "gr-node-c",
+			switchName:        "switch-node-c",
+			podSubnets:        []net.IPNet{{IP: net.ParseIP("fd00:0:0:2::"), Mask: net.CIDRMask(64, 128)}},
+		},
+	}
+
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "dns-default", Namespace: "openshift-dns"},
+		Spec:       corev1.ServiceSpec{Type: corev1.ServiceTypeClusterIP},
+	}
+	configs := []lbConfig{
+		{
+			vips:     []string{"fd10::10"},
+			protocol: corev1.ProtocolTCP,
+			inport:   53,
+			clusterEndpoints: util.LBEndpoints{{
+				V6IPs: []string{"fd00::2", "fd00:0:0:1::2"},
+				Port:  5353,
+			}},
+		},
+	}
+
+	actual := buildPerNodeLBs(svc, configs, nodes, &util.DefaultNetInfo{})
+
+	// 3 per-node LBs: node-a and node-b get local-only targets; node-c has no local
+	// endpoint so both router and switch fall back to all endpoints.
+	assert.Len(t, actual, 3)
+	// node-a: local fd00::2 only — router+switch merged.
+	assert.Equal(t, []string{"gr-node-a"}, actual[0].Routers)
+	assert.Equal(t, []string{"switch-node-a"}, actual[0].Switches)
+	assert.Equal(t, []Addr{{"fd00::2", 5353, nil}}, actual[0].Rules[0].Targets)
+	// node-b: local fd00:0:0:1::2 only — router+switch merged.
+	assert.Equal(t, []string{"gr-node-b"}, actual[1].Routers)
+	assert.Equal(t, []string{"switch-node-b"}, actual[1].Switches)
+	assert.Equal(t, []Addr{{"fd00:0:0:1::2", 5353, nil}}, actual[1].Rules[0].Targets)
+	// node-c: no local endpoint — fallback returns all endpoints, router+switch merged.
+	assert.Equal(t, []string{"gr-node-c"}, actual[2].Routers)
+	assert.Equal(t, []string{"switch-node-c"}, actual[2].Switches)
+	assert.ElementsMatch(t, []Addr{{"fd00::2", 5353, nil}, {"fd00:0:0:1::2", 5353, nil}}, actual[2].Rules[0].Targets)
+}
+
+// Test_buildPerNodeLBs_OCPHackForDNS_NonDNSService verifies that the router-target preferLocal
+// logic is scoped strictly to the dns-default service and does not affect other services in the
+// same namespace.
+func Test_buildPerNodeLBs_OCPHackForDNS_NonDNSService(t *testing.T) {
+	oldClusterSubnet := globalconfig.Default.ClusterSubnets
+	oldGwMode := globalconfig.Gateway.Mode
+	oldIPv4Mode := globalconfig.IPv4Mode
+	defer func() {
+		globalconfig.Gateway.Mode = oldGwMode
+		globalconfig.Default.ClusterSubnets = oldClusterSubnet
+		globalconfig.IPv4Mode = oldIPv4Mode
+	}()
+	_, cidr4, _ := net.ParseCIDR("10.128.0.0/16")
+	globalconfig.Default.ClusterSubnets = []globalconfig.CIDRNetworkEntry{{CIDR: cidr4, HostSubnetLength: 26}}
+	globalconfig.IPv4Mode = true
+	globalconfig.Gateway.Mode = globalconfig.GatewayModeShared
+
+	nodes := []nodeInfo{
+		{
+			name:              nodeA,
+			hostAddresses:     []net.IP{net.ParseIP("10.0.0.1")},
+			gatewayRouterName: "gr-node-a",
+			switchName:        "switch-node-a",
+			podSubnets:        []net.IPNet{{IP: net.ParseIP("10.128.0.0"), Mask: net.CIDRMask(24, 32)}},
+		},
+		{
+			name:              nodeB,
+			hostAddresses:     []net.IP{net.ParseIP("10.0.0.2")},
+			gatewayRouterName: "gr-node-b",
+			switchName:        "switch-node-b",
+			podSubnets:        []net.IPNet{{IP: net.ParseIP("10.128.1.0"), Mask: net.CIDRMask(24, 32)}},
+		},
+	}
+
+	// A non-dns service in openshift-dns: router preferLocal must not apply.
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "node-resolver", Namespace: "openshift-dns"},
+		Spec:       corev1.ServiceSpec{Type: corev1.ServiceTypeClusterIP},
+	}
+	configs := []lbConfig{
+		{
+			vips:     []string{"192.168.1.2"},
+			protocol: corev1.ProtocolTCP,
+			inport:   80,
+			clusterEndpoints: util.LBEndpoints{{
+				V4IPs: []string{"10.128.0.2", "10.128.1.2"},
+				Port:  8080,
+			}},
+		},
+	}
+
+	actual := buildPerNodeLBs(svc, configs, nodes, &util.DefaultNetInfo{})
+
+	// Expect one merged LB — router and switch both have all endpoints (no preferLocal).
+	assert.Len(t, actual, 1)
+	assert.Equal(t, []string{"gr-node-a", "gr-node-b"}, actual[0].Routers)
+	assert.Equal(t, []string{"switch-node-a", "switch-node-b"}, actual[0].Switches)
+	assert.Equal(t, []Addr{{"10.128.0.2", 8080, nil}, {"10.128.1.2", 8080, nil}}, actual[0].Rules[0].Targets)
 }
 
 // OCP hack end

--- a/test/e2e/network_segmentation_services.go
+++ b/test/e2e/network_segmentation_services.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net"
 	"slices"
+	"strings"
 	"time"
 
 	nadclient "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/clientset/versioned/typed/k8s.cni.cncf.io/v1"
@@ -538,6 +539,151 @@ func checkConnectionToLoadBalancersFromExternalContainer(f *framework.Framework,
 			Should(Equal(expectedOutput), "Failed to verify that %s", msg)
 	}
 }
+
+// OCP CARRY: validateDNSDefaultRouterLBLocality verifies that each node's gateway router LB
+// for the dns-default service targets only the local dns-default pod, not all pods cluster-wide.
+// This validates the OCP CARRY fix that extends preferLocal to router LB targets for UDN traffic.
+//
+// The fix is in go-controller/pkg/ovn/controller/services/lb_config.go and is removed when
+// upstream internalTrafficPolicy: preferLocal is implemented.
+var _ = Describe("Network Segmentation: UDN DNS locality", feature.NetworkSegmentation, func() {
+	const (
+		udnDNSNADName = "udn-dns-locality"
+	)
+
+	f := wrappedTestFramework("udn-dns-locality")
+	f.SkipNamespaceCreation = true
+
+	BeforeEach(func() {
+		// This test requires the OCP dns-default service in the openshift-dns namespace.
+		// Skip on upstream kind clusters where openshift-dns does not exist.
+		_, err := f.ClientSet.CoreV1().Namespaces().Get(context.TODO(), "openshift-dns", metav1.GetOptions{})
+		if err != nil {
+			Skip("openshift-dns namespace not found; skipping OCP-specific UDN DNS locality test")
+		}
+	})
+
+	It("should route dns-default traffic from a primary UDN pod to the local dns-default pod only", func() {
+		cs := f.ClientSet
+		ovnNamespace := deploymentconfig.Get().OVNKubernetesNamespace()
+
+		By("selecting a schedulable node that has a running dns-default pod")
+		dnsPodList, err := cs.CoreV1().Pods("openshift-dns").List(context.TODO(), metav1.ListOptions{
+			LabelSelector: "dns.operator.openshift.io/daemonset-dns=default",
+		})
+		Expect(err).NotTo(HaveOccurred())
+		schedulableNodes, err := e2enode.GetReadySchedulableNodes(context.TODO(), cs)
+		Expect(err).NotTo(HaveOccurred())
+		schedulableSet := make(map[string]bool)
+		for _, n := range schedulableNodes.Items {
+			schedulableSet[n.Name] = true
+		}
+		var targetNode string
+		for _, pod := range dnsPodList.Items {
+			if pod.Status.Phase == kapi.PodRunning && schedulableSet[pod.Spec.NodeName] {
+				targetNode = pod.Spec.NodeName
+				break
+			}
+		}
+		if targetNode == "" {
+			Skip("no schedulable node with a running dns-default pod found; skipping test")
+		}
+
+		By("creating a primary UDN namespace")
+		nadClient, err := nadclient.NewForConfig(f.ClientConfig())
+		Expect(err).NotTo(HaveOccurred())
+		namespace, err := f.CreateNamespace(context.TODO(), f.BaseName, map[string]string{
+			"e2e-framework":           f.BaseName,
+			RequiredUDNNamespaceLabel: "",
+		})
+		f.Namespace = namespace
+		Expect(err).NotTo(HaveOccurred())
+
+		By("creating a primary Layer3 UDN")
+		netConfig := newNetworkAttachmentConfig(networkAttachmentConfigParams{
+			topology:  "layer3",
+			role:      "primary",
+			name:      udnDNSNADName,
+			namespace: namespace.Name,
+			cidr:      "172.16.0.0/16",
+		})
+		_, err = nadClient.NetworkAttachmentDefinitions(namespace.Name).Create(
+			context.Background(),
+			generateNAD(netConfig, cs),
+			metav1.CreateOptions{},
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("creating a UDN pod on " + targetNode)
+		udnPod, err := createPod(f, "udn-dns-client", targetNode, namespace.Name,
+			[]string{"sleep", "3600"}, map[string]string{"app": "udn-dns-client"})
+		Expect(err).NotTo(HaveOccurred())
+		err = e2epod.WaitForPodRunningInNamespace(context.TODO(), cs, udnPod)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("verifying DNS works from the UDN pod")
+		nslookupOut, _, err := ExecShellInPodWithFullOutput(f, namespace.Name, udnPod.Name,
+			"nslookup kubernetes.default.svc.cluster.local")
+		Expect(err).NotTo(HaveOccurred(), "nslookup should succeed from UDN pod")
+		Expect(nslookupOut).To(ContainSubstring("Address"), "expected valid DNS response")
+
+		By("finding the dns-default pod on " + targetNode)
+		dnsPods, err := cs.CoreV1().Pods("openshift-dns").List(context.TODO(), metav1.ListOptions{
+			LabelSelector: "dns.operator.openshift.io/daemonset-dns=default",
+		})
+		Expect(err).NotTo(HaveOccurred())
+		var localDNSPodIP string
+		for _, pod := range dnsPods.Items {
+			if pod.Spec.NodeName == targetNode && pod.Status.Phase == kapi.PodRunning {
+				localDNSPodIP = pod.Status.PodIP
+				break
+			}
+		}
+		Expect(localDNSPodIP).NotTo(BeEmpty(), "expected a running dns-default pod on node "+targetNode)
+
+		By("collecting dns-default pod IPs on other nodes")
+		var remoteDNSPodIPs []string
+		for _, pod := range dnsPods.Items {
+			if pod.Spec.NodeName != targetNode && pod.Status.Phase == kapi.PodRunning && pod.Status.PodIP != "" {
+				remoteDNSPodIPs = append(remoteDNSPodIPs, pod.Status.PodIP)
+			}
+		}
+
+		By("verifying the GR router LB for dns-default on " + targetNode + " targets only the local pod")
+		// The OVN NB router LB for dns-default on each node should have exactly 1 backend
+		// (the local dns-default pod IP) — not all dns-default pods cluster-wide.
+		// LB name format: Service_openshift-dns/dns-default_*_router+switch_<node>
+		ovnNBPod, err := findOVNNBDBPod(cs, ovnNamespace)
+		Expect(err).NotTo(HaveOccurred())
+		lbOutput, _, err := ExecCommandInContainerWithFullOutput(f, ovnNamespace, ovnNBPod.Name, "nb-ovsdb",
+			"ovn-nbctl", "--data=bare", "--no-heading", "--columns=name,vips",
+			"find", "Load_Balancer",
+			fmt.Sprintf(`external_ids:"k8s.ovn.org/owner"="openshift-dns/dns-default"`),
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		foundMatch := false
+		for _, line := range strings.Split(lbOutput, "\n") {
+			if line == "" {
+				continue
+			}
+			// Only check the per-node router LBs (names containing targetNode and "router")
+			if !strings.Contains(line, targetNode) || !strings.Contains(line, "router") {
+				continue
+			}
+			foundMatch = true
+			// Verify local dns-default pod IP is present
+			Expect(line).To(ContainSubstring(localDNSPodIP),
+				"router LB on node %s should target local dns-default pod %s", targetNode, localDNSPodIP)
+			// Verify remote dns-default pod IPs are NOT present
+			for _, remoteIP := range remoteDNSPodIPs {
+				Expect(line).NotTo(ContainSubstring(remoteIP),
+					"router LB on node %s should not target remote dns-default pod %s", targetNode, remoteIP)
+			}
+		}
+		Expect(foundMatch).To(BeTrue(), "expected at least one router LB line for node %s in dns-default LB output", targetNode)
+	})
+})
 
 func filterLoadBalancerIngressByIPFamily(f *framework.Framework, service *v1.Service) []v1.LoadBalancerIngress {
 	GinkgoHelper()


### PR DESCRIPTION
## Summary

DNS queries from primary UDN pods scatter across all nodes' dns-default pods
instead of hitting the local one. Root cause: UDN traffic crosses into the
default network via the management port → GR (br-ex) path. The existing OCP
HACK applies `preferLocal` to switch LB targets only; router LB targets remain
cluster-wide, causing scatter.

This extends `makeNodeRouterTargetIPs` with a `preferLocal` flag. For
`openshift-dns/dns-default` only, router targets are filtered to node-local
endpoints before hairpin masquerade substitution. Falls back to all endpoints
if no local dns-default pod exists on a node (handles tainted nodes, custom
nodePlacement, upgrade windows).

## Tests

- Existing `Test_buildPerNodeLBs_OCPHackForDNS` updated — router and switch
  now produce identical per-node targets and are merged into one LB per node
- New subcase: fallback when no local endpoint exists on a node
- New `Test_buildPerNodeLBs_OCPHackForDNS_NonDNSService` — regression guard:
  non-dns services in `openshift-dns` are NOT affected by the router filtering

## Notes

OCP CARRY. The DNS operator PR #474 (`internalTrafficPolicy: Local`) was
rejected — no fallback. This fix has fallback built in at the ovn-k layer.

Remove together with the switch-side hack when upstream `ITP: preferLocal`
is implemented.