### PR TITLE
[release-4.20] OCPBUGS-99643: Migrate ovs external_ids bash ovs-vsctl calls to libovsdb

### DIFF
--- a/go-controller/cmd/ovnkube/ovnkube.go
+++ b/go-controller/cmd/ovnkube/ovnkube.go
@@ -442,7 +442,7 @@ func runOvnKube(ctx context.Context, runMode *ovnkubeRunMode, ovnClientset *util
 	startTime := time.Now()
 
 	if runMode.cleanupNode {
-		return ovnnode.CleanupClusterNode(ctx.Done(), runMode.identity)
+		return ovnnode.CleanupClusterNode(runMode.identity)
 	}
 
 	watchFactory, err := newWatchFactory(runMode, ovnClientset)

--- a/go-controller/cmd/ovnkube/ovnkube.go
+++ b/go-controller/cmd/ovnkube/ovnkube.go
@@ -442,7 +442,7 @@ func runOvnKube(ctx context.Context, runMode *ovnkubeRunMode, ovnClientset *util
 	startTime := time.Now()
 
 	if runMode.cleanupNode {
-		return ovnnode.CleanupClusterNode(runMode.identity)
+		return ovnnode.CleanupClusterNode(ctx.Done(), runMode.identity)
 	}
 
 	watchFactory, err := newWatchFactory(runMode, ovnClientset)

--- a/go-controller/pkg/libovsdb/ops/model.go
+++ b/go-controller/pkg/libovsdb/ops/model.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/sbdb"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/vswitchd"
 )
 
 func getUUID(model model.Model) string {
@@ -76,6 +77,14 @@ func getUUID(model model.Model) string {
 	case *nbdb.ChassisTemplateVar:
 		return t.UUID
 	case *nbdb.DHCPOptions:
+		return t.UUID
+	case *vswitchd.Interface:
+		return t.UUID
+	case *vswitchd.Port:
+		return t.UUID
+	case *vswitchd.Bridge:
+		return t.UUID
+	case *vswitchd.OpenvSwitch:
 		return t.UUID
 	default:
 		panic(fmt.Sprintf("getUUID: unknown model %T", t))
@@ -145,6 +154,14 @@ func setUUID(model model.Model, uuid string) {
 	case *nbdb.ChassisTemplateVar:
 		t.UUID = uuid
 	case *nbdb.DHCPOptions:
+		t.UUID = uuid
+	case *vswitchd.Interface:
+		t.UUID = uuid
+	case *vswitchd.Port:
+		t.UUID = uuid
+	case *vswitchd.Bridge:
+		t.UUID = uuid
+	case *vswitchd.OpenvSwitch:
 		t.UUID = uuid
 	default:
 		panic(fmt.Sprintf("setUUID: unknown model %T", t))
@@ -312,6 +329,14 @@ func copyIndexes(model model.Model) model.Model {
 			UUID:        t.UUID,
 			ExternalIDs: copyExternalIDs(t.ExternalIDs, types.PrimaryIDKey),
 		}
+	case *vswitchd.Interface:
+		return &vswitchd.Interface{UUID: t.UUID, Name: t.Name}
+	case *vswitchd.Port:
+		return &vswitchd.Port{UUID: t.UUID, Name: t.Name}
+	case *vswitchd.Bridge:
+		return &vswitchd.Bridge{UUID: t.UUID, Name: t.Name}
+	case *vswitchd.OpenvSwitch:
+		return &vswitchd.OpenvSwitch{UUID: t.UUID}
 	default:
 		panic(fmt.Sprintf("copyIndexes: unknown model %T", t))
 	}
@@ -379,6 +404,14 @@ func getListFromModel(model model.Model) interface{} {
 		return &[]*nbdb.ChassisTemplateVar{}
 	case *nbdb.DHCPOptions:
 		return &[]nbdb.DHCPOptions{}
+	case *vswitchd.Interface:
+		return &[]*vswitchd.Interface{}
+	case *vswitchd.Port:
+		return &[]*vswitchd.Port{}
+	case *vswitchd.Bridge:
+		return &[]*vswitchd.Bridge{}
+	case *vswitchd.OpenvSwitch:
+		return &[]*vswitchd.OpenvSwitch{}
 	default:
 		panic(fmt.Sprintf("getModelList: unknown model %T", t))
 	}

--- a/go-controller/pkg/libovsdb/ops/ovs/openvswitch.go
+++ b/go-controller/pkg/libovsdb/ops/ovs/openvswitch.go
@@ -34,3 +34,9 @@ func GetOpenvSwitch(ovsClient libovsdbclient.Client) (*vswitchd.OpenvSwitch, err
 func UpdateOpenvSwitchExternalIDs(ovsClient libovsdbclient.Client, kv map[string]string) error {
 	return libovsdbops.UpdateOpenvSwitchExternalIDs(ovsClient, kv)
 }
+
+// RemoveOpenvSwitchExternalIDs is the libovsdb equivalent of
+// `ovs-vsctl --if-exists remove Open_vSwitch . external_ids <key> ...`.
+func RemoveOpenvSwitchExternalIDs(ovsClient libovsdbclient.Client, keys ...string) error {
+	return libovsdbops.RemoveOpenvSwitchExternalIDs(ovsClient, keys...)
+}

--- a/go-controller/pkg/libovsdb/ops/ovs/openvswitch.go
+++ b/go-controller/pkg/libovsdb/ops/ovs/openvswitch.go
@@ -6,11 +6,14 @@ import (
 
 	libovsdbclient "github.com/ovn-kubernetes/libovsdb/client"
 
+	libovsdbops "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdb/ops"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/vswitchd"
 )
 
-// Get OpenvSwitch entry from the cache
+// GetOpenvSwitch returns the singleton Open_vSwitch row from the cache.
+// When no row exists, the returned error wraps libovsdbclient.ErrNotFound so
+// callers can detect that case via errors.Is.
 func GetOpenvSwitch(ovsClient libovsdbclient.Client) (*vswitchd.OpenvSwitch, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout)
 	defer cancel()
@@ -20,8 +23,14 @@ func GetOpenvSwitch(ovsClient libovsdbclient.Client) (*vswitchd.OpenvSwitch, err
 		return nil, err
 	}
 	if len(openvSwitchList) == 0 {
-		return nil, fmt.Errorf("no openvSwitch entry found")
+		return nil, fmt.Errorf("no openvSwitch entry found: %w", libovsdbclient.ErrNotFound)
 	}
 
-	return openvSwitchList[0], err
+	return openvSwitchList[0], nil
+}
+
+// UpdateOpenvSwitchExternalIDs is the libovsdb equivalent of
+// `ovs-vsctl set Open_vSwitch . external_ids:key=value ...`.
+func UpdateOpenvSwitchExternalIDs(ovsClient libovsdbclient.Client, kv map[string]string) error {
+	return libovsdbops.UpdateOpenvSwitchExternalIDs(ovsClient, kv)
 }

--- a/go-controller/pkg/libovsdb/ops/vswitchdb.go
+++ b/go-controller/pkg/libovsdb/ops/vswitchdb.go
@@ -36,6 +36,31 @@ func UpdateOpenvSwitchExternalIDs(ovsClient libovsdbclient.Client, kv map[string
 	return err
 }
 
+// RemoveOpenvSwitchExternalIDs removes the given keys from the Open_vSwitch
+// row's external_ids. Keys that are not present, and a missing row, are both
+// no-ops.
+func RemoveOpenvSwitchExternalIDs(ovsClient libovsdbclient.Client, keys ...string) error {
+	if len(keys) == 0 {
+		return nil
+	}
+	// modelClient interprets a map field with empty string values as a
+	// delete-by-key mutation (see buildMutationsFromFields).
+	ids := make(map[string]string, len(keys))
+	for _, k := range keys {
+		ids[k] = ""
+	}
+	ovs := &vswitchd.OpenvSwitch{ExternalIDs: ids}
+	opModel := operationModel{
+		Model:            ovs,
+		ModelPredicate:   func(*vswitchd.OpenvSwitch) bool { return true },
+		OnModelMutations: []interface{}{&ovs.ExternalIDs},
+		ErrNotFound:      false,
+		BulkOp:           false,
+	}
+	m := newModelClient(ovsClient)
+	return m.Delete(opModel)
+}
+
 // FindOVSPortsWithPredicate returns all OVS ports matching the predicate.
 func FindOVSPortsWithPredicate(ovsClient libovsdbclient.Client, p ovsPortPredicate) ([]*vswitchd.Port, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout)

--- a/go-controller/pkg/libovsdb/ops/vswitchdb.go
+++ b/go-controller/pkg/libovsdb/ops/vswitchdb.go
@@ -1,0 +1,179 @@
+package ops
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	libovsdbclient "github.com/ovn-kubernetes/libovsdb/client"
+	"github.com/ovn-kubernetes/libovsdb/ovsdb"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/vswitchd"
+)
+
+// OVS port predicates for filtering
+type ovsPortPredicate func(*vswitchd.Port) bool
+
+// UpdateOpenvSwitchExternalIDs merges the given map into the Open_vSwitch
+// row's external_ids. Every entry in the map is inserted or overwritten;
+// existing keys that are not in the map are left alone. Returns ErrNotFound
+// if the row does not exist.
+func UpdateOpenvSwitchExternalIDs(ovsClient libovsdbclient.Client, kv map[string]string) error {
+	if len(kv) == 0 {
+		return nil
+	}
+	ovs := &vswitchd.OpenvSwitch{ExternalIDs: kv}
+	opModel := operationModel{
+		Model:            ovs,
+		ModelPredicate:   func(*vswitchd.OpenvSwitch) bool { return true },
+		OnModelMutations: []interface{}{&ovs.ExternalIDs},
+		ErrNotFound:      true,
+		BulkOp:           false,
+	}
+	m := newModelClient(ovsClient)
+	_, err := m.CreateOrUpdate(opModel)
+	return err
+}
+
+// FindOVSPortsWithPredicate returns all OVS ports matching the predicate.
+func FindOVSPortsWithPredicate(ovsClient libovsdbclient.Client, p ovsPortPredicate) ([]*vswitchd.Port, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout)
+	defer cancel()
+	var ports []*vswitchd.Port
+	err := ovsClient.WhereCache(p).List(ctx, &ports)
+	return ports, err
+}
+
+// GetOVSPort looks up an OVS port by name.
+func GetOVSPort(ovsClient libovsdbclient.Client, name string) (*vswitchd.Port, error) {
+	found := []*vswitchd.Port{}
+	opModel := operationModel{
+		Model:          &vswitchd.Port{Name: name},
+		ExistingResult: &found,
+		ErrNotFound:    true,
+		BulkOp:         false,
+	}
+
+	m := newModelClient(ovsClient)
+	if err := m.Lookup(opModel); err != nil {
+		return nil, err
+	}
+
+	return found[0], nil
+}
+
+// CreateOrUpdatePortWithInterface creates or updates an OVS port and its interface on a bridge.
+// This creates both the Port and Interface objects atomically in a single transaction,
+// and attaches the port to the specified bridge.
+// The interface type is set to "internal".
+func CreateOrUpdatePortWithInterface(ovsClient libovsdbclient.Client, bridgeName, portName string, portExternalIDs, ifaceExternalIDs map[string]string) error {
+	ops, err := CreateOrUpdatePortWithInterfaceOps(ovsClient, nil, bridgeName, portName, portExternalIDs, ifaceExternalIDs)
+	if err != nil {
+		return err
+	}
+	_, err = TransactAndCheck(ovsClient, ops)
+	return err
+}
+
+// CreateOrUpdatePortWithInterfaceOps returns operations to create or update an OVS port and its interface.
+// OVS uses the following hierarchy: Bridge/Port/Interface. A port is referenced by a bridge,
+// and an interface is referenced by a port.
+func CreateOrUpdatePortWithInterfaceOps(ovsClient libovsdbclient.Client, ops []ovsdb.Operation, bridgeName, portName string, portExternalIDs, ifaceExternalIDs map[string]string) ([]ovsdb.Operation, error) {
+	iface := &vswitchd.Interface{Name: portName, Type: "internal", ExternalIDs: ifaceExternalIDs}
+	port := &vswitchd.Port{Name: portName, ExternalIDs: portExternalIDs}
+	bridge := &vswitchd.Bridge{Name: bridgeName}
+
+	// Interface model - DoAfter captures UUID for port reference
+	ifaceModel := operationModel{
+		Model:          iface,
+		OnModelUpdates: []interface{}{&iface.Type, &iface.ExternalIDs},
+		DoAfter: func() {
+			port.Interfaces = []string{iface.UUID}
+		},
+		ErrNotFound: false,
+		BulkOp:      false,
+	}
+
+	// Port model - DoAfter captures UUID for bridge reference
+	portModel := operationModel{
+		Model:          port,
+		OnModelUpdates: []interface{}{&port.ExternalIDs},
+		DoAfter: func() {
+			bridge.Ports = append(bridge.Ports, port.UUID)
+		},
+		ErrNotFound: false,
+		BulkOp:      false,
+	}
+
+	// Bridge model - mutates Ports to add our port
+	bridgeModel := operationModel{
+		Model:            bridge,
+		OnModelMutations: []interface{}{&bridge.Ports},
+		ErrNotFound:      true,
+		BulkOp:           false,
+	}
+
+	m := newModelClient(ovsClient)
+	return m.CreateOrUpdateOps(ops, ifaceModel, portModel, bridgeModel)
+}
+
+// DeletePortWithInterfaces deletes an OVS port and all its interfaces from a bridge.
+// This removes both the Port and Interface objects, and detaches the port from the bridge.
+// This function is idempotent - it's safe to call even if the port doesn't exist.
+func DeletePortWithInterfaces(ovsClient libovsdbclient.Client, bridgeName, portName string) error {
+	port, err := GetOVSPort(ovsClient, portName)
+	if err != nil {
+		if errors.Is(err, libovsdbclient.ErrNotFound) {
+			return nil // Port doesn't exist, nothing to delete
+		}
+		return err
+	}
+	ops, err := DeletePortWithInterfacesOps(ovsClient, nil, port, bridgeName)
+	if err != nil {
+		return err
+	}
+	if len(ops) == 0 {
+		return nil // Port doesn't exist
+	}
+	_, err = TransactAndCheck(ovsClient, ops)
+	return err
+}
+
+// DeletePortWithInterfacesOps returns operations to delete an OVS port and all its interfaces.
+// This handles both the Port and Interface objects, and detaches the port from the bridge.
+func DeletePortWithInterfacesOps(ovsClient libovsdbclient.Client, ops []ovsdb.Operation, port *vswitchd.Port, bridgeName string) ([]ovsdb.Operation, error) {
+	bridge := &vswitchd.Bridge{Name: bridgeName}
+
+	m := newModelClient(ovsClient)
+	// Delete interfaces
+	for _, ifaceUUID := range port.Interfaces {
+		iface := &vswitchd.Interface{UUID: ifaceUUID}
+		ifaceModel := operationModel{
+			Model:       iface,
+			ErrNotFound: false,
+			BulkOp:      false,
+		}
+		var err error
+		ops, err = m.DeleteOps(ops, ifaceModel)
+		if err != nil {
+			return nil, fmt.Errorf("failed to build delete interface ops: %w", err)
+		}
+	}
+
+	// Delete port and remove from bridge
+	bridge.Ports = []string{port.UUID}
+	portModel := operationModel{
+		Model:       port,
+		ErrNotFound: false,
+		BulkOp:      false,
+	}
+	bridgeModel := operationModel{
+		Model:            bridge,
+		OnModelMutations: []interface{}{&bridge.Ports},
+		ErrNotFound:      false,
+		BulkOp:           false,
+	}
+
+	return m.DeleteOps(ops, portModel, bridgeModel)
+}

--- a/go-controller/pkg/libovsdb/ops/vswitchdb_test.go
+++ b/go-controller/pkg/libovsdb/ops/vswitchdb_test.go
@@ -1,0 +1,383 @@
+package ops
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	libovsdbclient "github.com/ovn-kubernetes/libovsdb/client"
+
+	libovsdbtest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/vswitchd"
+)
+
+func TestGetOVSPort(t *testing.T) {
+	bridgeUUID := buildNamedUUID()
+	portUUID := buildNamedUUID()
+	ifaceUUID := buildNamedUUID()
+
+	ovs := vswitchd.OpenvSwitch{UUID: "root-ovs", Bridges: []string{bridgeUUID}}
+	bridge := vswitchd.Bridge{UUID: bridgeUUID, Name: "br-int", Ports: []string{portUUID}}
+	port := vswitchd.Port{UUID: portUUID, Name: "test-port", Interfaces: []string{ifaceUUID}}
+	iface := vswitchd.Interface{UUID: ifaceUUID, Name: "test-port", Type: "internal"}
+
+	tests := []struct {
+		desc       string
+		portName   string
+		expectErr  bool
+		initialOvs libovsdbtest.TestSetup
+	}{
+		{
+			desc:      "returns existing port",
+			portName:  "test-port",
+			expectErr: false,
+			initialOvs: libovsdbtest.TestSetup{
+				OVSData: []libovsdbtest.TestData{
+					ovs.DeepCopy(), bridge.DeepCopy(), port.DeepCopy(), iface.DeepCopy(),
+				},
+			},
+		},
+		{
+			desc:      "returns error for non-existent port",
+			portName:  "no-such-port",
+			expectErr: true,
+			initialOvs: libovsdbtest.TestSetup{
+				OVSData: []libovsdbtest.TestData{
+					&vswitchd.OpenvSwitch{UUID: "root-ovs", Bridges: []string{bridgeUUID}},
+					&vswitchd.Bridge{UUID: bridgeUUID, Name: "br-int"},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			ovsClient, cleanup, err := libovsdbtest.NewOVSTestHarness(tt.initialOvs)
+			if err != nil {
+				t.Fatalf("test: \"%s\" failed to set up test harness: %v", tt.desc, err)
+			}
+			t.Cleanup(cleanup.Cleanup)
+
+			got, err := GetOVSPort(ovsClient, tt.portName)
+			if err != nil && !tt.expectErr {
+				t.Fatal(fmt.Errorf("GetOVSPort() error = %v", err))
+			}
+			if err == nil && tt.expectErr {
+				t.Fatal("expected error but got nil")
+			}
+			if !tt.expectErr && got.Name != tt.portName {
+				t.Fatalf("expected port name %q, got %q", tt.portName, got.Name)
+			}
+		})
+	}
+}
+
+func TestFindOVSPortsWithPredicate(t *testing.T) {
+	bridgeUUID := buildNamedUUID()
+	port1UUID := buildNamedUUID()
+	port2UUID := buildNamedUUID()
+	iface1UUID := buildNamedUUID()
+	iface2UUID := buildNamedUUID()
+
+	ovs := vswitchd.OpenvSwitch{UUID: "root-ovs", Bridges: []string{bridgeUUID}}
+	bridge := vswitchd.Bridge{UUID: bridgeUUID, Name: "br-int", Ports: []string{port1UUID, port2UUID}}
+	port1 := vswitchd.Port{UUID: port1UUID, Name: "evpn-port", ExternalIDs: map[string]string{"evpn-vtep": "vtep1"}, Interfaces: []string{iface1UUID}}
+	port2 := vswitchd.Port{UUID: port2UUID, Name: "other-port", ExternalIDs: map[string]string{"other": "val"}, Interfaces: []string{iface2UUID}}
+	iface1 := vswitchd.Interface{UUID: iface1UUID, Name: "evpn-port", Type: "internal"}
+	iface2 := vswitchd.Interface{UUID: iface2UUID, Name: "other-port", Type: "internal"}
+
+	tests := []struct {
+		desc          string
+		predicate     ovsPortPredicate
+		expectedCount int
+		initialOvs    libovsdbtest.TestSetup
+	}{
+		{
+			desc:          "finds ports matching predicate",
+			predicate:     func(p *vswitchd.Port) bool { return p.ExternalIDs["evpn-vtep"] == "vtep1" },
+			expectedCount: 1,
+			initialOvs: libovsdbtest.TestSetup{
+				OVSData: []libovsdbtest.TestData{
+					ovs.DeepCopy(), bridge.DeepCopy(),
+					port1.DeepCopy(), port2.DeepCopy(),
+					iface1.DeepCopy(), iface2.DeepCopy(),
+				},
+			},
+		},
+		{
+			desc:          "returns empty for no matches",
+			predicate:     func(_ *vswitchd.Port) bool { return false },
+			expectedCount: 0,
+			initialOvs: libovsdbtest.TestSetup{
+				OVSData: []libovsdbtest.TestData{
+					ovs.DeepCopy(), bridge.DeepCopy(),
+					port1.DeepCopy(), port2.DeepCopy(),
+					iface1.DeepCopy(), iface2.DeepCopy(),
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			ovsClient, cleanup, err := libovsdbtest.NewOVSTestHarness(tt.initialOvs)
+			if err != nil {
+				t.Fatalf("test: \"%s\" failed to set up test harness: %v", tt.desc, err)
+			}
+			t.Cleanup(cleanup.Cleanup)
+
+			ports, err := FindOVSPortsWithPredicate(ovsClient, tt.predicate)
+			if err != nil {
+				t.Fatal(fmt.Errorf("FindOVSPortsWithPredicate() error = %v", err))
+			}
+			if len(ports) != tt.expectedCount {
+				t.Fatalf("expected %d ports, got %d", tt.expectedCount, len(ports))
+			}
+		})
+	}
+}
+
+func TestCreateOrUpdatePortWithInterface(t *testing.T) {
+	bridgeUUID := buildNamedUUID()
+
+	ovs := vswitchd.OpenvSwitch{UUID: "root-ovs", Bridges: []string{bridgeUUID}}
+	bridge := vswitchd.Bridge{UUID: bridgeUUID, Name: "br-int"}
+
+	tests := []struct {
+		desc              string
+		bridgeName        string
+		portName          string
+		portExternalIDs   map[string]string
+		expectErr         bool
+		initialOvs        libovsdbtest.TestSetup
+		verifyExternalIDs map[string]string
+	}{
+		{
+			desc:            "creates new port and interface",
+			bridgeName:      "br-int",
+			portName:        "new-port",
+			portExternalIDs: map[string]string{"evpn-vtep": "vtep1"},
+			expectErr:       false,
+			initialOvs: libovsdbtest.TestSetup{
+				OVSData: []libovsdbtest.TestData{
+					ovs.DeepCopy(), bridge.DeepCopy(),
+				},
+			},
+			verifyExternalIDs: map[string]string{"evpn-vtep": "vtep1"},
+		},
+		{
+			desc:            "updates existing port external IDs",
+			bridgeName:      "br-int",
+			portName:        "upd-port",
+			portExternalIDs: map[string]string{"k": "v2"},
+			expectErr:       false,
+			initialOvs: libovsdbtest.TestSetup{
+				OVSData: []libovsdbtest.TestData{
+					ovs.DeepCopy(), bridge.DeepCopy(),
+				},
+			},
+			verifyExternalIDs: map[string]string{"k": "v2"},
+		},
+		{
+			desc:            "fails for non-existent bridge",
+			bridgeName:      "no-bridge",
+			portName:        "port",
+			portExternalIDs: nil,
+			expectErr:       true,
+			initialOvs: libovsdbtest.TestSetup{
+				OVSData: []libovsdbtest.TestData{
+					ovs.DeepCopy(), bridge.DeepCopy(),
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			ovsClient, cleanup, err := libovsdbtest.NewOVSTestHarness(tt.initialOvs)
+			if err != nil {
+				t.Fatalf("test: \"%s\" failed to set up test harness: %v", tt.desc, err)
+			}
+			t.Cleanup(cleanup.Cleanup)
+
+			// For update test, create the port first with initial external IDs
+			if tt.desc == "updates existing port external IDs" {
+				err = CreateOrUpdatePortWithInterface(ovsClient, tt.bridgeName, tt.portName, map[string]string{"k": "v1"}, nil)
+				if err != nil {
+					t.Fatalf("setup create failed: %v", err)
+				}
+			}
+
+			err = CreateOrUpdatePortWithInterface(ovsClient, tt.bridgeName, tt.portName, tt.portExternalIDs, nil)
+			if err != nil && !tt.expectErr {
+				t.Fatal(fmt.Errorf("CreateOrUpdatePortWithInterface() error = %v", err))
+			}
+			if err == nil && tt.expectErr {
+				t.Fatal("expected error but got nil")
+			}
+
+			if !tt.expectErr {
+				got, err := GetOVSPort(ovsClient, tt.portName)
+				if err != nil {
+					t.Fatalf("port not found after create: %v", err)
+				}
+				for k, v := range tt.verifyExternalIDs {
+					if got.ExternalIDs[k] != v {
+						t.Fatalf("expected external ID %q=%q, got %v", k, v, got.ExternalIDs)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestDeletePortWithInterfaces(t *testing.T) {
+	bridgeUUID := buildNamedUUID()
+	portUUID := buildNamedUUID()
+	ifaceUUID := buildNamedUUID()
+
+	ovs := vswitchd.OpenvSwitch{UUID: "root-ovs", Bridges: []string{bridgeUUID}}
+	bridge := vswitchd.Bridge{UUID: bridgeUUID, Name: "br-int", Ports: []string{portUUID}}
+	port := vswitchd.Port{UUID: portUUID, Name: "del-port", Interfaces: []string{ifaceUUID}}
+	iface := vswitchd.Interface{UUID: ifaceUUID, Name: "del-port", Type: "internal"}
+
+	tests := []struct {
+		desc        string
+		portName    string
+		expectErr   bool
+		initialOvs  libovsdbtest.TestSetup
+		expectedOvs libovsdbtest.TestSetup
+	}{
+		{
+			desc:      "deletes existing port and interface",
+			portName:  "del-port",
+			expectErr: false,
+			initialOvs: libovsdbtest.TestSetup{
+				OVSData: []libovsdbtest.TestData{
+					ovs.DeepCopy(), bridge.DeepCopy(), port.DeepCopy(), iface.DeepCopy(),
+				},
+			},
+			expectedOvs: libovsdbtest.TestSetup{
+				OVSData: []libovsdbtest.TestData{
+					ovs.DeepCopy(),
+					&vswitchd.Bridge{UUID: bridgeUUID, Name: "br-int"},
+				},
+			},
+		},
+		{
+			desc:      "is idempotent for non-existent port",
+			portName:  "no-such-port",
+			expectErr: false,
+			initialOvs: libovsdbtest.TestSetup{
+				OVSData: []libovsdbtest.TestData{
+					&vswitchd.OpenvSwitch{UUID: "root-ovs", Bridges: []string{bridgeUUID}},
+					&vswitchd.Bridge{UUID: bridgeUUID, Name: "br-int"},
+				},
+			},
+			expectedOvs: libovsdbtest.TestSetup{
+				OVSData: []libovsdbtest.TestData{
+					&vswitchd.OpenvSwitch{UUID: "root-ovs", Bridges: []string{bridgeUUID}},
+					&vswitchd.Bridge{UUID: bridgeUUID, Name: "br-int"},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			ovsClient, cleanup, err := libovsdbtest.NewOVSTestHarness(tt.initialOvs)
+			if err != nil {
+				t.Fatalf("test: \"%s\" failed to set up test harness: %v", tt.desc, err)
+			}
+			t.Cleanup(cleanup.Cleanup)
+
+			err = DeletePortWithInterfaces(ovsClient, "br-int", tt.portName)
+			if err != nil && !tt.expectErr {
+				t.Fatal(fmt.Errorf("DeletePortWithInterfaces() error = %v", err))
+			}
+			if err == nil && tt.expectErr {
+				t.Fatal("expected error but got nil")
+			}
+
+			matcher := libovsdbtest.HaveData(tt.expectedOvs.OVSData)
+			success, err := matcher.Match(ovsClient)
+			if !success {
+				t.Fatal(fmt.Errorf("test: \"%s\" didn't match expected with actual, err: %v", tt.desc, matcher.FailureMessage(ovsClient)))
+			}
+			if err != nil {
+				t.Fatal(fmt.Errorf("test: \"%s\" encountered error: %v", tt.desc, err))
+			}
+		})
+	}
+}
+
+func TestUpdateOpenvSwitchExternalIDs(t *testing.T) {
+	tests := []struct {
+		desc                string
+		initialExternalIDs  map[string]string
+		update              map[string]string
+		expectedExternalIDs map[string]string
+		setupNoOpenvSwitch  bool
+		expectErrIs         error
+	}{
+		{
+			desc:                "sets a new key on empty external_ids",
+			initialExternalIDs:  nil,
+			update:              map[string]string{"ovn-encap-ip": "10.0.0.1"},
+			expectedExternalIDs: map[string]string{"ovn-encap-ip": "10.0.0.1"},
+		},
+		{
+			desc:                "overwrites an existing key, preserves unrelated keys",
+			initialExternalIDs:  map[string]string{"ovn-encap-ip": "10.0.0.1", "system-id": "node-a"},
+			update:              map[string]string{"ovn-encap-ip": "10.0.0.2"},
+			expectedExternalIDs: map[string]string{"ovn-encap-ip": "10.0.0.2", "system-id": "node-a"},
+		},
+		{
+			desc:                "no-op for empty update",
+			initialExternalIDs:  map[string]string{"system-id": "node-a"},
+			update:              nil,
+			expectedExternalIDs: map[string]string{"system-id": "node-a"},
+		},
+		{
+			desc:               "returns ErrNotFound when no Open_vSwitch row exists",
+			update:             map[string]string{"ovn-encap-ip": "10.0.0.1"},
+			setupNoOpenvSwitch: true,
+			expectErrIs:        libovsdbclient.ErrNotFound,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			setup := libovsdbtest.TestSetup{}
+			if !tt.setupNoOpenvSwitch {
+				setup.OVSData = []libovsdbtest.TestData{
+					&vswitchd.OpenvSwitch{UUID: "root-ovs", ExternalIDs: tt.initialExternalIDs},
+				}
+			}
+
+			ovsClient, cleanup, err := libovsdbtest.NewOVSTestHarness(setup)
+			if err != nil {
+				t.Fatalf("failed to set up test harness: %v", err)
+			}
+			t.Cleanup(cleanup.Cleanup)
+
+			err = UpdateOpenvSwitchExternalIDs(ovsClient, tt.update)
+			if tt.expectErrIs != nil {
+				if !errors.Is(err, tt.expectErrIs) {
+					t.Fatalf("expected error %v, got %v", tt.expectErrIs, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("UpdateOpenvSwitchExternalIDs() error = %v", err)
+			}
+
+			expected := []libovsdbtest.TestData{
+				&vswitchd.OpenvSwitch{UUID: "root-ovs", ExternalIDs: tt.expectedExternalIDs},
+			}
+			matcher := libovsdbtest.HaveData(expected)
+			success, err := matcher.Match(ovsClient)
+			if !success {
+				t.Fatalf("post-condition mismatch: %v", matcher.FailureMessage(ovsClient))
+			}
+			if err != nil {
+				t.Fatalf("matcher encountered error: %v", err)
+			}
+		})
+	}
+}

--- a/go-controller/pkg/libovsdb/ops/vswitchdb_test.go
+++ b/go-controller/pkg/libovsdb/ops/vswitchdb_test.go
@@ -381,3 +381,78 @@ func TestUpdateOpenvSwitchExternalIDs(t *testing.T) {
 		})
 	}
 }
+
+func TestRemoveOpenvSwitchExternalIDs(t *testing.T) {
+	tests := []struct {
+		desc                string
+		initialExternalIDs  map[string]string
+		removeKeys          []string
+		expectedExternalIDs map[string]string
+		setupNoOpenvSwitch  bool
+	}{
+		{
+			desc:                "removes a single existing key, preserves unrelated keys",
+			initialExternalIDs:  map[string]string{"ovn-bridge-mappings": "physnet1:br1", "system-id": "node-a"},
+			removeKeys:          []string{"ovn-bridge-mappings"},
+			expectedExternalIDs: map[string]string{"system-id": "node-a"},
+		},
+		{
+			desc:                "removes multiple keys",
+			initialExternalIDs:  map[string]string{"a": "1", "b": "2", "c": "3"},
+			removeKeys:          []string{"a", "c"},
+			expectedExternalIDs: map[string]string{"b": "2"},
+		},
+		{
+			desc:                "removing a non-existent key is a no-op",
+			initialExternalIDs:  map[string]string{"system-id": "node-a"},
+			removeKeys:          []string{"ovn-bridge-mappings"},
+			expectedExternalIDs: map[string]string{"system-id": "node-a"},
+		},
+		{
+			desc:                "no-op for empty key list",
+			initialExternalIDs:  map[string]string{"system-id": "node-a"},
+			removeKeys:          nil,
+			expectedExternalIDs: map[string]string{"system-id": "node-a"},
+		},
+		{
+			desc:               "missing Open_vSwitch row is not an error (matches --if-exists)",
+			removeKeys:         []string{"ovn-bridge-mappings"},
+			setupNoOpenvSwitch: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			setup := libovsdbtest.TestSetup{}
+			if !tt.setupNoOpenvSwitch {
+				setup.OVSData = []libovsdbtest.TestData{
+					&vswitchd.OpenvSwitch{UUID: "root-ovs", ExternalIDs: tt.initialExternalIDs},
+				}
+			}
+
+			ovsClient, cleanup, err := libovsdbtest.NewOVSTestHarness(setup)
+			if err != nil {
+				t.Fatalf("failed to set up test harness: %v", err)
+			}
+			t.Cleanup(cleanup.Cleanup)
+
+			if err := RemoveOpenvSwitchExternalIDs(ovsClient, tt.removeKeys...); err != nil {
+				t.Fatalf("RemoveOpenvSwitchExternalIDs() error = %v", err)
+			}
+
+			if tt.setupNoOpenvSwitch {
+				return
+			}
+			expected := []libovsdbtest.TestData{
+				&vswitchd.OpenvSwitch{UUID: "root-ovs", ExternalIDs: tt.expectedExternalIDs},
+			}
+			matcher := libovsdbtest.HaveData(expected)
+			success, err := matcher.Match(ovsClient)
+			if !success {
+				t.Fatalf("post-condition mismatch: %v", matcher.FailureMessage(ovsClient))
+			}
+			if err != nil {
+				t.Fatalf("matcher encountered error: %v", err)
+			}
+		})
+	}
+}

--- a/go-controller/pkg/node/bridgeconfig/bridgeconfig.go
+++ b/go-controller/pkg/node/bridgeconfig/bridgeconfig.go
@@ -1,6 +1,7 @@
 package bridgeconfig
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"strings"
@@ -10,8 +11,11 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
 
+	libovsdbclient "github.com/ovn-kubernetes/libovsdb/client"
+
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/generator/udn"
+	ovsops "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdb/ops/ovs"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/egressip"
 	nodetypes "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/types"
 	nodeutil "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/util"
@@ -85,7 +89,7 @@ type BridgeConfiguration struct {
 	dropGARP   bool
 }
 
-func NewBridgeConfiguration(intfName, nodeName,
+func NewBridgeConfiguration(ovsClient libovsdbclient.Client, intfName, nodeName,
 	physicalNetworkName string,
 	nodeSubnets, gwIPs []*net.IPNet,
 	advertised bool) (*BridgeConfiguration, error) {
@@ -214,7 +218,7 @@ func NewBridgeConfiguration(intfName, nodeName,
 		}
 	}
 
-	res.interfaceID, err = bridgedGatewayNodeSetup(nodeName, res.bridgeName, physicalNetworkName)
+	res.interfaceID, err = bridgedGatewayNodeSetup(ovsClient, nodeName, res.bridgeName, physicalNetworkName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to set up shared interface gateway: %v", err)
 	}
@@ -523,7 +527,7 @@ func getIntfName(gatewayIntf string) (string, error) {
 
 // bridgedGatewayNodeSetup enables forwarding on bridge interface, sets up the physical network name mappings for the bridge,
 // and returns an ifaceID created from the bridge name and the node name
-func bridgedGatewayNodeSetup(nodeName, bridgeName, physicalNetworkName string) (string, error) {
+func bridgedGatewayNodeSetup(ovsClient libovsdbclient.Client, nodeName, bridgeName, physicalNetworkName string) (string, error) {
 	// IPv6 forwarding is enabled globally
 	if config.IPv4Mode {
 		// we use forward slash as path separator to allow dotted bridgeName e.g. foo.200
@@ -539,21 +543,27 @@ func bridgedGatewayNodeSetup(nodeName, bridgeName, physicalNetworkName string) (
 	// that provides connectivity to that network. It is in the form of physnet1:br1,physnet2:br2.
 	// Note that there may be multiple ovs bridge mappings, be sure not to override
 	// the mappings for the other physical network
-	stdout, stderr, err := util.RunOVSVsctl("--if-exists", "get", "Open_vSwitch", ".",
-		"external_ids:ovn-bridge-mappings")
-	if err != nil {
-		return "", fmt.Errorf("failed to get ovn-bridge-mappings stderr:%s (%v)", stderr, err)
+	existing := ""
+	if ovs, err := ovsops.GetOpenvSwitch(ovsClient); err != nil {
+		if !errors.Is(err, libovsdbclient.ErrNotFound) {
+			return "", fmt.Errorf("failed to get Open_vSwitch row: %w", err)
+		}
+		// no row yet => no existing mappings
+	} else {
+		existing = ovs.ExternalIDs["ovn-bridge-mappings"]
 	}
+
 	// skip the existing mapping setting for the specified physicalNetworkName
 	mapString := ""
-	bridgeMappings := strings.Split(stdout, ",")
-	for _, bridgeMapping := range bridgeMappings {
-		m := strings.Split(bridgeMapping, ":")
-		if network := m[0]; network != physicalNetworkName {
-			if len(mapString) != 0 {
-				mapString += ","
+	if existing != "" {
+		for _, bridgeMapping := range strings.Split(existing, ",") {
+			m := strings.Split(bridgeMapping, ":")
+			if network := m[0]; network != physicalNetworkName {
+				if len(mapString) != 0 {
+					mapString += ","
+				}
+				mapString += bridgeMapping
 			}
-			mapString += bridgeMapping
 		}
 	}
 	if len(mapString) != 0 {
@@ -561,11 +571,10 @@ func bridgedGatewayNodeSetup(nodeName, bridgeName, physicalNetworkName string) (
 	}
 	mapString += physicalNetworkName + ":" + bridgeName
 
-	_, stderr, err = util.RunOVSVsctl("set", "Open_vSwitch", ".",
-		fmt.Sprintf("external_ids:ovn-bridge-mappings=%s", mapString))
-	if err != nil {
-		return "", fmt.Errorf("failed to set ovn-bridge-mappings for ovs bridge %s"+
-			", stderr:%s (%v)", bridgeName, stderr, err)
+	if err := ovsops.UpdateOpenvSwitchExternalIDs(ovsClient, map[string]string{
+		"ovn-bridge-mappings": mapString,
+	}); err != nil {
+		return "", fmt.Errorf("failed to set ovn-bridge-mappings for ovs bridge %s: %w", bridgeName, err)
 	}
 
 	ifaceID := bridgeName + "_" + nodeName

--- a/go-controller/pkg/node/default_node_network_controller.go
+++ b/go-controller/pkg/node/default_node_network_controller.go
@@ -764,6 +764,7 @@ func getMgmtPortAndRepName(node *corev1.Node) (string, string, error) {
 }
 
 func createNodeManagementPortController(
+	ovsClient client.Client,
 	node *corev1.Node,
 	subnets []*net.IPNet,
 	nodeAnnotator kube.Annotator,
@@ -781,7 +782,7 @@ func createNodeManagementPortController(
 			return nil, err
 		}
 	}
-	return managementport.NewManagementPortController(node, subnets, netdevName, rep, routeManager, netInfo)
+	return managementport.NewManagementPortController(ovsClient, node, subnets, netdevName, rep, routeManager, netInfo)
 }
 
 // getOVNSBZone returns the zone name stored in the Southbound db.
@@ -934,6 +935,7 @@ func (nc *DefaultNodeNetworkController) Init(ctx context.Context) error {
 
 	// Setup management ports
 	nc.mgmtPortController, err = createNodeManagementPortController(
+		nc.ovsClient,
 		node,
 		subnets,
 		nodeAnnotator,

--- a/go-controller/pkg/node/gateway.go
+++ b/go-controller/pkg/node/gateway.go
@@ -12,6 +12,8 @@ import (
 	discovery "k8s.io/api/discovery/v1"
 	"k8s.io/klog/v2"
 
+	libovsdbclient "github.com/ovn-kubernetes/libovsdb/client"
+
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	egressipv1 "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressip/v1"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
@@ -357,16 +359,16 @@ func setupUDPAggregationUplink(ifname string) error {
 	return nil
 }
 
-func gatewayInitInternal(nodeName, gwIntf, egressGatewayIntf string, gwNextHops []net.IP, nodeSubnets, gwIPs []*net.IPNet,
+func gatewayInitInternal(ovsClient libovsdbclient.Client, nodeName, gwIntf, egressGatewayIntf string, gwNextHops []net.IP, nodeSubnets, gwIPs []*net.IPNet,
 	advertised bool, nodeAnnotator kube.Annotator) (
 	*bridgeconfig.BridgeConfiguration, *bridgeconfig.BridgeConfiguration, error) {
-	gatewayBridge, err := bridgeconfig.NewBridgeConfiguration(gwIntf, nodeName, types.PhysicalNetworkName, nodeSubnets, gwIPs, advertised)
+	gatewayBridge, err := bridgeconfig.NewBridgeConfiguration(ovsClient, gwIntf, nodeName, types.PhysicalNetworkName, nodeSubnets, gwIPs, advertised)
 	if err != nil {
 		return nil, nil, fmt.Errorf("bridge for interface failed for %s: %w", gwIntf, err)
 	}
 	var egressGWBridge *bridgeconfig.BridgeConfiguration
 	if egressGatewayIntf != "" {
-		egressGWBridge, err = bridgeconfig.NewBridgeConfiguration(egressGatewayIntf, nodeName, types.PhysicalNetworkExGwName, nodeSubnets, nil, false)
+		egressGWBridge, err = bridgeconfig.NewBridgeConfiguration(ovsClient, egressGatewayIntf, nodeName, types.PhysicalNetworkExGwName, nodeSubnets, nil, false)
 		if err != nil {
 			return nil, nil, fmt.Errorf("bridge for interface failed for %s: %w", egressGatewayIntf, err)
 		}

--- a/go-controller/pkg/node/gateway_init.go
+++ b/go-controller/pkg/node/gateway_init.go
@@ -525,11 +525,17 @@ func (nc *DefaultNodeNetworkController) initGatewayDPUHost() error {
 
 // CleanupClusterNode cleans up OVS resources on the k8s node on ovnkube-node daemonset deletion.
 // This is going to be a best effort cleanup.
-func CleanupClusterNode(stopChan <-chan struct{}, name string) error {
+func CleanupClusterNode(name string) error {
 	klog.V(5).Infof("Cleaning up gateway resources on node: %q", name)
 
 	var ovsClient libovsdbclient.Client
-	c, err := libovsdb.NewOVSClient(stopChan)
+	// NewOVSClient closes its client when the stop channel fires; use a
+	// dedicated never-shared channel so an in-flight cleanup transaction
+	// can't be torn down mid-operation. Close on return so the libovsdb
+	// lifecycle goroutine exits cleanly.
+	cleanupStopCh := make(chan struct{})
+	defer close(cleanupStopCh)
+	c, err := libovsdb.NewOVSClient(cleanupStopCh)
 	if err != nil {
 		klog.Warningf("Skipping OVS-side cleanup: failed to initialize libovsdb vswitchd client: %v", err)
 	} else {
@@ -538,18 +544,23 @@ func CleanupClusterNode(stopChan <-chan struct{}, name string) error {
 
 	if config.Gateway.Mode == config.GatewayModeLocal || config.Gateway.Mode == config.GatewayModeShared {
 		if ovsClient != nil {
-			if err := cleanupLocalnetGateway(ovsClient, types.LocalNetworkName); err != nil {
-				klog.Errorf("Failed to cleanup Localnet Gateway, error: %v", err)
+			if localErr := cleanupLocalnetGateway(ovsClient, types.LocalNetworkName); localErr != nil {
+				klog.Errorf("Failed to cleanup Localnet Gateway, error: %v", localErr)
+				err = localErr
 			}
 		}
 		// cleanupSharedGateway handles both the OVS-side (no-op when ovsClient
 		// is nil) and the host-side iptables chains.
-		if err := cleanupSharedGateway(ovsClient); err != nil {
-			klog.Errorf("Failed to cleanup Gateway, error: %v", err)
+		if sharedErr := cleanupSharedGateway(ovsClient); sharedErr != nil {
+			klog.Errorf("Failed to cleanup Gateway, error: %v", sharedErr)
+			err = sharedErr
 		}
 	}
 
-	if ovsClient != nil {
+	// Only strip ovn-bridge-mappings once gateway cleanup has fully
+	// succeeded — otherwise we leave bridges/flows behind without the
+	// external_ids that would let a retry re-attach them.
+	if err == nil && ovsClient != nil {
 		if err := ovsops.RemoveOpenvSwitchExternalIDs(ovsClient, "ovn-bridge-mappings"); err != nil {
 			klog.Errorf("Failed to delete ovn-bridge-mappings: %v", err)
 		}

--- a/go-controller/pkg/node/gateway_init.go
+++ b/go-controller/pkg/node/gateway_init.go
@@ -276,6 +276,7 @@ func (nc *DefaultNodeNetworkController) initGatewayPreStart(
 			nc.linkManager,
 			nc.networkManager,
 			config.Gateway.Mode,
+			nc.ovsClient,
 		)
 	case config.GatewayModeDisabled:
 		var chassisID string
@@ -494,6 +495,7 @@ func (nc *DefaultNodeNetworkController) initGatewayDPUHost() error {
 
 	// TODO(adrianc): revisit if support for nodeIPManager is needed.
 	gw := nc.Gateway.(*gateway)
+	gw.nodeIPManager = newAddressManager(nc.name, nc.Kube, nil, nc.watchFactory, nil, nc.ovsClient)
 	if config.Gateway.NodeportEnable {
 		if err := initSharedGatewayIPTables(); err != nil {
 			return err

--- a/go-controller/pkg/node/gateway_init.go
+++ b/go-controller/pkg/node/gateway_init.go
@@ -13,9 +13,13 @@ import (
 	"k8s.io/klog/v2"
 	utilnet "k8s.io/utils/net"
 
+	libovsdbclient "github.com/ovn-kubernetes/libovsdb/client"
+
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdb"
+	ovsops "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdb/ops/ovs"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/managementport"
 	nodenft "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/nftables"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/routemanager"
@@ -521,25 +525,34 @@ func (nc *DefaultNodeNetworkController) initGatewayDPUHost() error {
 
 // CleanupClusterNode cleans up OVS resources on the k8s node on ovnkube-node daemonset deletion.
 // This is going to be a best effort cleanup.
-func CleanupClusterNode(name string) error {
-	var err error
-
+func CleanupClusterNode(stopChan <-chan struct{}, name string) error {
 	klog.V(5).Infof("Cleaning up gateway resources on node: %q", name)
-	if config.Gateway.Mode == config.GatewayModeLocal || config.Gateway.Mode == config.GatewayModeShared {
-		err = cleanupLocalnetGateway(types.LocalNetworkName)
-		if err != nil {
-			klog.Errorf("Failed to cleanup Localnet Gateway, error: %v", err)
-		}
-		err = cleanupSharedGateway()
-	}
+
+	var ovsClient libovsdbclient.Client
+	c, err := libovsdb.NewOVSClient(stopChan)
 	if err != nil {
-		klog.Errorf("Failed to cleanup Gateway, error: %v", err)
+		klog.Warningf("Skipping OVS-side cleanup: failed to initialize libovsdb vswitchd client: %v", err)
+	} else {
+		ovsClient = c
 	}
 
-	stdout, stderr, err := util.RunOVSVsctl("--", "--if-exists", "remove", "Open_vSwitch", ".", "external_ids",
-		"ovn-bridge-mappings")
-	if err != nil {
-		klog.Errorf("Failed to delete ovn-bridge-mappings, stdout: %q, stderr: %q, error: %v", stdout, stderr, err)
+	if config.Gateway.Mode == config.GatewayModeLocal || config.Gateway.Mode == config.GatewayModeShared {
+		if ovsClient != nil {
+			if err := cleanupLocalnetGateway(ovsClient, types.LocalNetworkName); err != nil {
+				klog.Errorf("Failed to cleanup Localnet Gateway, error: %v", err)
+			}
+		}
+		// cleanupSharedGateway handles both the OVS-side (no-op when ovsClient
+		// is nil) and the host-side iptables chains.
+		if err := cleanupSharedGateway(ovsClient); err != nil {
+			klog.Errorf("Failed to cleanup Gateway, error: %v", err)
+		}
+	}
+
+	if ovsClient != nil {
+		if err := ovsops.RemoveOpenvSwitchExternalIDs(ovsClient, "ovn-bridge-mappings"); err != nil {
+			klog.Errorf("Failed to delete ovn-bridge-mappings: %v", err)
+		}
 	}
 
 	// Clean up legacy IPTables rules for management port

--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -34,6 +34,7 @@ import (
 	udnfakeclient "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/userdefinednetwork/v1/apis/clientset/versioned/fake"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
+	ovsops "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdb/ops/ovs"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/networkmanager"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/managementport"
 	nodenft "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/nftables"
@@ -394,6 +395,9 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 				ovsClient,
 			)
 			Expect(err).NotTo(HaveOccurred())
+			ovs, err := ovsops.GetOpenvSwitch(ovsClient)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ovs.ExternalIDs).To(HaveKeyWithValue("ovn-bridge-mappings", types.PhysicalNetworkName+":breth0"))
 			err = sharedGw.initFunc()
 			Expect(err).NotTo(HaveOccurred())
 			err = sharedGw.Init(stop, wg)
@@ -805,6 +809,9 @@ func shareGatewayInterfaceDPUTest(app *cli.App, testNS ns.NetNS,
 				ovsClient,
 			)
 			Expect(err).NotTo(HaveOccurred())
+			ovs, err := ovsops.GetOpenvSwitch(ovsClient)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ovs.ExternalIDs).To(HaveKeyWithValue("ovn-bridge-mappings", types.PhysicalNetworkName+":"+brphys))
 			err = sharedGw.initFunc()
 			Expect(err).NotTo(HaveOccurred())
 			err = sharedGw.Init(stop, wg)
@@ -1310,6 +1317,9 @@ OFPT_GET_CONFIG_REPLY (xid=0x4): frags=normal miss_send_len=0`
 				ovsClient,
 			)
 			Expect(err).NotTo(HaveOccurred())
+			ovs, err := ovsops.GetOpenvSwitch(ovsClient)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ovs.ExternalIDs).To(HaveKeyWithValue("ovn-bridge-mappings", types.PhysicalNetworkName+":breth0"))
 			err = localGw.initFunc()
 			Expect(err).NotTo(HaveOccurred())
 			err = localGw.Init(stop, wg)

--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -276,6 +276,9 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 		iptV4, iptV6 := util.SetFakeIPTablesHelpers()
 		nft := nodenft.SetFakeNFTablesHelper()
 
+		ovsClient, ovsCleanup := newTestOVSClient()
+		defer ovsCleanup.Cleanup()
+
 		// Make Management port
 		hostSubnets := ovntest.MustParseIPNets(nodeSubnet)
 		rm := routemanager.NewController()
@@ -283,7 +286,7 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 		netInfo.On("GetPodNetworkAdvertisedOnNodeVRFs", nodeName).Return(nil)
 		netInfo.On("GetNodeGatewayIP", hostSubnets[0]).Return(util.GetNodeGatewayIfAddr(hostSubnets[0]))
 		netInfo.On("GetNodeManagementIP", hostSubnets[0]).Return(util.GetNodeManagementIfAddr(hostSubnets[0]))
-		mp, err := managementport.NewManagementPortController(&existingNode, hostSubnets, "", "", rm, netInfo)
+		mp, err := managementport.NewManagementPortController(ovsClient, &existingNode, hostSubnets, "", "", rm, netInfo)
 		Expect(err).NotTo(HaveOccurred())
 
 		kubeFakeClient := fake.NewSimpleClientset(&corev1.NodeList{
@@ -375,8 +378,6 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 			Expect(err).NotTo(HaveOccurred())
 
 			ifAddrs := ovntest.MustParseIPNets(eth0CIDR)
-			ovsClient, ovsCleanup := newTestOVSClient()
-			defer ovsCleanup.Cleanup()
 			sharedGw, err := newGateway(
 				nodeName,
 				ovntest.MustParseIPNets(nodeSubnet),
@@ -1220,6 +1221,9 @@ OFPT_GET_CONFIG_REPLY (xid=0x4): frags=normal miss_send_len=0`
 
 		nft := nodenft.SetFakeNFTablesHelper()
 
+		ovsClient, ovsCleanup := newTestOVSClient()
+		defer ovsCleanup.Cleanup()
+
 		// Make Management port
 		hostSubnets := ovntest.MustParseIPNets(nodeSubnet)
 		rm := routemanager.NewController()
@@ -1227,7 +1231,7 @@ OFPT_GET_CONFIG_REPLY (xid=0x4): frags=normal miss_send_len=0`
 		netInfo.On("GetPodNetworkAdvertisedOnNodeVRFs", nodeName).Return(nil)
 		netInfo.On("GetNodeGatewayIP", hostSubnets[0]).Return(util.GetNodeGatewayIfAddr(hostSubnets[0]))
 		netInfo.On("GetNodeManagementIP", hostSubnets[0]).Return(util.GetNodeManagementIfAddr(hostSubnets[0]))
-		mp, err := managementport.NewManagementPortController(&existingNode, hostSubnets, "", "", rm, netInfo)
+		mp, err := managementport.NewManagementPortController(ovsClient, &existingNode, hostSubnets, "", "", rm, netInfo)
 		Expect(err).NotTo(HaveOccurred())
 
 		if util.IsNetworkSegmentationSupportEnabled() {
@@ -1297,8 +1301,6 @@ OFPT_GET_CONFIG_REPLY (xid=0x4): frags=normal miss_send_len=0`
 			gatewayNextHops, gatewayIntf, err := getGatewayNextHops()
 			Expect(err).NotTo(HaveOccurred())
 			ifAddrs := ovntest.MustParseIPNets(eth0CIDR)
-			ovsClient, ovsCleanup := newTestOVSClient()
-			defer ovsCleanup.Cleanup()
 			localGw, err := newGateway(
 				nodeName,
 				ovntest.MustParseIPNets(nodeSubnet),

--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -190,14 +190,8 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 			Cmd:    "ovs-vsctl --timeout=15 --if-exists get interface breth0 mac_in_use",
 			Output: eth0MAC,
 		})
-		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-			Cmd:    "ovs-vsctl --timeout=15 --if-exists get Open_vSwitch . external_ids:ovn-bridge-mappings",
-			Output: "",
-		})
-		fexec.AddFakeCmdsNoOutputNoError([]string{
-			"ovs-vsctl --timeout=15 set Open_vSwitch . external_ids:ovn-bridge-mappings=" + types.PhysicalNetworkName + ":breth0",
-		})
-
+		// ovn-bridge-mappings get/set are now handled via libovsdb in
+		// bridgeconfig.bridgedGatewayNodeSetup; no fexec entries needed.
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 			Cmd:    "ovs-vsctl --timeout=15 --if-exists get Open_vSwitch . external_ids:system-id",
 			Output: systemID,
@@ -652,13 +646,8 @@ func shareGatewayInterfaceDPUTest(app *cli.App, testNS ns.NetNS,
 			Cmd:    "ovs-vsctl --timeout=15 --if-exists get interface " + brphys + " mac_in_use",
 			Output: uplinkMAC,
 		})
-		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-			Cmd:    "ovs-vsctl --timeout=15 --if-exists get Open_vSwitch . external_ids:ovn-bridge-mappings",
-			Output: "",
-		})
-		fexec.AddFakeCmdsNoOutputNoError([]string{
-			"ovs-vsctl --timeout=15 set Open_vSwitch . external_ids:ovn-bridge-mappings=" + types.PhysicalNetworkName + ":" + brphys,
-		})
+		// ovn-bridge-mappings get/set are now handled via libovsdb in
+		// bridgeconfig.bridgedGatewayNodeSetup; no fexec entries needed.
 		// GetNodeChassisID
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 			Cmd:    "ovs-vsctl --timeout=15 --if-exists get Open_vSwitch . external_ids:system-id",
@@ -1121,14 +1110,8 @@ OFPT_GET_CONFIG_REPLY (xid=0x4): frags=normal miss_send_len=0`
 			Cmd:    "ovs-vsctl --timeout=15 --if-exists get interface breth0 mac_in_use",
 			Output: eth0MAC,
 		})
-		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-			Cmd:    "ovs-vsctl --timeout=15 --if-exists get Open_vSwitch . external_ids:ovn-bridge-mappings",
-			Output: "",
-		})
-		fexec.AddFakeCmdsNoOutputNoError([]string{
-			"ovs-vsctl --timeout=15 set Open_vSwitch . external_ids:ovn-bridge-mappings=" + types.PhysicalNetworkName + ":breth0",
-		})
-
+		// ovn-bridge-mappings get/set are now handled via libovsdb in
+		// bridgeconfig.bridgedGatewayNodeSetup; no fexec entries needed.
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 			Cmd:    "ovs-vsctl --timeout=15 --if-exists get Open_vSwitch . external_ids:system-id",
 			Output: systemID,

--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -221,17 +221,6 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 			Cmd:    "ovs-vsctl --timeout=15 get interface eth0 ofport",
 			Output: "7",
 		})
-		if setNodeIP {
-			fexec.AddFakeCmdsNoOutputNoError([]string{
-				"ovs-vsctl --timeout=15 get Open_vSwitch . external_ids:ovn-encap-ip",
-			})
-			fexec.AddFakeCmdsNoOutputNoError([]string{
-				"ovs-vsctl --timeout=15 set Open_vSwitch . external_ids:ovn-encap-ip=192.168.1.10",
-			})
-			fexec.AddFakeCmdsNoOutputNoError([]string{
-				"ovn-appctl --timeout=5 -t ovn-controller exit --restart",
-			})
-		}
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 			Cmd:    "ip route replace table 7 172.16.1.0/24 via 10.1.1.1 dev ovn-k8s-mp0",
 			Output: "0",
@@ -258,7 +247,16 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 		})
 		// syncServices()
 
-		err := util.SetExec(fexec)
+		if setNodeIP {
+			// addressManager.sync() will call updateOVNEncapIPAndReconnect,
+			// which writes ovn-encap-ip via libovsdb (asserted after Init)
+			// and asks ovn-controller to reconnect.
+			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+				Cmd: "ovn-appctl --timeout=5 -t ovn-controller exit --restart",
+			})
+		}
+
+		err = util.SetExec(fexec)
 		Expect(err).NotTo(HaveOccurred())
 
 		_, err = config.InitConfig(ctx, fexec, nil)
@@ -382,6 +380,8 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 			Expect(err).NotTo(HaveOccurred())
 
 			ifAddrs := ovntest.MustParseIPNets(eth0CIDR)
+			ovsClient, ovsCleanup := newTestOVSClient()
+			defer ovsCleanup.Cleanup()
 			sharedGw, err := newGateway(
 				nodeName,
 				ovntest.MustParseIPNets(nodeSubnet),
@@ -397,6 +397,7 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 				nil,
 				networkmanager.Default().Interface(),
 				config.GatewayModeShared,
+				ovsClient,
 			)
 			Expect(err).NotTo(HaveOccurred())
 			err = sharedGw.initFunc()
@@ -410,6 +411,15 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 			// Start does two things, starts nodeIPManager which spawns a go routine and also starts openflow manager by spawning a go routine
 			//sharedGw.Start()
 			sharedGw.nodeIPManager.sync()
+			if setNodeIP {
+				// updateOVNEncapIPAndReconnect should have written the
+				// node primary IP into Open_vSwitch.external_ids.
+				expectedAddr, perr := netlink.ParseAddr(eth0CIDR)
+				Expect(perr).NotTo(HaveOccurred())
+				ovs, gerr := ovsops.GetOpenvSwitch(ovsClient)
+				Expect(gerr).NotTo(HaveOccurred())
+				Expect(ovs.ExternalIDs).To(HaveKeyWithValue("ovn-encap-ip", expectedAddr.IP.String()))
+			}
 			// we cannot start openflow manager directly because it spawns a go routine
 			// FIXME: extract openflow manager func from the spawning of a go routine so it can be called directly below.
 			sharedGw.openflowManager.syncFlows()
@@ -571,6 +581,9 @@ func shareGatewayInterfaceDPUTest(app *cli.App, testNS ns.NetNS,
 	brphys, hostMAC, hostCIDR, dpuIP string) {
 	const mtu string = "1400"
 	const clusterCIDR string = "10.1.0.0/16"
+	// addressManager.sync() short-circuits when Mode == DPU, so the
+	// encap-update path never fires here. Keep the field empty to avoid
+	// polluting later tests.
 	app.Action = func(ctx *cli.Context) error {
 		const (
 			nodeName   string = "node1"
@@ -783,6 +796,8 @@ func shareGatewayInterfaceDPUTest(app *cli.App, testNS ns.NetNS,
 
 			gatewayNextHops, gatewayIntf, err := getGatewayNextHops()
 			Expect(err).NotTo(HaveOccurred())
+			ovsClient, ovsCleanup := newTestOVSClient()
+			defer ovsCleanup.Cleanup()
 			sharedGw, err := newGateway(
 				nodeName,
 				ovntest.MustParseIPNets(nodeSubnet),
@@ -798,6 +813,7 @@ func shareGatewayInterfaceDPUTest(app *cli.App, testNS ns.NetNS,
 				nil,
 				networkmanager.Default().Interface(),
 				config.GatewayModeShared,
+				ovsClient,
 			)
 			Expect(err).NotTo(HaveOccurred())
 			err = sharedGw.initFunc()
@@ -1136,11 +1152,8 @@ OFPT_GET_CONFIG_REPLY (xid=0x4): frags=normal miss_send_len=0`
 			Cmd:    "ovs-vsctl --timeout=15 get interface eth0 ofport",
 			Output: "7",
 		})
-		// IP already configured, do not try to set it or restart ovn-controller
-		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-			Cmd:    "ovs-vsctl --timeout=15 get Open_vSwitch . external_ids:ovn-encap-ip",
-			Output: "192.168.1.10",
-		})
+		// Encap IP reconciliation moved to libovsdb; addressManager.sync()
+		// is gated off via config.Default.EncapIP for this test.
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 			Cmd:    "ip route replace table 7 172.16.1.0/24 via 10.1.1.1 dev ovn-k8s-mp0",
 			Output: "0",
@@ -1177,6 +1190,13 @@ OFPT_GET_CONFIG_REPLY (xid=0x4): frags=normal miss_send_len=0`
 			Output: ovsOFOutput,
 		})
 		// syncServices()
+
+		// addressManager.sync() will call updateOVNEncapIPAndReconnect,
+		// which writes ovn-encap-ip via libovsdb (asserted after Init) and
+		// asks ovn-controller to reconnect.
+		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+			Cmd: "ovn-appctl --timeout=5 -t ovn-controller exit --restart",
+		})
 
 		err := util.SetExec(fexec)
 		Expect(err).NotTo(HaveOccurred())
@@ -1287,6 +1307,8 @@ OFPT_GET_CONFIG_REPLY (xid=0x4): frags=normal miss_send_len=0`
 			gatewayNextHops, gatewayIntf, err := getGatewayNextHops()
 			Expect(err).NotTo(HaveOccurred())
 			ifAddrs := ovntest.MustParseIPNets(eth0CIDR)
+			ovsClient, ovsCleanup := newTestOVSClient()
+			defer ovsCleanup.Cleanup()
 			localGw, err := newGateway(
 				nodeName,
 				ovntest.MustParseIPNets(nodeSubnet),
@@ -1302,6 +1324,7 @@ OFPT_GET_CONFIG_REPLY (xid=0x4): frags=normal miss_send_len=0`
 				nil,
 				networkmanager.Default().Interface(),
 				config.GatewayModeLocal,
+				ovsClient,
 			)
 			Expect(err).NotTo(HaveOccurred())
 			err = localGw.initFunc()
@@ -1316,6 +1339,11 @@ OFPT_GET_CONFIG_REPLY (xid=0x4): frags=normal miss_send_len=0`
 			// Start does two things, starts nodeIPManager which spawns a go routine and also starts openflow manager by spawning a go routine
 			// localGw.Start()
 			localGw.nodeIPManager.sync()
+			// updateOVNEncapIPAndReconnect should have written the node
+			// primary IP into Open_vSwitch.external_ids.
+			localOVS, lerr := ovsops.GetOpenvSwitch(ovsClient)
+			Expect(lerr).NotTo(HaveOccurred())
+			Expect(localOVS.ExternalIDs).To(HaveKeyWithValue("ovn-encap-ip", expectedAddr.IP.String()))
 			// we cannot start openflow manager directly because it spawns a go routine
 			// FIXME: extract openflow manager func from the spawning of a go routine so it can be called directly below.
 			localGw.openflowManager.syncFlows()

--- a/go-controller/pkg/node/gateway_localnet.go
+++ b/go-controller/pkg/node/gateway_localnet.go
@@ -97,7 +97,11 @@ func cleanupLocalnetGateway(ovsClient libovsdbclient.Client, physnet string) err
 		return nil
 	}
 	for _, bridgeMapping := range strings.Split(mappings, ",") {
-		m := strings.Split(bridgeMapping, ":")
+		m := strings.SplitN(bridgeMapping, ":", 2)
+		if len(m) != 2 || m[1] == "" {
+			klog.Warningf("Ignoring malformed ovn-bridge-mappings entry %q", bridgeMapping)
+			continue
+		}
 		if physnet == m[0] {
 			bridgeName := m[1]
 			if _, stderr, err := util.RunOVSVsctl("--", "--if-exists", "del-br", bridgeName); err != nil {

--- a/go-controller/pkg/node/gateway_localnet.go
+++ b/go-controller/pkg/node/gateway_localnet.go
@@ -4,6 +4,7 @@
 package node
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"strings"
@@ -11,6 +12,9 @@ import (
 	"k8s.io/klog/v2"
 	utilnet "k8s.io/utils/net"
 
+	libovsdbclient "github.com/ovn-kubernetes/libovsdb/client"
+
+	ovsops "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdb/ops/ovs"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/managementport"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 )
@@ -79,23 +83,28 @@ func getLocalAddrs() (map[string]net.IPNet, error) {
 	return localAddrSet, nil
 }
 
-func cleanupLocalnetGateway(physnet string) error {
-	stdout, stderr, err := util.RunOVSVsctl("--if-exists", "get", "Open_vSwitch", ".",
-		"external_ids:ovn-bridge-mappings")
+func cleanupLocalnetGateway(ovsClient libovsdbclient.Client, physnet string) error {
+	ovs, err := ovsops.GetOpenvSwitch(ovsClient)
 	if err != nil {
-		return fmt.Errorf("failed to get ovn-bridge-mappings stderr:%s (%v)", stderr, err)
+		if errors.Is(err, libovsdbclient.ErrNotFound) {
+			// Nothing configured yet — nothing to clean up.
+			return nil
+		}
+		return fmt.Errorf("failed to get Open_vSwitch row: %w", err)
 	}
-	bridgeMappings := strings.Split(stdout, ",")
-	for _, bridgeMapping := range bridgeMappings {
+	mappings := ovs.ExternalIDs["ovn-bridge-mappings"]
+	if mappings == "" {
+		return nil
+	}
+	for _, bridgeMapping := range strings.Split(mappings, ",") {
 		m := strings.Split(bridgeMapping, ":")
 		if physnet == m[0] {
 			bridgeName := m[1]
-			_, stderr, err = util.RunOVSVsctl("--", "--if-exists", "del-br", bridgeName)
-			if err != nil {
+			if _, stderr, err := util.RunOVSVsctl("--", "--if-exists", "del-br", bridgeName); err != nil {
 				return fmt.Errorf("failed to ovs-vsctl del-br %s stderr:%s (%v)", bridgeName, stderr, err)
 			}
 			break
 		}
 	}
-	return err
+	return nil
 }

--- a/go-controller/pkg/node/gateway_localnet_linux_test.go
+++ b/go-controller/pkg/node/gateway_localnet_linux_test.go
@@ -81,7 +81,7 @@ func startNodePortWatcher(n *nodePortWatcher, fakeClient *util.OVNNodeClientset)
 	}
 
 	k := &kube.Kube{KClient: fakeClient.KubeClient}
-	n.nodeIPManager = newAddressManagerInternal(fakeNodeName, k, nil, n.watchFactory, nil, false)
+	n.nodeIPManager = newAddressManagerInternal(fakeNodeName, k, nil, n.watchFactory, nil, nil, false)
 	localHostNetEp := "192.168.18.15/32"
 	ip, ipnet, _ := net.ParseCIDR(localHostNetEp)
 	ipFullNet := net.IPNet{IP: ip, Mask: ipnet.Mask}
@@ -131,7 +131,7 @@ func startNodePortWatcherWithRetry(n *nodePortWatcher, fakeClient *util.OVNNodeC
 	}
 
 	k := &kube.Kube{KClient: fakeClient.KubeClient}
-	n.nodeIPManager = newAddressManagerInternal(fakeNodeName, k, nil, n.watchFactory, nil, false)
+	n.nodeIPManager = newAddressManagerInternal(fakeNodeName, k, nil, n.watchFactory, nil, nil, false)
 	localHostNetEp := "192.168.18.15/32"
 	ip, ipnet, _ := net.ParseCIDR(localHostNetEp)
 	ipFullNet := net.IPNet{IP: ip, Mask: ipnet.Mask}

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -22,6 +22,8 @@ import (
 	utilnet "k8s.io/utils/net"
 	"sigs.k8s.io/knftables"
 
+	libovsdbclient "github.com/ovn-kubernetes/libovsdb/client"
+
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
@@ -1447,6 +1449,7 @@ func newGateway(
 	linkManager *linkmanager.Controller,
 	networkManager networkmanager.Interface,
 	gatewayMode config.GatewayMode,
+	ovsClient libovsdbclient.Client,
 ) (*gateway, error) {
 	klog.Info("Creating new gateway")
 	gw := &gateway{
@@ -1509,7 +1512,7 @@ func newGateway(
 			gw.bridgeEIPAddrManager = egressip.NewBridgeEIPAddrManager(nodeName, gwBridge.GetBridgeName(), linkManager, kube, watchFactory.EgressIPInformer(), watchFactory.NodeCoreInformer())
 			gwBridge.SetEIPMarkIPs(gw.bridgeEIPAddrManager.GetCache())
 		}
-		gw.nodeIPManager = newAddressManager(nodeName, kube, mgmtPort, watchFactory, gwBridge)
+		gw.nodeIPManager = newAddressManager(nodeName, kube, mgmtPort, watchFactory, gwBridge, ovsClient)
 
 		if config.OvnKubeNode.Mode == types.NodeModeFull {
 			// Delete stale masquerade resources if there are any. This is to make sure that there

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -2,6 +2,7 @@ package node
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"hash/fnv"
 	"math"
@@ -27,6 +28,7 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
+	ovsops "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdb/ops/ovs"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/networkmanager"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/bridgeconfig"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/egressip"
@@ -1666,45 +1668,51 @@ func newNodePortWatcher(
 	return npw, nil
 }
 
-func cleanupSharedGateway() error {
-	// NicToBridge() may be created before-hand, only delete the patch port here
-	stdout, stderr, err := util.RunOVSVsctl("--columns=name", "--no-heading", "find", "port",
-		"external_ids:ovn-localnet-port!=_")
-	if err != nil {
-		return fmt.Errorf("failed to get ovn-localnet-port port stderr:%s (%v)", stderr, err)
-	}
-	ports := strings.Fields(strings.Trim(stdout, "\""))
-	for _, port := range ports {
-		_, stderr, err := util.RunOVSVsctl("--if-exists", "del-port", strings.Trim(port, "\""))
+func cleanupSharedGateway(ovsClient libovsdbclient.Client) error {
+	if ovsClient != nil {
+		// NicToBridge() may be created before-hand, only delete the patch port here
+		stdout, stderr, err := util.RunOVSVsctl("--columns=name", "--no-heading", "find", "port",
+			"external_ids:ovn-localnet-port!=_")
 		if err != nil {
-			return fmt.Errorf("failed to delete port %s stderr:%s (%v)", port, stderr, err)
+			return fmt.Errorf("failed to get ovn-localnet-port port stderr:%s (%v)", stderr, err)
 		}
-	}
-
-	// Get the OVS bridge name from ovn-bridge-mappings
-	stdout, stderr, err = util.RunOVSVsctl("--if-exists", "get", "Open_vSwitch", ".",
-		"external_ids:ovn-bridge-mappings")
-	if err != nil {
-		return fmt.Errorf("failed to get ovn-bridge-mappings stderr:%s (%v)", stderr, err)
-	}
-
-	// skip the existing mapping setting for the specified physicalNetworkName
-	bridgeName := ""
-	bridgeMappings := strings.Split(stdout, ",")
-	for _, bridgeMapping := range bridgeMappings {
-		m := strings.Split(bridgeMapping, ":")
-		if network := m[0]; network == types.PhysicalNetworkName {
-			bridgeName = m[1]
-			break
+		ports := strings.Fields(strings.Trim(stdout, "\""))
+		for _, port := range ports {
+			_, stderr, err := util.RunOVSVsctl("--if-exists", "del-port", strings.Trim(port, "\""))
+			if err != nil {
+				return fmt.Errorf("failed to delete port %s stderr:%s (%v)", port, stderr, err)
+			}
 		}
-	}
-	if len(bridgeName) == 0 {
-		return nil
-	}
 
-	_, stderr, err = util.AddOFFlowWithSpecificAction(bridgeName, util.NormalAction)
-	if err != nil {
-		return fmt.Errorf("failed to replace-flows on bridge %q stderr:%s (%v)", bridgeName, stderr, err)
+		// Get the OVS bridge name from ovn-bridge-mappings
+		ovs, err := ovsops.GetOpenvSwitch(ovsClient)
+		if err != nil {
+			if errors.Is(err, libovsdbclient.ErrNotFound) {
+				return nil
+			}
+			return fmt.Errorf("failed to get Open_vSwitch row: %w", err)
+		}
+		mappings := ovs.ExternalIDs["ovn-bridge-mappings"]
+		if mappings == "" {
+			return nil
+		}
+
+		bridgeName := ""
+		for _, bridgeMapping := range strings.Split(mappings, ",") {
+			m := strings.Split(bridgeMapping, ":")
+			if network := m[0]; network == types.PhysicalNetworkName {
+				bridgeName = m[1]
+				break
+			}
+		}
+		if len(bridgeName) == 0 {
+			return nil
+		}
+
+		_, stderr, err = util.AddOFFlowWithSpecificAction(bridgeName, util.NormalAction)
+		if err != nil {
+			return fmt.Errorf("failed to replace-flows on bridge %q stderr:%s (%v)", bridgeName, stderr, err)
+		}
 	}
 
 	cleanupSharedGatewayIPTChains()

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -1699,7 +1699,11 @@ func cleanupSharedGateway(ovsClient libovsdbclient.Client) error {
 
 		bridgeName := ""
 		for _, bridgeMapping := range strings.Split(mappings, ",") {
-			m := strings.Split(bridgeMapping, ":")
+			m := strings.SplitN(bridgeMapping, ":", 2)
+			if len(m) != 2 {
+				klog.Warningf("Ignoring malformed ovn-bridge-mappings entry %q", bridgeMapping)
+				continue
+			}
 			if network := m[0]; network == types.PhysicalNetworkName {
 				bridgeName = m[1]
 				break

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -1466,7 +1466,7 @@ func newGateway(
 
 	advertised := util.IsPodNetworkAdvertisedAtNode(networkManager.GetNetwork(types.DefaultNetworkName), nodeName)
 	gwBridge, exGwBridge, err := gatewayInitInternal(
-		nodeName, gwIntf, egressGWIntf, gwNextHops, subnets, gwIPs, advertised, nodeAnnotator)
+		ovsClient, nodeName, gwIntf, egressGWIntf, gwNextHops, subnets, gwIPs, advertised, nodeAnnotator)
 	if err != nil {
 		return nil, err
 	}

--- a/go-controller/pkg/node/gateway_shared_intf_test.go
+++ b/go-controller/pkg/node/gateway_shared_intf_test.go
@@ -1,0 +1,483 @@
+//go:build linux
+// +build linux
+
+package node
+
+import (
+	"fmt"
+
+	nadfake "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/clientset/versioned/fake"
+
+	corev1 "k8s.io/api/core/v1"
+	discovery "k8s.io/api/discovery/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	adminpolicybasedrouteclient "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/adminpolicybasedroute/v1/apis/clientset/versioned/fake"
+	udnfakeclient "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/userdefinednetwork/v1/apis/clientset/versioned/fake"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/networkmanager"
+	nodenft "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/nftables"
+	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// Note: Local mocks are used instead of FakeNetworkManager to test specific error conditions
+// (NotFound, InvalidPrimaryNetworkError) from GetActiveNetworkForNamespace. FakeNetworkManager
+// doesn't support error injection. And the tests here are not dependent on the methods that
+// FakeNetworkManager implements. If more node tests need this, we will enhance FakeNetworkManager.
+
+// mockNetworkManagerWithNamespaceNotFoundError simulates namespace deletion race condition
+type mockNetworkManagerWithNamespaceNotFoundError struct {
+	networkmanager.Interface
+}
+
+func (m *mockNetworkManagerWithNamespaceNotFoundError) GetPrimaryNADForNamespace(_ string) (string, error) {
+	// Simulate namespace deletion: no primary NAD by definition.
+	return "", nil
+}
+
+func (m *mockNetworkManagerWithNamespaceNotFoundError) GetActiveNetworkForNamespace(_ string) (util.NetInfo, error) {
+	// Namespace is gone; new GetActiveNetworkForNamespace semantics return nil, nil.
+	return nil, nil
+}
+
+// mockNetworkManagerWithInvalidPrimaryNetworkError simulates UDN deletion scenario
+type mockNetworkManagerWithInvalidPrimaryNetworkError struct {
+	networkmanager.Interface
+}
+
+func (m *mockNetworkManagerWithInvalidPrimaryNetworkError) GetPrimaryNADForNamespace(_ string) (string, error) {
+	// just a trigger to ensure GetActiveNetworkForNamespace gets called
+	return types.DefaultNetworkName, nil
+}
+
+func (m *mockNetworkManagerWithInvalidPrimaryNetworkError) GetActiveNetworkForNamespace(namespace string) (util.NetInfo, error) {
+	return nil, util.NewInvalidPrimaryNetworkError(namespace)
+}
+
+// mockNetworkManagerWithError tests that non-graceful errors are properly propagated
+type mockNetworkManagerWithError struct {
+	networkmanager.Interface
+}
+
+func (m *mockNetworkManagerWithError) GetPrimaryNADForNamespace(_ string) (string, error) {
+	// just a trigger to ensure GetActiveNetworkForNamespace gets called
+	return types.DefaultNetworkName, nil
+}
+
+func (m *mockNetworkManagerWithError) GetActiveNetworkForNamespace(namespace string) (util.NetInfo, error) {
+	return nil, fmt.Errorf("network lookup failed for namespace %q", namespace)
+}
+
+// mockNetworkManagerWithInvalidPrimaryNetworkSkip simulates a namespace that
+// requires a primary UDN but is currently in invalid primary network state.
+type mockNetworkManagerWithInvalidPrimaryNetworkSkip struct {
+	networkmanager.Interface
+}
+
+func (m *mockNetworkManagerWithInvalidPrimaryNetworkSkip) GetPrimaryNADForNamespace(namespace string) (string, error) {
+	return "", util.NewInvalidPrimaryNetworkError(namespace)
+}
+
+func (m *mockNetworkManagerWithInvalidPrimaryNetworkSkip) GetActiveNetworkForNamespace(namespace string) (util.NetInfo, error) {
+	return nil, util.NewInvalidPrimaryNetworkError(namespace)
+}
+
+// mockNetworkManagerWithInactiveNode simulates a UDN where the node is inactive for the network.
+type mockNetworkManagerWithInactiveNode struct {
+	networkmanager.Interface
+}
+
+func (m *mockNetworkManagerWithInactiveNode) GetPrimaryNADForNamespace(_ string) (string, error) {
+	return "test-namespace/test-nad", nil
+}
+
+func (m *mockNetworkManagerWithInactiveNode) GetNetworkNameForNADKey(_ string) string {
+	return "test-udn"
+}
+
+func (m *mockNetworkManagerWithInactiveNode) NodeHasNetwork(_, _ string) bool {
+	return false
+}
+
+func (m *mockNetworkManagerWithInactiveNode) GetActiveNetworkForNamespace(_ string) (util.NetInfo, error) {
+	// New code paths resolve activity directly via GetActiveNetworkForNamespace.
+	// Returning nil netInfo means "network not active on this node".
+	return nil, nil
+}
+
+// mockNetworkManagerWithActiveUDN simulates a UDN active on this node.
+type mockNetworkManagerWithActiveUDN struct {
+	networkmanager.Interface
+	netInfo util.NetInfo
+}
+
+func (m *mockNetworkManagerWithActiveUDN) GetPrimaryNADForNamespace(_ string) (string, error) {
+	return "test-namespace/test-nad", nil
+}
+
+func (m *mockNetworkManagerWithActiveUDN) GetNetworkNameForNADKey(_ string) string {
+	return m.netInfo.GetNetworkName()
+}
+
+func (m *mockNetworkManagerWithActiveUDN) NodeHasNetwork(_, _ string) bool {
+	return true
+}
+
+func (m *mockNetworkManagerWithActiveUDN) GetActiveNetworkForNamespace(_ string) (util.NetInfo, error) {
+	return m.netInfo, nil
+}
+
+// verifyIPTablesRule checks if an iptables rule exists and asserts the expected state
+func verifyIPTablesRule(ipt util.IPTablesHelper, serviceIP string, servicePort, nodePort int32, shouldExist bool, message string) {
+	exists, err := ipt.Exists("nat", "OVN-KUBE-NODEPORT",
+		"-p", "TCP", "-m", "addrtype", "--dst-type", "LOCAL",
+		"--dport", fmt.Sprintf("%d", nodePort), "-j", "DNAT",
+		"--to-destination", fmt.Sprintf("%s:%d", serviceIP, servicePort))
+	Expect(err).NotTo(HaveOccurred())
+	if shouldExist {
+		Expect(exists).To(BeTrue(), message)
+	} else {
+		Expect(exists).To(BeFalse(), message)
+	}
+}
+
+// setupServiceAndEndpointSliceWithRules creates a service and endpoint slice, adds them to npw,
+// and verifies iptables rules are created. Returns the created endpoint slice.
+func setupServiceAndEndpointSliceWithRules(npw *nodePortWatcher, ipt util.IPTablesHelper, svcName, namespace, serviceIP, endpointIP string, servicePort, nodePort int32, annotations map[string]string) *discovery.EndpointSlice {
+	// Create service
+	service := newService(svcName, namespace, serviceIP,
+		[]corev1.ServicePort{{
+			Name:       "http",
+			Protocol:   corev1.ProtocolTCP,
+			Port:       servicePort,
+			TargetPort: intstr.FromInt(int(servicePort) + 8000), // e.g., 80 -> 8080
+			NodePort:   nodePort,
+		}},
+		corev1.ServiceTypeNodePort, nil, corev1.ServiceStatus{}, false, false)
+
+	// Create endpoint slice with endpoints
+	epPortName := "http"
+	epPortValue := servicePort + 8000 // Match targetPort
+	epPortProtocol := corev1.ProtocolTCP
+	epSlice := newEndpointSlice(
+		svcName,
+		namespace,
+		[]discovery.Endpoint{
+			{
+				Addresses: []string{endpointIP},
+			},
+		},
+		[]discovery.EndpointPort{
+			{
+				Name:     &epPortName,
+				Protocol: &epPortProtocol,
+				Port:     &epPortValue,
+			},
+		},
+	)
+
+	// Apply annotations if provided
+	if len(annotations) > 0 {
+		if epSlice.Annotations == nil {
+			epSlice.Annotations = make(map[string]string)
+		}
+		for k, v := range annotations {
+			epSlice.Annotations[k] = v
+		}
+	}
+
+	// Add service and endpoint slice
+	err := npw.AddService(service)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = npw.AddEndpointSlice(epSlice)
+	Expect(err).NotTo(HaveOccurred())
+
+	// Verify iptables rules were created
+	verifyIPTablesRule(ipt, serviceIP, servicePort, nodePort, true, "iptables rule should exist before deletion")
+
+	return epSlice
+}
+
+var _ = Describe("DeleteEndpointSlice", func() {
+	var (
+		fakeClient *util.OVNNodeClientset
+		watcher    *factory.WatchFactory
+		npw        *nodePortWatcher
+		iptV4      util.IPTablesHelper
+	)
+
+	const (
+		nodeName      = "test-node"
+		testNamespace = "test-namespace"
+		testService   = "test-service"
+	)
+
+	BeforeEach(func() {
+		var err error
+		// Restore global default values before each test
+		Expect(config.PrepareTestConfig()).To(Succeed())
+		config.Gateway.Mode = config.GatewayModeLocal
+		config.IPv4Mode = true
+		config.IPv6Mode = false
+
+		fakeClient = &util.OVNNodeClientset{
+			KubeClient: fake.NewSimpleClientset(),
+		}
+		fakeClient.AdminPolicyRouteClient = adminpolicybasedrouteclient.NewSimpleClientset()
+		fakeClient.NetworkAttchDefClient = nadfake.NewSimpleClientset()
+		fakeClient.UserDefinedNetworkClient = udnfakeclient.NewSimpleClientset()
+
+		watcher, err = factory.NewNodeWatchFactory(fakeClient, nodeName)
+		Expect(err).NotTo(HaveOccurred())
+		err = watcher.Start()
+		Expect(err).NotTo(HaveOccurred())
+
+		// Initialize nodePortWatcher with default network manager
+		var iptV6 util.IPTablesHelper
+		iptV4, iptV6 = util.SetFakeIPTablesHelpers()
+		npw = initFakeNodePortWatcher(iptV4, iptV6)
+		npw.watchFactory = watcher
+		npw.networkManager = networkmanager.Default().Interface()
+
+		// Initialize nodeIPManager (required for GetLocalEligibleEndpointAddresses)
+		k := &kube.Kube{KClient: fakeClient.KubeClient}
+		npw.nodeIPManager = newAddressManagerInternal(nodeName, k, nil, watcher, nil, nil, false)
+	})
+
+	AfterEach(func() {
+		watcher.Shutdown()
+	})
+
+	Context("when UDN is deleted before processing endpoint slice", func() {
+		It("should execute delServiceRules and gracefully skip addServiceRules", func() {
+			// Setup service and endpoint slice with iptables rules
+			// Add UDN annotation to simulate a mirrored UDN EndpointSlice
+			epSlice := setupServiceAndEndpointSliceWithRules(npw, iptV4, testService, testNamespace, "10.96.0.2", "10.244.0.2", 80, 30081,
+				map[string]string{types.UserDefinedNetworkEndpointSliceAnnotation: "test-udn"})
+
+			// Replace network manager with one that returns InvalidPrimaryNetworkError
+			// This simulates UDN deletion scenario
+			npw.networkManager = &mockNetworkManagerWithInvalidPrimaryNetworkError{}
+
+			// Call DeleteEndpointSlice - should not return error
+			err := npw.DeleteEndpointSlice(epSlice)
+
+			// Should gracefully handle UDN deletion (no error)
+			Expect(err).NotTo(HaveOccurred())
+
+			// iptables rules should be deleted even when UDN is deleted
+			verifyIPTablesRule(iptV4, "10.96.0.2", 80, 30081, false, "iptables rule should be deleted even when UDN is deleted")
+		})
+	})
+
+	Context("when network lookup returns other errors", func() {
+		It("should execute delServiceRules but return error from network lookup", func() {
+			// Setup service and endpoint slice with iptables rules
+			epSlice := setupServiceAndEndpointSliceWithRules(npw, iptV4, testService, testNamespace, "10.96.0.3", "10.244.0.3", 80, 30082, nil)
+
+			// Replace network manager with one that returns a generic error
+			npw.networkManager = &mockNetworkManagerWithError{}
+
+			// Call DeleteEndpointSlice - should return error
+			err := npw.DeleteEndpointSlice(epSlice)
+
+			// Should return error for other types of failures
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("error getting active network"))
+			Expect(err.Error()).To(ContainSubstring(testNamespace))
+			Expect(err.Error()).To(ContainSubstring(testService))
+
+			// iptables rules should still be deleted even when error is returned
+			verifyIPTablesRule(iptV4, "10.96.0.3", 80, 30082, false, "iptables rule should be deleted even when error occurs")
+		})
+	})
+
+	Context("when service does not exist in cache", func() {
+		It("should return nil without error", func() {
+			// Create endpoint slice (but no service in cache)
+			epSlice := newEndpointSlice(testService, testNamespace, nil, nil)
+
+			// Call DeleteEndpointSlice when service not in cache
+			err := npw.DeleteEndpointSlice(epSlice)
+
+			// Should return nil (no-op when not in cache)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Context("when namespace is deleted before processing endpoint slice", func() {
+		It("should clean up old rules even when namespace is gone", func() {
+			// Setup service and endpoint slice with iptables rules
+			epSlice := setupServiceAndEndpointSliceWithRules(npw, iptV4, testService, testNamespace, "10.96.0.10", "10.244.0.5", 80, 30090, nil)
+
+			// Simulate namespace not found error
+			npw.networkManager = &mockNetworkManagerWithNamespaceNotFoundError{}
+			err := npw.DeleteEndpointSlice(epSlice)
+			// Verify no error (graceful handling)
+			Expect(err).NotTo(HaveOccurred())
+
+			// iptables rules should be deleted even though namespace lookup failed
+			verifyIPTablesRule(iptV4, "10.96.0.10", 80, 30090, false, "iptables rule should be deleted even when namespace lookup fails")
+		})
+	})
+})
+
+var _ = Describe("SyncServices", func() {
+	var (
+		fakeClient *util.OVNNodeClientset
+		watcher    *factory.WatchFactory
+		npw        *nodePortWatcher
+		iptV4      util.IPTablesHelper
+	)
+
+	const (
+		nodeName      = "test-node"
+		testNamespace = "test-namespace"
+		testService   = "test-service"
+	)
+
+	BeforeEach(func() {
+		var err error
+		Expect(config.PrepareTestConfig()).To(Succeed())
+		config.Gateway.Mode = config.GatewayModeLocal
+		config.IPv4Mode = true
+		config.IPv6Mode = false
+		_ = nodenft.SetFakeNFTablesHelper()
+
+		fakeClient = &util.OVNNodeClientset{
+			KubeClient: fake.NewSimpleClientset(),
+		}
+		fakeClient.AdminPolicyRouteClient = adminpolicybasedrouteclient.NewSimpleClientset()
+		fakeClient.NetworkAttchDefClient = nadfake.NewSimpleClientset()
+		fakeClient.UserDefinedNetworkClient = udnfakeclient.NewSimpleClientset()
+
+		watcher, err = factory.NewNodeWatchFactory(fakeClient, nodeName)
+		Expect(err).NotTo(HaveOccurred())
+		err = watcher.Start()
+		Expect(err).NotTo(HaveOccurred())
+
+		var iptV6 util.IPTablesHelper
+		iptV4, iptV6 = util.SetFakeIPTablesHelpers()
+		npw = initFakeNodePortWatcher(iptV4, iptV6)
+		npw.watchFactory = watcher
+		npw.networkManager = networkmanager.Default().Interface()
+
+		k := &kube.Kube{KClient: fakeClient.KubeClient}
+		npw.nodeIPManager = newAddressManagerInternal(nodeName, k, nil, watcher, nil, nil, false)
+	})
+
+	AfterEach(func() {
+		watcher.Shutdown()
+	})
+
+	Context("when namespace has invalid primary network", func() {
+		It("should skip service sync without failing startup", func() {
+			service := newService(testService, testNamespace, "10.96.0.20",
+				[]corev1.ServicePort{{
+					Name:       "http",
+					Protocol:   corev1.ProtocolTCP,
+					Port:       80,
+					TargetPort: intstr.FromInt(8080),
+					NodePort:   30091,
+				}},
+				corev1.ServiceTypeNodePort, nil, corev1.ServiceStatus{}, false, false)
+
+			npw.networkManager = &mockNetworkManagerWithInvalidPrimaryNetworkSkip{}
+
+			err := npw.SyncServices([]interface{}{service})
+			Expect(err).NotTo(HaveOccurred())
+
+			verifyIPTablesRule(iptV4, "10.96.0.20", 80, 30091, false,
+				"iptables rule should not be created when primary network is invalid")
+		})
+	})
+
+	Context("when UDN is inactive on this node", func() {
+		It("should skip service sync without installing rules", func() {
+			service := newService(testService, testNamespace, "10.96.0.30",
+				[]corev1.ServicePort{{
+					Name:       "http",
+					Protocol:   corev1.ProtocolTCP,
+					Port:       80,
+					TargetPort: intstr.FromInt(8080),
+					NodePort:   30092,
+				}},
+				corev1.ServiceTypeNodePort, nil, corev1.ServiceStatus{}, false, false)
+
+			npw.networkManager = &mockNetworkManagerWithInactiveNode{}
+
+			err := npw.SyncServices([]interface{}{service})
+			Expect(err).NotTo(HaveOccurred())
+
+			verifyIPTablesRule(iptV4, "10.96.0.30", 80, 30092, false,
+				"iptables rule should not be created when UDN is inactive on this node")
+		})
+	})
+
+	Context("when UDN is active on this node", func() {
+		It("should install nodeport rules", func() {
+			// Avoid openflow dependency in this test.
+			config.Gateway.AllowNoUplink = true
+			npw.ofportPhys = ""
+
+			service := newService(testService, testNamespace, "10.96.0.40",
+				[]corev1.ServicePort{{
+					Name:       "http",
+					Protocol:   corev1.ProtocolTCP,
+					Port:       80,
+					TargetPort: intstr.FromInt(8080),
+					NodePort:   30093,
+				}},
+				corev1.ServiceTypeNodePort, nil, corev1.ServiceStatus{}, false, false)
+
+			nad := ovntest.GenerateNAD("test-udn", "test-nad", testNamespace, types.Layer3Topology, "10.1.0.0/16", types.NetworkRolePrimary)
+			netInfo, err := util.ParseNADInfo(nad)
+			Expect(err).NotTo(HaveOccurred())
+			npw.networkManager = &mockNetworkManagerWithActiveUDN{netInfo: netInfo}
+
+			nodeName := npw.nodeIPManager.nodeName
+			epPortName := "http"
+			epPortValue := int32(8080)
+			epPortProtocol := corev1.ProtocolTCP
+			epSlice := &discovery.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testService + "ab23",
+					Namespace: testNamespace,
+					Labels: map[string]string{
+						types.LabelUserDefinedServiceName: testService,
+					},
+					Annotations: map[string]string{
+						types.UserDefinedNetworkEndpointSliceAnnotation: netInfo.GetNetworkName(),
+					},
+				},
+				AddressType: discovery.AddressTypeIPv4,
+				Endpoints: []discovery.Endpoint{{
+					Addresses: []string{"10.244.0.9"},
+					NodeName:  &nodeName,
+				}},
+				Ports: []discovery.EndpointPort{{
+					Name:     &epPortName,
+					Protocol: &epPortProtocol,
+					Port:     &epPortValue,
+				}},
+			}
+			Expect(watcher.EndpointSliceInformer().GetStore().Add(epSlice)).To(Succeed())
+
+			err = npw.SyncServices([]interface{}{service})
+			Expect(err).NotTo(HaveOccurred())
+
+			verifyIPTablesRule(iptV4, "10.96.0.40", 80, 30093, true,
+				"iptables rule should be created when UDN is active on this node")
+		})
+	})
+})

--- a/go-controller/pkg/node/gateway_udn_test.go
+++ b/go-controller/pkg/node/gateway_udn_test.go
@@ -24,6 +24,8 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/knftables"
 
+	libovsdbclient "github.com/ovn-kubernetes/libovsdb/client"
+
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	rafakeclient "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/routeadvertisements/v1/apis/clientset/versioned/fake"
 	udnfakeclient "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/userdefinednetwork/v1/apis/clientset/versioned/fake"
@@ -38,6 +40,7 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/routemanager"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/vrfmanager"
 	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
+	libovsdbtest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
 	coreinformermocks "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/mocks/k8s.io/client-go/informers/core/v1"
 	v1mocks "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/mocks/k8s.io/client-go/listers/core/v1"
 	fakenetworkmanager "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/networkmanager"
@@ -189,10 +192,6 @@ func setUpGatewayFakeOVSCommands(fexec *ovntest.FakeExec) {
 		Output: "7",
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-		Cmd:    "ovs-vsctl --timeout=15 get Open_vSwitch . external_ids:ovn-encap-ip",
-		Output: "192.168.1.10",
-	})
-	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 		Cmd:    "ovs-vsctl --timeout=15 --if-exists get interface breth0 ofport",
 		Output: "7",
 	})
@@ -277,11 +276,19 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 		mgtPort        = fmt.Sprintf("%s%s", types.K8sMgmtIntfNamePrefix, netID)
 		v4NodeIP       = "192.168.1.10/24"
 		v6NodeIP       = "fc00:f853:ccd:e793::3/64"
+		ovsClient      libovsdbclient.Client
+		ovsCleanup     *libovsdbtest.Context
 	)
 	BeforeEach(func() {
 		// Restore global default values before each testcase
 		err := config.PrepareTestConfig()
 		Expect(err).NotTo(HaveOccurred())
+		// Skip the encap-update path inside addressManager.sync() — these tests
+		// don't fake ovn-appctl and aren't exercising encap reconciliation.
+		config.Default.EncapIP = "test-encap-ip"
+		ovsClient, ovsCleanup = newTestOVSClient()
+		// Ensure gateway tests never rely on host iptables binaries.
+		util.SetFakeIPTablesHelpers()
 
 		// Set dual-stack service CIDRs directly after PrepareTestConfig
 		config.Kubernetes.ServiceCIDRs = ovntest.MustParseIPNets("172.16.1.0/24", "fd02::/112")
@@ -346,6 +353,7 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 	AfterEach(func() {
 		close(stopCh)
 		wg.Wait()
+		ovsCleanup.Cleanup()
 		Expect(testNS.Close()).To(Succeed())
 		Expect(testutils.UnmountNS(testNS)).To(Succeed())
 	})
@@ -642,6 +650,7 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 				nil,
 				networkmanager.Default().Interface(),
 				config.GatewayModeLocal,
+				ovsClient,
 			)
 			Expect(err).NotTo(HaveOccurred())
 			stop := make(chan struct{})
@@ -875,6 +884,7 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 				nil,
 				networkmanager.Default().Interface(),
 				config.GatewayModeLocal,
+				ovsClient,
 			)
 			Expect(err).NotTo(HaveOccurred())
 			stop := make(chan struct{})
@@ -1114,6 +1124,7 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 				nil,
 				networkmanager.Default().Interface(),
 				config.GatewayModeLocal,
+				ovsClient,
 			)
 			Expect(err).NotTo(HaveOccurred())
 			stop := make(chan struct{})

--- a/go-controller/pkg/node/gateway_udn_test.go
+++ b/go-controller/pkg/node/gateway_udn_test.go
@@ -161,13 +161,8 @@ func setUpGatewayFakeOVSCommands(fexec *ovntest.FakeExec) {
 			Output: "net.ipv4.conf.breth0.forwarding = 1",
 		})
 	}
-	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-		Cmd:    "ovs-vsctl --timeout=15 --if-exists get Open_vSwitch . external_ids:ovn-bridge-mappings",
-		Output: "",
-	})
-	fexec.AddFakeCmdsNoOutputNoError([]string{
-		"ovs-vsctl --timeout=15 set Open_vSwitch . external_ids:ovn-bridge-mappings=" + types.PhysicalNetworkName + ":breth0",
-	})
+	// ovn-bridge-mappings get/set are now handled via libovsdb in
+	// bridgeconfig.bridgedGatewayNodeSetup; no fexec entries needed.
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 		Cmd:    "ovs-vsctl --timeout=15 --if-exists get Open_vSwitch . external_ids:system-id",
 		Output: "cb9ec8fa-b409-4ef3-9f42-d9283c47aac6",

--- a/go-controller/pkg/node/gateway_udn_test.go
+++ b/go-controller/pkg/node/gateway_udn_test.go
@@ -580,7 +580,7 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 
 		// Make Management port
 		nodeSubnets := ovntest.MustParseIPNets(v4NodeSubnet, v6NodeSubnet)
-		mp, err := managementport.NewManagementPortController(node, nodeSubnets, "", "", rm, netInfo)
+		mp, err := managementport.NewManagementPortController(ovsClient, node, nodeSubnets, "", "", rm, netInfo)
 		Expect(err).NotTo(HaveOccurred())
 
 		nodeAnnotatorMock := &kubemocks.Annotator{}
@@ -822,7 +822,7 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 
 		// Make Management port
 		nodeSubnets := ovntest.MustParseIPNets(v4NodeSubnet, v6NodeSubnet)
-		mp, err := managementport.NewManagementPortController(node, nodeSubnets, "", "", rm, netInfo)
+		mp, err := managementport.NewManagementPortController(ovsClient, node, nodeSubnets, "", "", rm, netInfo)
 		Expect(err).NotTo(HaveOccurred())
 
 		nodeAnnotatorMock := &kubemocks.Annotator{}
@@ -1060,7 +1060,7 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 
 		// Make Management port
 		nodeSubnets := ovntest.MustParseIPNets(v4NodeSubnet, v6NodeSubnet)
-		mp, err := managementport.NewManagementPortController(node, nodeSubnets, "", "", rm, mutableNetInfo)
+		mp, err := managementport.NewManagementPortController(ovsClient, node, nodeSubnets, "", "", rm, mutableNetInfo)
 		Expect(err).NotTo(HaveOccurred())
 
 		nodeAnnotatorMock := &kubemocks.Annotator{}

--- a/go-controller/pkg/node/gateway_udn_test.go
+++ b/go-controller/pkg/node/gateway_udn_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	factoryMocks "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory/mocks"
 	kubemocks "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube/mocks"
+	ovsops "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdb/ops/ovs"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/networkmanager"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/bridgeconfig"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/iprulemanager"
@@ -648,6 +649,9 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 				ovsClient,
 			)
 			Expect(err).NotTo(HaveOccurred())
+			ovs, err := ovsops.GetOpenvSwitch(ovsClient)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ovs.ExternalIDs).To(HaveKeyWithValue("ovn-bridge-mappings", types.PhysicalNetworkName+":breth0"))
 			stop := make(chan struct{})
 			wg := &sync.WaitGroup{}
 			err = localGw.initFunc()
@@ -882,6 +886,9 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 				ovsClient,
 			)
 			Expect(err).NotTo(HaveOccurred())
+			ovs, err := ovsops.GetOpenvSwitch(ovsClient)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ovs.ExternalIDs).To(HaveKeyWithValue("ovn-bridge-mappings", types.PhysicalNetworkName+":breth0"))
 			stop := make(chan struct{})
 			wg := &sync.WaitGroup{}
 			Expect(localGw.initFunc()).To(Succeed())
@@ -1122,6 +1129,9 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 				ovsClient,
 			)
 			Expect(err).NotTo(HaveOccurred())
+			ovs, err := ovsops.GetOpenvSwitch(ovsClient)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ovs.ExternalIDs).To(HaveKeyWithValue("ovn-bridge-mappings", types.PhysicalNetworkName+":breth0"))
 			stop := make(chan struct{})
 			wg := &sync.WaitGroup{}
 			err = localGw.initFunc()

--- a/go-controller/pkg/node/managementport/port_dpu_linux.go
+++ b/go-controller/pkg/node/managementport/port_dpu_linux.go
@@ -12,7 +12,10 @@ import (
 
 	"k8s.io/klog/v2"
 
+	libovsdbclient "github.com/ovn-kubernetes/libovsdb/client"
+
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	ovsops "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdb/ops/ovs"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/routemanager"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
@@ -23,14 +26,19 @@ type managementPortRepresentor struct {
 	ifName     string
 	repDevName string
 	link       netlink.Link
+	ovsClient  libovsdbclient.Client
 }
 
-// newManagementPortRepresentor creates a new managementPortRepresentor
-func newManagementPortRepresentor(name, repDevName string, cfg *managementPortConfig) *managementPortRepresentor {
+// newManagementPortRepresentor creates a new managementPort representor
+// For management port representor only.
+// name is types.K8sMgmtIntfName (on dpu mode node) or types.K8sMgmtIntfName+"_0" (on full mode)
+// repDevName is the representor VF device name
+func newManagementPortRepresentor(name, repDevName string, cfg *managementPortConfig, ovsClient libovsdbclient.Client) *managementPortRepresentor {
 	return &managementPortRepresentor{
 		cfg:        cfg,
 		ifName:     name,
 		repDevName: repDevName,
+		ovsClient:  ovsClient,
 	}
 }
 
@@ -48,7 +56,7 @@ func (mp *managementPortRepresentor) create() error {
 	}
 
 	if link.Attrs().Name != mp.ifName {
-		if err := syncMgmtPortInterface(mp.ifName, false); err != nil {
+		if err := syncMgmtPortInterface(mp.ovsClient, mp.ifName, false); err != nil {
 			return fmt.Errorf("failed to check existing management port: %v", err)
 		}
 	}
@@ -154,15 +162,17 @@ type managementPortNetdev struct {
 	netdevDevName string
 	cfg           *managementPortConfig
 	routeManager  *routemanager.Controller
+	ovsClient     libovsdbclient.Client
 }
 
 // newManagementPortNetdev creates a new managementPortNetdev
-func newManagementPortNetdev(netdevDevName string, cfg *managementPortConfig, routeManager *routemanager.Controller) *managementPortNetdev {
+func newManagementPortNetdev(netdevDevName string, cfg *managementPortConfig, routeManager *routemanager.Controller, ovsClient libovsdbclient.Client) *managementPortNetdev {
 	return &managementPortNetdev{
 		ifName:        types.K8sMgmtIntfName,
 		netdevDevName: netdevDevName,
 		cfg:           cfg,
 		routeManager:  routeManager,
+		ovsClient:     ovsClient,
 	}
 }
 
@@ -174,7 +184,7 @@ func (mp *managementPortNetdev) create() error {
 	}
 
 	if link.Attrs().Name != mp.ifName {
-		err = syncMgmtPortInterface(mp.ifName, false)
+		err = syncMgmtPortInterface(mp.ovsClient, mp.ifName, false)
 		if err != nil {
 			return fmt.Errorf("failed to sync management port: %v", err)
 		}
@@ -217,10 +227,10 @@ func (mp *managementPortNetdev) create() error {
 	}
 
 	if mp.netdevDevName != mp.ifName && config.OvnKubeNode.Mode != types.NodeModeDPUHost {
-		// Store original interface name for later use
-		if _, stderr, err := util.RunOVSVsctl("set", "Open_vSwitch", ".",
-			"external-ids:ovn-orig-mgmt-port-netdev-name="+mp.netdevDevName); err != nil {
-			return fmt.Errorf("failed to store original mgmt port interface name: %s", stderr)
+		if err := ovsops.UpdateOpenvSwitchExternalIDs(mp.ovsClient, map[string]string{
+			"ovn-orig-mgmt-port-netdev-name": mp.netdevDevName,
+		}); err != nil {
+			return fmt.Errorf("failed to store original mgmt port interface name: %w", err)
 		}
 	}
 

--- a/go-controller/pkg/node/managementport/port_dpu_linux_test.go
+++ b/go-controller/pkg/node/managementport/port_dpu_linux_test.go
@@ -14,15 +14,20 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 
+	libovsdbclient "github.com/ovn-kubernetes/libovsdb/client"
+
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	kubeMocks "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube/mocks"
+	ovsops "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdb/ops/ovs"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/nftables"
 	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
+	libovsdbtest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
 	mocks "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/mocks/github.com/vishvananda/netlink"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 	utilMocks "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util/mocks"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/vswitchd"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -52,6 +57,8 @@ var _ = Describe("Mananagement port DPU tests", func() {
 	var netlinkOpsMock *utilMocks.NetLinkOps
 	var execMock *ovntest.FakeExec
 	var nodeAnnotatorMock *kubeMocks.Annotator
+	var ovsClient libovsdbclient.Client
+	var ovsCleanup *libovsdbtest.Context
 
 	BeforeEach(func() {
 		Expect(config.PrepareTestConfig()).To(Succeed())
@@ -64,10 +71,18 @@ var _ = Describe("Mananagement port DPU tests", func() {
 		Expect(err).NotTo(HaveOccurred())
 		util.SetNetLinkOpMockInst(netlinkOpsMock)
 		nftables.SetFakeNFTablesHelper()
+
+		ovsClient, ovsCleanup, err = libovsdbtest.NewOVSTestHarness(libovsdbtest.TestSetup{
+			OVSData: []libovsdbtest.TestData{
+				&vswitchd.OpenvSwitch{UUID: "root-ovs"},
+			},
+		})
+		Expect(err).NotTo(HaveOccurred())
 	})
 
 	AfterEach(func() {
 		util.SetNetLinkOpMockInst(origNetlinkOps)
+		ovsCleanup.Cleanup()
 	})
 
 	Context("Create Management port DPU", func() {
@@ -106,7 +121,7 @@ var _ = Describe("Mananagement port DPU tests", func() {
 		})
 
 		It("Fails if set Name to ovn-k8s-mp0 fails", func() {
-			mgmtPortDpu := newManagementPortRepresentor(types.K8sMgmtIntfName+"_0", "enp3s0f0v0", nil)
+			mgmtPortDpu := newManagementPortRepresentor(types.K8sMgmtIntfName+"_0", "enp3s0f0v0", nil, ovsClient)
 			linkMock := &mocks.Link{}
 			linkMock.On("Attrs").Return(&netlink.LinkAttrs{Name: "enp3s0f0v0", MTU: 1400})
 
@@ -144,7 +159,7 @@ var _ = Describe("Mananagement port DPU tests", func() {
 				nodeName:    "k8s-worker0",
 				hostSubnets: []*net.IPNet{ipnet},
 			}
-			mgmtPortDpu := newManagementPortRepresentor(types.K8sMgmtIntfName+"_0", "enp3s0f0v0", cfg)
+			mgmtPortDpu := newManagementPortRepresentor(types.K8sMgmtIntfName+"_0", "enp3s0f0v0", cfg, ovsClient)
 			nodeAnnotatorMock.On("Set", mock.Anything, map[string]string{"default": expectedMgmtPortMac.String()}).Return(nil)
 			linkMock := &mocks.Link{}
 			linkMock.On("Attrs").Return(&netlink.LinkAttrs{Name: "enp3s0f0v0", MTU: 1500})
@@ -198,7 +213,7 @@ var _ = Describe("Mananagement port DPU tests", func() {
 				nodeName:    "k8s-worker0",
 				hostSubnets: []*net.IPNet{ipnet},
 			}
-			mgmtPortDpu := newManagementPortRepresentor(types.K8sMgmtIntfName+"_0", "enp3s0f0v0", cfg)
+			mgmtPortDpu := newManagementPortRepresentor(types.K8sMgmtIntfName+"_0", "enp3s0f0v0", cfg, ovsClient)
 			nodeAnnotatorMock.On("Set", mock.Anything, map[string]string{"default": expectedMgmtPortMac.String()}).Return(nil)
 			linkMock := &mocks.Link{}
 			linkMock.On("Attrs").Return(&netlink.LinkAttrs{Name: types.K8sMgmtIntfName + "_0", MTU: config.Default.MTU})
@@ -266,7 +281,7 @@ var _ = Describe("Mananagement port DPU tests", func() {
 			cfg := &managementPortConfig{
 				hostSubnets: []*net.IPNet{ipnet},
 			}
-			mgmtPortDpuHost := newManagementPortNetdev("enp3s0f0v0", cfg, nil)
+			mgmtPortDpuHost := newManagementPortNetdev("enp3s0f0v0", cfg, nil, ovsClient)
 			linkMock := &mocks.Link{}
 			linkMock.On("Attrs").Return(&netlink.LinkAttrs{
 				Name: "enp3s0f0v0", MTU: 1500, HardwareAddr: currentMgmtPortMac})
@@ -280,9 +295,6 @@ var _ = Describe("Mananagement port DPU tests", func() {
 			netlinkOpsMock.On("LinkSetMTU", linkMock, config.Default.MTU).Return(nil)
 			netlinkOpsMock.On("LinkSetUp", linkMock).Return(nil, nil)
 			mockOVSListInterfaceMgmtPortNotExistCmd(execMock, types.K8sMgmtIntfName)
-			execMock.AddFakeCmdsNoOutputNoError([]string{
-				"ovs-vsctl --timeout=15 set Open_vSwitch . external-ids:ovn-orig-mgmt-port-netdev-name=" + mgmtPortDpuHost.netdevDevName,
-			})
 
 			// mock createPlatformManagementPort, we fail it as it covers what we want to test without the
 			// need to mock the entire flow down to routes and iptable rules.
@@ -292,6 +304,10 @@ var _ = Describe("Mananagement port DPU tests", func() {
 			err = mgmtPortDpuHost.create()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("createPlatformManagementPort error"))
+
+			ovs, err := ovsops.GetOpenvSwitch(ovsClient)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ovs.ExternalIDs).To(HaveKeyWithValue("ovn-orig-mgmt-port-netdev-name", "enp3s0f0v0"))
 		})
 
 		It("Does not configure VF if already configured", func() {
@@ -305,10 +321,7 @@ var _ = Describe("Mananagement port DPU tests", func() {
 			cfg := &managementPortConfig{
 				hostSubnets: []*net.IPNet{ipnet},
 			}
-			mgmtPortDpuHost := managementPortNetdev{
-				cfg:           cfg,
-				netdevDevName: "enp3s0f0v0",
-			}
+			mgmtPortDpuHost := newManagementPortNetdev("ovn-k8s-mp0", cfg, nil, ovsClient)
 			linkMock := &mocks.Link{}
 			linkMock.On("Attrs").Return(&netlink.LinkAttrs{
 				Name: "ovn-k8s-mp0", MTU: 1400, HardwareAddr: expectedMgmtPortMac})
@@ -320,8 +333,8 @@ var _ = Describe("Mananagement port DPU tests", func() {
 
 			err = mgmtPortDpuHost.create()
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring(
-				"createPlatformManagementPort error"))
+			Expect(err.Error()).To(ContainSubstring("createPlatformManagementPort error"))
 		})
 	})
+
 })

--- a/go-controller/pkg/node/managementport/port_linux.go
+++ b/go-controller/pkg/node/managementport/port_linux.go
@@ -5,6 +5,7 @@ package managementport
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"strings"
@@ -18,7 +19,10 @@ import (
 	utilnet "k8s.io/utils/net"
 	"sigs.k8s.io/knftables"
 
+	libovsdbclient "github.com/ovn-kubernetes/libovsdb/client"
+
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	ovsops "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdb/ops/ovs"
 	nodenft "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/nftables"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/routemanager"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
@@ -54,6 +58,7 @@ type managementPortController struct {
 
 // NewManagementPortController creates a new ManagementPorts
 func NewManagementPortController(
+	ovsClient libovsdbclient.Client,
 	node *corev1.Node,
 	hostSubnets []*net.IPNet,
 	netdevDevName string,
@@ -87,17 +92,17 @@ func NewManagementPortController(
 	}
 
 	if hasOVS {
-		c.ports[ovsPort] = newManagementPortOVS(cfg, routeManager)
+		c.ports[ovsPort] = newManagementPortOVS(cfg, routeManager, ovsClient)
 	}
 	if hasNetdev {
-		c.ports[netdevPort] = newManagementPortNetdev(netdevDevName, cfg, routeManager)
+		c.ports[netdevPort] = newManagementPortNetdev(netdevDevName, cfg, routeManager, ovsClient)
 	}
 	if hasRepresentor {
 		ifName := types.K8sMgmtIntfName
 		if hasNetdev {
 			ifName += "_0"
 		}
-		c.ports[representorPort] = newManagementPortRepresentor(ifName, repDevName, cfg)
+		c.ports[representorPort] = newManagementPortRepresentor(ifName, repDevName, cfg, ovsClient)
 	}
 
 	// setup NFT sets early as gateway initialization depends on it
@@ -150,19 +155,21 @@ func (c *managementPortController) start(stopChan <-chan struct{}) error {
 type managementPortOVS struct {
 	cfg          *managementPortConfig
 	routeManager *routemanager.Controller
+	ovsClient    libovsdbclient.Client
 }
 
 // newManagementPort creates a new newManagementPort
-func newManagementPortOVS(cfg *managementPortConfig, routeManager *routemanager.Controller) *managementPortOVS {
+func newManagementPortOVS(cfg *managementPortConfig, routeManager *routemanager.Controller, ovsClient libovsdbclient.Client) *managementPortOVS {
 	return &managementPortOVS{
 		cfg:          cfg,
 		routeManager: routeManager,
+		ovsClient:    ovsClient,
 	}
 }
 
 func (mp *managementPortOVS) create() error {
 	for _, mgmtPortName := range []string{types.K8sMgmtIntfName, types.K8sMgmtIntfName + "_0"} {
-		if err := syncMgmtPortInterface(mgmtPortName, true); err != nil {
+		if err := syncMgmtPortInterface(mp.ovsClient, mgmtPortName, true); err != nil {
 			return fmt.Errorf("failed to sync management port: %v", err)
 		}
 	}
@@ -559,7 +566,7 @@ func createPlatformManagementPort(interfaceName string, cfg *managementPortConfi
 // syncMgmtPortInterface verifies if no other interface configured as management port. This may happen if another
 // interface had been used as management port or Node was running in different mode.
 // If old management port is found, its IP configuration is flushed and interface renamed.
-func syncMgmtPortInterface(mgmtPortName string, isExpectedToBeInternal bool) error {
+func syncMgmtPortInterface(ovsClient libovsdbclient.Client, mgmtPortName string, isExpectedToBeInternal bool) error {
 	// Query both type and name, because with type only stdout will be empty for both non-existing port and representor netdevice
 	stdout, _, _ := util.RunOVSVsctl("--no-headings",
 		"--data", "bare",
@@ -568,7 +575,7 @@ func syncMgmtPortInterface(mgmtPortName string, isExpectedToBeInternal bool) err
 		"find", "Interface", "name="+mgmtPortName)
 	if stdout == "" {
 		// Not found on the bridge. But could be that interface with the same name exists
-		return unconfigureMgmtNetdevicePort(mgmtPortName)
+		return unconfigureMgmtNetdevicePort(ovsClient, mgmtPortName)
 	}
 
 	// Found existing port. Check its type
@@ -625,7 +632,7 @@ func unconfigureMgmtRepresentorPort(mgmtPortName string) error {
 	return nil
 }
 
-func unconfigureMgmtNetdevicePort(mgmtPortName string) error {
+func unconfigureMgmtNetdevicePort(ovsClient libovsdbclient.Client, mgmtPortName string) error {
 	link, err := util.GetNetLinkOps().LinkByName(mgmtPortName)
 	if err != nil {
 		if !util.GetNetLinkOps().IsLinkNotFoundError(err) {
@@ -652,11 +659,14 @@ func unconfigureMgmtNetdevicePort(mgmtPortName string) error {
 	savedName := ""
 	if config.OvnKubeNode.Mode != types.NodeModeDPUHost {
 		// Get original interface name saved at OVS database
-		stdout, stderr, err := util.RunOVSVsctl("--if-exists", "get", "Open_vSwitch", ".", "external-ids:ovn-orig-mgmt-port-netdev-name")
+		ovs, err := ovsops.GetOpenvSwitch(ovsClient)
 		if err != nil {
-			klog.Warningf("Failed to get external-ds:ovn-orig-mgmt-port-netdev-name: %s", stderr)
+			if !errors.Is(err, libovsdbclient.ErrNotFound) {
+				klog.Warningf("Failed to get Open_vSwitch row: %v", err)
+			}
+		} else {
+			savedName = ovs.ExternalIDs["ovn-orig-mgmt-port-netdev-name"]
 		}
-		savedName = stdout
 	}
 
 	if savedName == "" {

--- a/go-controller/pkg/node/managementport/port_linux_test.go
+++ b/go-controller/pkg/node/managementport/port_linux_test.go
@@ -25,6 +25,8 @@ import (
 	"sigs.k8s.io/knftables"
 	anpfake "sigs.k8s.io/network-policy-api/pkg/client/clientset/versioned/fake"
 
+	libovsdbclient "github.com/ovn-kubernetes/libovsdb/client"
+
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	egressfirewallfake "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressfirewall/v1/apis/clientset/versioned/fake"
 	egressipv1fake "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressip/v1/apis/clientset/versioned/fake"
@@ -32,14 +34,17 @@ import (
 	networkqosfake "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/networkqos/v1alpha1/apis/clientset/versioned/fake"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
+	ovsops "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdb/ops/ovs"
 	nodenft "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/nftables"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/routemanager"
 	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
+	libovsdbtest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
 	mocks "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/mocks/github.com/vishvananda/netlink"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 	utilMocks "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util/mocks"
 	multinetworkmocks "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util/mocks/multinetwork"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/vswitchd"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -303,7 +308,7 @@ func testManagementPort(ctx *cli.Context, fexec *ovntest.FakeExec, testNS ns.Net
 
 		netdevName, rep := "", ""
 
-		mgmtPortController, err := NewManagementPortController(&existingNode, nodeSubnetCIDRs, netdevName, rep, rm, netInfo)
+		mgmtPortController, err := NewManagementPortController(nil, &existingNode, nodeSubnetCIDRs, netdevName, rep, rm, netInfo)
 		Expect(err).NotTo(HaveOccurred())
 		stop := make(chan struct{})
 		err = mgmtPortController.Start(stop)
@@ -405,7 +410,7 @@ func testManagementPortDPU(ctx *cli.Context, fexec *ovntest.FakeExec, testNS ns.
 
 		netdevName, rep := "pf0vf0", "pf0vf0"
 
-		mgmtPortController, err := NewManagementPortController(node, nodeSubnetCIDRs, netdevName, rep, rm, netInfo)
+		mgmtPortController, err := NewManagementPortController(nil, node, nodeSubnetCIDRs, netdevName, rep, rm, netInfo)
 		Expect(err).NotTo(HaveOccurred())
 		stop := make(chan struct{})
 		err = mgmtPortController.Start(stop)
@@ -493,7 +498,7 @@ func testManagementPortDPUHost(ctx *cli.Context, fexec *ovntest.FakeExec, testNS
 
 		netdevName, rep := "pf0vf0", ""
 
-		mgmtPortController, err := NewManagementPortController(node, nodeSubnetCIDRs, netdevName, rep, rm, netInfo)
+		mgmtPortController, err := NewManagementPortController(nil, node, nodeSubnetCIDRs, netdevName, rep, rm, netInfo)
 		Expect(err).NotTo(HaveOccurred())
 		stop := make(chan struct{})
 		err = mgmtPortController.Start(stop)
@@ -531,6 +536,10 @@ var _ = Describe("Management Port tests", func() {
 		netlinkMockErr := fmt.Errorf("netlink mock error")
 		fakeExecErr := fmt.Errorf("face exec error")
 		linkMock := &mocks.Link{}
+		var (
+			ovsClient  libovsdbclient.Client
+			ovsCleanup *libovsdbtest.Context
+		)
 
 		BeforeEach(func() {
 			Expect(config.PrepareTestConfig()).To(Succeed())
@@ -542,12 +551,20 @@ var _ = Describe("Management Port tests", func() {
 			Expect(err).NotTo(HaveOccurred())
 			util.SetNetLinkOpMockInst(netlinkOpsMock)
 			nodenft.SetFakeNFTablesHelper()
+
+			ovsClient, ovsCleanup, err = libovsdbtest.NewOVSTestHarness(libovsdbtest.TestSetup{
+				OVSData: []libovsdbtest.TestData{
+					&vswitchd.OpenvSwitch{UUID: "root-ovs"},
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		AfterEach(func() {
 			netlinkOpsMock.AssertExpectations(t)
 			Expect(execMock.CalledMatchesExpected()).To(BeTrue(), execMock.ErrorDesc)
 			util.SetNetLinkOpMockInst(origNetlinkOps)
+			ovsCleanup.Cleanup()
 		})
 
 		Context("Syncing netdevice interface", func() {
@@ -558,7 +575,7 @@ var _ = Describe("Management Port tests", func() {
 				netlinkOpsMock.On("LinkByName", mgmtPortName).Return(nil, netlinkMockErr)
 				netlinkOpsMock.On("IsLinkNotFoundError", mock.Anything).Return(false)
 
-				err := syncMgmtPortInterface(mgmtPortName, false)
+				err := syncMgmtPortInterface(ovsClient, mgmtPortName, false)
 				Expect(err).To(HaveOccurred())
 			})
 
@@ -570,7 +587,7 @@ var _ = Describe("Management Port tests", func() {
 				netlinkOpsMock.On("AddrList", linkMock, netlink.FAMILY_ALL).Return([]netlink.Addr{}, netlinkMockErr)
 				linkMock.On("Attrs").Return(&netlink.LinkAttrs{Name: netdevName})
 
-				err := syncMgmtPortInterface(mgmtPortName, false)
+				err := syncMgmtPortInterface(ovsClient, mgmtPortName, false)
 				Expect(err).To(HaveOccurred())
 			})
 
@@ -583,7 +600,7 @@ var _ = Describe("Management Port tests", func() {
 				netlinkOpsMock.On("RouteList", linkMock, netlink.FAMILY_ALL).Return([]netlink.Route{}, nil)
 				netlinkOpsMock.On("LinkSetDown", linkMock).Return(netlinkMockErr)
 
-				err := syncMgmtPortInterface(mgmtPortName, false)
+				err := syncMgmtPortInterface(ovsClient, mgmtPortName, false)
 				Expect(err).To(HaveOccurred())
 			})
 
@@ -591,34 +608,32 @@ var _ = Describe("Management Port tests", func() {
 				execMock.AddFakeCmdsNoOutputNoError([]string{
 					"ovs-vsctl --timeout=15 --no-headings --data bare --format csv --columns type,name find Interface name=" + mgmtPortName,
 				})
-				execMock.AddFakeCmd(&ovntest.ExpectedCmd{
-					Cmd:    "ovs-vsctl --timeout=15 --if-exists get Open_vSwitch . external-ids:ovn-orig-mgmt-port-netdev-name",
-					Output: netdevName,
-				})
+				Expect(ovsops.UpdateOpenvSwitchExternalIDs(ovsClient, map[string]string{
+					"ovn-orig-mgmt-port-netdev-name": netdevName,
+				})).To(Succeed())
 				netlinkOpsMock.On("LinkByName", mgmtPortName).Return(linkMock, nil)
 				netlinkOpsMock.On("AddrList", linkMock, netlink.FAMILY_ALL).Return([]netlink.Addr{}, nil)
 				netlinkOpsMock.On("RouteList", linkMock, netlink.FAMILY_ALL).Return([]netlink.Route{}, nil)
 				netlinkOpsMock.On("LinkSetDown", linkMock).Return(nil)
 				netlinkOpsMock.On("LinkSetName", linkMock, netdevName).Return(netlinkMockErr)
 
-				err := syncMgmtPortInterface(mgmtPortName, false)
+				err := syncMgmtPortInterface(ovsClient, mgmtPortName, false)
 				Expect(err).To(HaveOccurred())
 			})
 			It("Unconfigures old management port netdevice", func() {
 				execMock.AddFakeCmdsNoOutputNoError([]string{
 					"ovs-vsctl --timeout=15 --no-headings --data bare --format csv --columns type,name find Interface name=" + mgmtPortName,
 				})
-				execMock.AddFakeCmd(&ovntest.ExpectedCmd{
-					Cmd:    "ovs-vsctl --timeout=15 --if-exists get Open_vSwitch . external-ids:ovn-orig-mgmt-port-netdev-name",
-					Output: netdevName,
-				})
+				Expect(ovsops.UpdateOpenvSwitchExternalIDs(ovsClient, map[string]string{
+					"ovn-orig-mgmt-port-netdev-name": netdevName,
+				})).To(Succeed())
 				netlinkOpsMock.On("LinkByName", mgmtPortName).Return(linkMock, nil)
 				netlinkOpsMock.On("AddrList", linkMock, netlink.FAMILY_ALL).Return([]netlink.Addr{}, nil)
 				netlinkOpsMock.On("RouteList", linkMock, netlink.FAMILY_ALL).Return([]netlink.Route{}, nil)
 				netlinkOpsMock.On("LinkSetDown", linkMock).Return(nil)
 				netlinkOpsMock.On("LinkSetName", linkMock, netdevName).Return(nil)
 
-				err := syncMgmtPortInterface(mgmtPortName, false)
+				err := syncMgmtPortInterface(ovsClient, mgmtPortName, false)
 				Expect(err).ToNot(HaveOccurred())
 			})
 		})
@@ -630,7 +645,7 @@ var _ = Describe("Management Port tests", func() {
 					Output: "internal," + mgmtPortName,
 				})
 
-				err := syncMgmtPortInterface(mgmtPortName, true)
+				err := syncMgmtPortInterface(ovsClient, mgmtPortName, true)
 				Expect(err).ToNot(HaveOccurred())
 			})
 			It("Fails to remove port from the bridge", func() {
@@ -643,7 +658,7 @@ var _ = Describe("Management Port tests", func() {
 					Err: fakeExecErr,
 				})
 
-				err := syncMgmtPortInterface(mgmtPortName, false)
+				err := syncMgmtPortInterface(ovsClient, mgmtPortName, false)
 				Expect(err).To(HaveOccurred())
 			})
 
@@ -656,7 +671,7 @@ var _ = Describe("Management Port tests", func() {
 					"ovs-vsctl --timeout=15 del-port br-int " + mgmtPortName,
 				})
 
-				err := syncMgmtPortInterface(mgmtPortName, false)
+				err := syncMgmtPortInterface(ovsClient, mgmtPortName, false)
 				Expect(err).ToNot(HaveOccurred())
 			})
 		})
@@ -675,7 +690,7 @@ var _ = Describe("Management Port tests", func() {
 					Err: fakeExecErr,
 				})
 
-				err := syncMgmtPortInterface(mgmtPortName, false)
+				err := syncMgmtPortInterface(ovsClient, mgmtPortName, false)
 				Expect(err).To(HaveOccurred())
 			})
 
@@ -694,7 +709,7 @@ var _ = Describe("Management Port tests", func() {
 
 				// Return error here, so we know that function didn't returned earlier
 				netlinkOpsMock.On("LinkByName", mgmtPortName).Return(nil, netlinkMockErr)
-				err := syncMgmtPortInterface(mgmtPortName, false)
+				err := syncMgmtPortInterface(ovsClient, mgmtPortName, false)
 				Expect(err).To(HaveOccurred())
 			})
 
@@ -709,7 +724,7 @@ var _ = Describe("Management Port tests", func() {
 				})
 				netlinkOpsMock.On("LinkByName", mgmtPortName).Return(nil, netlinkMockErr)
 
-				err := syncMgmtPortInterface(mgmtPortName, false)
+				err := syncMgmtPortInterface(ovsClient, mgmtPortName, false)
 				Expect(err).To(HaveOccurred())
 			})
 
@@ -725,7 +740,7 @@ var _ = Describe("Management Port tests", func() {
 				netlinkOpsMock.On("LinkByName", mgmtPortName).Return(linkMock, nil)
 				netlinkOpsMock.On("LinkSetDown", linkMock).Return(netlinkMockErr)
 
-				err := syncMgmtPortInterface(mgmtPortName, false)
+				err := syncMgmtPortInterface(ovsClient, mgmtPortName, false)
 				Expect(err).To(HaveOccurred())
 			})
 
@@ -745,7 +760,7 @@ var _ = Describe("Management Port tests", func() {
 				netlinkOpsMock.On("LinkSetDown", linkMock).Return(nil)
 				netlinkOpsMock.On("LinkSetName", linkMock, repName).Return(netlinkMockErr)
 
-				err := syncMgmtPortInterface(mgmtPortName, false)
+				err := syncMgmtPortInterface(ovsClient, mgmtPortName, false)
 				Expect(err).To(HaveOccurred())
 			})
 
@@ -765,7 +780,7 @@ var _ = Describe("Management Port tests", func() {
 				netlinkOpsMock.On("LinkSetDown", linkMock).Return(nil)
 				netlinkOpsMock.On("LinkSetName", linkMock, repName).Return(nil)
 
-				err := syncMgmtPortInterface(mgmtPortName, false)
+				err := syncMgmtPortInterface(ovsClient, mgmtPortName, false)
 				Expect(err).ToNot(HaveOccurred())
 			})
 		})
@@ -1181,7 +1196,7 @@ var _ = Describe("Management Port tests", func() {
 		netInfo.On("GetNodeGatewayIP", hostSubnets[0]).Return(util.GetNodeGatewayIfAddr(hostSubnets[0]))
 		netInfo.On("GetNodeManagementIP", hostSubnets[0]).Return(util.GetNodeManagementIfAddr(hostSubnets[0]))
 		It("Creates managementPort by default", func() {
-			mgmtPort, err := NewManagementPortController(node, hostSubnets, netdevName, rep, nil, netInfo)
+			mgmtPort, err := NewManagementPortController(nil, node, hostSubnets, netdevName, rep, nil, netInfo)
 			Expect(err).NotTo(HaveOccurred())
 			mgmtPortImpl := mgmtPort.(*managementPortController)
 			Expect(mgmtPortImpl.ports[ovsPort]).ToNot(BeNil())
@@ -1190,7 +1205,7 @@ var _ = Describe("Management Port tests", func() {
 		})
 		It("Creates managementPortRepresentor for Ovnkube Node mode dpu", func() {
 			config.OvnKubeNode.Mode = types.NodeModeDPU
-			mgmtPort, err := NewManagementPortController(node, hostSubnets, netdevName, rep, nil, netInfo)
+			mgmtPort, err := NewManagementPortController(nil, node, hostSubnets, netdevName, rep, nil, netInfo)
 			Expect(err).NotTo(HaveOccurred())
 			mgmtPortImpl := mgmtPort.(*managementPortController)
 			Expect(mgmtPortImpl.ports[ovsPort]).To(BeNil())
@@ -1201,7 +1216,7 @@ var _ = Describe("Management Port tests", func() {
 		})
 		It("Creates managementPortNetdev for Ovnkube Node mode dpu-host", func() {
 			config.OvnKubeNode.Mode = types.NodeModeDPUHost
-			mgmtPort, err := NewManagementPortController(node, hostSubnets, netdevName, rep, nil, netInfo)
+			mgmtPort, err := NewManagementPortController(nil, node, hostSubnets, netdevName, rep, nil, netInfo)
 			Expect(err).NotTo(HaveOccurred())
 			mgmtPortImpl := mgmtPort.(*managementPortController)
 			Expect(mgmtPortImpl.ports[ovsPort]).To(BeNil())
@@ -1212,7 +1227,7 @@ var _ = Describe("Management Port tests", func() {
 		})
 		It("Creates managementPortNetdev and managementPortRepresentor for Ovnkube Node mode full", func() {
 			config.OvnKubeNode.MgmtPortNetdev = netdevName
-			mgmtPort, err := NewManagementPortController(node, hostSubnets, netdevName, rep, nil, netInfo)
+			mgmtPort, err := NewManagementPortController(nil, node, hostSubnets, netdevName, rep, nil, netInfo)
 			Expect(err).NotTo(HaveOccurred())
 			mgmtPortImpl := mgmtPort.(*managementPortController)
 			Expect(mgmtPortImpl.ports[ovsPort]).To(BeNil())

--- a/go-controller/pkg/node/managementport/port_linux_test.go
+++ b/go-controller/pkg/node/managementport/port_linux_test.go
@@ -550,6 +550,9 @@ var _ = Describe("Management Port tests", func() {
 			err := util.SetExec(execMock)
 			Expect(err).NotTo(HaveOccurred())
 			util.SetNetLinkOpMockInst(netlinkOpsMock)
+			// Restore global netlink ops unconditionally — registered here so a
+			// failing assertion in AfterEach cannot leak the mock to other specs.
+			DeferCleanup(func() { util.SetNetLinkOpMockInst(origNetlinkOps) })
 			nodenft.SetFakeNFTablesHelper()
 
 			ovsClient, ovsCleanup, err = libovsdbtest.NewOVSTestHarness(libovsdbtest.TestSetup{
@@ -558,13 +561,12 @@ var _ = Describe("Management Port tests", func() {
 				},
 			})
 			Expect(err).NotTo(HaveOccurred())
+			DeferCleanup(func() { ovsCleanup.Cleanup() })
 		})
 
 		AfterEach(func() {
 			netlinkOpsMock.AssertExpectations(t)
 			Expect(execMock.CalledMatchesExpected()).To(BeTrue(), execMock.ErrorDesc)
-			util.SetNetLinkOpMockInst(origNetlinkOps)
-			ovsCleanup.Cleanup()
 		})
 
 		Context("Syncing netdevice interface", func() {

--- a/go-controller/pkg/node/node_ip_handler_linux.go
+++ b/go-controller/pkg/node/node_ip_handler_linux.go
@@ -17,9 +17,12 @@ import (
 	"k8s.io/klog/v2"
 	utilnet "k8s.io/utils/net"
 
+	libovsdbclient "github.com/ovn-kubernetes/libovsdb/client"
+
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
+	ovsops "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdb/ops/ovs"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/bridgeconfig"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/managementport"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
@@ -32,6 +35,7 @@ type addressManager struct {
 	cidrs         sets.Set[string]
 	nodeAnnotator kube.Annotator
 	mgmtPort      managementport.Interface
+	ovsClient     libovsdbclient.Client
 	// useNetlink indicates the addressManager should use machine
 	// information from netlink. Set to false for testcases.
 	useNetlink bool
@@ -45,20 +49,21 @@ type addressManager struct {
 }
 
 // initializes a new address manager which will hold all the IPs on a node
-func newAddressManager(nodeName string, k kube.Interface, mgmtPort managementport.Interface, watchFactory factory.NodeWatchFactory, gwBridge *bridgeconfig.BridgeConfiguration) *addressManager {
-	return newAddressManagerInternal(nodeName, k, mgmtPort, watchFactory, gwBridge, true)
+func newAddressManager(nodeName string, k kube.Interface, mgmtPort managementport.Interface, watchFactory factory.NodeWatchFactory, gwBridge *bridgeconfig.BridgeConfiguration, ovsClient libovsdbclient.Client) *addressManager {
+	return newAddressManagerInternal(nodeName, k, mgmtPort, watchFactory, gwBridge, ovsClient, true)
 }
 
 // newAddressManagerInternal creates a new address manager; this function is
 // only expose for testcases to disable netlink subscription to ensure
 // reproducibility of unit tests.
-func newAddressManagerInternal(nodeName string, k kube.Interface, mgmtPort managementport.Interface, watchFactory factory.NodeWatchFactory, gwBridge *bridgeconfig.BridgeConfiguration, useNetlink bool) *addressManager {
+func newAddressManagerInternal(nodeName string, k kube.Interface, mgmtPort managementport.Interface, watchFactory factory.NodeWatchFactory, gwBridge *bridgeconfig.BridgeConfiguration, ovsClient libovsdbclient.Client, useNetlink bool) *addressManager {
 	mgr := &addressManager{
 		nodeName:      nodeName,
 		watchFactory:  watchFactory,
 		cidrs:         sets.New[string](),
 		mgmtPort:      mgmtPort,
 		gatewayBridge: gwBridge,
+		ovsClient:     ovsClient,
 		OnChanged:     func() {},
 		useNetlink:    useNetlink,
 		syncPeriod:    30 * time.Second,
@@ -527,41 +532,26 @@ func (c *addressManager) getPrimaryHostEgressIPs() (sets.Set[string], error) {
 
 // updateOVNEncapIPAndReconnect updates encap IP to OVS when the node primary IP changed.
 func (c *addressManager) updateOVNEncapIPAndReconnect(newIP net.IP) {
-	checkCmd := []string{
-		"get",
-		"Open_vSwitch",
-		".",
-		"external_ids:ovn-encap-ip",
-	}
-	encapIP, stderr, err := util.RunOVSVsctl(checkCmd...)
+	ovs, err := ovsops.GetOpenvSwitch(c.ovsClient)
 	if err != nil {
-		klog.Warningf("Unable to retrieve configured ovn-encap-ip from OVS: %v, %q", err, stderr)
-	} else {
-		encapIP = strings.TrimSuffix(encapIP, "\n")
-		if len(encapIP) > 0 && newIP.String() == encapIP {
-			klog.V(4).Infof("Will not update encap IP %s - it is already configured", newIP.String())
-			return
-		}
+		klog.Warningf("Unable to retrieve configured ovn-encap-ip from OVS: %v", err)
+	} else if encapIP := ovs.ExternalIDs["ovn-encap-ip"]; encapIP != "" && newIP.String() == encapIP {
+		klog.V(4).Infof("Will not update encap IP %s - it is already configured", newIP.String())
+		return
 	}
 
 	config.Default.EffectiveEncapIP = newIP.String()
-	confCmd := []string{
-		"set",
-		"Open_vSwitch",
-		".",
-		fmt.Sprintf("external_ids:ovn-encap-ip=%s", newIP),
-	}
-
-	_, stderr, err = util.RunOVSVsctl(confCmd...)
-	if err != nil {
-		klog.Errorf("Error setting OVS encap IP %s: %v %q", newIP.String(), err, stderr)
+	if err := ovsops.UpdateOpenvSwitchExternalIDs(c.ovsClient, map[string]string{
+		"ovn-encap-ip": newIP.String(),
+	}); err != nil {
+		klog.Errorf("Error setting OVS encap IP %s: %v", newIP.String(), err)
 		return
 	}
 
 	// force ovn-controller to reconnect SB with new encap IP immediately.
 	// otherwise there will be a max delay of 200s due to the 100s
 	// ovn-controller inactivity probe.
-	_, stderr, err = util.RunOVNAppctlWithTimeout(5, "-t", "ovn-controller", "exit", "--restart")
+	_, stderr, err := util.RunOVNAppctlWithTimeout(5, "-t", "ovn-controller", "exit", "--restart")
 	if err != nil {
 		klog.Errorf("Failed to exit ovn-controller %v %q", err, stderr)
 		return

--- a/go-controller/pkg/node/node_ip_handler_linux.go
+++ b/go-controller/pkg/node/node_ip_handler_linux.go
@@ -532,29 +532,33 @@ func (c *addressManager) getPrimaryHostEgressIPs() (sets.Set[string], error) {
 
 // updateOVNEncapIPAndReconnect updates encap IP to OVS when the node primary IP changed.
 func (c *addressManager) updateOVNEncapIPAndReconnect(newIP net.IP) {
+	alreadyConfigured := false
 	ovs, err := ovsops.GetOpenvSwitch(c.ovsClient)
 	if err != nil {
 		klog.Warningf("Unable to retrieve configured ovn-encap-ip from OVS: %v", err)
 	} else if encapIP := ovs.ExternalIDs["ovn-encap-ip"]; encapIP != "" && newIP.String() == encapIP {
 		klog.V(4).Infof("Will not update encap IP %s - it is already configured", newIP.String())
-		return
+		alreadyConfigured = true
 	}
 
+	if !alreadyConfigured {
+		if err := ovsops.UpdateOpenvSwitchExternalIDs(c.ovsClient, map[string]string{
+			"ovn-encap-ip": newIP.String(),
+		}); err != nil {
+			klog.Errorf("Error setting OVS encap IP %s: %v", newIP.String(), err)
+			return
+		}
+	}
 	config.Default.EffectiveEncapIP = newIP.String()
-	if err := ovsops.UpdateOpenvSwitchExternalIDs(c.ovsClient, map[string]string{
-		"ovn-encap-ip": newIP.String(),
-	}); err != nil {
-		klog.Errorf("Error setting OVS encap IP %s: %v", newIP.String(), err)
-		return
-	}
 
-	// force ovn-controller to reconnect SB with new encap IP immediately.
-	// otherwise there will be a max delay of 200s due to the 100s
-	// ovn-controller inactivity probe.
-	_, stderr, err := util.RunOVNAppctlWithTimeout(5, "-t", "ovn-controller", "exit", "--restart")
-	if err != nil {
-		klog.Errorf("Failed to exit ovn-controller %v %q", err, stderr)
-		return
+	if !alreadyConfigured {
+		// force ovn-controller to reconnect SB with new encap IP immediately.
+		// otherwise there will be a max delay of 200s due to the 100s
+		// ovn-controller inactivity probe. Best-effort: still let the
+		// annotation below converge on failure.
+		if _, stderr, err := util.RunOVNAppctlWithTimeout(5, "-t", "ovn-controller", "exit", "--restart"); err != nil {
+			klog.Errorf("Failed to exit ovn-controller %v %q", err, stderr)
+		}
 	}
 
 	// Update node-encap-ips annotation

--- a/go-controller/pkg/node/node_ip_handler_linux_test.go
+++ b/go-controller/pkg/node/node_ip_handler_linux_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/containernetworking/plugins/pkg/testutils"
-	libovsdbclient "github.com/ovn-kubernetes/libovsdb/client"
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
 
@@ -18,6 +17,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
+
+	libovsdbclient "github.com/ovn-kubernetes/libovsdb/client"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"

--- a/go-controller/pkg/node/node_ip_handler_linux_test.go
+++ b/go-controller/pkg/node/node_ip_handler_linux_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/containernetworking/plugins/pkg/testutils"
+	libovsdbclient "github.com/ovn-kubernetes/libovsdb/client"
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
 
@@ -24,13 +25,28 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/bridgeconfig"
 	nodenft "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/nftables"
 	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
+	libovsdbtest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
 	nodemocks "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/mocks/github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node"
 	ovntypes "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/vswitchd"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
+
+// newTestOVSClient starts an in-memory OVSDB harness seeded with an empty
+// Open_vSwitch root row so tests that wire an addressManager have a real
+// libovsdb client. Mirrors the pattern used in pkg/metrics/ovs_test.go.
+func newTestOVSClient() (libovsdbclient.Client, *libovsdbtest.Context) {
+	client, ctx, err := libovsdbtest.NewOVSTestHarness(libovsdbtest.TestSetup{
+		OVSData: []libovsdbtest.TestData{
+			&vswitchd.OpenvSwitch{UUID: "root-ovs"},
+		},
+	})
+	Expect(err).NotTo(HaveOccurred())
+	return client, ctx
+}
 
 func ipEvent(ipStr string, isAdd bool, addrChan chan netlink.AddrUpdate) *net.IPNet {
 	ipNet := ovntest.MustParseIPNet(ipStr)
@@ -60,6 +76,7 @@ type testCtx struct {
 	mgmtPortIP4  *net.IPNet
 	mgmtPortIP6  *net.IPNet
 	subscribed   uint32
+	ovsCleanup   *libovsdbtest.Context
 }
 
 var _ = Describe("Node IP Handler event tests", func() {
@@ -78,10 +95,6 @@ var _ = Describe("Node IP Handler event tests", func() {
 		// Restore global default values before each testcase
 		Expect(config.PrepareTestConfig()).To(Succeed())
 		fexec := ovntest.NewFakeExec()
-		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-			Cmd:    "ovs-vsctl --timeout=15 get Open_vSwitch . external_ids:ovn-encap-ip",
-			Output: "10.1.1.10",
-		})
 		Expect(util.SetExec(fexec)).ShouldNot(HaveOccurred())
 		useNetlink := false
 		tc = configureKubeOVNContext(nodeName, useNetlink)
@@ -109,6 +122,7 @@ var _ = Describe("Node IP Handler event tests", func() {
 		close(tc.stopCh)
 		tc.doneWg.Wait()
 		tc.watchFactory.Shutdown()
+		tc.ovsCleanup.Cleanup()
 		close(tc.addrChan)
 		util.ResetRunner()
 	})
@@ -191,10 +205,6 @@ var _ = Describe("Node IP Handler tests", func() {
 
 	BeforeEach(func() {
 		fexec := ovntest.NewFakeExec()
-		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-			Cmd:    "ovs-vsctl --timeout=15 get Open_vSwitch . external_ids:ovn-encap-ip",
-			Output: dummyBrInternalIPv4,
-		})
 		Expect(util.SetExec(fexec)).ShouldNot(HaveOccurred())
 		// Restore global default values before each testcase
 		Expect(config.PrepareTestConfig()).To(Succeed())
@@ -208,6 +218,7 @@ var _ = Describe("Node IP Handler tests", func() {
 		close(tc.stopCh)
 		tc.doneWg.Wait()
 		tc.watchFactory.Shutdown()
+		tc.ovsCleanup.Cleanup()
 		Expect(tc.ns.Close()).ShouldNot(HaveOccurred())
 		util.ResetRunner()
 	})
@@ -404,7 +415,14 @@ func configureKubeOVNContext(nodeName string, useNetlink bool) *testCtx {
 
 	fakeBridgeConfiguration := bridgeconfig.TestBridgeConfig("breth0")
 
+	// Skip the encap-update path inside addressManager.sync() — these tests
+	// don't fake ovn-appctl and aren't exercising encap reconciliation.
+	config.Default.EncapIP = "test-encap-ip"
+
+	ovsClient, ovsCleanup := newTestOVSClient()
+	tc.ovsCleanup = ovsCleanup
+
 	k := &kube.Kube{KClient: tc.fakeClient}
-	tc.ipManager = newAddressManagerInternal(nodeName, k, mpmock, tc.watchFactory, fakeBridgeConfiguration, useNetlink)
+	tc.ipManager = newAddressManagerInternal(nodeName, k, mpmock, tc.watchFactory, fakeBridgeConfiguration, ovsClient, useNetlink)
 	return tc
 }

--- a/go-controller/pkg/node/user_defined_node_network_controller_test.go
+++ b/go-controller/pkg/node/user_defined_node_network_controller_test.go
@@ -20,6 +20,8 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/utils/ptr"
 
+	libovsdbclient "github.com/ovn-kubernetes/libovsdb/client"
+
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	udnfakeclient "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/userdefinednetwork/v1/apis/clientset/versioned/fake"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
@@ -32,6 +34,7 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/routemanager"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/vrfmanager"
 	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
+	libovsdbtest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
 	coreinformermocks "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/mocks/k8s.io/client-go/informers/core/v1"
 	v1mocks "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/mocks/k8s.io/client-go/listers/core/v1"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
@@ -175,10 +178,16 @@ var _ = Describe("UserDefinedNodeNetworkController: UserDefinedPrimaryNetwork Ga
 		kubeMock         kubemocks.Interface
 		v4NodeIP         = "192.168.1.10/24"
 		v6NodeIP         = "fc00:f853:ccd:e793::3/64"
+		ovsClient        libovsdbclient.Client
+		ovsCleanup       *libovsdbtest.Context
 	)
 	BeforeEach(func() {
 		// Restore global default values before each testcase
 		Expect(config.PrepareTestConfig()).To(Succeed())
+		// Skip the encap-update path inside addressManager.sync() — these tests
+		// don't fake ovn-appctl and aren't exercising encap reconciliation.
+		config.Default.EncapIP = "test-encap-ip"
+		ovsClient, ovsCleanup = newTestOVSClient()
 		// Use a larger masq subnet to allow OF manager to allocate IPs for UDNs.
 		config.Gateway.V6MasqueradeSubnet = "fd69::/112"
 		config.Gateway.V4MasqueradeSubnet = "169.254.0.0/17"
@@ -255,6 +264,7 @@ var _ = Describe("UserDefinedNodeNetworkController: UserDefinedPrimaryNetwork Ga
 	AfterEach(func() {
 		close(stopCh)
 		wg.Wait()
+		ovsCleanup.Cleanup()
 		Expect(testNS.Close()).To(Succeed())
 		Expect(testutils.UnmountNS(testNS)).To(Succeed())
 		util.ResetRunner()
@@ -402,6 +412,7 @@ var _ = Describe("UserDefinedNodeNetworkController: UserDefinedPrimaryNetwork Ga
 				nil,
 				networkmanager.Default().Interface(),
 				config.GatewayModeLocal,
+				ovsClient,
 			)
 			Expect(err).NotTo(HaveOccurred())
 			stop := make(chan struct{})

--- a/go-controller/pkg/node/user_defined_node_network_controller_test.go
+++ b/go-controller/pkg/node/user_defined_node_network_controller_test.go
@@ -366,7 +366,7 @@ var _ = Describe("UserDefinedNodeNetworkController: UserDefinedPrimaryNetwork Ga
 		mgtPortMAC = util.IPAddrToHWAddr(util.GetNodeManagementIfAddr(ipNet).IP).String()
 		// Make Management port
 		nodeSubnets := ovntest.MustParseIPNets(v4NodeSubnet, v6NodeSubnet)
-		mp, err := managementport.NewManagementPortController(node, nodeSubnets, "", "", routeManager, NetInfo)
+		mp, err := managementport.NewManagementPortController(ovsClient, node, nodeSubnets, "", "", routeManager, NetInfo)
 		Expect(err).NotTo(HaveOccurred())
 
 		err = testNS.Do(func(ns.NetNS) error {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->
Merge conflict resolutions:
  
  Commit 1: 8d8c6fefb94d6ed0d846265d3f8de5c02cb1a402 — libovsdb/ops: Add UpdateOpenvSwitchExternalIDs
  - Import path fixes (ovn-kubernetes/ovn-kubernetes → ovn-org/ovn-kubernetes) in model.go, ovs/openvswitch.go, vswitchdb.go, vswitchdb_test.go
  - Dropped SPDX license headers not present in 4.20

  Commit 2: 5eb1b7f6e48ac7fd4294e98127501c985fd44324 — node: migrate ovn-encap-ip update to libovsdb
  - Import path fixes across all files
  - Replaced config.IsModeDPU()/IsModeFull()/IsModeDPUHost() helpers with direct config.OvnKubeNode.Mode comparisons (helpers don't exist in 4.20)
  - Replaced nc.masqReconciler.ensure() with explicit masquerade calls (setNodeMasqueradeIPOnExtBridge, addMasqueradeRoute, configureSvcRouteViaInterface, addHostMACBindings)
  - Kept older updateServiceFlowCache/createLbAndExternalSvcFlows signatures without localEndpoints parameter
  - Reverted addressManager to OnChanged callback (upstream's OnMasqueradeIPChanged + onAddressesChangedHandlers not in 4.20)
  - Tests: NFT rules use format-string constants, sysctl paths use . separators, ovs-appctl --timeout=15 style, added OCP HACK MCS blocking rules
  - Tests: removed SetupMockOVSPidFile() calls, masqueradeReconciler suite, masquerade IP test cases, "should handle gateway delete idempotently" UDN test
  - Tests: fixed initFakeNodePortWatcher signatures, changed mgmtportmock.Interface → nodemocks.ManagementPort
  - Dropped SPDX license headers not present in 4.20

  Commit 3: 702a058b81a5ca0c247f53d00993a0303b41ad32 — libovsdb/ops: add RemoveOpenvSwitchExternalIDs
  - Import path fixes in ovs/openvswitch.go, vswitchdb.go, vswitchdb_test.go

  Commit 4: e10b37541a0fca4bdcc0dbe408d8054c2c4e03f7 — node: migrate CleanupClusterNode chain to libovsdb
  - Import path fixes across ovnkube.go, gateway_init.go, gateway_localnet.go, gateway_shared_intf.go
  - Removed DPU Host Mode checks from cleanup functions
  - CleanupClusterNode kept without stopChan parameter (4.20 uses RunOVSVsctl, not libovsdb client)
  - Retained 4.20's simpler metrics setup (no combineMetricsEndpoints/MetricServerOptions)
  - Kept OCP HACK for pod-name-based identity in determineOvnkubeRunMode
  - Same masquerade and gateway_shared_intf.go signature differences as commit 2

  Commit 5: 9a13fc28ab64bec6ec4abf56ff4ff166803513d1 — node/bridgeconfig: migrate bridgedGatewayNodeSetup to libovsdb
  - Import path fixes across bridgeconfig.go, gateway.go, gateway_init_linux_test.go, gateway_shared_intf.go, gateway_udn_test.go
  - bridgeconfig.go: SetOfPorts() instead of upstream's ConfigureBridgePorts(), removed DPU host gateway representor/VLAN blocks, used 4.20's GetDPUHostInterface()/GetRepresentorPeerMacAddress() instead of
  GetDPUOps(), inline RunSysctl() with . separators instead of SetforwardingModeForInterface(), removed canHandleBridgeEgressIP()
  - Same test and gateway_shared_intf.go differences as commit 2

  Commit 6: 8386a5a3277e9e573c25a16f41210064af597ee8 — node/bridgeconfig: add UDN test coverage for libovsdb migration
  - Import path fixes in gateway_init_linux_test.go, gateway_udn_test.go
  - Same test infrastructure differences carried forward (NFT format strings, sysctl . separators, ovs-appctl --timeout=15)

  Commit 7: 9adfa32713d28b837e304b76a68ffa7a7f22f8f4 — node/managementport: migrate root-row sites to libovsdb
  - Import path fixes across 9 files
  - default_node_network_controller.go: removed dpuNodeLeaseManager/masqReconciler fields, retained device-plugin resource handling functions removed upstream, used 4.20's management port annotation style
  (GetDeviceIDFromNetdevice/GetVfIndexByPciAddress) instead of GetDPUOps().ResolveDeviceDetails(), manual PID/ctl-socket ovn-controller check instead of RunOVNControllerAppCtl()
  - port_linux.go: netdevDevName (interface name) instead of deviceID (PCI address), direct LinkByName instead of findNetdevByDeviceID(), inline link configuration instead of bringupManagementPortLink()
  - port_dpu_linux.go: inline link setup and RunOVSVsctl instead of helpers, retained DPDK datapath type handling, removed OvnManagementPortNameExternalID
  - Tests: removed DPU host reconcile context, replaced 6 device-ID test cases with 2 netdev-name cases, removed masquerade/DPU-host-event test blocks, removed deleteStaleManagementPortFakeCommands calls, It
  instead of OnSupportedPlatformsIt

  Commit 8: e69b6d3524ad71c8fbe7891e3e9bd9fbccbc958a — node: harden OVS cleanup state handling
  - Import path fixes across ovnkube.go, gateway_init.go, gateway_localnet.go, gateway_shared_intf.go, port_linux_test.go, node_ip_handler_linux.go
  - Same 4.20 adaptations carried forward: mode helper replacements, simpler metrics, explicit masquerade calls
  - node_ip_handler_linux.go: OnChanged instead of OnMasqueradeIPChanged, delAddr kept with linkIndex parameter
  - gateway_init.go: DelLegacyMgtPortIptRules/CleanupNFTables called unconditionally (upstream gates behind DPU mode check)

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code does not require changes to the documentation
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] My code does not require tests
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
