### PR TITLE
[release-4.18] OCPBUGS-93966: Dockerfile: Unpin libreswan to pick up CVE-2026-12413 fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN INSTALL_PKGS=" \
 	openssl firewalld-filesystem \
 	libpcap iproute iproute-tc strace \
 	tcpdump iputils \
-	libreswan-4.6-3.el9_0.3 \
+	libreswan \
 	ethtool conntrack-tools \
 	openshift-clients \
 	" && \


### PR DESCRIPTION
## 📑 Description

Unpin `libreswan-4.6-3.el9_0.3` → `libreswan` to pick up the CVE-2026-12413 fix.

**CVE-2026-12413** (CVSS 7.5 HIGH): An invalidly formatted IKEv2 fragment causes
the libreswan pluto daemon to crash and restart — a denial of service.
Affects libreswan 4.6 through 5.3.

The pin to `4.6-3.el9_0.3` was introduced in [OCPBUGS-45096](https://redhat.atlassian.net/browse/OCPBUGS-45096)
to work around regressions in libreswan-4.9 affecting **containerized IPsec on
OCP 4.14 only**. Since OCP 4.15, IPsec has moved to the host (RHCOS), so this
pin is no longer needed. The `release-4.19` branch already has libreswan unpinned.

Removing the pin allows the container to consume the latest libreswan from the
base image, which includes the CVE fix (RHSA-2026:46397 → `libreswan-4.15-10.el9_8`).

## Additional Information for reviewers

- The pin was explicitly scoped to 4.14 only per OCPBUGS-45096
- IPsec is host-based since 4.15 — the container's libreswan is not the critical IPsec engine
- `release-4.19` already runs with unpinned libreswan without issues
- Same change submitted for 4.15, 4.16, and 4.17

## ✅ Checks
- [x] My code does not require changes to the documentation
- [x] My code does not require tests
- [ ] All the tests have passed in the CI