### PR TITLE
OCPBUGS-105423: Fix traffic leak in egress IP on secondary interface

### DIFF
--- a/docs/features/cluster-egress-controls/egress-ip.md
+++ b/docs/features/cluster-egress-controls/egress-ip.md
@@ -86,18 +86,19 @@ Routing Policies
 ### EgressIP IP is assigned to a secondary host interface
 Note that this is unsupported for user defined networks.
 Lets now imagine the Egress IP(s) mentioned previously, are not hosted by the OVN primary network and is hosted
-by a secondary host network which is assigned to a standard linux interface, a redirect to the egress-able node management port IP address:
+by a secondary host network which is assigned to a standard linux interface, in addition to the policy we saw previously to redirect to the egress node,
+another policy is added to the egress node itself redirecting the egressIP traffic to the secondary host interface via the 
+node management port IP address:
 ```shell
 Routing Policies
-  1004 inport == "rtos-ovn-control-plane" && ip4.dst == 172.18.0.4 /* ovn-control-plane */                            reroute  10.244.0.2
-  1004 inport == "rtos-ovn-worker" && ip4.dst == 172.18.0.2 /* ovn-worker */                                          reroute  10.244.1.2
-  1004 inport == "rtos-ovn-worker2" && ip4.dst == 172.18.0.3 /* ovn-worker2 */                                        reroute  10.244.2.2
+  1004 inport == "rtos-ovn-worker" && ip4.dst == 172.18.0.121 /* ovn-worker */                                      reroute  10.244.1.2
 
-   102 (ip4.src == $a12749576804119081385 || ip4.src == $a16335301576733828072) && ip4.dst == $a11079093880111560446  allow    pkt_mark=1008
-   102 ip4.src == 10.244.0.0/16 && ip4.dst == 10.244.0.0/16                                                           allow
-   102 ip4.src == 10.244.0.0/16 && ip4.dst == 100.64.0.0/16                                                           allow
+  102 (ip4.src == $a8519615025667110816 || ip4.src == $a13607449821398607916) && ip4.dst == $a1042611113178530741   allow    pkt_mark=1008
+  102 ip4.src == 10.244.0.0/16 && ip4.dst == 10.244.0.0/16                                                          allow
+  102 ip4.src == 10.244.0.0/16 && ip4.dst == 100.64.0.0/16                                                          allow
+  102                                     pkt.mark == 42                                                            allow
 
-   100 ip4.src == 10.244.1.3                                                                                          reroute  10.244.1.2, 10.244.2.2
+  100 ip4.src == 10.244.0.13                                                                                        reroute  10.244.1.2  pkt_mark=1009
 ```
 
 IPTables will have the following chain in NAT table and also rules within that chain to source NAT to the correct IP address:
