### PR TITLE
OCPBUGS-112470: Register test images using tests extension

### DIFF
--- a/openshift/Makefile
+++ b/openshift/Makefile
@@ -1,0 +1,6 @@
+EXCLUDE_DIRS ?= test/
+TEST_PKGS := $$(go list ./... | grep -v $(EXCLUDE_DIRS))
+
+.PHONY: test
+test:
+	go test -v $(TEST_PKGS)

--- a/openshift/cmd/ovn-kubernetes-tests-ext/images.go
+++ b/openshift/cmd/ovn-kubernetes-tests-ext/images.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	imageutils "k8s.io/kubernetes/test/utils/image"
+
+	"github.com/openshift-eng/openshift-tests-extension/pkg/extension"
+)
+
+// requiredImage associates an e2e image pullspec with an index used to generate
+// the image tag so that it matches with the tag in quay.io/openshift/community-e2e-images.
+type requiredImage struct {
+	pullSpec string
+	index    int
+}
+
+var requiredImages []requiredImage
+
+func init() {
+	agnhostImage := requiredImage{
+		pullSpec: imageutils.GetE2EImage(imageutils.Agnhost),
+		index:    int(imageutils.Agnhost),
+	}
+	requiredImages = append(requiredImages, agnhostImage)
+}
+
+// registerTestImages advertises OVN-Kubernetes e2e images to the openshift-tests
+// extension so origin can list and mirror them (see "images" subcommand).
+func registerTestImages(ext *extension.Extension) error {
+	for _, ri := range requiredImages {
+		img, err := extensionImageFromPullSpec(ri.pullSpec)
+		if err != nil {
+			return fmt.Errorf("failed to register test image %q: %v", ri.pullSpec, err)
+		}
+		img.Index = ri.index
+		ext.RegisterImage(img)
+	}
+	return nil
+}
+
+// extensionImageFromPullSpec splits a pullspec into the registry/name/version
+// layout expected by k8s.io/kubernetes/test/utils/image.Config.GetE2EImage
+// (fmt.Sprintf("%s/%s:%s", registry, name, version)).
+func extensionImageFromPullSpec(pullSpec string) (extension.Image, error) {
+	registry, name, version, err := splitImagePullSpec(pullSpec)
+	if err != nil {
+		return extension.Image{}, err
+	}
+	return extension.Image{
+		Registry: registry,
+		Name:     name,
+		Version:  version,
+	}, nil
+}
+
+func splitImagePullSpec(pullSpec string) (registry, name, version string, err error) {
+	if pullSpec == "" {
+		return "", "", "", fmt.Errorf("empty image pullspec")
+	}
+	if strings.Contains(pullSpec, "@") {
+		return "", "", "", fmt.Errorf("digest image pullspecs are not supported: %q", pullSpec)
+	}
+
+	remainder := pullSpec
+	if tagIndex := strings.LastIndex(pullSpec, ":"); tagIndex > strings.LastIndex(pullSpec, "/") {
+		version = pullSpec[tagIndex+1:]
+		remainder = pullSpec[:tagIndex]
+	}
+	if version == "" {
+		version = "latest"
+	}
+
+	first, rest, ok := strings.Cut(remainder, "/")
+	if !ok {
+		// Short docker-library name, e.g. "nginx" → docker.io/library/nginx
+		return "docker.io", "library/" + remainder, version, nil
+	}
+
+	if strings.ContainsAny(first, ".:") || first == "localhost" {
+		// Explicit registry, e.g. "quay.io/foo/bar", "registry.k8s.io/...",
+		// or "localhost:5000/ovn/test"
+		return first, rest, version, nil
+	}
+
+	// Docker Hub user/org image, e.g. "cloudflare/goflow"
+	return "docker.io", remainder, version, nil
+}

