### PR TITLE
Prevent duplicate MAC responses during egress IP failover with nftables

### DIFF
--- a/go-controller/pkg/controllermanager/node_controller_manager.go
+++ b/go-controller/pkg/controllermanager/node_controller_manager.go
@@ -6,6 +6,7 @@ package controllermanager
 import (
 	"context"
 	"fmt"
+	"net"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -13,6 +14,7 @@ import (
 
 	v1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 
+	"k8s.io/apimachinery/pkg/labels"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -480,6 +482,12 @@ waitForControllerSyncLoop:
 	}
 	// end workaround
 
+	// Cleanup stale nftables from previous shutdown. Critical for container restarts where
+	// nftables state persists and would block ARP responses for reassigned egress IPs.
+	if err := node.CleanupEgressIPARPBlockNFTTable(ctx); err != nil {
+		return fmt.Errorf("failed to cleanup egress IP ARP/NDP block table: %v", err)
+	}
+
 	return nil
 }
 
@@ -496,6 +504,23 @@ func (ncm *NodeControllerManager) Stop(isOVNKubeControllerSyncd *atomic.Bool) {
 
 	if ncm.defaultNodeNetworkController != nil {
 		if isOVNKubeControllerSyncd != nil && ncm.defaultNodeNetworkController.Gateway != nil {
+			// Upon node reboot, egressIP reassignment happens after healthcheck fails. After reassignment of
+			// EIP, new egressIPNode sends GARP and old egressIPNode can respond with unicast ARP if either
+			// EIP is still attached to interface or ovs-vswitchd is still running(SNAT in GR creates lflow to
+			// respond to such ARP requests). addEgressIPARPBlockRules takes care of this scenario. On the other
+			// hand SetDefaultBridgeGARPDropFlows makes sure that GARP packets coming from br-int bridge is dropped
+			// except for node IPs and makes sure that OVN database has synced at least once so that SNATs gets removed.
+			assignedIPs, err := ncm.getAssignedEgressIPs()
+			if err != nil {
+				klog.Errorf("Failed to get assigned Egress IPs during shutdown: %v", err)
+			}
+
+			if len(assignedIPs) > 0 {
+				if err := ncm.addEgressIPARPBlockRules(assignedIPs); err != nil {
+					klog.Errorf("Failed to add egress IP ARP block rules during shutdown: %v", err)
+				}
+			}
+
 			ncm.defaultNodeNetworkController.Gateway.SetDefaultBridgeGARPDropFlows(true)
 			if err := ncm.defaultNodeNetworkController.Gateway.Reconcile(); err != nil {
 				klog.Errorf("Failed to reconcile gateway after attempting to add flows to the external bridge to drop GARPs: %v", err)
@@ -558,6 +583,57 @@ func (ncm *NodeControllerManager) checkForStaleOVSPodInterfaces() {
 			}
 		}
 	}
+}
+
+// getAssignedEgressIPs returns IP addresses of all Egress IPs assigned to this node
+func (ncm *NodeControllerManager) getAssignedEgressIPs() ([]string, error) {
+	// Use informer lister for cached access (doesn't hit API server)
+	egressIPLister := ncm.watchFactory.EgressIPInformer().Lister()
+
+	// List all EgressIP resources from cache
+	egressIPs, err := egressIPLister.List(labels.Everything())
+	if err != nil {
+		return nil, fmt.Errorf("failed to list EgressIPs from cache: %w", err)
+	}
+
+	// Filter for EgressIPs assigned to this node and extract IP addresses
+	var assignedIPs []string
+	for _, eip := range egressIPs {
+		for _, status := range eip.Status.Items {
+			if status.Node == ncm.name {
+				ip := net.ParseIP(status.EgressIP)
+				if ip != nil {
+					assignedIPs = append(assignedIPs, ip.String())
+					klog.V(5).Infof("Found Egress IP %s (IP: %s) assigned to this node", eip.Name, status.EgressIP)
+				} else {
+					klog.Warningf("Invalid Egress IP format in status: %s", status.EgressIP)
+				}
+				break // Move to next EgressIP resource
+			}
+		}
+	}
+
+	klog.V(5).Infof("Found %d Egress IPs assigned to node %s", len(assignedIPs), ncm.name)
+	return assignedIPs, nil
+}
+
+// addEgressIPARPBlockRules adds nftables rules to block ARP/NDP requests for egress IPs
+// during graceful shutdown. This prevents duplicate MAC responses during migration.
+func (ncm *NodeControllerManager) addEgressIPARPBlockRules(egressIPs []string) error {
+	if len(egressIPs) == 0 {
+		klog.V(5).Info("No egress IPs to add ARP block rules for")
+		return nil
+	}
+
+	klog.Infof("Adding nftables ARP/NDP block rules for %d egress IPs during shutdown", len(egressIPs))
+
+	uplinkName := ncm.defaultNodeNetworkController.Gateway.GetUplinkName()
+	if err := node.SetupEgressIPARPBlockNFTables(egressIPs, uplinkName); err != nil {
+		return fmt.Errorf("failed to setup egress IP ARP block nftables: %w", err)
+	}
+
+	klog.Infof("Successfully added nftables ARP/NDP block rules for %d egress IPs", len(egressIPs))
+	return nil
 }
 
 // checkForStaleOVSInternalPorts checks for OVS internal ports without any ofport assigned,

--- a/go-controller/pkg/node/gateway.go
+++ b/go-controller/pkg/node/gateway.go
@@ -40,6 +40,7 @@ type Gateway interface {
 	Start() error
 	GetGatewayBridgeIface() string
 	GetGatewayIface() string
+	GetUplinkName() string
 	SetDefaultGatewayBridgeMAC(addr net.HardwareAddr)
 	SetDefaultPodNetworkAdvertised(bool)
 	SetDefaultBridgeGARPDropFlows(bool)
@@ -512,6 +513,14 @@ func (g *gateway) GetDefaultPodNetworkAdvertised() bool {
 		return false
 	}
 	return g.openflowManager.defaultBridge.GetNetworkConfig(types.DefaultNetworkName).Advertised.Load()
+}
+
+// GetUplinkName returns the physical uplink interface name
+func (g *gateway) GetUplinkName() string {
+	if config.IsModeDPUHost() {
+		return ""
+	}
+	return g.openflowManager.defaultBridge.GetUplinkName()
 }
 
 // SetDefaultBridgeGARPDropFlows will enable flows to drop GARPs if the openflow

--- a/go-controller/pkg/node/nftables/helpers.go
+++ b/go-controller/pkg/node/nftables/helpers.go
@@ -13,8 +13,10 @@ import (
 )
 
 const OVNKubernetesNFTablesName = "ovn-kubernetes"
+const OVNKubernetesEgressIPNFTablesName = "ovn-kubernetes-egressip"
 
 var nftHelper knftables.Interface
+var nftEgressIPHelper knftables.Interface
 
 // SetFakeNFTablesHelper creates a fake knftables.Interface
 func SetFakeNFTablesHelper() *knftables.Fake {
@@ -45,6 +47,30 @@ func GetNFTablesHelper() (knftables.Interface, error) {
 		nftHelper = nft
 	}
 	return nftHelper, nil
+}
+
+// SetFakeEgressIPNFTablesHelper creates a fake knftables.Interface for egress IP with NetDev family
+func SetFakeEgressIPNFTablesHelper() *knftables.Fake {
+	fake := knftables.NewFake(knftables.NetDevFamily, OVNKubernetesEgressIPNFTablesName)
+	tx := fake.NewTransaction()
+	tx.Add(&knftables.Table{})
+	_ = fake.Run(context.TODO(), tx)
+
+	nftEgressIPHelper = fake
+	return fake
+}
+
+// GetEgressIPNFTablesHelper returns a knftables.Interface for egress IP with NetDev family.
+// If SetFakeEgressIPNFTablesHelper has not been called, it will create a "real" knftables.Interface
+func GetEgressIPNFTablesHelper() (knftables.Interface, error) {
+	if nftEgressIPHelper == nil {
+		nft, err := knftables.New(knftables.NetDevFamily, OVNKubernetesEgressIPNFTablesName)
+		if err != nil {
+			return nil, err
+		}
+		nftEgressIPHelper = nft
+	}
+	return nftEgressIPHelper, nil
 }
 
 // CleanupNFTables cleans up all ovn-kubernetes NFTables data, on ovnkube-node daemonset

--- a/go-controller/pkg/node/node_nftables.go
+++ b/go-controller/pkg/node/node_nftables.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 
+	"k8s.io/klog/v2"
 	utilnet "k8s.io/utils/net"
 	"sigs.k8s.io/knftables"
 
@@ -16,6 +17,7 @@ import (
 )
 
 const nftPMTUDChain = "no-pmtud"
+const nftEgressIPDropChain = "egressip-drop"
 
 // setupRemoteNodeNFTSets sets up the NFT sets that contain remote Kubernetes node IPs
 func setupRemoteNodeNFTSets() error {
@@ -202,5 +204,124 @@ func setupPMTUDNFTChain() error {
 	if err != nil {
 		return fmt.Errorf("could not update nftables rule for PMTUD: %v", err)
 	}
+	return nil
+}
+
+// SetupEgressIPARPBlockNFTables sets up nftables for blocking ARP/NDP responses for egress IPs during
+// graceful shutdown. Uses netdev family with ingress hook on the physical uplink interface to intercept
+// packets before they reach the OVS bridge, preventing OVN from responding to ARP/NDP requests.
+func SetupEgressIPARPBlockNFTables(egressIPs []string, uplinkName string) error {
+	if len(egressIPs) == 0 {
+		klog.V(5).Info("No egress IPs to setup ARP block rules for")
+		return nil
+	}
+
+	if uplinkName == "" {
+		return fmt.Errorf("uplink interface name is required for netdev nftables rules")
+	}
+
+	var ipv4Addrs, ipv6Addrs []string
+	for _, ipStr := range egressIPs {
+		if !utilnet.IsIPv6String(ipStr) {
+			ipv4Addrs = append(ipv4Addrs, ipStr)
+		} else {
+			ipv6Addrs = append(ipv6Addrs, ipStr)
+		}
+	}
+
+	// There are two entity which can reply to ARP broadcast messages:
+	// - EgressIP attached to bridge interface
+	// - SNAT rules at gateway router
+	// netdev table family in nftables evaluates network packets very early and before reaches bridge interface. Any other
+	// table family can cause ARP response until ovs-vswitchd is stopped on egressNode(before EIP migration) during node reboot.
+	nft, err := nodenft.GetEgressIPNFTablesHelper()
+	if err != nil {
+		return fmt.Errorf("failed to get egress IP nftables helper: %w", err)
+	}
+
+	tx := nft.NewTransaction()
+
+	tx.Add(&knftables.Table{})
+
+	tx.Add(&knftables.Chain{
+		Name:     nftEgressIPDropChain,
+		Comment:  knftables.PtrTo("Block ARP/NDP for egress IPs during application restart"),
+		Type:     knftables.PtrTo(knftables.FilterType),
+		Hook:     knftables.PtrTo(knftables.IngressHook),
+		Device:   knftables.PtrTo(uplinkName),
+		Priority: knftables.PtrTo(knftables.FilterPriority),
+	})
+
+	if config.IPv4Mode && len(ipv4Addrs) > 0 {
+		tx.Add(&knftables.Set{
+			Name:    types.NFTEgressIPARPBlockV4,
+			Comment: knftables.PtrTo("IPv4 egress IPs"),
+			Type:    "ipv4_addr",
+		})
+
+		for _, ipStr := range ipv4Addrs {
+			tx.Add(&knftables.Element{
+				Set: types.NFTEgressIPARPBlockV4,
+				Key: []string{ipStr},
+			})
+		}
+
+		tx.Add(&knftables.Rule{
+			Chain: nftEgressIPDropChain,
+			Rule: knftables.Concat(
+				"arp daddr ip @"+types.NFTEgressIPARPBlockV4,
+				"drop",
+			),
+		})
+	}
+
+	if config.IPv6Mode && len(ipv6Addrs) > 0 {
+		tx.Add(&knftables.Set{
+			Name:    types.NFTEgressIPNDPBlockV6,
+			Comment: knftables.PtrTo("IPv6 egress IPs"),
+			Type:    "ipv6_addr",
+		})
+
+		for _, ipStr := range ipv6Addrs {
+			tx.Add(&knftables.Element{
+				Set: types.NFTEgressIPNDPBlockV6,
+				Key: []string{ipStr},
+			})
+		}
+
+		tx.Add(&knftables.Rule{
+			Chain: nftEgressIPDropChain,
+			Rule: knftables.Concat(
+				"icmpv6 type nd-neighbor-solicit",
+				"icmpv6 taddr @"+types.NFTEgressIPNDPBlockV6,
+				"drop",
+			),
+		})
+	}
+
+	if err = nft.Run(context.TODO(), tx); err != nil {
+		return fmt.Errorf("could not setup egress IP nftables: %v", err)
+	}
+
+	return nil
+}
+
+// CleanupEgressIPARPBlockNFTTable deletes the dedicated nftables table for egress IP ARP/NDP blocking.
+// Called during startup to remove stale rules from previous container shutdown.
+// On full node reboot, nftables state is cleared automatically, so this primarily handles container restarts.
+func CleanupEgressIPARPBlockNFTTable(ctx context.Context) error {
+	nft, err := nodenft.GetEgressIPNFTablesHelper()
+	if err != nil {
+		return fmt.Errorf("failed to get egress IP nftables helper: %w", err)
+	}
+
+	tx := nft.NewTransaction()
+	tx.Delete(&knftables.Table{})
+
+	if err = nft.Run(ctx, tx); err != nil && !knftables.IsNotFound(err) {
+		return fmt.Errorf("could not delete egress IP nftables table: %v", err)
+	}
+
+	klog.Infof("Cleaned up egress IP nftables table from previous shutdown")
 	return nil
 }

--- a/go-controller/pkg/node/node_nftables_test.go
+++ b/go-controller/pkg/node/node_nftables_test.go
@@ -1,0 +1,269 @@
+// SPDX-FileCopyrightText: Copyright The OVN-Kubernetes Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+// +build linux
+
+package node
+
+import (
+	"context"
+	"testing"
+
+	"sigs.k8s.io/knftables"
+
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
+	nodenft "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/nftables"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestSetupEgressIPARPBlockNFTables(t *testing.T) {
+	const testUplinkName = "eth0"
+
+	tests := []struct {
+		name               string
+		egressIPs          []string
+		uplinkName         string
+		ipv4Mode           bool
+		ipv6Mode           bool
+		expectedV4Elements []string
+		expectedV6Elements []string
+		expectedRules      []*knftables.Rule
+		expectError        string
+	}{
+		{
+			name:               "single IPv4 egress IP",
+			egressIPs:          []string{"192.168.1.10"},
+			uplinkName:         testUplinkName,
+			ipv4Mode:           true,
+			ipv6Mode:           false,
+			expectedV4Elements: []string{"192.168.1.10"},
+			expectedV6Elements: nil,
+			expectedRules: []*knftables.Rule{{
+				Chain: nftEgressIPDropChain,
+				Rule: knftables.Concat(
+					"arp daddr ip @"+types.NFTEgressIPARPBlockV4,
+					"drop"),
+			}},
+			expectError: "",
+		},
+		{
+			name:               "multiple IPv4 egress IPs",
+			egressIPs:          []string{"192.168.1.10", "192.168.1.20", "10.0.0.5"},
+			uplinkName:         testUplinkName,
+			ipv4Mode:           true,
+			ipv6Mode:           false,
+			expectedV4Elements: []string{"192.168.1.10", "192.168.1.20", "10.0.0.5"},
+			expectedV6Elements: nil,
+			expectedRules: []*knftables.Rule{{
+				Chain: nftEgressIPDropChain,
+				Rule: knftables.Concat(
+					"arp daddr ip @"+types.NFTEgressIPARPBlockV4,
+					"drop"),
+			}},
+			expectError: "",
+		},
+		{
+			name:               "single IPv6 egress IP",
+			egressIPs:          []string{"2001:db8::1"},
+			uplinkName:         testUplinkName,
+			ipv4Mode:           false,
+			ipv6Mode:           true,
+			expectedV4Elements: nil,
+			expectedV6Elements: []string{"2001:db8::1"},
+			expectedRules: []*knftables.Rule{{
+				Chain: nftEgressIPDropChain,
+				Rule: knftables.Concat(
+					"icmpv6 type nd-neighbor-solicit",
+					"icmpv6 taddr @"+types.NFTEgressIPNDPBlockV6,
+					"drop"),
+			}},
+			expectError: "",
+		},
+		{
+			name:               "multiple IPv6 egress IPs",
+			egressIPs:          []string{"2001:db8::1", "2001:db8::2", "fd00::100"},
+			uplinkName:         testUplinkName,
+			ipv4Mode:           false,
+			ipv6Mode:           true,
+			expectedV4Elements: nil,
+			expectedV6Elements: []string{"2001:db8::1", "2001:db8::2", "fd00::100"},
+			expectedRules: []*knftables.Rule{{
+				Chain: nftEgressIPDropChain,
+				Rule: knftables.Concat(
+					"icmpv6 type nd-neighbor-solicit",
+					"icmpv6 taddr @"+types.NFTEgressIPNDPBlockV6,
+					"drop"),
+			}},
+			expectError: "",
+		},
+		{
+			name:               "dual-stack egress IPs",
+			egressIPs:          []string{"192.168.1.10", "2001:db8::1", "10.0.0.5", "fd00::200"},
+			uplinkName:         testUplinkName,
+			ipv4Mode:           true,
+			ipv6Mode:           true,
+			expectedV4Elements: []string{"192.168.1.10", "10.0.0.5"},
+			expectedV6Elements: []string{"2001:db8::1", "fd00::200"},
+			expectedRules: []*knftables.Rule{
+				{
+					Chain: nftEgressIPDropChain,
+					Rule: knftables.Concat(
+						"arp daddr ip @"+types.NFTEgressIPARPBlockV4,
+						"drop"),
+				},
+				{
+					Chain: nftEgressIPDropChain,
+					Rule: knftables.Concat(
+						"icmpv6 type nd-neighbor-solicit",
+						"icmpv6 taddr @"+types.NFTEgressIPNDPBlockV6,
+						"drop"),
+				},
+			},
+			expectError: "",
+		},
+		{
+			name:        "missing uplink name",
+			egressIPs:   []string{"192.168.1.10"},
+			uplinkName:  "",
+			ipv4Mode:    true,
+			ipv6Mode:    false,
+			expectError: "uplink interface name is required for netdev nftables rules",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			config.IPv4Mode = tt.ipv4Mode
+			config.IPv6Mode = tt.ipv6Mode
+
+			nft := nodenft.SetFakeEgressIPNFTablesHelper()
+
+			err := SetupEgressIPARPBlockNFTables(tt.egressIPs, tt.uplinkName)
+
+			if tt.expectError != "" {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(ContainSubstring(tt.expectError))
+				return
+			}
+
+			g.Expect(err).NotTo(HaveOccurred())
+
+			// Verify IPv4 elements
+			if tt.expectedV4Elements != nil {
+				v4Elements, err := nft.ListElements(context.TODO(), "set", types.NFTEgressIPARPBlockV4)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(v4Elements).To(HaveLen(len(tt.expectedV4Elements)))
+				for i, expectedIP := range tt.expectedV4Elements {
+					g.Expect(v4Elements[i].Key).To(Equal([]string{expectedIP}))
+				}
+			}
+
+			// Verify IPv6 elements
+			if tt.expectedV6Elements != nil {
+				v6Elements, err := nft.ListElements(context.TODO(), "set", types.NFTEgressIPNDPBlockV6)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(v6Elements).To(HaveLen(len(tt.expectedV6Elements)))
+				for i, expectedIP := range tt.expectedV6Elements {
+					g.Expect(v6Elements[i].Key).To(Equal([]string{expectedIP}))
+				}
+			}
+
+			// Verify rules
+			if tt.expectedRules != nil {
+				rules, err := nft.ListRules(context.TODO(), nftEgressIPDropChain)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(rules).To(HaveLen(len(tt.expectedRules)))
+				for i, expectedRule := range tt.expectedRules {
+					g.Expect(rules[i].Rule).To(Equal(expectedRule.Rule))
+				}
+			}
+		})
+	}
+}
+
+func TestCleanupEgressIPARPBlockNFTTable(t *testing.T) {
+	const testUplinkName = "eth0"
+
+	tests := []struct {
+		name        string
+		setupTable  bool
+		egressIPs   []string
+		uplinkName  string
+		ipv4Mode    bool
+		ipv6Mode    bool
+		expectError string
+	}{
+		{
+			name:        "delete existing table with IPv4 rules",
+			setupTable:  true,
+			egressIPs:   []string{"192.168.1.10"},
+			uplinkName:  testUplinkName,
+			ipv4Mode:    true,
+			ipv6Mode:    false,
+			expectError: "",
+		},
+		{
+			name:        "delete existing table with IPv6 rules",
+			setupTable:  true,
+			egressIPs:   []string{"2001:db8::1"},
+			uplinkName:  testUplinkName,
+			ipv4Mode:    false,
+			ipv6Mode:    true,
+			expectError: "",
+		},
+		{
+			name:        "delete existing table with dual-stack rules",
+			setupTable:  true,
+			egressIPs:   []string{"192.168.1.10", "2001:db8::1"},
+			uplinkName:  testUplinkName,
+			ipv4Mode:    true,
+			ipv6Mode:    true,
+			expectError: "",
+		},
+		{
+			name:        "delete non-existent table",
+			setupTable:  false,
+			ipv4Mode:    false,
+			ipv6Mode:    false,
+			expectError: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			config.IPv4Mode = tt.ipv4Mode
+			config.IPv6Mode = tt.ipv6Mode
+
+			nft := nodenft.SetFakeEgressIPNFTablesHelper()
+
+			if tt.setupTable {
+				// Create the table first by calling SetupEgressIPARPBlockNFTables
+				err := SetupEgressIPARPBlockNFTables(tt.egressIPs, tt.uplinkName)
+				g.Expect(err).NotTo(HaveOccurred())
+				rules, err := nft.ListRules(context.TODO(), nftEgressIPDropChain)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(rules).NotTo(BeEmpty(), "Rules should exist before cleanup")
+			}
+
+			// Call the cleanup function
+			err := CleanupEgressIPARPBlockNFTTable(context.TODO())
+
+			if tt.expectError != "" {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(ContainSubstring(tt.expectError))
+				return
+			}
+			g.Expect(err).NotTo(HaveOccurred())
+
+			_, err = nft.ListRules(context.TODO(), nftEgressIPDropChain)
+			g.Expect(knftables.IsNotFound(err)).To(BeTrue(), "Chain should not exist after cleanup")
+		})
+	}
+}

--- a/go-controller/pkg/types/const.go
+++ b/go-controller/pkg/types/const.go
@@ -382,6 +382,14 @@ const (
 	// Contains cluster CIDRs + local node IPv6 addresses that should be exempted from SNAT.
 	NFTNoOverlaySNATExemptV6 = "no-overlay-snat-exempt-v6"
 
+	// NFTEgressIPARPBlockV4 is a set in the dedicated ovn-kubernetes-egressip-ipv4 ARP table
+	// used during application restart to block ARP responses for IPv4 egress IPs
+	NFTEgressIPARPBlockV4 = "egressip-v4"
+
+	// NFTEgressIPNDPBlockV6 is a set in the dedicated ovn-kubernetes-egressip-ipv6 inet table
+	// used during application restart to block NDP responses for IPv6 egress IPs
+	NFTEgressIPNDPBlockV6 = "egressip-v6"
+
 	// Metrics
 	MetricOvnkubeNamespace               = "ovnkube"
 	MetricOvnkubeSubsystemController     = "controller"

--- a/test/e2e/egressip.go
+++ b/test/e2e/egressip.go
@@ -394,6 +394,69 @@ func removeSliceElement(s []string, i int) []string {
 	return s[:len(s)-1]
 }
 
+// checkForDuplicateMAC performs arping (IPv4) or ndisc6 (IPv6) checks to detect duplicate MAC address responses
+// after egress IP migration. Returns error immediately if old node MAC is detected responding.
+func checkForDuplicateMAC(externalContainer infraapi.ExternalContainer, interfaceName, egressIP, oldMAC, expectedMAC string, isIPv6 bool, maxChecks int, checkInterval time.Duration) error {
+	// For arping: MAC is in brackets [aa:bb:cc:dd:ee:ff]
+	// For ndisc6: MAC is on the line "Target link-layer address: aa:bb:cc:dd:ee:ff"
+	macRegexArping := regexp.MustCompile(`\[([0-9a-fA-F:]+)\]`)
+	macRegexNdisc6 := regexp.MustCompile(`Target link-layer address:\s+([0-9a-fA-F]{1,2}:[0-9a-fA-F]{1,2}:[0-9a-fA-F]{1,2}:[0-9a-fA-F]{1,2}:[0-9a-fA-F]{1,2}:[0-9a-fA-F]{1,2})`)
+
+	oldMAC = strings.ToLower(oldMAC)
+	expectedMAC = strings.ToLower(expectedMAC)
+
+	var toolName string
+	if isIPv6 {
+		toolName = "ndisc6"
+	} else {
+		toolName = "arping"
+	}
+
+	framework.Logf("Checking for duplicate MAC responses after migration using %s (old MAC: %s, expected MAC: %s)...", toolName, oldMAC, expectedMAC)
+
+	foundExpected := false
+	for i := 0; i < maxChecks; i++ {
+		var cmd string
+		var macRegex *regexp.Regexp
+
+		if isIPv6 {
+			cmd = fmt.Sprintf("ndisc6 -1 -w 1000 %s %s 2>&1", egressIP, interfaceName)
+			macRegex = macRegexNdisc6
+		} else {
+			cmd = fmt.Sprintf("arping -c 1 -I %s %s 2>&1", interfaceName, egressIP)
+			macRegex = macRegexArping
+		}
+
+		output, err := infraprovider.Get().ExecExternalContainerCommand(externalContainer, []string{"sh", "-c", cmd})
+		if err != nil {
+			framework.Logf("Check %d/%d: %s command returned error: %v; output: %s", i+1, maxChecks, toolName, err, output)
+		}
+		matches := macRegex.FindStringSubmatch(output)
+		if len(matches) >= 2 {
+			respondingMAC := strings.ToLower(strings.TrimSpace(matches[1]))
+			if respondingMAC == oldMAC {
+				return fmt.Errorf("DUPLICATE MAC DETECTED on check %d: Old node MAC %s responded to %s for egress IP %s after migration. "+
+					"The nftables drop rules should have prevented this response", i+1, oldMAC, toolName, egressIP)
+			} else if respondingMAC == expectedMAC {
+				foundExpected = true
+				framework.Logf("Check %d/%d: New node MAC %s is responding (expected)", i+1, maxChecks, expectedMAC)
+			} else {
+				return fmt.Errorf("Unexpected MAC %s (not old or expected)", respondingMAC)
+			}
+		}
+
+		if i < maxChecks-1 {
+			time.Sleep(checkInterval)
+		}
+	}
+
+	if !foundExpected {
+		return fmt.Errorf("did not observe expected MAC %s responding to %s for egress IP %s after %d checks", expectedMAC, toolName, egressIP, maxChecks)
+	}
+	framework.Logf("✓ No duplicate MAC detected - nftables rules successfully blocked responses from old node")
+	return nil
+}
+
 type egressIPStatus struct {
 	Node     string `json:"node"`
 	EgressIP string `json:"egressIP"`
@@ -3788,6 +3851,190 @@ spec:
 			_, err = e2ekubectl.RunKubectl("", "annotate", "--overwrite", "egressip", egressIPName, fmt.Sprintf("%s-", util.EgressIPMarkAnnotation))
 			gomega.Expect(err).To(gomega.HaveOccurred(), "Should fail if k8s.ovn.org/egressip-mark is being removed")
 			gomega.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("The \"k8s.ovn.org/egressip-mark\" annotation cannot be modified or removed once set. This annotation is managed by the system.")))
+		})
+
+		ginkgo.It("should prevent duplicate MAC responses when egress node is rebooted", func() {
+			if !isNetworkSegmentationEnabled() {
+				ginkgo.Skip("network segmentation is disabled")
+			}
+
+			ginkgo.By("1. Label node 1 as egress-assignable")
+			e2enode.AddOrUpdateLabelOnNode(f.ClientSet, egress1Node.name, "k8s.ovn.org/egress-assignable", "")
+			defer e2enode.RemoveLabelOffNode(f.ClientSet, egress1Node.name, "k8s.ovn.org/egress-assignable")
+
+			ginkgo.By("2. Creating EgressIP object")
+			podNamespace := f.Namespace
+			labels := map[string]string{
+				"name": f.Namespace.Name,
+			}
+			updateNamespaceLabels(f, podNamespace, labels)
+			var egressIP net.IP
+			var err error
+			if isIPv6TestRun {
+				egressIP, err = ipalloc.NewPrimaryIPv6()
+			} else {
+				egressIP, err = ipalloc.NewPrimaryIPv4()
+			}
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "must allocate egress IP")
+			egressIPConfig := createEIPManifest(egressIPName, podEgressLabel, labels, egressIP.String())
+			if err := os.WriteFile(egressIPYaml, []byte(egressIPConfig), 0644); err != nil {
+				framework.Failf("Unable to write EgressIP config: %v", err)
+			}
+			defer os.Remove(egressIPYaml)
+			e2ekubectl.RunKubectlOrDie("default", "create", "-f", egressIPYaml)
+
+			ginkgo.By("3. Verifying EgressIP assigned to node 1 and creating a pod on this node")
+			statuses := verifyEgressIPStatusLengthEquals(1, func(statuses []egressIPStatus) bool {
+				return statuses[0].Node == egress1Node.name
+			})
+			framework.Logf("Egress IP %s assigned to node: %s", egressIP.String(), statuses[0].Node)
+			_, err = createGenericPodWithLabel(f, pod1Name, egress1Node.name, f.Namespace.Name, getAgnHostHTTPPortBindFullCMD(clusterNetworkHTTPPort), podEgressLabel)
+			framework.ExpectNoError(err, "failed to create pod matching EgressIP selector")
+
+			ginkgo.By("4. Labeling node 2 as egress-assignable for failover")
+			e2enode.AddOrUpdateLabelOnNode(f.ClientSet, egress2Node.name, "k8s.ovn.org/egress-assignable", "")
+			defer e2enode.RemoveLabelOffNode(f.ClientSet, egress2Node.name, "k8s.ovn.org/egress-assignable")
+
+			ginkgo.By("5. Getting network interfaces of both EgressIP nodes and external container")
+			primaryProviderNetwork, err := infraprovider.Get().PrimaryNetwork()
+			framework.ExpectNoError(err, "failed to get primary network")
+			egress1NodeInf, err := infraprovider.Get().GetK8NodeNetworkInterface(egress1Node.name, primaryProviderNetwork)
+			framework.ExpectNoError(err, "failed to get node 1 interface")
+			egress2NodeInf, err := infraprovider.Get().GetK8NodeNetworkInterface(egress2Node.name, primaryProviderNetwork)
+			framework.ExpectNoError(err, "failed to get node 2 interface")
+			extContainerInf, err := infraprovider.Get().GetExternalContainerNetworkInterface(primaryTargetExternalContainer, primaryProviderNetwork)
+			framework.ExpectNoError(err, "failed to get external container interface")
+
+			ginkgo.By("6. Installing arping/ndisc6 in external container")
+			var installCmd string
+			if isIPv6TestRun {
+				installCmd = "which ndisc6 >/dev/null 2>&1 || (apk update && apk add ndisc6)"
+			} else {
+				installCmd = "which arping >/dev/null 2>&1 || (apk update && apk add iputils)"
+			}
+			_, err = infraprovider.Get().ExecExternalContainerCommand(primaryTargetExternalContainer, []string{
+				"sh", "-c", installCmd,
+			})
+			framework.ExpectNoError(err, "failed to install network discovery tool")
+
+			ginkgo.By("7. Verifying egress IP resolves to node 1 MAC before migration")
+			var discoveryCmd string
+			var macRegex *regexp.Regexp
+			if isIPv6TestRun {
+				discoveryCmd = fmt.Sprintf("ndisc6 -1 -w 1000 %s %s 2>&1", egressIP.String(), extContainerInf.InfName)
+				// ndisc6 output format: "Target link-layer address: aa:bb:cc:dd:ee:ff"
+				macRegex = regexp.MustCompile(`Target link-layer address:\s+([0-9a-fA-F]{1,2}:[0-9a-fA-F]{1,2}:[0-9a-fA-F]{1,2}:[0-9a-fA-F]{1,2}:[0-9a-fA-F]{1,2}:[0-9a-fA-F]{1,2})`)
+			} else {
+				discoveryCmd = fmt.Sprintf("arping -c 1 -I %s %s 2>&1", extContainerInf.InfName, egressIP.String())
+				macRegex = regexp.MustCompile(`\[([0-9a-fA-F:]+)\]`)
+			}
+			output, err := infraprovider.Get().ExecExternalContainerCommand(primaryTargetExternalContainer, []string{"sh", "-c", discoveryCmd})
+			framework.ExpectNoError(err, "network discovery should succeed before migration")
+			matches := macRegex.FindStringSubmatch(output)
+			gomega.Expect(matches).To(gomega.HaveLen(2), "should extract MAC from discovery output")
+			macBeforeMigration := strings.ToLower(strings.TrimSpace(matches[1]))
+			expectedMAC1 := strings.ToLower(egress1NodeInf.MAC)
+			framework.Logf("MAC before migration: %s, expected: %s", macBeforeMigration, expectedMAC1)
+			gomega.Expect(macBeforeMigration).To(gomega.Equal(expectedMAC1), "Egress IP should resolve to node 1 MAC before migration")
+
+			ginkgo.By("8. Getting ovnkube-node pod name on egress node 1")
+			ovnkubeNodePods, err := f.ClientSet.CoreV1().Pods("ovn-kubernetes").List(context.TODO(), metav1.ListOptions{
+				FieldSelector: fmt.Sprintf("spec.nodeName=%s", egress1Node.name),
+				LabelSelector: "app=ovnkube-node",
+			})
+			framework.ExpectNoError(err, "failed to list ovnkube-node pods")
+			gomega.Expect(ovnkubeNodePods.Items).To(gomega.HaveLen(1), "should have exactly one ovnkube-node pod on egress node 1")
+			ovnkubeNodePod := ovnkubeNodePods.Items[0].Name
+			framework.Logf("Found ovnkube-node pod: %s on node %s", ovnkubeNodePod, egress1Node.name)
+
+			ginkgo.By("9. Start a goroutine to check for nftables chain during pod deletion")
+			nftChainFound := make(chan bool, 1)
+			stopChecking := make(chan bool, 1)
+			goroutineReady := make(chan bool, 1)
+			nftChainCheckCmd := "nft -j list chains | jq '.nftables[] | select(.chain.table==\"ovn-kubernetes-egressip\" and .chain.family==\"netdev\" and .chain.name==\"egressip-drop\").chain'"
+			go func() {
+				defer close(nftChainFound)
+				ticker := time.NewTicker(100 * time.Millisecond)
+				defer ticker.Stop()
+				goroutineReady <- true
+				for {
+					select {
+					case <-stopChecking:
+						return
+					case <-ticker.C:
+						output, err := infraprovider.Get().ExecK8NodeCommand(egress1Node.name, []string{"sh", "-c", nftChainCheckCmd})
+						if err == nil && strings.Contains(output, "egressip-drop") {
+							nftChainFound <- true
+							return
+						}
+					}
+				}
+			}()
+			<-goroutineReady
+			framework.Logf("Nftables chain monitoring goroutine started")
+
+			ginkgo.By("10. Deleting ovnkube-node pod and intentionally dropping EgressIP health check packets to trigger egress IP migration")
+			framework.Logf("Deleting ovnkube-node pod %s to trigger egress IP migration", ovnkubeNodePod)
+			err = deletePodWithWaitByName(context.TODO(), f.ClientSet, ovnkubeNodePod, "ovn-kubernetes")
+			framework.ExpectNoError(err, "failed to delete ovnkube-node pod and wait for termination")
+			framework.Logf("✓ ovnkube-node pod %s deleted and fully terminated", ovnkubeNodePod)
+			framework.Logf("Dropping EgressIP health check packets on node %s to trigger EgressIP migration", egress1Node.name)
+			setNodeReachable(egress1Node.name, false)
+			defer setNodeReachable(egress1Node.name, true)
+
+			ginkgo.By("11. Verifying nftables chain exists on node 1 during shutdown")
+			close(stopChecking)
+			chainFound, ok := <-nftChainFound
+			if !ok || !chainFound {
+				framework.Failf("Nftables chain egressip-drop was not found on node %s during pod shutdown", egress1Node.name)
+			}
+			framework.Logf("✓ Nftables chain egressip-drop verified on node %s", egress1Node.name)
+
+			ginkgo.By("12. Waiting for egress IP to migrate to node 2")
+			verifyEgressIPStatusLengthEquals(1, func(statuses []egressIPStatus) bool {
+				return statuses[0].Node == egress2Node.name
+			})
+			framework.Logf("✓ Egress IP successfully migrated to node %s", egress2Node.name)
+
+			ginkgo.By("13. Checking for duplicate MAC responses after migration")
+			// The old node should NOT respond to ARP/NDP requests even though the SNAT rule is present on the gateway router and egress IP might
+			// still be on its br-ex interface temporarily. The nftables rules added during pod shutdown should prevent any ARP/NDP responses.
+			err = checkForDuplicateMAC(
+				primaryTargetExternalContainer,
+				extContainerInf.InfName,
+				egressIP.String(),
+				egress1NodeInf.MAC,
+				egress2NodeInf.MAC,
+				isIPv6TestRun,
+				20,                   // maxChecks
+				500*time.Millisecond, // checkInterval
+			)
+			framework.ExpectNoError(err, "duplicate MAC detection check failed")
+
+			ginkgo.By("14. Waiting for ovnkube-node pod to restart and OVN cluster to be healthy")
+			err = waitOVNKubernetesHealthy(f)
+			framework.ExpectNoError(err, "OVN-Kubernetes cluster should be healthy after ovnkube-node pod restart")
+
+			ginkgo.By("15. Verifying nftables cleanup on node 1 after pod restart")
+			ovnkubeNodePods, err = f.ClientSet.CoreV1().Pods("ovn-kubernetes").List(context.TODO(), metav1.ListOptions{
+				FieldSelector: fmt.Sprintf("spec.nodeName=%s", egress1Node.name),
+				LabelSelector: "app=ovnkube-node",
+			})
+			framework.ExpectNoError(err, "failed to list ovnkube-node pods")
+			if len(ovnkubeNodePods.Items) > 0 {
+				podName := ovnkubeNodePods.Items[0].Name
+				nftCmd := "nft list table netdev ovn-kubernetes-egressip 2>&1"
+				_, err := e2ekubectl.RunKubectl("ovn-kubernetes", "exec", podName, "-c", "ovnkube-controller", "--", "sh", "-c", nftCmd)
+				// Command should fail because table should be deleted
+				gomega.Expect(err).ToNot(gomega.BeNil(), "nft command should fail because table should be deleted")
+				gomega.Expect(err.Error()).To(gomega.Or(
+					gomega.ContainSubstring("No such file or directory"),
+					gomega.ContainSubstring("No such file"),
+				), "nftables egress IP table should be deleted after cleanup")
+				framework.Logf("✓ Nftables table cleaned up on node 1")
+			}
+
+			framework.Logf("✓ Test passed: Egress IP migrated cleanly without duplicate MAC responses")
 		})
 
 		ginkgo.DescribeTable("[OVN network] multiple namespaces with different primary networks", func(otherNetworkAttachParms networkAttachmentConfigParams) {


### PR DESCRIPTION
Issue:
When an egress IP node is rebooted, the egress IP moves to another egress assignable node after health check failure. However the old egress IP node keep on responding to ARP request for the egress IP. This happens due to following reasons:

- EgressIP stays attached to primary interface of the old EgressIP node until the primary interface is brought down as per node reboot workflow.
- SNAT rules at GR creates logical flows which can respond with unicast ARP in response of broadcast GARPs from newly assigned egressIP node. This can happen till ovs-vswitchd is running.

In baremetal environment node reboot takes longer time(~10-20 second) and as a result we get multiple MAC for an egress IP during that interval.

This commit Implement dedicated nftables rules to prevent duplicate MAC/IP conflicts during egress IP failover scenarios.

Changes:
- Create dedicated nftables tables for egress IP ARP/NDP blocking:
  - ovn-kubernetes-egressip (netdev family) for both IPv4 and IPv6 egress IPs
- Implement cleanup on startup to remove stale nftables rules
- Add e2e test to validate no duplicate MAC responses during node reboot

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code does not require changes to the documentation
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] My code does not require tests
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