@@ -213,6 +214,33 @@ priority=103,ip,in_port=2,nw_src=<clusterSubnet> actions=drop
 # Commit connections coming from IPs not in cluster network
 priority=100,ip,in_port=2 actions=ct(commit,zone=64000,exec(set_field:0x1->ct_mark)),output:1
 ```
+
+In case of an egress IP assigned to a secondary host interface, a pkt_mark=1009 is added to the reroute policy in the egress node:
+```shell
+[root@ovn-worker ~]# ovn-nbctl lr-policy-list ovn_cluster_router
+Routing Policies
+      1004 inport == "rtos-ovn-worker" && ip4.dst == 172.18.0.121 /* ovn-worker */         reroute                10.244.1.2
+       102 (ip4.src == $a8519615025667110816 || ip4.src == $a13607449821398607916) && ip4.dst == $a1042611113178530741           allow               pkt_mark=1008
+       102 ip4.src == 10.244.0.0/16 && ip4.dst == 10.244.0.0/16           allow
+       102 ip4.src == 10.244.0.0/16 && ip4.dst == 100.64.0.0/16           allow
+       102                                     pkt.mark == 42           allow
+       100                             ip4.src == 10.244.0.13         reroute                10.244.1.2               pkt_mark=1009
+```
+
+And in each node an nftable chain is added in postrouting hook with priority `srcnat+1` 
+with a set of rules to drop marked (notice, 1009 == 0x000003f1) traffic from any pod CIDR subnet:
+```shell
+table inet ovn-kubernetes {
+	chain ovn-kube-egress-ip {
+		comment "OVN egress IP traffic handling"
+		type filter hook postrouting priority srcnat + 1; policy accept;
+		ip saddr 10.244.0.0/16 meta mark 0x000003f1 drop comment "Drop egress IP pod traffic from 10.244.0.0/16"
+	}
+}
+```
+
+This guarantees that while differences might occur in reconciliation time, traffic would not
+leak the egress secondary interface with the pod IP as source address (i.e., when the reroute LRP is applied before the SNAT).
 
 ## Special considerations for Egress IPs hosted by standard linux interfaces
 If you wish to assign an Egress IP to a standard linux interface (non OVS type), then the following is required:

--- a/go-controller/pkg/node/controllers/egressip/egressip.go
+++ b/go-controller/pkg/node/controllers/egressip/egressip.go
@@ -41,6 +41,7 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/iprulemanager"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/iptables"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/linkmanager"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/nftables"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/routemanager"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/syncmap"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
@@ -321,6 +322,10 @@ func (c *Controller) Run(stopCh <-chan struct{}, wg *sync.WaitGroup, threads int
 		})
 	if err != nil {
 		return fmt.Errorf("failed to run EgressIP controller because migration from using address labels to a node annotation failed: %v", err)
+	}
+
+	if err := nftables.InitEgressIPNFTChain(c.v4, c.v6); err != nil {
+		return fmt.Errorf("failed to initialize nftables default drop rule for secondary egressip: %w", err)
 	}
 
 	err = wait.PollUntilContextTimeout(wait.ContextForChannel(stopCh), 1*time.Second, 10*time.Second, true,

--- a/go-controller/pkg/node/nftables/egressip.go
+++ b/go-controller/pkg/node/nftables/egressip.go
@@ -1,0 +1,105 @@
+// SPDX-FileCopyrightText: Copyright The OVN-Kubernetes Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+// +build linux
+
+package nftables
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/knftables"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+)
+
+const (
+	nftEgressIPChain = "ovn-kube-egress-ip"
+)
+
+// TODO: further investigation is needed to redesign and simplify this approach.
+// Marking packages and dropping them to avoid leaking might not be necessary.
+// It might be possible to drop leaking packets solely based on source IP after prerouting SNAT.
+
+// InitEgressIPNFTChain creates the nftables chain for egress IP traffic
+// on secondary interface, so it makes sure no traffic with pod IP is leaked.
+// This needs to be called once at controller startup
+func InitEgressIPNFTChain(v4, v6 bool) error {
+	// Get cluster-wide pod CIDRs from config
+	podIPv4CIDRs, podIPv6CIDRs := util.GetClusterSubnets()
+	if v4 && len(podIPv4CIDRs) == 0 {
+		return fmt.Errorf("IPv4 enabled but no cluster pod CIDRs configured")
+	}
+	if v6 && len(podIPv6CIDRs) == 0 {
+		return fmt.Errorf("IPv6 enabled but no cluster pod CIDRs configured")
+	}
+	klog.Infof("Using cluster pod CIDRs for egress IP traffic: IPv4=%v, IPv6=%v",
+		podIPv4CIDRs, podIPv6CIDRs)
+
+	nft, err := GetNFTablesHelper()
+	if err != nil {
+		return fmt.Errorf("failed to get nftables helper: %w", err)
+	}
+	tx := nft.NewTransaction()
+
+	// Create the dedicated chain for egress IP traffic
+	// Use priority 101 (after all SNAT rules at 100, before local gateway masquerade)
+	eipChain := &knftables.Chain{
+		Name:     nftEgressIPChain,
+		Comment:  knftables.PtrTo("OVN egress IP traffic handling"),
+		Type:     knftables.PtrTo(knftables.FilterType),
+		Hook:     knftables.PtrTo(knftables.PostroutingHook),
+		Priority: knftables.PtrTo(knftables.BaseChainPriority("srcnat + 1")),
+	}
+	tx.Add(eipChain)
+
+	tx.Flush(eipChain)
+
+	counterIfDebug := ""
+	if config.Logging.Level > 4 {
+		counterIfDebug = "counter"
+	}
+
+	// Rule 1: DROP if marked AND from any cluster pod CIDR
+	// This prevents pod traffic from leaking before SNAT is ready
+	if v4 {
+		for _, cidr := range podIPv4CIDRs {
+			dropPodIPv4 := &knftables.Rule{
+				Chain: nftEgressIPChain,
+				Rule: knftables.Concat(
+					"ip", "saddr", cidr.String(),
+					"meta", "mark", types.EgressIPSecondaryInterfaceMark,
+					counterIfDebug,
+					"drop",
+					"comment", fmt.Sprintf("\"Drop egress IP pod traffic from %s\"", cidr),
+				),
+			}
+			tx.Add(dropPodIPv4)
+		}
+	}
+	if v6 {
+		for _, cidr := range podIPv6CIDRs {
+			dropPodIPv6 := &knftables.Rule{
+				Chain: nftEgressIPChain,
+				Rule: knftables.Concat(
+					"ip6", "saddr", cidr.String(),
+					"meta", "mark", types.EgressIPSecondaryInterfaceMark,
+					counterIfDebug,
+					"drop",
+					"comment", fmt.Sprintf("\"Drop egress IP pod traffic from %s\"", cidr),
+				),
+			}
+			tx.Add(dropPodIPv6)
+		}
+	}
+
+	if err := nft.Run(context.TODO(), tx); err != nil {
+		return fmt.Errorf("failed to setup egress IP nftables chain: %w", err)
+	}
+	return nil
+}

--- a/go-controller/pkg/node/nftables/egressip_test.go
+++ b/go-controller/pkg/node/nftables/egressip_test.go
@@ -1,0 +1,175 @@
+// SPDX-FileCopyrightText: Copyright The OVN-Kubernetes Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+// +build linux
+
+package nftables
+
+import (
+	"fmt"
+	"net"
+	"testing"
+
+	ovnconfig "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+)
+
+var (
+	nftRuleEgressIPSecondaryInterfaceAnnotation = `
+      add table inet ovn-kubernetes
+      add chain inet ovn-kubernetes ovn-kube-egress-ip { type filter hook postrouting priority srcnat + 1 ; comment "OVN egress IP traffic handling" ; }
+	`
+	nftRuleEgressIPSecondaryInterfaceMarkRuleIPv4 = `
+      add rule inet ovn-kubernetes ovn-kube-egress-ip ip saddr %s meta mark 1009  drop comment "Drop egress IP pod traffic from %s"
+	`
+	nftRuleEgressIPSecondaryInterfaceMarkRuleIPv6 = `
+      add rule inet ovn-kubernetes ovn-kube-egress-ip ip6 saddr %s meta mark 1009  drop comment "Drop egress IP pod traffic from %s"
+	`
+	nftRuleEgressIPSecondaryInterfaceMarkRuleIPv4Counter = `
+      add rule inet ovn-kubernetes ovn-kube-egress-ip ip saddr %s meta mark 1009 counter drop comment "Drop egress IP pod traffic from %s"
+	`
+	nftRuleEgressIPSecondaryInterfaceMarkRuleIPv6Counter = `
+      add rule inet ovn-kubernetes ovn-kube-egress-ip ip6 saddr %s meta mark 1009 counter drop comment "Drop egress IP pod traffic from %s"
+	`
+)
+
+func TestInitEgressIPNFTChain(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		v4            bool
+		v6            bool
+		v4CIDRs       []string
+		v6CIDRs       []string
+		logLevel      int
+		expectInitErr string
+	}{
+		{
+			name:    "Dual-stack single CIDRs",
+			v4:      true,
+			v6:      true,
+			v4CIDRs: []string{"5.5.5.0/24"},
+			v6CIDRs: []string{"2001:0:0:1::/64"},
+		},
+		{
+			name:    "IPv4 only",
+			v4:      true,
+			v6:      false,
+			v4CIDRs: []string{"10.128.0.0/14"},
+		},
+		{
+			name:    "IPv6 only",
+			v4:      false,
+			v6:      true,
+			v6CIDRs: []string{"fd00:10:244::/48"},
+		},
+		{
+			name:          "IPv4 enabled but no CIDRs configured",
+			v4:            true,
+			v6:            false,
+			v4CIDRs:       nil,
+			expectInitErr: "IPv4 enabled but no cluster pod CIDRs configured",
+		},
+		{
+			name:          "IPv6 enabled but no CIDRs configured",
+			v4:            false,
+			v6:            true,
+			v6CIDRs:       nil,
+			expectInitErr: "IPv6 enabled but no cluster pod CIDRs configured",
+		},
+		{
+			name:    "Multiple IPv4 CIDRs",
+			v4:      true,
+			v6:      false,
+			v4CIDRs: []string{"10.128.0.0/14", "10.132.0.0/14"},
+		},
+		{
+			name:    "Multiple IPv6 CIDRs",
+			v4:      false,
+			v6:      true,
+			v6CIDRs: []string{"fd00:10:244::/48", "fd00:10:245::/48"},
+		},
+		{
+			name:    "Dual-stack multiple CIDRs",
+			v4:      true,
+			v6:      true,
+			v4CIDRs: []string{"10.128.0.0/14", "10.132.0.0/14"},
+			v6CIDRs: []string{"fd00:10:244::/48", "fd00:10:245::/48"},
+		},
+		{
+			name: "Both protocols disabled creates chain only",
+			v4:   false,
+			v6:   false,
+		},
+		{
+			name:     "Debug logging enables counter in rules",
+			v4:       true,
+			v6:       true,
+			v4CIDRs:  []string{"10.0.0.0/16"},
+			v6CIDRs:  []string{"fd00::/112"},
+			logLevel: 5,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fake := SetFakeNFTablesHelper()
+
+			ovnconfig.Default.ClusterSubnets = nil
+			for _, cidrStr := range tc.v4CIDRs {
+				_, cidr, _ := net.ParseCIDR(cidrStr)
+				ovnconfig.Default.ClusterSubnets = append(ovnconfig.Default.ClusterSubnets,
+					ovnconfig.CIDRNetworkEntry{CIDR: cidr})
+			}
+			for _, cidrStr := range tc.v6CIDRs {
+				_, cidr, _ := net.ParseCIDR(cidrStr)
+				ovnconfig.Default.ClusterSubnets = append(ovnconfig.Default.ClusterSubnets,
+					ovnconfig.CIDRNetworkEntry{CIDR: cidr})
+			}
+
+			savedLogLevel := ovnconfig.Logging.Level
+			if tc.logLevel > 0 {
+				ovnconfig.Logging.Level = tc.logLevel
+			} else {
+				ovnconfig.Logging.Level = 0
+			}
+			defer func() { ovnconfig.Logging.Level = savedLogLevel }()
+
+			err := InitEgressIPNFTChain(tc.v4, tc.v6)
+			if tc.expectInitErr != "" {
+				if err == nil {
+					t.Fatalf("expected error %q but got nil", tc.expectInitErr)
+				}
+				if err.Error() != tc.expectInitErr {
+					t.Fatalf("expected error %q but got %q", tc.expectInitErr, err.Error())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			expectedChain := nftRuleEgressIPSecondaryInterfaceAnnotation
+			useCounter := tc.logLevel > 4
+			if tc.v4 {
+				tmpl := nftRuleEgressIPSecondaryInterfaceMarkRuleIPv4
+				if useCounter {
+					tmpl = nftRuleEgressIPSecondaryInterfaceMarkRuleIPv4Counter
+				}
+				for _, cidr := range tc.v4CIDRs {
+					expectedChain += "\n" + fmt.Sprintf(tmpl, cidr, cidr)
+				}
+			}
+			if tc.v6 {
+				tmpl := nftRuleEgressIPSecondaryInterfaceMarkRuleIPv6
+				if useCounter {
+					tmpl = nftRuleEgressIPSecondaryInterfaceMarkRuleIPv6Counter
+				}
+				for _, cidr := range tc.v6CIDRs {
+					expectedChain += "\n" + fmt.Sprintf(tmpl, cidr, cidr)
+				}
+			}
+
+			if err = MatchNFTRules(expectedChain, fake.Dump()); err != nil {
+				t.Fatalf("expected egressIP NFT rules to match: %v", err)
+			}
+		})
+	}
+}

--- a/go-controller/pkg/ovn/egressip.go
+++ b/go-controller/pkg/ovn/egressip.go
@@ -2454,6 +2454,18 @@ func (e *EgressIPController) addPodEgressIPAssignment(ni util.NetInfo, egressIPN
 		return fmt.Errorf("could not calculate the next hop for pod %s/%s when configuring egress IP %s"+
 			" IP %s", pod.Namespace, pod.Name, egressIPName, status.EgressIP)
 	}
+	policyOpsMark := ""
+	if ni.IsUserDefinedNetwork() {
+		if !mark.IsAvailable() {
+			return fmt.Errorf("egressIP %s object must contain a mark for user defined networks", egressIPName)
+		}
+		policyOpsMark = mark.String()
+	}
+	// For default network with secondary host interface, set egress ip secondary interface mark in reroute policy
+	if ni.IsDefault() && !isOVNNetwork && isLocalZoneEgressNode {
+		policyOpsMark = types.EgressIPSecondaryInterfaceMark
+	}
+
 	var ops []ovsdb.Operation
 	if loadedEgressNode && isLocalZoneEgressNode {
 		// create NATs for CDNs only
@@ -2468,7 +2480,7 @@ func (e *EgressIPController) addPodEgressIPAssignment(ni util.NetInfo, egressIPN
 
 			} else if ni.IsUserDefinedNetwork() && ni.TopologyType() == types.Layer3Topology {
 				// not required for L2 because we always have LRPs using reroute action to pkt mark
-				ops, err = e.createGWMarkPolicyOps(ni, ops, podIPs, status, mark, pod.Namespace, pod.Name, egressIPName)
+				ops, err = e.createGWMarkPolicyOps(ni, ops, podIPs, status, policyOpsMark, pod.Namespace, pod.Name, egressIPName)
 				if err != nil {
 					return fmt.Errorf("unable to create GW router LRP ops to packet mark pod %s/%s: %v", pod.Namespace, pod.Name, err)
 				}
@@ -2481,7 +2493,7 @@ func (e *EgressIPController) addPodEgressIPAssignment(ni util.NetInfo, egressIPN
 			if err != nil {
 				return err
 			}
-			ops, err = e.createReroutePolicyOps(ni, ops, podIPs, status, mark, egressIPName, nextHopIP, routerName, pod.Namespace, pod.Name)
+			ops, err = e.createReroutePolicyOps(ni, ops, podIPs, status, policyOpsMark, egressIPName, nextHopIP, routerName, pod.Namespace, pod.Name)
 			if err != nil {
 				return fmt.Errorf("unable to create logical router policy ops %v, err: %v", status, err)
 			}
@@ -2502,7 +2514,7 @@ func (e *EgressIPController) addPodEgressIPAssignment(ni util.NetInfo, egressIPN
 	// don't add a reroute policy if the egress node towards which we are adding this doesn't exist
 	if loadedEgressNode && loadedPodNode {
 		if isLocalZonePod || (isLocalZoneEgressNode && ni.IsUserDefinedNetwork() && ni.TopologyType() == types.Layer2Topology) {
-			ops, err = e.createReroutePolicyOps(ni, ops, podIPs, status, mark, egressIPName, nextHopIP, routerName, pod.Namespace, pod.Name)
+			ops, err = e.createReroutePolicyOps(ni, ops, podIPs, status, policyOpsMark, egressIPName, nextHopIP, routerName, pod.Namespace, pod.Name)
 			if err != nil {
 				return fmt.Errorf("unable to create logical router policy ops, err: %v", err)
 			}
@@ -2897,15 +2909,13 @@ func (e *EgressIPController) getNextHop(ni util.NetInfo, egressNodeName, egressI
 // enabled, the appropriate transit switch port.
 // This function should be called with lock on nodeZoneState cache key status.Node
 func (e *EgressIPController) createReroutePolicyOps(ni util.NetInfo, ops []ovsdb.Operation, podIPNets []*net.IPNet, status egressipv1.EgressIPStatusItem,
-	mark util.EgressIPMark, egressIPName, nextHopIP, routerName, podNamespace, podName string) ([]ovsdb.Operation, error) {
+	mark, egressIPName, nextHopIP, routerName, podNamespace, podName string) ([]ovsdb.Operation, error) {
 	isEgressIPv6 := utilnet.IsIPv6String(status.EgressIP)
 	ipFamily := getEIPIPFamily(isEgressIPv6)
 	options := make(map[string]string)
-	if ni.IsUserDefinedNetwork() {
-		if !mark.IsAvailable() {
-			return nil, fmt.Errorf("egressIP %s object must contain a mark for user defined networks", egressIPName)
-		}
-		addPktMarkToLRPOptions(options, mark.String())
+
+	if mark != "" {
+		addPktMarkToLRPOptions(options, mark)
 	}
 	dbIDs := getEgressIPLRPReRouteDbIDs(egressIPName, podNamespace, podName, ipFamily, ni.GetNetworkName(), e.controllerName)
 	p := libovsdbops.GetPredicate[*nbdb.LogicalRouterPolicy](dbIDs, nil)
@@ -2967,15 +2977,14 @@ func (e *EgressIPController) deleteReroutePolicyOps(ni util.NetInfo, ops []ovsdb
 }
 
 func (e *EgressIPController) createGWMarkPolicyOps(ni util.NetInfo, ops []ovsdb.Operation, podIPNets []*net.IPNet, status egressipv1.EgressIPStatusItem,
-	mark util.EgressIPMark, podNamespace, podName, egressIPName string) ([]ovsdb.Operation, error) {
+	mark, podNamespace, podName, egressIPName string) ([]ovsdb.Operation, error) {
 	isEgressIPv6 := utilnet.IsIPv6String(status.EgressIP)
 	routerName := ni.GetNetworkScopedGWRouterName(status.Node)
 	options := make(map[string]string)
-	if !mark.IsAvailable() {
-		return nil, fmt.Errorf("egressIP object must contain a mark for user defined networks")
-	}
-	addPktMarkToLRPOptions(options, mark.String())
 	var err error
+	if mark != "" {
+		addPktMarkToLRPOptions(options, mark)
+	}
 	ovnIPFamilyName := ipFamilyName(isEgressIPv6)
 	ipFamilyValue := getEIPIPFamily(isEgressIPv6)
 	dbIDs := getEgressIPLRPSNATMarkDbIDs(egressIPName, podNamespace, podName, ipFamilyValue, ni.GetNetworkName(), e.controllerName)

--- a/go-controller/pkg/ovn/egressip_test.go
+++ b/go-controller/pkg/ovn/egressip_test.go
@@ -596,6 +596,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 					Match:       fmt.Sprintf("ip4.src == %s", egressPod.Status.PodIP),
 					Action:      nbdb.LogicalRouterPolicyActionReroute,
 					Nexthops:    []string{node1MgntIP.To4().String()},
+					Options:     map[string]string{"pkt_mark": types.EgressIPSecondaryInterfaceMark},
 					ExternalIDs: getEgressIPLRPReRouteDbIDs(eIP.Name, egressPod.Namespace, egressPod.Name, IPFamilyValueV4, types.DefaultNetworkName, fakeOvn.controller.eIPC.controllerName).GetExternalIDs(),
 					UUID:        "reroute-UUID",
 				},
@@ -1638,6 +1639,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 							Match:       fmt.Sprintf("ip4.src == %s", egressPod.Status.PodIP),
 							Action:      nbdb.LogicalRouterPolicyActionReroute,
 							Nexthops:    []string{node2MgntIP.To4().String()},
+							Options:     map[string]string{"pkt_mark": types.EgressIPSecondaryInterfaceMark},
 							ExternalIDs: getEgressIPLRPReRouteDbIDs(eIP.Name, egressPod.Namespace, egressPod.Name, IPFamilyValueV4, types.DefaultNetworkName, fakeOvn.controller.eIPC.controllerName).GetExternalIDs(),
 							UUID:        "reroute-UUID",
 						},
@@ -1989,9 +1991,16 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 						servedPodIPs = nil
 					}
 					egressIPServedPodsASv4, _ := buildEgressIPServedPodsAddressSets(servedPodIPs, types.DefaultNetworkName, fakeOvn.controller.eIPC.controllerName)
+					var reroutePolicy *nbdb.LogicalRouterPolicy
+					if node2Zone == "remote" {
+						reroutePolicy = getReRoutePolicy(egressPod.Status.PodIP, "4", "reroute-UUID", reroutePolicyNextHop,
+							getEgressIPLRPReRouteDbIDs(eIP.Name, egressPod.Namespace, egressPod.Name, IPFamilyValueV4, types.DefaultNetworkName, fakeOvn.controller.eIPC.controllerName).GetExternalIDs())
+					} else {
+						reroutePolicy = getReRoutePolicySecondaryHost(egressPod.Status.PodIP, "4", "reroute-UUID", reroutePolicyNextHop,
+							getEgressIPLRPReRouteDbIDs(eIP.Name, egressPod.Namespace, egressPod.Name, IPFamilyValueV4, types.DefaultNetworkName, fakeOvn.controller.eIPC.controllerName).GetExternalIDs())
+					}
 					expectedDatabaseState := []libovsdbtest.TestData{
-						getReRoutePolicy(egressPod.Status.PodIP, "4", "reroute-UUID", reroutePolicyNextHop,
-							getEgressIPLRPReRouteDbIDs(eIP.Name, egressPod.Namespace, egressPod.Name, IPFamilyValueV4, types.DefaultNetworkName, fakeOvn.controller.eIPC.controllerName).GetExternalIDs()),
+						reroutePolicy,
 						&nbdb.LogicalRouterPolicy{
 							Priority:    types.DefaultNoRereoutePriority,
 							Match:       "ip4.src == 10.128.0.0/14 && ip4.dst == 10.128.0.0/14",
@@ -2103,12 +2112,23 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 						egressNodeIPsASv4, _ := buildEgressIPNodeAddressSets(egressNodeIPs)
 						expectedDatabaseState = append(expectedDatabaseState, egressNodeIPsASv4)
 					}
-					if node1Zone == "remote" {
+					if node1Zone == "remote" && node2Zone == "remote" {
 						expectedDatabaseState = append(expectedDatabaseState, getReRoutePolicy(egressPod.Status.PodIP, "4", "remote-reroute-UUID", reroutePolicyNextHop,
 							getEgressIPLRPReRouteDbIDs(eIP.Name, egressPod.Namespace, egressPod.Name, IPFamilyValueV4, types.DefaultNetworkName, fakeOvn.controller.eIPC.controllerName).GetExternalIDs()))
 						expectedDatabaseState[6].(*nbdb.LogicalRouter).Policies = expectedDatabaseState[6].(*nbdb.LogicalRouter).Policies[1:]                            // remove LRP ref
 						expectedDatabaseState[6].(*nbdb.LogicalRouter).Policies = append(expectedDatabaseState[6].(*nbdb.LogicalRouter).Policies, "remote-reroute-UUID") // remove LRP ref
 						expectedDatabaseState = expectedDatabaseState[1:]                                                                                                // remove LRP
+						ipNets, _ := util.ParseIPNets(append(node1IPv4Addresses, node2IPv4Addresses...))
+						egressNodeIPs := []string{}
+						for _, ipNet := range ipNets {
+							egressNodeIPs = append(egressNodeIPs, ipNet.IP.String())
+						}
+						egressNodeIPsASv4, _ := buildEgressIPNodeAddressSets(egressNodeIPs)
+						expectedDatabaseState = append(expectedDatabaseState, egressNodeIPsASv4)
+					}
+					if node1Zone == "remote" && node2Zone == "global" {
+						// For secondary host networks with remote pods on local egress nodes,
+						// reroute policy is still created to redirect to local management port
 						ipNets, _ := util.ParseIPNets(append(node1IPv4Addresses, node2IPv4Addresses...))
 						egressNodeIPs := []string{}
 						for _, ipNet := range ipNets {
@@ -2378,31 +2398,31 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 					if !interconnect {
 						lrps = append(lrps, getReRoutePolicy(egressPod1Node1.Status.PodIP, "4", "reroute-UUID", egressPod1Node1Reroute,
 							getEgressIPLRPReRouteDbIDs(eIPOVN.Name, egressPod1Node1.Namespace, egressPod1Node1.Name, IPFamilyValueV4, types.DefaultNetworkName, fakeOvn.controller.eIPC.controllerName).GetExternalIDs()),
-							getReRoutePolicy(egressPod2Node1.Status.PodIP, "4", "reroute-UUID2", egressPod2Node1Reroute,
+							getReRoutePolicySecondaryHost(egressPod2Node1.Status.PodIP, "4", "reroute-UUID2", egressPod2Node1Reroute,
 								getEgressIPLRPReRouteDbIDs(eIPSecondaryHost.Name, egressPod2Node1.Namespace, egressPod2Node1.Name, IPFamilyValueV4, types.DefaultNetworkName, fakeOvn.controller.eIPC.controllerName).GetExternalIDs()),
 							getReRoutePolicy(egressPod3Node2.Status.PodIP, "4", "reroute-UUID3", egressPod3Node2Reroute,
 								getEgressIPLRPReRouteDbIDs(eIPOVN.Name, egressPod3Node2.Namespace, egressPod3Node2.Name, IPFamilyValueV4, types.DefaultNetworkName, fakeOvn.controller.eIPC.controllerName).GetExternalIDs()),
-							getReRoutePolicy(egressPod4Node2.Status.PodIP, "4", "reroute-UUID4", egressPod4Node2Reroute,
+							getReRoutePolicySecondaryHost(egressPod4Node2.Status.PodIP, "4", "reroute-UUID4", egressPod4Node2Reroute,
 								getEgressIPLRPReRouteDbIDs(eIPSecondaryHost.Name, egressPod4Node2.Namespace, egressPod4Node2.Name, IPFamilyValueV4, types.DefaultNetworkName, fakeOvn.controller.eIPC.controllerName).GetExternalIDs()))
 					}
 
 					if interconnect && node1Zone == "global" && node2Zone == "global" {
 						lrps = append(lrps, getReRoutePolicy(egressPod1Node1.Status.PodIP, "4", "reroute-UUID", egressPod1Node1Reroute,
 							getEgressIPLRPReRouteDbIDs(eIPOVN.Name, egressPod1Node1.Namespace, egressPod1Node1.Name, IPFamilyValueV4, types.DefaultNetworkName, fakeOvn.controller.eIPC.controllerName).GetExternalIDs()),
-							getReRoutePolicy(egressPod2Node1.Status.PodIP, "4", "reroute-UUID2", egressPod2Node1Reroute,
+							getReRoutePolicySecondaryHost(egressPod2Node1.Status.PodIP, "4", "reroute-UUID2", egressPod2Node1Reroute,
 								getEgressIPLRPReRouteDbIDs(eIPSecondaryHost.Name, egressPod2Node1.Namespace, egressPod2Node1.Name, IPFamilyValueV4, types.DefaultNetworkName, fakeOvn.controller.eIPC.controllerName).GetExternalIDs()),
 							getReRoutePolicy(egressPod3Node2.Status.PodIP, "4", "reroute-UUID3", egressPod3Node2Reroute,
 								getEgressIPLRPReRouteDbIDs(eIPOVN.Name, egressPod3Node2.Namespace, egressPod3Node2.Name, IPFamilyValueV4, types.DefaultNetworkName, fakeOvn.controller.eIPC.controllerName).GetExternalIDs()),
-							getReRoutePolicy(egressPod4Node2.Status.PodIP, "4", "reroute-UUID4", egressPod4Node2Reroute,
+							getReRoutePolicySecondaryHost(egressPod4Node2.Status.PodIP, "4", "reroute-UUID4", egressPod4Node2Reroute,
 								getEgressIPLRPReRouteDbIDs(eIPSecondaryHost.Name, egressPod4Node2.Namespace, egressPod4Node2.Name, IPFamilyValueV4, types.DefaultNetworkName, fakeOvn.controller.eIPC.controllerName).GetExternalIDs()))
 					}
 
 					if interconnect && node1Zone == "global" && node2Zone == "remote" {
 						lrps = append(lrps, getReRoutePolicy(egressPod1Node1.Status.PodIP, "4", "reroute-UUID", egressPod1Node1Reroute,
 							getEgressIPLRPReRouteDbIDs(eIPOVN.Name, egressPod1Node1.Namespace, egressPod1Node1.Name, IPFamilyValueV4, types.DefaultNetworkName, fakeOvn.controller.eIPC.controllerName).GetExternalIDs()),
-							getReRoutePolicy(egressPod2Node1.Status.PodIP, "4", "reroute-UUID2", egressPod2Node1Reroute,
+							getReRoutePolicySecondaryHost(egressPod2Node1.Status.PodIP, "4", "reroute-UUID2", egressPod2Node1Reroute,
 								getEgressIPLRPReRouteDbIDs(eIPSecondaryHost.Name, egressPod2Node1.Namespace, egressPod2Node1.Name, IPFamilyValueV4, types.DefaultNetworkName, fakeOvn.controller.eIPC.controllerName).GetExternalIDs()),
-							getReRoutePolicy(podV4IP4, "4", "egressip-pod4node2", egressPod4Node2Reroute,
+							getReRoutePolicySecondaryHost(podV4IP4, "4", "egressip-pod4node2", egressPod4Node2Reroute,
 								getEgressIPLRPReRouteDbIDs(eIPSecondaryHost.Name, egressPod4Node2.Namespace, egressPod4Node2.Name, IPFamilyValueV4, types.DefaultNetworkName, fakeOvn.controller.eIPC.controllerName).GetExternalIDs()))
 					}
 
@@ -3259,9 +3279,16 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 						egressNodeIPs = append(egressNodeIPs, ipNet.IP.String())
 					}
 					egressNodeIPsASv4, _ := buildEgressIPNodeAddressSets(egressNodeIPs)
+					var reroutePolicy *nbdb.LogicalRouterPolicy
+					if node2Zone == "remote" {
+						reroutePolicy = getReRoutePolicy(egressPod.Status.PodIP, "4", "reroute-UUID", reroutePolicyNextHop,
+							getEgressIPLRPReRouteDbIDs(eIP.Name, egressPod.Namespace, egressPod.Name, IPFamilyValueV4, types.DefaultNetworkName, fakeOvn.controller.eIPC.controllerName).GetExternalIDs())
+					} else {
+						reroutePolicy = getReRoutePolicySecondaryHost(egressPod.Status.PodIP, "4", "reroute-UUID", reroutePolicyNextHop,
+							getEgressIPLRPReRouteDbIDs(eIP.Name, egressPod.Namespace, egressPod.Name, IPFamilyValueV4, types.DefaultNetworkName, fakeOvn.controller.eIPC.controllerName).GetExternalIDs())
+					}
 					expectedDatabaseState := []libovsdbtest.TestData{
-						getReRoutePolicy(egressPod.Status.PodIP, "4", "reroute-UUID", reroutePolicyNextHop,
-							getEgressIPLRPReRouteDbIDs(eIP.Name, egressPod.Namespace, egressPod.Name, IPFamilyValueV4, types.DefaultNetworkName, fakeOvn.controller.eIPC.controllerName).GetExternalIDs()),
+						reroutePolicy,
 						&nbdb.LogicalRouterPolicy{
 							Priority:    types.DefaultNoRereoutePriority,
 							Match:       "(ip4.src == $a8519615025667110816 || ip4.src == $a13607449821398607916) && ip4.dst == $a712973235162149816",
@@ -3370,7 +3397,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 						node2Switch.QOSRules = []string{"default-QoS-UUID"}
 					}
 					if node1Zone == "remote" {
-						podPolicy := getReRoutePolicy(podV4IP, "4", "static-reroute-UUID", []string{node2MgntIP.To4().String()},
+						podPolicy := getReRoutePolicySecondaryHost(podV4IP, "4", "static-reroute-UUID", []string{node2MgntIP.To4().String()},
 							getEgressIPLRPReRouteDbIDs(eIP.Name, egressPod.Namespace, egressPod.Name, IPFamilyValueV4, types.DefaultNetworkName, fakeOvn.controller.eIPC.controllerName).GetExternalIDs())
 						expectedDatabaseState = append(expectedDatabaseState, podPolicy)
 						expectedDatabaseState[6].(*nbdb.LogicalRouter).Policies = append(expectedDatabaseState[6].(*nbdb.LogicalRouter).Policies, "static-reroute-UUID")
@@ -15169,6 +15196,18 @@ func getReRoutePolicy(podIP, ipFamily, uuid string, nextHops []string, externalI
 		Match:       fmt.Sprintf("ip%s.src == %s", ipFamily, podIP),
 		Action:      nbdb.LogicalRouterPolicyActionReroute,
 		Nexthops:    nextHops,
+		ExternalIDs: externalID,
+		UUID:        uuid,
+	}
+}
+
+func getReRoutePolicySecondaryHost(podIP, ipFamily, uuid string, nextHops []string, externalID map[string]string) *nbdb.LogicalRouterPolicy {
+	return &nbdb.LogicalRouterPolicy{
+		Priority:    types.EgressIPReroutePriority,
+		Match:       fmt.Sprintf("ip%s.src == %s", ipFamily, podIP),
+		Action:      nbdb.LogicalRouterPolicyActionReroute,
+		Nexthops:    nextHops,
+		Options:     map[string]string{"pkt_mark": types.EgressIPSecondaryInterfaceMark},
 		ExternalIDs: externalID,
 		UUID:        uuid,
 	}

--- a/go-controller/pkg/types/const.go
+++ b/go-controller/pkg/types/const.go
@@ -143,6 +143,9 @@ const (
 	// Packet marking
 	EgressIPNodeConnectionMark         = "1008"
 	EgressIPReplyTrafficConnectionMark = 42
+	// Packet mark for egress IP traffic on secondary host interfaces
+	// This mark will be cleared by node controller when SNAT is ready
+	EgressIPSecondaryInterfaceMark = "1009"
 
 	// primary user defined network's default join subnet value
 	// users can configure custom values using NADs

--- a/test/e2e/egressip.go
+++ b/test/e2e/egressip.go
@@ -11,11 +11,13 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/ginkgo/v2/dsl/table"
 	"github.com/onsi/gomega"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
@@ -3064,6 +3066,272 @@ spec:
 		}, 30*time.Second, 2*time.Second).Should(gomega.BeTrue(),
 			"Neighbor entry should appear")
 		gomega.Expect(neighborMAC).Should(gomega.Equal(inf.MAC), "neighbor entry should have the correct MAC address")
+	})
+
+	var _ = ginkgo.Describe("[secondary-host-eip] Egress IP Traffic Leak Prevention with Packet Mark Validation", func() {
+		const (
+			egressIPName   = "egressip-pktmark-validation-test"
+			egressIPYaml   = "/tmp/egressip-pktmark-validation.yaml"
+			monitorPodName = "traffic-monitor-existing"
+			podNamePrefix  = "existing-pod"
+			numTestPods    = 2 // Create multiple pods to stress reconciliation
+			retryInterval  = 1 * time.Second
+			retryTimeout   = 120 * time.Second
+		)
+
+		var (
+			// Pod IPs to check for leaks
+			podIPs     []string
+			podIPsLock sync.Mutex
+		)
+
+		ginkgo.BeforeEach(func() {
+			podIPsLock.Lock()
+			podIPs = []string{}
+			podIPsLock.Unlock()
+		})
+
+		ginkgo.It("Should prevent pod IP traffic leak when EgressIP on secondary interface is applied to existing running pods", func() {
+			// Test Overview:
+			// This test validates a different race condition scenario:
+			// 1. Pods are created FIRST and are actively sending traffic
+			// 2. Then an EgressIP object is created and applied to them
+			// 3. During the reconciliation window, traffic should NOT leak with pod IPs
+			//
+			// This tests the transition from "normal routing" to "egress IP routing"
+			// which is common in production when EgressIP policies are added to existing workloads.
+
+			if isUserDefinedNetwork(netConfigParams) {
+				ginkgo.Skip("Unsupported for UDNs")
+			}
+
+			ginkgo.By("Step 0: Setting up egress IP address")
+
+			// Determine egress IP based on IP family
+			// Use SubTree's existing secondary network infrastructure
+			egressIPAddr := "10.10.10.200" // IPv4 egress IP (different from other test)
+			if isIPv6TestRun {
+				egressIPAddr = "2001:db8:abcd:1234::200" // IPv6 egress IP (different from other test)
+			}
+
+			targetIP := secondaryTargetExternalContainer.GetIPv4()
+			if isIPv6TestRun {
+				targetIP = secondaryTargetExternalContainer.GetIPv6()
+			}
+			framework.Logf("Using external target container with IP %s", targetIP)
+
+			ginkgo.By("Step 1: Label egress node for future egress IP assignment")
+			labelNodeForEgress(f, egress1Node.name)
+			defer unlabelNodeForEgress(f, egress1Node.name)
+
+			ginkgo.By("Step 2: Label namespace for egress IP selection")
+			podNamespace := f.Namespace
+			labels := map[string]string{
+				"egress-test": "existing-pods",
+			}
+			updateNamespaceLabels(f, podNamespace, labels)
+
+			ginkgo.By("Step 3: Start traffic monitoring BEFORE creating EgressIP and pods")
+			// Starts monitor pod with tcpdump using filter to get traffic from
+			// egress node secondary interface, and filter it based on external node IP address
+			// and source address from pod IPs subnet.
+			// Given this filter, any tcpdump packet output is a traffic leak.
+			secondaryNetwork, err := infraprovider.Get().GetNetwork(secondaryNetworkName)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "network %s must exist", secondaryNetworkName)
+			secondaryIface, err := infraprovider.Get().GetK8NodeNetworkInterface(egress1Node.name, secondaryNetwork)
+			framework.ExpectNoError(err, "failed to get network interface for network %s on node %s", secondaryNetworkName, egress1Node.name)
+
+			podV4CIDR, podV6CIDR, err := getNodePodCIDRs(pod1Node.name, "default")
+			framework.ExpectNoError(err, "failed to get pod CIDRs for node %s", pod1Node.name)
+			podCIDR := podV4CIDR
+			if isIPv6TestRun {
+				podCIDR = podV6CIDR
+			}
+			gomega.Expect(podCIDR).NotTo(gomega.BeEmpty(), "pod CIDR must not be empty for node %s", pod1Node.name)
+			monitorFilter := fmt.Sprintf("src net %s and dst host %s", podCIDR, targetIP)
+
+			ctx, ctxCancel := context.WithCancel(context.Background())
+			monitorOutput := ""
+			finishedMonitor := make(chan struct{})
+			go func() {
+				defer close(finishedMonitor)
+				var monitorErr error
+				monitorOutput, monitorErr = monitorTcpdumpOnNode(ctx, f, monitorPodName, egress1Node.name, secondaryIface.InfName,
+					"-n -vv -l", monitorFilter)
+				framework.ExpectNoError(monitorErr, "Failed to read monitor pod logs")
+			}()
+			framework.Logf("Traffic monitor pod started on node %s", egress1Node.name)
+
+			ginkgo.By(fmt.Sprintf("Step 4: Create %d pods FIRST (before EgressIP exists)", numTestPods))
+			// Pods are created before EgressIP, they will initially use normal routing (their pod IPs as source)
+
+			podEgressLabel := map[string]string{
+				"egress-existing-pod": "true",
+			}
+
+			// Create pods with continuous traffic generation
+			// These pods will keep sending traffic throughout the test
+			eg := errgroup.Group{}
+			for i := 0; i < numTestPods; i++ {
+				podName := fmt.Sprintf("%s-%d", podNamePrefix, i)
+				eg.Go(func() error {
+					// Main container continuously pings the target
+					// This ensures traffic is flowing when EgressIP is applied
+					mainCommand := []string{
+						"/bin/sh",
+						"-c",
+						fmt.Sprintf("while true; do ping -c 1 -W 1 %s || true; sleep 0.5; done", targetIP),
+					}
+
+					createPod := &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      podName,
+							Namespace: podNamespace.Name,
+							Labels:    podEgressLabel,
+						},
+						Spec: corev1.PodSpec{
+							NodeSelector: map[string]string{
+								"kubernetes.io/hostname": pod1Node.name,
+							},
+							Containers: []corev1.Container{
+								{
+									Name:    "continuous-ping",
+									Image:   images.AgnHost(),
+									Command: mainCommand,
+								},
+							},
+							RestartPolicy: corev1.RestartPolicyNever,
+						},
+					}
+
+					createdPod, err := f.ClientSet.CoreV1().Pods(podNamespace.Name).Create(context.TODO(), createPod, metav1.CreateOptions{})
+					if err != nil {
+						return fmt.Errorf("failed to create pod %s: %v", podName, err)
+					}
+
+					// Wait for pod to be running
+					err = pod.WaitForPodRunningInNamespace(context.TODO(), f.ClientSet, createdPod)
+					if err != nil {
+						return fmt.Errorf("failed waiting for pod %s to be running: %v", podName, err)
+					}
+
+					// Get pod IP
+					podIP, err := getPodIPWithRetry(f.ClientSet, isIPv6TestRun, podNamespace.Name, podName)
+					if err != nil {
+						return fmt.Errorf("failed to get IP for pod %s: %v", podName, err)
+					}
+
+					podIPsLock.Lock()
+					podIPs = append(podIPs, podIP.String())
+					podIPsLock.Unlock()
+
+					framework.Logf("Created pod %s with IP %s", podName, podIP.String())
+					return nil
+				})
+			}
+
+			// Check for any pod creation errors
+			if err := eg.Wait(); err != nil {
+				framework.Failf("Failed to create some pods: %v", err)
+			}
+
+			framework.Logf("Successfully created %d pods, collected %d pod IPs", numTestPods, len(podIPs))
+			defer func() {
+				ginkgo.By("Cleanup - Delete test pods")
+				for i := 0; i < numTestPods; i++ {
+					podName := fmt.Sprintf("%s-%d", podNamePrefix, i)
+					err := f.ClientSet.CoreV1().Pods(podNamespace.Name).Delete(context.TODO(), podName, metav1.DeleteOptions{})
+					if err != nil {
+						framework.Logf("Warning: failed to delete pod %s: %v", podName, err)
+					}
+				}
+			}()
+
+			ginkgo.By("Step 5: Create EgressIP object and apply it to existing running pods")
+			// THIS IS THE CRITICAL MOMENT: EgressIP is created while pods are actively sending traffic
+			// We want to detect any leaks during the reconciliation window
+
+			// Create the EgressIP CRD
+			egressIPConfig := fmt.Sprintf(`apiVersion: k8s.ovn.org/v1
+kind: EgressIP
+metadata:
+  name: %s
+spec:
+  egressIPs:
+  - "%s"
+  podSelector:
+    matchLabels:
+      egress-existing-pod: "true"
+  namespaceSelector:
+    matchLabels:
+      egress-test: existing-pods
+`, egressIPName, egressIPAddr)
+
+			// Normalize IPv6 address for comparison
+			normalizedEgressIP := egressIPAddr
+			if isIPv6TestRun {
+				normalizedEgressIP = net.ParseIP(egressIPAddr).String()
+			}
+
+			err = os.WriteFile(egressIPYaml, []byte(egressIPConfig), 0644)
+			framework.ExpectNoError(err, "Failed to write EgressIP YAML")
+			defer func() {
+				if err := os.Remove(egressIPYaml); err != nil {
+					framework.Logf("Unable to remove the egressIPYaml CRD config from disk: %v", err)
+				}
+			}()
+			framework.Logf("Creating EgressIP object with IP %s for existing running pods", normalizedEgressIP)
+			e2ekubectl.RunKubectlOrDie("default", "create", "-f", egressIPYaml)
+			defer func() {
+				framework.Logf("Deleting EgressIP object")
+				e2ekubectl.RunKubectlOrDie("default", "delete", "-f", egressIPYaml, "--ignore-not-found=true")
+			}()
+
+			ginkgo.By("Step 6: Verify EgressIP status is assigned to egress node")
+			var egressIPStatusItems []egressIPStatus
+			err = wait.PollUntilContextTimeout(context.Background(), retryInterval, retryTimeout, true, func(ctx context.Context) (bool, error) {
+				egressIPStatusItems = verifyEgressIPStatusLengthEquals(1, nil)
+				if len(egressIPStatusItems) != 1 {
+					return false, nil
+				}
+				if egressIPStatusItems[0].Node != egress1Node.name {
+					framework.Logf("EgressIP not yet assigned to correct node, current: %s, expected: %s",
+						egressIPStatusItems[0].Node, egress1Node.name)
+					return false, nil
+				}
+				if egressIPStatusItems[0].EgressIP != normalizedEgressIP {
+					framework.Logf("EgressIP address mismatch, current: %s, expected: %s",
+						egressIPStatusItems[0].EgressIP, normalizedEgressIP)
+					return false, nil
+				}
+				return true, nil
+			})
+			framework.ExpectNoError(err, "Failed to verify EgressIP status")
+			framework.Logf("EgressIP %s assigned to node %s", normalizedEgressIP, egress1Node.name)
+
+			ginkgo.By("Step 7: Wait for reconciliation to complete and verify egress IP is used")
+
+			// Verify pods are now using the egress IP
+			for i := 0; i < numTestPods; i++ {
+				podName := fmt.Sprintf("%s-%d", podNamePrefix, i)
+				conditionFunc := targetExternalContainerAndTest(secondaryTargetExternalContainer, podNamespace.Name, podName, true, []string{normalizedEgressIP})
+				err = wait.PollUntilContextTimeout(context.Background(), retryInterval, retryTimeout, true, func(ctx context.Context) (bool, error) {
+					return conditionFunc()
+				})
+				framework.ExpectNoError(err, "Pod %s should be using egress IP after reconciliation", podName)
+			}
+			framework.Logf("Verified pods are now using egress IP %s correctly", normalizedEgressIP)
+
+			ginkgo.By("Step 8: Analyze traffic capture for pod IP leaks during EgressIP application")
+			// This is the critical check: did any traffic leak with pod IPs during the transition?
+			ctxCancel()
+			<-finishedMonitor
+			if strings.Contains(monitorOutput, targetIP) {
+				framework.Failf("TRAFFIC LEAK DETECTED! Pod IPs were seen in traffic to %s"+
+					"This indicates traffic leaked with pod source IPs instead of egress IP %s during EgressIP application to existing pods.\ntcpdump output:\n%s",
+					targetIP, normalizedEgressIP, monitorOutput)
+			}
+		})
 	})
 
 	// two pods attached to different namespaces but the same role primary user defined network

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -26,6 +26,7 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/test/e2e/infraprovider"
 	infraapi "github.com/ovn-org/ovn-kubernetes/test/e2e/infraprovider/api"
 
+	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -1861,4 +1862,51 @@ func findOVNDBLeaderPod(f *framework.Framework, cs clientset.Interface, namespac
 	}
 
 	return nil, fmt.Errorf("no nbdb leader pod found among %d ovnkube-db pods", len(dbPods.Items))
+}
+
+// monitorTcpdumpOnNode creates a privileged host-network pod on the given node that runs
+// tcpdump on the specified interface with the provided filter. It blocks until ctx is
+// cancelled, then fetches the pod logs and deletes the monitor pod. Returns all captured
+// tcpdump output.
+func monitorTcpdumpOnNode(ctx context.Context, f *framework.Framework,
+	name, nodeName, nodeIface, options, filter string) (string, error) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: f.Namespace.Name,
+		},
+		Spec: corev1.PodSpec{
+			NodeSelector: map[string]string{
+				"kubernetes.io/hostname": nodeName,
+			},
+			HostNetwork: true,
+			Containers: []corev1.Container{
+				{
+					Name:  "traffic-monitor",
+					Image: images.Netshoot(),
+					Command: []string{
+						"/bin/bash",
+						"-c",
+						fmt.Sprintf("exec tcpdump -i %s %s %s", nodeIface, options, filter),
+					},
+					SecurityContext: &corev1.SecurityContext{
+						Privileged: func(b bool) *bool { return &b }(true),
+					},
+				},
+			},
+			RestartPolicy: corev1.RestartPolicyNever,
+		},
+	}
+
+	createdPod, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{})
+	framework.ExpectNoError(err, "Failed to create traffic monitor pod")
+	err = e2epod.WaitForPodRunningInNamespace(ctx, f.ClientSet, createdPod)
+	framework.ExpectNoError(err, "Monitor pod failed to start")
+
+	<-ctx.Done()
+	logs, err := e2ekubectl.RunKubectl(f.Namespace.Name, "logs", name)
+	if err != nil {
+		return "", err
+	}
+	return logs, nil
 }


### PR DESCRIPTION
Adds pkt_mark in ovn reroute policies for egress IP on secondary interface Adds nftables rules in nodes by default, to check packets with mark from pod subnets and drop them, otherwise remove the mark.

This guarantees that while ovn reconciles reroute policy, any pod with traffic destined to egress IP secondary interface does not get leaked containing the pod IP as src address.

Adds e2e tests in egress IP to validate changes, checking pkt_mark, ovn LRP, ovs flows, and monitor traffic for any leak detection.

Cherry-pick of commit https://github.com/openshift/ovn-kubernetes/pull/3337/commits/fa8e140a6a576d23c1a26c2e39daf62c53b14ce7 from downstream backport of release-4.21.

Conflicts addressed:
- Fixing import renames, such as `github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config`  -> `github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config`.
- Removal of condition `ni.TopologyType() == types.Layer2Topology && config.Layer2UsesTransitRouter) ` in https://github.com/openshift/ovn-kubernetes/commit/fa8e140a6a576d23c1a26c2e39daf62c53b14ce7#diff-0f91bbc7bdb15165a9fc2e1cf7492425cbf1cbd35bf3daa22a000fc4027c9b9eR2774:~:text=ni%2ETopologyType%28%29%20%3D%3D%20types%2ELayer2Topology%20%26%26%20config%2ELayer2UsesTransitRouter%29 

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code does not require changes to the documentation
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] My code does not require tests
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