--- a/openshift/cmd/ovn-kubernetes-tests-ext/images_test.go
+++ b/openshift/cmd/ovn-kubernetes-tests-ext/images_test.go
@@ -1,0 +1,194 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/openshift-eng/openshift-tests-extension/pkg/extension"
+)
+
+func TestSplitImagePullSpec(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		pullSpec         string
+		wantRegistry     string
+		wantName         string
+		wantVersion      string
+		wantErrSubstring string
+	}{
+		{
+			name:         "k8s promoter image",
+			pullSpec:     "registry.k8s.io/e2e-test-images/agnhost:2.40",
+			wantRegistry: "registry.k8s.io",
+			wantName:     "e2e-test-images/agnhost",
+			wantVersion:  "2.40",
+		},
+		{
+			name:         "quay image with org and repo",
+			pullSpec:     "quay.io/sronanrh/iperf:latest",
+			wantRegistry: "quay.io",
+			wantName:     "sronanrh/iperf",
+			wantVersion:  "latest",
+		},
+		{
+			name:         "ghcr image",
+			pullSpec:     "ghcr.io/nicolaka/netshoot:v0.13",
+			wantRegistry: "ghcr.io",
+			wantName:     "nicolaka/netshoot",
+			wantVersion:  "v0.13",
+		},
+		{
+			name:         "docker library short name",
+			pullSpec:     "nginx:1",
+			wantRegistry: "docker.io",
+			wantName:     "library/nginx",
+			wantVersion:  "1",
+		},
+		{
+			name:         "image name contains colon in tag only",
+			pullSpec:     "quay.io/itssurya/dev-images:metallb-lbservice",
+			wantRegistry: "quay.io",
+			wantName:     "itssurya/dev-images",
+			wantVersion:  "metallb-lbservice",
+		},
+		{
+			name:         "docker hub org image without tag defaults to latest",
+			pullSpec:     "cloudflare/goflow",
+			wantRegistry: "docker.io",
+			wantName:     "cloudflare/goflow",
+			wantVersion:  "latest",
+		},
+		{
+			name:         "localhost registry with port",
+			pullSpec:     "localhost:5000/ovn/test:v1",
+			wantRegistry: "localhost:5000",
+			wantName:     "ovn/test",
+			wantVersion:  "v1",
+		},
+		{
+			name:         "ip address registry with port",
+			pullSpec:     "192.168.1.10:5000/ovn/test:v1",
+			wantRegistry: "192.168.1.10:5000",
+			wantName:     "ovn/test",
+			wantVersion:  "v1",
+		},
+		{
+			name:         "bare ip address registry",
+			pullSpec:     "192.168.1.10/ovn/test:v1",
+			wantRegistry: "192.168.1.10",
+			wantName:     "ovn/test",
+			wantVersion:  "v1",
+		},
+		{
+			name:         "arbitrary dns registry",
+			pullSpec:     "evil.example.com/ovn/test:v1",
+			wantRegistry: "evil.example.com",
+			wantName:     "ovn/test",
+			wantVersion:  "v1",
+		},
+		{
+			name:             "digest pullspec",
+			pullSpec:         "quay.io/frrouting/frr@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+			wantErrSubstring: "digest image pullspecs are not supported",
+		},
+		{
+			name:             "empty pullspec",
+			pullSpec:         "",
+			wantErrSubstring: "empty image pullspec",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			registry, name, version, err := splitImagePullSpec(tc.pullSpec)
+			if tc.wantErrSubstring != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tc.wantErrSubstring)
+				}
+				if !strings.Contains(err.Error(), tc.wantErrSubstring) {
+					t.Fatalf("expected error containing %q, got %q", tc.wantErrSubstring, err.Error())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if registry != tc.wantRegistry {
+				t.Errorf("registry: got %q, want %q", registry, tc.wantRegistry)
+			}
+			if name != tc.wantName {
+				t.Errorf("name: got %q, want %q", name, tc.wantName)
+			}
+			if version != tc.wantVersion {
+				t.Errorf("version: got %q, want %q", version, tc.wantVersion)
+			}
+		})
+	}
+}
+
+func TestExtensionImageFromPullSpec(t *testing.T) {
+	t.Parallel()
+
+	img, err := extensionImageFromPullSpec("quay.io/frrouting/frr:10.5.3")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if img.Registry != "quay.io" {
+		t.Errorf("Registry: got %q, want %q", img.Registry, "quay.io")
+	}
+	if img.Name != "frrouting/frr" {
+		t.Errorf("Name: got %q, want %q", img.Name, "frrouting/frr")
+	}
+	if img.Version != "10.5.3" {
+		t.Errorf("Version: got %q, want %q", img.Version, "10.5.3")
+	}
+
+	if _, err := extensionImageFromPullSpec(""); err == nil {
+		t.Fatal("expected error for empty pullspec")
+	}
+}
+
+func TestRegisterTestImages(t *testing.T) {
+	if len(requiredImages) == 0 {
+		t.Fatal("requiredImages is empty")
+	}
+
+	ext := extension.NewExtension("openshift", "payload", "ovn-kubernetes")
+	err := registerTestImages(ext)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got, want := len(ext.Images), len(requiredImages); got != want {
+		t.Fatalf("registered %d images, want %d from requiredImages", got, want)
+	}
+
+	type imageKey struct {
+		index    int
+		pullSpec string
+	}
+	want := make(map[imageKey]int)
+	for _, ri := range requiredImages {
+		want[imageKey{ri.index, ri.pullSpec}]++
+	}
+
+	got := make(map[imageKey]int, len(ext.Images))
+	for _, img := range ext.Images {
+		got[imageKey{img.Index, fmt.Sprintf("%s/%s:%s", img.Registry, img.Name, img.Version)}]++
+	}
+
+	if len(got) != len(want) {
+		t.Fatalf("registered %d unique images, want %d", len(got), len(want))
+	}
+	for key, count := range want {
+		if got[key] != count {
+			t.Errorf("image %+v: got count %d, want %d", key, got[key], count)
+		}
+	}
+}

--- a/openshift/cmd/ovn-kubernetes-tests-ext/main.go
+++ b/openshift/cmd/ovn-kubernetes-tests-ext/main.go
@@ -77,7 +77,10 @@ func main() {
 	// Create our registry of openshift-tests extensions
 	extensionRegistry := extension.NewRegistry()
 	ovnTestsExtension := extension.NewExtension("openshift", "payload", "ovn-kubernetes")
-	// TODO: register test images using tests extension
+	// register OVN-Kubernetes e2e images to the openshift-tests extension
+	if err := registerTestImages(ovnTestsExtension); err != nil {
+		panic(err)
+	}
 	// add ovn-kubernetes test suites into openshift suites
 	// by default, we treat all tests as parallel and only expose tests as Serial if the appropriate label is added - "Serial"
 	ovnTestsExtension.AddSuite(extension.Suite{


### PR DESCRIPTION
This PR registers the test images using tests extension so that these images are always available whenever the ovnk OTE tests are run.