### PR TITLE
OCPBUGS-99542: kubevirt: skip source LSP re-enable when source pod is not local

### DIFF
--- a/go-controller/pkg/ovn/base_network_controller_user_defined.go
+++ b/go-controller/pkg/ovn/base_network_controller_user_defined.go
@@ -357,10 +357,10 @@ func (bsnc *BaseUserDefinedNetworkController) addLogicalPortToNetworkForNAD(pod 
 		bsnc.logicalPortCache.remove(pod, nadName)
 	}
 
-	if shouldHandleLiveMigration &&
-		kubevirtLiveMigrationStatus.IsTargetDomainReady() &&
-		// At localnet there is no source pod remote LSP so it should be skipped
-		(bsnc.TopologyType() != types.LocalnetTopology || bsnc.isPodScheduledinLocalZone(kubevirtLiveMigrationStatus.SourcePod)) {
+	if shouldHandleLiveMigration && kubevirtLiveMigrationStatus.IsTargetDomainReady() {
+		// We have a source pod LSP at this zone if the source pod and:
+		// - layer2 IC There is one at all the zones since we have the remote LSP to implement east/west
+		// - localnet only if this is the zone where the source pod is running
 		ops, err = bsnc.disableLiveMigrationSourceLSPOps(kubevirtLiveMigrationStatus, nadName, ops)
 		if err != nil {
 			return fmt.Errorf("failed to create LSP ops for source pod during Live-migration status: %w", err)
@@ -430,11 +430,6 @@ func (bsnc *BaseUserDefinedNetworkController) removePodForUserDefinedNetwork(pod
 
 	podDesc := pod.Namespace + "/" + pod.Name
 
-	// there is only a logical port for local pods or remote pods of layer2
-	// networks on interconnect, so only delete in these cases
-	isLocalPod := bsnc.isPodScheduledinLocalZone(pod)
-	hasLogicalPort := isLocalPod || bsnc.isLayer2Interconnect()
-
 	// for a specific NAD belongs to this network, Pod's logical port might already be created half-way
 	// without its lpInfo cache being created; need to deleted resources created for that NAD as well.
 	// So, first get all nadNames from pod annotation, but handle NADs belong to this network only.
@@ -457,7 +452,7 @@ func (bsnc *BaseUserDefinedNetworkController) removePodForUserDefinedNetwork(pod
 		klog.Infof("Deleting pod: %s for network %s, NAD: %s", podDesc, bsnc.GetNetworkName(), nadName)
 
 		// handle remote pod clean up but only do this one time
-		if !hasLogicalPort && !alreadyProcessed {
+		if !bsnc.hasPodLogicalPort(pod) && !alreadyProcessed {
 			if bsnc.doesNetworkRequireIPAM() &&
 				// address set is for network policy only. So either multi network policy is enabled or network
 				// segmentation, and it is a primary UDN (regular netpol)
@@ -968,7 +963,12 @@ func (bsnc *BaseUserDefinedNetworkController) disableLiveMigrationSourceLSPOps(
 	kubevirtLiveMigrationStatus *kubevirt.LiveMigrationStatus,
 	nadName string, ops []ovsdb.Operation,
 ) ([]ovsdb.Operation, error) {
-	// closing the sourcePod lsp to ensure traffic goes to the now ready targetPod.
+
+	// Only disable the source LSP if it exists at this zone
+	if !bsnc.hasPodLogicalPort(kubevirtLiveMigrationStatus.SourcePod) {
+		return ops, nil
+	}
+
 	ops, _, err := bsnc.setPodLogicalSwitchPortAddressesAndEnabledField(kubevirtLiveMigrationStatus.SourcePod, nadName, "", nil, false, ops)
 	return ops, err
 }
@@ -983,6 +983,12 @@ func (bsnc *BaseUserDefinedNetworkController) enableSourceLSPFailedLiveMigration
 		kubevirtLiveMigrationStatus.State != kubevirt.LiveMigrationFailed {
 		return nil
 	}
+
+	// Only re-enable the source LSP if it exists at this zone
+	if !bsnc.hasPodLogicalPort(kubevirtLiveMigrationStatus.SourcePod) {
+		return nil
+	}
+
 	// make sure sourcePod lsp is enabled if migration failed after DomainReady was set.
 	ops, sourcePodLsp, err := bsnc.setPodLogicalSwitchPortAddressesAndEnabledField(kubevirtLiveMigrationStatus.SourcePod, nadName, mac, ips, true, nil)
 	if err != nil {
@@ -994,6 +1000,12 @@ func (bsnc *BaseUserDefinedNetworkController) enableSourceLSPFailedLiveMigration
 	}
 
 	return nil
+}
+
+// hasPodLogicalPort On localnet topologies with interconnect the pod's LSP lives only on the
+// node where the pod was scheduled
+func (bsnc *BaseUserDefinedNetworkController) hasPodLogicalPort(pod *corev1.Pod) bool {
+	return pod != nil && (bsnc.isPodScheduledinLocalZone(pod) || bsnc.isLayer2Interconnect())
 }
 
 func shouldAddPort(oldPod, newPod *corev1.Pod, inRetryCache bool) bool {

--- a/go-controller/pkg/ovn/base_network_controller_user_defined_test.go
+++ b/go-controller/pkg/ovn/base_network_controller_user_defined_test.go
@@ -2,11 +2,15 @@ package ovn
 
 import (
 	"context"
+	"sync"
+	"time"
 
 	kubevirtv1 "kubevirt.io/api/core/v1"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
@@ -207,6 +211,161 @@ var _ = Describe("BaseUserDefinedNetworkController", func() {
 			},
 		}),
 	)
+	Context("enableSourceLSPFailedLiveMigration", func() {
+		const (
+			vmName        = "test-vm"
+			nadKey        = "awips/mgmt"
+			localNodeName = "node-local"
+		)
+
+		newVirtLauncherPod := func(name, nodeName string, phase corev1.PodPhase, annotations map[string]string) *corev1.Pod {
+			if annotations == nil {
+				annotations = map[string]string{}
+			}
+			annotations[kubevirtv1.DomainAnnotation] = vmName
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: "awips",
+					Labels: map[string]string{
+						kubevirtv1.AppLabel:                "virt-launcher",
+						kubevirtv1.VirtualMachineNameLabel: vmName,
+					},
+					CreationTimestamp: metav1.Time{Time: time.Now()},
+					Annotations:       annotations,
+					OwnerReferences: []metav1.OwnerReference{{
+						APIVersion: "kubevirt.io/v1",
+						Kind:       "VirtualMachineInstance",
+						Name:       vmName,
+					}},
+				},
+				Spec: corev1.PodSpec{
+					NodeName: nodeName,
+				},
+				Status: corev1.PodStatus{
+					Phase: phase,
+				},
+			}
+			return pod
+		}
+
+		setupControllerWithDBSetup := func(dbSetup *libovsdbtest.TestSetup, pods ...*corev1.Pod) (*BaseUserDefinedNetworkController, *FakeOVN) {
+			localnetNAD := ovntest.GenerateNAD("mgmt", "mgmt", "awips",
+				types.LocalnetTopology, "", types.NetworkRoleSecondary)
+
+			fakeOVN := NewFakeOVN(false)
+			objs := []runtime.Object{}
+			for _, p := range pods {
+				objs = append(objs, p)
+			}
+			if dbSetup != nil {
+				fakeOVN.startWithDBSetup(*dbSetup, objs...)
+			} else {
+				fakeOVN.start(objs...)
+			}
+			DeferCleanup(fakeOVN.shutdown)
+
+			Expect(fakeOVN.NewUserDefinedNetworkController(localnetNAD)).To(Succeed())
+			controller, ok := fakeOVN.userDefinedNetworkControllers["mgmt"]
+			Expect(ok).To(BeTrue())
+
+			// Set local zone to only include localNodeName
+			controller.bnc.localZoneNodes = &sync.Map{}
+			controller.bnc.localZoneNodes.Store(localNodeName, true)
+
+			return controller.bnc, fakeOVN
+		}
+
+		setupController := func(pods ...*corev1.Pod) *BaseUserDefinedNetworkController {
+			bnc, _ := setupControllerWithDBSetup(nil, pods...)
+			return bnc
+		}
+
+		It("should skip source LSP re-enable when source pod is on a remote node", func() {
+			config.OVNKubernetesFeature.EnableInterconnect = true
+			config.OVNKubernetesFeature.EnableNetworkSegmentation = true
+			config.OVNKubernetesFeature.EnableMultiNetwork = true
+
+			sourcePod := newVirtLauncherPod("virt-launcher-"+vmName+"-source", "node-remote", corev1.PodRunning, nil)
+			// Target pod is local, failed (completed) — triggers LiveMigrationFailed detection
+			targetPod := newVirtLauncherPod("virt-launcher-"+vmName+"-target", localNodeName, corev1.PodFailed, nil)
+			// Make target created after source so DiscoverLiveMigrationStatus picks it as target
+			targetPod.CreationTimestamp = metav1.Time{Time: sourcePod.CreationTimestamp.Add(time.Second)}
+
+			bnc := setupController(sourcePod, targetPod)
+
+			// Call with empty IPs (IPAM-less localnet) — this would fail without the locality guard
+			err := bnc.enableSourceLSPFailedLiveMigration(targetPod, nadKey, "", nil)
+			Expect(err).NotTo(HaveOccurred(), "should not error when source pod is on a remote node")
+		})
+
+		It("should skip source LSP re-enable when source pod LSP is not local", func() {
+			config.OVNKubernetesFeature.EnableInterconnect = true
+			config.OVNKubernetesFeature.EnableNetworkSegmentation = true
+			config.OVNKubernetesFeature.EnableMultiNetwork = true
+
+			sourcePod := newVirtLauncherPod("virt-launcher-"+vmName+"-source", "node-remote", corev1.PodRunning, nil)
+			targetPod := newVirtLauncherPod("virt-launcher-"+vmName+"-target", localNodeName, corev1.PodSucceeded, nil)
+			targetPod.CreationTimestamp = metav1.Time{Time: sourcePod.CreationTimestamp.Add(time.Second)}
+
+			bnc := setupController(sourcePod, targetPod)
+
+			err := bnc.enableSourceLSPFailedLiveMigration(targetPod, nadKey, "", nil)
+			Expect(err).NotTo(HaveOccurred(), "should not error when source pod LSP is not local")
+		})
+
+		It("should re-enable source LSP when source pod is local and migration failed", func() {
+			config.OVNKubernetesFeature.EnableInterconnect = true
+			config.OVNKubernetesFeature.EnableNetworkSegmentation = true
+			config.OVNKubernetesFeature.EnableMultiNetwork = true
+
+			sourcePodName := "virt-launcher-" + vmName + "-source"
+			sourcePod := newVirtLauncherPod(sourcePodName, localNodeName, corev1.PodRunning, nil)
+			targetPod := newVirtLauncherPod("virt-launcher-"+vmName+"-target", localNodeName, corev1.PodFailed, nil)
+			targetPod.CreationTimestamp = metav1.Time{Time: sourcePod.CreationTimestamp.Add(time.Second)}
+
+			// Build LSP and switch names matching what the controller will compute:
+			//   LSP name: GetUserDefinedNetworkLogicalPortName(namespace, podName, nadKey)
+			//   Switch name: GetNetworkScopedSwitchName(OVNLocalnetSwitch)
+			sourceLSPName := util.GetUserDefinedNetworkLogicalPortName(sourcePod.Namespace, sourcePodName, nadKey)
+			sourceLSP := &nbdb.LogicalSwitchPort{
+				UUID:    sourceLSPName + "-UUID",
+				Name:    sourceLSPName,
+				Enabled: ptr.To(false),
+			}
+			switchName := util.GetUserDefinedNetworkPrefix("mgmt") + types.OVNLocalnetSwitch
+			logicalSwitch := &nbdb.LogicalSwitch{
+				UUID:  switchName + "-UUID",
+				Name:  switchName,
+				Ports: []string{sourceLSP.UUID},
+			}
+
+			dbSetup := &libovsdbtest.TestSetup{
+				NBData: []libovsdbtest.TestData{
+					logicalSwitch,
+					sourceLSP,
+				},
+			}
+
+			bnc, fakeOVN := setupControllerWithDBSetup(dbSetup, sourcePod, targetPod)
+
+			mac := "0a:58:0a:80:00:05"
+			ips := []string{"10.128.0.5/24"}
+			err := bnc.enableSourceLSPFailedLiveMigration(targetPod, nadKey, mac, ips)
+			Expect(err).NotTo(HaveOccurred(), "should re-enable source LSP without error")
+
+			// Verify the LSP was updated: Enabled=true and addresses set
+			expectedLSP := &nbdb.LogicalSwitchPort{
+				UUID:      sourceLSP.UUID,
+				Name:      sourceLSPName,
+				Enabled:   ptr.To(true),
+				Addresses: []string{mac + " 10.128.0.5"},
+			}
+			expectedSwitch := logicalSwitch.DeepCopy()
+			Expect(fakeOVN.nbClient).To(libovsdbtest.HaveData(expectedSwitch, expectedLSP))
+		})
+	})
+
 	It("should not fail to sync pods if namespace is gone", func() {
 		config.OVNKubernetesFeature.EnableNetworkSegmentation = true
 		config.OVNKubernetesFeature.EnableMultiNetwork = true


### PR DESCRIPTION
## 📑 Description

Manual backport of upstream ovn-kubernetes PR [#6229](https://github.com/ovn-kubernetes/ovn-kubernetes/pull/6229) to `release-4.20`.

Jira: [OCPBUGS-99542](https://issues.redhat.com/browse/OCPBUGS-99542)
4.21 backport: [OCPBUGS-99276](https://issues.redhat.com/browse/OCPBUGS-99276) (landed via branch sync openshift/ovn-kubernetes#3306)

During pod deletion on localnet topologies with interconnect, `enableSourceLSPFailedLiveMigration` attempts to re-enable the source pod's LSP when a migration is detected as failed. On localnet with IC the source pod's LSP only exists on the node where the source pod was scheduled, so when the target pod is deleted on a different node the function fails with "missing mac and ips", blocking target pod cleanup and leaving a zombie LSP re-created by the retry framework.

The fix adds the same locality guard used in `addLogicalPortToNetworkForNAD` to the delete path via a new `hasPodLogicalPort` helper: only touch the source LSP when it exists in the local zone (or the network is layer2 with IC).

## Additional Information for reviewers

Cherry-pick of 7c3330262d16 with conflict resolution for release-4.20:
- 4.20 uses `nadName` instead of `nadKey` and `isLayer2Interconnect()` instead of `isLayer2WithInterconnectTransport()`.
- Kept the 4.20-specific remote-pod cleanup block (`removeRemoteZonePodFromNamespaceAddressSet`) in `removePodForUserDefinedNetwork`, only switching its condition to the new `hasPodLogicalPort` helper.
- The added unit tests set the `kubevirt.io/domain` annotation and `virt-launcher` app label on the fake pods (as upstream later did in PR #6118) so this backport stays compatible with the [OCPBUGS-99543 ](https://github.com/openshift/ovn-kubernetes/pull/3319) backport regardless of merge order.

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [x] My code requires tests
- [x] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI

## How to verify it

Unit tests: `go test ./pkg/ovn/ -run TestClusterNode -args -ginkgo.focus="enableSourceLSPFailedLiveMigration"` (3 specs).

Manual: on a localnet secondary network with IC, live-migrate a VM, force the migration to fail, then delete the target virt-launcher pod from a node other than the source pod's node; verify no zombie LSP remains and connectivity is preserved.
