### PR TITLE
egressfirewall: reject denied traffic instead of dropping it

### DIFF
--- a/docs/design/acls.md
+++ b/docs/design/acls.md
@@ -97,7 +97,7 @@ options             : {}
 priority            : 9999
 severity            : []
 
-action              : drop
+action              : reject
 direction           : to-lport
 external_ids        : {
     "k8s.ovn.org/id"="default-network-controller:EgressFirewall:default:9998", 
@@ -116,8 +116,14 @@ priority            : 9998
 severity            : []
 ```
 
-Egress firewall should be applied after egress network policy independently, to make sure that connection that are
-allowed by network policy, but denied by egress firewall will be dropped.
+Deny rules use OVN ACL action `reject` instead of `drop`. Unlike `drop`, which silently
+discards packets and leaves clients waiting for TCP timeouts, `reject` notifies the
+initiating pod immediately: TCP connections receive a TCP RST, and other IPv4/IPv6
+traffic receives an ICMP unreachable response.
+
+Egress firewall should be applied after egress network policy independently, to make sure that connections that are
+allowed by network policy, but denied by egress firewall will be rejected with the
+protocol-specific responses above instead of being silently dropped.
 
 ## Multicast
 

--- a/go-controller/observability-lib/model/network_event.go
+++ b/go-controller/observability-lib/model/network_event.go
@@ -51,6 +51,8 @@ func (e *ACLEvent) String() string {
 		action = "Allowed"
 	case aclActionDrop:
 		action = "Dropped"
+	case aclActionReject:
+		action = "Rejected"
 	case aclActionPass:
 		action = "Delegated to network policy"
 	default:

--- a/go-controller/pkg/ovn/controller/egressfirewall/egressfirewall.go
+++ b/go-controller/pkg/ovn/controller/egressfirewall/egressfirewall.go
@@ -761,7 +761,10 @@ func (oc *EFController) addEgressFirewallRules(ef *egressFirewall, pgName string
 		if rule.access == egressfirewallapi.EgressFirewallRuleAllow {
 			action = nbdb.ACLActionAllow
 		} else {
-			action = nbdb.ACLActionDrop
+			// Reject denied traffic so the initiating pod gets an immediate TCP RST
+			// (or ICMP unreachable for non-TCP) instead of waiting for a timeout
+			// on a silently dropped packet.
+			action = nbdb.ACLActionReject
 		}
 		if len(rule.to.nodeAddrs) > 0 {
 			// sort node ips to ensure the same order when no changes are present

--- a/go-controller/pkg/ovn/egressfirewall_test.go
+++ b/go-controller/pkg/ovn/egressfirewall_test.go
@@ -615,7 +615,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 					expectedDatabaseState := getEFExpectedDb(initialData, fakeOVN, namespace1.Name,
-						"(ip4.dst == 1.2.3.4/23)", "((udp && ( udp.dst == 100 )))", nbdb.ACLActionDrop)
+						"(ip4.dst == 1.2.3.4/23)", "((udp && ( udp.dst == 100 )))", nbdb.ACLActionReject)
 					gomega.Eventually(fakeOVN.nbClient).Should(libovsdb.HaveData(expectedDatabaseState))
 					return nil
 				}
@@ -659,7 +659,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 					expectedDatabaseState := getEFExpectedDbUDN(initialData, fakeOVN, namespace1.Name,
-						"(ip4.dst == 1.2.3.4/23)", "((udp && ( udp.dst == 100 )))", nbdb.ACLActionDrop, networkConfig.GetNetworkName())
+						"(ip4.dst == 1.2.3.4/23)", "((udp && ( udp.dst == 100 )))", nbdb.ACLActionReject, networkConfig.GetNetworkName())
 					gomega.Eventually(fakeOVN.nbClient).Should(libovsdb.HaveData(expectedDatabaseState))
 					return nil
 				}
@@ -859,7 +859,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 					expectedDatabaseState = getEFExpectedDb(initialData, fakeOVN, namespace1.Name,
-						"(ip4.dst == 1.2.3.4/23)", "", nbdb.ACLActionDrop)
+						"(ip4.dst == 1.2.3.4/23)", "", nbdb.ACLActionReject)
 					gomega.Eventually(fakeOVN.nbClient).Should(libovsdb.HaveData(expectedDatabaseState))
 
 					return nil
@@ -1112,7 +1112,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 					resetNBClient(connCtx, fakeOVN.controller.nbClient)
 
 					expectedDatabaseState = getEFExpectedDb(initialData, fakeOVN, namespace1.Name,
-						"(ip4.dst == 1.2.3.4/23)", "", nbdb.ACLActionDrop)
+						"(ip4.dst == 1.2.3.4/23)", "", nbdb.ACLActionReject)
 					gomega.Eventually(fakeOVN.nbClient).Should(libovsdb.HaveData(expectedDatabaseState))
 					return nil
 				}
@@ -1243,7 +1243,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 					expectedDatabaseState := getEFExpectedDb(initialData, fakeOVN, namespace1.Name,
-						"(ip4.dst == 0.0.0.0/0 && ip4.dst != "+clusterSubnetStr+")", "", nbdb.ACLActionDrop)
+						"(ip4.dst == 0.0.0.0/0 && ip4.dst != "+clusterSubnetStr+")", "", nbdb.ACLActionReject)
 					gomega.Eventually(fakeOVN.nbClient).Should(libovsdb.HaveData(expectedDatabaseState))
 
 					return nil
@@ -1386,7 +1386,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 						dnsnameresolver.GetEgressFirewallDNSAddrSetDbIDs(dnsNameForAddrSet, fakeOVN.controller.controllerName),
 						[]string{resolvedIP})
 					addrSetUUID := strings.TrimSuffix(addrSet.UUID, "-UUID")
-					expectedDatabaseState := getEFExpectedDb(append(initialData, addrSet), fakeOVN, namespace1.Name, "(ip4.dst == $"+addrSetUUID+")", "", nbdb.ACLActionDrop)
+					expectedDatabaseState := getEFExpectedDb(append(initialData, addrSet), fakeOVN, namespace1.Name, "(ip4.dst == $"+addrSetUUID+")", "", nbdb.ACLActionReject)
 					gomega.Eventually(fakeOVN.nbClient).Should(libovsdb.HaveData(expectedDatabaseState))
 
 					ginkgo.By("deleting egress firewall, DNS, and namespace")

--- a/test/e2e/egress_firewall.go
+++ b/test/e2e/egress_firewall.go
@@ -227,6 +227,24 @@ func egressFirewallPolicyValidationTests(useUDN bool, udnTopology string) {
 				}
 			}
 
+			checkConnectivityRejected := func(srcPodName, dstIP, dstPort string) {
+				testContainer := fmt.Sprintf("%s-container", srcPodName)
+				testContainerFlag := fmt.Sprintf("--container=%s", testContainer)
+				gomega.Eventually(func() error {
+					_, err := e2ekubectl.RunKubectl(f.Namespace.Name, "exec", srcPodName, testContainerFlag, "--",
+						"curl", "-s", "--connect-timeout", "1", net.JoinHostPort(dstIP, dstPort))
+					if err == nil {
+						return fmt.Errorf("connection to [%s]:%s succeeded but should be rejected", dstIP, dstPort)
+					}
+					if strings.Contains(err.Error(), "exit code 7") {
+						return nil
+					}
+					return fmt.Errorf("expected connection refused (exit code 7) to [%s]:%s, got: %w", dstIP, dstPort, err)
+				}, 15*time.Second, 500*time.Millisecond).Should(gomega.Succeed(),
+					fmt.Sprintf("expected pod %s to receive connection refused for denied egress to [%s]:%s",
+						srcPodName, dstIP, dstPort))
+			}
+
 			checkExternalContainerConnectivity := func(externalContainer infraapi.ExternalContainer, dstIP string, dstPort int) {
 				gomega.Eventually(func() error {
 					_, err := infraprovider.Get().ExecExternalContainerCommand(externalContainer, []string{
@@ -348,6 +366,31 @@ spec:
 				ginkgo.By(fmt.Sprintf("Verifying connectivity to an implicitly denied host %s is not permitted as defined "+
 					"by the external firewall policy", getExternalContainerIP(externalContainer2)))
 				checkConnectivity(srcPodName, getExternalContainerIP(externalContainer2), externalContainer2.GetPortStr(), false)
+			})
+
+			ginkgo.It("Should reject denied egress firewall connections instead of timing out", func() {
+				srcPodName := "e2e-egress-fw-reject-pod"
+				createSrcPod(srcPodName, serverNodeInfo.name, retryInterval, retryTimeout, f)
+
+				var egressFirewallConfig = fmt.Sprintf(`kind: EgressFirewall
+apiVersion: k8s.ovn.org/v1
+metadata:
+  name: default
+  namespace: %s
+spec:
+  egress:
+  - type: Allow
+    to:
+      cidrSelector: %s/%s
+  - type: Deny
+    to:
+      cidrSelector: %s
+`, f.Namespace.Name, getExternalContainerIP(externalContainer1), singleIPMask, denyAllCIDR)
+				applyEF(egressFirewallConfig, f.Namespace.Name)
+
+				ginkgo.By(fmt.Sprintf("Verifying denied egress to %s is rejected immediately with connection refused",
+					getExternalContainerIP(externalContainer2)))
+				checkConnectivityRejected(srcPodName, getExternalContainerIP(externalContainer2), externalContainer2.GetPortStr())
 			})
 
 			ginkgo.It("Should validate the egress firewall policy functionality for allowed CIDR and port", func() {


### PR DESCRIPTION
Denied egress connections previously used OVN ACL action drop, which silently discarded packets and forced clients to wait for TCP timeouts. Use reject so OVN returns TCP RST (or ICMP unreachable for non-TCP) and applications fail fast.

## 📑 Description
EgressFirewall `Deny` rules now program OVN ACL action `reject` instead of `drop`.

- TCP: immediate TCP RST
- UDP: ICMP unreachable
- SCTP: abort

Allow rules are unchanged. This is a behavior change on upgrade: denied connections fail fast instead of hanging until TCP timeout.

## Additional Information for reviewers
- Core: `go-controller/pkg/ovn/controller/egressfirewall/egressfirewall.go`
- Unit tests: `go-controller/pkg/ovn/egressfirewall_test.go`
- Observability: `observability-lib/model/network_event.go` (`Rejected` for reject ACLs)
- Docs: `docs/design/acls.md` (protocol-level reject behavior)
- E2E: `test/e2e/egress_firewall.go` — verifies `exit code 7` on denied egress

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code does not require changes to the documentation
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] My code does not require tests
- [ ] All the tests have passed in the CI

## How to verify it
```
cd go-controller
go test ./pkg/ovn/controller/egressfirewall/ -count=1
go test ./pkg/ovn/ -count=1 -ginkgo.focus='EgressFirewall'
go test ./observability-lib/model/ -count=1
```

Reference: [RFE-8279](https://redhat.atlassian.net/browse/RFE-8279) 