### PR TITLE
NO-JIRA: DownStream Merge [08-11-2026]

### DIFF
--- a/go-controller/pkg/clustermanager/network_cluster_controller.go
+++ b/go-controller/pkg/clustermanager/network_cluster_controller.go
@@ -1069,7 +1069,7 @@ func (ncc *networkClusterController) clearInitialNodeNetworkUnavailableCondition
 					condition.Reason = "RouteCreated"
 					condition.Message = "ovn-kube cleared kubelet-set NoRouteCreated"
 					condition.LastTransitionTime = metav1.Now()
-					if err = ncc.kube.UpdateNodeStatus(node); err == nil {
+					if err = ncc.kube.PatchNodeStatus(oldNode, node); err == nil {
 						cleared = true
 					}
 				}

--- a/go-controller/pkg/clustermanager/node/node_allocator.go
+++ b/go-controller/pkg/clustermanager/node/node_allocator.go
@@ -538,7 +538,7 @@ func (na *NodeAllocator) updateNodeNetworkAnnotationsWithRetry(nodeName string, 
 	// Retry if it fails because of potential conflict which is transient. Return error in the
 	// case of other errors (say temporary API server down), and it will be taken care of by the
 	// retry mechanism.
-	resultErr := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+	resultErr := retry.OnError(retry.DefaultBackoff, util.IsNodeAnnotationPatchRetryable, func() error {
 		// Informer cache should not be mutated, so get a copy of the object
 		node, err := na.nodeLister.Get(nodeName)
 		if err != nil {
@@ -570,9 +570,10 @@ func (na *NodeAllocator) updateNodeNetworkAnnotationsWithRetry(nodeName string, 
 					node.Name, tunnelID, networkName, err)
 			}
 		}
-		// It is possible to update the node annotations using status subresource
-		// because changes to metadata via status subresource are not restricted for nodes.
-		return na.kube.UpdateNodeStatus(cnode)
+		// Patch only the changed annotations via the status subresource instead
+		// of a full status update, which would overwrite fields trimmed by the
+		// informer transform (e.g. Images, VolumesAttached).
+		return na.kube.PatchNodeStatusAnnotations(node, cnode)
 	})
 	if resultErr != nil {
 		return fmt.Errorf("failed to update node %s annotation: %w", nodeName, resultErr)

--- a/go-controller/pkg/clustermanager/routeadvertisements/controller.go
+++ b/go-controller/pkg/clustermanager/routeadvertisements/controller.go
@@ -12,6 +12,7 @@ import (
 	"reflect"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 
 	nadtypes "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
@@ -99,6 +100,12 @@ type Controller struct {
 	// networkRefReconcilerID identifies our registration with the network
 	// manager for network activity change notifications
 	networkRefReconcilerID uint64
+
+	// raNetworks caches the networks each RouteAdvertisements selects, so
+	// that a network activity change only reconciles the RouteAdvertisements
+	// selecting that network
+	raNetworksLock sync.RWMutex
+	raNetworks     map[string]sets.Set[string]
 }
 
 // networkRefReconcilerFunc adapts a function to the
@@ -106,6 +113,37 @@ type Controller struct {
 type networkRefReconcilerFunc func(node, networkName string)
 
 func (f networkRefReconcilerFunc) Reconcile(node, networkName string) { f(node, networkName) }
+
+// setRANetworks caches the networks selected by a RouteAdvertisements.
+func (c *Controller) setRANetworks(ra string, networks []string) {
+	c.raNetworksLock.Lock()
+	defer c.raNetworksLock.Unlock()
+	c.raNetworks[ra] = sets.New(networks...)
+}
+
+// deleteRANetworks removes a RouteAdvertisements from the selected networks
+// cache.
+func (c *Controller) deleteRANetworks(ra string) {
+	c.raNetworksLock.Lock()
+	defer c.raNetworksLock.Unlock()
+	delete(c.raNetworks, ra)
+}
+
+// getRAsForNetwork returns the RouteAdvertisements known to select the
+// network. A RouteAdvertisements not in the cache has not been reconciled
+// yet: its pending reconcile will read the current activity state of its
+// networks, so it doesn't need this notification.
+func (c *Controller) getRAsForNetwork(network string) []string {
+	c.raNetworksLock.RLock()
+	defer c.raNetworksLock.RUnlock()
+	var ras []string
+	for ra, networks := range c.raNetworks {
+		if networks.Has(network) {
+			ras = append(ras, ra)
+		}
+	}
+	return ras
+}
 
 // NewController builds a controller that reconciles RouteAdvertisements
 func NewController(
@@ -124,6 +162,7 @@ func NewController(
 		nadClient:       ovnClient.NetworkAttchDefClient,
 		raClient:        ovnClient.RouteAdvertisementsClient,
 		nm:              nm,
+		raNetworks:      map[string]sets.Set[string]{},
 	}
 	if util.IsUplinkEnabled() {
 		c.uplinkStateLister = wf.UplinkStateInformer().Lister()
@@ -237,8 +276,15 @@ func (c *Controller) Start() error {
 	// reconcile when a network goes active or inactive on a node: some of
 	// these changes, like a network going active again during the deletion
 	// grace period, update no object we watch
-	c.networkRefReconcilerID = c.nm.RegisterNetworkRefReconciler(networkRefReconcilerFunc(func(_, _ string) {
-		c.raController.ReconcileAll()
+	c.networkRefReconcilerID = c.nm.RegisterNetworkRefReconciler(networkRefReconcilerFunc(func(_, networkName string) {
+		ras := c.getRAsForNetwork(networkName)
+		if len(ras) == 0 {
+			klog.V(5).Infof("No RouteAdvertisements select network %s, ignoring its activity change", networkName)
+			return
+		}
+		for _, ra := range ras {
+			c.raController.Reconcile(ra)
+		}
 	}))
 	controllers := []controllerutil.Reconciler{
 		c.frrController,
@@ -340,6 +386,7 @@ func (c *Controller) reconcile(name string) error {
 
 	if ra == nil {
 		metrics.DeleteRouteAdvertisementCondition(name)
+		c.deleteRANetworks(name)
 	}
 
 	hadUpdates, err := c.reconcileRouteAdvertisements(name, ra)
@@ -565,6 +612,13 @@ func (c *Controller) generateFRRConfigurations(ra *ratypes.RouteAdvertisements) 
 	slices.SortFunc(selectedNetworks.macVRFConfigs, func(a, b *vrfConfig) int { return int(a.VNI - b.VNI) })
 	slices.SortFunc(selectedNetworks.ipVRFConfigs, func(a, b *ipVRFConfig) int { return int(a.VNI - b.VNI) })
 	selectedNetworks.networks = sets.List(networkSet)
+	// cache the selected networks so that network activity changes only
+	// reconcile the RouteAdvertisements selecting them. Returning early above
+	// keeps the previous entry, which matches the FRRConfigurations still
+	// deployed from the last successful reconcile; the errors returned above
+	// are only resolved by RA/NAD/node updates, which we watch and which
+	// refresh this cache.
+	c.setRANetworks(ra.Name, selectedNetworks.networks)
 
 	// gather selected nodes
 	nodeSelector, err := metav1.LabelSelectorAsSelector(&ra.Spec.NodeSelector)

--- a/go-controller/pkg/clustermanager/routeadvertisements/controller_test.go
+++ b/go-controller/pkg/clustermanager/routeadvertisements/controller_test.go
@@ -3207,6 +3207,12 @@ func TestController_reconcileOnNetworkActivity(t *testing.T) {
 	g.Eventually(raAccepted, 5*time.Second).Should(gomega.BeTrue())
 	g.Expect(generatedFRRConfigs()).To(gomega.BeEmpty())
 
+	// the initial reconcile cached which networks the RouteAdvertisements
+	// selects
+	networkName := util.GenerateCUDNNetworkName("blue")
+	g.Expect(c.getRAsForNetwork(networkName)).To(gomega.ConsistOf("ra"))
+	g.Expect(c.getRAsForNetwork(util.GenerateCUDNNetworkName("red"))).To(gomega.BeEmpty())
+
 	// scheduling a pod on the node activates the network there without
 	// updating any object the controller watches: the network manager
 	// notification must trigger the reconcile that advertises the node
@@ -3215,6 +3221,11 @@ func TestController_reconcileOnNetworkActivity(t *testing.T) {
 	g.Expect(err).ToNot(gomega.HaveOccurred())
 
 	g.Eventually(generatedFRRConfigs, 5*time.Second).Should(gomega.ConsistOf("ra/frrConfig/node"))
+
+	// deleting the RouteAdvertisements removes it from the cache
+	err = fakeClientset.RouteAdvertisementsClient.K8sV1().RouteAdvertisements().Delete(context.Background(), "ra", metav1.DeleteOptions{})
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	g.Eventually(func() []string { return c.getRAsForNetwork(networkName) }, 5*time.Second).Should(gomega.BeEmpty())
 }
 
 func TestUpdates(t *testing.T) {

--- a/go-controller/pkg/factory/factory.go
+++ b/go-controller/pkg/factory/factory.go
@@ -318,6 +318,22 @@ func informerObjectTrim(obj interface{}) (interface{}, error) {
 			pod.Status.Conditions[i].ObservedGeneration = 0
 		}
 	}
+	if node, ok := obj.(*corev1.Node); ok {
+		// OVN-K does not consume these node fields from informer cache.
+		node.Status.Images = nil
+		node.Status.VolumesAttached = nil
+		node.Status.VolumesInUse = nil
+		node.Status.DaemonEndpoints = corev1.NodeDaemonEndpoints{}
+		node.Status.Capacity = nil
+		node.Status.Allocatable = nil
+		node.Status.Config = nil
+		node.Status.RuntimeHandlers = nil
+		node.Status.Features = nil
+		node.Spec.Taints = nil
+		node.Spec.PodCIDRs = nil
+		node.OwnerReferences = nil
+		node.Finalizers = nil
+	}
 	return obj, nil
 }
 

--- a/go-controller/pkg/factory/factory_test.go
+++ b/go-controller/pkg/factory/factory_test.go
@@ -20,6 +20,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1"
 	knet "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -2253,5 +2254,112 @@ var _ = Describe("Watch Factory Operations", func() {
 		Consistently(c.getUpdated, 2).Should(Equal(0))
 
 		wf.RemovePodHandler(h)
+	})
+})
+
+var _ = Describe("informerObjectTrim", func() {
+	It("strips unnecessary node fields", func() {
+		node := &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-node",
+				Labels: map[string]string{
+					"kubernetes.io/hostname": "test-node",
+				},
+				Annotations: map[string]string{
+					"k8s.ovn.org/node-subnets": `{"default":"10.128.0.0/23"}`,
+				},
+				ManagedFields: []metav1.ManagedFieldsEntry{
+					{Manager: "kubelet"},
+				},
+				OwnerReferences: []metav1.OwnerReference{
+					{Name: "owner"},
+				},
+				Finalizers: []string{"ovn-kubernetes.io/node-cleanup"},
+			},
+			Status: corev1.NodeStatus{
+				Images: []corev1.ContainerImage{
+					{Names: []string{"registry.io/image:latest"}, SizeBytes: 100000},
+				},
+				VolumesAttached: []corev1.AttachedVolume{
+					{Name: "vol1", DevicePath: "/dev/sda"},
+				},
+				VolumesInUse: []corev1.UniqueVolumeName{"vol1"},
+				Addresses: []corev1.NodeAddress{
+					{Type: corev1.NodeInternalIP, Address: "10.0.0.1"},
+				},
+				Conditions: []corev1.NodeCondition{
+					{
+						Type:    corev1.NodeReady,
+						Status:  corev1.ConditionTrue,
+						Reason:  "KubeletReady",
+						Message: "kubelet is posting ready status",
+					},
+				},
+				Capacity: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("4"),
+				},
+				Allocatable: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("3"),
+				},
+				DaemonEndpoints: corev1.NodeDaemonEndpoints{
+					KubeletEndpoint: corev1.DaemonEndpoint{Port: 10250},
+				},
+				NodeInfo: corev1.NodeSystemInfo{
+					KernelVersion: "5.14.0",
+				},
+				Config: &corev1.NodeConfigStatus{
+					Active: &corev1.NodeConfigSource{
+						ConfigMap: &corev1.ConfigMapNodeConfigSource{
+							Name:      "kubelet-config",
+							Namespace: "kube-system",
+						},
+					},
+				},
+				RuntimeHandlers: []corev1.NodeRuntimeHandler{
+					{Name: "runc", Features: &corev1.NodeRuntimeHandlerFeatures{}},
+				},
+				Features: &corev1.NodeFeatures{},
+			},
+			Spec: corev1.NodeSpec{
+				PodCIDR:  "10.128.0.0/23",
+				PodCIDRs: []string{"10.128.0.0/23"},
+				Taints: []corev1.Taint{
+					{Key: "node-role.kubernetes.io/master", Effect: corev1.TaintEffectNoSchedule},
+				},
+			},
+		}
+
+		trimmed, err := informerObjectTrim(node)
+		Expect(err).NotTo(HaveOccurred())
+		n := trimmed.(*corev1.Node)
+
+		// Verify fields that SHOULD be cleared
+		Expect(n.Status.Images).To(BeNil(), "Status.Images should be cleared")
+		Expect(n.Status.VolumesAttached).To(BeNil(), "Status.VolumesAttached should be cleared")
+		Expect(n.Status.VolumesInUse).To(BeNil(), "Status.VolumesInUse should be cleared")
+		Expect(n.OwnerReferences).To(BeNil(), "OwnerReferences should be cleared")
+		Expect(n.ManagedFields).To(BeNil(), "ManagedFields should be cleared")
+		Expect(n.Finalizers).To(BeNil(), "Finalizers should be cleared")
+		Expect(n.Status.DaemonEndpoints).To(Equal(corev1.NodeDaemonEndpoints{}), "Status.DaemonEndpoints should be cleared")
+		Expect(n.Status.NodeInfo).To(Equal(corev1.NodeSystemInfo{KernelVersion: "5.14.0"}), "Status.NodeInfo must be preserved")
+		Expect(n.Status.Capacity).To(BeNil(), "Status.Capacity should be cleared")
+		Expect(n.Status.Allocatable).To(BeNil(), "Status.Allocatable should be cleared")
+		Expect(n.Status.Config).To(BeNil(), "Status.Config should be cleared")
+		Expect(n.Status.RuntimeHandlers).To(BeNil(), "Status.RuntimeHandlers should be cleared")
+		Expect(n.Status.Features).To(BeNil(), "Status.Features should be cleared")
+		Expect(n.Spec.Taints).To(BeNil(), "Spec.Taints should be cleared")
+		Expect(n.Spec.PodCIDRs).To(BeNil(), "Spec.PodCIDRs should be cleared")
+
+		// Verify condition subfields: Type/Status/Reason/Message preserved
+		Expect(n.Status.Conditions).To(HaveLen(1))
+		Expect(n.Status.Conditions[0].Reason).To(Equal("KubeletReady"), "Condition.Reason must be preserved")
+		Expect(n.Status.Conditions[0].Message).To(Equal("kubelet is posting ready status"), "Condition.Message must be preserved")
+
+		// Verify fields that MUST be preserved
+		Expect(n.Name).To(Equal("test-node"))
+		Expect(n.Labels).To(HaveKey("kubernetes.io/hostname"))
+		Expect(n.Annotations).To(HaveKey("k8s.ovn.org/node-subnets"))
+		Expect(n.Status.Addresses).To(HaveLen(1))
+		Expect(n.Spec.PodCIDR).To(Equal("10.128.0.0/23"))
 	})
 })

--- a/go-controller/pkg/kube/kube.go
+++ b/go-controller/pkg/kube/kube.go
@@ -63,7 +63,8 @@ type Interface interface {
 	SetAnnotationsOnNamespace(namespaceName string, annotations map[string]interface{}) error
 	SetLabelsOnNode(nodeName string, labels map[string]interface{}) error
 	PatchNode(old, new *corev1.Node) error
-	UpdateNodeStatus(node *corev1.Node) error
+	PatchNodeStatus(old, new *corev1.Node) error
+	PatchNodeStatusAnnotations(oldNode, newNode *corev1.Node) error
 	PatchPodStatusAnnotations(oldPod, newPod *corev1.Pod) error
 	// GetNodeForWindows should only be used for windows hybrid overlay binary and never in linux code
 	GetNodeForWindows(name string) (*corev1.Node, error)
@@ -176,7 +177,7 @@ func (k *Kube) PatchPodStatusAnnotations(oldPod, newPod *corev1.Pod) error {
 
 	ops := []jsonPatchOp{}
 	requiresResourceVersionGuard := false
-	if oldPod.Annotations == nil {
+	if len(oldPod.Annotations) == 0 {
 		ops = append(ops, jsonPatchOp{
 			Op:    "add",
 			Path:  "/metadata/annotations",
@@ -384,10 +385,161 @@ func (k *Kube) PatchNode(old, new *corev1.Node) error {
 	return nil
 }
 
-// UpdateNodeStatus takes the node object and sets the provided update status
-func (k *Kube) UpdateNodeStatus(node *corev1.Node) error {
-	klog.Infof("Updating status on node %s", node.Name)
-	_, err := k.KClient.CoreV1().Nodes().UpdateStatus(context.TODO(), node, metav1.UpdateOptions{})
+// PatchNodeStatus patches the node status subresource using a strategic merge
+// patch computed from the old and new node objects. Only the fields that differ
+// between old and new are sent to the API server, so informer-trimmed fields
+// that are identical in both objects do not overwrite the server state.
+//
+// ResourceVersion from the new object is included in the patch to enable
+// optimistic conflict detection: the API server rejects the patch with 409
+// if the server's current resourceVersion differs, preventing silent
+// overwrites from stale data.
+func (k *Kube) PatchNodeStatus(old, new *corev1.Node) error {
+	// Clear ResourceVersion from old so it appears in the computed diff.
+	// This makes the patch carry new's resourceVersion, enabling the API
+	// server to reject stale updates with 409 Conflict.
+	oldForPatch := old.DeepCopy()
+	oldForPatch.ResourceVersion = ""
+
+	oldNodeObjectJson, err := json.Marshal(oldForPatch)
+	if err != nil {
+		klog.Errorf("Unable to marshal node %s: %v", old.Name, err)
+		return err
+	}
+
+	newNodeObjectJson, err := json.Marshal(new)
+	if err != nil {
+		klog.Errorf("Unable to marshal node %s: %v", new.Name, err)
+		return err
+	}
+
+	patchBytes, err := strategicpatch.CreateTwoWayMergePatch(oldNodeObjectJson, newNodeObjectJson, corev1.Node{})
+	if err != nil {
+		klog.Errorf("Unable to create patch for node %s: %v", old.Name, err)
+		return err
+	}
+
+	if _, err = k.KClient.CoreV1().Nodes().Patch(context.TODO(), old.Name, types.StrategicMergePatchType, patchBytes, metav1.PatchOptions{}, "status"); err != nil {
+		klog.Errorf("Unable to patch node status %s: %v", old.Name, err)
+		return err
+	}
+
+	return nil
+}
+
+// PatchNodeStatusAnnotations patches only node annotations through the status
+// subresource using compare-and-retry semantics on the old node state. This
+// avoids sending the full node status (which may have fields trimmed by the
+// informer transform) back to the API server.
+//
+// There are two concurrency cases to handle:
+//  1. The annotation key already exists on the old node. In that case we can use a
+//     narrow JSON patch "test" on that specific key so we only retry if another
+//     writer changed the same annotation.
+//  2. The annotation key does not exist on the old node. In that case a per-key
+//     "test" cannot protect us because two stale writers could both issue an
+//     unconditional "add" and the last one would win. For that create case we add
+//     a resourceVersion guard so only one writer based on that node snapshot can
+//     create the missing key; losers will retry from the latest node state and
+//     recompute a merged annotation value.
+//
+// Real informer/API nodes always have a resourceVersion. If a synthetic caller
+// passes an object without one, we skip that extra guard and fall back to the
+// narrower per-key tests that are available.
+func (k *Kube) PatchNodeStatusAnnotations(oldNode, newNode *corev1.Node) error {
+	if oldNode.Name != newNode.Name {
+		return fmt.Errorf("cannot patch annotations for different nodes %s and %s",
+			oldNode.Name, newNode.Name)
+	}
+
+	changedKeys := make(map[string]struct{})
+	for key, oldValue := range oldNode.Annotations {
+		if newValue, ok := newNode.Annotations[key]; !ok || oldValue != newValue {
+			changedKeys[key] = struct{}{}
+		}
+	}
+	for key, newValue := range newNode.Annotations {
+		if oldValue, ok := oldNode.Annotations[key]; !ok || oldValue != newValue {
+			changedKeys[key] = struct{}{}
+		}
+	}
+	if len(changedKeys) == 0 {
+		return nil
+	}
+
+	keys := make([]string, 0, len(changedKeys))
+	for key := range changedKeys {
+		keys = append(keys, key)
+	}
+
+	ops := []jsonPatchOp{}
+	requiresResourceVersionGuard := false
+	if len(oldNode.Annotations) == 0 {
+		ops = append(ops, jsonPatchOp{
+			Op:    "add",
+			Path:  "/metadata/annotations",
+			Value: map[string]string{},
+		})
+		requiresResourceVersionGuard = true
+	}
+	for _, key := range keys {
+		path := "/metadata/annotations/" + escapeJSONPatchPathKey(key)
+		oldValue, oldOK := oldNode.Annotations[key]
+		newValue, newOK := newNode.Annotations[key]
+		if oldOK {
+			ops = append(ops, jsonPatchOp{
+				Op:    "test",
+				Path:  path,
+				Value: oldValue,
+			})
+		} else if newOK {
+			requiresResourceVersionGuard = true
+		}
+		switch {
+		case newOK && oldOK:
+			ops = append(ops, jsonPatchOp{
+				Op:    "replace",
+				Path:  path,
+				Value: newValue,
+			})
+		case newOK:
+			ops = append(ops, jsonPatchOp{
+				Op:    "add",
+				Path:  path,
+				Value: newValue,
+			})
+		default:
+			ops = append(ops, jsonPatchOp{
+				Op:   "remove",
+				Path: path,
+			})
+		}
+	}
+	if requiresResourceVersionGuard && oldNode.ResourceVersion != "" {
+		ops = append([]jsonPatchOp{{
+			Op:    "test",
+			Path:  "/metadata/resourceVersion",
+			Value: oldNode.ResourceVersion,
+		}}, ops...)
+	}
+
+	patchData, err := json.Marshal(ops)
+	if err != nil {
+		return fmt.Errorf("failed to marshal annotation patch for node %s: %w", oldNode.Name, err)
+	}
+
+	klog.Infof("Patching annotations on node %s", oldNode.Name)
+	_, err = k.KClient.CoreV1().Nodes().Patch(
+		context.TODO(),
+		oldNode.Name,
+		types.JSONPatchType,
+		patchData,
+		metav1.PatchOptions{},
+		"status",
+	)
+	if err != nil {
+		klog.Errorf("Error in patching annotations on node %s: %v", oldNode.Name, err)
+	}
 	return err
 }
 

--- a/go-controller/pkg/kube/kube_test.go
+++ b/go-controller/pkg/kube/kube_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
@@ -246,6 +247,338 @@ var _ = Describe("Kube", func() {
 			Expect(patchOps[1].Op).To(Equal("replace"))
 			Expect(patchOps[1].Path).To(Equal("/metadata/annotations/ovn"))
 			Expect(patchOps[1].Value).To(Equal("new"))
+		})
+	})
+
+	Describe("PatchNodeStatusAnnotations", func() {
+		var kube Kube
+
+		BeforeEach(func() {
+			kube = Kube{
+				KClient: fake.NewSimpleClientset(),
+			}
+		})
+
+		It("adds annotations without dropping existing ones", func() {
+			_, err := kube.KClient.CoreV1().Nodes().Create(context.TODO(), &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "my-node",
+					Annotations: map[string]string{"existing": "value"},
+				},
+			}, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			node, err := kube.KClient.CoreV1().Nodes().Get(context.TODO(), "my-node", metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			oldNode := node.DeepCopy()
+			newNode := node.DeepCopy()
+			newNode.Annotations["added"] = "new-value"
+
+			err = kube.PatchNodeStatusAnnotations(oldNode, newNode)
+			Expect(err).ToNot(HaveOccurred())
+
+			node, err = kube.KClient.CoreV1().Nodes().Get(context.TODO(), "my-node", metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(node.Annotations).To(HaveKeyWithValue("existing", "value"))
+			Expect(node.Annotations).To(HaveKeyWithValue("added", "new-value"))
+		})
+
+		It("can create and remove annotations", func() {
+			_, err := kube.KClient.CoreV1().Nodes().Create(context.TODO(), &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "my-node",
+				},
+			}, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			node, err := kube.KClient.CoreV1().Nodes().Get(context.TODO(), "my-node", metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			oldNode := node.DeepCopy()
+			newNode := node.DeepCopy()
+			newNode.Annotations = map[string]string{"ovn": "value"}
+
+			err = kube.PatchNodeStatusAnnotations(oldNode, newNode)
+			Expect(err).ToNot(HaveOccurred())
+
+			node, err = kube.KClient.CoreV1().Nodes().Get(context.TODO(), "my-node", metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(node.Annotations).To(HaveKeyWithValue("ovn", "value"))
+
+			oldNode = node.DeepCopy()
+			newNode = node.DeepCopy()
+			delete(newNode.Annotations, "ovn")
+
+			err = kube.PatchNodeStatusAnnotations(oldNode, newNode)
+			Expect(err).ToNot(HaveOccurred())
+
+			node, err = kube.KClient.CoreV1().Nodes().Get(context.TODO(), "my-node", metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(node.Annotations).ToNot(HaveKey("ovn"))
+		})
+
+		It("adds a resourceVersion guard when creating a missing annotation key", func() {
+			var patchOps []jsonPatchOp
+			kube.KClient.(*fake.Clientset).Fake.PrependReactor("patch", "nodes", func(action ktesting.Action) (bool, runtime.Object, error) {
+				patchAction := action.(ktesting.PatchAction)
+				Expect(patchAction.GetSubresource()).To(Equal("status"))
+				Expect(json.Unmarshal(patchAction.GetPatch(), &patchOps)).To(Succeed())
+				return true, &corev1.Node{}, nil
+			})
+
+			oldNode := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "my-node",
+					ResourceVersion: "7",
+				},
+			}
+			newNode := oldNode.DeepCopy()
+			newNode.Annotations = map[string]string{"ovn": "value"}
+
+			err := kube.PatchNodeStatusAnnotations(oldNode, newNode)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(patchOps).To(HaveLen(3))
+			Expect(patchOps[0].Op).To(Equal("test"))
+			Expect(patchOps[0].Path).To(Equal("/metadata/resourceVersion"))
+			Expect(patchOps[0].Value).To(Equal("7"))
+			Expect(patchOps[1].Op).To(Equal("add"))
+			Expect(patchOps[1].Path).To(Equal("/metadata/annotations"))
+			Expect(patchOps[2].Op).To(Equal("add"))
+			Expect(patchOps[2].Path).To(Equal("/metadata/annotations/ovn"))
+		})
+
+		It("uses a per-key guard when updating an existing annotation key", func() {
+			var patchOps []jsonPatchOp
+			kube.KClient.(*fake.Clientset).Fake.PrependReactor("patch", "nodes", func(action ktesting.Action) (bool, runtime.Object, error) {
+				patchAction := action.(ktesting.PatchAction)
+				Expect(patchAction.GetSubresource()).To(Equal("status"))
+				Expect(json.Unmarshal(patchAction.GetPatch(), &patchOps)).To(Succeed())
+				return true, &corev1.Node{}, nil
+			})
+
+			oldNode := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "my-node",
+					ResourceVersion: "9",
+					Annotations:     map[string]string{"ovn": "old"},
+				},
+			}
+			newNode := oldNode.DeepCopy()
+			newNode.Annotations["ovn"] = "new"
+
+			err := kube.PatchNodeStatusAnnotations(oldNode, newNode)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(patchOps).To(HaveLen(2))
+			Expect(patchOps[0].Op).To(Equal("test"))
+			Expect(patchOps[0].Path).To(Equal("/metadata/annotations/ovn"))
+			Expect(patchOps[0].Value).To(Equal("old"))
+			Expect(patchOps[1].Op).To(Equal("replace"))
+			Expect(patchOps[1].Path).To(Equal("/metadata/annotations/ovn"))
+			Expect(patchOps[1].Value).To(Equal("new"))
+		})
+
+		It("adds annotations when oldNode has empty non-nil annotation map", func() {
+			_, err := kube.KClient.CoreV1().Nodes().Create(context.TODO(), &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "my-node",
+					Annotations: map[string]string{},
+				},
+			}, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			node, err := kube.KClient.CoreV1().Nodes().Get(context.TODO(), "my-node", metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			oldNode := node.DeepCopy()
+			if oldNode.Annotations == nil {
+				oldNode.Annotations = map[string]string{}
+			}
+			newNode := oldNode.DeepCopy()
+			newNode.Annotations["k8s.ovn.org/node-subnets"] = `{"default":"10.128.0.0/23"}`
+
+			err = kube.PatchNodeStatusAnnotations(oldNode, newNode)
+			Expect(err).ToNot(HaveOccurred())
+
+			node, err = kube.KClient.CoreV1().Nodes().Get(context.TODO(), "my-node", metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(node.Annotations).To(HaveKeyWithValue("k8s.ovn.org/node-subnets", `{"default":"10.128.0.0/23"}`))
+		})
+
+		It("returns an error when old and new node names differ", func() {
+			oldNode := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "node-a",
+					Annotations: map[string]string{"ovn": "value"},
+				},
+			}
+			newNode := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "node-b",
+					Annotations: map[string]string{"ovn": "updated"},
+				},
+			}
+
+			err := kube.PatchNodeStatusAnnotations(oldNode, newNode)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("different nodes"))
+			Expect(err.Error()).To(ContainSubstring("node-a"))
+			Expect(err.Error()).To(ContainSubstring("node-b"))
+
+			actions := kube.KClient.(*fake.Clientset).Actions()
+			for _, a := range actions {
+				Expect(a.GetVerb()).ToNot(Equal("patch"), "no patch should be sent for mismatched node names")
+			}
+		})
+
+		It("does not send trimmed node status fields via annotations patch", func() {
+			_, err := kube.KClient.CoreV1().Nodes().Create(context.TODO(), &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "my-node",
+					Annotations: map[string]string{"existing": "value"},
+				},
+				Status: corev1.NodeStatus{
+					Images:          []corev1.ContainerImage{{Names: []string{"img:latest"}, SizeBytes: 100}},
+					VolumesAttached: []corev1.AttachedVolume{{Name: "vol1", DevicePath: "/dev/sda"}},
+					VolumesInUse:    []corev1.UniqueVolumeName{"vol1"},
+				},
+			}, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			serverNode, err := kube.KClient.CoreV1().Nodes().Get(context.TODO(), "my-node", metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			oldNode := serverNode.DeepCopy()
+			oldNode.Status.Images = nil
+			oldNode.Status.VolumesAttached = nil
+			oldNode.Status.VolumesInUse = nil
+			newNode := oldNode.DeepCopy()
+			newNode.Annotations["ovn"] = "subnet-data"
+
+			err = kube.PatchNodeStatusAnnotations(oldNode, newNode)
+			Expect(err).ToNot(HaveOccurred())
+
+			node, err := kube.KClient.CoreV1().Nodes().Get(context.TODO(), "my-node", metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(node.Annotations).To(HaveKeyWithValue("ovn", "subnet-data"))
+			Expect(node.Status.Images).To(HaveLen(1))
+			Expect(node.Status.VolumesAttached).To(HaveLen(1))
+			Expect(node.Status.VolumesInUse).To(HaveLen(1))
+		})
+	})
+
+	Describe("PatchNodeStatus", func() {
+		var kube Kube
+
+		BeforeEach(func() {
+			kube.KClient = fake.NewSimpleClientset()
+		})
+
+		It("updates a node condition without clobbering other status fields", func() {
+			_, err := kube.KClient.CoreV1().Nodes().Create(context.TODO(), &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: "my-node"},
+				Status: corev1.NodeStatus{
+					Images:          []corev1.ContainerImage{{Names: []string{"img:latest"}, SizeBytes: 100}},
+					VolumesAttached: []corev1.AttachedVolume{{Name: "vol1", DevicePath: "/dev/sda"}},
+					Conditions: []corev1.NodeCondition{
+						{Type: corev1.NodeNetworkUnavailable, Status: corev1.ConditionTrue, Reason: "NoRouteCreated"},
+					},
+				},
+			}, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			oldNode := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: "my-node"},
+				Status: corev1.NodeStatus{
+					Images:          nil,
+					VolumesAttached: nil,
+					Conditions: []corev1.NodeCondition{
+						{Type: corev1.NodeNetworkUnavailable, Status: corev1.ConditionTrue, Reason: "NoRouteCreated"},
+					},
+				},
+			}
+			newNode := oldNode.DeepCopy()
+			newNode.Status.Conditions[0].Status = corev1.ConditionFalse
+			newNode.Status.Conditions[0].Reason = "RouteCreated"
+
+			err = kube.PatchNodeStatus(oldNode, newNode)
+			Expect(err).ToNot(HaveOccurred())
+
+			node, err := kube.KClient.CoreV1().Nodes().Get(context.TODO(), "my-node", metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(node.Status.Conditions).To(HaveLen(1))
+			Expect(node.Status.Conditions[0].Status).To(Equal(corev1.ConditionFalse))
+			Expect(node.Status.Conditions[0].Reason).To(Equal("RouteCreated"))
+			Expect(node.Status.Images).To(HaveLen(1), "trimmed field should not be overwritten on server")
+			Expect(node.Status.VolumesAttached).To(HaveLen(1), "trimmed field should not be overwritten on server")
+		})
+
+		It("does not overwrite additionally trimmed status fields", func() {
+			_, err := kube.KClient.CoreV1().Nodes().Create(context.TODO(), &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: "my-node"},
+				Spec: corev1.NodeSpec{
+					Taints:   []corev1.Taint{{Key: "node-role.kubernetes.io/master", Effect: corev1.TaintEffectNoSchedule}},
+					PodCIDRs: []string{"10.128.0.0/23"},
+				},
+				Status: corev1.NodeStatus{
+					Capacity:    corev1.ResourceList{corev1.ResourceCPU: *resource.NewQuantity(4, resource.DecimalSI)},
+					Allocatable: corev1.ResourceList{corev1.ResourceCPU: *resource.NewQuantity(3, resource.DecimalSI)},
+					DaemonEndpoints: corev1.NodeDaemonEndpoints{
+						KubeletEndpoint: corev1.DaemonEndpoint{Port: 10250},
+					},
+					NodeInfo: corev1.NodeSystemInfo{KernelVersion: "5.14.0"},
+					Conditions: []corev1.NodeCondition{
+						{Type: corev1.NodeReady, Status: corev1.ConditionTrue, Reason: "KubeletReady"},
+					},
+					Config: &corev1.NodeConfigStatus{
+						Active: &corev1.NodeConfigSource{
+							ConfigMap: &corev1.ConfigMapNodeConfigSource{
+								Name:      "kubelet-config",
+								Namespace: "kube-system",
+							},
+						},
+					},
+					RuntimeHandlers: []corev1.NodeRuntimeHandler{
+						{Name: "runc"},
+					},
+					Features: &corev1.NodeFeatures{},
+				},
+			}, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			oldNode := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: "my-node"},
+				Spec:       corev1.NodeSpec{Taints: nil, PodCIDRs: nil},
+				Status: corev1.NodeStatus{
+					Capacity:        nil,
+					Allocatable:     nil,
+					DaemonEndpoints: corev1.NodeDaemonEndpoints{},
+					NodeInfo:        corev1.NodeSystemInfo{KernelVersion: "5.14.0"},
+					Config:          nil,
+					RuntimeHandlers: nil,
+					Features:        nil,
+					Conditions: []corev1.NodeCondition{
+						{Type: corev1.NodeReady, Status: corev1.ConditionTrue, Reason: "KubeletReady"},
+					},
+				},
+			}
+			newNode := oldNode.DeepCopy()
+			newNode.Status.Conditions[0].Reason = "KubeletReady-Updated"
+
+			err = kube.PatchNodeStatus(oldNode, newNode)
+			Expect(err).ToNot(HaveOccurred())
+
+			node, err := kube.KClient.CoreV1().Nodes().Get(context.TODO(), "my-node", metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(node.Status.Conditions[0].Reason).To(Equal("KubeletReady-Updated"))
+			Expect(node.Status.Capacity).NotTo(BeNil(), "Capacity must not be overwritten by trimmed patch")
+			Expect(node.Status.Allocatable).NotTo(BeNil(), "Allocatable must not be overwritten by trimmed patch")
+			Expect(node.Status.DaemonEndpoints.KubeletEndpoint.Port).To(Equal(int32(10250)), "DaemonEndpoints must not be overwritten")
+			Expect(node.Status.NodeInfo.KernelVersion).To(Equal("5.14.0"), "NodeInfo must not be overwritten")
+			Expect(node.Spec.Taints).To(HaveLen(1), "Taints must not be overwritten by trimmed patch")
+			Expect(node.Spec.PodCIDRs).To(HaveLen(1), "PodCIDRs must not be overwritten by trimmed patch")
+			Expect(node.Status.Config).NotTo(BeNil(), "Status.Config must not be overwritten by trimmed patch")
+			Expect(node.Status.RuntimeHandlers).To(HaveLen(1), "RuntimeHandlers must not be overwritten by trimmed patch")
+			Expect(node.Status.Features).NotTo(BeNil(), "Features must not be overwritten by trimmed patch")
 		})
 	})
 })

--- a/go-controller/pkg/kube/mocks/Interface.go
+++ b/go-controller/pkg/kube/mocks/Interface.go
@@ -116,6 +116,42 @@ func (_m *Interface) PatchNode(old *corev1.Node, new *corev1.Node) error {
 	return r0
 }
 
+// PatchNodeStatus provides a mock function with given fields: old, new
+func (_m *Interface) PatchNodeStatus(old *corev1.Node, new *corev1.Node) error {
+	ret := _m.Called(old, new)
+
+	if len(ret) == 0 {
+		panic("no return value specified for PatchNodeStatus")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(*corev1.Node, *corev1.Node) error); ok {
+		r0 = rf(old, new)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// PatchNodeStatusAnnotations provides a mock function with given fields: oldNode, newNode
+func (_m *Interface) PatchNodeStatusAnnotations(oldNode *corev1.Node, newNode *corev1.Node) error {
+	ret := _m.Called(oldNode, newNode)
+
+	if len(ret) == 0 {
+		panic("no return value specified for PatchNodeStatusAnnotations")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(*corev1.Node, *corev1.Node) error); ok {
+		r0 = rf(oldNode, newNode)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // PatchPodStatusAnnotations provides a mock function with given fields: oldPod, newPod
 func (_m *Interface) PatchPodStatusAnnotations(oldPod *corev1.Pod, newPod *corev1.Pod) error {
 	ret := _m.Called(oldPod, newPod)
@@ -235,24 +271,6 @@ func (_m *Interface) SetLabelsOnNode(nodeName string, labels map[string]interfac
 	var r0 error
 	if rf, ok := ret.Get(0).(func(string, map[string]interface{}) error); ok {
 		r0 = rf(nodeName, labels)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-// UpdateNodeStatus provides a mock function with given fields: node
-func (_m *Interface) UpdateNodeStatus(node *corev1.Node) error {
-	ret := _m.Called(node)
-
-	if len(ret) == 0 {
-		panic("no return value specified for UpdateNodeStatus")
-	}
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(*corev1.Node) error); ok {
-		r0 = rf(node)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/go-controller/pkg/kube/mocks/InterfaceOVN.go
+++ b/go-controller/pkg/kube/mocks/InterfaceOVN.go
@@ -278,6 +278,42 @@ func (_m *InterfaceOVN) PatchNode(old *apicorev1.Node, new *apicorev1.Node) erro
 	return r0
 }
 
+// PatchNodeStatus provides a mock function with given fields: old, new
+func (_m *InterfaceOVN) PatchNodeStatus(old *apicorev1.Node, new *apicorev1.Node) error {
+	ret := _m.Called(old, new)
+
+	if len(ret) == 0 {
+		panic("no return value specified for PatchNodeStatus")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(*apicorev1.Node, *apicorev1.Node) error); ok {
+		r0 = rf(old, new)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// PatchNodeStatusAnnotations provides a mock function with given fields: oldNode, newNode
+func (_m *InterfaceOVN) PatchNodeStatusAnnotations(oldNode *apicorev1.Node, newNode *apicorev1.Node) error {
+	ret := _m.Called(oldNode, newNode)
+
+	if len(ret) == 0 {
+		panic("no return value specified for PatchNodeStatusAnnotations")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(*apicorev1.Node, *apicorev1.Node) error); ok {
+		r0 = rf(oldNode, newNode)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // PatchPodStatusAnnotations provides a mock function with given fields: oldPod, newPod
 func (_m *InterfaceOVN) PatchPodStatusAnnotations(oldPod *apicorev1.Pod, newPod *apicorev1.Pod) error {
 	ret := _m.Called(oldPod, newPod)
@@ -499,24 +535,6 @@ func (_m *InterfaceOVN) UpdateIPAMClaimIPs(updatedIPAMClaim *v1alpha1.IPAMClaim)
 	var r0 error
 	if rf, ok := ret.Get(0).(func(*v1alpha1.IPAMClaim) error); ok {
 		r0 = rf(updatedIPAMClaim)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-// UpdateNodeStatus provides a mock function with given fields: node
-func (_m *InterfaceOVN) UpdateNodeStatus(node *apicorev1.Node) error {
-	ret := _m.Called(node)
-
-	if len(ret) == 0 {
-		panic("no return value specified for UpdateNodeStatus")
-	}
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(*apicorev1.Node) error); ok {
-		r0 = rf(node)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/go-controller/pkg/node/OCP_HACKS.go
+++ b/go-controller/pkg/node/OCP_HACKS.go
@@ -4,51 +4,115 @@
 package node
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/coreos/go-iptables/iptables"
 
+	"sigs.k8s.io/knftables"
+
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
 	nodeipt "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/iptables"
+	nodenft "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/nftables"
 )
 
-// Block MCS Access. https://github.com/openshift/ovn-kubernetes/pull/170
-func generateBlockMCSRules(rules *[]nodeipt.Rule, protocol iptables.Protocol) {
-	var delRules []nodeipt.Rule
+const (
+	mcsBlockingChain        = "mcs-blocking"
+	mcsBlockingOutputChain  = "mcs-blocking-output"
+	mcsBlockingForwardChain = "mcs-blocking-forward"
+)
 
-	for _, chain := range []string{"FORWARD", "OUTPUT"} {
-		for _, port := range []string{"22623", "22624"} {
-			*rules = append(*rules, nodeipt.Rule{
-				Table:    "filter",
-				Chain:    chain,
-				Args:     []string{"-p", "tcp", "-m", "tcp", "--dport", port, "--syn", "-j", "REJECT"},
-				Protocol: protocol,
-			})
-			// Delete the old "--syn"-less rules on upgrade
-			delRules = append(delRules, nodeipt.Rule{
-				Table:    "filter",
-				Chain:    chain,
-				Args:     []string{"-p", "tcp", "-m", "tcp", "--dport", port, "-j", "REJECT"},
-				Protocol: protocol,
-			})
+// cleanupLegacyMCSBlockIptRules best-effort deletes leftover host iptables MCS REJECT
+// rules from before the nftables migration (both --syn and legacy non--syn variants).
+func cleanupLegacyMCSBlockIptRules() {
+	var delRules []nodeipt.Rule
+	for _, protocol := range []iptables.Protocol{iptables.ProtocolIPv4, iptables.ProtocolIPv6} {
+		if protocol == iptables.ProtocolIPv4 && !config.IPv4Mode {
+			continue
+		}
+		if protocol == iptables.ProtocolIPv6 && !config.IPv6Mode {
+			continue
+		}
+		for _, chain := range []string{"FORWARD", "OUTPUT"} {
+			for _, port := range []string{"22623", "22624"} {
+				delRules = append(delRules,
+					nodeipt.Rule{
+						Table:    "filter",
+						Chain:    chain,
+						Args:     []string{"-p", "tcp", "-m", "tcp", "--dport", port, "--syn", "-j", "REJECT"},
+						Protocol: protocol,
+					},
+					nodeipt.Rule{
+						Table:    "filter",
+						Chain:    chain,
+						Args:     []string{"-p", "tcp", "-m", "tcp", "--dport", port, "-j", "REJECT"},
+						Protocol: protocol,
+					},
+				)
+			}
 		}
 	}
-
 	_ = nodeipt.DelRules(delRules)
 }
 
-// insertMCSBlockIptRules inserts iptables rules to block local Machine Config Service
+// setupMCSBlockNFTRules inserts nftables rules to block local Machine Config Service
 // ports. See https://github.com/openshift/ovn-kubernetes/pull/170
-func insertMCSBlockIptRules() error {
-	rules := []nodeipt.Rule{}
-	if config.IPv4Mode {
-		generateBlockMCSRules(&rules, iptables.ProtocolIPv4)
-	}
-	if config.IPv6Mode {
-		generateBlockMCSRules(&rules, iptables.ProtocolIPv6)
-	}
-	if err := insertIptRules(rules); err != nil {
+func setupMCSBlockNFTRules() error {
+	nft, err := nodenft.GetNFTablesHelper()
+	if err != nil {
 		return fmt.Errorf("failed to setup MCS-blocking rules: %w", err)
 	}
+
+	tx := nft.NewTransaction()
+
+	tx.Add(&knftables.Chain{
+		Name: mcsBlockingChain,
+	})
+	tx.Flush(&knftables.Chain{
+		Name: mcsBlockingChain,
+	})
+	tx.Add(&knftables.Rule{
+		Chain: mcsBlockingChain,
+		Rule: knftables.Concat(
+			"tcp dport { 22623, 22624 } tcp flags syn / fin,syn,rst,ack",
+			"reject",
+		),
+	})
+
+	tx.Add(&knftables.Chain{
+		Name:     mcsBlockingOutputChain,
+		Type:     knftables.PtrTo(knftables.FilterType),
+		Hook:     knftables.PtrTo(knftables.OutputHook),
+		Priority: knftables.PtrTo(knftables.FilterPriority),
+	})
+	tx.Flush(&knftables.Chain{
+		Name: mcsBlockingOutputChain,
+	})
+	tx.Add(&knftables.Rule{
+		Chain: mcsBlockingOutputChain,
+		Rule:  "jump " + mcsBlockingChain,
+	})
+
+	tx.Add(&knftables.Chain{
+		Name:     mcsBlockingForwardChain,
+		Type:     knftables.PtrTo(knftables.FilterType),
+		Hook:     knftables.PtrTo(knftables.ForwardHook),
+		Priority: knftables.PtrTo(knftables.FilterPriority),
+	})
+	tx.Flush(&knftables.Chain{
+		Name: mcsBlockingForwardChain,
+	})
+	tx.Add(&knftables.Rule{
+		Chain: mcsBlockingForwardChain,
+		Rule:  "jump " + mcsBlockingChain,
+	})
+
+	if err := nft.Run(context.TODO(), tx); err != nil {
+		return fmt.Errorf("failed to setup MCS-blocking rules: %w", err)
+	}
+
+	// If there are legacy IPTables rules left around, try to clean them up.
+	cleanupLegacyMCSBlockIptRules()
+
 	return nil
 }

--- a/go-controller/pkg/node/controllers/egressip/egressip.go
+++ b/go-controller/pkg/node/controllers/egressip/egressip.go
@@ -1112,7 +1112,7 @@ func (c *Controller) migrateFromAddrLabelToAnnotation() error {
 	if len(assignedAddresses) == 0 {
 		return nil
 	}
-	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+	return retry.OnError(retry.DefaultRetry, util.IsNodeAnnotationPatchRetryable, func() error {
 		node, err = c.nodeLister.Get(c.nodeName)
 		if err != nil {
 			return err
@@ -1126,7 +1126,7 @@ func (c *Controller) migrateFromAddrLabelToAnnotation() error {
 			nodeToUpdate.Annotations = map[string]string{}
 		}
 		nodeToUpdate.Annotations[util.OVNNodeSecondaryHostEgressIPs] = string(patch)
-		return c.kube.UpdateNodeStatus(nodeToUpdate)
+		return c.kube.PatchNodeStatusAnnotations(node, nodeToUpdate)
 	})
 }
 
@@ -1136,7 +1136,7 @@ func (c *Controller) addIPToAnnotation(ip string) error {
 	if !isValidIP(ip) {
 		return fmt.Errorf("invalid IP %q", ip)
 	}
-	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+	return retry.OnError(retry.DefaultRetry, util.IsNodeAnnotationPatchRetryable, func() error {
 		node, err := c.nodeLister.Get(c.nodeName)
 		if err != nil {
 			return err
@@ -1162,7 +1162,7 @@ func (c *Controller) addIPToAnnotation(ip string) error {
 			nodeToUpdate.Annotations = map[string]string{}
 		}
 		nodeToUpdate.Annotations[util.OVNNodeSecondaryHostEgressIPs] = string(patch)
-		return c.kube.UpdateNodeStatus(nodeToUpdate)
+		return c.kube.PatchNodeStatusAnnotations(node, nodeToUpdate)
 	})
 }
 
@@ -1172,7 +1172,7 @@ func (c *Controller) deleteIPFromAnnotation(ip string) error {
 	if !isValidIP(ip) {
 		return fmt.Errorf("invalid IP %q", ip)
 	}
-	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+	return retry.OnError(retry.DefaultRetry, util.IsNodeAnnotationPatchRetryable, func() error {
 		node, err := c.nodeLister.Get(c.nodeName)
 		if err != nil {
 			return err
@@ -1198,7 +1198,7 @@ func (c *Controller) deleteIPFromAnnotation(ip string) error {
 			nodeToUpdate.Annotations = map[string]string{}
 		}
 		nodeToUpdate.Annotations[util.OVNNodeSecondaryHostEgressIPs] = string(patch)
-		return c.kube.UpdateNodeStatus(nodeToUpdate)
+		return c.kube.PatchNodeStatusAnnotations(node, nodeToUpdate)
 	})
 }
 

--- a/go-controller/pkg/node/default_node_network_controller.go
+++ b/go-controller/pkg/node/default_node_network_controller.go
@@ -1468,9 +1468,17 @@ func (nc *DefaultNodeNetworkController) deleteNode(node *corev1.Node) {
 	}
 }
 
+var nodeIPSets = []knftables.Object{
+	&knftables.Set{
+		Name: types.NFTRemoteNodeIPsv4,
+	},
+	&knftables.Set{
+		Name: types.NFTRemoteNodeIPsv6,
+	},
+}
+
 func (nc *DefaultNodeNetworkController) syncNodes(objs []interface{}) error {
-	var keepNFTSetElemsV4, keepNFTSetElemsV6 []knftables.Object
-	var errors []error
+	var keepNFTSetElems []knftables.Object
 
 	if config.IsModeDPU() {
 		return nil
@@ -1497,7 +1505,7 @@ func (nc *DefaultNodeNetworkController) syncNodes(objs []interface{}) error {
 
 		// Process IPv4 addresses
 		for _, nodeIP := range ipsv4 {
-			keepNFTSetElemsV4 = append(keepNFTSetElemsV4, &knftables.Element{
+			keepNFTSetElems = append(keepNFTSetElems, &knftables.Element{
 				Set: types.NFTRemoteNodeIPsv4,
 				Key: []string{nodeIP.String()},
 			})
@@ -1505,21 +1513,19 @@ func (nc *DefaultNodeNetworkController) syncNodes(objs []interface{}) error {
 
 		// Process IPv6 addresses
 		for _, nodeIP := range ipsv6 {
-			keepNFTSetElemsV6 = append(keepNFTSetElemsV6, &knftables.Element{
+			keepNFTSetElems = append(keepNFTSetElems, &knftables.Element{
 				Set: types.NFTRemoteNodeIPsv6,
 				Key: []string{nodeIP.String()},
 			})
 		}
 	}
-	if err := recreateNFTSet(types.NFTRemoteNodeIPsv4, keepNFTSetElemsV4); err != nil {
-		errors = append(errors, err)
-	}
-	if err := recreateNFTSet(types.NFTRemoteNodeIPsv6, keepNFTSetElemsV6); err != nil {
-		errors = append(errors, err)
+	err := nodenft.SyncObjects(nodeIPSets, keepNFTSetElems)
+	if err != nil {
+		err = fmt.Errorf("unable to sync nftables rules for nodes: %w", err)
 	}
 
 	klog.Infof("Node controller node sync done. Time taken: %s", time.Since(start))
-	return utilerrors.Join(errors...)
+	return err
 }
 
 // validateVTEPInterfaceMTU checks if the MTU of the interface that has ovn-encap-ip is big

--- a/go-controller/pkg/node/default_node_network_controller.go
+++ b/go-controller/pkg/node/default_node_network_controller.go
@@ -1377,7 +1377,7 @@ func (nc *DefaultNodeNetworkController) WatchNodes() error {
 
 // addOrUpdateNode handles creating flows or nftables rules for each node to handle PMTUD
 func (nc *DefaultNodeNetworkController) addOrUpdateNode(node *corev1.Node) error {
-	var nftElems []*knftables.Element
+	var nftElems []knftables.Object
 	var addrs []string
 
 	// Use GetNodeAddresses to get all node IPs (including current node for openflow)
@@ -1412,7 +1412,7 @@ func (nc *DefaultNodeNetworkController) addOrUpdateNode(node *corev1.Node) error
 		}
 	}
 	if (config.IsModeDPUHost() || config.IsModeFull()) && len(nftElems) > 0 {
-		if err := nodenft.UpdateNFTElements(nftElems); err != nil {
+		if err := nodenft.AddObjects(nftElems); err != nil {
 			return fmt.Errorf("unable to update NFT elements for node %q, error: %w", node.Name, err)
 		}
 	}
@@ -1424,7 +1424,7 @@ func (nc *DefaultNodeNetworkController) addOrUpdateNode(node *corev1.Node) error
 }
 
 func removePMTUDNodeNFTRules(nodeIPs []net.IP) error {
-	var nftElems []*knftables.Element
+	var nftElems []knftables.Object
 	for _, nodeIP := range nodeIPs {
 		// Remove IPs from NFT sets
 		if utilnet.IsIPv4(nodeIP) {
@@ -1440,8 +1440,8 @@ func removePMTUDNodeNFTRules(nodeIPs []net.IP) error {
 		}
 	}
 	if len(nftElems) > 0 {
-		if err := nodenft.DeleteNFTElements(nftElems); err != nil {
-			return err
+		if err := nodenft.DeleteObjects(nftElems); err != nil {
+			return fmt.Errorf("unable to remove PMTUD rules for nodes: %w", err)
 		}
 	}
 	return nil
@@ -1468,9 +1468,17 @@ func (nc *DefaultNodeNetworkController) deleteNode(node *corev1.Node) {
 	}
 }
 
+var nodeIPSets = []knftables.Object{
+	&knftables.Set{
+		Name: types.NFTRemoteNodeIPsv4,
+	},
+	&knftables.Set{
+		Name: types.NFTRemoteNodeIPsv6,
+	},
+}
+
 func (nc *DefaultNodeNetworkController) syncNodes(objs []interface{}) error {
-	var keepNFTSetElemsV4, keepNFTSetElemsV6 []*knftables.Element
-	var errors []error
+	var keepNFTSetElems []knftables.Object
 
 	if config.IsModeDPU() {
 		return nil
@@ -1497,7 +1505,7 @@ func (nc *DefaultNodeNetworkController) syncNodes(objs []interface{}) error {
 
 		// Process IPv4 addresses
 		for _, nodeIP := range ipsv4 {
-			keepNFTSetElemsV4 = append(keepNFTSetElemsV4, &knftables.Element{
+			keepNFTSetElems = append(keepNFTSetElems, &knftables.Element{
 				Set: types.NFTRemoteNodeIPsv4,
 				Key: []string{nodeIP.String()},
 			})
@@ -1505,21 +1513,19 @@ func (nc *DefaultNodeNetworkController) syncNodes(objs []interface{}) error {
 
 		// Process IPv6 addresses
 		for _, nodeIP := range ipsv6 {
-			keepNFTSetElemsV6 = append(keepNFTSetElemsV6, &knftables.Element{
+			keepNFTSetElems = append(keepNFTSetElems, &knftables.Element{
 				Set: types.NFTRemoteNodeIPsv6,
 				Key: []string{nodeIP.String()},
 			})
 		}
 	}
-	if err := recreateNFTSet(types.NFTRemoteNodeIPsv4, keepNFTSetElemsV4); err != nil {
-		errors = append(errors, err)
-	}
-	if err := recreateNFTSet(types.NFTRemoteNodeIPsv6, keepNFTSetElemsV6); err != nil {
-		errors = append(errors, err)
+	err := nodenft.SyncObjects(nodeIPSets, keepNFTSetElems)
+	if err != nil {
+		err = fmt.Errorf("unable to sync nftables rules for nodes: %w", err)
 	}
 
 	klog.Infof("Node controller node sync done. Time taken: %s", time.Since(start))
-	return utilerrors.Join(errors...)
+	return err
 }
 
 // validateVTEPInterfaceMTU checks if the MTU of the interface that has ovn-encap-ip is big

--- a/go-controller/pkg/node/default_node_network_controller.go
+++ b/go-controller/pkg/node/default_node_network_controller.go
@@ -1377,7 +1377,7 @@ func (nc *DefaultNodeNetworkController) WatchNodes() error {
 
 // addOrUpdateNode handles creating flows or nftables rules for each node to handle PMTUD
 func (nc *DefaultNodeNetworkController) addOrUpdateNode(node *corev1.Node) error {
-	var nftElems []*knftables.Element
+	var nftElems []knftables.Object
 	var addrs []string
 
 	// Use GetNodeAddresses to get all node IPs (including current node for openflow)
@@ -1412,7 +1412,7 @@ func (nc *DefaultNodeNetworkController) addOrUpdateNode(node *corev1.Node) error
 		}
 	}
 	if (config.IsModeDPUHost() || config.IsModeFull()) && len(nftElems) > 0 {
-		if err := nodenft.UpdateNFTElements(nftElems); err != nil {
+		if err := nodenft.AddObjects(nftElems); err != nil {
 			return fmt.Errorf("unable to update NFT elements for node %q, error: %w", node.Name, err)
 		}
 	}
@@ -1424,7 +1424,7 @@ func (nc *DefaultNodeNetworkController) addOrUpdateNode(node *corev1.Node) error
 }
 
 func removePMTUDNodeNFTRules(nodeIPs []net.IP) error {
-	var nftElems []*knftables.Element
+	var nftElems []knftables.Object
 	for _, nodeIP := range nodeIPs {
 		// Remove IPs from NFT sets
 		if utilnet.IsIPv4(nodeIP) {
@@ -1440,8 +1440,8 @@ func removePMTUDNodeNFTRules(nodeIPs []net.IP) error {
 		}
 	}
 	if len(nftElems) > 0 {
-		if err := nodenft.DeleteNFTElements(nftElems); err != nil {
-			return err
+		if err := nodenft.DeleteObjects(nftElems); err != nil {
+			return fmt.Errorf("unable to remove PMTUD rules for nodes: %w", err)
 		}
 	}
 	return nil
@@ -1469,7 +1469,7 @@ func (nc *DefaultNodeNetworkController) deleteNode(node *corev1.Node) {
 }
 
 func (nc *DefaultNodeNetworkController) syncNodes(objs []interface{}) error {
-	var keepNFTSetElemsV4, keepNFTSetElemsV6 []*knftables.Element
+	var keepNFTSetElemsV4, keepNFTSetElemsV6 []knftables.Object
 	var errors []error
 
 	if config.IsModeDPU() {

--- a/go-controller/pkg/node/egressip/gateway_egressip.go
+++ b/go-controller/pkg/node/egressip/gateway_egressip.go
@@ -257,25 +257,35 @@ func (g *BridgeEIPAddrManager) UpdateEgressIP(oldEIP, newEIP *egressipv1.EgressI
 
 	var isUpdated bool
 
-	// Delete old if it exists and is different from new
+	// Delete old from bridge and cache if it exists
 	if !oldSkip {
 		if err = g.deleteIPBridge(oldIP); err != nil {
 			return isUpdated, fmt.Errorf("failed to update EgressIP gateway config because failed to delete address from link: %v", err)
 		}
 		g.cache.deleteMarkIP(oldMark, oldIP)
-		if err = g.deleteIPsFromAnnotation(oldIP); err != nil {
-			return isUpdated, fmt.Errorf("failed to update EgressIP gateway config because unable to delete EgressIP IP from Node annotation: %v", err)
-		}
 		isUpdated = true
 	}
 
-	// Add new if it exists
+	// Add new to cache before annotation update
 	if !newSkip {
-		// must always add to cache before adding IP because we want to inform node ip handler that this is not a valid node IP
 		g.cache.insertMarkIP(newMark, newIP)
-		if err = g.addIPToAnnotation(newIP); err != nil {
-			return isUpdated, fmt.Errorf("failed to update EgressIP gateway config because unable to add EgressIP IP to Node annotation: %v", err)
-		}
+	}
+
+	// Combined annotation update: delete old and add new in a single patch
+	// to avoid stale-lister races between consecutive patches.
+	var addIPs, delIPs []net.IP
+	if !oldSkip {
+		delIPs = []net.IP{oldIP}
+	}
+	if !newSkip {
+		addIPs = []net.IP{newIP}
+	}
+	if err = g.updateAnnotationIPs(addIPs, delIPs); err != nil {
+		return isUpdated, fmt.Errorf("failed to update EgressIP gateway config because unable to update Node annotation: %v", err)
+	}
+
+	// Add new to bridge if it exists
+	if !newSkip {
 		if err = g.addIPBridge(newIP); err != nil {
 			return isUpdated, fmt.Errorf("failed to update EgressIP gateway config because failed to add address to link: %v", err)
 		}
@@ -314,6 +324,7 @@ func (g *BridgeEIPAddrManager) SyncEgressIP(objs []interface{}) error {
 	g.annotationIPs = sets.New[string](getIPsStr(annotIPs...)...)
 	g.nodeAnnotationMu.Unlock()
 	configs := markIPs{v4: map[int]string{}, v6: map[int]string{}}
+	ipsToAdd := make([]net.IP, 0)
 	for _, obj := range objs {
 		eip, ok := obj.(*egressipv1.EgressIP)
 		if !ok {
@@ -329,12 +340,10 @@ func (g *BridgeEIPAddrManager) SyncEgressIP(objs []interface{}) error {
 			continue
 		}
 		configs.insert(pktMark, ip)
-		if err = g.addIPToAnnotation(ip); err != nil {
-			return fmt.Errorf("failed to sync EgressIP gateway config because unable to add EgressIP IP to Node annotation: %v", err)
-		}
 		if err = g.addIPBridge(ip); err != nil {
 			return fmt.Errorf("failed to sync EgressIP gateway config because failed to add address to link: %v", err)
 		}
+		ipsToAdd = append(ipsToAdd, ip)
 	}
 	ipsToDel := make([]net.IP, 0)
 	for _, annotIP := range annotIPs {
@@ -346,10 +355,9 @@ func (g *BridgeEIPAddrManager) SyncEgressIP(objs []interface{}) error {
 		}
 		ipsToDel = append(ipsToDel, annotIP)
 	}
-	if len(ipsToDel) > 0 {
-		klog.V(5).Infof("Deleting stale EgressIP IPs from Node annotation: %v", getIPsStr(ipsToDel...))
-		if err = g.deleteIPsFromAnnotation(ipsToDel...); err != nil {
-			return fmt.Errorf("failed to delete EgressIP IPs from Node annotation: %v", err)
+	if len(ipsToAdd) > 0 || len(ipsToDel) > 0 {
+		if err = g.updateAnnotationIPs(ipsToAdd, ipsToDel); err != nil {
+			return fmt.Errorf("failed to update EgressIP IPs in Node annotation: %v", err)
 		}
 	}
 	g.cache.replaceAll(configs)
@@ -360,7 +368,7 @@ func (g *BridgeEIPAddrManager) SyncEgressIP(objs []interface{}) error {
 // updateAnnotationLocked updates the node's egress IPs
 // Must be called with nodeAnnotationMu locked
 func (g *BridgeEIPAddrManager) updateAnnotationLocked(updatedIPs sets.Set[string]) error {
-	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+	return retry.OnError(retry.DefaultRetry, util.IsNodeAnnotationPatchRetryable, func() error {
 		node, err := g.nodeLister.Get(g.nodeName)
 		if err != nil {
 			return err
@@ -374,17 +382,18 @@ func (g *BridgeEIPAddrManager) updateAnnotationLocked(updatedIPs sets.Set[string
 			nodeToUpdate.Annotations = map[string]string{}
 		}
 		nodeToUpdate.Annotations[util.OVNNodeBridgeEgressIPs] = string(patch)
-		return g.kube.UpdateNodeStatus(nodeToUpdate)
+		return g.kube.PatchNodeStatusAnnotations(node, nodeToUpdate)
 	})
 }
 
-// addIPToAnnotation adds an address to the collection of existing addresses stored in the nodes annotation. Caller
-// may repeat addition of addresses without care for duplicate addresses being added.
-func (g *BridgeEIPAddrManager) addIPToAnnotation(candidateIP net.IP) error {
+// updateAnnotationIPs atomically adds and deletes IPs from the node annotation
+// in a single patch. Either addIPs or delIPs may be nil.
+func (g *BridgeEIPAddrManager) updateAnnotationIPs(addIPs, delIPs []net.IP) error {
 	g.nodeAnnotationMu.Lock()
 	defer g.nodeAnnotationMu.Unlock()
 	updatedIPs := sets.New[string](g.annotationIPs.UnsortedList()...)
-	updatedIPs.Insert(candidateIP.String())
+	updatedIPs.Delete(getIPsStr(delIPs...)...)
+	updatedIPs.Insert(getIPsStr(addIPs...)...)
 	if updatedIPs.Equal(g.annotationIPs) {
 		return nil
 	}
@@ -395,22 +404,12 @@ func (g *BridgeEIPAddrManager) addIPToAnnotation(candidateIP net.IP) error {
 	return nil
 }
 
-// deleteIPsFromAnnotation deletes address from annotation. If multiple users, callers must synchronise.
-// deletion of address that doesn't exist will not cause an error.
+func (g *BridgeEIPAddrManager) addIPToAnnotation(candidateIP net.IP) error {
+	return g.updateAnnotationIPs([]net.IP{candidateIP}, nil)
+}
+
 func (g *BridgeEIPAddrManager) deleteIPsFromAnnotation(candidateIPs ...net.IP) error {
-	g.nodeAnnotationMu.Lock()
-	defer g.nodeAnnotationMu.Unlock()
-	candidateIPsStr := getIPsStr(candidateIPs...)
-	updatedIPs := sets.New[string](g.annotationIPs.UnsortedList()...)
-	updatedIPs.Delete(candidateIPsStr...)
-	if updatedIPs.Equal(g.annotationIPs) {
-		return nil
-	}
-	if err := g.updateAnnotationLocked(updatedIPs); err != nil {
-		return err
-	}
-	g.annotationIPs = updatedIPs
-	return nil
+	return g.updateAnnotationIPs(nil, candidateIPs)
 }
 
 func (g *BridgeEIPAddrManager) addIPBridge(ip net.IP) error {

--- a/go-controller/pkg/node/gateway.go
+++ b/go-controller/pkg/node/gateway.go
@@ -51,8 +51,8 @@ type gateway struct {
 	loadBalancerHealthChecker informer.ServiceAndEndpointsEventHandler
 	// portClaimWatcher is for reserving ports for virtual IPs allocated by the cluster on the host
 	portClaimWatcher informer.ServiceEventHandler
-	// nodePortWatcherIptables is used in Shared GW mode to handle nodePort IPTable rules
-	nodePortWatcherIptables informer.ServiceEventHandler
+	// nodePortWatcherNFTables is used in Shared GW mode to handle nodePort nftables rules
+	nodePortWatcherNFTables informer.ServiceEventHandler
 	// nodePortWatcher is used in Local+Shared GW modes to handle nodePort flows in shared OVS bridge
 	nodePortWatcher      informer.ServiceAndEndpointsEventHandler
 	openflowManager      *openflowManager
@@ -89,8 +89,8 @@ func (g *gateway) AddService(svc *corev1.Service) error {
 			errors = append(errors, err)
 		}
 	}
-	if g.nodePortWatcherIptables != nil {
-		if err = g.nodePortWatcherIptables.AddService(svc); err != nil {
+	if g.nodePortWatcherNFTables != nil {
+		if err = g.nodePortWatcherNFTables.AddService(svc); err != nil {
 			errors = append(errors, err)
 		}
 	}
@@ -116,8 +116,8 @@ func (g *gateway) UpdateService(old, new *corev1.Service) error {
 			errors = append(errors, err)
 		}
 	}
-	if g.nodePortWatcherIptables != nil {
-		if err = g.nodePortWatcherIptables.UpdateService(old, new); err != nil {
+	if g.nodePortWatcherNFTables != nil {
+		if err = g.nodePortWatcherNFTables.UpdateService(old, new); err != nil {
 			errors = append(errors, err)
 		}
 	}
@@ -143,8 +143,8 @@ func (g *gateway) DeleteService(svc *corev1.Service) error {
 			errors = append(errors, err)
 		}
 	}
-	if g.nodePortWatcherIptables != nil {
-		if err = g.nodePortWatcherIptables.DeleteService(svc); err != nil {
+	if g.nodePortWatcherNFTables != nil {
+		if err = g.nodePortWatcherNFTables.DeleteService(svc); err != nil {
 			errors = append(errors, err)
 		}
 	}
@@ -164,8 +164,8 @@ func (g *gateway) SyncServices(objs []interface{}) error {
 	if err == nil && g.nodePortWatcher != nil {
 		err = g.nodePortWatcher.SyncServices(objs)
 	}
-	if err == nil && g.nodePortWatcherIptables != nil {
-		err = g.nodePortWatcherIptables.SyncServices(objs)
+	if err == nil && g.nodePortWatcherNFTables != nil {
+		err = g.nodePortWatcherNFTables.SyncServices(objs)
 	}
 	if err != nil {
 		return fmt.Errorf("gateway sync services failed: %v", err)

--- a/go-controller/pkg/node/gateway_init.go
+++ b/go-controller/pkg/node/gateway_init.go
@@ -501,9 +501,6 @@ func (nc *DefaultNodeNetworkController) initGatewayDPUHost() error {
 	gw := nc.Gateway.(*gateway)
 	gw.nodeIPManager = newAddressManager(nc.name, nc.Kube, nil, nc.watchFactory, nil, nc.ovsClient)
 	if config.Gateway.NodeportEnable {
-		if err := initSharedGatewayIPTables(); err != nil {
-			return err
-		}
 		if err := initGatewayNFTables(); err != nil {
 			return err
 		}

--- a/go-controller/pkg/node/gateway_init.go
+++ b/go-controller/pkg/node/gateway_init.go
@@ -504,6 +504,9 @@ func (nc *DefaultNodeNetworkController) initGatewayDPUHost() error {
 		if err := initSharedGatewayIPTables(); err != nil {
 			return err
 		}
+		if err := initGatewayNFTables(); err != nil {
+			return err
+		}
 		if util.IsNetworkSegmentationSupportEnabled() {
 			if err := configureUDNServicesNFTables(); err != nil {
 				return fmt.Errorf("unable to configure UDN nftables: %w", err)

--- a/go-controller/pkg/node/gateway_init.go
+++ b/go-controller/pkg/node/gateway_init.go
@@ -493,7 +493,7 @@ func (nc *DefaultNodeNetworkController) initGatewayDPUHostPreStart(kubeNodeIP ne
 func (nc *DefaultNodeNetworkController) initGatewayDPUHost() error {
 	// A DPU host gateway is complementary to the shared gateway running
 	// on the DPU embedded CPU. it performs some initializations and
-	// watch on services for iptable rule updates and run a loadBalancerHealth checker
+	// watch on services for nftables rule updates and run a loadBalancerHealth checker
 	// Note: all K8s Node related annotations are handled from DPU.
 	klog.Info("Initializing Shared Gateway Functionality for Gateway Start on DPU host")
 	var err error
@@ -501,7 +501,7 @@ func (nc *DefaultNodeNetworkController) initGatewayDPUHost() error {
 	gw := nc.Gateway.(*gateway)
 	gw.nodeIPManager = newAddressManager(nc.name, nc.Kube, nil, nc.watchFactory, nil, nc.ovsClient)
 	if config.Gateway.NodeportEnable {
-		if err := initSharedGatewayIPTables(); err != nil {
+		if err := initGatewayNFTables(); err != nil {
 			return err
 		}
 		if util.IsNetworkSegmentationSupportEnabled() {
@@ -509,7 +509,7 @@ func (nc *DefaultNodeNetworkController) initGatewayDPUHost() error {
 				return fmt.Errorf("unable to configure UDN nftables: %w", err)
 			}
 		}
-		gw.nodePortWatcherIptables = newNodePortWatcherIptables(nc.networkManager)
+		gw.nodePortWatcherNFTables = newNodePortWatcherNFTables(nc.networkManager)
 		gw.loadBalancerHealthChecker = newLoadBalancerHealthChecker(nc.name, nc.watchFactory)
 		portClaimWatcher, err := newPortClaimWatcher(nc.recorder)
 		if err != nil {
@@ -556,7 +556,7 @@ func CleanupClusterNode(name string) error {
 			}
 		}
 		// cleanupSharedGateway handles both the OVS-side (no-op when ovsClient
-		// is nil) and the host-side iptables chains.
+		// is nil) and the host-side nftables chains.
 		if sharedErr := cleanupSharedGateway(ovsClient); sharedErr != nil {
 			klog.Errorf("Failed to cleanup Gateway, error: %v", sharedErr)
 			err = sharedErr

--- a/go-controller/pkg/node/gateway_init.go
+++ b/go-controller/pkg/node/gateway_init.go
@@ -493,7 +493,7 @@ func (nc *DefaultNodeNetworkController) initGatewayDPUHostPreStart(kubeNodeIP ne
 func (nc *DefaultNodeNetworkController) initGatewayDPUHost() error {
 	// A DPU host gateway is complementary to the shared gateway running
 	// on the DPU embedded CPU. it performs some initializations and
-	// watch on services for iptable rule updates and run a loadBalancerHealth checker
+	// watch on services for nftables rule updates and run a loadBalancerHealth checker
 	// Note: all K8s Node related annotations are handled from DPU.
 	klog.Info("Initializing Shared Gateway Functionality for Gateway Start on DPU host")
 	var err error
@@ -509,7 +509,7 @@ func (nc *DefaultNodeNetworkController) initGatewayDPUHost() error {
 				return fmt.Errorf("unable to configure UDN nftables: %w", err)
 			}
 		}
-		gw.nodePortWatcherIptables = newNodePortWatcherIptables(nc.networkManager)
+		gw.nodePortWatcherNFTables = newNodePortWatcherNFTables(nc.networkManager)
 		gw.loadBalancerHealthChecker = newLoadBalancerHealthChecker(nc.name, nc.watchFactory)
 		portClaimWatcher, err := newPortClaimWatcher(nc.recorder)
 		if err != nil {
@@ -556,7 +556,7 @@ func CleanupClusterNode(name string) error {
 			}
 		}
 		// cleanupSharedGateway handles both the OVS-side (no-op when ovsClient
-		// is nil) and the host-side iptables chains.
+		// is nil) and the host-side nftables chains.
 		if sharedErr := cleanupSharedGateway(ovsClient); sharedErr != nil {
 			klog.Errorf("Failed to cleanup Gateway, error: %v", sharedErr)
 			err = sharedErr

--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -105,6 +105,7 @@ add rule inet ovn-kubernetes ovn-kube-pod-subnet-masq ip saddr 10.1.1.0/24 masqu
 const nftablesRulesGatewayServices = `
 add chain inet ovn-kubernetes services { comment "DNAT for ordinary NodePort/ExternalIP/LB traffic" ; }
 add chain inet ovn-kubernetes services-etp { comment "Special DNAT for NodePort/ExternalIP/LB traffic with ExternalTrafficPolicy: Local" ; }
+add chain inet ovn-kubernetes services-etp-no-nodeport { comment "Special DNAT for ExternalIP/LB traffic with ExternalTrafficPolicy: Local and no NodePorts" ; }
 add chain inet ovn-kubernetes services-output { type nat hook output priority -100 ; }
 add chain inet ovn-kubernetes services-prerouting { type nat hook prerouting priority -100 ; }
 add map inet ovn-kubernetes nodeports-v4 { type inet_proto . inet_service : ipv4_addr . inet_service ; comment "DNAT mappings for ordinary IPv4 NodePort traffic" ; }
@@ -125,6 +126,7 @@ add rule inet ovn-kubernetes services fib daddr type local dnat ip addr . port t
 add rule inet ovn-kubernetes services fib daddr type local dnat ip6 addr . port to meta l4proto . th dport map @nodeports-v6
 add rule inet ovn-kubernetes services-output jump services
 add rule inet ovn-kubernetes services-prerouting jump services-etp
+add rule inet ovn-kubernetes services-prerouting jump services-etp-no-nodeport
 add rule inet ovn-kubernetes services-prerouting jump services
 `
 

--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -106,6 +106,8 @@ const nftablesRulesGatewayServices = `
 add chain inet ovn-kubernetes services { comment "DNAT for ordinary NodePort/ExternalIP/LB traffic" ; }
 add chain inet ovn-kubernetes services-etp { comment "Special DNAT for NodePort/ExternalIP/LB traffic with ExternalTrafficPolicy: Local" ; }
 add chain inet ovn-kubernetes services-etp-no-nodeport { comment "Special DNAT for ExternalIP/LB traffic with ExternalTrafficPolicy: Local and no NodePorts" ; }
+add chain inet ovn-kubernetes services-itp { comment "Redirects for traffic with InternalTrafficPolicy: Local" ; }
+add chain inet ovn-kubernetes services-itp-mark { type route hook output priority -150 ; comment "Chain to mark InternalTrafficPolicy: Local traffic for special routing" ; }
 add chain inet ovn-kubernetes services-output { type nat hook output priority -100 ; }
 add chain inet ovn-kubernetes services-prerouting { type nat hook prerouting priority -100 ; }
 add map inet ovn-kubernetes nodeports-v4 { type inet_proto . inet_service : ipv4_addr . inet_service ; comment "DNAT mappings for ordinary IPv4 NodePort traffic" ; }
@@ -116,14 +118,23 @@ add map inet ovn-kubernetes external-ips-etp-local-v4 { type ipv4_addr . inet_pr
 add map inet ovn-kubernetes external-ips-etp-local-v6 { type ipv6_addr . inet_proto . inet_service : ipv6_addr . inet_service ; comment "DNAT mappings for IPv6 ExternalIP/LB traffic with ExternalTrafficPolicy: Local" ; }
 add map inet ovn-kubernetes external-ips-v4 { type ipv4_addr . inet_proto . inet_service : ipv4_addr . inet_service ; comment "DNAT mappings for ordinary IPv4 ExternalIP/LB traffic" ; }
 add map inet ovn-kubernetes external-ips-v6 { type ipv6_addr . inet_proto . inet_service : ipv6_addr . inet_service ; comment "DNAT mappings for ordinary IPv6 ExternalIP/LB traffic" ; }
+add set inet ovn-kubernetes itp-services-to-mark-v4 { type ipv4_addr . inet_proto . inet_service ; comment "InternalTrafficPolicy: Local traffic to mark for special routing" ; }
+add set inet ovn-kubernetes itp-services-to-mark-v6 { type ipv6_addr . inet_proto . inet_service ; comment "InternalTrafficPolicy: Local traffic to mark for special routing" ; }
+add map inet ovn-kubernetes itp-services-to-redirect-v4 { type ipv4_addr . inet_proto . inet_service : inet_service ; comment "Port redirections for ordinary InternalTrafficPolicy: Local traffic" ; }
+add map inet ovn-kubernetes itp-services-to-redirect-v6 { type ipv6_addr . inet_proto . inet_service : inet_service ; comment "Port redirections for ordinary InternalTrafficPolicy: Local traffic" ; }
 add rule inet ovn-kubernetes services-etp dnat ip addr . port to  ip daddr . meta l4proto . th dport map @external-ips-etp-local-v4
 add rule inet ovn-kubernetes services-etp dnat ip6 addr . port to  ip6 daddr . meta l4proto . th dport map @external-ips-etp-local-v6
 add rule inet ovn-kubernetes services-etp fib daddr type local dnat ip addr . port to meta l4proto . th dport map @nodeports-etp-local-v4
 add rule inet ovn-kubernetes services-etp fib daddr type local dnat ip6 addr . port to meta l4proto . th dport map @nodeports-etp-local-v6
+add rule inet ovn-kubernetes services-itp meta l4proto { tcp, udp, sctp } redirect to ip daddr . meta l4proto . th dport map @itp-services-to-redirect-v4
+add rule inet ovn-kubernetes services-itp meta l4proto { tcp, udp, sctp } redirect to ip6 daddr . meta l4proto . th dport map @itp-services-to-redirect-v6
+add rule inet ovn-kubernetes services-itp-mark ip daddr . meta l4proto . th dport @itp-services-to-mark-v4 mark set 0x1745ec
+add rule inet ovn-kubernetes services-itp-mark ip6 daddr . meta l4proto . th dport @itp-services-to-mark-v6 mark set 0x1745ec
 add rule inet ovn-kubernetes services dnat ip to  ip daddr . meta l4proto . th dport map @external-ips-v4
 add rule inet ovn-kubernetes services dnat ip6 to  ip6 daddr . meta l4proto . th dport map @external-ips-v6
 add rule inet ovn-kubernetes services fib daddr type local dnat ip addr . port to meta l4proto . th dport map @nodeports-v4
 add rule inet ovn-kubernetes services fib daddr type local dnat ip6 addr . port to meta l4proto . th dport map @nodeports-v6
+add rule inet ovn-kubernetes services-output jump services-itp
 add rule inet ovn-kubernetes services-output jump services
 add rule inet ovn-kubernetes services-prerouting jump services-etp
 add rule inet ovn-kubernetes services-prerouting jump services-etp-no-nodeport

--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -107,6 +107,14 @@ add chain inet ovn-kubernetes services { comment "DNAT for ordinary NodePort/Ext
 add chain inet ovn-kubernetes services-etp { comment "Special DNAT for NodePort/ExternalIP/LB traffic with ExternalTrafficPolicy: Local" ; }
 add chain inet ovn-kubernetes services-output { type nat hook output priority -100 ; }
 add chain inet ovn-kubernetes services-prerouting { type nat hook prerouting priority -100 ; }
+add map inet ovn-kubernetes nodeports-v4 { type inet_proto . inet_service : ipv4_addr . inet_service ; comment "DNAT mappings for ordinary IPv4 NodePort traffic" ; }
+add map inet ovn-kubernetes nodeports-v6 { type inet_proto . inet_service : ipv6_addr . inet_service ; comment "DNAT mappings for ordinary IPv6 NodePort traffic" ; }
+add map inet ovn-kubernetes nodeports-etp-local-v4 { type inet_proto . inet_service : ipv4_addr . inet_service ; comment "DNAT mappings for IPv4 NodePort traffic with ExternalTrafficPolicy: Local" ; }
+add map inet ovn-kubernetes nodeports-etp-local-v6 { type inet_proto . inet_service : ipv6_addr . inet_service ; comment "DNAT mappings for IPv6 NodePort traffic with ExternalTrafficPolicy: Local" ; }
+add rule inet ovn-kubernetes services-etp fib daddr type local dnat ip addr . port to meta l4proto . th dport map @nodeports-etp-local-v4
+add rule inet ovn-kubernetes services-etp fib daddr type local dnat ip6 addr . port to meta l4proto . th dport map @nodeports-etp-local-v6
+add rule inet ovn-kubernetes services fib daddr type local dnat ip addr . port to meta l4proto . th dport map @nodeports-v4
+add rule inet ovn-kubernetes services fib daddr type local dnat ip6 addr . port to meta l4proto . th dport map @nodeports-v6
 add rule inet ovn-kubernetes services-output jump services
 add rule inet ovn-kubernetes services-prerouting jump services-etp
 add rule inet ovn-kubernetes services-prerouting jump services

--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -101,6 +101,17 @@ add chain inet ovn-kubernetes ovn-kube-pod-subnet-masq
 add rule inet ovn-kubernetes ovn-kube-pod-subnet-masq ip saddr 10.1.1.0/24 masquerade
 `
 
+// The additional rules expected if initGatewayNFTables() is called
+const nftablesRulesGatewayServices = `
+add chain inet ovn-kubernetes services { comment "DNAT for ordinary NodePort/ExternalIP/LB traffic" ; }
+add chain inet ovn-kubernetes services-etp { comment "Special DNAT for NodePort/ExternalIP/LB traffic with ExternalTrafficPolicy: Local" ; }
+add chain inet ovn-kubernetes services-output { type nat hook output priority -100 ; }
+add chain inet ovn-kubernetes services-prerouting { type nat hook prerouting priority -100 ; }
+add rule inet ovn-kubernetes services-output jump services
+add rule inet ovn-kubernetes services-prerouting jump services-etp
+add rule inet ovn-kubernetes services-prerouting jump services
+`
+
 func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 	eth0Name, eth0MAC, eth0GWIP, eth0CIDR string, gatewayVLANID uint, l netlink.Link, hwOffload, setNodeIP bool) {
 	const mtu string = "1234"
@@ -539,7 +550,7 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 		err = f6.MatchState(expectedTables, nil)
 		Expect(err).NotTo(HaveOccurred())
 
-		expectedNFT := nftablesRulesBase
+		expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
 		err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 		Expect(err).NotTo(HaveOccurred())
 
@@ -1406,7 +1417,7 @@ OFPT_GET_CONFIG_REPLY (xid=0x4): frags=normal miss_send_len=0`
 		err = f6.MatchState(expectedTables, nil)
 		Expect(err).NotTo(HaveOccurred())
 
-		expectedNFT := nftablesRulesBase + nftablesRulesLocalGateway
+		expectedNFT := nftablesRulesBase + nftablesRulesLocalGateway + nftablesRulesGatewayServices
 		if util.IsNetworkSegmentationSupportEnabled() {
 			expectedNFT += nftablesRulesUDN
 		}

--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -101,6 +101,58 @@ add chain inet ovn-kubernetes ovn-kube-pod-subnet-masq
 add rule inet ovn-kubernetes ovn-kube-pod-subnet-masq ip saddr 10.1.1.0/24 masquerade
 `
 
+// The additional rules expected if initGatewayNFTables() is called
+const nftablesRulesGatewayServices = `
+add chain inet ovn-kubernetes services { comment "DNAT for ordinary NodePort/ExternalIP/LB traffic" ; }
+add chain inet ovn-kubernetes services-etp { comment "Special DNAT for NodePort/ExternalIP/LB traffic with ExternalTrafficPolicy: Local" ; }
+add chain inet ovn-kubernetes services-etp-no-nodeport { comment "Special DNAT for ExternalIP/LB traffic with ExternalTrafficPolicy: Local and no NodePorts" ; }
+add chain inet ovn-kubernetes services-itp { comment "Redirects for traffic with InternalTrafficPolicy: Local" ; }
+add chain inet ovn-kubernetes services-itp-mark { type route hook output priority -150 ; comment "Chain to mark InternalTrafficPolicy: Local traffic for special routing" ; }
+add chain inet ovn-kubernetes services-output { type nat hook output priority -100 ; }
+add chain inet ovn-kubernetes services-prerouting { type nat hook prerouting priority -100 ; }
+add map inet ovn-kubernetes nodeports-v4 { type inet_proto . inet_service : ipv4_addr . inet_service ; comment "DNAT mappings for ordinary IPv4 NodePort traffic" ; }
+add map inet ovn-kubernetes nodeports-v6 { type inet_proto . inet_service : ipv6_addr . inet_service ; comment "DNAT mappings for ordinary IPv6 NodePort traffic" ; }
+add map inet ovn-kubernetes nodeports-etp-local-v4 { type inet_proto . inet_service : ipv4_addr . inet_service ; comment "DNAT mappings for IPv4 NodePort traffic with ExternalTrafficPolicy: Local" ; }
+add map inet ovn-kubernetes nodeports-etp-local-v6 { type inet_proto . inet_service : ipv6_addr . inet_service ; comment "DNAT mappings for IPv6 NodePort traffic with ExternalTrafficPolicy: Local" ; }
+add map inet ovn-kubernetes external-ips-etp-local-v4 { type ipv4_addr . inet_proto . inet_service : ipv4_addr . inet_service ; comment "DNAT mappings for IPv4 ExternalIP/LB traffic with ExternalTrafficPolicy: Local" ; }
+add map inet ovn-kubernetes external-ips-etp-local-v6 { type ipv6_addr . inet_proto . inet_service : ipv6_addr . inet_service ; comment "DNAT mappings for IPv6 ExternalIP/LB traffic with ExternalTrafficPolicy: Local" ; }
+add map inet ovn-kubernetes external-ips-v4 { type ipv4_addr . inet_proto . inet_service : ipv4_addr . inet_service ; comment "DNAT mappings for ordinary IPv4 ExternalIP/LB traffic" ; }
+add map inet ovn-kubernetes external-ips-v6 { type ipv6_addr . inet_proto . inet_service : ipv6_addr . inet_service ; comment "DNAT mappings for ordinary IPv6 ExternalIP/LB traffic" ; }
+add set inet ovn-kubernetes itp-services-to-mark-v4 { type ipv4_addr . inet_proto . inet_service ; comment "InternalTrafficPolicy: Local traffic to mark for special routing" ; }
+add set inet ovn-kubernetes itp-services-to-mark-v6 { type ipv6_addr . inet_proto . inet_service ; comment "InternalTrafficPolicy: Local traffic to mark for special routing" ; }
+add map inet ovn-kubernetes itp-services-to-redirect-v4 { type ipv4_addr . inet_proto . inet_service : inet_service ; comment "Port redirections for ordinary InternalTrafficPolicy: Local traffic" ; }
+add map inet ovn-kubernetes itp-services-to-redirect-v6 { type ipv6_addr . inet_proto . inet_service : inet_service ; comment "Port redirections for ordinary InternalTrafficPolicy: Local traffic" ; }
+add rule inet ovn-kubernetes services-etp dnat ip addr . port to  ip daddr . meta l4proto . th dport map @external-ips-etp-local-v4
+add rule inet ovn-kubernetes services-etp dnat ip6 addr . port to  ip6 daddr . meta l4proto . th dport map @external-ips-etp-local-v6
+add rule inet ovn-kubernetes services-etp fib daddr type local dnat ip addr . port to meta l4proto . th dport map @nodeports-etp-local-v4
+add rule inet ovn-kubernetes services-etp fib daddr type local dnat ip6 addr . port to meta l4proto . th dport map @nodeports-etp-local-v6
+add rule inet ovn-kubernetes services-itp meta l4proto { tcp, udp, sctp } redirect to ip daddr . meta l4proto . th dport map @itp-services-to-redirect-v4
+add rule inet ovn-kubernetes services-itp meta l4proto { tcp, udp, sctp } redirect to ip6 daddr . meta l4proto . th dport map @itp-services-to-redirect-v6
+add rule inet ovn-kubernetes services-itp-mark ip daddr . meta l4proto . th dport @itp-services-to-mark-v4 mark set 0x1745ec
+add rule inet ovn-kubernetes services-itp-mark ip6 daddr . meta l4proto . th dport @itp-services-to-mark-v6 mark set 0x1745ec
+add rule inet ovn-kubernetes services dnat ip to  ip daddr . meta l4proto . th dport map @external-ips-v4
+add rule inet ovn-kubernetes services dnat ip6 to  ip6 daddr . meta l4proto . th dport map @external-ips-v6
+add rule inet ovn-kubernetes services fib daddr type local dnat ip addr . port to meta l4proto . th dport map @nodeports-v4
+add rule inet ovn-kubernetes services fib daddr type local dnat ip6 addr . port to meta l4proto . th dport map @nodeports-v6
+add rule inet ovn-kubernetes services-output jump services-itp
+add rule inet ovn-kubernetes services-output jump services
+add rule inet ovn-kubernetes services-prerouting jump services-etp
+add rule inet ovn-kubernetes services-prerouting jump services-etp-no-nodeport
+add rule inet ovn-kubernetes services-prerouting jump services
+`
+
+// OCP HACK: Block MCS Access. https://github.com/openshift/ovn-kubernetes/pull/170
+const nftablesRulesMCS = `
+add chain inet ovn-kubernetes mcs-blocking
+add rule inet ovn-kubernetes mcs-blocking tcp dport { 22623, 22624 } tcp flags syn / fin,syn,rst,ack reject
+add chain inet ovn-kubernetes mcs-blocking-output { type filter hook output priority 0 ; }
+add rule inet ovn-kubernetes mcs-blocking-output jump mcs-blocking
+add chain inet ovn-kubernetes mcs-blocking-forward { type filter hook forward priority 0 ; }
+add rule inet ovn-kubernetes mcs-blocking-forward jump mcs-blocking
+`
+
+// END OCP HACK
+
 func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 	eth0Name, eth0MAC, eth0GWIP, eth0CIDR string, gatewayVLANID uint, l netlink.Link, hwOffload, setNodeIP bool) {
 	const mtu string = "1234"
@@ -261,7 +313,6 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 			existingNode.Status = corev1.NodeStatus{Addresses: []corev1.NodeAddress{nodeAddr}}
 		}
 
-		iptV4, iptV6 := util.SetFakeIPTablesHelpers()
 		nft := nodenft.SetFakeNFTablesHelper()
 
 		ovsClient, ovsCleanup := newTestOVSClient()
@@ -501,53 +552,7 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 				"'k8s.ovn.org/gateway-mtu-support' with value == \"false\"")
 		}
 
-		expectedTables := map[string]util.FakeTable{
-			"nat": {
-				"PREROUTING": []string{
-					"-j OVN-KUBE-ETP",
-					"-j OVN-KUBE-EXTERNALIP",
-					"-j OVN-KUBE-NODEPORT",
-				},
-				"OUTPUT": []string{
-					"-j OVN-KUBE-EXTERNALIP",
-					"-j OVN-KUBE-NODEPORT",
-					"-j OVN-KUBE-ITP",
-				},
-				"OVN-KUBE-NODEPORT":   []string{},
-				"OVN-KUBE-EXTERNALIP": []string{},
-				"OVN-KUBE-ETP":        []string{},
-				"OVN-KUBE-ITP":        []string{},
-			},
-			"filter": {},
-			"mangle": {
-				"OUTPUT": []string{
-					"-j OVN-KUBE-ITP",
-				},
-				"OVN-KUBE-ITP": []string{},
-			},
-		}
-		// OCP HACK: Block MCS Access. https://github.com/openshift/ovn-kubernetes/pull/170
-		expectedMCSRules := []string{
-			"-p tcp -m tcp --dport 22624 --syn -j REJECT",
-			"-p tcp -m tcp --dport 22623 --syn -j REJECT",
-		}
-		expectedTables["filter"]["FORWARD"] = append(expectedMCSRules, expectedTables["filter"]["FORWARD"]...)
-		expectedTables["filter"]["OUTPUT"] = append(expectedMCSRules, expectedTables["filter"]["OUTPUT"]...)
-		// END OCP HACK
-		f4 := iptV4.(*util.FakeIPTables)
-		err = f4.MatchState(expectedTables, nil)
-		Expect(err).NotTo(HaveOccurred())
-
-		expectedTables = map[string]util.FakeTable{
-			"nat":    {},
-			"filter": {},
-			"mangle": {},
-		}
-		f6 := iptV6.(*util.FakeIPTables)
-		err = f6.MatchState(expectedTables, nil)
-		Expect(err).NotTo(HaveOccurred())
-
-		expectedNFT := nftablesRulesBase
+		expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices + nftablesRulesMCS
 		err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 		Expect(err).NotTo(HaveOccurred())
 
@@ -1253,7 +1258,6 @@ OFPT_GET_CONFIG_REPLY (xid=0x4): frags=normal miss_send_len=0`
 		Expect(err).NotTo(HaveOccurred())
 
 		k := &kube.Kube{KClient: kubeFakeClient}
-		iptV4, iptV6 := util.SetFakeIPTablesHelpers()
 
 		nodeAnnotator := kube.NewNodeAnnotator(k, existingNode.Name)
 
@@ -1374,68 +1378,11 @@ OFPT_GET_CONFIG_REPLY (xid=0x4): frags=normal miss_send_len=0`
 		Expect(err).NotTo(HaveOccurred())
 		Eventually(fexec.CalledMatchesExpected, 5).Should(BeTrue(), fexec.ErrorDesc)
 
-		expectedTables := map[string]util.FakeTable{
-			"nat": {
-				"PREROUTING": []string{
-					"-j OVN-KUBE-ETP",
-					"-j OVN-KUBE-EXTERNALIP",
-					"-j OVN-KUBE-NODEPORT",
-				},
-				"OUTPUT": []string{
-					"-j OVN-KUBE-EXTERNALIP",
-					"-j OVN-KUBE-NODEPORT",
-					"-j OVN-KUBE-ITP",
-				},
-				"OVN-KUBE-NODEPORT": []string{},
-				"OVN-KUBE-EXTERNALIP": []string{
-					fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, externalIP, service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
-				},
-				"OVN-KUBE-ETP": []string{},
-				"OVN-KUBE-ITP": []string{},
-			},
-			"filter": {},
-			"mangle": {
-				"OUTPUT": []string{
-					"-j OVN-KUBE-ITP",
-				},
-				"OVN-KUBE-ITP": []string{},
-			},
-		}
-		// OCP HACK: Block MCS Access. https://github.com/openshift/ovn-kubernetes/pull/170
-		expectedMCSRules := []string{
-			"-p tcp -m tcp --dport 22624 --syn -j REJECT",
-			"-p tcp -m tcp --dport 22623 --syn -j REJECT",
-		}
-		expectedTables["filter"]["FORWARD"] = append(expectedMCSRules, expectedTables["filter"]["FORWARD"]...)
-		expectedTables["filter"]["OUTPUT"] = append(expectedMCSRules, expectedTables["filter"]["OUTPUT"]...)
-		// END OCP HACK
-		if util.IsNetworkSegmentationSupportEnabled() {
-			expectedTables["nat"]["POSTROUTING"] = append(expectedTables["nat"]["POSTROUTING"],
-				"-j OVN-KUBE-UDN-MASQUERADE",
-			)
-			expectedTables["nat"]["OVN-KUBE-UDN-MASQUERADE"] = append(expectedTables["nat"]["OVN-KUBE-UDN-MASQUERADE"],
-				"-s 169.254.169.0/29 -j RETURN",     // this guarantees we don't SNAT default network masqueradeIPs
-				"-d 172.16.1.0/24 -j RETURN",        // this guarantees we don't SNAT service traffic
-				"-s 169.254.169.0/24 -j MASQUERADE", // this guarantees we SNAT all UDN MasqueradeIPs traffic leaving the node
-			)
-		}
-		f4 := iptV4.(*util.FakeIPTables)
-		err = f4.MatchState(expectedTables, nil)
-		Expect(err).NotTo(HaveOccurred())
-
-		expectedTables = map[string]util.FakeTable{
-			"nat":    {},
-			"filter": {},
-			"mangle": {},
-		}
-		f6 := iptV6.(*util.FakeIPTables)
-		err = f6.MatchState(expectedTables, nil)
-		Expect(err).NotTo(HaveOccurred())
-
-		expectedNFT := nftablesRulesBase + nftablesRulesLocalGateway
+		expectedNFT := nftablesRulesBase + nftablesRulesLocalGateway + nftablesRulesGatewayServices + nftablesRulesMCS
 		if util.IsNetworkSegmentationSupportEnabled() {
 			expectedNFT += nftablesRulesUDN
 		}
+		expectedNFT += "add element inet ovn-kubernetes external-ips-v4 { 1.1.1.1 . tcp . 8032 : 10.129.0.2 . 8032 }"
 		err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 		Expect(err).NotTo(HaveOccurred())
 

--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -111,8 +111,16 @@ add map inet ovn-kubernetes nodeports-v4 { type inet_proto . inet_service : ipv4
 add map inet ovn-kubernetes nodeports-v6 { type inet_proto . inet_service : ipv6_addr . inet_service ; comment "DNAT mappings for ordinary IPv6 NodePort traffic" ; }
 add map inet ovn-kubernetes nodeports-etp-local-v4 { type inet_proto . inet_service : ipv4_addr . inet_service ; comment "DNAT mappings for IPv4 NodePort traffic with ExternalTrafficPolicy: Local" ; }
 add map inet ovn-kubernetes nodeports-etp-local-v6 { type inet_proto . inet_service : ipv6_addr . inet_service ; comment "DNAT mappings for IPv6 NodePort traffic with ExternalTrafficPolicy: Local" ; }
+add map inet ovn-kubernetes external-ips-etp-local-v4 { type ipv4_addr . inet_proto . inet_service : ipv4_addr . inet_service ; comment "DNAT mappings for IPv4 ExternalIP/LB traffic with ExternalTrafficPolicy: Local" ; }
+add map inet ovn-kubernetes external-ips-etp-local-v6 { type ipv6_addr . inet_proto . inet_service : ipv6_addr . inet_service ; comment "DNAT mappings for IPv6 ExternalIP/LB traffic with ExternalTrafficPolicy: Local" ; }
+add map inet ovn-kubernetes external-ips-v4 { type ipv4_addr . inet_proto . inet_service : ipv4_addr . inet_service ; comment "DNAT mappings for ordinary IPv4 ExternalIP/LB traffic" ; }
+add map inet ovn-kubernetes external-ips-v6 { type ipv6_addr . inet_proto . inet_service : ipv6_addr . inet_service ; comment "DNAT mappings for ordinary IPv6 ExternalIP/LB traffic" ; }
+add rule inet ovn-kubernetes services-etp dnat ip addr . port to  ip daddr . meta l4proto . th dport map @external-ips-etp-local-v4
+add rule inet ovn-kubernetes services-etp dnat ip6 addr . port to  ip6 daddr . meta l4proto . th dport map @external-ips-etp-local-v6
 add rule inet ovn-kubernetes services-etp fib daddr type local dnat ip addr . port to meta l4proto . th dport map @nodeports-etp-local-v4
 add rule inet ovn-kubernetes services-etp fib daddr type local dnat ip6 addr . port to meta l4proto . th dport map @nodeports-etp-local-v6
+add rule inet ovn-kubernetes services dnat ip to  ip daddr . meta l4proto . th dport map @external-ips-v4
+add rule inet ovn-kubernetes services dnat ip6 to  ip6 daddr . meta l4proto . th dport map @external-ips-v6
 add rule inet ovn-kubernetes services fib daddr type local dnat ip addr . port to meta l4proto . th dport map @nodeports-v4
 add rule inet ovn-kubernetes services fib daddr type local dnat ip6 addr . port to meta l4proto . th dport map @nodeports-v6
 add rule inet ovn-kubernetes services-output jump services
@@ -1397,12 +1405,10 @@ OFPT_GET_CONFIG_REPLY (xid=0x4): frags=normal miss_send_len=0`
 					"-j OVN-KUBE-NODEPORT",
 					"-j OVN-KUBE-ITP",
 				},
-				"OVN-KUBE-NODEPORT": []string{},
-				"OVN-KUBE-EXTERNALIP": []string{
-					fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, externalIP, service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
-				},
-				"OVN-KUBE-ETP": []string{},
-				"OVN-KUBE-ITP": []string{},
+				"OVN-KUBE-NODEPORT":   []string{},
+				"OVN-KUBE-EXTERNALIP": []string{},
+				"OVN-KUBE-ETP":        []string{},
+				"OVN-KUBE-ITP":        []string{},
 			},
 			"filter": {},
 			"mangle": {
@@ -1429,6 +1435,7 @@ OFPT_GET_CONFIG_REPLY (xid=0x4): frags=normal miss_send_len=0`
 		if util.IsNetworkSegmentationSupportEnabled() {
 			expectedNFT += nftablesRulesUDN
 		}
+		expectedNFT += "add element inet ovn-kubernetes external-ips-v4 { 1.1.1.1 . tcp . 8032 : 10.129.0.2 . 8032 }"
 		err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 		Expect(err).NotTo(HaveOccurred())
 

--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -301,7 +301,6 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 			existingNode.Status = corev1.NodeStatus{Addresses: []corev1.NodeAddress{nodeAddr}}
 		}
 
-		iptV4, iptV6 := util.SetFakeIPTablesHelpers()
 		nft := nodenft.SetFakeNFTablesHelper()
 
 		ovsClient, ovsCleanup := newTestOVSClient()
@@ -540,44 +539,6 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 			}, 5).Should(BeTrue(), "invalid annotation, hw-offload is disabled but found annotation "+
 				"'k8s.ovn.org/gateway-mtu-support' with value == \"false\"")
 		}
-
-		expectedTables := map[string]util.FakeTable{
-			"nat": {
-				"PREROUTING": []string{
-					"-j OVN-KUBE-ETP",
-					"-j OVN-KUBE-EXTERNALIP",
-					"-j OVN-KUBE-NODEPORT",
-				},
-				"OUTPUT": []string{
-					"-j OVN-KUBE-EXTERNALIP",
-					"-j OVN-KUBE-NODEPORT",
-					"-j OVN-KUBE-ITP",
-				},
-				"OVN-KUBE-NODEPORT":   []string{},
-				"OVN-KUBE-EXTERNALIP": []string{},
-				"OVN-KUBE-ETP":        []string{},
-				"OVN-KUBE-ITP":        []string{},
-			},
-			"filter": {},
-			"mangle": {
-				"OUTPUT": []string{
-					"-j OVN-KUBE-ITP",
-				},
-				"OVN-KUBE-ITP": []string{},
-			},
-		}
-		f4 := iptV4.(*util.FakeIPTables)
-		err = f4.MatchState(expectedTables, nil)
-		Expect(err).NotTo(HaveOccurred())
-
-		expectedTables = map[string]util.FakeTable{
-			"nat":    {},
-			"filter": {},
-			"mangle": {},
-		}
-		f6 := iptV6.(*util.FakeIPTables)
-		err = f6.MatchState(expectedTables, nil)
-		Expect(err).NotTo(HaveOccurred())
 
 		expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
 		err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
@@ -1285,7 +1246,6 @@ OFPT_GET_CONFIG_REPLY (xid=0x4): frags=normal miss_send_len=0`
 		Expect(err).NotTo(HaveOccurred())
 
 		k := &kube.Kube{KClient: kubeFakeClient}
-		iptV4, iptV6 := util.SetFakeIPTablesHelpers()
 
 		nodeAnnotator := kube.NewNodeAnnotator(k, existingNode.Name)
 
@@ -1405,44 +1365,6 @@ OFPT_GET_CONFIG_REPLY (xid=0x4): frags=normal miss_send_len=0`
 		})
 		Expect(err).NotTo(HaveOccurred())
 		Eventually(fexec.CalledMatchesExpected, 5).Should(BeTrue(), fexec.ErrorDesc)
-
-		expectedTables := map[string]util.FakeTable{
-			"nat": {
-				"PREROUTING": []string{
-					"-j OVN-KUBE-ETP",
-					"-j OVN-KUBE-EXTERNALIP",
-					"-j OVN-KUBE-NODEPORT",
-				},
-				"OUTPUT": []string{
-					"-j OVN-KUBE-EXTERNALIP",
-					"-j OVN-KUBE-NODEPORT",
-					"-j OVN-KUBE-ITP",
-				},
-				"OVN-KUBE-NODEPORT":   []string{},
-				"OVN-KUBE-EXTERNALIP": []string{},
-				"OVN-KUBE-ETP":        []string{},
-				"OVN-KUBE-ITP":        []string{},
-			},
-			"filter": {},
-			"mangle": {
-				"OUTPUT": []string{
-					"-j OVN-KUBE-ITP",
-				},
-				"OVN-KUBE-ITP": []string{},
-			},
-		}
-		f4 := iptV4.(*util.FakeIPTables)
-		err = f4.MatchState(expectedTables, nil)
-		Expect(err).NotTo(HaveOccurred())
-
-		expectedTables = map[string]util.FakeTable{
-			"nat":    {},
-			"filter": {},
-			"mangle": {},
-		}
-		f6 := iptV6.(*util.FakeIPTables)
-		err = f6.MatchState(expectedTables, nil)
-		Expect(err).NotTo(HaveOccurred())
 
 		expectedNFT := nftablesRulesBase + nftablesRulesLocalGateway + nftablesRulesGatewayServices
 		if util.IsNetworkSegmentationSupportEnabled() {

--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -101,6 +101,46 @@ add chain inet ovn-kubernetes ovn-kube-pod-subnet-masq
 add rule inet ovn-kubernetes ovn-kube-pod-subnet-masq ip saddr 10.1.1.0/24 masquerade
 `
 
+// The additional rules expected if initGatewayNFTables() is called
+const nftablesRulesGatewayServices = `
+add chain inet ovn-kubernetes services { comment "DNAT for ordinary NodePort/ExternalIP/LB traffic" ; }
+add chain inet ovn-kubernetes services-etp { comment "Special DNAT for NodePort/ExternalIP/LB traffic with ExternalTrafficPolicy: Local" ; }
+add chain inet ovn-kubernetes services-etp-no-nodeport { comment "Special DNAT for ExternalIP/LB traffic with ExternalTrafficPolicy: Local and no NodePorts" ; }
+add chain inet ovn-kubernetes services-itp { comment "Redirects for traffic with InternalTrafficPolicy: Local" ; }
+add chain inet ovn-kubernetes services-itp-mark { type route hook output priority -150 ; comment "Chain to mark InternalTrafficPolicy: Local traffic for special routing" ; }
+add chain inet ovn-kubernetes services-output { type nat hook output priority -100 ; }
+add chain inet ovn-kubernetes services-prerouting { type nat hook prerouting priority -100 ; }
+add map inet ovn-kubernetes nodeports-v4 { type inet_proto . inet_service : ipv4_addr . inet_service ; comment "DNAT mappings for ordinary IPv4 NodePort traffic" ; }
+add map inet ovn-kubernetes nodeports-v6 { type inet_proto . inet_service : ipv6_addr . inet_service ; comment "DNAT mappings for ordinary IPv6 NodePort traffic" ; }
+add map inet ovn-kubernetes nodeports-etp-local-v4 { type inet_proto . inet_service : ipv4_addr . inet_service ; comment "DNAT mappings for IPv4 NodePort traffic with ExternalTrafficPolicy: Local" ; }
+add map inet ovn-kubernetes nodeports-etp-local-v6 { type inet_proto . inet_service : ipv6_addr . inet_service ; comment "DNAT mappings for IPv6 NodePort traffic with ExternalTrafficPolicy: Local" ; }
+add map inet ovn-kubernetes external-ips-etp-local-v4 { type ipv4_addr . inet_proto . inet_service : ipv4_addr . inet_service ; comment "DNAT mappings for IPv4 ExternalIP/LB traffic with ExternalTrafficPolicy: Local" ; }
+add map inet ovn-kubernetes external-ips-etp-local-v6 { type ipv6_addr . inet_proto . inet_service : ipv6_addr . inet_service ; comment "DNAT mappings for IPv6 ExternalIP/LB traffic with ExternalTrafficPolicy: Local" ; }
+add map inet ovn-kubernetes external-ips-v4 { type ipv4_addr . inet_proto . inet_service : ipv4_addr . inet_service ; comment "DNAT mappings for ordinary IPv4 ExternalIP/LB traffic" ; }
+add map inet ovn-kubernetes external-ips-v6 { type ipv6_addr . inet_proto . inet_service : ipv6_addr . inet_service ; comment "DNAT mappings for ordinary IPv6 ExternalIP/LB traffic" ; }
+add set inet ovn-kubernetes itp-services-to-mark-v4 { type ipv4_addr . inet_proto . inet_service ; comment "InternalTrafficPolicy: Local traffic to mark for special routing" ; }
+add set inet ovn-kubernetes itp-services-to-mark-v6 { type ipv6_addr . inet_proto . inet_service ; comment "InternalTrafficPolicy: Local traffic to mark for special routing" ; }
+add map inet ovn-kubernetes itp-services-to-redirect-v4 { type ipv4_addr . inet_proto . inet_service : inet_service ; comment "Port redirections for ordinary InternalTrafficPolicy: Local traffic" ; }
+add map inet ovn-kubernetes itp-services-to-redirect-v6 { type ipv6_addr . inet_proto . inet_service : inet_service ; comment "Port redirections for ordinary InternalTrafficPolicy: Local traffic" ; }
+add rule inet ovn-kubernetes services-etp dnat ip addr . port to  ip daddr . meta l4proto . th dport map @external-ips-etp-local-v4
+add rule inet ovn-kubernetes services-etp dnat ip6 addr . port to  ip6 daddr . meta l4proto . th dport map @external-ips-etp-local-v6
+add rule inet ovn-kubernetes services-etp fib daddr type local dnat ip addr . port to meta l4proto . th dport map @nodeports-etp-local-v4
+add rule inet ovn-kubernetes services-etp fib daddr type local dnat ip6 addr . port to meta l4proto . th dport map @nodeports-etp-local-v6
+add rule inet ovn-kubernetes services-itp meta l4proto { tcp, udp, sctp } redirect to ip daddr . meta l4proto . th dport map @itp-services-to-redirect-v4
+add rule inet ovn-kubernetes services-itp meta l4proto { tcp, udp, sctp } redirect to ip6 daddr . meta l4proto . th dport map @itp-services-to-redirect-v6
+add rule inet ovn-kubernetes services-itp-mark ip daddr . meta l4proto . th dport @itp-services-to-mark-v4 mark set 0x1745ec
+add rule inet ovn-kubernetes services-itp-mark ip6 daddr . meta l4proto . th dport @itp-services-to-mark-v6 mark set 0x1745ec
+add rule inet ovn-kubernetes services dnat ip to  ip daddr . meta l4proto . th dport map @external-ips-v4
+add rule inet ovn-kubernetes services dnat ip6 to  ip6 daddr . meta l4proto . th dport map @external-ips-v6
+add rule inet ovn-kubernetes services fib daddr type local dnat ip addr . port to meta l4proto . th dport map @nodeports-v4
+add rule inet ovn-kubernetes services fib daddr type local dnat ip6 addr . port to meta l4proto . th dport map @nodeports-v6
+add rule inet ovn-kubernetes services-output jump services-itp
+add rule inet ovn-kubernetes services-output jump services
+add rule inet ovn-kubernetes services-prerouting jump services-etp
+add rule inet ovn-kubernetes services-prerouting jump services-etp-no-nodeport
+add rule inet ovn-kubernetes services-prerouting jump services
+`
+
 func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 	eth0Name, eth0MAC, eth0GWIP, eth0CIDR string, gatewayVLANID uint, l netlink.Link, hwOffload, setNodeIP bool) {
 	const mtu string = "1234"
@@ -261,7 +301,6 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 			existingNode.Status = corev1.NodeStatus{Addresses: []corev1.NodeAddress{nodeAddr}}
 		}
 
-		iptV4, iptV6 := util.SetFakeIPTablesHelpers()
 		nft := nodenft.SetFakeNFTablesHelper()
 
 		ovsClient, ovsCleanup := newTestOVSClient()
@@ -501,45 +540,7 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 				"'k8s.ovn.org/gateway-mtu-support' with value == \"false\"")
 		}
 
-		expectedTables := map[string]util.FakeTable{
-			"nat": {
-				"PREROUTING": []string{
-					"-j OVN-KUBE-ETP",
-					"-j OVN-KUBE-EXTERNALIP",
-					"-j OVN-KUBE-NODEPORT",
-				},
-				"OUTPUT": []string{
-					"-j OVN-KUBE-EXTERNALIP",
-					"-j OVN-KUBE-NODEPORT",
-					"-j OVN-KUBE-ITP",
-				},
-				"OVN-KUBE-NODEPORT":   []string{},
-				"OVN-KUBE-EXTERNALIP": []string{},
-				"OVN-KUBE-ETP":        []string{},
-				"OVN-KUBE-ITP":        []string{},
-			},
-			"filter": {},
-			"mangle": {
-				"OUTPUT": []string{
-					"-j OVN-KUBE-ITP",
-				},
-				"OVN-KUBE-ITP": []string{},
-			},
-		}
-		f4 := iptV4.(*util.FakeIPTables)
-		err = f4.MatchState(expectedTables, nil)
-		Expect(err).NotTo(HaveOccurred())
-
-		expectedTables = map[string]util.FakeTable{
-			"nat":    {},
-			"filter": {},
-			"mangle": {},
-		}
-		f6 := iptV6.(*util.FakeIPTables)
-		err = f6.MatchState(expectedTables, nil)
-		Expect(err).NotTo(HaveOccurred())
-
-		expectedNFT := nftablesRulesBase
+		expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
 		err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 		Expect(err).NotTo(HaveOccurred())
 
@@ -1245,7 +1246,6 @@ OFPT_GET_CONFIG_REPLY (xid=0x4): frags=normal miss_send_len=0`
 		Expect(err).NotTo(HaveOccurred())
 
 		k := &kube.Kube{KClient: kubeFakeClient}
-		iptV4, iptV6 := util.SetFakeIPTablesHelpers()
 
 		nodeAnnotator := kube.NewNodeAnnotator(k, existingNode.Name)
 
@@ -1366,50 +1366,11 @@ OFPT_GET_CONFIG_REPLY (xid=0x4): frags=normal miss_send_len=0`
 		Expect(err).NotTo(HaveOccurred())
 		Eventually(fexec.CalledMatchesExpected, 5).Should(BeTrue(), fexec.ErrorDesc)
 
-		expectedTables := map[string]util.FakeTable{
-			"nat": {
-				"PREROUTING": []string{
-					"-j OVN-KUBE-ETP",
-					"-j OVN-KUBE-EXTERNALIP",
-					"-j OVN-KUBE-NODEPORT",
-				},
-				"OUTPUT": []string{
-					"-j OVN-KUBE-EXTERNALIP",
-					"-j OVN-KUBE-NODEPORT",
-					"-j OVN-KUBE-ITP",
-				},
-				"OVN-KUBE-NODEPORT": []string{},
-				"OVN-KUBE-EXTERNALIP": []string{
-					fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, externalIP, service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
-				},
-				"OVN-KUBE-ETP": []string{},
-				"OVN-KUBE-ITP": []string{},
-			},
-			"filter": {},
-			"mangle": {
-				"OUTPUT": []string{
-					"-j OVN-KUBE-ITP",
-				},
-				"OVN-KUBE-ITP": []string{},
-			},
-		}
-		f4 := iptV4.(*util.FakeIPTables)
-		err = f4.MatchState(expectedTables, nil)
-		Expect(err).NotTo(HaveOccurred())
-
-		expectedTables = map[string]util.FakeTable{
-			"nat":    {},
-			"filter": {},
-			"mangle": {},
-		}
-		f6 := iptV6.(*util.FakeIPTables)
-		err = f6.MatchState(expectedTables, nil)
-		Expect(err).NotTo(HaveOccurred())
-
-		expectedNFT := nftablesRulesBase + nftablesRulesLocalGateway
+		expectedNFT := nftablesRulesBase + nftablesRulesLocalGateway + nftablesRulesGatewayServices
 		if util.IsNetworkSegmentationSupportEnabled() {
 			expectedNFT += nftablesRulesUDN
 		}
+		expectedNFT += "add element inet ovn-kubernetes external-ips-v4 { 1.1.1.1 . tcp . 8032 : 10.129.0.2 . 8032 }"
 		err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 		Expect(err).NotTo(HaveOccurred())
 

--- a/go-controller/pkg/node/gateway_iptables.go
+++ b/go-controller/pkg/node/gateway_iptables.go
@@ -12,22 +12,20 @@ import (
 
 	"github.com/coreos/go-iptables/iptables"
 
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/klog/v2"
 	utilnet "k8s.io/utils/net"
 
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
 	nodeipt "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/iptables"
 	nodeutil "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/util"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
-	utilerrors "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util/errors"
 )
 
 const (
-	iptableNodePortChain   = "OVN-KUBE-NODEPORT"   // called from nat-PREROUTING and nat-OUTPUT
-	iptableExternalIPChain = "OVN-KUBE-EXTERNALIP" // called from nat-PREROUTING and nat-OUTPUT
-	iptableETPChain        = "OVN-KUBE-ETP"        // called from nat-PREROUTING only
-	iptableITPChain        = "OVN-KUBE-ITP"        // called from mangle-OUTPUT and nat-OUTPUT
+	// Legacy iptables service chains; only cleaned up; never used
+	iptableNodePortChain   = "OVN-KUBE-NODEPORT"
+	iptableExternalIPChain = "OVN-KUBE-EXTERNALIP"
+	iptableETPChain        = "OVN-KUBE-ETP"
+	iptableITPChain        = "OVN-KUBE-ITP"
 )
 
 func clusterIPTablesProtocols() []iptables.Protocol {
@@ -49,26 +47,10 @@ func getIPTablesProtocol(ip string) iptables.Protocol {
 	return iptables.ProtocolIPv4
 }
 
-// getMasqueradeVIP returns the .3 masquerade VIP based on the protocol (v4/v6) of provided IP string
-func getMasqueradeVIP(ip string) string {
-	if utilnet.IsIPv6String(ip) {
-		return config.Gateway.MasqueradeIPs.V6HostETPLocalMasqueradeIP.String()
-	}
-	return config.Gateway.MasqueradeIPs.V4HostETPLocalMasqueradeIP.String()
-}
-
 // insertIptRules adds the provided rules in an insert fashion
 // i.e each rule gets added at the first position in the chain
 func insertIptRules(rules []nodeipt.Rule) error {
 	return nodeipt.AddRules(rules, false)
-}
-
-// restoreIptRulesFiltered restores the provided rules in an insert fashion with a filter for table/chain
-// i.e each rule gets added at the first position in the chain
-// filter is defined as a map of table/chains. Only rules matching this filter will be restored.
-// If no rules match the filter, the chain will still be restored as empty as specified in the filter.
-func restoreIptRulesFiltered(rules []nodeipt.Rule, filter map[string]map[string]struct{}) error {
-	return nodeipt.RestoreRulesFiltered(rules, filter)
 }
 
 // deleteIptRules removes provided rules from the chain
@@ -262,77 +244,25 @@ func initLocalGatewayIPTFilterRules(ifname string) error {
 	return nil
 }
 
-func addChaintoTable(ipt util.IPTablesHelper, tableName, chain string) {
-	if err := ipt.NewChain(tableName, chain); err != nil {
-		klog.V(5).Infof("Chain: \"%s\" in table: \"%s\" already exists, skipping creation: %v", chain, tableName, err)
-	}
-}
-
-func handleGatewayIPTables(iptCallback func(rules []nodeipt.Rule) error, genGatewayChainRules func(chain string, proto iptables.Protocol) []nodeipt.Rule) error {
+func cleanupGatewayIPTables() {
 	rules := make([]nodeipt.Rule, 0)
-	// (NOTE: Order is important, add jump to iptableETPChain before jump to NP/EIP chains)
-	for _, chain := range []string{iptableITPChain, iptableNodePortChain, iptableExternalIPChain, iptableETPChain} {
-		for _, proto := range clusterIPTablesProtocols() {
-			ipt, err := util.GetIPTablesHelper(proto)
-			if err != nil {
-				return err
-			}
-			addChaintoTable(ipt, "nat", chain)
-			if chain == iptableITPChain {
-				addChaintoTable(ipt, "mangle", chain)
-			}
-			rules = append(rules, genGatewayChainRules(chain, proto)...)
+	// We clean up both IPv4 and IPv6, regardless of what is currently in use
+	for _, proto := range []iptables.Protocol{iptables.ProtocolIPv4, iptables.ProtocolIPv6} {
+		ipt, err := util.GetIPTablesHelper(proto)
+		if err != nil {
+			continue
 		}
-	}
-	if err := iptCallback(rules); err != nil {
-		return fmt.Errorf("failed to handle iptables rules %v: %v", rules, err)
-	}
-	return nil
-}
-
-func initSharedGatewayIPTables() error {
-	if err := handleGatewayIPTables(insertIptRules, getGatewayInitRules); err != nil {
-		return err
-	}
-	return nil
-}
-
-func initLocalGatewayIPTables() error {
-	if err := handleGatewayIPTables(insertIptRules, getGatewayInitRules); err != nil {
-		return err
-	}
-	return nil
-}
-
-func cleanupSharedGatewayIPTChains() {
-	for _, chain := range []string{iptableNodePortChain, iptableExternalIPChain} {
-		// We clean up both IPv4 and IPv6, regardless of what is currently in use
-		for _, proto := range []iptables.Protocol{iptables.ProtocolIPv4, iptables.ProtocolIPv6} {
-			ipt, err := util.GetIPTablesHelper(proto)
-			if err != nil {
-				return
-			}
+		for _, chain := range []string{iptableITPChain, iptableNodePortChain, iptableExternalIPChain, iptableETPChain} {
+			rules = append(rules, getGatewayInitRules(chain, proto)...)
+		}
+		_ = nodeipt.DelRules(rules)
+		for _, chain := range []string{iptableITPChain, iptableNodePortChain, iptableExternalIPChain, iptableETPChain} {
 			_ = ipt.ClearChain("nat", chain)
 			_ = ipt.DeleteChain("nat", chain)
+			if chain == iptableITPChain {
+				_ = ipt.ClearChain("mangle", chain)
+				_ = ipt.DeleteChain("mangle", chain)
+			}
 		}
 	}
-}
-
-func recreateIPTRules(table, chain string, keepIPTRules []nodeipt.Rule) error {
-	var errors []error
-	var err error
-	klog.Infof("Recreating iptables rules for table: %s, chain: %s", table, chain)
-	// filter is a map of the table/chain to program rules for, as all rules are included in keepIPTRules
-	filter := map[string]map[string]struct{}{table: {chain: {}}}
-	if err = restoreIptRulesFiltered(keepIPTRules, filter); err != nil {
-		errors = append(errors, err)
-	}
-	return utilerrors.Join(errors...)
-}
-
-// getGatewayIPTRules returns ClusterIP, NodePort, ExternalIP and LoadBalancer iptables
-// rules for service. This must be used in conjunction with getGatewayNFTRules.
-func getGatewayIPTRules(service *corev1.Service, localEndpoints util.PortToLBEndpoints, svcHasLocalHostNetEndPnt bool) []nodeipt.Rule {
-	rules := make([]nodeipt.Rule, 0)
-	return rules
 }

--- a/go-controller/pkg/node/gateway_iptables.go
+++ b/go-controller/pkg/node/gateway_iptables.go
@@ -19,7 +19,6 @@ import (
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
 	nodeipt "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/iptables"
 	nodeutil "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/util"
-	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
 	utilerrors "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util/errors"
 )
@@ -109,44 +108,6 @@ func getGatewayInitRules(chain string, proto iptables.Protocol) []nodeipt.Rule {
 		)
 	}
 	return iptRules
-}
-
-// getITPLocalIPTRules returns the IPTable REDIRECT or MARK rules for the provided service
-// `svcPort` corresponds to port details for this service as specified in the service object
-// `clusterIP` is clusterIP is the VIP of the service to match on
-// `svcHasLocalHostNetEndPnt` is true if this service has at least one host-networked endpoint that is local to this node
-// NOTE: Currently invoked only for Internal Traffic Policy
-func getITPLocalIPTRules(svcPort corev1.ServicePort, clusterIP string, svcHasLocalHostNetEndPnt bool) []nodeipt.Rule {
-	if svcHasLocalHostNetEndPnt {
-		return []nodeipt.Rule{
-			{
-				Table: "nat",
-				Chain: iptableITPChain,
-				Args: []string{
-					"-p", string(svcPort.Protocol),
-					"-d", clusterIP,
-					"--dport", fmt.Sprintf("%v", svcPort.Port),
-					"-j", "REDIRECT",
-					"--to-port", fmt.Sprintf("%v", int32(svcPort.TargetPort.IntValue())),
-				},
-				Protocol: getIPTablesProtocol(clusterIP),
-			},
-		}
-	}
-	return []nodeipt.Rule{
-		{
-			Table: "mangle",
-			Chain: iptableITPChain,
-			Args: []string{
-				"-p", string(svcPort.Protocol),
-				"-d", string(clusterIP),
-				"--dport", fmt.Sprintf("%d", svcPort.Port),
-				"-j", "MARK",
-				"--set-xmark", string(types.OVNKubeITPMark),
-			},
-			Protocol: getIPTablesProtocol(clusterIP),
-		},
-	}
 }
 
 func getGatewayForwardRules(cidrs []*net.IPNet) map[iptables.Protocol][]nodeipt.Rule {
@@ -371,21 +332,7 @@ func recreateIPTRules(table, chain string, keepIPTRules []nodeipt.Rule) error {
 
 // getGatewayIPTRules returns ClusterIP, NodePort, ExternalIP and LoadBalancer iptables
 // rules for service. This must be used in conjunction with getGatewayNFTRules.
-//
-// case3: if svcHasLocalHostNetEndPnt and svcTypeIsITPLocal, rule that redirects clusterIP traffic to host targetPort is added.
-//
-//	if !svcHasLocalHostNetEndPnt and svcTypeIsITPLocal, rule that marks clusterIP traffic to steer it to ovn-k8s-mp0 is added.
 func getGatewayIPTRules(service *corev1.Service, localEndpoints util.PortToLBEndpoints, svcHasLocalHostNetEndPnt bool) []nodeipt.Rule {
 	rules := make([]nodeipt.Rule, 0)
-	clusterIPs := util.GetClusterIPs(service)
-	svcTypeIsITPLocal := util.ServiceInternalTrafficPolicyLocal(service)
-	for _, svcPort := range service.Spec.Ports {
-		if svcTypeIsITPLocal {
-			// case3 (see function decription for details)
-			for _, clusterIP := range clusterIPs {
-				rules = append(rules, getITPLocalIPTRules(svcPort, clusterIP, svcHasLocalHostNetEndPnt)...)
-			}
-		}
-	}
 	return rules
 }

--- a/go-controller/pkg/node/gateway_iptables.go
+++ b/go-controller/pkg/node/gateway_iptables.go
@@ -111,40 +111,6 @@ func getGatewayInitRules(chain string, proto iptables.Protocol) []nodeipt.Rule {
 	return iptRules
 }
 
-// getNodePortIPTRules returns the IPTable DNAT rules for a service of type nodePort
-// `svcPort` corresponds to port details for this service as specified in the service object
-// `targetIP` is clusterIP towards which the DNAT of nodePort service is to be added
-// `targetPort` is the port towards which the DNAT of the nodePort service is to be added
-//
-//	case1: if svcHasLocalHostNetEndPnt=false + isETPLocal=true targetIP=config.masqueradeIP["HostETPLocalMasqueradeIP"] and targetPort=svcPort.NodePort
-//	case2: default: targetIP=clusterIP and targetPort=svcPort.Port
-//
-// `svcHasLocalHostNetEndPnt` is true if this service has at least one host-networked endpoint that is local to this node
-// `isETPLocal` is true if the svc.Spec.ExternalTrafficPolicy=Local
-func getNodePortIPTRules(svcPort corev1.ServicePort, targetIP string, targetPort int32, svcHasLocalHostNetEndPnt, isETPLocal bool) []nodeipt.Rule {
-	chainName := iptableNodePortChain
-	if !svcHasLocalHostNetEndPnt && isETPLocal {
-		// DNAT it to the masqueradeIP:nodePort instead of clusterIP:targetPort
-		targetIP = getMasqueradeVIP(targetIP)
-		chainName = iptableETPChain
-	}
-	return []nodeipt.Rule{
-		{
-			Table: "nat",
-			Chain: chainName,
-			Args: []string{
-				"-p", string(svcPort.Protocol),
-				"-m", "addrtype",
-				"--dst-type", "LOCAL",
-				"--dport", fmt.Sprintf("%d", svcPort.NodePort),
-				"-j", "DNAT",
-				"--to-destination", util.JoinHostPortInt32(targetIP, targetPort),
-			},
-			Protocol: getIPTablesProtocol(targetIP),
-		},
-	}
-}
-
 // getITPLocalIPTRules returns the IPTable REDIRECT or MARK rules for the provided service
 // `svcPort` corresponds to port details for this service as specified in the service object
 // `clusterIP` is clusterIP is the VIP of the service to match on
@@ -504,31 +470,6 @@ func getGatewayIPTRules(service *corev1.Service, localEndpoints util.PortToLBEnd
 	svcTypeIsETPLocal := util.ServiceExternalTrafficPolicyLocal(service)
 	svcTypeIsITPLocal := util.ServiceInternalTrafficPolicyLocal(service)
 	for _, svcPort := range service.Spec.Ports {
-		if util.ServiceTypeHasNodePort(service) {
-			err := util.ValidatePort(svcPort.Protocol, svcPort.NodePort)
-			if err != nil {
-				klog.Errorf("Skipping service: %s, invalid service NodePort: %v", svcPort.Name, err)
-				continue
-			}
-			err = util.ValidatePort(svcPort.Protocol, svcPort.Port)
-			if err != nil {
-				klog.Errorf("Skipping service: %s, invalid service port %v", svcPort.Name, err)
-				continue
-			}
-			for _, clusterIP := range clusterIPs {
-				if svcTypeIsETPLocal && !svcHasLocalHostNetEndPnt {
-					// case1 (see function description for details)
-					// A DNAT rule to masqueradeIP is added that takes priority over DNAT to clusterIP.
-					if config.Gateway.Mode == config.GatewayModeLocal {
-						rules = append(rules, getNodePortIPTRules(svcPort, clusterIP, svcPort.NodePort, svcHasLocalHostNetEndPnt, svcTypeIsETPLocal)...)
-					}
-					// Note: getGatewayNFTRules will add rules to ensure that sourceIP is preserved
-				}
-				// case2 (see function description for details)
-				rules = append(rules, getNodePortIPTRules(svcPort, clusterIP, svcPort.Port, svcHasLocalHostNetEndPnt, false)...)
-			}
-		}
-
 		externalIPs := util.GetExternalAndLBIPs(service)
 
 		for _, externalIP := range externalIPs {

--- a/go-controller/pkg/node/gateway_iptables.go
+++ b/go-controller/pkg/node/gateway_iptables.go
@@ -12,23 +12,20 @@ import (
 
 	"github.com/coreos/go-iptables/iptables"
 
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/klog/v2"
 	utilnet "k8s.io/utils/net"
 
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
 	nodeipt "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/iptables"
 	nodeutil "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/util"
-	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
-	utilerrors "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util/errors"
 )
 
 const (
-	iptableNodePortChain   = "OVN-KUBE-NODEPORT"   // called from nat-PREROUTING and nat-OUTPUT
-	iptableExternalIPChain = "OVN-KUBE-EXTERNALIP" // called from nat-PREROUTING and nat-OUTPUT
-	iptableETPChain        = "OVN-KUBE-ETP"        // called from nat-PREROUTING only
-	iptableITPChain        = "OVN-KUBE-ITP"        // called from mangle-OUTPUT and nat-OUTPUT
+	// Legacy iptables service chains; only cleaned up; never used
+	iptableNodePortChain   = "OVN-KUBE-NODEPORT"
+	iptableExternalIPChain = "OVN-KUBE-EXTERNALIP"
+	iptableETPChain        = "OVN-KUBE-ETP"
+	iptableITPChain        = "OVN-KUBE-ITP"
 )
 
 func clusterIPTablesProtocols() []iptables.Protocol {
@@ -50,26 +47,10 @@ func getIPTablesProtocol(ip string) iptables.Protocol {
 	return iptables.ProtocolIPv4
 }
 
-// getMasqueradeVIP returns the .3 masquerade VIP based on the protocol (v4/v6) of provided IP string
-func getMasqueradeVIP(ip string) string {
-	if utilnet.IsIPv6String(ip) {
-		return config.Gateway.MasqueradeIPs.V6HostETPLocalMasqueradeIP.String()
-	}
-	return config.Gateway.MasqueradeIPs.V4HostETPLocalMasqueradeIP.String()
-}
-
 // insertIptRules adds the provided rules in an insert fashion
 // i.e each rule gets added at the first position in the chain
 func insertIptRules(rules []nodeipt.Rule) error {
 	return nodeipt.AddRules(rules, false)
-}
-
-// restoreIptRulesFiltered restores the provided rules in an insert fashion with a filter for table/chain
-// i.e each rule gets added at the first position in the chain
-// filter is defined as a map of table/chains. Only rules matching this filter will be restored.
-// If no rules match the filter, the chain will still be restored as empty as specified in the filter.
-func restoreIptRulesFiltered(rules []nodeipt.Rule, filter map[string]map[string]struct{}) error {
-	return nodeipt.RestoreRulesFiltered(rules, filter)
 }
 
 // deleteIptRules removes provided rules from the chain
@@ -109,162 +90,6 @@ func getGatewayInitRules(chain string, proto iptables.Protocol) []nodeipt.Rule {
 		)
 	}
 	return iptRules
-}
-
-// getNodePortIPTRules returns the IPTable DNAT rules for a service of type nodePort
-// `svcPort` corresponds to port details for this service as specified in the service object
-// `targetIP` is clusterIP towards which the DNAT of nodePort service is to be added
-// `targetPort` is the port towards which the DNAT of the nodePort service is to be added
-//
-//	case1: if svcHasLocalHostNetEndPnt=false + isETPLocal=true targetIP=config.masqueradeIP["HostETPLocalMasqueradeIP"] and targetPort=svcPort.NodePort
-//	case2: default: targetIP=clusterIP and targetPort=svcPort.Port
-//
-// `svcHasLocalHostNetEndPnt` is true if this service has at least one host-networked endpoint that is local to this node
-// `isETPLocal` is true if the svc.Spec.ExternalTrafficPolicy=Local
-func getNodePortIPTRules(svcPort corev1.ServicePort, targetIP string, targetPort int32, svcHasLocalHostNetEndPnt, isETPLocal bool) []nodeipt.Rule {
-	chainName := iptableNodePortChain
-	if !svcHasLocalHostNetEndPnt && isETPLocal {
-		// DNAT it to the masqueradeIP:nodePort instead of clusterIP:targetPort
-		targetIP = getMasqueradeVIP(targetIP)
-		chainName = iptableETPChain
-	}
-	return []nodeipt.Rule{
-		{
-			Table: "nat",
-			Chain: chainName,
-			Args: []string{
-				"-p", string(svcPort.Protocol),
-				"-m", "addrtype",
-				"--dst-type", "LOCAL",
-				"--dport", fmt.Sprintf("%d", svcPort.NodePort),
-				"-j", "DNAT",
-				"--to-destination", util.JoinHostPortInt32(targetIP, targetPort),
-			},
-			Protocol: getIPTablesProtocol(targetIP),
-		},
-	}
-}
-
-// getITPLocalIPTRules returns the IPTable REDIRECT or MARK rules for the provided service
-// `svcPort` corresponds to port details for this service as specified in the service object
-// `clusterIP` is clusterIP is the VIP of the service to match on
-// `svcHasLocalHostNetEndPnt` is true if this service has at least one host-networked endpoint that is local to this node
-// NOTE: Currently invoked only for Internal Traffic Policy
-func getITPLocalIPTRules(svcPort corev1.ServicePort, clusterIP string, svcHasLocalHostNetEndPnt bool) []nodeipt.Rule {
-	if svcHasLocalHostNetEndPnt {
-		return []nodeipt.Rule{
-			{
-				Table: "nat",
-				Chain: iptableITPChain,
-				Args: []string{
-					"-p", string(svcPort.Protocol),
-					"-d", clusterIP,
-					"--dport", fmt.Sprintf("%v", svcPort.Port),
-					"-j", "REDIRECT",
-					"--to-port", fmt.Sprintf("%v", int32(svcPort.TargetPort.IntValue())),
-				},
-				Protocol: getIPTablesProtocol(clusterIP),
-			},
-		}
-	}
-	return []nodeipt.Rule{
-		{
-			Table: "mangle",
-			Chain: iptableITPChain,
-			Args: []string{
-				"-p", string(svcPort.Protocol),
-				"-d", string(clusterIP),
-				"--dport", fmt.Sprintf("%d", svcPort.Port),
-				"-j", "MARK",
-				"--set-xmark", string(types.OVNKubeITPMark),
-			},
-			Protocol: getIPTablesProtocol(clusterIP),
-		},
-	}
-}
-
-func computeProbability(n, i int) string {
-	return fmt.Sprintf("%0.10f", 1.0/float64(n-i+1))
-}
-
-// generateIPTRulesForLoadBalancersWithoutNodePorts generates iptables DNAT rules for load balancer services
-// without NodePort allocation. It performs statistical load balancing between endpoints via iptables.
-func generateIPTRulesForLoadBalancersWithoutNodePorts(svcPort corev1.ServicePort, externalIP string, localEndpoints util.PortToLBEndpoints) []nodeipt.Rule {
-	if len(localEndpoints) == 0 {
-		// either its smart nic mode; etp&itp not implemented, OR
-		// fetching endpointSlices error-ed out prior to reaching here so nothing to do
-		return []nodeipt.Rule{}
-	}
-
-	// Get the endpoints for the port key.
-	// svcPortKey is of format e.g. "TCP/my-port-name" or "TCP/" if name is empty
-	// (is the case when only a single ServicePort is defined on this service).
-	svcPortKey := util.GetServicePortKey(svcPort.Protocol, svcPort.Name)
-	lbEndpoints := localEndpoints[svcPortKey]
-
-	// Get IPv4 or IPv6 IPs, depending on the type of the service's external IP.
-	destinations := lbEndpoints.GetV4Destinations()
-	if utilnet.IsIPv6String(externalIP) {
-		destinations = lbEndpoints.GetV6Destinations()
-	}
-
-	numLocalEndpoints := len(destinations)
-	iptRules := make([]nodeipt.Rule, 0, numLocalEndpoints)
-	for i, destination := range destinations {
-		iptRules = append([]nodeipt.Rule{
-			{
-				Table: "nat",
-				Chain: iptableETPChain,
-				Args: []string{
-					"-p", string(svcPort.Protocol),
-					"-d", externalIP,
-					"--dport", fmt.Sprintf("%v", svcPort.Port),
-					"-j", "DNAT",
-					"--to-destination", util.JoinHostPortInt32(destination.IP, destination.Port),
-					"-m", "statistic",
-					"--mode", "random",
-					"--probability", computeProbability(numLocalEndpoints, i+1),
-				},
-				Protocol: getIPTablesProtocol(externalIP),
-			},
-		}, iptRules...)
-	}
-	return iptRules
-}
-
-// getExternalIPTRules returns the IPTable DNAT rules for a service of type LB or ExternalIP
-// `svcPort` corresponds to port details for this service as specified in the service object
-// `externalIP` can either be the externalIP or LB.status.ingressIP
-// `dstIP` corresponds to the IP to which the provided externalIP needs to be DNAT-ed to
-//
-//	case1: if svcHasLocalHostNetEndPnt=false + isETPLocal=true, dstIP=config.MasqueradeIP["HostETPLocalMasqueradeIP"]
-//	case2: default: dstIP=clusterIP
-//
-// `svcHasLocalHostNetEndPnt` is true if this service has at least one host-networked endpoint that is local to this node
-// `isETPLocal` is true if the svc.Spec.ExternalTrafficPolicy=Local
-func getExternalIPTRules(svcPort corev1.ServicePort, externalIP, dstIP string, svcHasLocalHostNetEndPnt, isETPLocal bool) []nodeipt.Rule {
-	targetPort := svcPort.Port
-	chainName := iptableExternalIPChain
-	if !svcHasLocalHostNetEndPnt && isETPLocal {
-		// DNAT it to the masqueradeIP:nodePort instead of clusterIP:targetPort
-		dstIP = getMasqueradeVIP(externalIP)
-		targetPort = svcPort.NodePort
-		chainName = iptableETPChain
-	}
-	return []nodeipt.Rule{
-		{
-			Table: "nat",
-			Chain: chainName,
-			Args: []string{
-				"-p", string(svcPort.Protocol),
-				"-d", externalIP,
-				"--dport", fmt.Sprintf("%v", svcPort.Port),
-				"-j", "DNAT",
-				"--to-destination", util.JoinHostPortInt32(dstIP, targetPort),
-			},
-			Protocol: getIPTablesProtocol(externalIP),
-		},
-	}
 }
 
 func getGatewayForwardRules(cidrs []*net.IPNet) map[iptables.Protocol][]nodeipt.Rule {
@@ -419,145 +244,25 @@ func initLocalGatewayIPTFilterRules(ifname string) error {
 	return nil
 }
 
-func addChaintoTable(ipt util.IPTablesHelper, tableName, chain string) {
-	if err := ipt.NewChain(tableName, chain); err != nil {
-		klog.V(5).Infof("Chain: \"%s\" in table: \"%s\" already exists, skipping creation: %v", chain, tableName, err)
-	}
-}
-
-func handleGatewayIPTables(iptCallback func(rules []nodeipt.Rule) error, genGatewayChainRules func(chain string, proto iptables.Protocol) []nodeipt.Rule) error {
+func cleanupGatewayIPTables() {
 	rules := make([]nodeipt.Rule, 0)
-	// (NOTE: Order is important, add jump to iptableETPChain before jump to NP/EIP chains)
-	for _, chain := range []string{iptableITPChain, iptableNodePortChain, iptableExternalIPChain, iptableETPChain} {
-		for _, proto := range clusterIPTablesProtocols() {
-			ipt, err := util.GetIPTablesHelper(proto)
-			if err != nil {
-				return err
-			}
-			addChaintoTable(ipt, "nat", chain)
-			if chain == iptableITPChain {
-				addChaintoTable(ipt, "mangle", chain)
-			}
-			rules = append(rules, genGatewayChainRules(chain, proto)...)
+	// We clean up both IPv4 and IPv6, regardless of what is currently in use
+	for _, proto := range []iptables.Protocol{iptables.ProtocolIPv4, iptables.ProtocolIPv6} {
+		ipt, err := util.GetIPTablesHelper(proto)
+		if err != nil {
+			continue
 		}
-	}
-	if err := iptCallback(rules); err != nil {
-		return fmt.Errorf("failed to handle iptables rules %v: %v", rules, err)
-	}
-	return nil
-}
-
-func initSharedGatewayIPTables() error {
-	if err := handleGatewayIPTables(insertIptRules, getGatewayInitRules); err != nil {
-		return err
-	}
-	return nil
-}
-
-func initLocalGatewayIPTables() error {
-	if err := handleGatewayIPTables(insertIptRules, getGatewayInitRules); err != nil {
-		return err
-	}
-	return nil
-}
-
-func cleanupSharedGatewayIPTChains() {
-	for _, chain := range []string{iptableNodePortChain, iptableExternalIPChain} {
-		// We clean up both IPv4 and IPv6, regardless of what is currently in use
-		for _, proto := range []iptables.Protocol{iptables.ProtocolIPv4, iptables.ProtocolIPv6} {
-			ipt, err := util.GetIPTablesHelper(proto)
-			if err != nil {
-				return
-			}
+		for _, chain := range []string{iptableITPChain, iptableNodePortChain, iptableExternalIPChain, iptableETPChain} {
+			rules = append(rules, getGatewayInitRules(chain, proto)...)
+		}
+		_ = nodeipt.DelRules(rules)
+		for _, chain := range []string{iptableITPChain, iptableNodePortChain, iptableExternalIPChain, iptableETPChain} {
 			_ = ipt.ClearChain("nat", chain)
 			_ = ipt.DeleteChain("nat", chain)
-		}
-	}
-}
-
-func recreateIPTRules(table, chain string, keepIPTRules []nodeipt.Rule) error {
-	var errors []error
-	var err error
-	klog.Infof("Recreating iptables rules for table: %s, chain: %s", table, chain)
-	// filter is a map of the table/chain to program rules for, as all rules are included in keepIPTRules
-	filter := map[string]map[string]struct{}{table: {chain: {}}}
-	if err = restoreIptRulesFiltered(keepIPTRules, filter); err != nil {
-		errors = append(errors, err)
-	}
-	return utilerrors.Join(errors...)
-}
-
-// getGatewayIPTRules returns ClusterIP, NodePort, ExternalIP and LoadBalancer iptables
-// rules for service. This must be used in conjunction with getGatewayNFTRules.
-//
-// case1: If !svcHasLocalHostNetEndPnt and svcTypeIsETPLocal rules that redirect traffic
-// to ovn-k8s-mp0 preserving sourceIP are added.
-//
-// case2: (default) A DNAT rule towards clusterIP svc is added ALWAYS.
-//
-// case3: if svcHasLocalHostNetEndPnt and svcTypeIsITPLocal, rule that redirects clusterIP traffic to host targetPort is added.
-//
-//	if !svcHasLocalHostNetEndPnt and svcTypeIsITPLocal, rule that marks clusterIP traffic to steer it to ovn-k8s-mp0 is added.
-func getGatewayIPTRules(service *corev1.Service, localEndpoints util.PortToLBEndpoints, svcHasLocalHostNetEndPnt bool) []nodeipt.Rule {
-	rules := make([]nodeipt.Rule, 0)
-	clusterIPs := util.GetClusterIPs(service)
-	svcTypeIsETPLocal := util.ServiceExternalTrafficPolicyLocal(service)
-	svcTypeIsITPLocal := util.ServiceInternalTrafficPolicyLocal(service)
-	for _, svcPort := range service.Spec.Ports {
-		if util.ServiceTypeHasNodePort(service) {
-			err := util.ValidatePort(svcPort.Protocol, svcPort.NodePort)
-			if err != nil {
-				klog.Errorf("Skipping service: %s, invalid service NodePort: %v", svcPort.Name, err)
-				continue
-			}
-			err = util.ValidatePort(svcPort.Protocol, svcPort.Port)
-			if err != nil {
-				klog.Errorf("Skipping service: %s, invalid service port %v", svcPort.Name, err)
-				continue
-			}
-			for _, clusterIP := range clusterIPs {
-				if svcTypeIsETPLocal && !svcHasLocalHostNetEndPnt {
-					// case1 (see function description for details)
-					// A DNAT rule to masqueradeIP is added that takes priority over DNAT to clusterIP.
-					if config.Gateway.Mode == config.GatewayModeLocal {
-						rules = append(rules, getNodePortIPTRules(svcPort, clusterIP, svcPort.NodePort, svcHasLocalHostNetEndPnt, svcTypeIsETPLocal)...)
-					}
-					// Note: getGatewayNFTRules will add rules to ensure that sourceIP is preserved
-				}
-				// case2 (see function description for details)
-				rules = append(rules, getNodePortIPTRules(svcPort, clusterIP, svcPort.Port, svcHasLocalHostNetEndPnt, false)...)
-			}
-		}
-
-		externalIPs := util.GetExternalAndLBIPs(service)
-
-		for _, externalIP := range externalIPs {
-			err := util.ValidatePort(svcPort.Protocol, svcPort.Port)
-			if err != nil {
-				klog.Errorf("Skipping service: %s, invalid service port %v", svcPort.Name, err)
-				continue
-			}
-			if clusterIP, err := util.MatchIPStringFamily(utilnet.IsIPv6String(externalIP), clusterIPs); err == nil {
-				if svcTypeIsETPLocal && !svcHasLocalHostNetEndPnt {
-					// case1 (see function description for details)
-					// DNAT traffic to masqueradeIP:nodePort instead of clusterIP:Port. We are leveraging the existing rules for NODEPORT
-					// service so no need to add a rule to skip SNAT since the corresponding nodePort svc would have one.
-					if !util.ServiceTypeHasNodePort(service) {
-						rules = append(rules, generateIPTRulesForLoadBalancersWithoutNodePorts(svcPort, externalIP, localEndpoints)...)
-					} else {
-						rules = append(rules, getExternalIPTRules(svcPort, externalIP, "", svcHasLocalHostNetEndPnt, svcTypeIsETPLocal)...)
-					}
-				}
-				// case2 (see function description for details)
-				rules = append(rules, getExternalIPTRules(svcPort, externalIP, clusterIP, svcHasLocalHostNetEndPnt, false)...)
-			}
-		}
-		if svcTypeIsITPLocal {
-			// case3 (see function decription for details)
-			for _, clusterIP := range clusterIPs {
-				rules = append(rules, getITPLocalIPTRules(svcPort, clusterIP, svcHasLocalHostNetEndPnt)...)
+			if chain == iptableITPChain {
+				_ = ipt.ClearChain("mangle", chain)
+				_ = ipt.DeleteChain("mangle", chain)
 			}
 		}
 	}
-	return rules
 }

--- a/go-controller/pkg/node/gateway_iptables.go
+++ b/go-controller/pkg/node/gateway_iptables.go
@@ -149,55 +149,6 @@ func getITPLocalIPTRules(svcPort corev1.ServicePort, clusterIP string, svcHasLoc
 	}
 }
 
-func computeProbability(n, i int) string {
-	return fmt.Sprintf("%0.10f", 1.0/float64(n-i+1))
-}
-
-// generateIPTRulesForLoadBalancersWithoutNodePorts generates iptables DNAT rules for load balancer services
-// without NodePort allocation. It performs statistical load balancing between endpoints via iptables.
-func generateIPTRulesForLoadBalancersWithoutNodePorts(svcPort corev1.ServicePort, externalIP string, localEndpoints util.PortToLBEndpoints) []nodeipt.Rule {
-	if len(localEndpoints) == 0 {
-		// either its smart nic mode; etp&itp not implemented, OR
-		// fetching endpointSlices error-ed out prior to reaching here so nothing to do
-		return []nodeipt.Rule{}
-	}
-
-	// Get the endpoints for the port key.
-	// svcPortKey is of format e.g. "TCP/my-port-name" or "TCP/" if name is empty
-	// (is the case when only a single ServicePort is defined on this service).
-	svcPortKey := util.GetServicePortKey(svcPort.Protocol, svcPort.Name)
-	lbEndpoints := localEndpoints[svcPortKey]
-
-	// Get IPv4 or IPv6 IPs, depending on the type of the service's external IP.
-	destinations := lbEndpoints.GetV4Destinations()
-	if utilnet.IsIPv6String(externalIP) {
-		destinations = lbEndpoints.GetV6Destinations()
-	}
-
-	numLocalEndpoints := len(destinations)
-	iptRules := make([]nodeipt.Rule, 0, numLocalEndpoints)
-	for i, destination := range destinations {
-		iptRules = append([]nodeipt.Rule{
-			{
-				Table: "nat",
-				Chain: iptableETPChain,
-				Args: []string{
-					"-p", string(svcPort.Protocol),
-					"-d", externalIP,
-					"--dport", fmt.Sprintf("%v", svcPort.Port),
-					"-j", "DNAT",
-					"--to-destination", util.JoinHostPortInt32(destination.IP, destination.Port),
-					"-m", "statistic",
-					"--mode", "random",
-					"--probability", computeProbability(numLocalEndpoints, i+1),
-				},
-				Protocol: getIPTablesProtocol(externalIP),
-			},
-		}, iptRules...)
-	}
-	return iptRules
-}
-
 func getGatewayForwardRules(cidrs []*net.IPNet) map[iptables.Protocol][]nodeipt.Rule {
 	returnRules := map[iptables.Protocol][]nodeipt.Rule{}
 
@@ -421,37 +372,14 @@ func recreateIPTRules(table, chain string, keepIPTRules []nodeipt.Rule) error {
 // getGatewayIPTRules returns ClusterIP, NodePort, ExternalIP and LoadBalancer iptables
 // rules for service. This must be used in conjunction with getGatewayNFTRules.
 //
-// case1: If !svcHasLocalHostNetEndPnt and svcTypeIsETPLocal rules that redirect traffic
-// to ovn-k8s-mp0 preserving sourceIP are added.
-//
 // case3: if svcHasLocalHostNetEndPnt and svcTypeIsITPLocal, rule that redirects clusterIP traffic to host targetPort is added.
 //
 //	if !svcHasLocalHostNetEndPnt and svcTypeIsITPLocal, rule that marks clusterIP traffic to steer it to ovn-k8s-mp0 is added.
 func getGatewayIPTRules(service *corev1.Service, localEndpoints util.PortToLBEndpoints, svcHasLocalHostNetEndPnt bool) []nodeipt.Rule {
 	rules := make([]nodeipt.Rule, 0)
 	clusterIPs := util.GetClusterIPs(service)
-	svcTypeIsETPLocal := util.ServiceExternalTrafficPolicyLocal(service)
 	svcTypeIsITPLocal := util.ServiceInternalTrafficPolicyLocal(service)
 	for _, svcPort := range service.Spec.Ports {
-		externalIPs := util.GetExternalAndLBIPs(service)
-
-		for _, externalIP := range externalIPs {
-			err := util.ValidatePort(svcPort.Protocol, svcPort.Port)
-			if err != nil {
-				klog.Errorf("Skipping service: %s, invalid service port %v", svcPort.Name, err)
-				continue
-			}
-			if _, err := util.MatchIPStringFamily(utilnet.IsIPv6String(externalIP), clusterIPs); err == nil {
-				if svcTypeIsETPLocal && !svcHasLocalHostNetEndPnt {
-					// case1 (see function description for details)
-					// DNAT traffic to masqueradeIP:nodePort instead of clusterIP:Port. We are leveraging the existing rules for NODEPORT
-					// service so no need to add a rule to skip SNAT since the corresponding nodePort svc would have one.
-					if !util.ServiceTypeHasNodePort(service) {
-						rules = append(rules, generateIPTRulesForLoadBalancersWithoutNodePorts(svcPort, externalIP, localEndpoints)...)
-					}
-				}
-			}
-		}
 		if svcTypeIsITPLocal {
 			// case3 (see function decription for details)
 			for _, clusterIP := range clusterIPs {

--- a/go-controller/pkg/node/gateway_iptables.go
+++ b/go-controller/pkg/node/gateway_iptables.go
@@ -198,41 +198,6 @@ func generateIPTRulesForLoadBalancersWithoutNodePorts(svcPort corev1.ServicePort
 	return iptRules
 }
 
-// getExternalIPTRules returns the IPTable DNAT rules for a service of type LB or ExternalIP
-// `svcPort` corresponds to port details for this service as specified in the service object
-// `externalIP` can either be the externalIP or LB.status.ingressIP
-// `dstIP` corresponds to the IP to which the provided externalIP needs to be DNAT-ed to
-//
-//	case1: if svcHasLocalHostNetEndPnt=false + isETPLocal=true, dstIP=config.MasqueradeIP["HostETPLocalMasqueradeIP"]
-//	case2: default: dstIP=clusterIP
-//
-// `svcHasLocalHostNetEndPnt` is true if this service has at least one host-networked endpoint that is local to this node
-// `isETPLocal` is true if the svc.Spec.ExternalTrafficPolicy=Local
-func getExternalIPTRules(svcPort corev1.ServicePort, externalIP, dstIP string, svcHasLocalHostNetEndPnt, isETPLocal bool) []nodeipt.Rule {
-	targetPort := svcPort.Port
-	chainName := iptableExternalIPChain
-	if !svcHasLocalHostNetEndPnt && isETPLocal {
-		// DNAT it to the masqueradeIP:nodePort instead of clusterIP:targetPort
-		dstIP = getMasqueradeVIP(externalIP)
-		targetPort = svcPort.NodePort
-		chainName = iptableETPChain
-	}
-	return []nodeipt.Rule{
-		{
-			Table: "nat",
-			Chain: chainName,
-			Args: []string{
-				"-p", string(svcPort.Protocol),
-				"-d", externalIP,
-				"--dport", fmt.Sprintf("%v", svcPort.Port),
-				"-j", "DNAT",
-				"--to-destination", util.JoinHostPortInt32(dstIP, targetPort),
-			},
-			Protocol: getIPTablesProtocol(externalIP),
-		},
-	}
-}
-
 func getGatewayForwardRules(cidrs []*net.IPNet) map[iptables.Protocol][]nodeipt.Rule {
 	returnRules := map[iptables.Protocol][]nodeipt.Rule{}
 
@@ -459,8 +424,6 @@ func recreateIPTRules(table, chain string, keepIPTRules []nodeipt.Rule) error {
 // case1: If !svcHasLocalHostNetEndPnt and svcTypeIsETPLocal rules that redirect traffic
 // to ovn-k8s-mp0 preserving sourceIP are added.
 //
-// case2: (default) A DNAT rule towards clusterIP svc is added ALWAYS.
-//
 // case3: if svcHasLocalHostNetEndPnt and svcTypeIsITPLocal, rule that redirects clusterIP traffic to host targetPort is added.
 //
 //	if !svcHasLocalHostNetEndPnt and svcTypeIsITPLocal, rule that marks clusterIP traffic to steer it to ovn-k8s-mp0 is added.
@@ -478,19 +441,15 @@ func getGatewayIPTRules(service *corev1.Service, localEndpoints util.PortToLBEnd
 				klog.Errorf("Skipping service: %s, invalid service port %v", svcPort.Name, err)
 				continue
 			}
-			if clusterIP, err := util.MatchIPStringFamily(utilnet.IsIPv6String(externalIP), clusterIPs); err == nil {
+			if _, err := util.MatchIPStringFamily(utilnet.IsIPv6String(externalIP), clusterIPs); err == nil {
 				if svcTypeIsETPLocal && !svcHasLocalHostNetEndPnt {
 					// case1 (see function description for details)
 					// DNAT traffic to masqueradeIP:nodePort instead of clusterIP:Port. We are leveraging the existing rules for NODEPORT
 					// service so no need to add a rule to skip SNAT since the corresponding nodePort svc would have one.
 					if !util.ServiceTypeHasNodePort(service) {
 						rules = append(rules, generateIPTRulesForLoadBalancersWithoutNodePorts(svcPort, externalIP, localEndpoints)...)
-					} else {
-						rules = append(rules, getExternalIPTRules(svcPort, externalIP, "", svcHasLocalHostNetEndPnt, svcTypeIsETPLocal)...)
 					}
 				}
-				// case2 (see function description for details)
-				rules = append(rules, getExternalIPTRules(svcPort, externalIP, clusterIP, svcHasLocalHostNetEndPnt, false)...)
 			}
 		}
 		if svcTypeIsITPLocal {

--- a/go-controller/pkg/node/gateway_localnet.go
+++ b/go-controller/pkg/node/gateway_localnet.go
@@ -28,7 +28,7 @@ func initLocalGateway(hostSubnets []*net.IPNet, mgmtPort managementport.Interfac
 		return nil
 	}
 
-	klog.Info("Adding iptables/nftables masquerading rules for new local gateway")
+	klog.Info("Adding iptables/nftables rules for new local gateway")
 
 	// Set up iptables filter rules to allow traffic to/from the management port.
 	ifName := mgmtPort.GetInterfaceName()

--- a/go-controller/pkg/node/gateway_localnet_linux_test.go
+++ b/go-controller/pkg/node/gateway_localnet_linux_test.go
@@ -947,13 +947,8 @@ var _ = Describe("Node Operations", func() {
 						},
 						"OVN-KUBE-NODEPORT":   []string{},
 						"OVN-KUBE-EXTERNALIP": []string{},
-						"OVN-KUBE-ETP": []string{
-							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%d -m statistic --mode random --probability 0.5000000000", service.Spec.Ports[0].Protocol, service.Status.LoadBalancer.Ingress[0].IP, service.Spec.Ports[0].Port, ep1.Addresses[0], int32(service.Spec.Ports[0].TargetPort.IntValue())),
-							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%d -m statistic --mode random --probability 1.0000000000", service.Spec.Ports[0].Protocol, service.Status.LoadBalancer.Ingress[0].IP, service.Spec.Ports[0].Port, ep2.Addresses[0], int32(service.Spec.Ports[0].TargetPort.IntValue())),
-							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%d -m statistic --mode random --probability 0.5000000000", service.Spec.Ports[0].Protocol, externalIP, service.Spec.Ports[0].Port, ep1.Addresses[0], int32(service.Spec.Ports[0].TargetPort.IntValue())),
-							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%d -m statistic --mode random --probability 1.0000000000", service.Spec.Ports[0].Protocol, externalIP, service.Spec.Ports[0].Port, ep2.Addresses[0], int32(service.Spec.Ports[0].TargetPort.IntValue())),
-						},
-						"OVN-KUBE-ITP": []string{},
+						"OVN-KUBE-ETP":        []string{},
+						"OVN-KUBE-ITP":        []string{},
 					},
 					"filter": {},
 					"mangle": {
@@ -971,6 +966,8 @@ var _ = Describe("Node Operations", func() {
 				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes mgmtport-no-snat-services-v4 { %s . tcp . %d }\n", ep2.Addresses[0], int32(service.Spec.Ports[0].TargetPort.IntValue()))
 				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes external-ips-v4 { %s . %s . %d : %s . %d }\n", externalIP, strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port)
 				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes external-ips-v4 { %s . %s . %d : %s . %d }\n", service.Status.LoadBalancer.Ingress[0].IP, strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port)
+				expectedNFT += fmt.Sprintf("add rule inet ovn-kubernetes services-etp-no-nodeport ip daddr %s meta l4proto %s th dport %d dnat ip addr . port to numgen random mod 2 map { 0 : %s . %d , 1 : %s . %d } comment \"namespace1/service1:http\"\n", externalIP, strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].Port, ep1.Addresses[0], service.Spec.Ports[0].TargetPort.IntValue(), ep2.Addresses[0], service.Spec.Ports[0].TargetPort.IntValue())
+				expectedNFT += fmt.Sprintf("add rule inet ovn-kubernetes services-etp-no-nodeport ip daddr %s meta l4proto %s th dport %d dnat ip addr . port to numgen random mod 2 map { 0 : %s . %d , 1 : %s . %d } comment \"namespace1/service1:http\"\n", service.Status.LoadBalancer.Ingress[0].IP, strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].Port, ep1.Addresses[0], service.Spec.Ports[0].TargetPort.IntValue(), ep2.Addresses[0], service.Spec.Ports[0].TargetPort.IntValue())
 				err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				Expect(err).NotTo(HaveOccurred())
 
@@ -1127,21 +1124,8 @@ var _ = Describe("Node Operations", func() {
 						},
 						"OVN-KUBE-NODEPORT":   []string{},
 						"OVN-KUBE-EXTERNALIP": []string{},
-						"OVN-KUBE-ETP": []string{
-							fmt.Sprintf("-p %s -d %s --dport %d -j DNAT --to-destination %s:%d -m statistic --mode random --probability 0.5000000000",
-								service.Spec.Ports[0].Protocol,
-								service.Status.LoadBalancer.Ingress[0].IP,
-								service.Spec.Ports[0].Port,
-								endpointSlice.Endpoints[0].Addresses[0],
-								*endpointSlice.Ports[0].Port),
-							fmt.Sprintf("-p %s -d %s --dport %d -j DNAT --to-destination %s:%d -m statistic --mode random --probability 1.0000000000",
-								service.Spec.Ports[0].Protocol,
-								service.Status.LoadBalancer.Ingress[0].IP,
-								service.Spec.Ports[0].Port,
-								endpointSlice.Endpoints[1].Addresses[0],
-								*endpointSlice.Ports[0].Port),
-						},
-						"OVN-KUBE-ITP": []string{},
+						"OVN-KUBE-ETP":        []string{},
+						"OVN-KUBE-ITP":        []string{},
 					},
 					"filter": {},
 					"mangle": {
@@ -1164,6 +1148,7 @@ var _ = Describe("Node Operations", func() {
 					endpointSlice.Endpoints[0].Addresses[0],
 					*endpointSlice.Ports[0].Port)
 				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes external-ips-v4 { %s . %s . %d : %s . %d }\n", service.Status.LoadBalancer.Ingress[0].IP, strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port)
+				expectedNFT += fmt.Sprintf("add rule inet ovn-kubernetes services-etp-no-nodeport ip daddr %s meta l4proto %s th dport %d dnat ip addr . port to numgen random mod 2 map { 0 : %s . %d , 1 : %s . %d } comment \"namespace1/service1:https-port\"\n", service.Status.LoadBalancer.Ingress[0].IP, strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].Port, ep1.Addresses[0], *endpointSlice.Ports[0].Port, ep2.Addresses[0], *endpointSlice.Ports[0].Port)
 				err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				Expect(err).NotTo(HaveOccurred())
 

--- a/go-controller/pkg/node/gateway_localnet_linux_test.go
+++ b/go-controller/pkg/node/gateway_localnet_linux_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"strings"
 	"sync"
 	"sync/atomic"
 
@@ -32,7 +33,6 @@ import (
 	nodenft "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/nftables"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/retry"
 	ovntest "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing"
-	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util/mocks"
 
@@ -69,7 +69,7 @@ func initFakeNodePortWatcher() *nodePortWatcher {
 }
 
 func startNodePortWatcher(n *nodePortWatcher, fakeClient *util.OVNNodeClientset) error {
-	if err := initLocalGatewayIPTables(); err != nil {
+	if err := initGatewayNFTables(); err != nil {
 		return err
 	}
 
@@ -113,7 +113,7 @@ func startNodePortWatcher(n *nodePortWatcher, fakeClient *util.OVNNodeClientset)
 }
 
 func startNodePortWatcherWithRetry(n *nodePortWatcher, fakeClient *util.OVNNodeClientset, stopChan chan struct{}, wg *sync.WaitGroup) (*retry.RetryFramework, error) {
-	if err := initLocalGatewayIPTables(); err != nil {
+	if err := initGatewayNFTables(); err != nil {
 		return nil, err
 	}
 
@@ -245,12 +245,11 @@ one and started again to exercise the tests.
 */
 var _ = Describe("Node Operations", func() {
 	var (
-		app          *cli.App
-		fExec        *ovntest.FakeExec
-		iptV4, iptV6 util.IPTablesHelper
-		nft          *knftables.Fake
-		fNPW         *nodePortWatcher
-		netlinkMock  *mocks.NetLinkOps
+		app         *cli.App
+		fExec       *ovntest.FakeExec
+		nft         *knftables.Fake
+		fNPW        *nodePortWatcher
+		netlinkMock *mocks.NetLinkOps
 
 		nInitialFakeCommands int
 	)
@@ -271,7 +270,6 @@ var _ = Describe("Node Operations", func() {
 		Expect(err).NotTo(HaveOccurred())
 		nInitialFakeCommands = 1
 
-		iptV4, iptV6 = util.SetFakeIPTablesHelpers()
 		nft = nodenft.SetFakeNFTablesHelper()
 		err = nft.ParseDump(nftablesRulesBase)
 		Expect(err).NotTo(HaveOccurred())
@@ -284,8 +282,12 @@ var _ = Describe("Node Operations", func() {
 	})
 
 	Context("on startup", func() {
-		It("removes stale iptables rules while keeping remaining intact", func() {
+		It("removes stale nftables rules while keeping remaining intact", func() {
 			app.Action = func(*cli.Context) error {
+				// Create tables/chains/sets/etc
+				err := initGatewayNFTables()
+				Expect(err).NotTo(HaveOccurred())
+
 				// Depending on the order of informer event processing the initial
 				// Service might be "added" once or twice.  Take that into account.
 				minNFakeCommands := nInitialFakeCommands + 1
@@ -308,9 +310,9 @@ var _ = Describe("Node Operations", func() {
 					false, false,
 				)
 
-				fakeRules := getExternalIPTRules(service.Spec.Ports[0], externalIP, service.Spec.ClusterIP, false, false)
-				Expect(insertIptRules(fakeRules)).To(Succeed())
-				fakeRules = getExternalIPTRules(
+				fakeRules := getExternalIPNFTRules(service.Spec.Ports[0], externalIP, service.Spec.ClusterIP, false, false)
+				Expect(nodenft.AddObjects(fakeRules)).To(Succeed())
+				fakeRules = getExternalIPNFTRules(
 					corev1.ServicePort{
 						Port:     27000,
 						Protocol: corev1.ProtocolUDP,
@@ -321,21 +323,12 @@ var _ = Describe("Node Operations", func() {
 					false,
 					false,
 				)
-				Expect(insertIptRules(fakeRules)).To(Succeed())
+				Expect(nodenft.AddObjects(fakeRules)).To(Succeed())
 
-				expectedTables := map[string]util.FakeTable{
-					"nat": {
-						"OVN-KUBE-EXTERNALIP": []string{
-							"-p UDP -d 10.10.10.10 --dport 27000 -j DNAT --to-destination 172.32.0.12:27000",
-							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, externalIP, service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
-						},
-					},
-					"filter": {},
-					"mangle": {},
-				}
-
-				f4 := iptV4.(*util.FakeIPTables)
-				err := f4.MatchState(expectedTables, nil)
+				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
+				expectedNFT += "add element inet ovn-kubernetes external-ips-v4 { 1.1.1.1 . tcp . 8032 : 10.129.0.2 . 8032 }\n"
+				expectedNFT += "add element inet ovn-kubernetes external-ips-v4 { 10.10.10.10 . udp . 27000 : 172.32.0.12 . 27000 }\n"
+				err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				Expect(err).NotTo(HaveOccurred())
 
 				stopChan := make(chan struct{})
@@ -354,39 +347,8 @@ var _ = Describe("Node Operations", func() {
 					return fExec.CalledMatchesExpectedAtLeastN(minNFakeCommands)
 				}, "2s").Should(BeTrue(), fExec.ErrorDesc)
 
-				expectedTables = map[string]util.FakeTable{
-					"nat": {
-						"PREROUTING": []string{
-							"-j OVN-KUBE-ETP",
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-						},
-						"OUTPUT": []string{
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-NODEPORT": []string{},
-						"OVN-KUBE-EXTERNALIP": []string{
-							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, externalIP, service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
-						},
-						"OVN-KUBE-ETP": []string{},
-						"OVN-KUBE-ITP": []string{},
-					},
-					"filter": {},
-					"mangle": {
-						"OUTPUT": []string{
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-ITP": []string{},
-					},
-				}
-
-				f4 = iptV4.(*util.FakeIPTables)
-				err = f4.MatchState(expectedTables, nil)
-				Expect(err).NotTo(HaveOccurred())
-
-				expectedNFT := nftablesRulesBase
+				expectedNFT = nftablesRulesBase + nftablesRulesGatewayServices
+				expectedNFT += "add element inet ovn-kubernetes external-ips-v4 { 1.1.1.1 . tcp . 8032 : 10.129.0.2 . 8032 }\n"
 				err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				Expect(err).NotTo(HaveOccurred())
 
@@ -398,7 +360,7 @@ var _ = Describe("Node Operations", func() {
 	})
 
 	Context("on add", func() {
-		It("inits iptables rules with ExternalIP", func() {
+		It("inits nftables rules with ExternalIP", func() {
 			app.Action = func(*cli.Context) error {
 				externalIP := "1.1.1.1"
 				fExec.AddFakeCmd(&ovntest.ExpectedCmd{
@@ -431,46 +393,15 @@ var _ = Describe("Node Operations", func() {
 				fNPW.watchFactory = wf
 				Expect(startNodePortWatcher(fNPW, fakeClient)).To(Succeed())
 
-				expectedTables := map[string]util.FakeTable{
-					"nat": {
-						"PREROUTING": []string{
-							"-j OVN-KUBE-ETP",
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-						},
-						"OUTPUT": []string{
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-NODEPORT": []string{},
-						"OVN-KUBE-EXTERNALIP": []string{
-							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, externalIP, service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
-						},
-						"OVN-KUBE-ETP": []string{},
-						"OVN-KUBE-ITP": []string{},
-					},
-					"filter": {},
-					"mangle": {
-						"OUTPUT": []string{
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-ITP": []string{},
-					},
-				}
-
-				f4 := iptV4.(*util.FakeIPTables)
-				err = f4.MatchState(expectedTables, nil)
-				Expect(err).NotTo(HaveOccurred())
-
-				expectedNFT := nftablesRulesBase
+				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
+				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes external-ips-v4 { %s . %s . %d : %s . %d }\n", externalIP, strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port)
 				return nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 			}
 			err := app.Run([]string{app.Name})
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("inits iptables rules with NodePort", func() {
+		It("inits nftables rules with NodePort", func() {
 			app.Action = func(*cli.Context) error {
 
 				service := *newService("service1", "namespace1", "10.129.0.2",
@@ -507,46 +438,15 @@ var _ = Describe("Node Operations", func() {
 				Expect(startNodePortWatcher(fNPW, fakeClient)).To(Succeed())
 				Expect(fExec.CalledMatchesExpected()).To(BeTrue(), fExec.ErrorDesc)
 
-				expectedTables := map[string]util.FakeTable{
-					"nat": {
-						"PREROUTING": []string{
-							"-j OVN-KUBE-ETP",
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-						},
-						"OUTPUT": []string{
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-NODEPORT": []string{
-							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
-						},
-						"OVN-KUBE-EXTERNALIP": []string{},
-						"OVN-KUBE-ETP":        []string{},
-						"OVN-KUBE-ITP":        []string{},
-					},
-					"filter": {},
-					"mangle": {
-						"OUTPUT": []string{
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-ITP": []string{},
-					},
-				}
-
-				f4 := iptV4.(*util.FakeIPTables)
-				err = f4.MatchState(expectedTables, nil)
-				Expect(err).NotTo(HaveOccurred())
-
-				expectedNFT := nftablesRulesBase
+				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
+				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes nodeports-v4 { %s . %d : %s . %d }\n", strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port)
 				return nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 			}
 			err := app.Run([]string{app.Name})
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("inits iptables rules and openflows with NodePort where ETP=local, LGW", func() {
+		It("inits nftables rules and openflows with NodePort where ETP=local, LGW", func() {
 			app.Action = func(*cli.Context) error {
 				config.Gateway.Mode = config.GatewayModeLocal
 				epPortName := "https"
@@ -595,42 +495,10 @@ var _ = Describe("Node Operations", func() {
 				fNPW.watchFactory = wf
 				Expect(startNodePortWatcher(fNPW, fakeClient)).To(Succeed())
 
-				expectedTables := map[string]util.FakeTable{
-					"nat": {
-						"PREROUTING": []string{
-							"-j OVN-KUBE-ETP",
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-						},
-						"OUTPUT": []string{
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-NODEPORT": []string{
-							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
-						},
-						"OVN-KUBE-EXTERNALIP": []string{},
-						"OVN-KUBE-ETP": []string{
-							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, config.Gateway.MasqueradeIPs.V4HostETPLocalMasqueradeIP.String(), service.Spec.Ports[0].NodePort),
-						},
-						"OVN-KUBE-ITP": []string{},
-					},
-					"filter": {},
-					"mangle": {
-						"OUTPUT": []string{
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-ITP": []string{},
-					},
-				}
-
-				f4 := iptV4.(*util.FakeIPTables)
-				err = f4.MatchState(expectedTables, nil)
-				Expect(err).NotTo(HaveOccurred())
-
-				expectedNFT := nftablesRulesBase
+				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
 				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes mgmtport-no-snat-nodeports { tcp . %v }\n", service.Spec.Ports[0].NodePort)
+				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes nodeports-v4 { %s . %d : %s . %d }\n", strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port)
+				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes nodeports-etp-local-v4 { %s . %d : %s . %d }\n", strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].NodePort, config.Gateway.MasqueradeIPs.V4HostETPLocalMasqueradeIP.String(), service.Spec.Ports[0].NodePort)
 				err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				Expect(err).NotTo(HaveOccurred())
 
@@ -643,7 +511,7 @@ var _ = Describe("Node Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("inits iptables rules with LoadBalancer", func() {
+		It("inits nftables rules with LoadBalancer", func() {
 			app.Action = func(*cli.Context) error {
 				// Depending on the order of informer event processing the initial
 				// Service might be "added" once or twice.  Take that into account.
@@ -695,49 +563,17 @@ var _ = Describe("Node Operations", func() {
 					return fExec.CalledMatchesExpectedAtLeastN(minNFakeCommands)
 				}, "2s").Should(BeTrue(), fExec.ErrorDesc)
 
-				expectedTables := map[string]util.FakeTable{
-					"nat": {
-						"PREROUTING": []string{
-							"-j OVN-KUBE-ETP",
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-						},
-						"OUTPUT": []string{
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-NODEPORT": []string{
-							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
-						},
-						"OVN-KUBE-EXTERNALIP": []string{
-							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Status.LoadBalancer.Ingress[0].IP, service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
-							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, externalIP, service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
-						},
-						"OVN-KUBE-ETP": []string{},
-						"OVN-KUBE-ITP": []string{},
-					},
-					"filter": {},
-					"mangle": {
-						"OUTPUT": []string{
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-ITP": []string{},
-					},
-				}
-
-				f4 := iptV4.(*util.FakeIPTables)
-				err = f4.MatchState(expectedTables, nil)
-				Expect(err).NotTo(HaveOccurred())
-
-				expectedNFT := nftablesRulesBase
+				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
+				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes nodeports-v4 { %s . %d : %s . %d }\n", strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port)
+				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes external-ips-v4 { %s . %s . %d : %s . %d }\n", externalIP, strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port)
+				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes external-ips-v4 { %s . %s . %d : %s . %d }\n", service.Status.LoadBalancer.Ingress[0].IP, strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port)
 				return nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 			}
 			err := app.Run([]string{app.Name})
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("inits iptables rules and openflows with LoadBalancer where ETP=local, LGW mode", func() {
+		It("inits nftables rules and openflows with LoadBalancer where ETP=local, LGW mode", func() {
 			app.Action = func(*cli.Context) error {
 				externalIP := "1.1.1.1"
 				config.Gateway.Mode = config.GatewayModeLocal
@@ -790,56 +626,23 @@ var _ = Describe("Node Operations", func() {
 				fNPW.watchFactory = wf
 				Expect(startNodePortWatcher(fNPW, fakeClient)).To(Succeed())
 
-				expectedTables := map[string]util.FakeTable{
-					"nat": {
-						"PREROUTING": []string{
-							"-j OVN-KUBE-ETP",
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-						},
-						"OUTPUT": []string{
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-NODEPORT": []string{
-							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
-						},
-						"OVN-KUBE-EXTERNALIP": []string{
-							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Status.LoadBalancer.Ingress[0].IP, service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
-							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, externalIP, service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
-						},
-						"OVN-KUBE-ETP": []string{
-							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Status.LoadBalancer.Ingress[0].IP, service.Spec.Ports[0].Port, config.Gateway.MasqueradeIPs.V4HostETPLocalMasqueradeIP.String(), service.Spec.Ports[0].NodePort),
-							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, externalIP, service.Spec.Ports[0].Port, config.Gateway.MasqueradeIPs.V4HostETPLocalMasqueradeIP.String(), service.Spec.Ports[0].NodePort),
-							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, config.Gateway.MasqueradeIPs.V4HostETPLocalMasqueradeIP.String(), service.Spec.Ports[0].NodePort),
-						},
-						"OVN-KUBE-ITP": []string{},
-					},
-					"filter": {},
-					"mangle": {
-						"OUTPUT": []string{
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-ITP": []string{},
-					},
-				}
+				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
+				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes mgmtport-no-snat-nodeports { tcp . %v }\n", service.Spec.Ports[0].NodePort)
+				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes nodeports-v4 { %s . %d : %s . %d }\n", strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port)
+				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes external-ips-v4 { %s . %s . %d : %s . %d }\n", externalIP, strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port)
+				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes external-ips-v4 { %s . %s . %d : %s . %d }\n", service.Status.LoadBalancer.Ingress[0].IP, strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port)
+				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes nodeports-etp-local-v4 { %s . %d : %s . %d }\n", strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].NodePort, config.Gateway.MasqueradeIPs.V4HostETPLocalMasqueradeIP.String(), service.Spec.Ports[0].NodePort)
+				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes external-ips-etp-local-v4 { %s . %s . %d : %s . %d }\n", externalIP, strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].Port, config.Gateway.MasqueradeIPs.V4HostETPLocalMasqueradeIP.String(), service.Spec.Ports[0].NodePort)
+				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes external-ips-etp-local-v4 { %s . %s . %d : %s . %d }\n", service.Status.LoadBalancer.Ingress[0].IP, strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].Port, config.Gateway.MasqueradeIPs.V4HostETPLocalMasqueradeIP.String(), service.Spec.Ports[0].NodePort)
+				err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
+				Expect(err).NotTo(HaveOccurred())
+
 				expectedLBIngressFlows := []string{
 					"cookie=0x10c6b89e483ea111, priority=110, in_port=eth0, arp, arp_op=1, arp_tpa=5.5.5.5, actions=output:LOCAL",
 				}
 				expectedLBExternalIPFlows := []string{
 					"cookie=0x71765945a31dc2f1, priority=110, in_port=eth0, arp, arp_op=1, arp_tpa=1.1.1.1, actions=output:LOCAL",
 				}
-
-				f4 := iptV4.(*util.FakeIPTables)
-				err = f4.MatchState(expectedTables, nil)
-				Expect(err).NotTo(HaveOccurred())
-
-				expectedNFT := nftablesRulesBase
-				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes mgmtport-no-snat-nodeports { tcp . %v }\n", service.Spec.Ports[0].NodePort)
-				err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
-				Expect(err).NotTo(HaveOccurred())
-
 				flows := fNPW.ofm.getFlowsByKey("NodePort_namespace1_service1_tcp_31111")
 				Expect(flows).To(BeNil())
 				flows = fNPW.ofm.getFlowsByKey("Ingress_namespace1_service1_5.5.5.5_8080")
@@ -853,7 +656,7 @@ var _ = Describe("Node Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("inits iptables rules and openflows with LoadBalancer where AllocateLoadBalancerNodePorts=False, ETP=local, LGW mode", func() {
+		It("inits nftables rules and openflows with LoadBalancer where AllocateLoadBalancerNodePorts=False, ETP=local, LGW mode", func() {
 			app.Action = func(*cli.Context) error {
 				externalIP := "1.1.1.1"
 				config.Gateway.Mode = config.GatewayModeLocal
@@ -932,55 +735,22 @@ var _ = Describe("Node Operations", func() {
 				fNPW.watchFactory = wf
 				Expect(startNodePortWatcher(fNPW, fakeClient)).To(Succeed())
 
-				expectedTables := map[string]util.FakeTable{
-					"nat": {
-						"PREROUTING": []string{
-							"-j OVN-KUBE-ETP",
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-						},
-						"OUTPUT": []string{
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-NODEPORT": []string{},
-						"OVN-KUBE-EXTERNALIP": []string{
-							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Status.LoadBalancer.Ingress[0].IP, service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
-							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, externalIP, service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
-						},
-						"OVN-KUBE-ETP": []string{
-							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%d -m statistic --mode random --probability 0.5000000000", service.Spec.Ports[0].Protocol, service.Status.LoadBalancer.Ingress[0].IP, service.Spec.Ports[0].Port, ep1.Addresses[0], int32(service.Spec.Ports[0].TargetPort.IntValue())),
-							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%d -m statistic --mode random --probability 1.0000000000", service.Spec.Ports[0].Protocol, service.Status.LoadBalancer.Ingress[0].IP, service.Spec.Ports[0].Port, ep2.Addresses[0], int32(service.Spec.Ports[0].TargetPort.IntValue())),
-							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%d -m statistic --mode random --probability 0.5000000000", service.Spec.Ports[0].Protocol, externalIP, service.Spec.Ports[0].Port, ep1.Addresses[0], int32(service.Spec.Ports[0].TargetPort.IntValue())),
-							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%d -m statistic --mode random --probability 1.0000000000", service.Spec.Ports[0].Protocol, externalIP, service.Spec.Ports[0].Port, ep2.Addresses[0], int32(service.Spec.Ports[0].TargetPort.IntValue())),
-						},
-						"OVN-KUBE-ITP": []string{},
-					},
-					"filter": {},
-					"mangle": {
-						"OUTPUT": []string{
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-ITP": []string{},
-					},
-				}
+				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
+				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes mgmtport-no-snat-services-v4 { %s . tcp . %d }\n", ep1.Addresses[0], int32(service.Spec.Ports[0].TargetPort.IntValue()))
+				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes mgmtport-no-snat-services-v4 { %s . tcp . %d }\n", ep2.Addresses[0], int32(service.Spec.Ports[0].TargetPort.IntValue()))
+				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes external-ips-v4 { %s . %s . %d : %s . %d }\n", externalIP, strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port)
+				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes external-ips-v4 { %s . %s . %d : %s . %d }\n", service.Status.LoadBalancer.Ingress[0].IP, strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port)
+				expectedNFT += fmt.Sprintf("add rule inet ovn-kubernetes services-etp-no-nodeport ip daddr %s meta l4proto %s th dport %d dnat ip addr . port to numgen random mod 2 map { 0 : %s . %d , 1 : %s . %d } comment \"namespace1/service1:http\"\n", externalIP, strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].Port, ep1.Addresses[0], service.Spec.Ports[0].TargetPort.IntValue(), ep2.Addresses[0], service.Spec.Ports[0].TargetPort.IntValue())
+				expectedNFT += fmt.Sprintf("add rule inet ovn-kubernetes services-etp-no-nodeport ip daddr %s meta l4proto %s th dport %d dnat ip addr . port to numgen random mod 2 map { 0 : %s . %d , 1 : %s . %d } comment \"namespace1/service1:http\"\n", service.Status.LoadBalancer.Ingress[0].IP, strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].Port, ep1.Addresses[0], service.Spec.Ports[0].TargetPort.IntValue(), ep2.Addresses[0], service.Spec.Ports[0].TargetPort.IntValue())
+				err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
+				Expect(err).NotTo(HaveOccurred())
+
 				expectedLBIngressFlows := []string{
 					"cookie=0xd8c1fe514f305bc1, priority=110, in_port=eth0, arp, arp_op=1, arp_tpa=5.5.5.5, actions=output:LOCAL",
 				}
 				expectedLBExternalIPFlows := []string{
 					"cookie=0x799e0efe5404e9a1, priority=110, in_port=eth0, arp, arp_op=1, arp_tpa=1.1.1.1, actions=output:LOCAL",
 				}
-
-				f4 := iptV4.(*util.FakeIPTables)
-				Expect(f4.MatchState(expectedTables, nil)).To(Succeed())
-
-				expectedNFT := nftablesRulesBase
-				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes mgmtport-no-snat-services-v4 { %s . tcp . %d }\n", ep1.Addresses[0], int32(service.Spec.Ports[0].TargetPort.IntValue()))
-				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes mgmtport-no-snat-services-v4 { %s . tcp . %d }\n", ep2.Addresses[0], int32(service.Spec.Ports[0].TargetPort.IntValue()))
-				err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
-				Expect(err).NotTo(HaveOccurred())
-
 				Expect(fNPW.ofm.getFlowsByKey("Ingress_namespace1_service1_5.5.5.5_80")).To(Equal(expectedLBIngressFlows))
 				Expect(fNPW.ofm.getFlowsByKey("External_namespace1_service1_1.1.1.1_80")).To(Equal(expectedLBExternalIPFlows))
 
@@ -991,37 +761,8 @@ var _ = Describe("Node Operations", func() {
 					{"10.129.0.2", 80, corev1.ProtocolTCP, netlink.ConntrackOrigDstIP}})
 				Expect(fakeClient.KubeClient.CoreV1().Services(service.Namespace).Delete(
 					context.Background(), service.Name, metav1.DeleteOptions{})).To(Succeed())
-				expectedTables = map[string]util.FakeTable{
-					"nat": {
-						"PREROUTING": []string{
-							"-j OVN-KUBE-ETP",
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-						},
-						"OUTPUT": []string{
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-NODEPORT":   []string{},
-						"OVN-KUBE-EXTERNALIP": []string{},
-						"OVN-KUBE-ETP":        []string{},
-						"OVN-KUBE-ITP":        []string{},
-					},
-					"filter": {},
-					"mangle": {
-						"OUTPUT": []string{
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-ITP": []string{},
-					},
-				}
-				Eventually(func() error {
-					f4 := iptV4.(*util.FakeIPTables)
-					return f4.MatchState(expectedTables, nil)
-				}, "2s").Should(Succeed())
 
-				expectedNFT = nftablesRulesBase
+				expectedNFT = nftablesRulesBase + nftablesRulesGatewayServices
 				Eventually(func() error {
 					return nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				}, "2s").Should(Succeed())
@@ -1034,7 +775,7 @@ var _ = Describe("Node Operations", func() {
 			Expect(app.Run([]string{app.Name})).To(Succeed())
 		})
 
-		It("inits iptables rules and openflows with named port and AllocateLoadBalancerNodePorts=False, ETP=local, LGW mode", func() {
+		It("inits nftables rules and openflows with named port and AllocateLoadBalancerNodePorts=False, ETP=local, LGW mode", func() {
 			app.Action = func(*cli.Context) error {
 				minNFakeCommands := nInitialFakeCommands + 1
 				fExec.AddRepeatedFakeCmd(&ovntest.ExpectedCmd{
@@ -1114,63 +855,15 @@ var _ = Describe("Node Operations", func() {
 				fNPW.watchFactory = wf
 				Expect(startNodePortWatcher(fNPW, fakeClient)).To(Succeed())
 
-				expectedTables := map[string]util.FakeTable{
-					"nat": {
-						"PREROUTING": []string{
-							"-j OVN-KUBE-ETP",
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-						},
-						"OUTPUT": []string{
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-NODEPORT": []string{},
-						"OVN-KUBE-EXTERNALIP": []string{
-							fmt.Sprintf("-p %s -d %s --dport %d -j DNAT --to-destination %s:%v",
-								service.Spec.Ports[0].Protocol,
-								service.Status.LoadBalancer.Ingress[0].IP,
-								service.Spec.Ports[0].Port,
-								service.Spec.ClusterIP,
-								service.Spec.Ports[0].Port),
-						},
-						"OVN-KUBE-ETP": []string{
-							fmt.Sprintf("-p %s -d %s --dport %d -j DNAT --to-destination %s:%d -m statistic --mode random --probability 0.5000000000",
-								service.Spec.Ports[0].Protocol,
-								service.Status.LoadBalancer.Ingress[0].IP,
-								service.Spec.Ports[0].Port,
-								endpointSlice.Endpoints[0].Addresses[0],
-								*endpointSlice.Ports[0].Port),
-							fmt.Sprintf("-p %s -d %s --dport %d -j DNAT --to-destination %s:%d -m statistic --mode random --probability 1.0000000000",
-								service.Spec.Ports[0].Protocol,
-								service.Status.LoadBalancer.Ingress[0].IP,
-								service.Spec.Ports[0].Port,
-								endpointSlice.Endpoints[1].Addresses[0],
-								*endpointSlice.Ports[0].Port),
-						},
-						"OVN-KUBE-ITP": []string{},
-					},
-					"filter": {},
-					"mangle": {
-						"OUTPUT": []string{
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-ITP": []string{},
-					},
-				}
-
-				f4 := iptV4.(*util.FakeIPTables)
-				err = f4.MatchState(expectedTables, nil)
-				Expect(err).NotTo(HaveOccurred())
-
-				expectedNFT := nftablesRulesBase
+				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
 				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes mgmtport-no-snat-services-v4 { %s . tcp . %v }\n"+
 					"add element inet ovn-kubernetes mgmtport-no-snat-services-v4 { %s . tcp . %v }\n",
 					endpointSlice.Endpoints[1].Addresses[0],
 					*endpointSlice.Ports[0].Port,
 					endpointSlice.Endpoints[0].Addresses[0],
 					*endpointSlice.Ports[0].Port)
+				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes external-ips-v4 { %s . %s . %d : %s . %d }\n", service.Status.LoadBalancer.Ingress[0].IP, strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port)
+				expectedNFT += fmt.Sprintf("add rule inet ovn-kubernetes services-etp-no-nodeport ip daddr %s meta l4proto %s th dport %d dnat ip addr . port to numgen random mod 2 map { 0 : %s . %d , 1 : %s . %d } comment \"namespace1/service1:https-port\"\n", service.Status.LoadBalancer.Ingress[0].IP, strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].Port, ep1.Addresses[0], *endpointSlice.Ports[0].Port, ep2.Addresses[0], *endpointSlice.Ports[0].Port)
 				err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				Expect(err).NotTo(HaveOccurred())
 
@@ -1183,7 +876,7 @@ var _ = Describe("Node Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("inits iptables rules and openflows with LoadBalancer where ETP=cluster, LGW mode", func() {
+		It("inits nftables rules and openflows with LoadBalancer where ETP=cluster, LGW mode", func() {
 			app.Action = func(*cli.Context) error {
 				externalIP := "1.1.1.1"
 				config.Gateway.Mode = config.GatewayModeLocal
@@ -1236,36 +929,12 @@ var _ = Describe("Node Operations", func() {
 				fNPW.watchFactory = wf
 				Expect(startNodePortWatcher(fNPW, fakeClient)).To(Succeed())
 
-				expectedTables := map[string]util.FakeTable{
-					"nat": {
-						"PREROUTING": []string{
-							"-j OVN-KUBE-ETP",
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-						},
-						"OUTPUT": []string{
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-NODEPORT": []string{
-							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
-						},
-						"OVN-KUBE-EXTERNALIP": []string{
-							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Status.LoadBalancer.Ingress[0].IP, service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
-							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, externalIP, service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
-						},
-						"OVN-KUBE-ETP": []string{},
-						"OVN-KUBE-ITP": []string{},
-					},
-					"filter": {},
-					"mangle": {
-						"OUTPUT": []string{
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-ITP": []string{},
-					},
-				}
+				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
+				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes nodeports-v4 { %s . %d : %s . %d }\n", strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port)
+				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes external-ips-v4 { %s . %s . %d : %s . %d }\n", externalIP, strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port)
+				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes external-ips-v4 { %s . %s . %d : %s . %d }\n", service.Status.LoadBalancer.Ingress[0].IP, strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port)
+				err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
+				Expect(err).NotTo(HaveOccurred())
 
 				expectedLBIngressFlows := []string{
 					"cookie=0x10c6b89e483ea111, priority=110, in_port=eth0, arp, arp_op=1, arp_tpa=5.5.5.5, actions=output:LOCAL",
@@ -1273,15 +942,6 @@ var _ = Describe("Node Operations", func() {
 				expectedLBExternalIPFlows := []string{
 					"cookie=0x71765945a31dc2f1, priority=110, in_port=eth0, arp, arp_op=1, arp_tpa=1.1.1.1, actions=output:LOCAL",
 				}
-
-				f4 := iptV4.(*util.FakeIPTables)
-				err = f4.MatchState(expectedTables, nil)
-				Expect(err).NotTo(HaveOccurred())
-
-				expectedNFT := nftablesRulesBase
-				err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
-				Expect(err).NotTo(HaveOccurred())
-
 				flows := fNPW.ofm.getFlowsByKey("NodePort_namespace1_service1_tcp_31111")
 				Expect(flows).To(BeNil())
 				flows = fNPW.ofm.getFlowsByKey("Ingress_namespace1_service1_5.5.5.5_8080")
@@ -1295,7 +955,7 @@ var _ = Describe("Node Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("inits iptables rules and openflows with LoadBalancer where ETP=local, SGW mode", func() {
+		It("inits nftables rules and openflows with LoadBalancer where ETP=local, SGW mode", func() {
 			app.Action = func(*cli.Context) error {
 				externalIP := "1.1.1.1"
 				config.Gateway.Mode = config.GatewayModeShared
@@ -1347,39 +1007,16 @@ var _ = Describe("Node Operations", func() {
 				fNPW.watchFactory = wf
 				Expect(startNodePortWatcher(fNPW, fakeClient)).To(Succeed())
 
-				expectedTables := map[string]util.FakeTable{
-					"nat": {
-						"PREROUTING": []string{
-							"-j OVN-KUBE-ETP",
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-						},
-						"OUTPUT": []string{
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-NODEPORT": []string{
-							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
-						},
-						"OVN-KUBE-EXTERNALIP": []string{
-							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Status.LoadBalancer.Ingress[0].IP, service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
-							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, externalIP, service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
-						},
-						"OVN-KUBE-ETP": []string{
-							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Status.LoadBalancer.Ingress[0].IP, service.Spec.Ports[0].Port, config.Gateway.MasqueradeIPs.V4HostETPLocalMasqueradeIP.String(), service.Spec.Ports[0].NodePort),
-							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, externalIP, service.Spec.Ports[0].Port, config.Gateway.MasqueradeIPs.V4HostETPLocalMasqueradeIP.String(), service.Spec.Ports[0].NodePort),
-						},
-						"OVN-KUBE-ITP": []string{},
-					},
-					"filter": {},
-					"mangle": {
-						"OUTPUT": []string{
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-ITP": []string{},
-					},
-				}
+				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
+				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes mgmtport-no-snat-nodeports { tcp . %v }\n", service.Spec.Ports[0].NodePort)
+				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes nodeports-v4 { %s . %d : %s . %d }\n", strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port)
+				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes external-ips-v4 { %s . %s . %d : %s . %d }\n", externalIP, strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port)
+				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes external-ips-v4 { %s . %s . %d : %s . %d }\n", service.Status.LoadBalancer.Ingress[0].IP, strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port)
+				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes external-ips-etp-local-v4 { %s . %s . %d : %s . %d }\n", externalIP, strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].Port, config.Gateway.MasqueradeIPs.V4HostETPLocalMasqueradeIP.String(), service.Spec.Ports[0].NodePort)
+				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes external-ips-etp-local-v4 { %s . %s . %d : %s . %d }\n", service.Status.LoadBalancer.Ingress[0].IP, strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].Port, config.Gateway.MasqueradeIPs.V4HostETPLocalMasqueradeIP.String(), service.Spec.Ports[0].NodePort)
+				err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
+				Expect(err).NotTo(HaveOccurred())
+
 				expectedNodePortFlows := []string{
 					"cookie=0x453ae29bcbbc08bd, priority=110, in_port=eth0, tcp, tp_dst=31111, actions=output:patch-breth0_ov",
 					fmt.Sprintf("cookie=0x453ae29bcbbc08bd, priority=110, in_port=patch-breth0_ov, dl_src=%s, tcp, tp_src=31111, actions=output:eth0",
@@ -1399,16 +1036,6 @@ var _ = Describe("Node Operations", func() {
 					fmt.Sprintf("cookie=0x71765945a31dc2f1, priority=110, in_port=patch-breth0_ov, dl_src=%s, tcp, nw_src=1.1.1.1, tp_src=8080, actions=output:eth0",
 						gwMAC),
 				}
-
-				f4 := iptV4.(*util.FakeIPTables)
-				err = f4.MatchState(expectedTables, nil)
-				Expect(err).NotTo(HaveOccurred())
-
-				expectedNFT := nftablesRulesBase
-				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes mgmtport-no-snat-nodeports { tcp . %v }\n", service.Spec.Ports[0].NodePort)
-				err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
-				Expect(err).NotTo(HaveOccurred())
-
 				flows := fNPW.ofm.getFlowsByKey("NodePort_namespace1_service1_tcp_31111")
 				Expect(flows).To(Equal(expectedNodePortFlows))
 				flows = fNPW.ofm.getFlowsByKey("Ingress_namespace1_service1_5.5.5.5_8080")
@@ -1422,7 +1049,7 @@ var _ = Describe("Node Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("inits iptables rules and openflows with LoadBalancer where ETP=local, SGW mode, with named ports, with "+
+		It("inits nftables rules and openflows with LoadBalancer where ETP=local, SGW mode, with named ports, with "+
 			"host networked pods and with external IP", func() {
 			app.Action = func(*cli.Context) error {
 				nodeName := "node"
@@ -1494,50 +1121,13 @@ var _ = Describe("Node Operations", func() {
 				fNPW.watchFactory = wf
 				Expect(startNodePortWatcher(fNPW, fakeClient)).To(Succeed())
 
-				expectedTables := map[string]util.FakeTable{
-					"nat": {
-						"PREROUTING": []string{
-							"-j OVN-KUBE-ETP",
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-						},
-						"OUTPUT": []string{
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-NODEPORT": []string{
-							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v",
-								service.Spec.Ports[0].Protocol,
-								service.Spec.Ports[0].NodePort,
-								service.Spec.ClusterIP,
-								service.Spec.Ports[0].Port),
-						},
-						"OVN-KUBE-EXTERNALIP": []string{
-							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v",
-								service.Spec.Ports[0].Protocol,
-								svcStatusIP,
-								service.Spec.Ports[0].Port,
-								service.Spec.ClusterIP,
-								service.Spec.Ports[0].Port),
-							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v",
-								service.Spec.Ports[0].Protocol,
-								externalIP,
-								service.Spec.Ports[0].Port,
-								service.Spec.ClusterIP,
-								service.Spec.Ports[0].Port),
-						},
-						"OVN-KUBE-ETP": []string{},
-						"OVN-KUBE-ITP": []string{},
-					},
-					"filter": {},
-					"mangle": {
-						"OUTPUT": []string{
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-ITP": []string{},
-					},
-				}
+				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
+				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes nodeports-v4 { %s . %d : %s . %d }\n", strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port)
+				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes external-ips-v4 { %s . %s . %d : %s . %d }\n", externalIP, strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port)
+				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes external-ips-v4 { %s . %s . %d : %s . %d }\n", svcStatusIP, strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port)
+				err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
+				Expect(err).NotTo(HaveOccurred())
+
 				expectedNodePortFlows := []string{
 					fmt.Sprintf("cookie=0x453ae29bcbbc08bd, priority=110, in_port=eth0, tcp, tp_dst=%d, "+
 						"actions=ct(commit,zone=64003,nat(dst=%s:%d),table=6)", svcNodePort, v4localnetGatewayIP, epPortValue),
@@ -1568,15 +1158,6 @@ var _ = Describe("Node Operations", func() {
 						"actions=ct(zone=64003 nat,table=7)", epPortValue),
 					"cookie=0xe745ecf105, priority=110, table=7, actions=output:eth0",
 				}
-
-				f4 := iptV4.(*util.FakeIPTables)
-				err = f4.MatchState(expectedTables, nil)
-				Expect(err).NotTo(HaveOccurred())
-
-				expectedNFT := nftablesRulesBase
-				err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
-				Expect(err).NotTo(HaveOccurred())
-
 				flows := fNPW.ofm.getFlowsByKey("NodePort_namespace1_service1_tcp_31111")
 				Expect(flows).To(Equal(expectedNodePortFlows))
 				flows = fNPW.ofm.getFlowsByKey("Ingress_namespace1_service1_5.5.5.5_8080")
@@ -1590,7 +1171,7 @@ var _ = Describe("Node Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("inits iptables rules with DualStack NodePort", func() {
+		It("inits nftables rules with DualStack NodePort", func() {
 			app.Action = func(*cli.Context) error {
 				nodePort := int32(31111)
 
@@ -1631,52 +1212,9 @@ var _ = Describe("Node Operations", func() {
 				Expect(startNodePortWatcher(fNPW, fakeClient)).To(Succeed())
 				Expect(fExec.CalledMatchesExpected()).To(BeTrue(), fExec.ErrorDesc)
 
-				expectedTables4 := map[string]util.FakeTable{
-					"nat": {
-						"PREROUTING": []string{
-							"-j OVN-KUBE-ETP",
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-						},
-						"OUTPUT": []string{
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-NODEPORT": []string{
-							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, service.Spec.ClusterIPs[0], service.Spec.Ports[0].Port),
-						},
-						"OVN-KUBE-EXTERNALIP": []string{},
-						"OVN-KUBE-ETP":        []string{},
-						"OVN-KUBE-ITP":        []string{},
-					},
-					"filter": {},
-					"mangle": {
-						"OUTPUT": []string{
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-ITP": []string{},
-					},
-				}
-
-				f4 := iptV4.(*util.FakeIPTables)
-				err = f4.MatchState(expectedTables4, nil)
-				Expect(err).NotTo(HaveOccurred())
-
-				expectedTables6 := map[string]util.FakeTable{
-					"nat": {
-						"OVN-KUBE-NODEPORT": []string{
-							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination [%s]:%v", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, service.Spec.ClusterIPs[1], service.Spec.Ports[0].Port),
-						},
-					},
-					"filter": {},
-					"mangle": {},
-				}
-				f6 := iptV6.(*util.FakeIPTables)
-				err = f6.MatchState(expectedTables6, nil)
-				Expect(err).NotTo(HaveOccurred())
-
-				expectedNFT := nftablesRulesBase
+				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
+				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes nodeports-v4 { %s . %d : %s . %d }\n", strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].NodePort, service.Spec.ClusterIPs[0], service.Spec.Ports[0].Port)
+				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes nodeports-v6 { %s . %d : %s . %d }\n", strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].NodePort, service.Spec.ClusterIPs[1], service.Spec.Ports[0].Port)
 				err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				Expect(err).NotTo(HaveOccurred())
 
@@ -1686,7 +1224,7 @@ var _ = Describe("Node Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("inits iptables rules for ExternalIP with DualStack", func() {
+		It("inits nftables rules for ExternalIP with DualStack", func() {
 			app.Action = func(*cli.Context) error {
 
 				// Depending on the order of informer event processing the initial
@@ -1732,53 +1270,9 @@ var _ = Describe("Node Operations", func() {
 					return fExec.CalledMatchesExpectedAtLeastN(minNFakeCommands)
 				}, "2s").Should(BeTrue(), fExec.ErrorDesc)
 
-				expectedTables4 := map[string]util.FakeTable{
-					"nat": {
-						"PREROUTING": []string{
-							"-j OVN-KUBE-ETP",
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-						},
-						"OUTPUT": []string{
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-EXTERNALIP": []string{
-							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, externalIPv4, service.Spec.Ports[0].Port, clusterIPv4, service.Spec.Ports[0].Port),
-						},
-						"OVN-KUBE-NODEPORT": []string{},
-						"OVN-KUBE-ETP":      []string{},
-						"OVN-KUBE-ITP":      []string{},
-					},
-					"filter": {},
-					"mangle": {
-						"OUTPUT": []string{
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-ITP": []string{},
-					},
-				}
-
-				f4 := iptV4.(*util.FakeIPTables)
-				err = f4.MatchState(expectedTables4, nil)
-				Expect(err).NotTo(HaveOccurred())
-
-				expectedTables6 := map[string]util.FakeTable{
-					"nat": {
-						"OVN-KUBE-EXTERNALIP": []string{
-							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination [%s]:%v", service.Spec.Ports[0].Protocol, externalIPv6, service.Spec.Ports[0].Port, clusterIPv6, service.Spec.Ports[0].Port),
-						},
-					},
-					"filter": {},
-					"mangle": {},
-				}
-
-				f6 := iptV6.(*util.FakeIPTables)
-				err = f6.MatchState(expectedTables6, nil)
-				Expect(err).NotTo(HaveOccurred())
-
-				expectedNFT := nftablesRulesBase
+				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
+				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes external-ips-v4 { %s . %s . %d : %s . %d }\n", externalIPv4, strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].Port, clusterIPv4, service.Spec.Ports[0].Port)
+				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes external-ips-v6 { %s . %s . %d : %s . %d }\n", externalIPv6, strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].Port, clusterIPv6, service.Spec.Ports[0].Port)
 				return nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 			}
 			err := app.Run([]string{app.Name})
@@ -1787,7 +1281,7 @@ var _ = Describe("Node Operations", func() {
 	})
 
 	Context("on delete", func() {
-		It("deletes iptables rules with ExternalIP", func() {
+		It("deletes nftables rules with ExternalIP", func() {
 			app.Action = func(*cli.Context) error {
 				minNFakeCommands := nInitialFakeCommands + 1
 				// Depending on the order of informer event processing the initial
@@ -1831,49 +1325,8 @@ var _ = Describe("Node Operations", func() {
 					return fExec.CalledMatchesExpectedAtLeastN(minNFakeCommands)
 				}, "2s").Should(BeTrue(), fExec.ErrorDesc)
 
-				expectedTables := map[string]util.FakeTable{
-					"nat": {
-						"PREROUTING": []string{
-							"-j OVN-KUBE-ETP",
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-						},
-						"OUTPUT": []string{
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-NODEPORT":   []string{},
-						"OVN-KUBE-EXTERNALIP": []string{},
-						"OVN-KUBE-ETP":        []string{},
-						"OVN-KUBE-ITP":        []string{},
-					},
-					"filter": {},
-					"mangle": {
-						"OUTPUT": []string{
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-ITP": []string{},
-					},
-				}
-
+				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
 				Eventually(func() error {
-					f4 := iptV4.(*util.FakeIPTables)
-					return f4.MatchState(expectedTables, nil)
-				}, "2s").Should(Succeed())
-
-				expectedTables = map[string]util.FakeTable{
-					"nat":    {},
-					"filter": {},
-					"mangle": {},
-				}
-				Eventually(func() error {
-					f6 := iptV6.(*util.FakeIPTables)
-					return f6.MatchState(expectedTables, nil)
-				}, "2s").Should(Succeed())
-
-				Eventually(func() error {
-					expectedNFT := nftablesRulesBase
 					return nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				}, "2s").Should(Succeed())
 
@@ -1883,7 +1336,7 @@ var _ = Describe("Node Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("deletes iptables rules for NodePort", func() {
+		It("deletes nftables rules for NodePort", func() {
 			app.Action = func(*cli.Context) error {
 				nodePort := int32(31111)
 
@@ -1918,50 +1371,8 @@ var _ = Describe("Node Operations", func() {
 					context.Background(), service.Name, metav1.DeleteOptions{})).To(Succeed())
 				Eventually(fExec.CalledMatchesExpected, "2s").Should(BeTrue(), fExec.ErrorDesc)
 
-				expectedTables := map[string]util.FakeTable{
-					"nat": {
-						"PREROUTING": []string{
-							"-j OVN-KUBE-ETP",
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-						},
-						"OUTPUT": []string{
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-NODEPORT":   []string{},
-						"OVN-KUBE-EXTERNALIP": []string{},
-						"OVN-KUBE-ETP":        []string{},
-						"OVN-KUBE-ITP":        []string{},
-					},
-					"filter": {},
-					"mangle": {
-						"OUTPUT": []string{
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-ITP": []string{},
-					},
-				}
-
+				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
 				Eventually(func() error {
-					f4 := iptV4.(*util.FakeIPTables)
-					return f4.MatchState(expectedTables, nil)
-				}, "2s").Should(Succeed())
-
-				expectedTables = map[string]util.FakeTable{
-					"nat":    {},
-					"filter": {},
-					"mangle": {},
-				}
-
-				Eventually(func() error {
-					f6 := iptV6.(*util.FakeIPTables)
-					return f6.MatchState(expectedTables, nil)
-				}, "2s").Should(Succeed())
-
-				Eventually(func() error {
-					expectedNFT := nftablesRulesBase
 					return nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				}, "2s").Should(Succeed())
 
@@ -2382,7 +1793,7 @@ var _ = Describe("Node Operations", func() {
 	})
 
 	Context("on add and delete", func() {
-		It("manages iptables rules with ExternalIP", func() {
+		It("manages nftables rules with ExternalIP", func() {
 			app.Action = func(*cli.Context) error {
 				// Depending on the order of informer event processing the initial
 				// Service might be "added" once or twice.  Take that into account.
@@ -2422,43 +1833,9 @@ var _ = Describe("Node Operations", func() {
 					return fExec.CalledMatchesExpectedAtLeastN(minNFakeCommands)
 				}, "2s").Should(BeTrue(), fExec.ErrorDesc)
 
-				expectedTables := map[string]util.FakeTable{
-					"nat": {
-						"PREROUTING": []string{
-							"-j OVN-KUBE-ETP",
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-						},
-						"OUTPUT": []string{
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-EXTERNALIP": []string{
-							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v",
-								service.Spec.Ports[0].Protocol, externalIP, service.Spec.Ports[0].Port,
-								service.Spec.ClusterIP, service.Spec.Ports[0].Port),
-						},
-						"OVN-KUBE-NODEPORT": []string{},
-						"OVN-KUBE-ETP":      []string{},
-						"OVN-KUBE-ITP":      []string{},
-					},
-					"filter": {},
-					"mangle": {
-						"OUTPUT": []string{
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-ITP": []string{},
-					},
-				}
-
+				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
+				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes external-ips-v4 { %s . %s . %d : %s . %d }\n", externalIP, strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port)
 				Eventually(func() error {
-					f4 := iptV4.(*util.FakeIPTables)
-					return f4.MatchState(expectedTables, nil)
-				}).Should(Succeed())
-
-				Eventually(func() error {
-					expectedNFT := nftablesRulesBase
 					return nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				}).Should(Succeed())
 
@@ -2466,39 +1843,8 @@ var _ = Describe("Node Operations", func() {
 				Expect(fakeClient.KubeClient.CoreV1().Services(service.Namespace).Delete(
 					context.Background(), service.Name, metav1.DeleteOptions{})).To(Succeed())
 
-				expectedTables = map[string]util.FakeTable{
-					"nat": {
-						"OVN-KUBE-EXTERNALIP": []string{},
-						"OVN-KUBE-NODEPORT":   []string{},
-						"PREROUTING": []string{
-							"-j OVN-KUBE-ETP",
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-						},
-						"OUTPUT": []string{
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-ETP": []string{},
-						"OVN-KUBE-ITP": []string{},
-					},
-					"filter": {},
-					"mangle": {
-						"OUTPUT": []string{
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-ITP": []string{},
-					},
-				}
-
+				expectedNFT = nftablesRulesBase + nftablesRulesGatewayServices
 				Eventually(func() error {
-					f4 := iptV4.(*util.FakeIPTables)
-					return f4.MatchState(expectedTables, nil)
-				}, "2s").Should(Succeed())
-
-				Eventually(func() error {
-					expectedNFT := nftablesRulesBase
 					return nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				}, "2s").Should(Succeed())
 
@@ -2619,7 +1965,7 @@ var _ = Describe("Node Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("manages iptables rules with ExternalIP through retry logic", func() {
+		It("manages nftables rules with ExternalIP through retry logic", func() {
 			app.Action = func(*cli.Context) error {
 				var nodePortWatcherRetry *retry.RetryFramework
 				var err error
@@ -2671,39 +2017,14 @@ var _ = Describe("Node Operations", func() {
 					context.TODO(), &service, metav1.CreateOptions{})
 				Expect(err).NotTo(HaveOccurred())
 
-				// expected ip tables with no external IP set
-				expectedTables := map[string]util.FakeTable{
-					"nat": {
-						"PREROUTING": []string{
-							"-j OVN-KUBE-ETP",
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-						},
-						"OUTPUT": []string{
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-EXTERNALIP": []string{},
-						"OVN-KUBE-NODEPORT":   []string{},
-						"OVN-KUBE-ETP":        []string{},
-						"OVN-KUBE-ITP":        []string{},
-					},
-					"filter": {},
-					"mangle": {
-						"OUTPUT": []string{
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-ITP": []string{},
-					},
-				}
 				By("verify that a new retry entry for this service exists")
 				key, err := retry.GetResourceKey(&service)
 				Expect(err).NotTo(HaveOccurred())
 				retry.CheckRetryObjectEventually(key, true, nodePortWatcherRetry)
-				// check iptables
-				f4 := iptV4.(*util.FakeIPTables)
-				err = f4.MatchState(expectedTables, nil)
+
+				// check nftables
+				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
+				err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				Expect(err).NotTo(HaveOccurred())
 
 				// HACK: Fix the service by setting a correct external IP address in newObj field
@@ -2720,16 +2041,10 @@ var _ = Describe("Node Operations", func() {
 				nodePortWatcherRetry.RequestRetryObjs()
 				retry.CheckRetryObjectEventually(key, false, nodePortWatcherRetry) // entry should be gone
 
-				// now expect ip tables to show the external IP
-				ovn_kube_external_ip_field := []string{
-					fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v",
-						service.Spec.Ports[0].Protocol, goodExternalIP, service.Spec.Ports[0].Port,
-						service.Spec.ClusterIP, service.Spec.Ports[0].Port)}
-				expectedTables["nat"]["OVN-KUBE-EXTERNALIP"] = ovn_kube_external_ip_field
-				Eventually(func(g Gomega) {
-					f4 := iptV4.(*util.FakeIPTables)
-					err = f4.MatchState(expectedTables, nil)
-					g.Expect(err).NotTo(HaveOccurred())
+				// now expect nftables to show the external IP
+				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes external-ips-v4 { %s . %s . %d : %s . %d }\n", goodExternalIP, strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port)
+				Eventually(func() error {
+					return nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				}).Should(Succeed())
 
 				// TODO Make delete operation fail, check retry entry, run a successful delete
@@ -2739,7 +2054,7 @@ var _ = Describe("Node Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("manages iptables rules for NodePort", func() {
+		It("manages nftables rules for NodePort", func() {
 			app.Action = func(*cli.Context) error {
 				nodePort := int32(38034)
 
@@ -2771,41 +2086,9 @@ var _ = Describe("Node Operations", func() {
 				Expect(startNodePortWatcher(fNPW, fakeClient)).To(Succeed())
 				Eventually(fExec.CalledMatchesExpected).Should(BeTrue(), fExec.ErrorDesc)
 
-				expectedTables := map[string]util.FakeTable{
-					"nat": {
-						"PREROUTING": []string{
-							"-j OVN-KUBE-ETP",
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-						},
-						"OUTPUT": []string{
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-NODEPORT": []string{
-							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, nodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
-						},
-						"OVN-KUBE-EXTERNALIP": []string{},
-						"OVN-KUBE-ETP":        []string{},
-						"OVN-KUBE-ITP":        []string{},
-					},
-					"filter": {},
-					"mangle": {
-						"OUTPUT": []string{
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-ITP": []string{},
-					},
-				}
-
+				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
+				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes nodeports-v4 { %s . %d : %s . %d }\n", strings.ToLower(string(service.Spec.Ports[0].Protocol)), nodePort, service.Spec.ClusterIPs[0], service.Spec.Ports[0].Port)
 				Eventually(func() error {
-					f4 := iptV4.(*util.FakeIPTables)
-					return f4.MatchState(expectedTables, nil)
-				}).Should(Succeed())
-
-				Eventually(func() error {
-					expectedNFT := nftablesRulesBase
 					return nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				}).Should(Succeed())
 
@@ -2813,39 +2096,8 @@ var _ = Describe("Node Operations", func() {
 				Expect(fakeClient.KubeClient.CoreV1().Services(service.Namespace).Delete(
 					context.Background(), service.Name, metav1.DeleteOptions{})).To(Succeed())
 
-				expectedTables = map[string]util.FakeTable{
-					"nat": {
-						"OVN-KUBE-EXTERNALIP": []string{},
-						"OVN-KUBE-NODEPORT":   []string{},
-						"PREROUTING": []string{
-							"-j OVN-KUBE-ETP",
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-						},
-						"OUTPUT": []string{
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-ETP": []string{},
-						"OVN-KUBE-ITP": []string{},
-					},
-					"filter": {},
-					"mangle": {
-						"OUTPUT": []string{
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-ITP": []string{},
-					},
-				}
-
+				expectedNFT = nftablesRulesBase + nftablesRulesGatewayServices
 				Eventually(func() error {
-					f4 := iptV4.(*util.FakeIPTables)
-					return f4.MatchState(expectedTables, nil)
-				}, "2s").Should(Succeed())
-
-				Eventually(func() error {
-					expectedNFT := nftablesRulesBase
 					return nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				}, "2s").Should(Succeed())
 
@@ -2855,7 +2107,7 @@ var _ = Describe("Node Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("manages iptables rules and openflows for NodePort backed by ovn-k pods where ETP=local, LGW", func() {
+		It("manages nftables rules and openflows for NodePort backed by ovn-k pods where ETP=local, LGW", func() {
 			app.Action = func(*cli.Context) error {
 				config.Gateway.Mode = config.GatewayModeLocal
 				epPortName := "https"
@@ -2906,41 +2158,10 @@ var _ = Describe("Node Operations", func() {
 				fNPW.watchFactory = wf
 				Expect(startNodePortWatcher(fNPW, fakeClient)).To(Succeed())
 
-				expectedTables := map[string]util.FakeTable{
-					"nat": {
-						"PREROUTING": []string{
-							"-j OVN-KUBE-ETP",
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-						},
-						"OUTPUT": []string{
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-NODEPORT": []string{
-							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
-						},
-						"OVN-KUBE-EXTERNALIP": []string{},
-						"OVN-KUBE-ETP": []string{
-							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, config.Gateway.MasqueradeIPs.V4HostETPLocalMasqueradeIP.String(), service.Spec.Ports[0].NodePort),
-						},
-						"OVN-KUBE-ITP": []string{},
-					},
-					"filter": {},
-					"mangle": {
-						"OUTPUT": []string{
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-ITP": []string{},
-					},
-				}
-
-				f4 := iptV4.(*util.FakeIPTables)
-				Expect(f4.MatchState(expectedTables, nil)).To(Succeed())
-
-				expectedNFT := nftablesRulesBase
+				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
 				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes mgmtport-no-snat-nodeports { tcp . %v }\n", service.Spec.Ports[0].NodePort)
+				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes nodeports-v4 { %s . %d : %s . %d }\n", strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port)
+				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes nodeports-etp-local-v4 { %s . %d : %s . %d }\n", strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].NodePort, config.Gateway.MasqueradeIPs.V4HostETPLocalMasqueradeIP.String(), service.Spec.Ports[0].NodePort)
 				Expect(nodenft.MatchNFTRules(expectedNFT, nft.Dump())).To(Succeed())
 
 				flows := fNPW.ofm.getFlowsByKey("NodePort_namespace1_service1_tcp_31111")
@@ -2950,39 +2171,8 @@ var _ = Describe("Node Operations", func() {
 				Expect(fakeClient.KubeClient.CoreV1().Services(service.Namespace).Delete(
 					context.Background(), service.Name, metav1.DeleteOptions{})).To(Succeed())
 
-				expectedTables = map[string]util.FakeTable{
-					"nat": {
-						"OVN-KUBE-EXTERNALIP": []string{},
-						"OVN-KUBE-NODEPORT":   []string{},
-						"PREROUTING": []string{
-							"-j OVN-KUBE-ETP",
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-						},
-						"OUTPUT": []string{
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-ETP": []string{},
-						"OVN-KUBE-ITP": []string{},
-					},
-					"filter": {},
-					"mangle": {
-						"OUTPUT": []string{
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-ITP": []string{},
-					},
-				}
-
+				expectedNFT = nftablesRulesBase + nftablesRulesGatewayServices
 				Eventually(func() error {
-					f4 := iptV4.(*util.FakeIPTables)
-					return f4.MatchState(expectedTables, nil)
-				}, "2s").Should(Succeed())
-
-				Eventually(func() error {
-					expectedNFT = nftablesRulesBase
 					return nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				}, "2s").Should(Succeed())
 
@@ -2996,7 +2186,7 @@ var _ = Describe("Node Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("manages iptables rules and openflows for NodePort backed by ovn-k pods where ETP=local, SGW", func() {
+		It("manages nftables rules and openflows for NodePort backed by ovn-k pods where ETP=local, SGW", func() {
 			app.Action = func(*cli.Context) error {
 				config.Gateway.Mode = config.GatewayModeShared
 				epPortName := "https"
@@ -3048,47 +2238,17 @@ var _ = Describe("Node Operations", func() {
 				fNPW.watchFactory = wf
 				Expect(startNodePortWatcher(fNPW, fakeClient)).To(Succeed())
 
-				expectedTables := map[string]util.FakeTable{
-					"nat": {
-						"PREROUTING": []string{
-							"-j OVN-KUBE-ETP",
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-						},
-						"OUTPUT": []string{
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-NODEPORT": []string{
-							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
-						},
-						"OVN-KUBE-EXTERNALIP": []string{},
-						"OVN-KUBE-ETP":        []string{},
-						"OVN-KUBE-ITP":        []string{},
-					},
-					"filter": {},
-					"mangle": {
-						"OUTPUT": []string{
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-ITP": []string{},
-					},
-				}
+				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
+				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes mgmtport-no-snat-nodeports { tcp . %v }\n", service.Spec.Ports[0].NodePort)
+				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes nodeports-v4 { %s . %d : %s . %d }\n", strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port)
+				Expect(nodenft.MatchNFTRules(expectedNFT, nft.Dump())).To(Succeed())
+
 				expectedFlows := []string{
 					// default
 					"cookie=0x453ae29bcbbc08bd, priority=110, in_port=eth0, tcp, tp_dst=31111, actions=output:patch-breth0_ov",
 					fmt.Sprintf("cookie=0x453ae29bcbbc08bd, priority=110, in_port=patch-breth0_ov, dl_src=%s, tcp, tp_src=31111, actions=output:eth0",
 						gwMAC),
 				}
-
-				f4 := iptV4.(*util.FakeIPTables)
-				Expect(f4.MatchState(expectedTables, nil)).To(Succeed())
-
-				expectedNFT := nftablesRulesBase
-				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes mgmtport-no-snat-nodeports { tcp . %v }\n", service.Spec.Ports[0].NodePort)
-				Expect(nodenft.MatchNFTRules(expectedNFT, nft.Dump())).To(Succeed())
-
 				flows := fNPW.ofm.getFlowsByKey("NodePort_namespace1_service1_tcp_31111")
 				Expect(flows).To(Equal(expectedFlows))
 
@@ -3096,39 +2256,8 @@ var _ = Describe("Node Operations", func() {
 				Expect(fakeClient.KubeClient.CoreV1().Services(service.Namespace).Delete(
 					context.Background(), service.Name, metav1.DeleteOptions{})).To(Succeed())
 
-				expectedTables = map[string]util.FakeTable{
-					"nat": {
-						"OVN-KUBE-EXTERNALIP": []string{},
-						"OVN-KUBE-NODEPORT":   []string{},
-						"PREROUTING": []string{
-							"-j OVN-KUBE-ETP",
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-						},
-						"OUTPUT": []string{
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-ETP": []string{},
-						"OVN-KUBE-ITP": []string{},
-					},
-					"filter": {},
-					"mangle": {
-						"OUTPUT": []string{
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-ITP": []string{},
-					},
-				}
-
+				expectedNFT = nftablesRulesBase + nftablesRulesGatewayServices
 				Eventually(func() error {
-					f4 = iptV4.(*util.FakeIPTables)
-					return f4.MatchState(expectedTables, nil)
-				}, "2s").Should(Succeed())
-
-				Eventually(func() error {
-					expectedNFT = nftablesRulesBase
 					return nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				}, "2s").Should(Succeed())
 
@@ -3142,7 +2271,7 @@ var _ = Describe("Node Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("manages iptables rules and openflows for NodePort backed by local-host-networked pods where ETP=local, LGW", func() {
+		It("manages nftables rules and openflows for NodePort backed by local-host-networked pods where ETP=local, LGW", func() {
 			app.Action = func(*cli.Context) error {
 				config.Gateway.Mode = config.GatewayModeLocal
 				outport := int32(443)
@@ -3199,46 +2328,16 @@ var _ = Describe("Node Operations", func() {
 				res := fNPW.nodeIPManager.cidrs.Has(fmt.Sprintf("%s/32", ep1.Addresses[0]))
 				Expect(res).To(BeTrue())
 
-				expectedTables := map[string]util.FakeTable{
-					"nat": {
-						"PREROUTING": []string{
-							"-j OVN-KUBE-ETP",
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-						},
-						"OUTPUT": []string{
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-NODEPORT": []string{
-							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
-						},
-						"OVN-KUBE-EXTERNALIP": []string{},
-						"OVN-KUBE-ETP":        []string{},
-						"OVN-KUBE-ITP":        []string{},
-					},
-					"filter": {},
-					"mangle": {
-						"OUTPUT": []string{
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-ITP": []string{},
-					},
-				}
+				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
+				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes nodeports-v4 { %s . %d : %s . %d }\n", strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port)
+				Expect(nodenft.MatchNFTRules(expectedNFT, nft.Dump())).To(Succeed())
+
 				expectedFlows := []string{
 					"cookie=0x453ae29bcbbc08bd, priority=110, in_port=eth0, tcp, tp_dst=31111, actions=ct(commit,zone=64003,nat(dst=10.244.0.1:443),table=6)",
 					"cookie=0xe745ecf105, priority=110, table=6, actions=output:LOCAL",
 					"cookie=0x8ba455e19afe30d1, priority=110, in_port=LOCAL, tcp, tp_src=443, actions=ct(zone=64003 nat,table=7)",
 					"cookie=0xe745ecf105, priority=110, table=7, actions=output:eth0",
 				}
-
-				f4 := iptV4.(*util.FakeIPTables)
-				Expect(f4.MatchState(expectedTables, nil)).To(Succeed())
-
-				expectedNFT := nftablesRulesBase
-				Expect(nodenft.MatchNFTRules(expectedNFT, nft.Dump())).To(Succeed())
-
 				flows := fNPW.ofm.getFlowsByKey("NodePort_namespace1_service1_tcp_31111")
 				Expect(flows).To(Equal(expectedFlows))
 
@@ -3246,39 +2345,8 @@ var _ = Describe("Node Operations", func() {
 				Expect(fakeClient.KubeClient.CoreV1().Services(service.Namespace).Delete(
 					context.Background(), service.Name, metav1.DeleteOptions{})).To(Succeed())
 
-				expectedTables = map[string]util.FakeTable{
-					"nat": {
-						"OVN-KUBE-EXTERNALIP": []string{},
-						"OVN-KUBE-NODEPORT":   []string{},
-						"PREROUTING": []string{
-							"-j OVN-KUBE-ETP",
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-						},
-						"OUTPUT": []string{
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-ITP": []string{},
-						"OVN-KUBE-ETP": []string{},
-					},
-					"filter": {},
-					"mangle": {
-						"OUTPUT": []string{
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-ITP": []string{},
-					},
-				}
-
+				expectedNFT = nftablesRulesBase + nftablesRulesGatewayServices
 				Eventually(func() error {
-					f4 = iptV4.(*util.FakeIPTables)
-					return f4.MatchState(expectedTables, nil)
-				}, "2s").Should(Succeed())
-
-				Eventually(func() error {
-					expectedNFT = nftablesRulesBase
 					return nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				}, "2s").Should(Succeed())
 
@@ -3292,7 +2360,7 @@ var _ = Describe("Node Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("manages iptables rules and openflows for NodePort backed by ovn-k pods where ITP=local and ETP=local", func() {
+		It("manages nftables rules and openflows for NodePort backed by ovn-k pods where ITP=local and ETP=local", func() {
 			app.Action = func(*cli.Context) error {
 				config.Gateway.Mode = config.GatewayModeShared
 				epPortName := "https"
@@ -3341,49 +2409,18 @@ var _ = Describe("Node Operations", func() {
 				fNPW.watchFactory = wf
 				Expect(startNodePortWatcher(fNPW, fakeClient)).To(Succeed())
 
-				expectedTables := map[string]util.FakeTable{
-					"nat": {
-						"PREROUTING": []string{
-							"-j OVN-KUBE-ETP",
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-						},
-						"OUTPUT": []string{
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-NODEPORT": []string{
-							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
-						},
-						"OVN-KUBE-EXTERNALIP": []string{},
-						"OVN-KUBE-ITP":        []string{},
-						"OVN-KUBE-ETP":        []string{},
-					},
-					"filter": {},
-					"mangle": {
-						"OUTPUT": []string{
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-ITP": []string{
-							fmt.Sprintf("-p %s -d %s --dport %d -j MARK --set-xmark %s", service.Spec.Ports[0].Protocol, service.Spec.ClusterIP, service.Spec.Ports[0].Port, types.OVNKubeITPMark),
-						},
-					},
-				}
+				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
+				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes mgmtport-no-snat-nodeports { tcp . %v }\n", service.Spec.Ports[0].NodePort)
+				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes nodeports-v4 { %s . %d : %s . %d }\n", strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port)
+				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes itp-services-to-mark-v4 { %s . %s . %d }\n", service.Spec.ClusterIP, strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].Port)
+				Expect(nodenft.MatchNFTRules(expectedNFT, nft.Dump())).To(Succeed())
+
 				expectedFlows := []string{
 					// default
 					"cookie=0x453ae29bcbbc08bd, priority=110, in_port=eth0, tcp, tp_dst=31111, actions=output:patch-breth0_ov",
 					fmt.Sprintf("cookie=0x453ae29bcbbc08bd, priority=110, in_port=patch-breth0_ov, dl_src=%s, tcp, tp_src=31111, actions=output:eth0",
 						gwMAC),
 				}
-
-				f4 := iptV4.(*util.FakeIPTables)
-				Expect(f4.MatchState(expectedTables, nil)).To(Succeed())
-
-				expectedNFT := nftablesRulesBase
-				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes mgmtport-no-snat-nodeports { tcp . %v }\n", service.Spec.Ports[0].NodePort)
-				Expect(nodenft.MatchNFTRules(expectedNFT, nft.Dump())).To(Succeed())
-
 				flows := fNPW.ofm.getFlowsByKey("NodePort_namespace1_service1_tcp_31111")
 				Expect(flows).To(Equal(expectedFlows))
 
@@ -3391,39 +2428,8 @@ var _ = Describe("Node Operations", func() {
 				Expect(fakeClient.KubeClient.CoreV1().Services(service.Namespace).Delete(
 					context.Background(), service.Name, metav1.DeleteOptions{})).To(Succeed())
 
-				expectedTables = map[string]util.FakeTable{
-					"nat": {
-						"OVN-KUBE-EXTERNALIP": []string{},
-						"OVN-KUBE-NODEPORT":   []string{},
-						"OVN-KUBE-ITP":        []string{},
-						"PREROUTING": []string{
-							"-j OVN-KUBE-ETP",
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-						},
-						"OUTPUT": []string{
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-ETP": []string{},
-					},
-					"filter": {},
-					"mangle": {
-						"OUTPUT": []string{
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-ITP": []string{},
-					},
-				}
-
+				expectedNFT = nftablesRulesBase + nftablesRulesGatewayServices
 				Eventually(func() error {
-					f4 = iptV4.(*util.FakeIPTables)
-					return f4.MatchState(expectedTables, nil)
-				}, "2s").Should(Succeed())
-
-				Eventually(func() error {
-					expectedNFT = nftablesRulesBase
 					return nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				}, "2s").Should(Succeed())
 
@@ -3437,7 +2443,7 @@ var _ = Describe("Node Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("manages iptables rules and openflows for NodePort backed by local-host-networked pods where ETP=local and ITP=local", func() {
+		It("manages nftables rules and openflows for NodePort backed by local-host-networked pods where ETP=local and ITP=local", func() {
 			app.Action = func(*cli.Context) error {
 				config.Gateway.Mode = config.GatewayModeLocal
 				epPortName := "https"
@@ -3491,87 +2497,26 @@ var _ = Describe("Node Operations", func() {
 				// to ensure the endpoint is local-host-networked
 				res := fNPW.nodeIPManager.cidrs.Has(fmt.Sprintf("%s/32", endpointSlice.Endpoints[0].Addresses[0]))
 				Expect(res).To(BeTrue())
-				expectedTables := map[string]util.FakeTable{
-					"nat": {
-						"PREROUTING": []string{
-							"-j OVN-KUBE-ETP",
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-						},
-						"OUTPUT": []string{
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-NODEPORT": []string{
-							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
-						},
-						"OVN-KUBE-EXTERNALIP": []string{},
-						"OVN-KUBE-ITP": []string{
-							fmt.Sprintf("-p %s -d %s --dport %d -j REDIRECT --to-port %d", service.Spec.Ports[0].Protocol, service.Spec.ClusterIP, service.Spec.Ports[0].Port, int32(service.Spec.Ports[0].TargetPort.IntValue())),
-						},
-						"OVN-KUBE-ETP": []string{},
-					},
-					"filter": {},
-					"mangle": {
-						"OUTPUT": []string{
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-ITP": []string{},
-					},
-				}
+
+				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
+				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes nodeports-v4 { %s . %d : %s . %d }\n", strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port)
+				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes itp-services-to-redirect-v4 { %s . %s . %d : %d }\n", service.Spec.ClusterIP, strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].Port, service.Spec.Ports[0].TargetPort.IntValue())
+				Expect(nodenft.MatchNFTRules(expectedNFT, nft.Dump())).To(Succeed())
+
 				expectedFlows := []string{
 					"cookie=0x453ae29bcbbc08bd, priority=110, in_port=eth0, tcp, tp_dst=31111, actions=ct(commit,zone=64003,nat(dst=10.244.0.1:443),table=6)",
 					"cookie=0xe745ecf105, priority=110, table=6, actions=output:LOCAL",
 					"cookie=0x8ba455e19afe30d1, priority=110, in_port=LOCAL, tcp, tp_src=443, actions=ct(zone=64003 nat,table=7)",
 					"cookie=0xe745ecf105, priority=110, table=7, actions=output:eth0",
 				}
-
-				f4 := iptV4.(*util.FakeIPTables)
-				Expect(f4.MatchState(expectedTables, nil)).To(Succeed())
-
-				expectedNFT := nftablesRulesBase
-				Expect(nodenft.MatchNFTRules(expectedNFT, nft.Dump())).To(Succeed())
-
 				Expect(fNPW.ofm.getFlowsByKey("NodePort_namespace1_service1_tcp_31111")).To(Equal(expectedFlows))
 
 				addConntrackMocks(netlinkMock, []ctFilterDesc{{"10.129.0.2", 8080, corev1.ProtocolTCP, netlink.ConntrackOrigDstIP}, {"192.168.18.15", 31111, corev1.ProtocolTCP, netlink.ConntrackOrigDstIP}})
 				Expect(fakeClient.KubeClient.CoreV1().Services(service.Namespace).Delete(
 					context.Background(), service.Name, metav1.DeleteOptions{})).To(Succeed())
 
-				expectedTables = map[string]util.FakeTable{
-					"nat": {
-						"OVN-KUBE-EXTERNALIP": []string{},
-						"OVN-KUBE-NODEPORT":   []string{},
-						"PREROUTING": []string{
-							"-j OVN-KUBE-ETP",
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-						},
-						"OUTPUT": []string{
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-ITP": []string{},
-						"OVN-KUBE-ETP": []string{},
-					},
-					"filter": {},
-					"mangle": {
-						"OUTPUT": []string{
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-ITP": []string{},
-					},
-				}
-
+				expectedNFT = nftablesRulesBase + nftablesRulesGatewayServices
 				Eventually(func() error {
-					f4 := iptV4.(*util.FakeIPTables)
-					return f4.MatchState(expectedTables, nil)
-				}, "2s").Should(Succeed())
-
-				Eventually(func() error {
-					expectedNFT = nftablesRulesBase
 					return nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				}, "2s").Should(Succeed())
 
@@ -3596,6 +2541,7 @@ var _ = Describe("Node Operations", func() {
 				config.IPv4Mode = false
 				config.IPv6Mode = true
 				config.Gateway.DisableForwarding = true
+				_, iptV6 := util.SetFakeIPTablesHelpers()
 
 				stopChan := make(chan struct{})
 				fakeClient := util.GetOVNClientset().GetNodeClientset()
@@ -3612,22 +2558,7 @@ var _ = Describe("Node Operations", func() {
 				Expect(configureGlobalForwarding()).To(Succeed())
 
 				expectedTables := map[string]util.FakeTable{
-					"nat": {
-						"PREROUTING": []string{
-							"-j OVN-KUBE-ETP",
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-						},
-						"OUTPUT": []string{
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-NODEPORT":   []string{},
-						"OVN-KUBE-EXTERNALIP": []string{},
-						"OVN-KUBE-ETP":        []string{},
-						"OVN-KUBE-ITP":        []string{},
-					},
+					"nat": {},
 					"filter": {
 						"FORWARD": []string{
 							"-d fd69::1 -j ACCEPT",
@@ -3638,12 +2569,7 @@ var _ = Describe("Node Operations", func() {
 							"-s fd00:10:1::/48 -j ACCEPT",
 						},
 					},
-					"mangle": {
-						"OUTPUT": []string{
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-ITP": []string{},
-					},
+					"mangle": {},
 				}
 				f6 := iptV6.(*util.FakeIPTables)
 				err = f6.MatchState(expectedTables, map[util.FakePolicyKey]string{{
@@ -3659,31 +2585,11 @@ var _ = Describe("Node Operations", func() {
 				Expect(startNodePortWatcher(fNPW, fakeClient)).To(Succeed())
 
 				expectedTables = map[string]util.FakeTable{
-					"nat": {
-						"PREROUTING": []string{
-							"-j OVN-KUBE-ETP",
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-						},
-						"OUTPUT": []string{
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-NODEPORT":   []string{},
-						"OVN-KUBE-EXTERNALIP": []string{},
-						"OVN-KUBE-ETP":        []string{},
-						"OVN-KUBE-ITP":        []string{},
-					},
+					"nat": {},
 					"filter": {
 						"FORWARD": []string{},
 					},
-					"mangle": {
-						"OUTPUT": []string{
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-ITP": []string{},
-					},
+					"mangle": {},
 				}
 
 				f6 = iptV6.(*util.FakeIPTables)
@@ -3699,6 +2605,8 @@ var _ = Describe("Node Operations", func() {
 		})
 
 		ovntest.OnSupportedPlatformsIt("updates the default FORWARD policy correctly according to the config", func() {
+			iptV4, iptV6 := util.SetFakeIPTablesHelpers()
+
 			expectedTablesEmpty := map[string]util.FakeTable{
 				"filter": {
 					"FORWARD": []string{},

--- a/go-controller/pkg/node/gateway_localnet_linux_test.go
+++ b/go-controller/pkg/node/gateway_localnet_linux_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"strings"
 	"sync"
 	"sync/atomic"
 
@@ -525,9 +526,7 @@ var _ = Describe("Node Operations", func() {
 							"-j OVN-KUBE-NODEPORT",
 							"-j OVN-KUBE-ITP",
 						},
-						"OVN-KUBE-NODEPORT": []string{
-							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
-						},
+						"OVN-KUBE-NODEPORT":   []string{},
 						"OVN-KUBE-EXTERNALIP": []string{},
 						"OVN-KUBE-ETP":        []string{},
 						"OVN-KUBE-ITP":        []string{},
@@ -546,6 +545,7 @@ var _ = Describe("Node Operations", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
+				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes nodeports-v4 { %s . %d : %s . %d }\n", strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port)
 				return nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 			}
 			err := app.Run([]string{app.Name})
@@ -613,14 +613,10 @@ var _ = Describe("Node Operations", func() {
 							"-j OVN-KUBE-NODEPORT",
 							"-j OVN-KUBE-ITP",
 						},
-						"OVN-KUBE-NODEPORT": []string{
-							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
-						},
+						"OVN-KUBE-NODEPORT":   []string{},
 						"OVN-KUBE-EXTERNALIP": []string{},
-						"OVN-KUBE-ETP": []string{
-							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, config.Gateway.MasqueradeIPs.V4HostETPLocalMasqueradeIP.String(), service.Spec.Ports[0].NodePort),
-						},
-						"OVN-KUBE-ITP": []string{},
+						"OVN-KUBE-ETP":        []string{},
+						"OVN-KUBE-ITP":        []string{},
 					},
 					"filter": {},
 					"mangle": {
@@ -637,6 +633,8 @@ var _ = Describe("Node Operations", func() {
 
 				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
 				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes mgmtport-no-snat-nodeports { tcp . %v }\n", service.Spec.Ports[0].NodePort)
+				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes nodeports-v4 { %s . %d : %s . %d }\n", strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port)
+				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes nodeports-etp-local-v4 { %s . %d : %s . %d }\n", strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].NodePort, config.Gateway.MasqueradeIPs.V4HostETPLocalMasqueradeIP.String(), service.Spec.Ports[0].NodePort)
 				err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				Expect(err).NotTo(HaveOccurred())
 
@@ -713,9 +711,7 @@ var _ = Describe("Node Operations", func() {
 							"-j OVN-KUBE-NODEPORT",
 							"-j OVN-KUBE-ITP",
 						},
-						"OVN-KUBE-NODEPORT": []string{
-							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
-						},
+						"OVN-KUBE-NODEPORT": []string{},
 						"OVN-KUBE-EXTERNALIP": []string{
 							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Status.LoadBalancer.Ingress[0].IP, service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
 							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, externalIP, service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
@@ -737,6 +733,7 @@ var _ = Describe("Node Operations", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
+				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes nodeports-v4 { %s . %d : %s . %d }\n", strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port)
 				return nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 			}
 			err := app.Run([]string{app.Name})
@@ -808,9 +805,7 @@ var _ = Describe("Node Operations", func() {
 							"-j OVN-KUBE-NODEPORT",
 							"-j OVN-KUBE-ITP",
 						},
-						"OVN-KUBE-NODEPORT": []string{
-							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
-						},
+						"OVN-KUBE-NODEPORT": []string{},
 						"OVN-KUBE-EXTERNALIP": []string{
 							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Status.LoadBalancer.Ingress[0].IP, service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
 							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, externalIP, service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
@@ -818,7 +813,6 @@ var _ = Describe("Node Operations", func() {
 						"OVN-KUBE-ETP": []string{
 							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Status.LoadBalancer.Ingress[0].IP, service.Spec.Ports[0].Port, config.Gateway.MasqueradeIPs.V4HostETPLocalMasqueradeIP.String(), service.Spec.Ports[0].NodePort),
 							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, externalIP, service.Spec.Ports[0].Port, config.Gateway.MasqueradeIPs.V4HostETPLocalMasqueradeIP.String(), service.Spec.Ports[0].NodePort),
-							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, config.Gateway.MasqueradeIPs.V4HostETPLocalMasqueradeIP.String(), service.Spec.Ports[0].NodePort),
 						},
 						"OVN-KUBE-ITP": []string{},
 					},
@@ -836,6 +830,8 @@ var _ = Describe("Node Operations", func() {
 
 				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
 				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes mgmtport-no-snat-nodeports { tcp . %v }\n", service.Spec.Ports[0].NodePort)
+				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes nodeports-v4 { %s . %d : %s . %d }\n", strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port)
+				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes nodeports-etp-local-v4 { %s . %d : %s . %d }\n", strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].NodePort, config.Gateway.MasqueradeIPs.V4HostETPLocalMasqueradeIP.String(), service.Spec.Ports[0].NodePort)
 				err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				Expect(err).NotTo(HaveOccurred())
 
@@ -1252,9 +1248,7 @@ var _ = Describe("Node Operations", func() {
 							"-j OVN-KUBE-NODEPORT",
 							"-j OVN-KUBE-ITP",
 						},
-						"OVN-KUBE-NODEPORT": []string{
-							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
-						},
+						"OVN-KUBE-NODEPORT": []string{},
 						"OVN-KUBE-EXTERNALIP": []string{
 							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Status.LoadBalancer.Ingress[0].IP, service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
 							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, externalIP, service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
@@ -1275,6 +1269,7 @@ var _ = Describe("Node Operations", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
+				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes nodeports-v4 { %s . %d : %s . %d }\n", strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port)
 				err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				Expect(err).NotTo(HaveOccurred())
 
@@ -1361,9 +1356,7 @@ var _ = Describe("Node Operations", func() {
 							"-j OVN-KUBE-NODEPORT",
 							"-j OVN-KUBE-ITP",
 						},
-						"OVN-KUBE-NODEPORT": []string{
-							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
-						},
+						"OVN-KUBE-NODEPORT": []string{},
 						"OVN-KUBE-EXTERNALIP": []string{
 							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Status.LoadBalancer.Ingress[0].IP, service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
 							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, externalIP, service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
@@ -1388,6 +1381,7 @@ var _ = Describe("Node Operations", func() {
 
 				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
 				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes mgmtport-no-snat-nodeports { tcp . %v }\n", service.Spec.Ports[0].NodePort)
+				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes nodeports-v4 { %s . %d : %s . %d }\n", strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port)
 				err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				Expect(err).NotTo(HaveOccurred())
 
@@ -1507,13 +1501,7 @@ var _ = Describe("Node Operations", func() {
 							"-j OVN-KUBE-NODEPORT",
 							"-j OVN-KUBE-ITP",
 						},
-						"OVN-KUBE-NODEPORT": []string{
-							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v",
-								service.Spec.Ports[0].Protocol,
-								service.Spec.Ports[0].NodePort,
-								service.Spec.ClusterIP,
-								service.Spec.Ports[0].Port),
-						},
+						"OVN-KUBE-NODEPORT": []string{},
 						"OVN-KUBE-EXTERNALIP": []string{
 							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v",
 								service.Spec.Ports[0].Protocol,
@@ -1544,6 +1532,7 @@ var _ = Describe("Node Operations", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
+				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes nodeports-v4 { %s . %d : %s . %d }\n", strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port)
 				err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				Expect(err).NotTo(HaveOccurred())
 
@@ -1643,9 +1632,7 @@ var _ = Describe("Node Operations", func() {
 							"-j OVN-KUBE-NODEPORT",
 							"-j OVN-KUBE-ITP",
 						},
-						"OVN-KUBE-NODEPORT": []string{
-							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, service.Spec.ClusterIPs[0], service.Spec.Ports[0].Port),
-						},
+						"OVN-KUBE-NODEPORT":   []string{},
 						"OVN-KUBE-EXTERNALIP": []string{},
 						"OVN-KUBE-ETP":        []string{},
 						"OVN-KUBE-ITP":        []string{},
@@ -1664,11 +1651,7 @@ var _ = Describe("Node Operations", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				expectedTables6 := map[string]util.FakeTable{
-					"nat": {
-						"OVN-KUBE-NODEPORT": []string{
-							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination [%s]:%v", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, service.Spec.ClusterIPs[1], service.Spec.Ports[0].Port),
-						},
-					},
+					"nat":    {},
 					"filter": {},
 					"mangle": {},
 				}
@@ -1677,6 +1660,8 @@ var _ = Describe("Node Operations", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
+				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes nodeports-v4 { %s . %d : %s . %d }\n", strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].NodePort, service.Spec.ClusterIPs[0], service.Spec.Ports[0].Port)
+				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes nodeports-v6 { %s . %d : %s . %d }\n", strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].NodePort, service.Spec.ClusterIPs[1], service.Spec.Ports[0].Port)
 				err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				Expect(err).NotTo(HaveOccurred())
 
@@ -2786,9 +2771,7 @@ var _ = Describe("Node Operations", func() {
 							"-j OVN-KUBE-NODEPORT",
 							"-j OVN-KUBE-ITP",
 						},
-						"OVN-KUBE-NODEPORT": []string{
-							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, nodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
-						},
+						"OVN-KUBE-NODEPORT":   []string{},
 						"OVN-KUBE-EXTERNALIP": []string{},
 						"OVN-KUBE-ETP":        []string{},
 						"OVN-KUBE-ITP":        []string{},
@@ -2808,6 +2791,7 @@ var _ = Describe("Node Operations", func() {
 				}).Should(Succeed())
 
 				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
+				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes nodeports-v4 { %s . %d : %s . %d }\n", strings.ToLower(string(service.Spec.Ports[0].Protocol)), nodePort, service.Spec.ClusterIPs[0], service.Spec.Ports[0].Port)
 				Eventually(func() error {
 					return nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				}).Should(Succeed())
@@ -2921,14 +2905,10 @@ var _ = Describe("Node Operations", func() {
 							"-j OVN-KUBE-NODEPORT",
 							"-j OVN-KUBE-ITP",
 						},
-						"OVN-KUBE-NODEPORT": []string{
-							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
-						},
+						"OVN-KUBE-NODEPORT":   []string{},
 						"OVN-KUBE-EXTERNALIP": []string{},
-						"OVN-KUBE-ETP": []string{
-							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, config.Gateway.MasqueradeIPs.V4HostETPLocalMasqueradeIP.String(), service.Spec.Ports[0].NodePort),
-						},
-						"OVN-KUBE-ITP": []string{},
+						"OVN-KUBE-ETP":        []string{},
+						"OVN-KUBE-ITP":        []string{},
 					},
 					"filter": {},
 					"mangle": {
@@ -2944,6 +2924,8 @@ var _ = Describe("Node Operations", func() {
 
 				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
 				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes mgmtport-no-snat-nodeports { tcp . %v }\n", service.Spec.Ports[0].NodePort)
+				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes nodeports-v4 { %s . %d : %s . %d }\n", strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port)
+				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes nodeports-etp-local-v4 { %s . %d : %s . %d }\n", strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].NodePort, config.Gateway.MasqueradeIPs.V4HostETPLocalMasqueradeIP.String(), service.Spec.Ports[0].NodePort)
 				Expect(nodenft.MatchNFTRules(expectedNFT, nft.Dump())).To(Succeed())
 
 				flows := fNPW.ofm.getFlowsByKey("NodePort_namespace1_service1_tcp_31111")
@@ -3063,9 +3045,7 @@ var _ = Describe("Node Operations", func() {
 							"-j OVN-KUBE-NODEPORT",
 							"-j OVN-KUBE-ITP",
 						},
-						"OVN-KUBE-NODEPORT": []string{
-							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
-						},
+						"OVN-KUBE-NODEPORT":   []string{},
 						"OVN-KUBE-EXTERNALIP": []string{},
 						"OVN-KUBE-ETP":        []string{},
 						"OVN-KUBE-ITP":        []string{},
@@ -3083,6 +3063,7 @@ var _ = Describe("Node Operations", func() {
 
 				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
 				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes mgmtport-no-snat-nodeports { tcp . %v }\n", service.Spec.Ports[0].NodePort)
+				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes nodeports-v4 { %s . %d : %s . %d }\n", strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port)
 				Expect(nodenft.MatchNFTRules(expectedNFT, nft.Dump())).To(Succeed())
 
 				expectedFlows := []string{
@@ -3213,9 +3194,7 @@ var _ = Describe("Node Operations", func() {
 							"-j OVN-KUBE-NODEPORT",
 							"-j OVN-KUBE-ITP",
 						},
-						"OVN-KUBE-NODEPORT": []string{
-							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
-						},
+						"OVN-KUBE-NODEPORT":   []string{},
 						"OVN-KUBE-EXTERNALIP": []string{},
 						"OVN-KUBE-ETP":        []string{},
 						"OVN-KUBE-ITP":        []string{},
@@ -3232,6 +3211,7 @@ var _ = Describe("Node Operations", func() {
 				Expect(f4.MatchState(expectedTables, nil)).To(Succeed())
 
 				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
+				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes nodeports-v4 { %s . %d : %s . %d }\n", strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port)
 				Expect(nodenft.MatchNFTRules(expectedNFT, nft.Dump())).To(Succeed())
 
 				expectedFlows := []string{
@@ -3354,9 +3334,7 @@ var _ = Describe("Node Operations", func() {
 							"-j OVN-KUBE-NODEPORT",
 							"-j OVN-KUBE-ITP",
 						},
-						"OVN-KUBE-NODEPORT": []string{
-							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
-						},
+						"OVN-KUBE-NODEPORT":   []string{},
 						"OVN-KUBE-EXTERNALIP": []string{},
 						"OVN-KUBE-ITP":        []string{},
 						"OVN-KUBE-ETP":        []string{},
@@ -3376,6 +3354,7 @@ var _ = Describe("Node Operations", func() {
 
 				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
 				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes mgmtport-no-snat-nodeports { tcp . %v }\n", service.Spec.Ports[0].NodePort)
+				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes nodeports-v4 { %s . %d : %s . %d }\n", strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port)
 				Expect(nodenft.MatchNFTRules(expectedNFT, nft.Dump())).To(Succeed())
 
 				expectedFlows := []string{
@@ -3503,9 +3482,7 @@ var _ = Describe("Node Operations", func() {
 							"-j OVN-KUBE-NODEPORT",
 							"-j OVN-KUBE-ITP",
 						},
-						"OVN-KUBE-NODEPORT": []string{
-							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
-						},
+						"OVN-KUBE-NODEPORT":   []string{},
 						"OVN-KUBE-EXTERNALIP": []string{},
 						"OVN-KUBE-ITP": []string{
 							fmt.Sprintf("-p %s -d %s --dport %d -j REDIRECT --to-port %d", service.Spec.Ports[0].Protocol, service.Spec.ClusterIP, service.Spec.Ports[0].Port, int32(service.Spec.Ports[0].TargetPort.IntValue())),
@@ -3524,6 +3501,7 @@ var _ = Describe("Node Operations", func() {
 				Expect(f4.MatchState(expectedTables, nil)).To(Succeed())
 
 				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
+				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes nodeports-v4 { %s . %d : %s . %d }\n", strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port)
 				Expect(nodenft.MatchNFTRules(expectedNFT, nft.Dump())).To(Succeed())
 
 				expectedFlows := []string{

--- a/go-controller/pkg/node/gateway_localnet_linux_test.go
+++ b/go-controller/pkg/node/gateway_localnet_linux_test.go
@@ -282,7 +282,7 @@ var _ = Describe("Node Operations", func() {
 	})
 
 	Context("on startup", func() {
-		It("removes stale iptables rules while keeping remaining intact", func() {
+		It("removes stale nftables rules while keeping remaining intact", func() {
 			app.Action = func(*cli.Context) error {
 				// Create tables/chains/sets/etc
 				err := initGatewayNFTables()
@@ -360,7 +360,7 @@ var _ = Describe("Node Operations", func() {
 	})
 
 	Context("on add", func() {
-		It("inits iptables rules with ExternalIP", func() {
+		It("inits nftables rules with ExternalIP", func() {
 			app.Action = func(*cli.Context) error {
 				externalIP := "1.1.1.1"
 				fExec.AddFakeCmd(&ovntest.ExpectedCmd{
@@ -401,7 +401,7 @@ var _ = Describe("Node Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("inits iptables rules with NodePort", func() {
+		It("inits nftables rules with NodePort", func() {
 			app.Action = func(*cli.Context) error {
 
 				service := *newService("service1", "namespace1", "10.129.0.2",
@@ -446,7 +446,7 @@ var _ = Describe("Node Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("inits iptables rules and openflows with NodePort where ETP=local, LGW", func() {
+		It("inits nftables rules and openflows with NodePort where ETP=local, LGW", func() {
 			app.Action = func(*cli.Context) error {
 				config.Gateway.Mode = config.GatewayModeLocal
 				epPortName := "https"
@@ -511,7 +511,7 @@ var _ = Describe("Node Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("inits iptables rules with LoadBalancer", func() {
+		It("inits nftables rules with LoadBalancer", func() {
 			app.Action = func(*cli.Context) error {
 				// Depending on the order of informer event processing the initial
 				// Service might be "added" once or twice.  Take that into account.
@@ -573,7 +573,7 @@ var _ = Describe("Node Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("inits iptables rules and openflows with LoadBalancer where ETP=local, LGW mode", func() {
+		It("inits nftables rules and openflows with LoadBalancer where ETP=local, LGW mode", func() {
 			app.Action = func(*cli.Context) error {
 				externalIP := "1.1.1.1"
 				config.Gateway.Mode = config.GatewayModeLocal
@@ -656,7 +656,7 @@ var _ = Describe("Node Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("inits iptables rules and openflows with LoadBalancer where AllocateLoadBalancerNodePorts=False, ETP=local, LGW mode", func() {
+		It("inits nftables rules and openflows with LoadBalancer where AllocateLoadBalancerNodePorts=False, ETP=local, LGW mode", func() {
 			app.Action = func(*cli.Context) error {
 				externalIP := "1.1.1.1"
 				config.Gateway.Mode = config.GatewayModeLocal
@@ -775,7 +775,7 @@ var _ = Describe("Node Operations", func() {
 			Expect(app.Run([]string{app.Name})).To(Succeed())
 		})
 
-		It("inits iptables rules and openflows with named port and AllocateLoadBalancerNodePorts=False, ETP=local, LGW mode", func() {
+		It("inits nftables rules and openflows with named port and AllocateLoadBalancerNodePorts=False, ETP=local, LGW mode", func() {
 			app.Action = func(*cli.Context) error {
 				minNFakeCommands := nInitialFakeCommands + 1
 				fExec.AddRepeatedFakeCmd(&ovntest.ExpectedCmd{
@@ -876,7 +876,7 @@ var _ = Describe("Node Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("inits iptables rules and openflows with LoadBalancer where ETP=cluster, LGW mode", func() {
+		It("inits nftables rules and openflows with LoadBalancer where ETP=cluster, LGW mode", func() {
 			app.Action = func(*cli.Context) error {
 				externalIP := "1.1.1.1"
 				config.Gateway.Mode = config.GatewayModeLocal
@@ -955,7 +955,7 @@ var _ = Describe("Node Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("inits iptables rules and openflows with LoadBalancer where ETP=local, SGW mode", func() {
+		It("inits nftables rules and openflows with LoadBalancer where ETP=local, SGW mode", func() {
 			app.Action = func(*cli.Context) error {
 				externalIP := "1.1.1.1"
 				config.Gateway.Mode = config.GatewayModeShared
@@ -1049,7 +1049,7 @@ var _ = Describe("Node Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("inits iptables rules and openflows with LoadBalancer where ETP=local, SGW mode, with named ports, with "+
+		It("inits nftables rules and openflows with LoadBalancer where ETP=local, SGW mode, with named ports, with "+
 			"host networked pods and with external IP", func() {
 			app.Action = func(*cli.Context) error {
 				nodeName := "node"
@@ -1171,7 +1171,7 @@ var _ = Describe("Node Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("inits iptables rules with DualStack NodePort", func() {
+		It("inits nftables rules with DualStack NodePort", func() {
 			app.Action = func(*cli.Context) error {
 				nodePort := int32(31111)
 
@@ -1224,7 +1224,7 @@ var _ = Describe("Node Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("inits iptables rules for ExternalIP with DualStack", func() {
+		It("inits nftables rules for ExternalIP with DualStack", func() {
 			app.Action = func(*cli.Context) error {
 
 				// Depending on the order of informer event processing the initial
@@ -1281,7 +1281,7 @@ var _ = Describe("Node Operations", func() {
 	})
 
 	Context("on delete", func() {
-		It("deletes iptables rules with ExternalIP", func() {
+		It("deletes nftables rules with ExternalIP", func() {
 			app.Action = func(*cli.Context) error {
 				minNFakeCommands := nInitialFakeCommands + 1
 				// Depending on the order of informer event processing the initial
@@ -1336,7 +1336,7 @@ var _ = Describe("Node Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("deletes iptables rules for NodePort", func() {
+		It("deletes nftables rules for NodePort", func() {
 			app.Action = func(*cli.Context) error {
 				nodePort := int32(31111)
 
@@ -1793,7 +1793,7 @@ var _ = Describe("Node Operations", func() {
 	})
 
 	Context("on add and delete", func() {
-		It("manages iptables rules with ExternalIP", func() {
+		It("manages nftables rules with ExternalIP", func() {
 			app.Action = func(*cli.Context) error {
 				// Depending on the order of informer event processing the initial
 				// Service might be "added" once or twice.  Take that into account.
@@ -1965,7 +1965,7 @@ var _ = Describe("Node Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("manages iptables rules with ExternalIP through retry logic", func() {
+		It("manages nftables rules with ExternalIP through retry logic", func() {
 			app.Action = func(*cli.Context) error {
 				var nodePortWatcherRetry *retry.RetryFramework
 				var err error
@@ -2054,7 +2054,7 @@ var _ = Describe("Node Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("manages iptables rules for NodePort", func() {
+		It("manages nftables rules for NodePort", func() {
 			app.Action = func(*cli.Context) error {
 				nodePort := int32(38034)
 
@@ -2107,7 +2107,7 @@ var _ = Describe("Node Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("manages iptables rules and openflows for NodePort backed by ovn-k pods where ETP=local, LGW", func() {
+		It("manages nftables rules and openflows for NodePort backed by ovn-k pods where ETP=local, LGW", func() {
 			app.Action = func(*cli.Context) error {
 				config.Gateway.Mode = config.GatewayModeLocal
 				epPortName := "https"
@@ -2186,7 +2186,7 @@ var _ = Describe("Node Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("manages iptables rules and openflows for NodePort backed by ovn-k pods where ETP=local, SGW", func() {
+		It("manages nftables rules and openflows for NodePort backed by ovn-k pods where ETP=local, SGW", func() {
 			app.Action = func(*cli.Context) error {
 				config.Gateway.Mode = config.GatewayModeShared
 				epPortName := "https"
@@ -2271,7 +2271,7 @@ var _ = Describe("Node Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("manages iptables rules and openflows for NodePort backed by local-host-networked pods where ETP=local, LGW", func() {
+		It("manages nftables rules and openflows for NodePort backed by local-host-networked pods where ETP=local, LGW", func() {
 			app.Action = func(*cli.Context) error {
 				config.Gateway.Mode = config.GatewayModeLocal
 				outport := int32(443)
@@ -2360,7 +2360,7 @@ var _ = Describe("Node Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("manages iptables rules and openflows for NodePort backed by ovn-k pods where ITP=local and ETP=local", func() {
+		It("manages nftables rules and openflows for NodePort backed by ovn-k pods where ITP=local and ETP=local", func() {
 			app.Action = func(*cli.Context) error {
 				config.Gateway.Mode = config.GatewayModeShared
 				epPortName := "https"
@@ -2443,7 +2443,7 @@ var _ = Describe("Node Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("manages iptables rules and openflows for NodePort backed by local-host-networked pods where ETP=local and ITP=local", func() {
+		It("manages nftables rules and openflows for NodePort backed by local-host-networked pods where ETP=local and ITP=local", func() {
 			app.Action = func(*cli.Context) error {
 				config.Gateway.Mode = config.GatewayModeLocal
 				epPortName := "https"

--- a/go-controller/pkg/node/gateway_localnet_linux_test.go
+++ b/go-controller/pkg/node/gateway_localnet_linux_test.go
@@ -824,13 +824,6 @@ var _ = Describe("Node Operations", func() {
 						"OVN-KUBE-ITP": []string{},
 					},
 				}
-				expectedLBIngressFlows := []string{
-					"cookie=0x10c6b89e483ea111, priority=110, in_port=eth0, arp, arp_op=1, arp_tpa=5.5.5.5, actions=output:LOCAL",
-				}
-				expectedLBExternalIPFlows := []string{
-					"cookie=0x71765945a31dc2f1, priority=110, in_port=eth0, arp, arp_op=1, arp_tpa=1.1.1.1, actions=output:LOCAL",
-				}
-
 				f4 := iptV4.(*util.FakeIPTables)
 				err = f4.MatchState(expectedTables, nil)
 				Expect(err).NotTo(HaveOccurred())
@@ -840,6 +833,12 @@ var _ = Describe("Node Operations", func() {
 				err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				Expect(err).NotTo(HaveOccurred())
 
+				expectedLBIngressFlows := []string{
+					"cookie=0x10c6b89e483ea111, priority=110, in_port=eth0, arp, arp_op=1, arp_tpa=5.5.5.5, actions=output:LOCAL",
+				}
+				expectedLBExternalIPFlows := []string{
+					"cookie=0x71765945a31dc2f1, priority=110, in_port=eth0, arp, arp_op=1, arp_tpa=1.1.1.1, actions=output:LOCAL",
+				}
 				flows := fNPW.ofm.getFlowsByKey("NodePort_namespace1_service1_tcp_31111")
 				Expect(flows).To(BeNil())
 				flows = fNPW.ofm.getFlowsByKey("Ingress_namespace1_service1_5.5.5.5_8080")
@@ -965,13 +964,6 @@ var _ = Describe("Node Operations", func() {
 						"OVN-KUBE-ITP": []string{},
 					},
 				}
-				expectedLBIngressFlows := []string{
-					"cookie=0xd8c1fe514f305bc1, priority=110, in_port=eth0, arp, arp_op=1, arp_tpa=5.5.5.5, actions=output:LOCAL",
-				}
-				expectedLBExternalIPFlows := []string{
-					"cookie=0x799e0efe5404e9a1, priority=110, in_port=eth0, arp, arp_op=1, arp_tpa=1.1.1.1, actions=output:LOCAL",
-				}
-
 				f4 := iptV4.(*util.FakeIPTables)
 				Expect(f4.MatchState(expectedTables, nil)).To(Succeed())
 
@@ -981,6 +973,12 @@ var _ = Describe("Node Operations", func() {
 				err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				Expect(err).NotTo(HaveOccurred())
 
+				expectedLBIngressFlows := []string{
+					"cookie=0xd8c1fe514f305bc1, priority=110, in_port=eth0, arp, arp_op=1, arp_tpa=5.5.5.5, actions=output:LOCAL",
+				}
+				expectedLBExternalIPFlows := []string{
+					"cookie=0x799e0efe5404e9a1, priority=110, in_port=eth0, arp, arp_op=1, arp_tpa=1.1.1.1, actions=output:LOCAL",
+				}
 				Expect(fNPW.ofm.getFlowsByKey("Ingress_namespace1_service1_5.5.5.5_80")).To(Equal(expectedLBIngressFlows))
 				Expect(fNPW.ofm.getFlowsByKey("External_namespace1_service1_1.1.1.1_80")).To(Equal(expectedLBExternalIPFlows))
 
@@ -1266,14 +1264,6 @@ var _ = Describe("Node Operations", func() {
 						"OVN-KUBE-ITP": []string{},
 					},
 				}
-
-				expectedLBIngressFlows := []string{
-					"cookie=0x10c6b89e483ea111, priority=110, in_port=eth0, arp, arp_op=1, arp_tpa=5.5.5.5, actions=output:LOCAL",
-				}
-				expectedLBExternalIPFlows := []string{
-					"cookie=0x71765945a31dc2f1, priority=110, in_port=eth0, arp, arp_op=1, arp_tpa=1.1.1.1, actions=output:LOCAL",
-				}
-
 				f4 := iptV4.(*util.FakeIPTables)
 				err = f4.MatchState(expectedTables, nil)
 				Expect(err).NotTo(HaveOccurred())
@@ -1282,6 +1272,12 @@ var _ = Describe("Node Operations", func() {
 				err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				Expect(err).NotTo(HaveOccurred())
 
+				expectedLBIngressFlows := []string{
+					"cookie=0x10c6b89e483ea111, priority=110, in_port=eth0, arp, arp_op=1, arp_tpa=5.5.5.5, actions=output:LOCAL",
+				}
+				expectedLBExternalIPFlows := []string{
+					"cookie=0x71765945a31dc2f1, priority=110, in_port=eth0, arp, arp_op=1, arp_tpa=1.1.1.1, actions=output:LOCAL",
+				}
 				flows := fNPW.ofm.getFlowsByKey("NodePort_namespace1_service1_tcp_31111")
 				Expect(flows).To(BeNil())
 				flows = fNPW.ofm.getFlowsByKey("Ingress_namespace1_service1_5.5.5.5_8080")
@@ -1380,6 +1376,15 @@ var _ = Describe("Node Operations", func() {
 						"OVN-KUBE-ITP": []string{},
 					},
 				}
+				f4 := iptV4.(*util.FakeIPTables)
+				err = f4.MatchState(expectedTables, nil)
+				Expect(err).NotTo(HaveOccurred())
+
+				expectedNFT := nftablesRulesBase
+				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes mgmtport-no-snat-nodeports { tcp . %v }\n", service.Spec.Ports[0].NodePort)
+				err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
+				Expect(err).NotTo(HaveOccurred())
+
 				expectedNodePortFlows := []string{
 					"cookie=0x453ae29bcbbc08bd, priority=110, in_port=eth0, tcp, tp_dst=31111, actions=output:patch-breth0_ov",
 					fmt.Sprintf("cookie=0x453ae29bcbbc08bd, priority=110, in_port=patch-breth0_ov, dl_src=%s, tcp, tp_src=31111, actions=output:eth0",
@@ -1399,16 +1404,6 @@ var _ = Describe("Node Operations", func() {
 					fmt.Sprintf("cookie=0x71765945a31dc2f1, priority=110, in_port=patch-breth0_ov, dl_src=%s, tcp, nw_src=1.1.1.1, tp_src=8080, actions=output:eth0",
 						gwMAC),
 				}
-
-				f4 := iptV4.(*util.FakeIPTables)
-				err = f4.MatchState(expectedTables, nil)
-				Expect(err).NotTo(HaveOccurred())
-
-				expectedNFT := nftablesRulesBase
-				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes mgmtport-no-snat-nodeports { tcp . %v }\n", service.Spec.Ports[0].NodePort)
-				err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
-				Expect(err).NotTo(HaveOccurred())
-
 				flows := fNPW.ofm.getFlowsByKey("NodePort_namespace1_service1_tcp_31111")
 				Expect(flows).To(Equal(expectedNodePortFlows))
 				flows = fNPW.ofm.getFlowsByKey("Ingress_namespace1_service1_5.5.5.5_8080")
@@ -1538,6 +1533,14 @@ var _ = Describe("Node Operations", func() {
 						"OVN-KUBE-ITP": []string{},
 					},
 				}
+				f4 := iptV4.(*util.FakeIPTables)
+				err = f4.MatchState(expectedTables, nil)
+				Expect(err).NotTo(HaveOccurred())
+
+				expectedNFT := nftablesRulesBase
+				err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
+				Expect(err).NotTo(HaveOccurred())
+
 				expectedNodePortFlows := []string{
 					fmt.Sprintf("cookie=0x453ae29bcbbc08bd, priority=110, in_port=eth0, tcp, tp_dst=%d, "+
 						"actions=ct(commit,zone=64003,nat(dst=%s:%d),table=6)", svcNodePort, v4localnetGatewayIP, epPortValue),
@@ -1568,15 +1571,6 @@ var _ = Describe("Node Operations", func() {
 						"actions=ct(zone=64003 nat,table=7)", epPortValue),
 					"cookie=0xe745ecf105, priority=110, table=7, actions=output:eth0",
 				}
-
-				f4 := iptV4.(*util.FakeIPTables)
-				err = f4.MatchState(expectedTables, nil)
-				Expect(err).NotTo(HaveOccurred())
-
-				expectedNFT := nftablesRulesBase
-				err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
-				Expect(err).NotTo(HaveOccurred())
-
 				flows := fNPW.ofm.getFlowsByKey("NodePort_namespace1_service1_tcp_31111")
 				Expect(flows).To(Equal(expectedNodePortFlows))
 				flows = fNPW.ofm.getFlowsByKey("Ingress_namespace1_service1_5.5.5.5_8080")
@@ -1872,8 +1866,8 @@ var _ = Describe("Node Operations", func() {
 					return f6.MatchState(expectedTables, nil)
 				}, "2s").Should(Succeed())
 
+				expectedNFT := nftablesRulesBase
 				Eventually(func() error {
-					expectedNFT := nftablesRulesBase
 					return nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				}, "2s").Should(Succeed())
 
@@ -1960,8 +1954,8 @@ var _ = Describe("Node Operations", func() {
 					return f6.MatchState(expectedTables, nil)
 				}, "2s").Should(Succeed())
 
+				expectedNFT := nftablesRulesBase
 				Eventually(func() error {
-					expectedNFT := nftablesRulesBase
 					return nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				}, "2s").Should(Succeed())
 
@@ -2457,8 +2451,8 @@ var _ = Describe("Node Operations", func() {
 					return f4.MatchState(expectedTables, nil)
 				}).Should(Succeed())
 
+				expectedNFT := nftablesRulesBase
 				Eventually(func() error {
-					expectedNFT := nftablesRulesBase
 					return nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				}).Should(Succeed())
 
@@ -2497,8 +2491,8 @@ var _ = Describe("Node Operations", func() {
 					return f4.MatchState(expectedTables, nil)
 				}, "2s").Should(Succeed())
 
+				expectedNFT = nftablesRulesBase
 				Eventually(func() error {
-					expectedNFT := nftablesRulesBase
 					return nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				}, "2s").Should(Succeed())
 
@@ -2726,10 +2720,9 @@ var _ = Describe("Node Operations", func() {
 						service.Spec.Ports[0].Protocol, goodExternalIP, service.Spec.Ports[0].Port,
 						service.Spec.ClusterIP, service.Spec.Ports[0].Port)}
 				expectedTables["nat"]["OVN-KUBE-EXTERNALIP"] = ovn_kube_external_ip_field
-				Eventually(func(g Gomega) {
+				Eventually(func() error {
 					f4 := iptV4.(*util.FakeIPTables)
-					err = f4.MatchState(expectedTables, nil)
-					g.Expect(err).NotTo(HaveOccurred())
+					return f4.MatchState(expectedTables, nil)
 				}).Should(Succeed())
 
 				// TODO Make delete operation fail, check retry entry, run a successful delete
@@ -2804,8 +2797,8 @@ var _ = Describe("Node Operations", func() {
 					return f4.MatchState(expectedTables, nil)
 				}).Should(Succeed())
 
+				expectedNFT := nftablesRulesBase
 				Eventually(func() error {
-					expectedNFT := nftablesRulesBase
 					return nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				}).Should(Succeed())
 
@@ -2844,8 +2837,8 @@ var _ = Describe("Node Operations", func() {
 					return f4.MatchState(expectedTables, nil)
 				}, "2s").Should(Succeed())
 
+				expectedNFT = nftablesRulesBase
 				Eventually(func() error {
-					expectedNFT := nftablesRulesBase
 					return nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				}, "2s").Should(Succeed())
 
@@ -2981,8 +2974,8 @@ var _ = Describe("Node Operations", func() {
 					return f4.MatchState(expectedTables, nil)
 				}, "2s").Should(Succeed())
 
+				expectedNFT = nftablesRulesBase
 				Eventually(func() error {
-					expectedNFT = nftablesRulesBase
 					return nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				}, "2s").Should(Succeed())
 
@@ -3075,13 +3068,6 @@ var _ = Describe("Node Operations", func() {
 						"OVN-KUBE-ITP": []string{},
 					},
 				}
-				expectedFlows := []string{
-					// default
-					"cookie=0x453ae29bcbbc08bd, priority=110, in_port=eth0, tcp, tp_dst=31111, actions=output:patch-breth0_ov",
-					fmt.Sprintf("cookie=0x453ae29bcbbc08bd, priority=110, in_port=patch-breth0_ov, dl_src=%s, tcp, tp_src=31111, actions=output:eth0",
-						gwMAC),
-				}
-
 				f4 := iptV4.(*util.FakeIPTables)
 				Expect(f4.MatchState(expectedTables, nil)).To(Succeed())
 
@@ -3089,6 +3075,12 @@ var _ = Describe("Node Operations", func() {
 				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes mgmtport-no-snat-nodeports { tcp . %v }\n", service.Spec.Ports[0].NodePort)
 				Expect(nodenft.MatchNFTRules(expectedNFT, nft.Dump())).To(Succeed())
 
+				expectedFlows := []string{
+					// default
+					"cookie=0x453ae29bcbbc08bd, priority=110, in_port=eth0, tcp, tp_dst=31111, actions=output:patch-breth0_ov",
+					fmt.Sprintf("cookie=0x453ae29bcbbc08bd, priority=110, in_port=patch-breth0_ov, dl_src=%s, tcp, tp_src=31111, actions=output:eth0",
+						gwMAC),
+				}
 				flows := fNPW.ofm.getFlowsByKey("NodePort_namespace1_service1_tcp_31111")
 				Expect(flows).To(Equal(expectedFlows))
 
@@ -3127,8 +3119,8 @@ var _ = Describe("Node Operations", func() {
 					return f4.MatchState(expectedTables, nil)
 				}, "2s").Should(Succeed())
 
+				expectedNFT = nftablesRulesBase
 				Eventually(func() error {
-					expectedNFT = nftablesRulesBase
 					return nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				}, "2s").Should(Succeed())
 
@@ -3226,19 +3218,18 @@ var _ = Describe("Node Operations", func() {
 						"OVN-KUBE-ITP": []string{},
 					},
 				}
-				expectedFlows := []string{
-					"cookie=0x453ae29bcbbc08bd, priority=110, in_port=eth0, tcp, tp_dst=31111, actions=ct(commit,zone=64003,nat(dst=10.244.0.1:443),table=6)",
-					"cookie=0xe745ecf105, priority=110, table=6, actions=output:LOCAL",
-					"cookie=0x8ba455e19afe30d1, priority=110, in_port=LOCAL, tcp, tp_src=443, actions=ct(zone=64003 nat,table=7)",
-					"cookie=0xe745ecf105, priority=110, table=7, actions=output:eth0",
-				}
-
 				f4 := iptV4.(*util.FakeIPTables)
 				Expect(f4.MatchState(expectedTables, nil)).To(Succeed())
 
 				expectedNFT := nftablesRulesBase
 				Expect(nodenft.MatchNFTRules(expectedNFT, nft.Dump())).To(Succeed())
 
+				expectedFlows := []string{
+					"cookie=0x453ae29bcbbc08bd, priority=110, in_port=eth0, tcp, tp_dst=31111, actions=ct(commit,zone=64003,nat(dst=10.244.0.1:443),table=6)",
+					"cookie=0xe745ecf105, priority=110, table=6, actions=output:LOCAL",
+					"cookie=0x8ba455e19afe30d1, priority=110, in_port=LOCAL, tcp, tp_src=443, actions=ct(zone=64003 nat,table=7)",
+					"cookie=0xe745ecf105, priority=110, table=7, actions=output:eth0",
+				}
 				flows := fNPW.ofm.getFlowsByKey("NodePort_namespace1_service1_tcp_31111")
 				Expect(flows).To(Equal(expectedFlows))
 
@@ -3277,8 +3268,8 @@ var _ = Describe("Node Operations", func() {
 					return f4.MatchState(expectedTables, nil)
 				}, "2s").Should(Succeed())
 
+				expectedNFT = nftablesRulesBase
 				Eventually(func() error {
-					expectedNFT = nftablesRulesBase
 					return nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				}, "2s").Should(Succeed())
 
@@ -3370,13 +3361,6 @@ var _ = Describe("Node Operations", func() {
 						},
 					},
 				}
-				expectedFlows := []string{
-					// default
-					"cookie=0x453ae29bcbbc08bd, priority=110, in_port=eth0, tcp, tp_dst=31111, actions=output:patch-breth0_ov",
-					fmt.Sprintf("cookie=0x453ae29bcbbc08bd, priority=110, in_port=patch-breth0_ov, dl_src=%s, tcp, tp_src=31111, actions=output:eth0",
-						gwMAC),
-				}
-
 				f4 := iptV4.(*util.FakeIPTables)
 				Expect(f4.MatchState(expectedTables, nil)).To(Succeed())
 
@@ -3384,6 +3368,12 @@ var _ = Describe("Node Operations", func() {
 				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes mgmtport-no-snat-nodeports { tcp . %v }\n", service.Spec.Ports[0].NodePort)
 				Expect(nodenft.MatchNFTRules(expectedNFT, nft.Dump())).To(Succeed())
 
+				expectedFlows := []string{
+					// default
+					"cookie=0x453ae29bcbbc08bd, priority=110, in_port=eth0, tcp, tp_dst=31111, actions=output:patch-breth0_ov",
+					fmt.Sprintf("cookie=0x453ae29bcbbc08bd, priority=110, in_port=patch-breth0_ov, dl_src=%s, tcp, tp_src=31111, actions=output:eth0",
+						gwMAC),
+				}
 				flows := fNPW.ofm.getFlowsByKey("NodePort_namespace1_service1_tcp_31111")
 				Expect(flows).To(Equal(expectedFlows))
 
@@ -3422,8 +3412,8 @@ var _ = Describe("Node Operations", func() {
 					return f4.MatchState(expectedTables, nil)
 				}, "2s").Should(Succeed())
 
+				expectedNFT = nftablesRulesBase
 				Eventually(func() error {
-					expectedNFT = nftablesRulesBase
 					return nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				}, "2s").Should(Succeed())
 
@@ -3520,19 +3510,18 @@ var _ = Describe("Node Operations", func() {
 						"OVN-KUBE-ITP": []string{},
 					},
 				}
-				expectedFlows := []string{
-					"cookie=0x453ae29bcbbc08bd, priority=110, in_port=eth0, tcp, tp_dst=31111, actions=ct(commit,zone=64003,nat(dst=10.244.0.1:443),table=6)",
-					"cookie=0xe745ecf105, priority=110, table=6, actions=output:LOCAL",
-					"cookie=0x8ba455e19afe30d1, priority=110, in_port=LOCAL, tcp, tp_src=443, actions=ct(zone=64003 nat,table=7)",
-					"cookie=0xe745ecf105, priority=110, table=7, actions=output:eth0",
-				}
-
 				f4 := iptV4.(*util.FakeIPTables)
 				Expect(f4.MatchState(expectedTables, nil)).To(Succeed())
 
 				expectedNFT := nftablesRulesBase
 				Expect(nodenft.MatchNFTRules(expectedNFT, nft.Dump())).To(Succeed())
 
+				expectedFlows := []string{
+					"cookie=0x453ae29bcbbc08bd, priority=110, in_port=eth0, tcp, tp_dst=31111, actions=ct(commit,zone=64003,nat(dst=10.244.0.1:443),table=6)",
+					"cookie=0xe745ecf105, priority=110, table=6, actions=output:LOCAL",
+					"cookie=0x8ba455e19afe30d1, priority=110, in_port=LOCAL, tcp, tp_src=443, actions=ct(zone=64003 nat,table=7)",
+					"cookie=0xe745ecf105, priority=110, table=7, actions=output:eth0",
+				}
 				Expect(fNPW.ofm.getFlowsByKey("NodePort_namespace1_service1_tcp_31111")).To(Equal(expectedFlows))
 
 				addConntrackMocks(netlinkMock, []ctFilterDesc{{"10.129.0.2", 8080, corev1.ProtocolTCP, netlink.ConntrackOrigDstIP}, {"192.168.18.15", 31111, corev1.ProtocolTCP, netlink.ConntrackOrigDstIP}})
@@ -3570,8 +3559,8 @@ var _ = Describe("Node Operations", func() {
 					return f4.MatchState(expectedTables, nil)
 				}, "2s").Should(Succeed())
 
+				expectedNFT = nftablesRulesBase
 				Eventually(func() error {
-					expectedNFT = nftablesRulesBase
 					return nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				}, "2s").Should(Succeed())
 

--- a/go-controller/pkg/node/gateway_localnet_linux_test.go
+++ b/go-controller/pkg/node/gateway_localnet_linux_test.go
@@ -33,7 +33,6 @@ import (
 	nodenft "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/nftables"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/retry"
 	ovntest "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing"
-	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util/mocks"
 
@@ -3296,9 +3295,7 @@ var _ = Describe("Node Operations", func() {
 						"OUTPUT": []string{
 							"-j OVN-KUBE-ITP",
 						},
-						"OVN-KUBE-ITP": []string{
-							fmt.Sprintf("-p %s -d %s --dport %d -j MARK --set-xmark %s", service.Spec.Ports[0].Protocol, service.Spec.ClusterIP, service.Spec.Ports[0].Port, types.OVNKubeITPMark),
-						},
+						"OVN-KUBE-ITP": []string{},
 					},
 				}
 				f4 := iptV4.(*util.FakeIPTables)
@@ -3307,6 +3304,7 @@ var _ = Describe("Node Operations", func() {
 				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
 				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes mgmtport-no-snat-nodeports { tcp . %v }\n", service.Spec.Ports[0].NodePort)
 				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes nodeports-v4 { %s . %d : %s . %d }\n", strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port)
+				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes itp-services-to-mark-v4 { %s . %s . %d }\n", service.Spec.ClusterIP, strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].Port)
 				Expect(nodenft.MatchNFTRules(expectedNFT, nft.Dump())).To(Succeed())
 
 				expectedFlows := []string{
@@ -3436,10 +3434,8 @@ var _ = Describe("Node Operations", func() {
 						},
 						"OVN-KUBE-NODEPORT":   []string{},
 						"OVN-KUBE-EXTERNALIP": []string{},
-						"OVN-KUBE-ITP": []string{
-							fmt.Sprintf("-p %s -d %s --dport %d -j REDIRECT --to-port %d", service.Spec.Ports[0].Protocol, service.Spec.ClusterIP, service.Spec.Ports[0].Port, int32(service.Spec.Ports[0].TargetPort.IntValue())),
-						},
-						"OVN-KUBE-ETP": []string{},
+						"OVN-KUBE-ITP":        []string{},
+						"OVN-KUBE-ETP":        []string{},
 					},
 					"filter": {},
 					"mangle": {
@@ -3454,6 +3450,7 @@ var _ = Describe("Node Operations", func() {
 
 				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
 				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes nodeports-v4 { %s . %d : %s . %d }\n", strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port)
+				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes itp-services-to-redirect-v4 { %s . %s . %d : %d }\n", service.Spec.ClusterIP, strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].Port, service.Spec.Ports[0].TargetPort.IntValue())
 				Expect(nodenft.MatchNFTRules(expectedNFT, nft.Dump())).To(Succeed())
 
 				expectedFlows := []string{

--- a/go-controller/pkg/node/gateway_localnet_linux_test.go
+++ b/go-controller/pkg/node/gateway_localnet_linux_test.go
@@ -69,9 +69,6 @@ func initFakeNodePortWatcher() *nodePortWatcher {
 }
 
 func startNodePortWatcher(n *nodePortWatcher, fakeClient *util.OVNNodeClientset) error {
-	if err := initLocalGatewayIPTables(); err != nil {
-		return err
-	}
 	if err := initGatewayNFTables(); err != nil {
 		return err
 	}
@@ -116,9 +113,6 @@ func startNodePortWatcher(n *nodePortWatcher, fakeClient *util.OVNNodeClientset)
 }
 
 func startNodePortWatcherWithRetry(n *nodePortWatcher, fakeClient *util.OVNNodeClientset, stopChan chan struct{}, wg *sync.WaitGroup) (*retry.RetryFramework, error) {
-	if err := initLocalGatewayIPTables(); err != nil {
-		return nil, err
-	}
 	if err := initGatewayNFTables(); err != nil {
 		return nil, err
 	}
@@ -251,12 +245,11 @@ one and started again to exercise the tests.
 */
 var _ = Describe("Node Operations", func() {
 	var (
-		app          *cli.App
-		fExec        *ovntest.FakeExec
-		iptV4, iptV6 util.IPTablesHelper
-		nft          *knftables.Fake
-		fNPW         *nodePortWatcher
-		netlinkMock  *mocks.NetLinkOps
+		app         *cli.App
+		fExec       *ovntest.FakeExec
+		nft         *knftables.Fake
+		fNPW        *nodePortWatcher
+		netlinkMock *mocks.NetLinkOps
 
 		nInitialFakeCommands int
 	)
@@ -277,7 +270,6 @@ var _ = Describe("Node Operations", func() {
 		Expect(err).NotTo(HaveOccurred())
 		nInitialFakeCommands = 1
 
-		iptV4, iptV6 = util.SetFakeIPTablesHelpers()
 		nft = nodenft.SetFakeNFTablesHelper()
 		err = nft.ParseDump(nftablesRulesBase)
 		Expect(err).NotTo(HaveOccurred())
@@ -333,16 +325,6 @@ var _ = Describe("Node Operations", func() {
 				)
 				Expect(nodenft.AddObjects(fakeRules)).To(Succeed())
 
-				expectedTables := map[string]util.FakeTable{
-					"nat":    {},
-					"filter": {},
-					"mangle": {},
-				}
-
-				f4 := iptV4.(*util.FakeIPTables)
-				err = f4.MatchState(expectedTables, nil)
-				Expect(err).NotTo(HaveOccurred())
-
 				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
 				expectedNFT += "add element inet ovn-kubernetes external-ips-v4 { 1.1.1.1 . tcp . 8032 : 10.129.0.2 . 8032 }\n"
 				expectedNFT += "add element inet ovn-kubernetes external-ips-v4 { 10.10.10.10 . udp . 27000 : 172.32.0.12 . 27000 }\n"
@@ -364,36 +346,6 @@ var _ = Describe("Node Operations", func() {
 				Eventually(func() bool {
 					return fExec.CalledMatchesExpectedAtLeastN(minNFakeCommands)
 				}, "2s").Should(BeTrue(), fExec.ErrorDesc)
-
-				expectedTables = map[string]util.FakeTable{
-					"nat": {
-						"PREROUTING": []string{
-							"-j OVN-KUBE-ETP",
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-						},
-						"OUTPUT": []string{
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-NODEPORT":   []string{},
-						"OVN-KUBE-EXTERNALIP": []string{},
-						"OVN-KUBE-ETP":        []string{},
-						"OVN-KUBE-ITP":        []string{},
-					},
-					"filter": {},
-					"mangle": {
-						"OUTPUT": []string{
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-ITP": []string{},
-					},
-				}
-
-				f4 = iptV4.(*util.FakeIPTables)
-				err = f4.MatchState(expectedTables, nil)
-				Expect(err).NotTo(HaveOccurred())
 
 				expectedNFT = nftablesRulesBase + nftablesRulesGatewayServices
 				expectedNFT += "add element inet ovn-kubernetes external-ips-v4 { 1.1.1.1 . tcp . 8032 : 10.129.0.2 . 8032 }\n"
@@ -441,36 +393,6 @@ var _ = Describe("Node Operations", func() {
 				fNPW.watchFactory = wf
 				Expect(startNodePortWatcher(fNPW, fakeClient)).To(Succeed())
 
-				expectedTables := map[string]util.FakeTable{
-					"nat": {
-						"PREROUTING": []string{
-							"-j OVN-KUBE-ETP",
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-						},
-						"OUTPUT": []string{
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-NODEPORT":   []string{},
-						"OVN-KUBE-EXTERNALIP": []string{},
-						"OVN-KUBE-ETP":        []string{},
-						"OVN-KUBE-ITP":        []string{},
-					},
-					"filter": {},
-					"mangle": {
-						"OUTPUT": []string{
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-ITP": []string{},
-					},
-				}
-
-				f4 := iptV4.(*util.FakeIPTables)
-				err = f4.MatchState(expectedTables, nil)
-				Expect(err).NotTo(HaveOccurred())
-
 				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
 				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes external-ips-v4 { %s . %s . %d : %s . %d }\n", externalIP, strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port)
 				return nodenft.MatchNFTRules(expectedNFT, nft.Dump())
@@ -515,36 +437,6 @@ var _ = Describe("Node Operations", func() {
 				fNPW.watchFactory = wf
 				Expect(startNodePortWatcher(fNPW, fakeClient)).To(Succeed())
 				Expect(fExec.CalledMatchesExpected()).To(BeTrue(), fExec.ErrorDesc)
-
-				expectedTables := map[string]util.FakeTable{
-					"nat": {
-						"PREROUTING": []string{
-							"-j OVN-KUBE-ETP",
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-						},
-						"OUTPUT": []string{
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-NODEPORT":   []string{},
-						"OVN-KUBE-EXTERNALIP": []string{},
-						"OVN-KUBE-ETP":        []string{},
-						"OVN-KUBE-ITP":        []string{},
-					},
-					"filter": {},
-					"mangle": {
-						"OUTPUT": []string{
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-ITP": []string{},
-					},
-				}
-
-				f4 := iptV4.(*util.FakeIPTables)
-				err = f4.MatchState(expectedTables, nil)
-				Expect(err).NotTo(HaveOccurred())
 
 				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
 				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes nodeports-v4 { %s . %d : %s . %d }\n", strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port)
@@ -602,36 +494,6 @@ var _ = Describe("Node Operations", func() {
 
 				fNPW.watchFactory = wf
 				Expect(startNodePortWatcher(fNPW, fakeClient)).To(Succeed())
-
-				expectedTables := map[string]util.FakeTable{
-					"nat": {
-						"PREROUTING": []string{
-							"-j OVN-KUBE-ETP",
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-						},
-						"OUTPUT": []string{
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-NODEPORT":   []string{},
-						"OVN-KUBE-EXTERNALIP": []string{},
-						"OVN-KUBE-ETP":        []string{},
-						"OVN-KUBE-ITP":        []string{},
-					},
-					"filter": {},
-					"mangle": {
-						"OUTPUT": []string{
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-ITP": []string{},
-					},
-				}
-
-				f4 := iptV4.(*util.FakeIPTables)
-				err = f4.MatchState(expectedTables, nil)
-				Expect(err).NotTo(HaveOccurred())
 
 				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
 				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes mgmtport-no-snat-nodeports { tcp . %v }\n", service.Spec.Ports[0].NodePort)
@@ -701,36 +563,6 @@ var _ = Describe("Node Operations", func() {
 					return fExec.CalledMatchesExpectedAtLeastN(minNFakeCommands)
 				}, "2s").Should(BeTrue(), fExec.ErrorDesc)
 
-				expectedTables := map[string]util.FakeTable{
-					"nat": {
-						"PREROUTING": []string{
-							"-j OVN-KUBE-ETP",
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-						},
-						"OUTPUT": []string{
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-NODEPORT":   []string{},
-						"OVN-KUBE-EXTERNALIP": []string{},
-						"OVN-KUBE-ETP":        []string{},
-						"OVN-KUBE-ITP":        []string{},
-					},
-					"filter": {},
-					"mangle": {
-						"OUTPUT": []string{
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-ITP": []string{},
-					},
-				}
-
-				f4 := iptV4.(*util.FakeIPTables)
-				err = f4.MatchState(expectedTables, nil)
-				Expect(err).NotTo(HaveOccurred())
-
 				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
 				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes nodeports-v4 { %s . %d : %s . %d }\n", strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port)
 				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes external-ips-v4 { %s . %s . %d : %s . %d }\n", externalIP, strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port)
@@ -793,35 +625,6 @@ var _ = Describe("Node Operations", func() {
 
 				fNPW.watchFactory = wf
 				Expect(startNodePortWatcher(fNPW, fakeClient)).To(Succeed())
-
-				expectedTables := map[string]util.FakeTable{
-					"nat": {
-						"PREROUTING": []string{
-							"-j OVN-KUBE-ETP",
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-						},
-						"OUTPUT": []string{
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-NODEPORT":   []string{},
-						"OVN-KUBE-EXTERNALIP": []string{},
-						"OVN-KUBE-ETP":        []string{},
-						"OVN-KUBE-ITP":        []string{},
-					},
-					"filter": {},
-					"mangle": {
-						"OUTPUT": []string{
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-ITP": []string{},
-					},
-				}
-				f4 := iptV4.(*util.FakeIPTables)
-				err = f4.MatchState(expectedTables, nil)
-				Expect(err).NotTo(HaveOccurred())
 
 				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
 				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes mgmtport-no-snat-nodeports { tcp . %v }\n", service.Spec.Ports[0].NodePort)
@@ -932,34 +735,6 @@ var _ = Describe("Node Operations", func() {
 				fNPW.watchFactory = wf
 				Expect(startNodePortWatcher(fNPW, fakeClient)).To(Succeed())
 
-				expectedTables := map[string]util.FakeTable{
-					"nat": {
-						"PREROUTING": []string{
-							"-j OVN-KUBE-ETP",
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-						},
-						"OUTPUT": []string{
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-NODEPORT":   []string{},
-						"OVN-KUBE-EXTERNALIP": []string{},
-						"OVN-KUBE-ETP":        []string{},
-						"OVN-KUBE-ITP":        []string{},
-					},
-					"filter": {},
-					"mangle": {
-						"OUTPUT": []string{
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-ITP": []string{},
-					},
-				}
-				f4 := iptV4.(*util.FakeIPTables)
-				Expect(f4.MatchState(expectedTables, nil)).To(Succeed())
-
 				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
 				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes mgmtport-no-snat-services-v4 { %s . tcp . %d }\n", ep1.Addresses[0], int32(service.Spec.Ports[0].TargetPort.IntValue()))
 				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes mgmtport-no-snat-services-v4 { %s . tcp . %d }\n", ep2.Addresses[0], int32(service.Spec.Ports[0].TargetPort.IntValue()))
@@ -986,35 +761,6 @@ var _ = Describe("Node Operations", func() {
 					{"10.129.0.2", 80, corev1.ProtocolTCP, netlink.ConntrackOrigDstIP}})
 				Expect(fakeClient.KubeClient.CoreV1().Services(service.Namespace).Delete(
 					context.Background(), service.Name, metav1.DeleteOptions{})).To(Succeed())
-				expectedTables = map[string]util.FakeTable{
-					"nat": {
-						"PREROUTING": []string{
-							"-j OVN-KUBE-ETP",
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-						},
-						"OUTPUT": []string{
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-NODEPORT":   []string{},
-						"OVN-KUBE-EXTERNALIP": []string{},
-						"OVN-KUBE-ETP":        []string{},
-						"OVN-KUBE-ITP":        []string{},
-					},
-					"filter": {},
-					"mangle": {
-						"OUTPUT": []string{
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-ITP": []string{},
-					},
-				}
-				Eventually(func() error {
-					f4 := iptV4.(*util.FakeIPTables)
-					return f4.MatchState(expectedTables, nil)
-				}, "2s").Should(Succeed())
 
 				expectedNFT = nftablesRulesBase + nftablesRulesGatewayServices
 				Eventually(func() error {
@@ -1109,36 +855,6 @@ var _ = Describe("Node Operations", func() {
 				fNPW.watchFactory = wf
 				Expect(startNodePortWatcher(fNPW, fakeClient)).To(Succeed())
 
-				expectedTables := map[string]util.FakeTable{
-					"nat": {
-						"PREROUTING": []string{
-							"-j OVN-KUBE-ETP",
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-						},
-						"OUTPUT": []string{
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-NODEPORT":   []string{},
-						"OVN-KUBE-EXTERNALIP": []string{},
-						"OVN-KUBE-ETP":        []string{},
-						"OVN-KUBE-ITP":        []string{},
-					},
-					"filter": {},
-					"mangle": {
-						"OUTPUT": []string{
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-ITP": []string{},
-					},
-				}
-
-				f4 := iptV4.(*util.FakeIPTables)
-				err = f4.MatchState(expectedTables, nil)
-				Expect(err).NotTo(HaveOccurred())
-
 				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
 				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes mgmtport-no-snat-services-v4 { %s . tcp . %v }\n"+
 					"add element inet ovn-kubernetes mgmtport-no-snat-services-v4 { %s . tcp . %v }\n",
@@ -1212,35 +928,6 @@ var _ = Describe("Node Operations", func() {
 
 				fNPW.watchFactory = wf
 				Expect(startNodePortWatcher(fNPW, fakeClient)).To(Succeed())
-
-				expectedTables := map[string]util.FakeTable{
-					"nat": {
-						"PREROUTING": []string{
-							"-j OVN-KUBE-ETP",
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-						},
-						"OUTPUT": []string{
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-NODEPORT":   []string{},
-						"OVN-KUBE-EXTERNALIP": []string{},
-						"OVN-KUBE-ETP":        []string{},
-						"OVN-KUBE-ITP":        []string{},
-					},
-					"filter": {},
-					"mangle": {
-						"OUTPUT": []string{
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-ITP": []string{},
-					},
-				}
-				f4 := iptV4.(*util.FakeIPTables)
-				err = f4.MatchState(expectedTables, nil)
-				Expect(err).NotTo(HaveOccurred())
 
 				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
 				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes nodeports-v4 { %s . %d : %s . %d }\n", strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port)
@@ -1319,35 +1006,6 @@ var _ = Describe("Node Operations", func() {
 				}()
 				fNPW.watchFactory = wf
 				Expect(startNodePortWatcher(fNPW, fakeClient)).To(Succeed())
-
-				expectedTables := map[string]util.FakeTable{
-					"nat": {
-						"PREROUTING": []string{
-							"-j OVN-KUBE-ETP",
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-						},
-						"OUTPUT": []string{
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-NODEPORT":   []string{},
-						"OVN-KUBE-EXTERNALIP": []string{},
-						"OVN-KUBE-ETP":        []string{},
-						"OVN-KUBE-ITP":        []string{},
-					},
-					"filter": {},
-					"mangle": {
-						"OUTPUT": []string{
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-ITP": []string{},
-					},
-				}
-				f4 := iptV4.(*util.FakeIPTables)
-				err = f4.MatchState(expectedTables, nil)
-				Expect(err).NotTo(HaveOccurred())
 
 				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
 				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes mgmtport-no-snat-nodeports { tcp . %v }\n", service.Spec.Ports[0].NodePort)
@@ -1463,35 +1121,6 @@ var _ = Describe("Node Operations", func() {
 				fNPW.watchFactory = wf
 				Expect(startNodePortWatcher(fNPW, fakeClient)).To(Succeed())
 
-				expectedTables := map[string]util.FakeTable{
-					"nat": {
-						"PREROUTING": []string{
-							"-j OVN-KUBE-ETP",
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-						},
-						"OUTPUT": []string{
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-NODEPORT":   []string{},
-						"OVN-KUBE-EXTERNALIP": []string{},
-						"OVN-KUBE-ETP":        []string{},
-						"OVN-KUBE-ITP":        []string{},
-					},
-					"filter": {},
-					"mangle": {
-						"OUTPUT": []string{
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-ITP": []string{},
-					},
-				}
-				f4 := iptV4.(*util.FakeIPTables)
-				err = f4.MatchState(expectedTables, nil)
-				Expect(err).NotTo(HaveOccurred())
-
 				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
 				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes nodeports-v4 { %s . %d : %s . %d }\n", strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port)
 				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes external-ips-v4 { %s . %s . %d : %s . %d }\n", externalIP, strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port)
@@ -1583,45 +1212,6 @@ var _ = Describe("Node Operations", func() {
 				Expect(startNodePortWatcher(fNPW, fakeClient)).To(Succeed())
 				Expect(fExec.CalledMatchesExpected()).To(BeTrue(), fExec.ErrorDesc)
 
-				expectedTables4 := map[string]util.FakeTable{
-					"nat": {
-						"PREROUTING": []string{
-							"-j OVN-KUBE-ETP",
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-						},
-						"OUTPUT": []string{
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-NODEPORT":   []string{},
-						"OVN-KUBE-EXTERNALIP": []string{},
-						"OVN-KUBE-ETP":        []string{},
-						"OVN-KUBE-ITP":        []string{},
-					},
-					"filter": {},
-					"mangle": {
-						"OUTPUT": []string{
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-ITP": []string{},
-					},
-				}
-
-				f4 := iptV4.(*util.FakeIPTables)
-				err = f4.MatchState(expectedTables4, nil)
-				Expect(err).NotTo(HaveOccurred())
-
-				expectedTables6 := map[string]util.FakeTable{
-					"nat":    {},
-					"filter": {},
-					"mangle": {},
-				}
-				f6 := iptV6.(*util.FakeIPTables)
-				err = f6.MatchState(expectedTables6, nil)
-				Expect(err).NotTo(HaveOccurred())
-
 				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
 				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes nodeports-v4 { %s . %d : %s . %d }\n", strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].NodePort, service.Spec.ClusterIPs[0], service.Spec.Ports[0].Port)
 				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes nodeports-v6 { %s . %d : %s . %d }\n", strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].NodePort, service.Spec.ClusterIPs[1], service.Spec.Ports[0].Port)
@@ -1680,46 +1270,6 @@ var _ = Describe("Node Operations", func() {
 					return fExec.CalledMatchesExpectedAtLeastN(minNFakeCommands)
 				}, "2s").Should(BeTrue(), fExec.ErrorDesc)
 
-				expectedTables4 := map[string]util.FakeTable{
-					"nat": {
-						"PREROUTING": []string{
-							"-j OVN-KUBE-ETP",
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-						},
-						"OUTPUT": []string{
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-EXTERNALIP": []string{},
-						"OVN-KUBE-NODEPORT":   []string{},
-						"OVN-KUBE-ETP":        []string{},
-						"OVN-KUBE-ITP":        []string{},
-					},
-					"filter": {},
-					"mangle": {
-						"OUTPUT": []string{
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-ITP": []string{},
-					},
-				}
-
-				f4 := iptV4.(*util.FakeIPTables)
-				err = f4.MatchState(expectedTables4, nil)
-				Expect(err).NotTo(HaveOccurred())
-
-				expectedTables6 := map[string]util.FakeTable{
-					"nat":    {},
-					"filter": {},
-					"mangle": {},
-				}
-
-				f6 := iptV6.(*util.FakeIPTables)
-				err = f6.MatchState(expectedTables6, nil)
-				Expect(err).NotTo(HaveOccurred())
-
 				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
 				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes external-ips-v4 { %s . %s . %d : %s . %d }\n", externalIPv4, strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].Port, clusterIPv4, service.Spec.Ports[0].Port)
 				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes external-ips-v6 { %s . %s . %d : %s . %d }\n", externalIPv6, strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].Port, clusterIPv6, service.Spec.Ports[0].Port)
@@ -1775,47 +1325,6 @@ var _ = Describe("Node Operations", func() {
 					return fExec.CalledMatchesExpectedAtLeastN(minNFakeCommands)
 				}, "2s").Should(BeTrue(), fExec.ErrorDesc)
 
-				expectedTables := map[string]util.FakeTable{
-					"nat": {
-						"PREROUTING": []string{
-							"-j OVN-KUBE-ETP",
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-						},
-						"OUTPUT": []string{
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-NODEPORT":   []string{},
-						"OVN-KUBE-EXTERNALIP": []string{},
-						"OVN-KUBE-ETP":        []string{},
-						"OVN-KUBE-ITP":        []string{},
-					},
-					"filter": {},
-					"mangle": {
-						"OUTPUT": []string{
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-ITP": []string{},
-					},
-				}
-
-				Eventually(func() error {
-					f4 := iptV4.(*util.FakeIPTables)
-					return f4.MatchState(expectedTables, nil)
-				}, "2s").Should(Succeed())
-
-				expectedTables = map[string]util.FakeTable{
-					"nat":    {},
-					"filter": {},
-					"mangle": {},
-				}
-				Eventually(func() error {
-					f6 := iptV6.(*util.FakeIPTables)
-					return f6.MatchState(expectedTables, nil)
-				}, "2s").Should(Succeed())
-
 				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
 				Eventually(func() error {
 					return nodenft.MatchNFTRules(expectedNFT, nft.Dump())
@@ -1861,48 +1370,6 @@ var _ = Describe("Node Operations", func() {
 				Expect(fakeClient.KubeClient.CoreV1().Services(service.Namespace).Delete(
 					context.Background(), service.Name, metav1.DeleteOptions{})).To(Succeed())
 				Eventually(fExec.CalledMatchesExpected, "2s").Should(BeTrue(), fExec.ErrorDesc)
-
-				expectedTables := map[string]util.FakeTable{
-					"nat": {
-						"PREROUTING": []string{
-							"-j OVN-KUBE-ETP",
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-						},
-						"OUTPUT": []string{
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-NODEPORT":   []string{},
-						"OVN-KUBE-EXTERNALIP": []string{},
-						"OVN-KUBE-ETP":        []string{},
-						"OVN-KUBE-ITP":        []string{},
-					},
-					"filter": {},
-					"mangle": {
-						"OUTPUT": []string{
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-ITP": []string{},
-					},
-				}
-
-				Eventually(func() error {
-					f4 := iptV4.(*util.FakeIPTables)
-					return f4.MatchState(expectedTables, nil)
-				}, "2s").Should(Succeed())
-
-				expectedTables = map[string]util.FakeTable{
-					"nat":    {},
-					"filter": {},
-					"mangle": {},
-				}
-
-				Eventually(func() error {
-					f6 := iptV6.(*util.FakeIPTables)
-					return f6.MatchState(expectedTables, nil)
-				}, "2s").Should(Succeed())
 
 				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
 				Eventually(func() error {
@@ -2366,37 +1833,6 @@ var _ = Describe("Node Operations", func() {
 					return fExec.CalledMatchesExpectedAtLeastN(minNFakeCommands)
 				}, "2s").Should(BeTrue(), fExec.ErrorDesc)
 
-				expectedTables := map[string]util.FakeTable{
-					"nat": {
-						"PREROUTING": []string{
-							"-j OVN-KUBE-ETP",
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-						},
-						"OUTPUT": []string{
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-EXTERNALIP": []string{},
-						"OVN-KUBE-NODEPORT":   []string{},
-						"OVN-KUBE-ETP":        []string{},
-						"OVN-KUBE-ITP":        []string{},
-					},
-					"filter": {},
-					"mangle": {
-						"OUTPUT": []string{
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-ITP": []string{},
-					},
-				}
-
-				Eventually(func() error {
-					f4 := iptV4.(*util.FakeIPTables)
-					return f4.MatchState(expectedTables, nil)
-				}).Should(Succeed())
-
 				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
 				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes external-ips-v4 { %s . %s . %d : %s . %d }\n", externalIP, strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port)
 				Eventually(func() error {
@@ -2406,37 +1842,6 @@ var _ = Describe("Node Operations", func() {
 				addConntrackMocks(netlinkMock, []ctFilterDesc{{"10.10.10.1", 8034, corev1.ProtocolTCP, netlink.ConntrackOrigDstIP}, {"10.129.0.2", 8034, corev1.ProtocolTCP, netlink.ConntrackOrigDstIP}})
 				Expect(fakeClient.KubeClient.CoreV1().Services(service.Namespace).Delete(
 					context.Background(), service.Name, metav1.DeleteOptions{})).To(Succeed())
-
-				expectedTables = map[string]util.FakeTable{
-					"nat": {
-						"OVN-KUBE-EXTERNALIP": []string{},
-						"OVN-KUBE-NODEPORT":   []string{},
-						"PREROUTING": []string{
-							"-j OVN-KUBE-ETP",
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-						},
-						"OUTPUT": []string{
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-ETP": []string{},
-						"OVN-KUBE-ITP": []string{},
-					},
-					"filter": {},
-					"mangle": {
-						"OUTPUT": []string{
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-ITP": []string{},
-					},
-				}
-
-				Eventually(func() error {
-					f4 := iptV4.(*util.FakeIPTables)
-					return f4.MatchState(expectedTables, nil)
-				}, "2s").Should(Succeed())
 
 				expectedNFT = nftablesRulesBase + nftablesRulesGatewayServices
 				Eventually(func() error {
@@ -2612,40 +2017,11 @@ var _ = Describe("Node Operations", func() {
 					context.TODO(), &service, metav1.CreateOptions{})
 				Expect(err).NotTo(HaveOccurred())
 
-				// expected ip tables with no external IP set
-				expectedTables := map[string]util.FakeTable{
-					"nat": {
-						"PREROUTING": []string{
-							"-j OVN-KUBE-ETP",
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-						},
-						"OUTPUT": []string{
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-EXTERNALIP": []string{},
-						"OVN-KUBE-NODEPORT":   []string{},
-						"OVN-KUBE-ETP":        []string{},
-						"OVN-KUBE-ITP":        []string{},
-					},
-					"filter": {},
-					"mangle": {
-						"OUTPUT": []string{
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-ITP": []string{},
-					},
-				}
 				By("verify that a new retry entry for this service exists")
 				key, err := retry.GetResourceKey(&service)
 				Expect(err).NotTo(HaveOccurred())
 				retry.CheckRetryObjectEventually(key, true, nodePortWatcherRetry)
-				// check iptables
-				f4 := iptV4.(*util.FakeIPTables)
-				err = f4.MatchState(expectedTables, nil)
-				Expect(err).NotTo(HaveOccurred())
+
 				// check nftables
 				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
 				err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
@@ -2710,37 +2086,6 @@ var _ = Describe("Node Operations", func() {
 				Expect(startNodePortWatcher(fNPW, fakeClient)).To(Succeed())
 				Eventually(fExec.CalledMatchesExpected).Should(BeTrue(), fExec.ErrorDesc)
 
-				expectedTables := map[string]util.FakeTable{
-					"nat": {
-						"PREROUTING": []string{
-							"-j OVN-KUBE-ETP",
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-						},
-						"OUTPUT": []string{
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-NODEPORT":   []string{},
-						"OVN-KUBE-EXTERNALIP": []string{},
-						"OVN-KUBE-ETP":        []string{},
-						"OVN-KUBE-ITP":        []string{},
-					},
-					"filter": {},
-					"mangle": {
-						"OUTPUT": []string{
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-ITP": []string{},
-					},
-				}
-
-				Eventually(func() error {
-					f4 := iptV4.(*util.FakeIPTables)
-					return f4.MatchState(expectedTables, nil)
-				}).Should(Succeed())
-
 				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
 				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes nodeports-v4 { %s . %d : %s . %d }\n", strings.ToLower(string(service.Spec.Ports[0].Protocol)), nodePort, service.Spec.ClusterIPs[0], service.Spec.Ports[0].Port)
 				Eventually(func() error {
@@ -2750,37 +2095,6 @@ var _ = Describe("Node Operations", func() {
 				addConntrackMocks(netlinkMock, []ctFilterDesc{{"10.129.0.2", 8080, corev1.ProtocolTCP, netlink.ConntrackOrigDstIP}, {"192.168.18.15", 38034, corev1.ProtocolTCP, netlink.ConntrackOrigDstIP}})
 				Expect(fakeClient.KubeClient.CoreV1().Services(service.Namespace).Delete(
 					context.Background(), service.Name, metav1.DeleteOptions{})).To(Succeed())
-
-				expectedTables = map[string]util.FakeTable{
-					"nat": {
-						"OVN-KUBE-EXTERNALIP": []string{},
-						"OVN-KUBE-NODEPORT":   []string{},
-						"PREROUTING": []string{
-							"-j OVN-KUBE-ETP",
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-						},
-						"OUTPUT": []string{
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-ETP": []string{},
-						"OVN-KUBE-ITP": []string{},
-					},
-					"filter": {},
-					"mangle": {
-						"OUTPUT": []string{
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-ITP": []string{},
-					},
-				}
-
-				Eventually(func() error {
-					f4 := iptV4.(*util.FakeIPTables)
-					return f4.MatchState(expectedTables, nil)
-				}, "2s").Should(Succeed())
 
 				expectedNFT = nftablesRulesBase + nftablesRulesGatewayServices
 				Eventually(func() error {
@@ -2844,35 +2158,6 @@ var _ = Describe("Node Operations", func() {
 				fNPW.watchFactory = wf
 				Expect(startNodePortWatcher(fNPW, fakeClient)).To(Succeed())
 
-				expectedTables := map[string]util.FakeTable{
-					"nat": {
-						"PREROUTING": []string{
-							"-j OVN-KUBE-ETP",
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-						},
-						"OUTPUT": []string{
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-NODEPORT":   []string{},
-						"OVN-KUBE-EXTERNALIP": []string{},
-						"OVN-KUBE-ETP":        []string{},
-						"OVN-KUBE-ITP":        []string{},
-					},
-					"filter": {},
-					"mangle": {
-						"OUTPUT": []string{
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-ITP": []string{},
-					},
-				}
-
-				f4 := iptV4.(*util.FakeIPTables)
-				Expect(f4.MatchState(expectedTables, nil)).To(Succeed())
-
 				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
 				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes mgmtport-no-snat-nodeports { tcp . %v }\n", service.Spec.Ports[0].NodePort)
 				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes nodeports-v4 { %s . %d : %s . %d }\n", strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port)
@@ -2885,37 +2170,6 @@ var _ = Describe("Node Operations", func() {
 				addConntrackMocks(netlinkMock, []ctFilterDesc{{"10.129.0.2", 8080, corev1.ProtocolTCP, netlink.ConntrackOrigDstIP}, {"192.168.18.15", 31111, corev1.ProtocolTCP, netlink.ConntrackOrigDstIP}})
 				Expect(fakeClient.KubeClient.CoreV1().Services(service.Namespace).Delete(
 					context.Background(), service.Name, metav1.DeleteOptions{})).To(Succeed())
-
-				expectedTables = map[string]util.FakeTable{
-					"nat": {
-						"OVN-KUBE-EXTERNALIP": []string{},
-						"OVN-KUBE-NODEPORT":   []string{},
-						"PREROUTING": []string{
-							"-j OVN-KUBE-ETP",
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-						},
-						"OUTPUT": []string{
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-ETP": []string{},
-						"OVN-KUBE-ITP": []string{},
-					},
-					"filter": {},
-					"mangle": {
-						"OUTPUT": []string{
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-ITP": []string{},
-					},
-				}
-
-				Eventually(func() error {
-					f4 := iptV4.(*util.FakeIPTables)
-					return f4.MatchState(expectedTables, nil)
-				}, "2s").Should(Succeed())
 
 				expectedNFT = nftablesRulesBase + nftablesRulesGatewayServices
 				Eventually(func() error {
@@ -2984,34 +2238,6 @@ var _ = Describe("Node Operations", func() {
 				fNPW.watchFactory = wf
 				Expect(startNodePortWatcher(fNPW, fakeClient)).To(Succeed())
 
-				expectedTables := map[string]util.FakeTable{
-					"nat": {
-						"PREROUTING": []string{
-							"-j OVN-KUBE-ETP",
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-						},
-						"OUTPUT": []string{
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-NODEPORT":   []string{},
-						"OVN-KUBE-EXTERNALIP": []string{},
-						"OVN-KUBE-ETP":        []string{},
-						"OVN-KUBE-ITP":        []string{},
-					},
-					"filter": {},
-					"mangle": {
-						"OUTPUT": []string{
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-ITP": []string{},
-					},
-				}
-				f4 := iptV4.(*util.FakeIPTables)
-				Expect(f4.MatchState(expectedTables, nil)).To(Succeed())
-
 				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
 				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes mgmtport-no-snat-nodeports { tcp . %v }\n", service.Spec.Ports[0].NodePort)
 				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes nodeports-v4 { %s . %d : %s . %d }\n", strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port)
@@ -3029,37 +2255,6 @@ var _ = Describe("Node Operations", func() {
 				addConntrackMocks(netlinkMock, []ctFilterDesc{{"10.129.0.2", 8080, corev1.ProtocolTCP, netlink.ConntrackOrigDstIP}, {"192.168.18.15", 31111, corev1.ProtocolTCP, netlink.ConntrackOrigDstIP}})
 				Expect(fakeClient.KubeClient.CoreV1().Services(service.Namespace).Delete(
 					context.Background(), service.Name, metav1.DeleteOptions{})).To(Succeed())
-
-				expectedTables = map[string]util.FakeTable{
-					"nat": {
-						"OVN-KUBE-EXTERNALIP": []string{},
-						"OVN-KUBE-NODEPORT":   []string{},
-						"PREROUTING": []string{
-							"-j OVN-KUBE-ETP",
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-						},
-						"OUTPUT": []string{
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-ETP": []string{},
-						"OVN-KUBE-ITP": []string{},
-					},
-					"filter": {},
-					"mangle": {
-						"OUTPUT": []string{
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-ITP": []string{},
-					},
-				}
-
-				Eventually(func() error {
-					f4 = iptV4.(*util.FakeIPTables)
-					return f4.MatchState(expectedTables, nil)
-				}, "2s").Should(Succeed())
 
 				expectedNFT = nftablesRulesBase + nftablesRulesGatewayServices
 				Eventually(func() error {
@@ -3133,34 +2328,6 @@ var _ = Describe("Node Operations", func() {
 				res := fNPW.nodeIPManager.cidrs.Has(fmt.Sprintf("%s/32", ep1.Addresses[0]))
 				Expect(res).To(BeTrue())
 
-				expectedTables := map[string]util.FakeTable{
-					"nat": {
-						"PREROUTING": []string{
-							"-j OVN-KUBE-ETP",
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-						},
-						"OUTPUT": []string{
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-NODEPORT":   []string{},
-						"OVN-KUBE-EXTERNALIP": []string{},
-						"OVN-KUBE-ETP":        []string{},
-						"OVN-KUBE-ITP":        []string{},
-					},
-					"filter": {},
-					"mangle": {
-						"OUTPUT": []string{
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-ITP": []string{},
-					},
-				}
-				f4 := iptV4.(*util.FakeIPTables)
-				Expect(f4.MatchState(expectedTables, nil)).To(Succeed())
-
 				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
 				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes nodeports-v4 { %s . %d : %s . %d }\n", strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port)
 				Expect(nodenft.MatchNFTRules(expectedNFT, nft.Dump())).To(Succeed())
@@ -3177,37 +2344,6 @@ var _ = Describe("Node Operations", func() {
 				addConntrackMocks(netlinkMock, []ctFilterDesc{{"10.129.0.2", 8080, corev1.ProtocolTCP, netlink.ConntrackOrigDstIP}, {"192.168.18.15", 31111, corev1.ProtocolTCP, netlink.ConntrackOrigDstIP}})
 				Expect(fakeClient.KubeClient.CoreV1().Services(service.Namespace).Delete(
 					context.Background(), service.Name, metav1.DeleteOptions{})).To(Succeed())
-
-				expectedTables = map[string]util.FakeTable{
-					"nat": {
-						"OVN-KUBE-EXTERNALIP": []string{},
-						"OVN-KUBE-NODEPORT":   []string{},
-						"PREROUTING": []string{
-							"-j OVN-KUBE-ETP",
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-						},
-						"OUTPUT": []string{
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-ITP": []string{},
-						"OVN-KUBE-ETP": []string{},
-					},
-					"filter": {},
-					"mangle": {
-						"OUTPUT": []string{
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-ITP": []string{},
-					},
-				}
-
-				Eventually(func() error {
-					f4 = iptV4.(*util.FakeIPTables)
-					return f4.MatchState(expectedTables, nil)
-				}, "2s").Should(Succeed())
 
 				expectedNFT = nftablesRulesBase + nftablesRulesGatewayServices
 				Eventually(func() error {
@@ -3273,34 +2409,6 @@ var _ = Describe("Node Operations", func() {
 				fNPW.watchFactory = wf
 				Expect(startNodePortWatcher(fNPW, fakeClient)).To(Succeed())
 
-				expectedTables := map[string]util.FakeTable{
-					"nat": {
-						"PREROUTING": []string{
-							"-j OVN-KUBE-ETP",
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-						},
-						"OUTPUT": []string{
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-NODEPORT":   []string{},
-						"OVN-KUBE-EXTERNALIP": []string{},
-						"OVN-KUBE-ITP":        []string{},
-						"OVN-KUBE-ETP":        []string{},
-					},
-					"filter": {},
-					"mangle": {
-						"OUTPUT": []string{
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-ITP": []string{},
-					},
-				}
-				f4 := iptV4.(*util.FakeIPTables)
-				Expect(f4.MatchState(expectedTables, nil)).To(Succeed())
-
 				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
 				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes mgmtport-no-snat-nodeports { tcp . %v }\n", service.Spec.Ports[0].NodePort)
 				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes nodeports-v4 { %s . %d : %s . %d }\n", strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port)
@@ -3319,37 +2427,6 @@ var _ = Describe("Node Operations", func() {
 				addConntrackMocks(netlinkMock, []ctFilterDesc{{"10.129.0.2", 8080, corev1.ProtocolTCP, netlink.ConntrackOrigDstIP}, {"192.168.18.15", 31111, corev1.ProtocolTCP, netlink.ConntrackOrigDstIP}})
 				Expect(fakeClient.KubeClient.CoreV1().Services(service.Namespace).Delete(
 					context.Background(), service.Name, metav1.DeleteOptions{})).To(Succeed())
-
-				expectedTables = map[string]util.FakeTable{
-					"nat": {
-						"OVN-KUBE-EXTERNALIP": []string{},
-						"OVN-KUBE-NODEPORT":   []string{},
-						"OVN-KUBE-ITP":        []string{},
-						"PREROUTING": []string{
-							"-j OVN-KUBE-ETP",
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-						},
-						"OUTPUT": []string{
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-ETP": []string{},
-					},
-					"filter": {},
-					"mangle": {
-						"OUTPUT": []string{
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-ITP": []string{},
-					},
-				}
-
-				Eventually(func() error {
-					f4 = iptV4.(*util.FakeIPTables)
-					return f4.MatchState(expectedTables, nil)
-				}, "2s").Should(Succeed())
 
 				expectedNFT = nftablesRulesBase + nftablesRulesGatewayServices
 				Eventually(func() error {
@@ -3420,33 +2497,6 @@ var _ = Describe("Node Operations", func() {
 				// to ensure the endpoint is local-host-networked
 				res := fNPW.nodeIPManager.cidrs.Has(fmt.Sprintf("%s/32", endpointSlice.Endpoints[0].Addresses[0]))
 				Expect(res).To(BeTrue())
-				expectedTables := map[string]util.FakeTable{
-					"nat": {
-						"PREROUTING": []string{
-							"-j OVN-KUBE-ETP",
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-						},
-						"OUTPUT": []string{
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-NODEPORT":   []string{},
-						"OVN-KUBE-EXTERNALIP": []string{},
-						"OVN-KUBE-ITP":        []string{},
-						"OVN-KUBE-ETP":        []string{},
-					},
-					"filter": {},
-					"mangle": {
-						"OUTPUT": []string{
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-ITP": []string{},
-					},
-				}
-				f4 := iptV4.(*util.FakeIPTables)
-				Expect(f4.MatchState(expectedTables, nil)).To(Succeed())
 
 				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
 				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes nodeports-v4 { %s . %d : %s . %d }\n", strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port)
@@ -3464,37 +2514,6 @@ var _ = Describe("Node Operations", func() {
 				addConntrackMocks(netlinkMock, []ctFilterDesc{{"10.129.0.2", 8080, corev1.ProtocolTCP, netlink.ConntrackOrigDstIP}, {"192.168.18.15", 31111, corev1.ProtocolTCP, netlink.ConntrackOrigDstIP}})
 				Expect(fakeClient.KubeClient.CoreV1().Services(service.Namespace).Delete(
 					context.Background(), service.Name, metav1.DeleteOptions{})).To(Succeed())
-
-				expectedTables = map[string]util.FakeTable{
-					"nat": {
-						"OVN-KUBE-EXTERNALIP": []string{},
-						"OVN-KUBE-NODEPORT":   []string{},
-						"PREROUTING": []string{
-							"-j OVN-KUBE-ETP",
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-						},
-						"OUTPUT": []string{
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-ITP": []string{},
-						"OVN-KUBE-ETP": []string{},
-					},
-					"filter": {},
-					"mangle": {
-						"OUTPUT": []string{
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-ITP": []string{},
-					},
-				}
-
-				Eventually(func() error {
-					f4 := iptV4.(*util.FakeIPTables)
-					return f4.MatchState(expectedTables, nil)
-				}, "2s").Should(Succeed())
 
 				expectedNFT = nftablesRulesBase + nftablesRulesGatewayServices
 				Eventually(func() error {
@@ -3522,6 +2541,7 @@ var _ = Describe("Node Operations", func() {
 				config.IPv4Mode = false
 				config.IPv6Mode = true
 				config.Gateway.DisableForwarding = true
+				_, iptV6 := util.SetFakeIPTablesHelpers()
 
 				stopChan := make(chan struct{})
 				fakeClient := util.GetOVNClientset().GetNodeClientset()
@@ -3538,22 +2558,7 @@ var _ = Describe("Node Operations", func() {
 				Expect(configureGlobalForwarding()).To(Succeed())
 
 				expectedTables := map[string]util.FakeTable{
-					"nat": {
-						"PREROUTING": []string{
-							"-j OVN-KUBE-ETP",
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-						},
-						"OUTPUT": []string{
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-NODEPORT":   []string{},
-						"OVN-KUBE-EXTERNALIP": []string{},
-						"OVN-KUBE-ETP":        []string{},
-						"OVN-KUBE-ITP":        []string{},
-					},
+					"nat": {},
 					"filter": {
 						"FORWARD": []string{
 							"-d fd69::1 -j ACCEPT",
@@ -3564,12 +2569,7 @@ var _ = Describe("Node Operations", func() {
 							"-s fd00:10:1::/48 -j ACCEPT",
 						},
 					},
-					"mangle": {
-						"OUTPUT": []string{
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-ITP": []string{},
-					},
+					"mangle": {},
 				}
 				f6 := iptV6.(*util.FakeIPTables)
 				err = f6.MatchState(expectedTables, map[util.FakePolicyKey]string{{
@@ -3585,31 +2585,11 @@ var _ = Describe("Node Operations", func() {
 				Expect(startNodePortWatcher(fNPW, fakeClient)).To(Succeed())
 
 				expectedTables = map[string]util.FakeTable{
-					"nat": {
-						"PREROUTING": []string{
-							"-j OVN-KUBE-ETP",
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-						},
-						"OUTPUT": []string{
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-NODEPORT":   []string{},
-						"OVN-KUBE-EXTERNALIP": []string{},
-						"OVN-KUBE-ETP":        []string{},
-						"OVN-KUBE-ITP":        []string{},
-					},
+					"nat": {},
 					"filter": {
 						"FORWARD": []string{},
 					},
-					"mangle": {
-						"OUTPUT": []string{
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-ITP": []string{},
-					},
+					"mangle": {},
 				}
 
 				f6 = iptV6.(*util.FakeIPTables)
@@ -3625,6 +2605,8 @@ var _ = Describe("Node Operations", func() {
 		})
 
 		ovntest.OnSupportedPlatformsIt("updates the default FORWARD policy correctly according to the config", func() {
+			iptV4, iptV6 := util.SetFakeIPTablesHelpers()
+
 			expectedTablesEmpty := map[string]util.FakeTable{
 				"filter": {
 					"FORWARD": []string{},

--- a/go-controller/pkg/node/gateway_localnet_linux_test.go
+++ b/go-controller/pkg/node/gateway_localnet_linux_test.go
@@ -293,6 +293,10 @@ var _ = Describe("Node Operations", func() {
 	Context("on startup", func() {
 		It("removes stale iptables rules while keeping remaining intact", func() {
 			app.Action = func(*cli.Context) error {
+				// Create tables/chains/sets/etc
+				err := initGatewayNFTables()
+				Expect(err).NotTo(HaveOccurred())
+
 				// Depending on the order of informer event processing the initial
 				// Service might be "added" once or twice.  Take that into account.
 				minNFakeCommands := nInitialFakeCommands + 1
@@ -315,9 +319,9 @@ var _ = Describe("Node Operations", func() {
 					false, false,
 				)
 
-				fakeRules := getExternalIPTRules(service.Spec.Ports[0], externalIP, service.Spec.ClusterIP, false, false)
-				Expect(insertIptRules(fakeRules)).To(Succeed())
-				fakeRules = getExternalIPTRules(
+				fakeRules := getExternalIPNFTRules(service.Spec.Ports[0], externalIP, service.Spec.ClusterIP, false, false)
+				Expect(nodenft.AddObjects(fakeRules)).To(Succeed())
+				fakeRules = getExternalIPNFTRules(
 					corev1.ServicePort{
 						Port:     27000,
 						Protocol: corev1.ProtocolUDP,
@@ -328,21 +332,22 @@ var _ = Describe("Node Operations", func() {
 					false,
 					false,
 				)
-				Expect(insertIptRules(fakeRules)).To(Succeed())
+				Expect(nodenft.AddObjects(fakeRules)).To(Succeed())
 
 				expectedTables := map[string]util.FakeTable{
-					"nat": {
-						"OVN-KUBE-EXTERNALIP": []string{
-							"-p UDP -d 10.10.10.10 --dport 27000 -j DNAT --to-destination 172.32.0.12:27000",
-							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, externalIP, service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
-						},
-					},
+					"nat":    {},
 					"filter": {},
 					"mangle": {},
 				}
 
 				f4 := iptV4.(*util.FakeIPTables)
-				err := f4.MatchState(expectedTables, nil)
+				err = f4.MatchState(expectedTables, nil)
+				Expect(err).NotTo(HaveOccurred())
+
+				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
+				expectedNFT += "add element inet ovn-kubernetes external-ips-v4 { 1.1.1.1 . tcp . 8032 : 10.129.0.2 . 8032 }\n"
+				expectedNFT += "add element inet ovn-kubernetes external-ips-v4 { 10.10.10.10 . udp . 27000 : 172.32.0.12 . 27000 }\n"
+				err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				Expect(err).NotTo(HaveOccurred())
 
 				stopChan := make(chan struct{})
@@ -373,12 +378,10 @@ var _ = Describe("Node Operations", func() {
 							"-j OVN-KUBE-NODEPORT",
 							"-j OVN-KUBE-ITP",
 						},
-						"OVN-KUBE-NODEPORT": []string{},
-						"OVN-KUBE-EXTERNALIP": []string{
-							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, externalIP, service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
-						},
-						"OVN-KUBE-ETP": []string{},
-						"OVN-KUBE-ITP": []string{},
+						"OVN-KUBE-NODEPORT":   []string{},
+						"OVN-KUBE-EXTERNALIP": []string{},
+						"OVN-KUBE-ETP":        []string{},
+						"OVN-KUBE-ITP":        []string{},
 					},
 					"filter": {},
 					"mangle": {
@@ -393,7 +396,8 @@ var _ = Describe("Node Operations", func() {
 				err = f4.MatchState(expectedTables, nil)
 				Expect(err).NotTo(HaveOccurred())
 
-				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
+				expectedNFT = nftablesRulesBase + nftablesRulesGatewayServices
+				expectedNFT += "add element inet ovn-kubernetes external-ips-v4 { 1.1.1.1 . tcp . 8032 : 10.129.0.2 . 8032 }\n"
 				err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				Expect(err).NotTo(HaveOccurred())
 
@@ -450,12 +454,10 @@ var _ = Describe("Node Operations", func() {
 							"-j OVN-KUBE-NODEPORT",
 							"-j OVN-KUBE-ITP",
 						},
-						"OVN-KUBE-NODEPORT": []string{},
-						"OVN-KUBE-EXTERNALIP": []string{
-							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, externalIP, service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
-						},
-						"OVN-KUBE-ETP": []string{},
-						"OVN-KUBE-ITP": []string{},
+						"OVN-KUBE-NODEPORT":   []string{},
+						"OVN-KUBE-EXTERNALIP": []string{},
+						"OVN-KUBE-ETP":        []string{},
+						"OVN-KUBE-ITP":        []string{},
 					},
 					"filter": {},
 					"mangle": {
@@ -471,6 +473,7 @@ var _ = Describe("Node Operations", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
+				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes external-ips-v4 { %s . %s . %d : %s . %d }\n", externalIP, strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port)
 				return nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 			}
 			err := app.Run([]string{app.Name})
@@ -711,13 +714,10 @@ var _ = Describe("Node Operations", func() {
 							"-j OVN-KUBE-NODEPORT",
 							"-j OVN-KUBE-ITP",
 						},
-						"OVN-KUBE-NODEPORT": []string{},
-						"OVN-KUBE-EXTERNALIP": []string{
-							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Status.LoadBalancer.Ingress[0].IP, service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
-							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, externalIP, service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
-						},
-						"OVN-KUBE-ETP": []string{},
-						"OVN-KUBE-ITP": []string{},
+						"OVN-KUBE-NODEPORT":   []string{},
+						"OVN-KUBE-EXTERNALIP": []string{},
+						"OVN-KUBE-ETP":        []string{},
+						"OVN-KUBE-ITP":        []string{},
 					},
 					"filter": {},
 					"mangle": {
@@ -734,6 +734,8 @@ var _ = Describe("Node Operations", func() {
 
 				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
 				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes nodeports-v4 { %s . %d : %s . %d }\n", strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port)
+				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes external-ips-v4 { %s . %s . %d : %s . %d }\n", externalIP, strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port)
+				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes external-ips-v4 { %s . %s . %d : %s . %d }\n", service.Status.LoadBalancer.Ingress[0].IP, strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port)
 				return nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 			}
 			err := app.Run([]string{app.Name})
@@ -805,16 +807,10 @@ var _ = Describe("Node Operations", func() {
 							"-j OVN-KUBE-NODEPORT",
 							"-j OVN-KUBE-ITP",
 						},
-						"OVN-KUBE-NODEPORT": []string{},
-						"OVN-KUBE-EXTERNALIP": []string{
-							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Status.LoadBalancer.Ingress[0].IP, service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
-							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, externalIP, service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
-						},
-						"OVN-KUBE-ETP": []string{
-							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Status.LoadBalancer.Ingress[0].IP, service.Spec.Ports[0].Port, config.Gateway.MasqueradeIPs.V4HostETPLocalMasqueradeIP.String(), service.Spec.Ports[0].NodePort),
-							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, externalIP, service.Spec.Ports[0].Port, config.Gateway.MasqueradeIPs.V4HostETPLocalMasqueradeIP.String(), service.Spec.Ports[0].NodePort),
-						},
-						"OVN-KUBE-ITP": []string{},
+						"OVN-KUBE-NODEPORT":   []string{},
+						"OVN-KUBE-EXTERNALIP": []string{},
+						"OVN-KUBE-ETP":        []string{},
+						"OVN-KUBE-ITP":        []string{},
 					},
 					"filter": {},
 					"mangle": {
@@ -831,7 +827,11 @@ var _ = Describe("Node Operations", func() {
 				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
 				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes mgmtport-no-snat-nodeports { tcp . %v }\n", service.Spec.Ports[0].NodePort)
 				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes nodeports-v4 { %s . %d : %s . %d }\n", strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port)
+				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes external-ips-v4 { %s . %s . %d : %s . %d }\n", externalIP, strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port)
+				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes external-ips-v4 { %s . %s . %d : %s . %d }\n", service.Status.LoadBalancer.Ingress[0].IP, strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port)
 				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes nodeports-etp-local-v4 { %s . %d : %s . %d }\n", strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].NodePort, config.Gateway.MasqueradeIPs.V4HostETPLocalMasqueradeIP.String(), service.Spec.Ports[0].NodePort)
+				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes external-ips-etp-local-v4 { %s . %s . %d : %s . %d }\n", externalIP, strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].Port, config.Gateway.MasqueradeIPs.V4HostETPLocalMasqueradeIP.String(), service.Spec.Ports[0].NodePort)
+				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes external-ips-etp-local-v4 { %s . %s . %d : %s . %d }\n", service.Status.LoadBalancer.Ingress[0].IP, strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].Port, config.Gateway.MasqueradeIPs.V4HostETPLocalMasqueradeIP.String(), service.Spec.Ports[0].NodePort)
 				err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				Expect(err).NotTo(HaveOccurred())
 
@@ -945,11 +945,8 @@ var _ = Describe("Node Operations", func() {
 							"-j OVN-KUBE-NODEPORT",
 							"-j OVN-KUBE-ITP",
 						},
-						"OVN-KUBE-NODEPORT": []string{},
-						"OVN-KUBE-EXTERNALIP": []string{
-							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Status.LoadBalancer.Ingress[0].IP, service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
-							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, externalIP, service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
-						},
+						"OVN-KUBE-NODEPORT":   []string{},
+						"OVN-KUBE-EXTERNALIP": []string{},
 						"OVN-KUBE-ETP": []string{
 							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%d -m statistic --mode random --probability 0.5000000000", service.Spec.Ports[0].Protocol, service.Status.LoadBalancer.Ingress[0].IP, service.Spec.Ports[0].Port, ep1.Addresses[0], int32(service.Spec.Ports[0].TargetPort.IntValue())),
 							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%d -m statistic --mode random --probability 1.0000000000", service.Spec.Ports[0].Protocol, service.Status.LoadBalancer.Ingress[0].IP, service.Spec.Ports[0].Port, ep2.Addresses[0], int32(service.Spec.Ports[0].TargetPort.IntValue())),
@@ -972,6 +969,8 @@ var _ = Describe("Node Operations", func() {
 				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
 				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes mgmtport-no-snat-services-v4 { %s . tcp . %d }\n", ep1.Addresses[0], int32(service.Spec.Ports[0].TargetPort.IntValue()))
 				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes mgmtport-no-snat-services-v4 { %s . tcp . %d }\n", ep2.Addresses[0], int32(service.Spec.Ports[0].TargetPort.IntValue()))
+				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes external-ips-v4 { %s . %s . %d : %s . %d }\n", externalIP, strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port)
+				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes external-ips-v4 { %s . %s . %d : %s . %d }\n", service.Status.LoadBalancer.Ingress[0].IP, strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port)
 				err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				Expect(err).NotTo(HaveOccurred())
 
@@ -1126,15 +1125,8 @@ var _ = Describe("Node Operations", func() {
 							"-j OVN-KUBE-NODEPORT",
 							"-j OVN-KUBE-ITP",
 						},
-						"OVN-KUBE-NODEPORT": []string{},
-						"OVN-KUBE-EXTERNALIP": []string{
-							fmt.Sprintf("-p %s -d %s --dport %d -j DNAT --to-destination %s:%v",
-								service.Spec.Ports[0].Protocol,
-								service.Status.LoadBalancer.Ingress[0].IP,
-								service.Spec.Ports[0].Port,
-								service.Spec.ClusterIP,
-								service.Spec.Ports[0].Port),
-						},
+						"OVN-KUBE-NODEPORT":   []string{},
+						"OVN-KUBE-EXTERNALIP": []string{},
 						"OVN-KUBE-ETP": []string{
 							fmt.Sprintf("-p %s -d %s --dport %d -j DNAT --to-destination %s:%d -m statistic --mode random --probability 0.5000000000",
 								service.Spec.Ports[0].Protocol,
@@ -1171,6 +1163,7 @@ var _ = Describe("Node Operations", func() {
 					*endpointSlice.Ports[0].Port,
 					endpointSlice.Endpoints[0].Addresses[0],
 					*endpointSlice.Ports[0].Port)
+				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes external-ips-v4 { %s . %s . %d : %s . %d }\n", service.Status.LoadBalancer.Ingress[0].IP, strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port)
 				err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				Expect(err).NotTo(HaveOccurred())
 
@@ -1248,13 +1241,10 @@ var _ = Describe("Node Operations", func() {
 							"-j OVN-KUBE-NODEPORT",
 							"-j OVN-KUBE-ITP",
 						},
-						"OVN-KUBE-NODEPORT": []string{},
-						"OVN-KUBE-EXTERNALIP": []string{
-							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Status.LoadBalancer.Ingress[0].IP, service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
-							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, externalIP, service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
-						},
-						"OVN-KUBE-ETP": []string{},
-						"OVN-KUBE-ITP": []string{},
+						"OVN-KUBE-NODEPORT":   []string{},
+						"OVN-KUBE-EXTERNALIP": []string{},
+						"OVN-KUBE-ETP":        []string{},
+						"OVN-KUBE-ITP":        []string{},
 					},
 					"filter": {},
 					"mangle": {
@@ -1270,6 +1260,8 @@ var _ = Describe("Node Operations", func() {
 
 				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
 				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes nodeports-v4 { %s . %d : %s . %d }\n", strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port)
+				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes external-ips-v4 { %s . %s . %d : %s . %d }\n", externalIP, strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port)
+				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes external-ips-v4 { %s . %s . %d : %s . %d }\n", service.Status.LoadBalancer.Ingress[0].IP, strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port)
 				err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				Expect(err).NotTo(HaveOccurred())
 
@@ -1356,16 +1348,10 @@ var _ = Describe("Node Operations", func() {
 							"-j OVN-KUBE-NODEPORT",
 							"-j OVN-KUBE-ITP",
 						},
-						"OVN-KUBE-NODEPORT": []string{},
-						"OVN-KUBE-EXTERNALIP": []string{
-							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Status.LoadBalancer.Ingress[0].IP, service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
-							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, externalIP, service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
-						},
-						"OVN-KUBE-ETP": []string{
-							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Status.LoadBalancer.Ingress[0].IP, service.Spec.Ports[0].Port, config.Gateway.MasqueradeIPs.V4HostETPLocalMasqueradeIP.String(), service.Spec.Ports[0].NodePort),
-							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, externalIP, service.Spec.Ports[0].Port, config.Gateway.MasqueradeIPs.V4HostETPLocalMasqueradeIP.String(), service.Spec.Ports[0].NodePort),
-						},
-						"OVN-KUBE-ITP": []string{},
+						"OVN-KUBE-NODEPORT":   []string{},
+						"OVN-KUBE-EXTERNALIP": []string{},
+						"OVN-KUBE-ETP":        []string{},
+						"OVN-KUBE-ITP":        []string{},
 					},
 					"filter": {},
 					"mangle": {
@@ -1382,6 +1368,10 @@ var _ = Describe("Node Operations", func() {
 				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
 				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes mgmtport-no-snat-nodeports { tcp . %v }\n", service.Spec.Ports[0].NodePort)
 				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes nodeports-v4 { %s . %d : %s . %d }\n", strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port)
+				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes external-ips-v4 { %s . %s . %d : %s . %d }\n", externalIP, strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port)
+				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes external-ips-v4 { %s . %s . %d : %s . %d }\n", service.Status.LoadBalancer.Ingress[0].IP, strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port)
+				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes external-ips-etp-local-v4 { %s . %s . %d : %s . %d }\n", externalIP, strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].Port, config.Gateway.MasqueradeIPs.V4HostETPLocalMasqueradeIP.String(), service.Spec.Ports[0].NodePort)
+				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes external-ips-etp-local-v4 { %s . %s . %d : %s . %d }\n", service.Status.LoadBalancer.Ingress[0].IP, strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].Port, config.Gateway.MasqueradeIPs.V4HostETPLocalMasqueradeIP.String(), service.Spec.Ports[0].NodePort)
 				err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				Expect(err).NotTo(HaveOccurred())
 
@@ -1501,23 +1491,10 @@ var _ = Describe("Node Operations", func() {
 							"-j OVN-KUBE-NODEPORT",
 							"-j OVN-KUBE-ITP",
 						},
-						"OVN-KUBE-NODEPORT": []string{},
-						"OVN-KUBE-EXTERNALIP": []string{
-							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v",
-								service.Spec.Ports[0].Protocol,
-								svcStatusIP,
-								service.Spec.Ports[0].Port,
-								service.Spec.ClusterIP,
-								service.Spec.Ports[0].Port),
-							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v",
-								service.Spec.Ports[0].Protocol,
-								externalIP,
-								service.Spec.Ports[0].Port,
-								service.Spec.ClusterIP,
-								service.Spec.Ports[0].Port),
-						},
-						"OVN-KUBE-ETP": []string{},
-						"OVN-KUBE-ITP": []string{},
+						"OVN-KUBE-NODEPORT":   []string{},
+						"OVN-KUBE-EXTERNALIP": []string{},
+						"OVN-KUBE-ETP":        []string{},
+						"OVN-KUBE-ITP":        []string{},
 					},
 					"filter": {},
 					"mangle": {
@@ -1533,6 +1510,8 @@ var _ = Describe("Node Operations", func() {
 
 				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
 				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes nodeports-v4 { %s . %d : %s . %d }\n", strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port)
+				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes external-ips-v4 { %s . %s . %d : %s . %d }\n", externalIP, strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port)
+				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes external-ips-v4 { %s . %s . %d : %s . %d }\n", svcStatusIP, strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port)
 				err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				Expect(err).NotTo(HaveOccurred())
 
@@ -1729,12 +1708,10 @@ var _ = Describe("Node Operations", func() {
 							"-j OVN-KUBE-NODEPORT",
 							"-j OVN-KUBE-ITP",
 						},
-						"OVN-KUBE-EXTERNALIP": []string{
-							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, externalIPv4, service.Spec.Ports[0].Port, clusterIPv4, service.Spec.Ports[0].Port),
-						},
-						"OVN-KUBE-NODEPORT": []string{},
-						"OVN-KUBE-ETP":      []string{},
-						"OVN-KUBE-ITP":      []string{},
+						"OVN-KUBE-EXTERNALIP": []string{},
+						"OVN-KUBE-NODEPORT":   []string{},
+						"OVN-KUBE-ETP":        []string{},
+						"OVN-KUBE-ITP":        []string{},
 					},
 					"filter": {},
 					"mangle": {
@@ -1750,11 +1727,7 @@ var _ = Describe("Node Operations", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				expectedTables6 := map[string]util.FakeTable{
-					"nat": {
-						"OVN-KUBE-EXTERNALIP": []string{
-							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination [%s]:%v", service.Spec.Ports[0].Protocol, externalIPv6, service.Spec.Ports[0].Port, clusterIPv6, service.Spec.Ports[0].Port),
-						},
-					},
+					"nat":    {},
 					"filter": {},
 					"mangle": {},
 				}
@@ -1764,6 +1737,8 @@ var _ = Describe("Node Operations", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
+				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes external-ips-v4 { %s . %s . %d : %s . %d }\n", externalIPv4, strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].Port, clusterIPv4, service.Spec.Ports[0].Port)
+				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes external-ips-v6 { %s . %s . %d : %s . %d }\n", externalIPv6, strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].Port, clusterIPv6, service.Spec.Ports[0].Port)
 				return nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 			}
 			err := app.Run([]string{app.Name})
@@ -2419,14 +2394,10 @@ var _ = Describe("Node Operations", func() {
 							"-j OVN-KUBE-NODEPORT",
 							"-j OVN-KUBE-ITP",
 						},
-						"OVN-KUBE-EXTERNALIP": []string{
-							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v",
-								service.Spec.Ports[0].Protocol, externalIP, service.Spec.Ports[0].Port,
-								service.Spec.ClusterIP, service.Spec.Ports[0].Port),
-						},
-						"OVN-KUBE-NODEPORT": []string{},
-						"OVN-KUBE-ETP":      []string{},
-						"OVN-KUBE-ITP":      []string{},
+						"OVN-KUBE-EXTERNALIP": []string{},
+						"OVN-KUBE-NODEPORT":   []string{},
+						"OVN-KUBE-ETP":        []string{},
+						"OVN-KUBE-ITP":        []string{},
 					},
 					"filter": {},
 					"mangle": {
@@ -2443,6 +2414,7 @@ var _ = Describe("Node Operations", func() {
 				}).Should(Succeed())
 
 				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
+				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes external-ips-v4 { %s . %s . %d : %s . %d }\n", externalIP, strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port)
 				Eventually(func() error {
 					return nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				}).Should(Succeed())
@@ -2709,15 +2681,10 @@ var _ = Describe("Node Operations", func() {
 				nodePortWatcherRetry.RequestRetryObjs()
 				retry.CheckRetryObjectEventually(key, false, nodePortWatcherRetry) // entry should be gone
 
-				// now expect ip tables to show the external IP
-				ovn_kube_external_ip_field := []string{
-					fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v",
-						service.Spec.Ports[0].Protocol, goodExternalIP, service.Spec.Ports[0].Port,
-						service.Spec.ClusterIP, service.Spec.Ports[0].Port)}
-				expectedTables["nat"]["OVN-KUBE-EXTERNALIP"] = ovn_kube_external_ip_field
+				// now expect nftables to show the external IP
+				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes external-ips-v4 { %s . %s . %d : %s . %d }\n", goodExternalIP, strings.ToLower(string(service.Spec.Ports[0].Protocol)), service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port)
 				Eventually(func() error {
-					f4 := iptV4.(*util.FakeIPTables)
-					return f4.MatchState(expectedTables, nil)
+					return nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				}).Should(Succeed())
 
 				// TODO Make delete operation fail, check retry entry, run a successful delete

--- a/go-controller/pkg/node/gateway_localnet_linux_test.go
+++ b/go-controller/pkg/node/gateway_localnet_linux_test.go
@@ -72,6 +72,9 @@ func startNodePortWatcher(n *nodePortWatcher, fakeClient *util.OVNNodeClientset)
 	if err := initLocalGatewayIPTables(); err != nil {
 		return err
 	}
+	if err := initGatewayNFTables(); err != nil {
+		return err
+	}
 
 	k := &kube.Kube{KClient: fakeClient.KubeClient}
 	n.nodeIPManager = newAddressManagerInternal(fakeNodeName, k, nil, n.watchFactory, nil, nil, false)
@@ -114,6 +117,9 @@ func startNodePortWatcher(n *nodePortWatcher, fakeClient *util.OVNNodeClientset)
 
 func startNodePortWatcherWithRetry(n *nodePortWatcher, fakeClient *util.OVNNodeClientset, stopChan chan struct{}, wg *sync.WaitGroup) (*retry.RetryFramework, error) {
 	if err := initLocalGatewayIPTables(); err != nil {
+		return nil, err
+	}
+	if err := initGatewayNFTables(); err != nil {
 		return nil, err
 	}
 
@@ -386,7 +392,7 @@ var _ = Describe("Node Operations", func() {
 				err = f4.MatchState(expectedTables, nil)
 				Expect(err).NotTo(HaveOccurred())
 
-				expectedNFT := nftablesRulesBase
+				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
 				err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				Expect(err).NotTo(HaveOccurred())
 
@@ -463,7 +469,7 @@ var _ = Describe("Node Operations", func() {
 				err = f4.MatchState(expectedTables, nil)
 				Expect(err).NotTo(HaveOccurred())
 
-				expectedNFT := nftablesRulesBase
+				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
 				return nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 			}
 			err := app.Run([]string{app.Name})
@@ -539,7 +545,7 @@ var _ = Describe("Node Operations", func() {
 				err = f4.MatchState(expectedTables, nil)
 				Expect(err).NotTo(HaveOccurred())
 
-				expectedNFT := nftablesRulesBase
+				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
 				return nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 			}
 			err := app.Run([]string{app.Name})
@@ -629,7 +635,7 @@ var _ = Describe("Node Operations", func() {
 				err = f4.MatchState(expectedTables, nil)
 				Expect(err).NotTo(HaveOccurred())
 
-				expectedNFT := nftablesRulesBase
+				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
 				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes mgmtport-no-snat-nodeports { tcp . %v }\n", service.Spec.Ports[0].NodePort)
 				err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				Expect(err).NotTo(HaveOccurred())
@@ -730,7 +736,7 @@ var _ = Describe("Node Operations", func() {
 				err = f4.MatchState(expectedTables, nil)
 				Expect(err).NotTo(HaveOccurred())
 
-				expectedNFT := nftablesRulesBase
+				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
 				return nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 			}
 			err := app.Run([]string{app.Name})
@@ -828,7 +834,7 @@ var _ = Describe("Node Operations", func() {
 				err = f4.MatchState(expectedTables, nil)
 				Expect(err).NotTo(HaveOccurred())
 
-				expectedNFT := nftablesRulesBase
+				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
 				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes mgmtport-no-snat-nodeports { tcp . %v }\n", service.Spec.Ports[0].NodePort)
 				err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				Expect(err).NotTo(HaveOccurred())
@@ -967,7 +973,7 @@ var _ = Describe("Node Operations", func() {
 				f4 := iptV4.(*util.FakeIPTables)
 				Expect(f4.MatchState(expectedTables, nil)).To(Succeed())
 
-				expectedNFT := nftablesRulesBase
+				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
 				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes mgmtport-no-snat-services-v4 { %s . tcp . %d }\n", ep1.Addresses[0], int32(service.Spec.Ports[0].TargetPort.IntValue()))
 				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes mgmtport-no-snat-services-v4 { %s . tcp . %d }\n", ep2.Addresses[0], int32(service.Spec.Ports[0].TargetPort.IntValue()))
 				err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
@@ -1019,7 +1025,7 @@ var _ = Describe("Node Operations", func() {
 					return f4.MatchState(expectedTables, nil)
 				}, "2s").Should(Succeed())
 
-				expectedNFT = nftablesRulesBase
+				expectedNFT = nftablesRulesBase + nftablesRulesGatewayServices
 				Eventually(func() error {
 					return nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				}, "2s").Should(Succeed())
@@ -1162,7 +1168,7 @@ var _ = Describe("Node Operations", func() {
 				err = f4.MatchState(expectedTables, nil)
 				Expect(err).NotTo(HaveOccurred())
 
-				expectedNFT := nftablesRulesBase
+				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
 				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes mgmtport-no-snat-services-v4 { %s . tcp . %v }\n"+
 					"add element inet ovn-kubernetes mgmtport-no-snat-services-v4 { %s . tcp . %v }\n",
 					endpointSlice.Endpoints[1].Addresses[0],
@@ -1268,7 +1274,7 @@ var _ = Describe("Node Operations", func() {
 				err = f4.MatchState(expectedTables, nil)
 				Expect(err).NotTo(HaveOccurred())
 
-				expectedNFT := nftablesRulesBase
+				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
 				err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				Expect(err).NotTo(HaveOccurred())
 
@@ -1380,7 +1386,7 @@ var _ = Describe("Node Operations", func() {
 				err = f4.MatchState(expectedTables, nil)
 				Expect(err).NotTo(HaveOccurred())
 
-				expectedNFT := nftablesRulesBase
+				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
 				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes mgmtport-no-snat-nodeports { tcp . %v }\n", service.Spec.Ports[0].NodePort)
 				err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				Expect(err).NotTo(HaveOccurred())
@@ -1537,7 +1543,7 @@ var _ = Describe("Node Operations", func() {
 				err = f4.MatchState(expectedTables, nil)
 				Expect(err).NotTo(HaveOccurred())
 
-				expectedNFT := nftablesRulesBase
+				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
 				err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				Expect(err).NotTo(HaveOccurred())
 
@@ -1670,7 +1676,7 @@ var _ = Describe("Node Operations", func() {
 				err = f6.MatchState(expectedTables6, nil)
 				Expect(err).NotTo(HaveOccurred())
 
-				expectedNFT := nftablesRulesBase
+				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
 				err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				Expect(err).NotTo(HaveOccurred())
 
@@ -1772,7 +1778,7 @@ var _ = Describe("Node Operations", func() {
 				err = f6.MatchState(expectedTables6, nil)
 				Expect(err).NotTo(HaveOccurred())
 
-				expectedNFT := nftablesRulesBase
+				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
 				return nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 			}
 			err := app.Run([]string{app.Name})
@@ -1866,7 +1872,7 @@ var _ = Describe("Node Operations", func() {
 					return f6.MatchState(expectedTables, nil)
 				}, "2s").Should(Succeed())
 
-				expectedNFT := nftablesRulesBase
+				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
 				Eventually(func() error {
 					return nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				}, "2s").Should(Succeed())
@@ -1954,7 +1960,7 @@ var _ = Describe("Node Operations", func() {
 					return f6.MatchState(expectedTables, nil)
 				}, "2s").Should(Succeed())
 
-				expectedNFT := nftablesRulesBase
+				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
 				Eventually(func() error {
 					return nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				}, "2s").Should(Succeed())
@@ -2451,7 +2457,7 @@ var _ = Describe("Node Operations", func() {
 					return f4.MatchState(expectedTables, nil)
 				}).Should(Succeed())
 
-				expectedNFT := nftablesRulesBase
+				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
 				Eventually(func() error {
 					return nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				}).Should(Succeed())
@@ -2491,7 +2497,7 @@ var _ = Describe("Node Operations", func() {
 					return f4.MatchState(expectedTables, nil)
 				}, "2s").Should(Succeed())
 
-				expectedNFT = nftablesRulesBase
+				expectedNFT = nftablesRulesBase + nftablesRulesGatewayServices
 				Eventually(func() error {
 					return nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				}, "2s").Should(Succeed())
@@ -2699,6 +2705,10 @@ var _ = Describe("Node Operations", func() {
 				f4 := iptV4.(*util.FakeIPTables)
 				err = f4.MatchState(expectedTables, nil)
 				Expect(err).NotTo(HaveOccurred())
+				// check nftables
+				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
+				err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
+				Expect(err).NotTo(HaveOccurred())
 
 				// HACK: Fix the service by setting a correct external IP address in newObj field
 				// of the retry entry
@@ -2797,7 +2807,7 @@ var _ = Describe("Node Operations", func() {
 					return f4.MatchState(expectedTables, nil)
 				}).Should(Succeed())
 
-				expectedNFT := nftablesRulesBase
+				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
 				Eventually(func() error {
 					return nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				}).Should(Succeed())
@@ -2837,7 +2847,7 @@ var _ = Describe("Node Operations", func() {
 					return f4.MatchState(expectedTables, nil)
 				}, "2s").Should(Succeed())
 
-				expectedNFT = nftablesRulesBase
+				expectedNFT = nftablesRulesBase + nftablesRulesGatewayServices
 				Eventually(func() error {
 					return nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				}, "2s").Should(Succeed())
@@ -2932,7 +2942,7 @@ var _ = Describe("Node Operations", func() {
 				f4 := iptV4.(*util.FakeIPTables)
 				Expect(f4.MatchState(expectedTables, nil)).To(Succeed())
 
-				expectedNFT := nftablesRulesBase
+				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
 				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes mgmtport-no-snat-nodeports { tcp . %v }\n", service.Spec.Ports[0].NodePort)
 				Expect(nodenft.MatchNFTRules(expectedNFT, nft.Dump())).To(Succeed())
 
@@ -2974,7 +2984,7 @@ var _ = Describe("Node Operations", func() {
 					return f4.MatchState(expectedTables, nil)
 				}, "2s").Should(Succeed())
 
-				expectedNFT = nftablesRulesBase
+				expectedNFT = nftablesRulesBase + nftablesRulesGatewayServices
 				Eventually(func() error {
 					return nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				}, "2s").Should(Succeed())
@@ -3071,7 +3081,7 @@ var _ = Describe("Node Operations", func() {
 				f4 := iptV4.(*util.FakeIPTables)
 				Expect(f4.MatchState(expectedTables, nil)).To(Succeed())
 
-				expectedNFT := nftablesRulesBase
+				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
 				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes mgmtport-no-snat-nodeports { tcp . %v }\n", service.Spec.Ports[0].NodePort)
 				Expect(nodenft.MatchNFTRules(expectedNFT, nft.Dump())).To(Succeed())
 
@@ -3119,7 +3129,7 @@ var _ = Describe("Node Operations", func() {
 					return f4.MatchState(expectedTables, nil)
 				}, "2s").Should(Succeed())
 
-				expectedNFT = nftablesRulesBase
+				expectedNFT = nftablesRulesBase + nftablesRulesGatewayServices
 				Eventually(func() error {
 					return nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				}, "2s").Should(Succeed())
@@ -3221,7 +3231,7 @@ var _ = Describe("Node Operations", func() {
 				f4 := iptV4.(*util.FakeIPTables)
 				Expect(f4.MatchState(expectedTables, nil)).To(Succeed())
 
-				expectedNFT := nftablesRulesBase
+				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
 				Expect(nodenft.MatchNFTRules(expectedNFT, nft.Dump())).To(Succeed())
 
 				expectedFlows := []string{
@@ -3268,7 +3278,7 @@ var _ = Describe("Node Operations", func() {
 					return f4.MatchState(expectedTables, nil)
 				}, "2s").Should(Succeed())
 
-				expectedNFT = nftablesRulesBase
+				expectedNFT = nftablesRulesBase + nftablesRulesGatewayServices
 				Eventually(func() error {
 					return nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				}, "2s").Should(Succeed())
@@ -3364,7 +3374,7 @@ var _ = Describe("Node Operations", func() {
 				f4 := iptV4.(*util.FakeIPTables)
 				Expect(f4.MatchState(expectedTables, nil)).To(Succeed())
 
-				expectedNFT := nftablesRulesBase
+				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
 				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes mgmtport-no-snat-nodeports { tcp . %v }\n", service.Spec.Ports[0].NodePort)
 				Expect(nodenft.MatchNFTRules(expectedNFT, nft.Dump())).To(Succeed())
 
@@ -3412,7 +3422,7 @@ var _ = Describe("Node Operations", func() {
 					return f4.MatchState(expectedTables, nil)
 				}, "2s").Should(Succeed())
 
-				expectedNFT = nftablesRulesBase
+				expectedNFT = nftablesRulesBase + nftablesRulesGatewayServices
 				Eventually(func() error {
 					return nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				}, "2s").Should(Succeed())
@@ -3513,7 +3523,7 @@ var _ = Describe("Node Operations", func() {
 				f4 := iptV4.(*util.FakeIPTables)
 				Expect(f4.MatchState(expectedTables, nil)).To(Succeed())
 
-				expectedNFT := nftablesRulesBase
+				expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
 				Expect(nodenft.MatchNFTRules(expectedNFT, nft.Dump())).To(Succeed())
 
 				expectedFlows := []string{
@@ -3559,7 +3569,7 @@ var _ = Describe("Node Operations", func() {
 					return f4.MatchState(expectedTables, nil)
 				}, "2s").Should(Succeed())
 
-				expectedNFT = nftablesRulesBase
+				expectedNFT = nftablesRulesBase + nftablesRulesGatewayServices
 				Eventually(func() error {
 					return nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				}, "2s").Should(Succeed())

--- a/go-controller/pkg/node/gateway_nftables.go
+++ b/go-controller/pkg/node/gateway_nftables.go
@@ -40,6 +40,69 @@ const (
 	nftablesUDNMasqChain          = "ovn-kube-udn-masq"
 )
 
+// initGatewayNFTables initializes chains/sets/maps used for Service proxying rules.
+func initGatewayNFTables() error {
+	nft, err := nodenft.GetNFTablesHelper()
+	if err != nil {
+		return err
+	}
+
+	tx := nft.NewTransaction()
+
+	tx.Add(&knftables.Chain{
+		Name:    "services",
+		Comment: knftables.PtrTo("DNAT for ordinary NodePort/ExternalIP/LB traffic"),
+	})
+	tx.Flush(&knftables.Chain{
+		Name: "services",
+	})
+	tx.Add(&knftables.Chain{
+		Name:    "services-etp",
+		Comment: knftables.PtrTo("Special DNAT for NodePort/ExternalIP/LB traffic with ExternalTrafficPolicy: Local"),
+	})
+	tx.Flush(&knftables.Chain{
+		Name: "services-etp",
+	})
+
+	// Create chains that hook to netfilter and invoke our service chains as appropriate.
+	tx.Add(&knftables.Chain{
+		Name:     "services-prerouting",
+		Type:     knftables.PtrTo(knftables.NATType),
+		Hook:     knftables.PtrTo(knftables.PreroutingHook),
+		Priority: knftables.PtrTo(knftables.DNATPriority),
+	})
+	tx.Flush(&knftables.Chain{
+		Name: "services-prerouting",
+	})
+	tx.Add(&knftables.Rule{
+		Chain: "services-prerouting",
+		Rule:  "jump services-etp",
+	})
+	tx.Add(&knftables.Rule{
+		Chain: "services-prerouting",
+		Rule:  "jump services",
+	})
+	tx.Add(&knftables.Chain{
+		Name:     "services-output",
+		Type:     knftables.PtrTo(knftables.NATType),
+		Hook:     knftables.PtrTo(knftables.OutputHook),
+		Priority: knftables.PtrTo(knftables.DNATPriority),
+	})
+	tx.Flush(&knftables.Chain{
+		Name: "services-output",
+	})
+	tx.Add(&knftables.Rule{
+		Chain: "services-output",
+		Rule:  "jump services",
+	})
+
+	if err := nft.Run(context.TODO(), tx); err != nil {
+		return fmt.Errorf("could not set up service nftables rules: %w", err)
+	}
+
+	return nil
+}
+
 // getNoSNATNodePortRules returns elements to add to the "mgmtport-no-snat-nodeports"
 // set to prevent SNAT of sourceIP when passing through the management port, for an
 // `externalTrafficPolicy: Local` service with NodePorts.

--- a/go-controller/pkg/node/gateway_nftables.go
+++ b/go-controller/pkg/node/gateway_nftables.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
 	utilnet "k8s.io/utils/net"
 	"sigs.k8s.io/knftables"
 
@@ -38,6 +39,11 @@ const (
 	nftablesLocalGatewayMasqChain = "ovn-kube-local-gw-masq"
 	nftablesPodSubnetMasqChain    = "ovn-kube-pod-subnet-masq"
 	nftablesUDNMasqChain          = "ovn-kube-udn-masq"
+
+	nftablesNodePortsV4    = "nodeports-v4"
+	nftablesNodePortsV6    = "nodeports-v6"
+	nftablesETPNodePortsV4 = "nodeports-etp-local-v4"
+	nftablesETPNodePortsV6 = "nodeports-etp-local-v6"
 )
 
 // initGatewayNFTables initializes chains/sets/maps used for Service proxying rules.
@@ -96,11 +102,111 @@ func initGatewayNFTables() error {
 		Rule:  "jump services",
 	})
 
+	// Create the maps and rules for ETP:Local services
+	tx.Add(&knftables.Map{
+		Name:    nftablesETPNodePortsV4,
+		Type:    "inet_proto . inet_service : ipv4_addr . inet_service",
+		Comment: knftables.PtrTo("DNAT mappings for IPv4 NodePort traffic with ExternalTrafficPolicy: Local"),
+	})
+	tx.Add(&knftables.Map{
+		Name:    nftablesETPNodePortsV6,
+		Type:    "inet_proto . inet_service : ipv6_addr . inet_service",
+		Comment: knftables.PtrTo("DNAT mappings for IPv6 NodePort traffic with ExternalTrafficPolicy: Local"),
+	})
+	tx.Add(&knftables.Rule{
+		Chain: "services-etp",
+		Rule: knftables.Concat(
+			"fib daddr type local",
+			"dnat ip addr . port to",
+			"meta l4proto . th dport map", "@", nftablesETPNodePortsV4,
+		),
+	})
+	tx.Add(&knftables.Rule{
+		Chain: "services-etp",
+		Rule: knftables.Concat(
+			"fib daddr type local",
+			"dnat ip6 addr . port to",
+			"meta l4proto . th dport map", "@", nftablesETPNodePortsV6,
+		),
+	})
+
+	// Create the maps and rules for ordinary (ETP:Cluster) services
+	tx.Add(&knftables.Map{
+		Name:    nftablesNodePortsV4,
+		Type:    "inet_proto . inet_service : ipv4_addr . inet_service",
+		Comment: knftables.PtrTo("DNAT mappings for ordinary IPv4 NodePort traffic"),
+	})
+	tx.Add(&knftables.Map{
+		Name:    nftablesNodePortsV6,
+		Type:    "inet_proto . inet_service : ipv6_addr . inet_service",
+		Comment: knftables.PtrTo("DNAT mappings for ordinary IPv6 NodePort traffic"),
+	})
+
+	tx.Add(&knftables.Rule{
+		Chain: "services",
+		Rule: knftables.Concat(
+			"fib daddr type local",
+			"dnat ip addr . port to",
+			"meta l4proto . th dport map", "@", nftablesNodePortsV4,
+		),
+	})
+	tx.Add(&knftables.Rule{
+		Chain: "services",
+		Rule: knftables.Concat(
+			"fib daddr type local",
+			"dnat ip6 addr . port to",
+			"meta l4proto . th dport map", "@", nftablesNodePortsV6,
+		),
+	})
+
 	if err := nft.Run(context.TODO(), tx); err != nil {
 		return fmt.Errorf("could not set up service nftables rules: %w", err)
 	}
 
 	return nil
+}
+
+// getNodePortNFTRules returns the nftables DNAT rules for a service of type nodePort.
+// `svcPort` corresponds to port details for this service as specified in the service object.
+// `targetIP` is the clusterIP towards which the DNAT of nodePort service is to be added.
+// `targetPort` is the port towards which the DNAT of the nodePort service is to be added
+//
+//	case1: if svcHasLocalHostNetEndPnt=false + isETPLocal=true targetIP=config.masqueradeIP["HostETPLocalMasqueradeIP"] and targetPort=svcPort.NodePort
+//	case2: default: targetIP=clusterIP and targetPort=svcPort.Port
+//
+// `svcHasLocalHostNetEndPnt` is true if this service has at least one host-networked endpoint that is local to this node
+// `isETPLocal` is true if the svc.Spec.ExternalTrafficPolicy=Local
+func getNodePortNFTRules(svcPort corev1.ServicePort, targetIP string, targetPort int32, svcHasLocalHostNetEndPnt, isETPLocal bool) []knftables.Object {
+	var mapName string
+	if !svcHasLocalHostNetEndPnt && isETPLocal {
+		// DNAT it to the masqueradeIP:nodePort instead of clusterIP:targetPort
+		targetIP = getMasqueradeVIP(targetIP)
+		if utilnet.IsIPv4String(targetIP) {
+			mapName = nftablesETPNodePortsV4
+		} else {
+			mapName = nftablesETPNodePortsV6
+		}
+	} else {
+		if utilnet.IsIPv4String(targetIP) {
+			mapName = nftablesNodePortsV4
+		} else {
+			mapName = nftablesNodePortsV6
+		}
+	}
+
+	return []knftables.Object{
+		&knftables.Element{
+			Map: mapName,
+			Key: []string{
+				strings.ToLower(string(svcPort.Protocol)),
+				fmt.Sprintf("%d", svcPort.NodePort),
+			},
+			Value: []string{
+				targetIP,
+				fmt.Sprintf("%d", targetPort),
+			},
+		},
+	}
 }
 
 // getNoSNATNodePortRules returns elements to add to the "mgmtport-no-snat-nodeports"
@@ -200,15 +306,40 @@ func getUDNExternalIPsMarkNFTRules(svcPort corev1.ServicePort, externalIPs []str
 // with getGatewayIPTRulesForService.
 func getGatewayNFTRules(service *corev1.Service, localEndpoints util.PortToLBEndpoints, svcHasLocalHostNetEndPnt bool) []knftables.Object {
 	rules := make([]knftables.Object, 0)
+	clusterIPs := util.GetClusterIPs(service)
 	svcTypeIsETPLocal := util.ServiceExternalTrafficPolicyLocal(service)
 	for _, svcPort := range service.Spec.Ports {
+		if util.ServiceTypeHasNodePort(service) {
+			err := util.ValidatePort(svcPort.Protocol, svcPort.NodePort)
+			if err != nil {
+				klog.Errorf("Skipping service: %s, invalid service NodePort: %v", svcPort.Name, err)
+				continue
+			}
+			err = util.ValidatePort(svcPort.Protocol, svcPort.Port)
+			if err != nil {
+				klog.Errorf("Skipping service: %s, invalid service port %v", svcPort.Name, err)
+				continue
+			}
+			for _, clusterIP := range clusterIPs {
+				if svcTypeIsETPLocal && !svcHasLocalHostNetEndPnt {
+					// case1 (see function description for details)
+					// A DNAT rule to masqueradeIP is added that takes priority over DNAT to clusterIP.
+					if config.Gateway.Mode == config.GatewayModeLocal {
+						rules = append(rules, getNodePortNFTRules(svcPort, clusterIP, svcPort.NodePort, svcHasLocalHostNetEndPnt, svcTypeIsETPLocal)...)
+					}
+					// add a skip SNAT rule to preserve sourceIP for etp=local traffic
+					rules = append(rules, getNoSNATNodePortRules(svcPort)...)
+				}
+				// case2 (see function description for details)
+				rules = append(rules, getNodePortNFTRules(svcPort, clusterIP, svcPort.Port, svcHasLocalHostNetEndPnt, false)...)
+			}
+		}
+
 		if svcTypeIsETPLocal && !svcHasLocalHostNetEndPnt {
 			// For `externalTrafficPolicy: Local` services with pod-network
 			// endpoints, we need to add rules to prevent them from being SNATted
 			// when entering the management port, to preserve the client IP.
-			if util.ServiceTypeHasNodePort(service) {
-				rules = append(rules, getNoSNATNodePortRules(svcPort)...)
-			} else if len(util.GetExternalAndLBIPs(service)) > 0 {
+			if !util.ServiceTypeHasNodePort(service) && len(util.GetExternalAndLBIPs(service)) > 0 {
 				rules = append(rules, getNoSNATLoadBalancerIPRules(svcPort, localEndpoints)...)
 			}
 		}
@@ -230,6 +361,18 @@ func getGatewayNFTContainerObjects() []knftables.Object {
 		},
 		&knftables.Set{
 			Name: types.NFTMgmtPortNoSNATServicesV6,
+		},
+		&knftables.Map{
+			Name: nftablesNodePortsV4,
+		},
+		&knftables.Map{
+			Name: nftablesNodePortsV6,
+		},
+		&knftables.Map{
+			Name: nftablesETPNodePortsV4,
+		},
+		&knftables.Map{
+			Name: nftablesETPNodePortsV6,
 		},
 	}
 }

--- a/go-controller/pkg/node/gateway_nftables.go
+++ b/go-controller/pkg/node/gateway_nftables.go
@@ -51,9 +51,18 @@ const (
 	nftablesETPExternalIPsV6 = "external-ips-etp-local-v6"
 
 	nftablesETPNoNodePortChain = "services-etp-no-nodeport"
+
+	nftablesITPMarkSetV4     = "itp-services-to-mark-v4"
+	nftablesITPMarkSetV6     = "itp-services-to-mark-v6"
+	nftablesITPServicesMapV4 = "itp-services-to-redirect-v4"
+	nftablesITPServicesMapV6 = "itp-services-to-redirect-v6"
 )
 
 // initGatewayNFTables initializes chains/sets/maps used for Service proxying rules.
+//
+// FIXME: This function is only called if config.NodeportEnable is true, but it and
+// getGatewayNFTRules are also used for `internalTrafficPolicy: Local` handling, which
+// should not be gated behind config.NodeportEnable.
 func initGatewayNFTables() error {
 	nft, err := nodenft.GetNFTablesHelper()
 	if err != nil {
@@ -82,6 +91,13 @@ func initGatewayNFTables() error {
 	})
 	tx.Flush(&knftables.Chain{
 		Name: nftablesETPNoNodePortChain,
+	})
+	tx.Add(&knftables.Chain{
+		Name:    "services-itp",
+		Comment: knftables.PtrTo("Redirects for traffic with InternalTrafficPolicy: Local"),
+	})
+	tx.Flush(&knftables.Chain{
+		Name: "services-itp",
 	})
 
 	// Create chains that hook to netfilter and invoke our service chains as appropriate.
@@ -116,6 +132,10 @@ func initGatewayNFTables() error {
 	})
 	tx.Flush(&knftables.Chain{
 		Name: "services-output",
+	})
+	tx.Add(&knftables.Rule{
+		Chain: "services-output",
+		Rule:  "jump services-itp",
 	})
 	tx.Add(&knftables.Rule{
 		Chain: "services-output",
@@ -224,6 +244,65 @@ func initGatewayNFTables() error {
 			"fib daddr type local",
 			"dnat ip6 addr . port to",
 			"meta l4proto . th dport map", "@", nftablesNodePortsV6,
+		),
+	})
+
+	// Add the remaining chains/sets/maps for InternalTrafficPolicy: Local.
+	tx.Add(&knftables.Set{
+		Name:    nftablesITPMarkSetV4,
+		Type:    "ipv4_addr . inet_proto . inet_service",
+		Comment: knftables.PtrTo("InternalTrafficPolicy: Local traffic to mark for special routing"),
+	})
+	tx.Add(&knftables.Set{
+		Name:    nftablesITPMarkSetV6,
+		Type:    "ipv6_addr . inet_proto . inet_service",
+		Comment: knftables.PtrTo("InternalTrafficPolicy: Local traffic to mark for special routing"),
+	})
+	tx.Add(&knftables.Map{
+		Name:    nftablesITPServicesMapV4,
+		Type:    "ipv4_addr . inet_proto . inet_service : inet_service",
+		Comment: knftables.PtrTo("Port redirections for ordinary InternalTrafficPolicy: Local traffic"),
+	})
+	tx.Add(&knftables.Map{
+		Name:    nftablesITPServicesMapV6,
+		Type:    "ipv6_addr . inet_proto . inet_service : inet_service",
+		Comment: knftables.PtrTo("Port redirections for ordinary InternalTrafficPolicy: Local traffic"),
+	})
+	tx.Add(&knftables.Rule{
+		Chain: "services-itp",
+		Rule: knftables.Concat(
+			"meta l4proto { tcp, udp, sctp } redirect to ip daddr . meta l4proto . th dport map", "@", nftablesITPServicesMapV4,
+		),
+	})
+	tx.Add(&knftables.Rule{
+		Chain: "services-itp",
+		Rule: knftables.Concat(
+			"meta l4proto { tcp, udp, sctp } redirect to ip6 daddr . meta l4proto . th dport map", "@", nftablesITPServicesMapV6,
+		),
+	})
+
+	tx.Add(&knftables.Chain{
+		Name:     "services-itp-mark",
+		Type:     knftables.PtrTo(knftables.RouteType),
+		Hook:     knftables.PtrTo(knftables.OutputHook),
+		Priority: knftables.PtrTo(knftables.ManglePriority),
+		Comment:  knftables.PtrTo("Chain to mark InternalTrafficPolicy: Local traffic for special routing"),
+	})
+	tx.Flush(&knftables.Chain{
+		Name: "services-itp-mark",
+	})
+	tx.Add(&knftables.Rule{
+		Chain: "services-itp-mark",
+		Rule: knftables.Concat(
+			"ip daddr . meta l4proto . th dport", "@", nftablesITPMarkSetV4,
+			"mark set", types.OVNKubeITPMark,
+		),
+	})
+	tx.Add(&knftables.Rule{
+		Chain: "services-itp-mark",
+		Rule: knftables.Concat(
+			"ip6 daddr . meta l4proto . th dport", "@", nftablesITPMarkSetV6,
+			"mark set", types.OVNKubeITPMark,
 		),
 	})
 
@@ -383,6 +462,55 @@ func getExternalIPNFTRules(svcPort corev1.ServicePort, externalIP, dstIP string,
 	}
 }
 
+// getITPLocalNFTRules returns the `InternalTrafficPolicy: Local`-related rules for the provided service
+// `svcPort` corresponds to port details for this service as specified in the service object
+// `clusterIP` is clusterIP is the VIP of the service to match on
+// `svcHasLocalHostNetEndPnt` is true if this service has at least one host-networked endpoint that is local to this node
+func getITPLocalNFTRules(svcPort corev1.ServicePort, clusterIP string, svcHasLocalHostNetEndPnt bool) []knftables.Object {
+	// If the service has a local host-network endpoint, add a rule that will cause
+	// traffic to the ITP service from this host to be redirected to that endpoint.
+	if svcHasLocalHostNetEndPnt {
+		var mapName string
+		if utilnet.IsIPv4String(clusterIP) {
+			mapName = nftablesITPServicesMapV4
+		} else {
+			mapName = nftablesITPServicesMapV6
+		}
+		return []knftables.Object{
+			&knftables.Element{
+				Map: mapName,
+				Key: []string{
+					clusterIP,
+					strings.ToLower(string(svcPort.Protocol)),
+					fmt.Sprintf("%v", svcPort.Port),
+				},
+				Value: []string{
+					fmt.Sprintf("%v", int32(svcPort.TargetPort.IntValue())),
+				},
+			},
+		}
+	}
+
+	// Otherwise, add a rule that will cause traffic to the ITP service from this host
+	// to be marked (which will then cause it to be steered to ovn-k8s-mp0).
+	var setName string
+	if utilnet.IsIPv4String(clusterIP) {
+		setName = nftablesITPMarkSetV4
+	} else {
+		setName = nftablesITPMarkSetV6
+	}
+	return []knftables.Object{
+		&knftables.Element{
+			Set: setName,
+			Key: []string{
+				clusterIP,
+				strings.ToLower(string(svcPort.Protocol)),
+				fmt.Sprintf("%v", svcPort.Port),
+			},
+		},
+	}
+}
+
 // getNoSNATNodePortRules returns elements to add to the "mgmtport-no-snat-nodeports"
 // set to prevent SNAT of sourceIP when passing through the management port, for an
 // `externalTrafficPolicy: Local` service with NodePorts.
@@ -478,10 +606,15 @@ func getUDNExternalIPsMarkNFTRules(svcPort corev1.ServicePort, externalIPs []str
 
 // getGatewayNFTRules returns nftables rules for service. This must be used in conjunction
 // with getGatewayIPTRulesForService.
+//
+// FIXME: This function is only called if config.NodeportEnable is true, but it is also
+// used for `internalTrafficPolicy: Local` handling, which should not be gated behind
+// config.NodeportEnable.
 func getGatewayNFTRules(service *corev1.Service, localEndpoints util.PortToLBEndpoints, svcHasLocalHostNetEndPnt bool) []knftables.Object {
 	rules := make([]knftables.Object, 0)
 	clusterIPs := util.GetClusterIPs(service)
 	svcTypeIsETPLocal := util.ServiceExternalTrafficPolicyLocal(service)
+	svcTypeIsITPLocal := util.ServiceInternalTrafficPolicyLocal(service)
 	for _, svcPort := range service.Spec.Ports {
 		if util.ServiceTypeHasNodePort(service) {
 			err := util.ValidatePort(svcPort.Protocol, svcPort.NodePort)
@@ -537,6 +670,12 @@ func getGatewayNFTRules(service *corev1.Service, localEndpoints util.PortToLBEnd
 				rules = append(rules, getExternalIPNFTRules(svcPort, externalIP, clusterIP, svcHasLocalHostNetEndPnt, false)...)
 			}
 		}
+
+		if svcTypeIsITPLocal {
+			for _, clusterIP := range clusterIPs {
+				rules = append(rules, getITPLocalNFTRules(svcPort, clusterIP, svcHasLocalHostNetEndPnt)...)
+			}
+		}
 	}
 	return rules
 }
@@ -582,6 +721,18 @@ func getGatewayNFTContainerObjects() []knftables.Object {
 		},
 		&knftables.Chain{
 			Name: nftablesETPNoNodePortChain,
+		},
+		&knftables.Set{
+			Name: nftablesITPMarkSetV4,
+		},
+		&knftables.Set{
+			Name: nftablesITPMarkSetV6,
+		},
+		&knftables.Map{
+			Name: nftablesITPServicesMapV4,
+		},
+		&knftables.Map{
+			Name: nftablesITPServicesMapV6,
 		},
 	}
 }

--- a/go-controller/pkg/node/gateway_nftables.go
+++ b/go-controller/pkg/node/gateway_nftables.go
@@ -43,9 +43,9 @@ const (
 // getNoSNATNodePortRules returns elements to add to the "mgmtport-no-snat-nodeports"
 // set to prevent SNAT of sourceIP when passing through the management port, for an
 // `externalTrafficPolicy: Local` service with NodePorts.
-func getNoSNATNodePortRules(svcPort corev1.ServicePort) []*knftables.Element {
-	return []*knftables.Element{
-		{
+func getNoSNATNodePortRules(svcPort corev1.ServicePort) []knftables.Object {
+	return []knftables.Object{
+		&knftables.Element{
 			Set: types.NFTMgmtPortNoSNATNodePorts,
 			Key: []string{
 				strings.ToLower(string(svcPort.Protocol)),
@@ -59,8 +59,8 @@ func getNoSNATNodePortRules(svcPort corev1.ServicePort) []*knftables.Element {
 // "mgmtport-no-snat-services-v4" and "mgmtport-no-snat-services-v6" sets to prevent SNAT
 // of sourceIP when passing through the management port, for an `externalTrafficPolicy:
 // Local` service *without* NodePorts.
-func getNoSNATLoadBalancerIPRules(svcPort corev1.ServicePort, localEndpoints util.PortToLBEndpoints) []*knftables.Element {
-	var nftRules []*knftables.Element
+func getNoSNATLoadBalancerIPRules(svcPort corev1.ServicePort, localEndpoints util.PortToLBEndpoints) []knftables.Object {
+	var nftRules []knftables.Object
 	protocol := strings.ToLower(string(svcPort.Protocol))
 
 	// Get the endpoints for the port key.
@@ -109,8 +109,8 @@ func getUDNNodePortMarkNFTRule(svcPort corev1.ServicePort, netInfo *bridgeconfig
 // getUDNExternalIPsMarkNFTRules returns a verdict map elements (nftablesUDNMarkExternalIPsV4Map or nftablesUDNMarkExternalIPsV6Map)
 // with a key composed of the external IP, svcPort protocol and port.
 // The value is a jump to the UDN chain mark if netInfo is provided,  or nil that is useful for map entry removal.
-func getUDNExternalIPsMarkNFTRules(svcPort corev1.ServicePort, externalIPs []string, netInfo *bridgeconfig.BridgeUDNConfiguration) []*knftables.Element {
-	var nftRules []*knftables.Element
+func getUDNExternalIPsMarkNFTRules(svcPort corev1.ServicePort, externalIPs []string, netInfo *bridgeconfig.BridgeUDNConfiguration) []knftables.Object {
+	var nftRules []knftables.Object
 	var val []string
 
 	if netInfo != nil {
@@ -133,7 +133,7 @@ func getUDNExternalIPsMarkNFTRules(svcPort corev1.ServicePort, externalIPs []str
 	return nftRules
 }
 
-func recreateNFTSet(setName string, keepNFTElems []*knftables.Element) error {
+func recreateNFTSet(setName string, keepNFTElems []knftables.Object) error {
 	nft, err := nodenft.GetNFTablesHelper()
 	if err != nil {
 		return err
@@ -143,7 +143,7 @@ func recreateNFTSet(setName string, keepNFTElems []*knftables.Element) error {
 		Name: setName,
 	})
 	for _, elem := range keepNFTElems {
-		if elem.Set == setName {
+		if elem.(*knftables.Element).Set == setName {
 			tx.Add(elem)
 		}
 	}
@@ -155,7 +155,7 @@ func recreateNFTSet(setName string, keepNFTElems []*knftables.Element) error {
 	return err
 }
 
-func recreateNFTMap(mapName string, keepNFTElems []*knftables.Element) error {
+func recreateNFTMap(mapName string, keepNFTElems []knftables.Object) error {
 	nft, err := nodenft.GetNFTablesHelper()
 	if err != nil {
 		return err
@@ -165,7 +165,7 @@ func recreateNFTMap(mapName string, keepNFTElems []*knftables.Element) error {
 		Name: mapName,
 	})
 	for _, elem := range keepNFTElems {
-		if elem.Map == mapName {
+		if elem.(*knftables.Element).Map == mapName {
 			tx.Add(elem)
 		}
 	}
@@ -179,8 +179,8 @@ func recreateNFTMap(mapName string, keepNFTElems []*knftables.Element) error {
 
 // getGatewayNFTRules returns nftables rules for service. This must be used in conjunction
 // with getGatewayIPTRules.
-func getGatewayNFTRules(service *corev1.Service, localEndpoints util.PortToLBEndpoints, svcHasLocalHostNetEndPnt bool) []*knftables.Element {
-	rules := make([]*knftables.Element, 0)
+func getGatewayNFTRules(service *corev1.Service, localEndpoints util.PortToLBEndpoints, svcHasLocalHostNetEndPnt bool) []knftables.Object {
+	rules := make([]knftables.Object, 0)
 	svcTypeIsETPLocal := util.ServiceExternalTrafficPolicyLocal(service)
 	for _, svcPort := range service.Spec.Ports {
 		if svcTypeIsETPLocal && !svcHasLocalHostNetEndPnt {
@@ -209,8 +209,8 @@ func getGatewayNFTSets() []string {
 // getUDNNFTRules generates nftables rules for a UDN service.
 // If netConfig is nil, the resulting map elements will have empty values,
 // suitable only for entry removal.
-func getUDNNFTRules(service *corev1.Service, netConfig *bridgeconfig.BridgeUDNConfiguration) []*knftables.Element {
-	rules := make([]*knftables.Element, 0)
+func getUDNNFTRules(service *corev1.Service, netConfig *bridgeconfig.BridgeUDNConfiguration) []knftables.Object {
+	rules := make([]knftables.Object, 0)
 	for _, svcPort := range service.Spec.Ports {
 		if util.ServiceTypeHasNodePort(service) {
 			rules = append(rules, getUDNNodePortMarkNFTRule(svcPort, netConfig))

--- a/go-controller/pkg/node/gateway_nftables.go
+++ b/go-controller/pkg/node/gateway_nftables.go
@@ -25,15 +25,6 @@ import (
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
 )
 
-// gateway_nftables.go contains code for dealing with nftables rules; it is used in
-// conjunction with gateway_iptables.go.
-//
-// For the most part, using a mix of iptables and nftables rules does not matter, since
-// both of them are handled by netfilter. However, in cases where there is a close
-// ordering dependency between two rules (especially, in any case where it's necessary to
-// use an "accept" rule to override a later "drop" rule), then those rules will need to
-// either both be iptables or both be nftables.
-
 // nftables chain names
 const (
 	nftablesLocalGatewayMasqChain = "ovn-kube-local-gw-masq"

--- a/go-controller/pkg/node/gateway_nftables.go
+++ b/go-controller/pkg/node/gateway_nftables.go
@@ -44,6 +44,11 @@ const (
 	nftablesNodePortsV6    = "nodeports-v6"
 	nftablesETPNodePortsV4 = "nodeports-etp-local-v4"
 	nftablesETPNodePortsV6 = "nodeports-etp-local-v6"
+
+	nftablesExternalIPsV4    = "external-ips-v4"
+	nftablesExternalIPsV6    = "external-ips-v6"
+	nftablesETPExternalIPsV4 = "external-ips-etp-local-v4"
+	nftablesETPExternalIPsV6 = "external-ips-etp-local-v6"
 )
 
 // initGatewayNFTables initializes chains/sets/maps used for Service proxying rules.
@@ -104,6 +109,16 @@ func initGatewayNFTables() error {
 
 	// Create the maps and rules for ETP:Local services
 	tx.Add(&knftables.Map{
+		Name:    nftablesETPExternalIPsV4,
+		Type:    "ipv4_addr . inet_proto . inet_service : ipv4_addr . inet_service",
+		Comment: knftables.PtrTo("DNAT mappings for IPv4 ExternalIP/LB traffic with ExternalTrafficPolicy: Local"),
+	})
+	tx.Add(&knftables.Map{
+		Name:    nftablesETPExternalIPsV6,
+		Type:    "ipv6_addr . inet_proto . inet_service : ipv6_addr . inet_service",
+		Comment: knftables.PtrTo("DNAT mappings for IPv6 ExternalIP/LB traffic with ExternalTrafficPolicy: Local"),
+	})
+	tx.Add(&knftables.Map{
 		Name:    nftablesETPNodePortsV4,
 		Type:    "inet_proto . inet_service : ipv4_addr . inet_service",
 		Comment: knftables.PtrTo("DNAT mappings for IPv4 NodePort traffic with ExternalTrafficPolicy: Local"),
@@ -112,6 +127,20 @@ func initGatewayNFTables() error {
 		Name:    nftablesETPNodePortsV6,
 		Type:    "inet_proto . inet_service : ipv6_addr . inet_service",
 		Comment: knftables.PtrTo("DNAT mappings for IPv6 NodePort traffic with ExternalTrafficPolicy: Local"),
+	})
+	tx.Add(&knftables.Rule{
+		Chain: "services-etp",
+		Rule: knftables.Concat(
+			"dnat ip addr . port to ",
+			"ip daddr . meta l4proto . th dport map", "@", nftablesETPExternalIPsV4,
+		),
+	})
+	tx.Add(&knftables.Rule{
+		Chain: "services-etp",
+		Rule: knftables.Concat(
+			"dnat ip6 addr . port to ",
+			"ip6 daddr . meta l4proto . th dport map", "@", nftablesETPExternalIPsV6,
+		),
 	})
 	tx.Add(&knftables.Rule{
 		Chain: "services-etp",
@@ -132,6 +161,16 @@ func initGatewayNFTables() error {
 
 	// Create the maps and rules for ordinary (ETP:Cluster) services
 	tx.Add(&knftables.Map{
+		Name:    nftablesExternalIPsV4,
+		Type:    "ipv4_addr . inet_proto . inet_service : ipv4_addr . inet_service",
+		Comment: knftables.PtrTo("DNAT mappings for ordinary IPv4 ExternalIP/LB traffic"),
+	})
+	tx.Add(&knftables.Map{
+		Name:    nftablesExternalIPsV6,
+		Type:    "ipv6_addr . inet_proto . inet_service : ipv6_addr . inet_service",
+		Comment: knftables.PtrTo("DNAT mappings for ordinary IPv6 ExternalIP/LB traffic"),
+	})
+	tx.Add(&knftables.Map{
 		Name:    nftablesNodePortsV4,
 		Type:    "inet_proto . inet_service : ipv4_addr . inet_service",
 		Comment: knftables.PtrTo("DNAT mappings for ordinary IPv4 NodePort traffic"),
@@ -142,6 +181,20 @@ func initGatewayNFTables() error {
 		Comment: knftables.PtrTo("DNAT mappings for ordinary IPv6 NodePort traffic"),
 	})
 
+	tx.Add(&knftables.Rule{
+		Chain: "services",
+		Rule: knftables.Concat(
+			"dnat ip to ",
+			"ip daddr . meta l4proto . th dport map", "@", nftablesExternalIPsV4,
+		),
+	})
+	tx.Add(&knftables.Rule{
+		Chain: "services",
+		Rule: knftables.Concat(
+			"dnat ip6 to ",
+			"ip6 daddr . meta l4proto . th dport map", "@", nftablesExternalIPsV6,
+		),
+	})
 	tx.Add(&knftables.Rule{
 		Chain: "services",
 		Rule: knftables.Concat(
@@ -203,6 +256,52 @@ func getNodePortNFTRules(svcPort corev1.ServicePort, targetIP string, targetPort
 			},
 			Value: []string{
 				targetIP,
+				fmt.Sprintf("%d", targetPort),
+			},
+		},
+	}
+}
+
+// getExternalIPNFTRules returns the nftables DNAT rules for a service of type LB or ExternalIP
+// `svcPort` corresponds to port details for this service as specified in the service object
+// `externalIP` can either be the externalIP or LB.status.ingressIP
+// `dstIP` corresponds to the IP to which the provided externalIP needs to be DNAT-ed to
+//
+//	case1: if svcHasLocalHostNetEndPnt=false + isETPLocal=true, dstIP=config.MasqueradeIP["HostETPLocalMasqueradeIP"]
+//	case2: default: dstIP=clusterIP
+//
+// `svcHasLocalHostNetEndPnt` is true if this service has at least one host-networked endpoint that is local to this node
+// `isETPLocal` is true if the svc.Spec.ExternalTrafficPolicy=Local
+func getExternalIPNFTRules(svcPort corev1.ServicePort, externalIP, dstIP string, svcHasLocalHostNetEndPnt, isETPLocal bool) []knftables.Object {
+	var mapName string
+	targetPort := svcPort.Port
+	if !svcHasLocalHostNetEndPnt && isETPLocal {
+		// DNAT it to the masqueradeIP:nodePort instead of clusterIP:targetPort
+		dstIP = getMasqueradeVIP(externalIP)
+		targetPort = svcPort.NodePort
+		if utilnet.IsIPv4String(dstIP) {
+			mapName = nftablesETPExternalIPsV4
+		} else {
+			mapName = nftablesETPExternalIPsV6
+		}
+	} else {
+		if utilnet.IsIPv4String(dstIP) {
+			mapName = nftablesExternalIPsV4
+		} else {
+			mapName = nftablesExternalIPsV6
+		}
+	}
+
+	return []knftables.Object{
+		&knftables.Element{
+			Map: mapName,
+			Key: []string{
+				externalIP,
+				strings.ToLower(string(svcPort.Protocol)),
+				fmt.Sprintf("%d", svcPort.Port),
+			},
+			Value: []string{
+				dstIP,
 				fmt.Sprintf("%d", targetPort),
 			},
 		},
@@ -335,12 +434,32 @@ func getGatewayNFTRules(service *corev1.Service, localEndpoints util.PortToLBEnd
 			}
 		}
 
-		if svcTypeIsETPLocal && !svcHasLocalHostNetEndPnt {
-			// For `externalTrafficPolicy: Local` services with pod-network
-			// endpoints, we need to add rules to prevent them from being SNATted
-			// when entering the management port, to preserve the client IP.
-			if !util.ServiceTypeHasNodePort(service) && len(util.GetExternalAndLBIPs(service)) > 0 {
-				rules = append(rules, getNoSNATLoadBalancerIPRules(svcPort, localEndpoints)...)
+		snatRulesCreated := false
+		externalIPs := util.GetExternalAndLBIPs(service)
+		for _, externalIP := range externalIPs {
+			err := util.ValidatePort(svcPort.Protocol, svcPort.Port)
+			if err != nil {
+				klog.Errorf("Skipping service: %s, invalid service port %v", svcPort.Name, err)
+				continue
+			}
+			if clusterIP, err := util.MatchIPStringFamily(utilnet.IsIPv6String(externalIP), clusterIPs); err == nil {
+				if svcTypeIsETPLocal && !svcHasLocalHostNetEndPnt {
+					// case1 (see function description for details)
+					// DNAT traffic to masqueradeIP:nodePort instead of clusterIP:Port. We are leveraging the existing rules for NODEPORT
+					// service so no need to add a rule to skip SNAT since the corresponding nodePort svc would have one.
+					if !util.ServiceTypeHasNodePort(service) {
+						// getGatewayIPTRulesForService generates the DNAT rules for now.
+						// The SNAT rules are per endpoint and should only be created one time per endpoint and port combination
+						if !snatRulesCreated {
+							rules = append(rules, getNoSNATLoadBalancerIPRules(svcPort, localEndpoints)...)
+							snatRulesCreated = true
+						}
+					} else {
+						rules = append(rules, getExternalIPNFTRules(svcPort, externalIP, "", svcHasLocalHostNetEndPnt, svcTypeIsETPLocal)...)
+					}
+				}
+				// case2 (see function description for details)
+				rules = append(rules, getExternalIPNFTRules(svcPort, externalIP, clusterIP, svcHasLocalHostNetEndPnt, false)...)
 			}
 		}
 	}
@@ -373,6 +492,18 @@ func getGatewayNFTContainerObjects() []knftables.Object {
 		},
 		&knftables.Map{
 			Name: nftablesETPNodePortsV6,
+		},
+		&knftables.Map{
+			Name: nftablesExternalIPsV4,
+		},
+		&knftables.Map{
+			Name: nftablesExternalIPsV6,
+		},
+		&knftables.Map{
+			Name: nftablesETPExternalIPsV4,
+		},
+		&knftables.Map{
+			Name: nftablesETPExternalIPsV6,
 		},
 	}
 }

--- a/go-controller/pkg/node/gateway_nftables.go
+++ b/go-controller/pkg/node/gateway_nftables.go
@@ -49,6 +49,8 @@ const (
 	nftablesExternalIPsV6    = "external-ips-v6"
 	nftablesETPExternalIPsV4 = "external-ips-etp-local-v4"
 	nftablesETPExternalIPsV6 = "external-ips-etp-local-v6"
+
+	nftablesETPNoNodePortChain = "services-etp-no-nodeport"
 )
 
 // initGatewayNFTables initializes chains/sets/maps used for Service proxying rules.
@@ -74,6 +76,13 @@ func initGatewayNFTables() error {
 	tx.Flush(&knftables.Chain{
 		Name: "services-etp",
 	})
+	tx.Add(&knftables.Chain{
+		Name:    nftablesETPNoNodePortChain,
+		Comment: knftables.PtrTo("Special DNAT for ExternalIP/LB traffic with ExternalTrafficPolicy: Local and no NodePorts"),
+	})
+	tx.Flush(&knftables.Chain{
+		Name: nftablesETPNoNodePortChain,
+	})
 
 	// Create chains that hook to netfilter and invoke our service chains as appropriate.
 	tx.Add(&knftables.Chain{
@@ -88,6 +97,12 @@ func initGatewayNFTables() error {
 	tx.Add(&knftables.Rule{
 		Chain: "services-prerouting",
 		Rule:  "jump services-etp",
+	})
+	tx.Add(&knftables.Rule{
+		Chain: "services-prerouting",
+		Rule: knftables.Concat(
+			"jump", nftablesETPNoNodePortChain,
+		),
 	})
 	tx.Add(&knftables.Rule{
 		Chain: "services-prerouting",
@@ -258,6 +273,66 @@ func getNodePortNFTRules(svcPort corev1.ServicePort, targetIP string, targetPort
 				targetIP,
 				fmt.Sprintf("%d", targetPort),
 			},
+		},
+	}
+}
+
+func generateNFTRulesForLoadBalancersWithoutNodePorts(service *corev1.Service, svcPort corev1.ServicePort, externalIP string, localEndpoints util.PortToLBEndpoints) []knftables.Object {
+	// Get the endpoints for the port key.
+	// svcPortKey is of format e.g. "TCP/my-port-name" or "TCP/" if name is empty
+	// (is the case when only a single ServicePort is defined on this service).
+	svcPortKey := util.GetServicePortKey(svcPort.Protocol, svcPort.Name)
+	lbEndpoints := localEndpoints[svcPortKey]
+
+	// Get IPv4 or IPv6 IPs, depending on the type of the service's external IP.
+	destinations := lbEndpoints.GetV4Destinations()
+	if utilnet.IsIPv6String(externalIP) {
+		destinations = lbEndpoints.GetV6Destinations()
+	}
+	numLocalEndpoints := len(destinations)
+	if numLocalEndpoints == 0 {
+		return nil
+	}
+
+	ipX := "ip"
+	if utilnet.IsIPv6String(externalIP) {
+		ipX = "ip6"
+	}
+	comment := service.Namespace + "/" + service.Name + ":" + svcPort.Name
+
+	// Build comma-separated list of "NUMBER : IP" mappings
+	mappings := make([]string, 0, numLocalEndpoints*2)
+	for i, destination := range destinations {
+		if i != 0 {
+			mappings = append(mappings, ",")
+		}
+		mappings = append(mappings, fmt.Sprintf("%d : %s . %d", i, destination.IP, destination.Port))
+	}
+
+	// There's no good way to do this with a single static rule and only add and
+	// remove set/map elements like we do for everything else. In particular, you
+	// can't have nested maps, so we'd have to have the "ip . protocol . port" and the
+	// random endpoint number be in the same map. (So we'd have to have one map and
+	// rule for single-endpoint services, another map and rule for 2-endpoint
+	// services, etc.)
+	//
+	// If the O(n)-ness here turns out to be a problem, an alternative implementation
+	// would be to have a vmap from "ip . protocol . port" to a jump rule, and then
+	// have each Service have its own chain with a single "dnat to random map entry"
+	// rule. That would be slightly more complicated to manage, but it would make it
+	// O(1)...
+	return []knftables.Object{
+		&knftables.Rule{
+			Chain: nftablesETPNoNodePortChain,
+			Rule: knftables.Concat(
+				ipX, "daddr", externalIP,
+				"meta l4proto", strings.ToLower(string(svcPort.Protocol)),
+				"th dport", svcPort.Port,
+				"dnat", ipX, "addr . port to",
+				"numgen random mod", numLocalEndpoints,
+				"map {", mappings, "}",
+			),
+			Comment: &comment,
 		},
 	}
 }
@@ -448,7 +523,7 @@ func getGatewayNFTRules(service *corev1.Service, localEndpoints util.PortToLBEnd
 					// DNAT traffic to masqueradeIP:nodePort instead of clusterIP:Port. We are leveraging the existing rules for NODEPORT
 					// service so no need to add a rule to skip SNAT since the corresponding nodePort svc would have one.
 					if !util.ServiceTypeHasNodePort(service) {
-						// getGatewayIPTRulesForService generates the DNAT rules for now.
+						rules = append(rules, generateNFTRulesForLoadBalancersWithoutNodePorts(service, svcPort, externalIP, localEndpoints)...)
 						// The SNAT rules are per endpoint and should only be created one time per endpoint and port combination
 						if !snatRulesCreated {
 							rules = append(rules, getNoSNATLoadBalancerIPRules(svcPort, localEndpoints)...)
@@ -504,6 +579,9 @@ func getGatewayNFTContainerObjects() []knftables.Object {
 		},
 		&knftables.Map{
 			Name: nftablesETPExternalIPsV6,
+		},
+		&knftables.Chain{
+			Name: nftablesETPNoNodePortChain,
 		},
 	}
 }

--- a/go-controller/pkg/node/gateway_nftables.go
+++ b/go-controller/pkg/node/gateway_nftables.go
@@ -133,52 +133,8 @@ func getUDNExternalIPsMarkNFTRules(svcPort corev1.ServicePort, externalIPs []str
 	return nftRules
 }
 
-func recreateNFTSet(setName string, keepNFTElems []knftables.Object) error {
-	nft, err := nodenft.GetNFTablesHelper()
-	if err != nil {
-		return err
-	}
-	tx := nft.NewTransaction()
-	tx.Flush(&knftables.Set{
-		Name: setName,
-	})
-	for _, elem := range keepNFTElems {
-		if elem.(*knftables.Element).Set == setName {
-			tx.Add(elem)
-		}
-	}
-	err = nft.Run(context.TODO(), tx)
-	// no error if set is not created and we desire zero NFT elements
-	if knftables.IsNotFound(err) && len(keepNFTElems) == 0 {
-		return nil
-	}
-	return err
-}
-
-func recreateNFTMap(mapName string, keepNFTElems []knftables.Object) error {
-	nft, err := nodenft.GetNFTablesHelper()
-	if err != nil {
-		return err
-	}
-	tx := nft.NewTransaction()
-	tx.Flush(&knftables.Map{
-		Name: mapName,
-	})
-	for _, elem := range keepNFTElems {
-		if elem.(*knftables.Element).Map == mapName {
-			tx.Add(elem)
-		}
-	}
-	err = nft.Run(context.TODO(), tx)
-	// no error if set is not created and we desire zero NFT elements
-	if knftables.IsNotFound(err) && len(keepNFTElems) == 0 {
-		return nil
-	}
-	return err
-}
-
 // getGatewayNFTRules returns nftables rules for service. This must be used in conjunction
-// with getGatewayIPTRules.
+// with getGatewayIPTRulesForService.
 func getGatewayNFTRules(service *corev1.Service, localEndpoints util.PortToLBEndpoints, svcHasLocalHostNetEndPnt bool) []knftables.Object {
 	rules := make([]knftables.Object, 0)
 	svcTypeIsETPLocal := util.ServiceExternalTrafficPolicyLocal(service)
@@ -197,12 +153,21 @@ func getGatewayNFTRules(service *corev1.Service, localEndpoints util.PortToLBEnd
 	return rules
 }
 
-// getGatewayNFTSets returns the names of all of the sets used by getGatewayNFTRules.
-func getGatewayNFTSets() []string {
-	return []string{
-		types.NFTMgmtPortNoSNATNodePorts,
-		types.NFTMgmtPortNoSNATServicesV4,
-		types.NFTMgmtPortNoSNATServicesV6,
+// getGatewayNFTContainerObjects returns all of the "container" objects (Sets/Maps/Chains)
+// used by getGatewayNFTRules. This is used (possibly along with
+// getUDNNFTContainerObjects) to determine the sets/maps/chains whose contents will be
+// synchronized by nodePortWatcher.SyncServices().
+func getGatewayNFTContainerObjects() []knftables.Object {
+	return []knftables.Object{
+		&knftables.Set{
+			Name: types.NFTMgmtPortNoSNATNodePorts,
+		},
+		&knftables.Set{
+			Name: types.NFTMgmtPortNoSNATServicesV4,
+		},
+		&knftables.Set{
+			Name: types.NFTMgmtPortNoSNATServicesV6,
+		},
 	}
 }
 
@@ -235,12 +200,21 @@ func shouldAddUDNServiceMarkRules(netInfo util.NetInfo, nodeName string) bool {
 	return slices.Contains(advertisedVRFs, types.DefaultNetworkName)
 }
 
-// getUDNNFTMaps returns the names of all of the maps used by getUDNNFTRules.
-func getUDNNFTMaps() []string {
-	return []string{
-		nftablesUDNMarkNodePortsMap,
-		nftablesUDNMarkExternalIPsV4Map,
-		nftablesUDNMarkExternalIPsV6Map,
+// getUDNNFTContainerObjects returns all of the "container" objects (Sets/Maps/Chains)
+// used by getUDNNFTRules. This is used (possibly along with
+// getGatewayNFTContainerObjects) to determine the sets/maps/chains whose contents will be
+// synchronized by nodePortWatcher.SyncServices().
+func getUDNNFTContainerObjects() []knftables.Object {
+	return []knftables.Object{
+		&knftables.Map{
+			Name: nftablesUDNMarkNodePortsMap,
+		},
+		&knftables.Map{
+			Name: nftablesUDNMarkExternalIPsV4Map,
+		},
+		&knftables.Map{
+			Name: nftablesUDNMarkExternalIPsV6Map,
+		},
 	}
 }
 

--- a/go-controller/pkg/node/gateway_nftables.go
+++ b/go-controller/pkg/node/gateway_nftables.go
@@ -310,6 +310,9 @@ func initGatewayNFTables() error {
 		return fmt.Errorf("could not set up service nftables rules: %w", err)
 	}
 
+	// If there are legacy IPTables rules left around, try to clean them up.
+	cleanupGatewayIPTables()
+
 	return nil
 }
 
@@ -604,8 +607,7 @@ func getUDNExternalIPsMarkNFTRules(svcPort corev1.ServicePort, externalIPs []str
 	return nftRules
 }
 
-// getGatewayNFTRules returns nftables rules for service. This must be used in conjunction
-// with getGatewayIPTRulesForService.
+// getGatewayNFTRules returns nftables rules for service.
 //
 // FIXME: This function is only called if config.NodeportEnable is true, but it is also
 // used for `internalTrafficPolicy: Local` handling, which should not be gated behind
@@ -1156,4 +1158,12 @@ func delLocalGatewayPodSubnetNFTRules() error {
 	}
 
 	return nil
+}
+
+// getMasqueradeVIP returns the .3 masquerade VIP based on the protocol (v4/v6) of provided IP string
+func getMasqueradeVIP(ip string) string {
+	if utilnet.IsIPv6String(ip) {
+		return config.Gateway.MasqueradeIPs.V6HostETPLocalMasqueradeIP.String()
+	}
+	return config.Gateway.MasqueradeIPs.V4HostETPLocalMasqueradeIP.String()
 }

--- a/go-controller/pkg/node/gateway_nftables.go
+++ b/go-controller/pkg/node/gateway_nftables.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
 	utilnet "k8s.io/utils/net"
 	"sigs.k8s.io/knftables"
 
@@ -24,28 +25,492 @@ import (
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
 )
 
-// gateway_nftables.go contains code for dealing with nftables rules; it is used in
-// conjunction with gateway_iptables.go.
-//
-// For the most part, using a mix of iptables and nftables rules does not matter, since
-// both of them are handled by netfilter. However, in cases where there is a close
-// ordering dependency between two rules (especially, in any case where it's necessary to
-// use an "accept" rule to override a later "drop" rule), then those rules will need to
-// either both be iptables or both be nftables.
-
 // nftables chain names
 const (
 	nftablesLocalGatewayMasqChain = "ovn-kube-local-gw-masq"
 	nftablesPodSubnetMasqChain    = "ovn-kube-pod-subnet-masq"
 	nftablesUDNMasqChain          = "ovn-kube-udn-masq"
+
+	nftablesNodePortsV4    = "nodeports-v4"
+	nftablesNodePortsV6    = "nodeports-v6"
+	nftablesETPNodePortsV4 = "nodeports-etp-local-v4"
+	nftablesETPNodePortsV6 = "nodeports-etp-local-v6"
+
+	nftablesExternalIPsV4    = "external-ips-v4"
+	nftablesExternalIPsV6    = "external-ips-v6"
+	nftablesETPExternalIPsV4 = "external-ips-etp-local-v4"
+	nftablesETPExternalIPsV6 = "external-ips-etp-local-v6"
+
+	nftablesETPNoNodePortChain = "services-etp-no-nodeport"
+
+	nftablesITPMarkSetV4     = "itp-services-to-mark-v4"
+	nftablesITPMarkSetV6     = "itp-services-to-mark-v6"
+	nftablesITPServicesMapV4 = "itp-services-to-redirect-v4"
+	nftablesITPServicesMapV6 = "itp-services-to-redirect-v6"
 )
+
+// initGatewayNFTables initializes chains/sets/maps used for Service proxying rules.
+//
+// FIXME: This function is only called if config.NodeportEnable is true, but it and
+// getGatewayNFTRules are also used for `internalTrafficPolicy: Local` handling, which
+// should not be gated behind config.NodeportEnable.
+func initGatewayNFTables() error {
+	nft, err := nodenft.GetNFTablesHelper()
+	if err != nil {
+		return err
+	}
+
+	tx := nft.NewTransaction()
+
+	tx.Add(&knftables.Chain{
+		Name:    "services",
+		Comment: knftables.PtrTo("DNAT for ordinary NodePort/ExternalIP/LB traffic"),
+	})
+	tx.Flush(&knftables.Chain{
+		Name: "services",
+	})
+	tx.Add(&knftables.Chain{
+		Name:    "services-etp",
+		Comment: knftables.PtrTo("Special DNAT for NodePort/ExternalIP/LB traffic with ExternalTrafficPolicy: Local"),
+	})
+	tx.Flush(&knftables.Chain{
+		Name: "services-etp",
+	})
+	tx.Add(&knftables.Chain{
+		Name:    nftablesETPNoNodePortChain,
+		Comment: knftables.PtrTo("Special DNAT for ExternalIP/LB traffic with ExternalTrafficPolicy: Local and no NodePorts"),
+	})
+	tx.Flush(&knftables.Chain{
+		Name: nftablesETPNoNodePortChain,
+	})
+	tx.Add(&knftables.Chain{
+		Name:    "services-itp",
+		Comment: knftables.PtrTo("Redirects for traffic with InternalTrafficPolicy: Local"),
+	})
+	tx.Flush(&knftables.Chain{
+		Name: "services-itp",
+	})
+
+	// Create chains that hook to netfilter and invoke our service chains as appropriate.
+	tx.Add(&knftables.Chain{
+		Name:     "services-prerouting",
+		Type:     knftables.PtrTo(knftables.NATType),
+		Hook:     knftables.PtrTo(knftables.PreroutingHook),
+		Priority: knftables.PtrTo(knftables.DNATPriority),
+	})
+	tx.Flush(&knftables.Chain{
+		Name: "services-prerouting",
+	})
+	tx.Add(&knftables.Rule{
+		Chain: "services-prerouting",
+		Rule:  "jump services-etp",
+	})
+	tx.Add(&knftables.Rule{
+		Chain: "services-prerouting",
+		Rule: knftables.Concat(
+			"jump", nftablesETPNoNodePortChain,
+		),
+	})
+	tx.Add(&knftables.Rule{
+		Chain: "services-prerouting",
+		Rule:  "jump services",
+	})
+	tx.Add(&knftables.Chain{
+		Name:     "services-output",
+		Type:     knftables.PtrTo(knftables.NATType),
+		Hook:     knftables.PtrTo(knftables.OutputHook),
+		Priority: knftables.PtrTo(knftables.DNATPriority),
+	})
+	tx.Flush(&knftables.Chain{
+		Name: "services-output",
+	})
+	tx.Add(&knftables.Rule{
+		Chain: "services-output",
+		Rule:  "jump services-itp",
+	})
+	tx.Add(&knftables.Rule{
+		Chain: "services-output",
+		Rule:  "jump services",
+	})
+
+	// Create the maps and rules for ETP:Local services
+	tx.Add(&knftables.Map{
+		Name:    nftablesETPExternalIPsV4,
+		Type:    "ipv4_addr . inet_proto . inet_service : ipv4_addr . inet_service",
+		Comment: knftables.PtrTo("DNAT mappings for IPv4 ExternalIP/LB traffic with ExternalTrafficPolicy: Local"),
+	})
+	tx.Add(&knftables.Map{
+		Name:    nftablesETPExternalIPsV6,
+		Type:    "ipv6_addr . inet_proto . inet_service : ipv6_addr . inet_service",
+		Comment: knftables.PtrTo("DNAT mappings for IPv6 ExternalIP/LB traffic with ExternalTrafficPolicy: Local"),
+	})
+	tx.Add(&knftables.Map{
+		Name:    nftablesETPNodePortsV4,
+		Type:    "inet_proto . inet_service : ipv4_addr . inet_service",
+		Comment: knftables.PtrTo("DNAT mappings for IPv4 NodePort traffic with ExternalTrafficPolicy: Local"),
+	})
+	tx.Add(&knftables.Map{
+		Name:    nftablesETPNodePortsV6,
+		Type:    "inet_proto . inet_service : ipv6_addr . inet_service",
+		Comment: knftables.PtrTo("DNAT mappings for IPv6 NodePort traffic with ExternalTrafficPolicy: Local"),
+	})
+	tx.Add(&knftables.Rule{
+		Chain: "services-etp",
+		Rule: knftables.Concat(
+			"dnat ip addr . port to ",
+			"ip daddr . meta l4proto . th dport map", "@", nftablesETPExternalIPsV4,
+		),
+	})
+	tx.Add(&knftables.Rule{
+		Chain: "services-etp",
+		Rule: knftables.Concat(
+			"dnat ip6 addr . port to ",
+			"ip6 daddr . meta l4proto . th dport map", "@", nftablesETPExternalIPsV6,
+		),
+	})
+	tx.Add(&knftables.Rule{
+		Chain: "services-etp",
+		Rule: knftables.Concat(
+			"fib daddr type local",
+			"dnat ip addr . port to",
+			"meta l4proto . th dport map", "@", nftablesETPNodePortsV4,
+		),
+	})
+	tx.Add(&knftables.Rule{
+		Chain: "services-etp",
+		Rule: knftables.Concat(
+			"fib daddr type local",
+			"dnat ip6 addr . port to",
+			"meta l4proto . th dport map", "@", nftablesETPNodePortsV6,
+		),
+	})
+
+	// Create the maps and rules for ordinary (ETP:Cluster) services
+	tx.Add(&knftables.Map{
+		Name:    nftablesExternalIPsV4,
+		Type:    "ipv4_addr . inet_proto . inet_service : ipv4_addr . inet_service",
+		Comment: knftables.PtrTo("DNAT mappings for ordinary IPv4 ExternalIP/LB traffic"),
+	})
+	tx.Add(&knftables.Map{
+		Name:    nftablesExternalIPsV6,
+		Type:    "ipv6_addr . inet_proto . inet_service : ipv6_addr . inet_service",
+		Comment: knftables.PtrTo("DNAT mappings for ordinary IPv6 ExternalIP/LB traffic"),
+	})
+	tx.Add(&knftables.Map{
+		Name:    nftablesNodePortsV4,
+		Type:    "inet_proto . inet_service : ipv4_addr . inet_service",
+		Comment: knftables.PtrTo("DNAT mappings for ordinary IPv4 NodePort traffic"),
+	})
+	tx.Add(&knftables.Map{
+		Name:    nftablesNodePortsV6,
+		Type:    "inet_proto . inet_service : ipv6_addr . inet_service",
+		Comment: knftables.PtrTo("DNAT mappings for ordinary IPv6 NodePort traffic"),
+	})
+
+	tx.Add(&knftables.Rule{
+		Chain: "services",
+		Rule: knftables.Concat(
+			"dnat ip to ",
+			"ip daddr . meta l4proto . th dport map", "@", nftablesExternalIPsV4,
+		),
+	})
+	tx.Add(&knftables.Rule{
+		Chain: "services",
+		Rule: knftables.Concat(
+			"dnat ip6 to ",
+			"ip6 daddr . meta l4proto . th dport map", "@", nftablesExternalIPsV6,
+		),
+	})
+	tx.Add(&knftables.Rule{
+		Chain: "services",
+		Rule: knftables.Concat(
+			"fib daddr type local",
+			"dnat ip addr . port to",
+			"meta l4proto . th dport map", "@", nftablesNodePortsV4,
+		),
+	})
+	tx.Add(&knftables.Rule{
+		Chain: "services",
+		Rule: knftables.Concat(
+			"fib daddr type local",
+			"dnat ip6 addr . port to",
+			"meta l4proto . th dport map", "@", nftablesNodePortsV6,
+		),
+	})
+
+	// Add the remaining chains/sets/maps for InternalTrafficPolicy: Local.
+	tx.Add(&knftables.Set{
+		Name:    nftablesITPMarkSetV4,
+		Type:    "ipv4_addr . inet_proto . inet_service",
+		Comment: knftables.PtrTo("InternalTrafficPolicy: Local traffic to mark for special routing"),
+	})
+	tx.Add(&knftables.Set{
+		Name:    nftablesITPMarkSetV6,
+		Type:    "ipv6_addr . inet_proto . inet_service",
+		Comment: knftables.PtrTo("InternalTrafficPolicy: Local traffic to mark for special routing"),
+	})
+	tx.Add(&knftables.Map{
+		Name:    nftablesITPServicesMapV4,
+		Type:    "ipv4_addr . inet_proto . inet_service : inet_service",
+		Comment: knftables.PtrTo("Port redirections for ordinary InternalTrafficPolicy: Local traffic"),
+	})
+	tx.Add(&knftables.Map{
+		Name:    nftablesITPServicesMapV6,
+		Type:    "ipv6_addr . inet_proto . inet_service : inet_service",
+		Comment: knftables.PtrTo("Port redirections for ordinary InternalTrafficPolicy: Local traffic"),
+	})
+	tx.Add(&knftables.Rule{
+		Chain: "services-itp",
+		Rule: knftables.Concat(
+			"meta l4proto { tcp, udp, sctp } redirect to ip daddr . meta l4proto . th dport map", "@", nftablesITPServicesMapV4,
+		),
+	})
+	tx.Add(&knftables.Rule{
+		Chain: "services-itp",
+		Rule: knftables.Concat(
+			"meta l4proto { tcp, udp, sctp } redirect to ip6 daddr . meta l4proto . th dport map", "@", nftablesITPServicesMapV6,
+		),
+	})
+
+	tx.Add(&knftables.Chain{
+		Name:     "services-itp-mark",
+		Type:     knftables.PtrTo(knftables.RouteType),
+		Hook:     knftables.PtrTo(knftables.OutputHook),
+		Priority: knftables.PtrTo(knftables.ManglePriority),
+		Comment:  knftables.PtrTo("Chain to mark InternalTrafficPolicy: Local traffic for special routing"),
+	})
+	tx.Flush(&knftables.Chain{
+		Name: "services-itp-mark",
+	})
+	tx.Add(&knftables.Rule{
+		Chain: "services-itp-mark",
+		Rule: knftables.Concat(
+			"ip daddr . meta l4proto . th dport", "@", nftablesITPMarkSetV4,
+			"mark set", types.OVNKubeITPMark,
+		),
+	})
+	tx.Add(&knftables.Rule{
+		Chain: "services-itp-mark",
+		Rule: knftables.Concat(
+			"ip6 daddr . meta l4proto . th dport", "@", nftablesITPMarkSetV6,
+			"mark set", types.OVNKubeITPMark,
+		),
+	})
+
+	if err := nft.Run(context.TODO(), tx); err != nil {
+		return fmt.Errorf("could not set up service nftables rules: %w", err)
+	}
+
+	// If there are legacy IPTables rules left around, try to clean them up.
+	cleanupGatewayIPTables()
+
+	return nil
+}
+
+// getNodePortNFTRules returns the nftables DNAT rules for a service of type nodePort.
+// `svcPort` corresponds to port details for this service as specified in the service object.
+// `targetIP` is the clusterIP towards which the DNAT of nodePort service is to be added.
+// `targetPort` is the port towards which the DNAT of the nodePort service is to be added
+//
+//	case1: if svcHasLocalHostNetEndPnt=false + isETPLocal=true targetIP=config.masqueradeIP["HostETPLocalMasqueradeIP"] and targetPort=svcPort.NodePort
+//	case2: default: targetIP=clusterIP and targetPort=svcPort.Port
+//
+// `svcHasLocalHostNetEndPnt` is true if this service has at least one host-networked endpoint that is local to this node
+// `isETPLocal` is true if the svc.Spec.ExternalTrafficPolicy=Local
+func getNodePortNFTRules(svcPort corev1.ServicePort, targetIP string, targetPort int32, svcHasLocalHostNetEndPnt, isETPLocal bool) []knftables.Object {
+	var mapName string
+	if !svcHasLocalHostNetEndPnt && isETPLocal {
+		// DNAT it to the masqueradeIP:nodePort instead of clusterIP:targetPort
+		targetIP = getMasqueradeVIP(targetIP)
+		if utilnet.IsIPv4String(targetIP) {
+			mapName = nftablesETPNodePortsV4
+		} else {
+			mapName = nftablesETPNodePortsV6
+		}
+	} else {
+		if utilnet.IsIPv4String(targetIP) {
+			mapName = nftablesNodePortsV4
+		} else {
+			mapName = nftablesNodePortsV6
+		}
+	}
+
+	return []knftables.Object{
+		&knftables.Element{
+			Map: mapName,
+			Key: []string{
+				strings.ToLower(string(svcPort.Protocol)),
+				fmt.Sprintf("%d", svcPort.NodePort),
+			},
+			Value: []string{
+				targetIP,
+				fmt.Sprintf("%d", targetPort),
+			},
+		},
+	}
+}
+
+func generateNFTRulesForLoadBalancersWithoutNodePorts(service *corev1.Service, svcPort corev1.ServicePort, externalIP string, localEndpoints util.PortToLBEndpoints) []knftables.Object {
+	// Get the endpoints for the port key.
+	// svcPortKey is of format e.g. "TCP/my-port-name" or "TCP/" if name is empty
+	// (is the case when only a single ServicePort is defined on this service).
+	svcPortKey := util.GetServicePortKey(svcPort.Protocol, svcPort.Name)
+	lbEndpoints := localEndpoints[svcPortKey]
+
+	// Get IPv4 or IPv6 IPs, depending on the type of the service's external IP.
+	destinations := lbEndpoints.GetV4Destinations()
+	if utilnet.IsIPv6String(externalIP) {
+		destinations = lbEndpoints.GetV6Destinations()
+	}
+	numLocalEndpoints := len(destinations)
+	if numLocalEndpoints == 0 {
+		return nil
+	}
+
+	ipX := "ip"
+	if utilnet.IsIPv6String(externalIP) {
+		ipX = "ip6"
+	}
+	comment := service.Namespace + "/" + service.Name + ":" + svcPort.Name
+
+	// Build comma-separated list of "NUMBER : IP" mappings
+	mappings := make([]string, 0, numLocalEndpoints*2)
+	for i, destination := range destinations {
+		if i != 0 {
+			mappings = append(mappings, ",")
+		}
+		mappings = append(mappings, fmt.Sprintf("%d : %s . %d", i, destination.IP, destination.Port))
+	}
+
+	// There's no good way to do this with a single static rule and only add and
+	// remove set/map elements like we do for everything else. In particular, you
+	// can't have nested maps, so we'd have to have the "ip . protocol . port" and the
+	// random endpoint number be in the same map. (So we'd have to have one map and
+	// rule for single-endpoint services, another map and rule for 2-endpoint
+	// services, etc.)
+	//
+	// If the O(n)-ness here turns out to be a problem, an alternative implementation
+	// would be to have a vmap from "ip . protocol . port" to a jump rule, and then
+	// have each Service have its own chain with a single "dnat to random map entry"
+	// rule. That would be slightly more complicated to manage, but it would make it
+	// O(1)...
+	return []knftables.Object{
+		&knftables.Rule{
+			Chain: nftablesETPNoNodePortChain,
+			Rule: knftables.Concat(
+				ipX, "daddr", externalIP,
+				"meta l4proto", strings.ToLower(string(svcPort.Protocol)),
+				"th dport", svcPort.Port,
+				"dnat", ipX, "addr . port to",
+				"numgen random mod", numLocalEndpoints,
+				"map {", mappings, "}",
+			),
+			Comment: &comment,
+		},
+	}
+}
+
+// getExternalIPNFTRules returns the nftables DNAT rules for a service of type LB or ExternalIP
+// `svcPort` corresponds to port details for this service as specified in the service object
+// `externalIP` can either be the externalIP or LB.status.ingressIP
+// `dstIP` corresponds to the IP to which the provided externalIP needs to be DNAT-ed to
+//
+//	case1: if svcHasLocalHostNetEndPnt=false + isETPLocal=true, dstIP=config.MasqueradeIP["HostETPLocalMasqueradeIP"]
+//	case2: default: dstIP=clusterIP
+//
+// `svcHasLocalHostNetEndPnt` is true if this service has at least one host-networked endpoint that is local to this node
+// `isETPLocal` is true if the svc.Spec.ExternalTrafficPolicy=Local
+func getExternalIPNFTRules(svcPort corev1.ServicePort, externalIP, dstIP string, svcHasLocalHostNetEndPnt, isETPLocal bool) []knftables.Object {
+	var mapName string
+	targetPort := svcPort.Port
+	if !svcHasLocalHostNetEndPnt && isETPLocal {
+		// DNAT it to the masqueradeIP:nodePort instead of clusterIP:targetPort
+		dstIP = getMasqueradeVIP(externalIP)
+		targetPort = svcPort.NodePort
+		if utilnet.IsIPv4String(dstIP) {
+			mapName = nftablesETPExternalIPsV4
+		} else {
+			mapName = nftablesETPExternalIPsV6
+		}
+	} else {
+		if utilnet.IsIPv4String(dstIP) {
+			mapName = nftablesExternalIPsV4
+		} else {
+			mapName = nftablesExternalIPsV6
+		}
+	}
+
+	return []knftables.Object{
+		&knftables.Element{
+			Map: mapName,
+			Key: []string{
+				externalIP,
+				strings.ToLower(string(svcPort.Protocol)),
+				fmt.Sprintf("%d", svcPort.Port),
+			},
+			Value: []string{
+				dstIP,
+				fmt.Sprintf("%d", targetPort),
+			},
+		},
+	}
+}
+
+// getITPLocalNFTRules returns the `InternalTrafficPolicy: Local`-related rules for the provided service
+// `svcPort` corresponds to port details for this service as specified in the service object
+// `clusterIP` is clusterIP is the VIP of the service to match on
+// `svcHasLocalHostNetEndPnt` is true if this service has at least one host-networked endpoint that is local to this node
+func getITPLocalNFTRules(svcPort corev1.ServicePort, clusterIP string, svcHasLocalHostNetEndPnt bool) []knftables.Object {
+	// If the service has a local host-network endpoint, add a rule that will cause
+	// traffic to the ITP service from this host to be redirected to that endpoint.
+	if svcHasLocalHostNetEndPnt {
+		var mapName string
+		if utilnet.IsIPv4String(clusterIP) {
+			mapName = nftablesITPServicesMapV4
+		} else {
+			mapName = nftablesITPServicesMapV6
+		}
+		return []knftables.Object{
+			&knftables.Element{
+				Map: mapName,
+				Key: []string{
+					clusterIP,
+					strings.ToLower(string(svcPort.Protocol)),
+					fmt.Sprintf("%v", svcPort.Port),
+				},
+				Value: []string{
+					fmt.Sprintf("%v", int32(svcPort.TargetPort.IntValue())),
+				},
+			},
+		}
+	}
+
+	// Otherwise, add a rule that will cause traffic to the ITP service from this host
+	// to be marked (which will then cause it to be steered to ovn-k8s-mp0).
+	var setName string
+	if utilnet.IsIPv4String(clusterIP) {
+		setName = nftablesITPMarkSetV4
+	} else {
+		setName = nftablesITPMarkSetV6
+	}
+	return []knftables.Object{
+		&knftables.Element{
+			Set: setName,
+			Key: []string{
+				clusterIP,
+				strings.ToLower(string(svcPort.Protocol)),
+				fmt.Sprintf("%v", svcPort.Port),
+			},
+		},
+	}
+}
 
 // getNoSNATNodePortRules returns elements to add to the "mgmtport-no-snat-nodeports"
 // set to prevent SNAT of sourceIP when passing through the management port, for an
 // `externalTrafficPolicy: Local` service with NodePorts.
-func getNoSNATNodePortRules(svcPort corev1.ServicePort) []*knftables.Element {
-	return []*knftables.Element{
-		{
+func getNoSNATNodePortRules(svcPort corev1.ServicePort) []knftables.Object {
+	return []knftables.Object{
+		&knftables.Element{
 			Set: types.NFTMgmtPortNoSNATNodePorts,
 			Key: []string{
 				strings.ToLower(string(svcPort.Protocol)),
@@ -59,8 +524,8 @@ func getNoSNATNodePortRules(svcPort corev1.ServicePort) []*knftables.Element {
 // "mgmtport-no-snat-services-v4" and "mgmtport-no-snat-services-v6" sets to prevent SNAT
 // of sourceIP when passing through the management port, for an `externalTrafficPolicy:
 // Local` service *without* NodePorts.
-func getNoSNATLoadBalancerIPRules(svcPort corev1.ServicePort, localEndpoints util.PortToLBEndpoints) []*knftables.Element {
-	var nftRules []*knftables.Element
+func getNoSNATLoadBalancerIPRules(svcPort corev1.ServicePort, localEndpoints util.PortToLBEndpoints) []knftables.Object {
+	var nftRules []knftables.Object
 	protocol := strings.ToLower(string(svcPort.Protocol))
 
 	// Get the endpoints for the port key.
@@ -109,8 +574,8 @@ func getUDNNodePortMarkNFTRule(svcPort corev1.ServicePort, netInfo *bridgeconfig
 // getUDNExternalIPsMarkNFTRules returns a verdict map elements (nftablesUDNMarkExternalIPsV4Map or nftablesUDNMarkExternalIPsV6Map)
 // with a key composed of the external IP, svcPort protocol and port.
 // The value is a jump to the UDN chain mark if netInfo is provided,  or nil that is useful for map entry removal.
-func getUDNExternalIPsMarkNFTRules(svcPort corev1.ServicePort, externalIPs []string, netInfo *bridgeconfig.BridgeUDNConfiguration) []*knftables.Element {
-	var nftRules []*knftables.Element
+func getUDNExternalIPsMarkNFTRules(svcPort corev1.ServicePort, externalIPs []string, netInfo *bridgeconfig.BridgeUDNConfiguration) []knftables.Object {
+	var nftRules []knftables.Object
 	var val []string
 
 	if netInfo != nil {
@@ -133,84 +598,143 @@ func getUDNExternalIPsMarkNFTRules(svcPort corev1.ServicePort, externalIPs []str
 	return nftRules
 }
 
-func recreateNFTSet(setName string, keepNFTElems []*knftables.Element) error {
-	nft, err := nodenft.GetNFTablesHelper()
-	if err != nil {
-		return err
-	}
-	tx := nft.NewTransaction()
-	tx.Flush(&knftables.Set{
-		Name: setName,
-	})
-	for _, elem := range keepNFTElems {
-		if elem.Set == setName {
-			tx.Add(elem)
-		}
-	}
-	err = nft.Run(context.TODO(), tx)
-	// no error if set is not created and we desire zero NFT elements
-	if knftables.IsNotFound(err) && len(keepNFTElems) == 0 {
-		return nil
-	}
-	return err
-}
-
-func recreateNFTMap(mapName string, keepNFTElems []*knftables.Element) error {
-	nft, err := nodenft.GetNFTablesHelper()
-	if err != nil {
-		return err
-	}
-	tx := nft.NewTransaction()
-	tx.Flush(&knftables.Map{
-		Name: mapName,
-	})
-	for _, elem := range keepNFTElems {
-		if elem.Map == mapName {
-			tx.Add(elem)
-		}
-	}
-	err = nft.Run(context.TODO(), tx)
-	// no error if set is not created and we desire zero NFT elements
-	if knftables.IsNotFound(err) && len(keepNFTElems) == 0 {
-		return nil
-	}
-	return err
-}
-
-// getGatewayNFTRules returns nftables rules for service. This must be used in conjunction
-// with getGatewayIPTRules.
-func getGatewayNFTRules(service *corev1.Service, localEndpoints util.PortToLBEndpoints, svcHasLocalHostNetEndPnt bool) []*knftables.Element {
-	rules := make([]*knftables.Element, 0)
+// getGatewayNFTRules returns nftables rules for service.
+//
+// FIXME: This function is only called if config.NodeportEnable is true, but it is also
+// used for `internalTrafficPolicy: Local` handling, which should not be gated behind
+// config.NodeportEnable.
+func getGatewayNFTRules(service *corev1.Service, localEndpoints util.PortToLBEndpoints, svcHasLocalHostNetEndPnt bool) []knftables.Object {
+	rules := make([]knftables.Object, 0)
+	clusterIPs := util.GetClusterIPs(service)
 	svcTypeIsETPLocal := util.ServiceExternalTrafficPolicyLocal(service)
+	svcTypeIsITPLocal := util.ServiceInternalTrafficPolicyLocal(service)
 	for _, svcPort := range service.Spec.Ports {
-		if svcTypeIsETPLocal && !svcHasLocalHostNetEndPnt {
-			// For `externalTrafficPolicy: Local` services with pod-network
-			// endpoints, we need to add rules to prevent them from being SNATted
-			// when entering the management port, to preserve the client IP.
-			if util.ServiceTypeHasNodePort(service) {
-				rules = append(rules, getNoSNATNodePortRules(svcPort)...)
-			} else if len(util.GetExternalAndLBIPs(service)) > 0 {
-				rules = append(rules, getNoSNATLoadBalancerIPRules(svcPort, localEndpoints)...)
+		if util.ServiceTypeHasNodePort(service) {
+			err := util.ValidatePort(svcPort.Protocol, svcPort.NodePort)
+			if err != nil {
+				klog.Errorf("Skipping service: %s, invalid service NodePort: %v", svcPort.Name, err)
+				continue
+			}
+			err = util.ValidatePort(svcPort.Protocol, svcPort.Port)
+			if err != nil {
+				klog.Errorf("Skipping service: %s, invalid service port %v", svcPort.Name, err)
+				continue
+			}
+			for _, clusterIP := range clusterIPs {
+				if svcTypeIsETPLocal && !svcHasLocalHostNetEndPnt {
+					// case1 (see function description for details)
+					// A DNAT rule to masqueradeIP is added that takes priority over DNAT to clusterIP.
+					if config.Gateway.Mode == config.GatewayModeLocal {
+						rules = append(rules, getNodePortNFTRules(svcPort, clusterIP, svcPort.NodePort, svcHasLocalHostNetEndPnt, svcTypeIsETPLocal)...)
+					}
+					// add a skip SNAT rule to preserve sourceIP for etp=local traffic
+					rules = append(rules, getNoSNATNodePortRules(svcPort)...)
+				}
+				// case2 (see function description for details)
+				rules = append(rules, getNodePortNFTRules(svcPort, clusterIP, svcPort.Port, svcHasLocalHostNetEndPnt, false)...)
+			}
+		}
+
+		snatRulesCreated := false
+		externalIPs := util.GetExternalAndLBIPs(service)
+		for _, externalIP := range externalIPs {
+			err := util.ValidatePort(svcPort.Protocol, svcPort.Port)
+			if err != nil {
+				klog.Errorf("Skipping service: %s, invalid service port %v", svcPort.Name, err)
+				continue
+			}
+			if clusterIP, err := util.MatchIPStringFamily(utilnet.IsIPv6String(externalIP), clusterIPs); err == nil {
+				if svcTypeIsETPLocal && !svcHasLocalHostNetEndPnt {
+					// case1 (see function description for details)
+					// DNAT traffic to masqueradeIP:nodePort instead of clusterIP:Port. We are leveraging the existing rules for NODEPORT
+					// service so no need to add a rule to skip SNAT since the corresponding nodePort svc would have one.
+					if !util.ServiceTypeHasNodePort(service) {
+						rules = append(rules, generateNFTRulesForLoadBalancersWithoutNodePorts(service, svcPort, externalIP, localEndpoints)...)
+						// The SNAT rules are per endpoint and should only be created one time per endpoint and port combination
+						if !snatRulesCreated {
+							rules = append(rules, getNoSNATLoadBalancerIPRules(svcPort, localEndpoints)...)
+							snatRulesCreated = true
+						}
+					} else {
+						rules = append(rules, getExternalIPNFTRules(svcPort, externalIP, "", svcHasLocalHostNetEndPnt, svcTypeIsETPLocal)...)
+					}
+				}
+				// case2 (see function description for details)
+				rules = append(rules, getExternalIPNFTRules(svcPort, externalIP, clusterIP, svcHasLocalHostNetEndPnt, false)...)
+			}
+		}
+
+		if svcTypeIsITPLocal {
+			for _, clusterIP := range clusterIPs {
+				rules = append(rules, getITPLocalNFTRules(svcPort, clusterIP, svcHasLocalHostNetEndPnt)...)
 			}
 		}
 	}
 	return rules
 }
 
-// getGatewayNFTSets returns the names of all of the sets used by getGatewayNFTRules.
-func getGatewayNFTSets() []string {
-	return []string{
-		types.NFTMgmtPortNoSNATNodePorts,
-		types.NFTMgmtPortNoSNATServicesV4,
-		types.NFTMgmtPortNoSNATServicesV6,
+// getGatewayNFTContainerObjects returns all of the "container" objects (Sets/Maps/Chains)
+// used by getGatewayNFTRules. This is used (possibly along with
+// getUDNNFTContainerObjects) to determine the sets/maps/chains whose contents will be
+// synchronized by nodePortWatcher.SyncServices().
+func getGatewayNFTContainerObjects() []knftables.Object {
+	return []knftables.Object{
+		&knftables.Set{
+			Name: types.NFTMgmtPortNoSNATNodePorts,
+		},
+		&knftables.Set{
+			Name: types.NFTMgmtPortNoSNATServicesV4,
+		},
+		&knftables.Set{
+			Name: types.NFTMgmtPortNoSNATServicesV6,
+		},
+		&knftables.Map{
+			Name: nftablesNodePortsV4,
+		},
+		&knftables.Map{
+			Name: nftablesNodePortsV6,
+		},
+		&knftables.Map{
+			Name: nftablesETPNodePortsV4,
+		},
+		&knftables.Map{
+			Name: nftablesETPNodePortsV6,
+		},
+		&knftables.Map{
+			Name: nftablesExternalIPsV4,
+		},
+		&knftables.Map{
+			Name: nftablesExternalIPsV6,
+		},
+		&knftables.Map{
+			Name: nftablesETPExternalIPsV4,
+		},
+		&knftables.Map{
+			Name: nftablesETPExternalIPsV6,
+		},
+		&knftables.Chain{
+			Name: nftablesETPNoNodePortChain,
+		},
+		&knftables.Set{
+			Name: nftablesITPMarkSetV4,
+		},
+		&knftables.Set{
+			Name: nftablesITPMarkSetV6,
+		},
+		&knftables.Map{
+			Name: nftablesITPServicesMapV4,
+		},
+		&knftables.Map{
+			Name: nftablesITPServicesMapV6,
+		},
 	}
 }
 
 // getUDNNFTRules generates nftables rules for a UDN service.
 // If netConfig is nil, the resulting map elements will have empty values,
 // suitable only for entry removal.
-func getUDNNFTRules(service *corev1.Service, netConfig *bridgeconfig.BridgeUDNConfiguration) []*knftables.Element {
-	rules := make([]*knftables.Element, 0)
+func getUDNNFTRules(service *corev1.Service, netConfig *bridgeconfig.BridgeUDNConfiguration) []knftables.Object {
+	rules := make([]knftables.Object, 0)
 	for _, svcPort := range service.Spec.Ports {
 		if util.ServiceTypeHasNodePort(service) {
 			rules = append(rules, getUDNNodePortMarkNFTRule(svcPort, netConfig))
@@ -235,12 +759,21 @@ func shouldAddUDNServiceMarkRules(netInfo util.NetInfo, nodeName string) bool {
 	return slices.Contains(advertisedVRFs, types.DefaultNetworkName)
 }
 
-// getUDNNFTMaps returns the names of all of the maps used by getUDNNFTRules.
-func getUDNNFTMaps() []string {
-	return []string{
-		nftablesUDNMarkNodePortsMap,
-		nftablesUDNMarkExternalIPsV4Map,
-		nftablesUDNMarkExternalIPsV6Map,
+// getUDNNFTContainerObjects returns all of the "container" objects (Sets/Maps/Chains)
+// used by getUDNNFTRules. This is used (possibly along with
+// getGatewayNFTContainerObjects) to determine the sets/maps/chains whose contents will be
+// synchronized by nodePortWatcher.SyncServices().
+func getUDNNFTContainerObjects() []knftables.Object {
+	return []knftables.Object{
+		&knftables.Map{
+			Name: nftablesUDNMarkNodePortsMap,
+		},
+		&knftables.Map{
+			Name: nftablesUDNMarkExternalIPsV4Map,
+		},
+		&knftables.Map{
+			Name: nftablesUDNMarkExternalIPsV6Map,
+		},
 	}
 }
 
@@ -616,4 +1149,12 @@ func delLocalGatewayPodSubnetNFTRules() error {
 	}
 
 	return nil
+}
+
+// getMasqueradeVIP returns the .3 masquerade VIP based on the protocol (v4/v6) of provided IP string
+func getMasqueradeVIP(ip string) string {
+	if utilnet.IsIPv6String(ip) {
+		return config.Gateway.MasqueradeIPs.V6HostETPLocalMasqueradeIP.String()
+	}
+	return config.Gateway.MasqueradeIPs.V4HostETPLocalMasqueradeIP.String()
 }

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -1323,7 +1323,7 @@ func (npw *nodePortWatcher) SyncServices(services []interface{}) error {
 	// sync netfilter rules once only for Full mode
 	if !npw.dpuMode {
 		// (NOTE: Order is important, add jump to iptableETPChain before jump to NP/EIP chains)
-		for _, chain := range []string{iptableITPChain, iptableExternalIPChain, iptableETPChain} {
+		for _, chain := range []string{iptableITPChain, iptableETPChain} {
 			if err = recreateIPTRules("nat", chain, keepIPTRules); err != nil {
 				errors = append(errors, err)
 			}
@@ -1715,13 +1715,6 @@ func (npwipt *nodePortWatcherIptables) SyncServices(services []interface{}) erro
 		// TODO: ETP and ITP is not implemented for smart NIC mode.
 		keepIPTRules = append(keepIPTRules, getGatewayIPTRules(service, nil, false)...)
 		keepNFTObjects = append(keepNFTObjects, getGatewayNFTRules(service, nil, false)...)
-	}
-
-	// sync rules once
-	for _, chain := range []string{iptableExternalIPChain} {
-		if err = recreateIPTRules("nat", chain, keepIPTRules); err != nil {
-			errors = append(errors, err)
-		}
 	}
 
 	nftContainers = append(nftContainers, getGatewayNFTContainerObjects()...)

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -181,19 +181,19 @@ func configureUDNServicesNFTables() error {
 	return nft.Run(context.TODO(), tx)
 }
 
-// nodePortWatcherIptables manages iptables rules for shared gateway
+// nodePortWatcherNFTables manages nftables rules for shared gateway
 // to ensure that services using NodePorts are accessible.
-type nodePortWatcherIptables struct {
+type nodePortWatcherNFTables struct {
 	networkManager networkmanager.Interface
 }
 
-func newNodePortWatcherIptables(networkManager networkmanager.Interface) *nodePortWatcherIptables {
-	return &nodePortWatcherIptables{
+func newNodePortWatcherNFTables(networkManager networkmanager.Interface) *nodePortWatcherNFTables {
+	return &nodePortWatcherNFTables{
 		networkManager: networkManager,
 	}
 }
 
-// nodePortWatcher manages OpenFlow and iptables rules
+// nodePortWatcher manages OpenFlow and nftables rules
 // to ensure that services using NodePorts are accessible
 type nodePortWatcher struct {
 	dpuMode       bool
@@ -202,7 +202,7 @@ type nodePortWatcher struct {
 	gatewayIPLock sync.Mutex
 	ofportPhys    string
 	gwBridge      *bridgeconfig.BridgeConfiguration
-	// Map of service name to programmed iptables/OF rules
+	// Map of service name to programmed nftables/OF rules
 	serviceInfo     map[ktypes.NamespacedName]*serviceConfig
 	serviceInfoLock sync.Mutex
 	ofm             *openflowManager
@@ -803,7 +803,7 @@ func (npw *nodePortWatcher) updateServiceInfo(index ktypes.NamespacedName, servi
 	return &ptrCopy, exists
 }
 
-// addServiceRules ensures the correct iptables rules and OpenFlow physical
+// addServiceRules ensures the correct nftables rules and OpenFlow physical
 // flows are programmed for a given service and endpoint configuration
 func addServiceRules(service *corev1.Service, netInfo util.NetInfo, localEndpoints util.PortToLBEndpoints, svcHasLocalHostNetEndPnt bool, npw *nodePortWatcher) error {
 	// For dpu or Full mode
@@ -822,23 +822,15 @@ func addServiceRules(service *corev1.Service, netInfo util.NetInfo, localEndpoin
 	}
 
 	if npw == nil || !npw.dpuMode {
-		// add iptables/nftables rules only in full mode
-		iptRules := getGatewayIPTRules(service, localEndpoints, svcHasLocalHostNetEndPnt)
-		if len(iptRules) > 0 {
-			if err := insertIptRules(iptRules); err != nil {
-				err = fmt.Errorf("failed to add iptables rules for service %s/%s: %v",
-					service.Namespace, service.Name, err)
-				errors = append(errors, err)
-			}
-		}
-		nftElems := getGatewayNFTRules(service, localEndpoints, svcHasLocalHostNetEndPnt)
+		// add nftables rules only in full mode
+		nftObjs := getGatewayNFTRules(service, localEndpoints, svcHasLocalHostNetEndPnt)
 		if activeNetwork != nil &&
 			shouldAddUDNServiceMarkRules(netInfo, npw.nodeIPManager.nodeName) {
-			nftElems = append(nftElems, getUDNNFTRules(service, activeNetwork)...)
+			nftObjs = append(nftObjs, getUDNNFTRules(service, activeNetwork)...)
 		}
-		if len(nftElems) > 0 {
-			if err := nodenft.UpdateNFTElements(nftElems); err != nil {
-				err = fmt.Errorf("failed to update nftables rules for service %s/%s: %v",
+		if len(nftObjs) > 0 {
+			if err := nodenft.AddObjects(nftObjs); err != nil {
+				err = fmt.Errorf("failed to update nftables rules for service %s/%s: %w",
 					service.Namespace, service.Name, err)
 				errors = append(errors, err)
 			}
@@ -848,7 +840,7 @@ func addServiceRules(service *corev1.Service, netInfo util.NetInfo, localEndpoin
 	return utilerrors.Join(errors...)
 }
 
-// delServiceRules deletes all possible iptables rules and OpenFlow physical
+// delServiceRules deletes all possible nftables rules and OpenFlow physical
 // flows for a service
 func delServiceRules(service *corev1.Service, localEndpoints util.PortToLBEndpoints, npw *nodePortWatcher) error {
 	var err error
@@ -862,7 +854,7 @@ func delServiceRules(service *corev1.Service, localEndpoints util.PortToLBEndpoi
 	}
 
 	if npw == nil || !npw.dpuMode {
-		// Always try and delete all rules here in full mode & in host only mode. We don't touch iptables in dpu mode.
+		// Always try and delete all rules here in full mode & in host only mode. We don't touch nftables in dpu mode.
 		// +--------------------------+-----------------------+-----------------------+--------------------------------+
 		// | svcHasLocalHostNetEndPnt | ExternalTrafficPolicy | InternalTrafficPolicy |     Scenario for deletion      |
 		// |--------------------------|-----------------------|-----------------------|--------------------------------|
@@ -888,23 +880,14 @@ func delServiceRules(service *corev1.Service, localEndpoints util.PortToLBEndpoi
 		// |                          |                       |                       |   + default dnat towards CIP   |
 		// +--------------------------+-----------------------+-----------------------+--------------------------------+
 
-		iptRules := getGatewayIPTRules(service, localEndpoints, true)
-		iptRules = append(iptRules, getGatewayIPTRules(service, localEndpoints, false)...)
-		if len(iptRules) > 0 {
-			if err := nodeipt.DelRules(iptRules); err != nil {
-				err := fmt.Errorf("failed to delete iptables rules for service %s/%s: %v",
-					service.Namespace, service.Name, err)
-				errors = append(errors, err)
-			}
-		}
-		nftElems := getGatewayNFTRules(service, localEndpoints, true)
-		nftElems = append(nftElems, getGatewayNFTRules(service, localEndpoints, false)...)
+		nftObjs := getGatewayNFTRules(service, localEndpoints, true)
+		nftObjs = append(nftObjs, getGatewayNFTRules(service, localEndpoints, false)...)
 		if util.IsNetworkSegmentationSupportEnabled() {
-			nftElems = append(nftElems, getUDNNFTRules(service, nil)...)
+			nftObjs = append(nftObjs, getUDNNFTRules(service, nil)...)
 		}
-		if len(nftElems) > 0 {
-			if err := nodenft.DeleteNFTElements(nftElems); err != nil {
-				err = fmt.Errorf("failed to delete nftables rules for service %s/%s: %v",
+		if len(nftObjs) > 0 {
+			if err := nodenft.DeleteObjects(nftObjs); err != nil {
+				err = fmt.Errorf("failed to delete nftables rules for service %s/%s: %w",
 					service.Namespace, service.Name, err)
 				errors = append(errors, err)
 			}
@@ -1250,8 +1233,7 @@ func (npw *nodePortWatcher) DeleteService(service *corev1.Service) error {
 func (npw *nodePortWatcher) SyncServices(services []interface{}) error {
 	var err error
 	var errors []error
-	var keepIPTRules []nodeipt.Rule
-	var keepNFTSetElems, keepNFTMapElems []*knftables.Element
+	var keepNFTObjects, nftContainers []knftables.Object
 	for _, serviceInterface := range services {
 		name := ktypes.NamespacedName{Namespace: serviceInterface.(*corev1.Service).Namespace, Name: serviceInterface.(*corev1.Service).Name}
 
@@ -1305,15 +1287,14 @@ func (npw *nodePortWatcher) SyncServices(services []interface{}) error {
 		}
 		// Add correct netfilter rules only for Full mode
 		if !npw.dpuMode {
-			keepIPTRules = append(keepIPTRules, getGatewayIPTRules(service, localEndpoints, hasLocalHostNetworkEp)...)
-			keepNFTSetElems = append(keepNFTSetElems, getGatewayNFTRules(service, localEndpoints, hasLocalHostNetworkEp)...)
+			keepNFTObjects = append(keepNFTObjects, getGatewayNFTRules(service, localEndpoints, hasLocalHostNetworkEp)...)
 			if util.IsNetworkSegmentationSupportEnabled() &&
 				shouldAddUDNServiceMarkRules(netInfo, npw.nodeIPManager.nodeName) {
 				netConfig := npw.ofm.getActiveNetwork(netInfo)
 				if netConfig == nil {
 					return fmt.Errorf("failed to get active network config for network %s", netInfo.GetNetworkName())
 				}
-				keepNFTMapElems = append(keepNFTMapElems, getUDNNFTRules(service, netConfig)...)
+				keepNFTObjects = append(keepNFTObjects, getUDNNFTRules(service, netConfig)...)
 			}
 		}
 	}
@@ -1322,27 +1303,12 @@ func (npw *nodePortWatcher) SyncServices(services []interface{}) error {
 	npw.ofm.requestFlowSync()
 	// sync netfilter rules once only for Full mode
 	if !npw.dpuMode {
-		// (NOTE: Order is important, add jump to iptableETPChain before jump to NP/EIP chains)
-		for _, chain := range []string{iptableITPChain, iptableNodePortChain, iptableExternalIPChain, iptableETPChain} {
-			if err = recreateIPTRules("nat", chain, keepIPTRules); err != nil {
-				errors = append(errors, err)
-			}
-		}
-		if err = recreateIPTRules("mangle", iptableITPChain, keepIPTRules); err != nil {
-			errors = append(errors, err)
-		}
-
-		for _, set := range getGatewayNFTSets() {
-			if err = recreateNFTSet(set, keepNFTSetElems); err != nil {
-				errors = append(errors, err)
-			}
-		}
+		nftContainers = append(nftContainers, getGatewayNFTContainerObjects()...)
 		if util.IsNetworkSegmentationSupportEnabled() {
-			for _, nftMap := range getUDNNFTMaps() {
-				if err = recreateNFTMap(nftMap, keepNFTMapElems); err != nil {
-					errors = append(errors, err)
-				}
-			}
+			nftContainers = append(nftContainers, getUDNNFTContainerObjects()...)
+		}
+		if err = nodenft.SyncObjects(nftContainers, keepNFTObjects); err != nil {
+			errors = append(errors, fmt.Errorf("failed to sync nftables rules for services: %w", err))
 		}
 	}
 	return utilerrors.Join(errors...)
@@ -1467,7 +1433,7 @@ func (npw *nodePortWatcher) DeleteEndpointSlice(epSlice *discovery.EndpointSlice
 	localEndpoints := npw.GetLocalEligibleEndpointAddresses(epSlices, svc)
 	if svcConfig, exists := npw.updateServiceInfo(*namespacedName, nil, &hasLocalHostNetworkEp, localEndpoints); exists {
 		// Lock the cache mutex here so we don't miss a service delete during an endpoint delete
-		// we have to do this because deleting and adding iptables rules is slow.
+		// we have to do this because deleting and adding nftables rules is slow.
 		npw.serviceInfoLock.Lock()
 		defer npw.serviceInfoLock.Unlock()
 
@@ -1564,7 +1530,7 @@ func (npw *nodePortWatcher) UpdateEndpointSlice(oldEpSlice, newEpSlice *discover
 	var exists bool
 	if serviceInfo, exists = npw.getServiceInfo(*namespacedName); !exists {
 		// When a service is updated from externalName to nodeport type, it won't be
-		// in nodePortWatcher cache (npw): in this case, have the new nodeport IPtable rules
+		// in nodePortWatcher cache (npw): in this case, have the new nodeport nftables rules
 		// installed.
 		if err = npw.AddEndpointSlice(newEpSlice); err != nil {
 			errors = append(errors, err)
@@ -1615,13 +1581,13 @@ func (npw *nodePortWatcher) UpdateEndpointSlice(oldEpSlice, newEpSlice *discover
 	return utilerrors.Join(errors...)
 }
 
-func (npwipt *nodePortWatcherIptables) AddService(service *corev1.Service) error {
+func (npwnft *nodePortWatcherNFTables) AddService(service *corev1.Service) error {
 	// don't process headless service or services that doesn't have NodePorts or ExternalIPs
 	if !util.ServiceTypeHasClusterIP(service) || !util.IsClusterIPSet(service) {
 		return nil
 	}
 
-	netInfo, err := npwipt.networkManager.GetActiveNetworkForNamespace(service.Namespace)
+	netInfo, err := npwnft.networkManager.GetActiveNetworkForNamespace(service.Namespace)
 	if err != nil {
 		return fmt.Errorf("error getting active network for service %s in namespace %s: %w", service.Name, service.Namespace, err)
 	}
@@ -1631,12 +1597,12 @@ func (npwipt *nodePortWatcherIptables) AddService(service *corev1.Service) error
 	}
 
 	if err := addServiceRules(service, netInfo, nil, false, nil); err != nil {
-		return fmt.Errorf("AddService failed for nodePortWatcherIptables: %v", err)
+		return fmt.Errorf("AddService failed for nodePortWatcherNFTables: %v", err)
 	}
 	return nil
 }
 
-func (npwipt *nodePortWatcherIptables) UpdateService(old, new *corev1.Service) error {
+func (npwnft *nodePortWatcherNFTables) UpdateService(old, new *corev1.Service) error {
 	var err error
 	var errors []error
 	if serviceUpdateNotNeeded(old, new) {
@@ -1653,7 +1619,7 @@ func (npwipt *nodePortWatcherIptables) UpdateService(old, new *corev1.Service) e
 	}
 
 	if util.ServiceTypeHasClusterIP(new) && util.IsClusterIPSet(new) {
-		netInfo, err := npwipt.networkManager.GetActiveNetworkForNamespace(new.Namespace)
+		netInfo, err := npwnft.networkManager.GetActiveNetworkForNamespace(new.Namespace)
 		if err != nil {
 			return fmt.Errorf("error getting active network for service %s in namespace %s: %w", new.Name, new.Namespace, err)
 		}
@@ -1667,29 +1633,28 @@ func (npwipt *nodePortWatcherIptables) UpdateService(old, new *corev1.Service) e
 		}
 	}
 	if err = utilerrors.Join(errors...); err != nil {
-		return fmt.Errorf("UpdateService failed for nodePortWatcherIptables: %v", err)
+		return fmt.Errorf("UpdateService failed for nodePortWatcherNFTables: %v", err)
 	}
 	return nil
 
 }
 
-func (npwipt *nodePortWatcherIptables) DeleteService(service *corev1.Service) error {
+func (npwnft *nodePortWatcherNFTables) DeleteService(service *corev1.Service) error {
 	// don't process headless service
 	if !util.ServiceTypeHasClusterIP(service) || !util.IsClusterIPSet(service) {
 		return nil
 	}
 
 	if err := delServiceRules(service, nil, nil); err != nil {
-		return fmt.Errorf("DeleteService failed for nodePortWatcherIptables: %v", err)
+		return fmt.Errorf("DeleteService failed for nodePortWatcherNFTables: %v", err)
 	}
 	return nil
 }
 
-func (npwipt *nodePortWatcherIptables) SyncServices(services []interface{}) error {
+func (npwnft *nodePortWatcherNFTables) SyncServices(services []interface{}) error {
 	var err error
 	var errors []error
-	keepIPTRules := []nodeipt.Rule{}
-	keepNFTElems := []*knftables.Element{}
+	var keepNFTObjects, nftContainers []knftables.Object
 	for _, serviceInterface := range services {
 		service, ok := serviceInterface.(*corev1.Service)
 		if !ok {
@@ -1701,7 +1666,7 @@ func (npwipt *nodePortWatcherIptables) SyncServices(services []interface{}) erro
 		if !util.ServiceTypeHasClusterIP(service) || !util.IsClusterIPSet(service) {
 			continue
 		}
-		netInfo, err := npwipt.networkManager.GetActiveNetworkForNamespace(service.GetNamespace())
+		netInfo, err := npwnft.networkManager.GetActiveNetworkForNamespace(service.GetNamespace())
 		if err != nil {
 			// During startup sync, avoid failing the entire processExisting loop for namespaces that
 			// require a UDN but have no primary NAD yet (or it has been deleted). Those services will
@@ -1716,23 +1681,14 @@ func (npwipt *nodePortWatcherIptables) SyncServices(services []interface{}) erro
 			// network not on our node
 			continue
 		}
-		// Add correct iptables rules.
+		// Add correct nftables rules.
 		// TODO: ETP and ITP is not implemented for smart NIC mode.
-		keepIPTRules = append(keepIPTRules, getGatewayIPTRules(service, nil, false)...)
-		keepNFTElems = append(keepNFTElems, getGatewayNFTRules(service, nil, false)...)
+		keepNFTObjects = append(keepNFTObjects, getGatewayNFTRules(service, nil, false)...)
 	}
 
-	// sync rules once
-	for _, chain := range []string{iptableNodePortChain, iptableExternalIPChain} {
-		if err = recreateIPTRules("nat", chain, keepIPTRules); err != nil {
-			errors = append(errors, err)
-		}
-	}
-
-	for _, set := range getGatewayNFTSets() {
-		if err = recreateNFTSet(set, keepNFTElems); err != nil {
-			errors = append(errors, err)
-		}
+	nftContainers = append(nftContainers, getGatewayNFTContainerObjects()...)
+	if err = nodenft.SyncObjects(nftContainers, keepNFTObjects); err != nil {
+		errors = append(errors, fmt.Errorf("failed to sync nftables rules for services: %w", err))
 	}
 
 	return utilerrors.Join(errors...)
@@ -1899,17 +1855,11 @@ func newNodePortWatcher(
 	// In the shared gateway mode, the NodePort service is handled by the OpenFlow flows configured
 	// on the OVS bridge in the host. These flows act only on the packets coming in from outside
 	// of the node. If someone on the node is trying to access the NodePort service, those packets
-	// will not be processed by the OpenFlow flows, so we need to add iptable rules that DNATs the
-	// NodePortIP:NodePort to ClusterServiceIP:Port. We don't need to do this on DPU.
+	// will not be processed by the OpenFlow flows, so we need to add nftables rules that
+	// DNATs the NodePortIP:NodePort to ClusterServiceIP:Port. We don't need to do this on DPU.
 	if config.IsModeFull() {
-		if config.Gateway.Mode == config.GatewayModeLocal {
-			if err := initLocalGatewayIPTables(); err != nil {
-				return nil, err
-			}
-		} else if config.Gateway.Mode == config.GatewayModeShared {
-			if err := initSharedGatewayIPTables(); err != nil {
-				return nil, err
-			}
+		if err := initGatewayNFTables(); err != nil {
+			return nil, err
 		}
 		if util.IsNetworkSegmentationSupportEnabled() {
 			if err := configureUDNServicesNFTables(); err != nil {
@@ -2009,9 +1959,6 @@ func cleanupSharedGateway(ovsClient libovsdbclient.Client) error {
 		}
 	}
 
-	if config.IsModeDPUHost() || config.IsModeFull() {
-		cleanupSharedGatewayIPTChains()
-	}
 	return nil
 }
 

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -1323,7 +1323,7 @@ func (npw *nodePortWatcher) SyncServices(services []interface{}) error {
 	// sync netfilter rules once only for Full mode
 	if !npw.dpuMode {
 		// (NOTE: Order is important, add jump to iptableETPChain before jump to NP/EIP chains)
-		for _, chain := range []string{iptableITPChain, iptableNodePortChain, iptableExternalIPChain, iptableETPChain} {
+		for _, chain := range []string{iptableITPChain, iptableExternalIPChain, iptableETPChain} {
 			if err = recreateIPTRules("nat", chain, keepIPTRules); err != nil {
 				errors = append(errors, err)
 			}
@@ -1718,7 +1718,7 @@ func (npwipt *nodePortWatcherIptables) SyncServices(services []interface{}) erro
 	}
 
 	// sync rules once
-	for _, chain := range []string{iptableNodePortChain, iptableExternalIPChain} {
+	for _, chain := range []string{iptableExternalIPChain} {
 		if err = recreateIPTRules("nat", chain, keepIPTRules); err != nil {
 			errors = append(errors, err)
 		}

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -823,14 +823,6 @@ func addServiceRules(service *corev1.Service, netInfo util.NetInfo, localEndpoin
 
 	if npw == nil || !npw.dpuMode {
 		// add iptables/nftables rules only in full mode
-		iptRules := getGatewayIPTRules(service, localEndpoints, svcHasLocalHostNetEndPnt)
-		if len(iptRules) > 0 {
-			if err := insertIptRules(iptRules); err != nil {
-				err = fmt.Errorf("failed to add iptables rules for service %s/%s: %v",
-					service.Namespace, service.Name, err)
-				errors = append(errors, err)
-			}
-		}
 		nftObjs := getGatewayNFTRules(service, localEndpoints, svcHasLocalHostNetEndPnt)
 		if activeNetwork != nil &&
 			shouldAddUDNServiceMarkRules(netInfo, npw.nodeIPManager.nodeName) {
@@ -888,15 +880,6 @@ func delServiceRules(service *corev1.Service, localEndpoints util.PortToLBEndpoi
 		// |                          |                       |                       |   + default dnat towards CIP   |
 		// +--------------------------+-----------------------+-----------------------+--------------------------------+
 
-		iptRules := getGatewayIPTRules(service, localEndpoints, true)
-		iptRules = append(iptRules, getGatewayIPTRules(service, localEndpoints, false)...)
-		if len(iptRules) > 0 {
-			if err := nodeipt.DelRules(iptRules); err != nil {
-				err := fmt.Errorf("failed to delete iptables rules for service %s/%s: %v",
-					service.Namespace, service.Name, err)
-				errors = append(errors, err)
-			}
-		}
 		nftObjs := getGatewayNFTRules(service, localEndpoints, true)
 		nftObjs = append(nftObjs, getGatewayNFTRules(service, localEndpoints, false)...)
 		if util.IsNetworkSegmentationSupportEnabled() {
@@ -1250,7 +1233,6 @@ func (npw *nodePortWatcher) DeleteService(service *corev1.Service) error {
 func (npw *nodePortWatcher) SyncServices(services []interface{}) error {
 	var err error
 	var errors []error
-	var keepIPTRules []nodeipt.Rule
 	var keepNFTObjects, nftContainers []knftables.Object
 	for _, serviceInterface := range services {
 		name := ktypes.NamespacedName{Namespace: serviceInterface.(*corev1.Service).Namespace, Name: serviceInterface.(*corev1.Service).Name}
@@ -1305,7 +1287,6 @@ func (npw *nodePortWatcher) SyncServices(services []interface{}) error {
 		}
 		// Add correct netfilter rules only for Full mode
 		if !npw.dpuMode {
-			keepIPTRules = append(keepIPTRules, getGatewayIPTRules(service, localEndpoints, hasLocalHostNetworkEp)...)
 			keepNFTObjects = append(keepNFTObjects, getGatewayNFTRules(service, localEndpoints, hasLocalHostNetworkEp)...)
 			if util.IsNetworkSegmentationSupportEnabled() &&
 				shouldAddUDNServiceMarkRules(netInfo, npw.nodeIPManager.nodeName) {
@@ -1322,16 +1303,6 @@ func (npw *nodePortWatcher) SyncServices(services []interface{}) error {
 	npw.ofm.requestFlowSync()
 	// sync netfilter rules once only for Full mode
 	if !npw.dpuMode {
-		// (NOTE: Order is important, add jump to iptableETPChain before jump to NP/EIP chains)
-		for _, chain := range []string{iptableITPChain, iptableETPChain} {
-			if err = recreateIPTRules("nat", chain, keepIPTRules); err != nil {
-				errors = append(errors, err)
-			}
-		}
-		if err = recreateIPTRules("mangle", iptableITPChain, keepIPTRules); err != nil {
-			errors = append(errors, err)
-		}
-
 		nftContainers = append(nftContainers, getGatewayNFTContainerObjects()...)
 		if util.IsNetworkSegmentationSupportEnabled() {
 			nftContainers = append(nftContainers, getUDNNFTContainerObjects()...)
@@ -1683,7 +1654,6 @@ func (npwipt *nodePortWatcherIptables) DeleteService(service *corev1.Service) er
 func (npwipt *nodePortWatcherIptables) SyncServices(services []interface{}) error {
 	var err error
 	var errors []error
-	var keepIPTRules []nodeipt.Rule
 	var keepNFTObjects, nftContainers []knftables.Object
 	for _, serviceInterface := range services {
 		service, ok := serviceInterface.(*corev1.Service)
@@ -1713,7 +1683,6 @@ func (npwipt *nodePortWatcherIptables) SyncServices(services []interface{}) erro
 		}
 		// Add correct iptables rules.
 		// TODO: ETP and ITP is not implemented for smart NIC mode.
-		keepIPTRules = append(keepIPTRules, getGatewayIPTRules(service, nil, false)...)
 		keepNFTObjects = append(keepNFTObjects, getGatewayNFTRules(service, nil, false)...)
 	}
 
@@ -1889,15 +1858,6 @@ func newNodePortWatcher(
 	// will not be processed by the OpenFlow flows, so we need to add iptable rules that DNATs the
 	// NodePortIP:NodePort to ClusterServiceIP:Port. We don't need to do this on DPU.
 	if config.IsModeFull() {
-		if config.Gateway.Mode == config.GatewayModeLocal {
-			if err := initLocalGatewayIPTables(); err != nil {
-				return nil, err
-			}
-		} else if config.Gateway.Mode == config.GatewayModeShared {
-			if err := initSharedGatewayIPTables(); err != nil {
-				return nil, err
-			}
-		}
 		if err := initGatewayNFTables(); err != nil {
 			return nil, err
 		}
@@ -1999,9 +1959,6 @@ func cleanupSharedGateway(ovsClient libovsdbclient.Client) error {
 		}
 	}
 
-	if config.IsModeDPUHost() || config.IsModeFull() {
-		cleanupSharedGatewayIPTChains()
-	}
 	return nil
 }
 

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -181,19 +181,19 @@ func configureUDNServicesNFTables() error {
 	return nft.Run(context.TODO(), tx)
 }
 
-// nodePortWatcherIptables manages iptables rules for shared gateway
+// nodePortWatcherNFTables manages nftables rules for shared gateway
 // to ensure that services using NodePorts are accessible.
-type nodePortWatcherIptables struct {
+type nodePortWatcherNFTables struct {
 	networkManager networkmanager.Interface
 }
 
-func newNodePortWatcherIptables(networkManager networkmanager.Interface) *nodePortWatcherIptables {
-	return &nodePortWatcherIptables{
+func newNodePortWatcherNFTables(networkManager networkmanager.Interface) *nodePortWatcherNFTables {
+	return &nodePortWatcherNFTables{
 		networkManager: networkManager,
 	}
 }
 
-// nodePortWatcher manages OpenFlow and iptables rules
+// nodePortWatcher manages OpenFlow and nftables rules
 // to ensure that services using NodePorts are accessible
 type nodePortWatcher struct {
 	dpuMode       bool
@@ -202,7 +202,7 @@ type nodePortWatcher struct {
 	gatewayIPLock sync.Mutex
 	ofportPhys    string
 	gwBridge      *bridgeconfig.BridgeConfiguration
-	// Map of service name to programmed iptables/OF rules
+	// Map of service name to programmed nftables/OF rules
 	serviceInfo     map[ktypes.NamespacedName]*serviceConfig
 	serviceInfoLock sync.Mutex
 	ofm             *openflowManager
@@ -803,7 +803,7 @@ func (npw *nodePortWatcher) updateServiceInfo(index ktypes.NamespacedName, servi
 	return &ptrCopy, exists
 }
 
-// addServiceRules ensures the correct iptables rules and OpenFlow physical
+// addServiceRules ensures the correct nftables rules and OpenFlow physical
 // flows are programmed for a given service and endpoint configuration
 func addServiceRules(service *corev1.Service, netInfo util.NetInfo, localEndpoints util.PortToLBEndpoints, svcHasLocalHostNetEndPnt bool, npw *nodePortWatcher) error {
 	// For dpu or Full mode
@@ -822,7 +822,7 @@ func addServiceRules(service *corev1.Service, netInfo util.NetInfo, localEndpoin
 	}
 
 	if npw == nil || !npw.dpuMode {
-		// add iptables/nftables rules only in full mode
+		// add nftables rules only in full mode
 		nftObjs := getGatewayNFTRules(service, localEndpoints, svcHasLocalHostNetEndPnt)
 		if activeNetwork != nil &&
 			shouldAddUDNServiceMarkRules(netInfo, npw.nodeIPManager.nodeName) {
@@ -840,7 +840,7 @@ func addServiceRules(service *corev1.Service, netInfo util.NetInfo, localEndpoin
 	return utilerrors.Join(errors...)
 }
 
-// delServiceRules deletes all possible iptables rules and OpenFlow physical
+// delServiceRules deletes all possible nftables rules and OpenFlow physical
 // flows for a service
 func delServiceRules(service *corev1.Service, localEndpoints util.PortToLBEndpoints, npw *nodePortWatcher) error {
 	var err error
@@ -854,7 +854,7 @@ func delServiceRules(service *corev1.Service, localEndpoints util.PortToLBEndpoi
 	}
 
 	if npw == nil || !npw.dpuMode {
-		// Always try and delete all rules here in full mode & in host only mode. We don't touch iptables in dpu mode.
+		// Always try and delete all rules here in full mode & in host only mode. We don't touch nftables in dpu mode.
 		// +--------------------------+-----------------------+-----------------------+--------------------------------+
 		// | svcHasLocalHostNetEndPnt | ExternalTrafficPolicy | InternalTrafficPolicy |     Scenario for deletion      |
 		// |--------------------------|-----------------------|-----------------------|--------------------------------|
@@ -1433,7 +1433,7 @@ func (npw *nodePortWatcher) DeleteEndpointSlice(epSlice *discovery.EndpointSlice
 	localEndpoints := npw.GetLocalEligibleEndpointAddresses(epSlices, svc)
 	if svcConfig, exists := npw.updateServiceInfo(*namespacedName, nil, &hasLocalHostNetworkEp, localEndpoints); exists {
 		// Lock the cache mutex here so we don't miss a service delete during an endpoint delete
-		// we have to do this because deleting and adding iptables rules is slow.
+		// we have to do this because deleting and adding nftables rules is slow.
 		npw.serviceInfoLock.Lock()
 		defer npw.serviceInfoLock.Unlock()
 
@@ -1530,7 +1530,7 @@ func (npw *nodePortWatcher) UpdateEndpointSlice(oldEpSlice, newEpSlice *discover
 	var exists bool
 	if serviceInfo, exists = npw.getServiceInfo(*namespacedName); !exists {
 		// When a service is updated from externalName to nodeport type, it won't be
-		// in nodePortWatcher cache (npw): in this case, have the new nodeport IPtable rules
+		// in nodePortWatcher cache (npw): in this case, have the new nodeport nftables rules
 		// installed.
 		if err = npw.AddEndpointSlice(newEpSlice); err != nil {
 			errors = append(errors, err)
@@ -1581,13 +1581,13 @@ func (npw *nodePortWatcher) UpdateEndpointSlice(oldEpSlice, newEpSlice *discover
 	return utilerrors.Join(errors...)
 }
 
-func (npwipt *nodePortWatcherIptables) AddService(service *corev1.Service) error {
+func (npwnft *nodePortWatcherNFTables) AddService(service *corev1.Service) error {
 	// don't process headless service or services that doesn't have NodePorts or ExternalIPs
 	if !util.ServiceTypeHasClusterIP(service) || !util.IsClusterIPSet(service) {
 		return nil
 	}
 
-	netInfo, err := npwipt.networkManager.GetActiveNetworkForNamespace(service.Namespace)
+	netInfo, err := npwnft.networkManager.GetActiveNetworkForNamespace(service.Namespace)
 	if err != nil {
 		return fmt.Errorf("error getting active network for service %s in namespace %s: %w", service.Name, service.Namespace, err)
 	}
@@ -1597,12 +1597,12 @@ func (npwipt *nodePortWatcherIptables) AddService(service *corev1.Service) error
 	}
 
 	if err := addServiceRules(service, netInfo, nil, false, nil); err != nil {
-		return fmt.Errorf("AddService failed for nodePortWatcherIptables: %v", err)
+		return fmt.Errorf("AddService failed for nodePortWatcherNFTables: %v", err)
 	}
 	return nil
 }
 
-func (npwipt *nodePortWatcherIptables) UpdateService(old, new *corev1.Service) error {
+func (npwnft *nodePortWatcherNFTables) UpdateService(old, new *corev1.Service) error {
 	var err error
 	var errors []error
 	if serviceUpdateNotNeeded(old, new) {
@@ -1619,7 +1619,7 @@ func (npwipt *nodePortWatcherIptables) UpdateService(old, new *corev1.Service) e
 	}
 
 	if util.ServiceTypeHasClusterIP(new) && util.IsClusterIPSet(new) {
-		netInfo, err := npwipt.networkManager.GetActiveNetworkForNamespace(new.Namespace)
+		netInfo, err := npwnft.networkManager.GetActiveNetworkForNamespace(new.Namespace)
 		if err != nil {
 			return fmt.Errorf("error getting active network for service %s in namespace %s: %w", new.Name, new.Namespace, err)
 		}
@@ -1633,25 +1633,25 @@ func (npwipt *nodePortWatcherIptables) UpdateService(old, new *corev1.Service) e
 		}
 	}
 	if err = utilerrors.Join(errors...); err != nil {
-		return fmt.Errorf("UpdateService failed for nodePortWatcherIptables: %v", err)
+		return fmt.Errorf("UpdateService failed for nodePortWatcherNFTables: %v", err)
 	}
 	return nil
 
 }
 
-func (npwipt *nodePortWatcherIptables) DeleteService(service *corev1.Service) error {
+func (npwnft *nodePortWatcherNFTables) DeleteService(service *corev1.Service) error {
 	// don't process headless service
 	if !util.ServiceTypeHasClusterIP(service) || !util.IsClusterIPSet(service) {
 		return nil
 	}
 
 	if err := delServiceRules(service, nil, nil); err != nil {
-		return fmt.Errorf("DeleteService failed for nodePortWatcherIptables: %v", err)
+		return fmt.Errorf("DeleteService failed for nodePortWatcherNFTables: %v", err)
 	}
 	return nil
 }
 
-func (npwipt *nodePortWatcherIptables) SyncServices(services []interface{}) error {
+func (npwnft *nodePortWatcherNFTables) SyncServices(services []interface{}) error {
 	var err error
 	var errors []error
 	var keepNFTObjects, nftContainers []knftables.Object
@@ -1666,7 +1666,7 @@ func (npwipt *nodePortWatcherIptables) SyncServices(services []interface{}) erro
 		if !util.ServiceTypeHasClusterIP(service) || !util.IsClusterIPSet(service) {
 			continue
 		}
-		netInfo, err := npwipt.networkManager.GetActiveNetworkForNamespace(service.GetNamespace())
+		netInfo, err := npwnft.networkManager.GetActiveNetworkForNamespace(service.GetNamespace())
 		if err != nil {
 			// During startup sync, avoid failing the entire processExisting loop for namespaces that
 			// require a UDN but have no primary NAD yet (or it has been deleted). Those services will
@@ -1681,7 +1681,7 @@ func (npwipt *nodePortWatcherIptables) SyncServices(services []interface{}) erro
 			// network not on our node
 			continue
 		}
-		// Add correct iptables rules.
+		// Add correct nftables rules.
 		// TODO: ETP and ITP is not implemented for smart NIC mode.
 		keepNFTObjects = append(keepNFTObjects, getGatewayNFTRules(service, nil, false)...)
 	}
@@ -1855,8 +1855,8 @@ func newNodePortWatcher(
 	// In the shared gateway mode, the NodePort service is handled by the OpenFlow flows configured
 	// on the OVS bridge in the host. These flows act only on the packets coming in from outside
 	// of the node. If someone on the node is trying to access the NodePort service, those packets
-	// will not be processed by the OpenFlow flows, so we need to add iptable rules that DNATs the
-	// NodePortIP:NodePort to ClusterServiceIP:Port. We don't need to do this on DPU.
+	// will not be processed by the OpenFlow flows, so we need to add nftables rules that
+	// DNATs the NodePortIP:NodePort to ClusterServiceIP:Port. We don't need to do this on DPU.
 	if config.IsModeFull() {
 		if err := initGatewayNFTables(); err != nil {
 			return nil, err

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -1251,7 +1251,7 @@ func (npw *nodePortWatcher) SyncServices(services []interface{}) error {
 	var err error
 	var errors []error
 	var keepIPTRules []nodeipt.Rule
-	var keepNFTSetElems, keepNFTMapElems []knftables.Object
+	var keepNFTObjects, nftContainers []knftables.Object
 	for _, serviceInterface := range services {
 		name := ktypes.NamespacedName{Namespace: serviceInterface.(*corev1.Service).Namespace, Name: serviceInterface.(*corev1.Service).Name}
 
@@ -1306,14 +1306,14 @@ func (npw *nodePortWatcher) SyncServices(services []interface{}) error {
 		// Add correct netfilter rules only for Full mode
 		if !npw.dpuMode {
 			keepIPTRules = append(keepIPTRules, getGatewayIPTRules(service, localEndpoints, hasLocalHostNetworkEp)...)
-			keepNFTSetElems = append(keepNFTSetElems, getGatewayNFTRules(service, localEndpoints, hasLocalHostNetworkEp)...)
+			keepNFTObjects = append(keepNFTObjects, getGatewayNFTRules(service, localEndpoints, hasLocalHostNetworkEp)...)
 			if util.IsNetworkSegmentationSupportEnabled() &&
 				shouldAddUDNServiceMarkRules(netInfo, npw.nodeIPManager.nodeName) {
 				netConfig := npw.ofm.getActiveNetwork(netInfo)
 				if netConfig == nil {
 					return fmt.Errorf("failed to get active network config for network %s", netInfo.GetNetworkName())
 				}
-				keepNFTMapElems = append(keepNFTMapElems, getUDNNFTRules(service, netConfig)...)
+				keepNFTObjects = append(keepNFTObjects, getUDNNFTRules(service, netConfig)...)
 			}
 		}
 	}
@@ -1332,17 +1332,12 @@ func (npw *nodePortWatcher) SyncServices(services []interface{}) error {
 			errors = append(errors, err)
 		}
 
-		for _, set := range getGatewayNFTSets() {
-			if err = recreateNFTSet(set, keepNFTSetElems); err != nil {
-				errors = append(errors, err)
-			}
-		}
+		nftContainers = append(nftContainers, getGatewayNFTContainerObjects()...)
 		if util.IsNetworkSegmentationSupportEnabled() {
-			for _, nftMap := range getUDNNFTMaps() {
-				if err = recreateNFTMap(nftMap, keepNFTMapElems); err != nil {
-					errors = append(errors, err)
-				}
-			}
+			nftContainers = append(nftContainers, getUDNNFTContainerObjects()...)
+		}
+		if err = nodenft.SyncObjects(nftContainers, keepNFTObjects); err != nil {
+			errors = append(errors, fmt.Errorf("failed to sync nftables rules for services: %w", err))
 		}
 	}
 	return utilerrors.Join(errors...)
@@ -1688,8 +1683,8 @@ func (npwipt *nodePortWatcherIptables) DeleteService(service *corev1.Service) er
 func (npwipt *nodePortWatcherIptables) SyncServices(services []interface{}) error {
 	var err error
 	var errors []error
-	keepIPTRules := []nodeipt.Rule{}
-	keepNFTElems := []knftables.Object{}
+	var keepIPTRules []nodeipt.Rule
+	var keepNFTObjects, nftContainers []knftables.Object
 	for _, serviceInterface := range services {
 		service, ok := serviceInterface.(*corev1.Service)
 		if !ok {
@@ -1719,7 +1714,7 @@ func (npwipt *nodePortWatcherIptables) SyncServices(services []interface{}) erro
 		// Add correct iptables rules.
 		// TODO: ETP and ITP is not implemented for smart NIC mode.
 		keepIPTRules = append(keepIPTRules, getGatewayIPTRules(service, nil, false)...)
-		keepNFTElems = append(keepNFTElems, getGatewayNFTRules(service, nil, false)...)
+		keepNFTObjects = append(keepNFTObjects, getGatewayNFTRules(service, nil, false)...)
 	}
 
 	// sync rules once
@@ -1729,10 +1724,9 @@ func (npwipt *nodePortWatcherIptables) SyncServices(services []interface{}) erro
 		}
 	}
 
-	for _, set := range getGatewayNFTSets() {
-		if err = recreateNFTSet(set, keepNFTElems); err != nil {
-			errors = append(errors, err)
-		}
+	nftContainers = append(nftContainers, getGatewayNFTContainerObjects()...)
+	if err = nodenft.SyncObjects(nftContainers, keepNFTObjects); err != nil {
+		errors = append(errors, fmt.Errorf("failed to sync nftables rules for services: %w", err))
 	}
 
 	return utilerrors.Join(errors...)

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -1905,6 +1905,9 @@ func newNodePortWatcher(
 				return nil, err
 			}
 		}
+		if err := initGatewayNFTables(); err != nil {
+			return nil, err
+		}
 		if util.IsNetworkSegmentationSupportEnabled() {
 			if err := configureUDNServicesNFTables(); err != nil {
 				return nil, fmt.Errorf("unable to configure UDN nftables: %w", err)

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -831,14 +831,14 @@ func addServiceRules(service *corev1.Service, netInfo util.NetInfo, localEndpoin
 				errors = append(errors, err)
 			}
 		}
-		nftElems := getGatewayNFTRules(service, localEndpoints, svcHasLocalHostNetEndPnt)
+		nftObjs := getGatewayNFTRules(service, localEndpoints, svcHasLocalHostNetEndPnt)
 		if activeNetwork != nil &&
 			shouldAddUDNServiceMarkRules(netInfo, npw.nodeIPManager.nodeName) {
-			nftElems = append(nftElems, getUDNNFTRules(service, activeNetwork)...)
+			nftObjs = append(nftObjs, getUDNNFTRules(service, activeNetwork)...)
 		}
-		if len(nftElems) > 0 {
-			if err := nodenft.UpdateNFTElements(nftElems); err != nil {
-				err = fmt.Errorf("failed to update nftables rules for service %s/%s: %v",
+		if len(nftObjs) > 0 {
+			if err := nodenft.AddObjects(nftObjs); err != nil {
+				err = fmt.Errorf("failed to update nftables rules for service %s/%s: %w",
 					service.Namespace, service.Name, err)
 				errors = append(errors, err)
 			}
@@ -897,14 +897,14 @@ func delServiceRules(service *corev1.Service, localEndpoints util.PortToLBEndpoi
 				errors = append(errors, err)
 			}
 		}
-		nftElems := getGatewayNFTRules(service, localEndpoints, true)
-		nftElems = append(nftElems, getGatewayNFTRules(service, localEndpoints, false)...)
+		nftObjs := getGatewayNFTRules(service, localEndpoints, true)
+		nftObjs = append(nftObjs, getGatewayNFTRules(service, localEndpoints, false)...)
 		if util.IsNetworkSegmentationSupportEnabled() {
-			nftElems = append(nftElems, getUDNNFTRules(service, nil)...)
+			nftObjs = append(nftObjs, getUDNNFTRules(service, nil)...)
 		}
-		if len(nftElems) > 0 {
-			if err := nodenft.DeleteNFTElements(nftElems); err != nil {
-				err = fmt.Errorf("failed to delete nftables rules for service %s/%s: %v",
+		if len(nftObjs) > 0 {
+			if err := nodenft.DeleteObjects(nftObjs); err != nil {
+				err = fmt.Errorf("failed to delete nftables rules for service %s/%s: %w",
 					service.Namespace, service.Name, err)
 				errors = append(errors, err)
 			}
@@ -1251,7 +1251,7 @@ func (npw *nodePortWatcher) SyncServices(services []interface{}) error {
 	var err error
 	var errors []error
 	var keepIPTRules []nodeipt.Rule
-	var keepNFTSetElems, keepNFTMapElems []*knftables.Element
+	var keepNFTSetElems, keepNFTMapElems []knftables.Object
 	for _, serviceInterface := range services {
 		name := ktypes.NamespacedName{Namespace: serviceInterface.(*corev1.Service).Namespace, Name: serviceInterface.(*corev1.Service).Name}
 
@@ -1689,7 +1689,7 @@ func (npwipt *nodePortWatcherIptables) SyncServices(services []interface{}) erro
 	var err error
 	var errors []error
 	keepIPTRules := []nodeipt.Rule{}
-	keepNFTElems := []*knftables.Element{}
+	keepNFTElems := []knftables.Object{}
 	for _, serviceInterface := range services {
 		service, ok := serviceInterface.(*corev1.Service)
 		if !ok {

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -181,19 +181,19 @@ func configureUDNServicesNFTables() error {
 	return nft.Run(context.TODO(), tx)
 }
 
-// nodePortWatcherIptables manages iptables rules for shared gateway
+// nodePortWatcherNFTables manages nftables rules for shared gateway
 // to ensure that services using NodePorts are accessible.
-type nodePortWatcherIptables struct {
+type nodePortWatcherNFTables struct {
 	networkManager networkmanager.Interface
 }
 
-func newNodePortWatcherIptables(networkManager networkmanager.Interface) *nodePortWatcherIptables {
-	return &nodePortWatcherIptables{
+func newNodePortWatcherNFTables(networkManager networkmanager.Interface) *nodePortWatcherNFTables {
+	return &nodePortWatcherNFTables{
 		networkManager: networkManager,
 	}
 }
 
-// nodePortWatcher manages OpenFlow and iptables rules
+// nodePortWatcher manages OpenFlow and nftables rules
 // to ensure that services using NodePorts are accessible
 type nodePortWatcher struct {
 	dpuMode       bool
@@ -202,7 +202,7 @@ type nodePortWatcher struct {
 	gatewayIPLock sync.Mutex
 	ofportPhys    string
 	gwBridge      *bridgeconfig.BridgeConfiguration
-	// Map of service name to programmed iptables/OF rules
+	// Map of service name to programmed nftables/OF rules
 	serviceInfo     map[ktypes.NamespacedName]*serviceConfig
 	serviceInfoLock sync.Mutex
 	ofm             *openflowManager
@@ -803,7 +803,7 @@ func (npw *nodePortWatcher) updateServiceInfo(index ktypes.NamespacedName, servi
 	return &ptrCopy, exists
 }
 
-// addServiceRules ensures the correct iptables rules and OpenFlow physical
+// addServiceRules ensures the correct nftables rules and OpenFlow physical
 // flows are programmed for a given service and endpoint configuration
 func addServiceRules(service *corev1.Service, netInfo util.NetInfo, localEndpoints util.PortToLBEndpoints, svcHasLocalHostNetEndPnt bool, npw *nodePortWatcher) error {
 	// For dpu or Full mode
@@ -822,23 +822,15 @@ func addServiceRules(service *corev1.Service, netInfo util.NetInfo, localEndpoin
 	}
 
 	if npw == nil || !npw.dpuMode {
-		// add iptables/nftables rules only in full mode
-		iptRules := getGatewayIPTRules(service, localEndpoints, svcHasLocalHostNetEndPnt)
-		if len(iptRules) > 0 {
-			if err := insertIptRules(iptRules); err != nil {
-				err = fmt.Errorf("failed to add iptables rules for service %s/%s: %v",
-					service.Namespace, service.Name, err)
-				errors = append(errors, err)
-			}
-		}
-		nftElems := getGatewayNFTRules(service, localEndpoints, svcHasLocalHostNetEndPnt)
+		// add nftables rules only in full mode
+		nftObjs := getGatewayNFTRules(service, localEndpoints, svcHasLocalHostNetEndPnt)
 		if activeNetwork != nil &&
 			shouldAddUDNServiceMarkRules(netInfo, npw.nodeIPManager.nodeName) {
-			nftElems = append(nftElems, getUDNNFTRules(service, activeNetwork)...)
+			nftObjs = append(nftObjs, getUDNNFTRules(service, activeNetwork)...)
 		}
-		if len(nftElems) > 0 {
-			if err := nodenft.UpdateNFTElements(nftElems); err != nil {
-				err = fmt.Errorf("failed to update nftables rules for service %s/%s: %v",
+		if len(nftObjs) > 0 {
+			if err := nodenft.AddObjects(nftObjs); err != nil {
+				err = fmt.Errorf("failed to update nftables rules for service %s/%s: %w",
 					service.Namespace, service.Name, err)
 				errors = append(errors, err)
 			}
@@ -848,7 +840,7 @@ func addServiceRules(service *corev1.Service, netInfo util.NetInfo, localEndpoin
 	return utilerrors.Join(errors...)
 }
 
-// delServiceRules deletes all possible iptables rules and OpenFlow physical
+// delServiceRules deletes all possible nftables rules and OpenFlow physical
 // flows for a service
 func delServiceRules(service *corev1.Service, localEndpoints util.PortToLBEndpoints, npw *nodePortWatcher) error {
 	var err error
@@ -862,7 +854,7 @@ func delServiceRules(service *corev1.Service, localEndpoints util.PortToLBEndpoi
 	}
 
 	if npw == nil || !npw.dpuMode {
-		// Always try and delete all rules here in full mode & in host only mode. We don't touch iptables in dpu mode.
+		// Always try and delete all rules here in full mode & in host only mode. We don't touch nftables in dpu mode.
 		// +--------------------------+-----------------------+-----------------------+--------------------------------+
 		// | svcHasLocalHostNetEndPnt | ExternalTrafficPolicy | InternalTrafficPolicy |     Scenario for deletion      |
 		// |--------------------------|-----------------------|-----------------------|--------------------------------|
@@ -888,23 +880,14 @@ func delServiceRules(service *corev1.Service, localEndpoints util.PortToLBEndpoi
 		// |                          |                       |                       |   + default dnat towards CIP   |
 		// +--------------------------+-----------------------+-----------------------+--------------------------------+
 
-		iptRules := getGatewayIPTRules(service, localEndpoints, true)
-		iptRules = append(iptRules, getGatewayIPTRules(service, localEndpoints, false)...)
-		if len(iptRules) > 0 {
-			if err := nodeipt.DelRules(iptRules); err != nil {
-				err := fmt.Errorf("failed to delete iptables rules for service %s/%s: %v",
-					service.Namespace, service.Name, err)
-				errors = append(errors, err)
-			}
-		}
-		nftElems := getGatewayNFTRules(service, localEndpoints, true)
-		nftElems = append(nftElems, getGatewayNFTRules(service, localEndpoints, false)...)
+		nftObjs := getGatewayNFTRules(service, localEndpoints, true)
+		nftObjs = append(nftObjs, getGatewayNFTRules(service, localEndpoints, false)...)
 		if util.IsNetworkSegmentationSupportEnabled() {
-			nftElems = append(nftElems, getUDNNFTRules(service, nil)...)
+			nftObjs = append(nftObjs, getUDNNFTRules(service, nil)...)
 		}
-		if len(nftElems) > 0 {
-			if err := nodenft.DeleteNFTElements(nftElems); err != nil {
-				err = fmt.Errorf("failed to delete nftables rules for service %s/%s: %v",
+		if len(nftObjs) > 0 {
+			if err := nodenft.DeleteObjects(nftObjs); err != nil {
+				err = fmt.Errorf("failed to delete nftables rules for service %s/%s: %w",
 					service.Namespace, service.Name, err)
 				errors = append(errors, err)
 			}
@@ -1250,8 +1233,7 @@ func (npw *nodePortWatcher) DeleteService(service *corev1.Service) error {
 func (npw *nodePortWatcher) SyncServices(services []interface{}) error {
 	var err error
 	var errors []error
-	var keepIPTRules []nodeipt.Rule
-	var keepNFTSetElems, keepNFTMapElems []*knftables.Element
+	var keepNFTObjects, nftContainers []knftables.Object
 	for _, serviceInterface := range services {
 		name := ktypes.NamespacedName{Namespace: serviceInterface.(*corev1.Service).Namespace, Name: serviceInterface.(*corev1.Service).Name}
 
@@ -1305,15 +1287,14 @@ func (npw *nodePortWatcher) SyncServices(services []interface{}) error {
 		}
 		// Add correct netfilter rules only for Full mode
 		if !npw.dpuMode {
-			keepIPTRules = append(keepIPTRules, getGatewayIPTRules(service, localEndpoints, hasLocalHostNetworkEp)...)
-			keepNFTSetElems = append(keepNFTSetElems, getGatewayNFTRules(service, localEndpoints, hasLocalHostNetworkEp)...)
+			keepNFTObjects = append(keepNFTObjects, getGatewayNFTRules(service, localEndpoints, hasLocalHostNetworkEp)...)
 			if util.IsNetworkSegmentationSupportEnabled() &&
 				shouldAddUDNServiceMarkRules(netInfo, npw.nodeIPManager.nodeName) {
 				netConfig := npw.ofm.getActiveNetwork(netInfo)
 				if netConfig == nil {
 					return fmt.Errorf("failed to get active network config for network %s", netInfo.GetNetworkName())
 				}
-				keepNFTMapElems = append(keepNFTMapElems, getUDNNFTRules(service, netConfig)...)
+				keepNFTObjects = append(keepNFTObjects, getUDNNFTRules(service, netConfig)...)
 			}
 		}
 	}
@@ -1322,27 +1303,12 @@ func (npw *nodePortWatcher) SyncServices(services []interface{}) error {
 	npw.ofm.requestFlowSync()
 	// sync netfilter rules once only for Full mode
 	if !npw.dpuMode {
-		// (NOTE: Order is important, add jump to iptableETPChain before jump to NP/EIP chains)
-		for _, chain := range []string{iptableITPChain, iptableNodePortChain, iptableExternalIPChain, iptableETPChain} {
-			if err = recreateIPTRules("nat", chain, keepIPTRules); err != nil {
-				errors = append(errors, err)
-			}
-		}
-		if err = recreateIPTRules("mangle", iptableITPChain, keepIPTRules); err != nil {
-			errors = append(errors, err)
-		}
-
-		for _, set := range getGatewayNFTSets() {
-			if err = recreateNFTSet(set, keepNFTSetElems); err != nil {
-				errors = append(errors, err)
-			}
-		}
+		nftContainers = append(nftContainers, getGatewayNFTContainerObjects()...)
 		if util.IsNetworkSegmentationSupportEnabled() {
-			for _, nftMap := range getUDNNFTMaps() {
-				if err = recreateNFTMap(nftMap, keepNFTMapElems); err != nil {
-					errors = append(errors, err)
-				}
-			}
+			nftContainers = append(nftContainers, getUDNNFTContainerObjects()...)
+		}
+		if err = nodenft.SyncObjects(nftContainers, keepNFTObjects); err != nil {
+			errors = append(errors, fmt.Errorf("failed to sync nftables rules for services: %w", err))
 		}
 	}
 	return utilerrors.Join(errors...)
@@ -1467,7 +1433,7 @@ func (npw *nodePortWatcher) DeleteEndpointSlice(epSlice *discovery.EndpointSlice
 	localEndpoints := npw.GetLocalEligibleEndpointAddresses(epSlices, svc)
 	if svcConfig, exists := npw.updateServiceInfo(*namespacedName, nil, &hasLocalHostNetworkEp, localEndpoints); exists {
 		// Lock the cache mutex here so we don't miss a service delete during an endpoint delete
-		// we have to do this because deleting and adding iptables rules is slow.
+		// we have to do this because deleting and adding nftables rules is slow.
 		npw.serviceInfoLock.Lock()
 		defer npw.serviceInfoLock.Unlock()
 
@@ -1564,7 +1530,7 @@ func (npw *nodePortWatcher) UpdateEndpointSlice(oldEpSlice, newEpSlice *discover
 	var exists bool
 	if serviceInfo, exists = npw.getServiceInfo(*namespacedName); !exists {
 		// When a service is updated from externalName to nodeport type, it won't be
-		// in nodePortWatcher cache (npw): in this case, have the new nodeport IPtable rules
+		// in nodePortWatcher cache (npw): in this case, have the new nodeport nftables rules
 		// installed.
 		if err = npw.AddEndpointSlice(newEpSlice); err != nil {
 			errors = append(errors, err)
@@ -1615,13 +1581,13 @@ func (npw *nodePortWatcher) UpdateEndpointSlice(oldEpSlice, newEpSlice *discover
 	return utilerrors.Join(errors...)
 }
 
-func (npwipt *nodePortWatcherIptables) AddService(service *corev1.Service) error {
+func (npwnft *nodePortWatcherNFTables) AddService(service *corev1.Service) error {
 	// don't process headless service or services that doesn't have NodePorts or ExternalIPs
 	if !util.ServiceTypeHasClusterIP(service) || !util.IsClusterIPSet(service) {
 		return nil
 	}
 
-	netInfo, err := npwipt.networkManager.GetActiveNetworkForNamespace(service.Namespace)
+	netInfo, err := npwnft.networkManager.GetActiveNetworkForNamespace(service.Namespace)
 	if err != nil {
 		return fmt.Errorf("error getting active network for service %s in namespace %s: %w", service.Name, service.Namespace, err)
 	}
@@ -1631,12 +1597,12 @@ func (npwipt *nodePortWatcherIptables) AddService(service *corev1.Service) error
 	}
 
 	if err := addServiceRules(service, netInfo, nil, false, nil); err != nil {
-		return fmt.Errorf("AddService failed for nodePortWatcherIptables: %v", err)
+		return fmt.Errorf("AddService failed for nodePortWatcherNFTables: %v", err)
 	}
 	return nil
 }
 
-func (npwipt *nodePortWatcherIptables) UpdateService(old, new *corev1.Service) error {
+func (npwnft *nodePortWatcherNFTables) UpdateService(old, new *corev1.Service) error {
 	var err error
 	var errors []error
 	if serviceUpdateNotNeeded(old, new) {
@@ -1653,7 +1619,7 @@ func (npwipt *nodePortWatcherIptables) UpdateService(old, new *corev1.Service) e
 	}
 
 	if util.ServiceTypeHasClusterIP(new) && util.IsClusterIPSet(new) {
-		netInfo, err := npwipt.networkManager.GetActiveNetworkForNamespace(new.Namespace)
+		netInfo, err := npwnft.networkManager.GetActiveNetworkForNamespace(new.Namespace)
 		if err != nil {
 			return fmt.Errorf("error getting active network for service %s in namespace %s: %w", new.Name, new.Namespace, err)
 		}
@@ -1667,29 +1633,28 @@ func (npwipt *nodePortWatcherIptables) UpdateService(old, new *corev1.Service) e
 		}
 	}
 	if err = utilerrors.Join(errors...); err != nil {
-		return fmt.Errorf("UpdateService failed for nodePortWatcherIptables: %v", err)
+		return fmt.Errorf("UpdateService failed for nodePortWatcherNFTables: %v", err)
 	}
 	return nil
 
 }
 
-func (npwipt *nodePortWatcherIptables) DeleteService(service *corev1.Service) error {
+func (npwnft *nodePortWatcherNFTables) DeleteService(service *corev1.Service) error {
 	// don't process headless service
 	if !util.ServiceTypeHasClusterIP(service) || !util.IsClusterIPSet(service) {
 		return nil
 	}
 
 	if err := delServiceRules(service, nil, nil); err != nil {
-		return fmt.Errorf("DeleteService failed for nodePortWatcherIptables: %v", err)
+		return fmt.Errorf("DeleteService failed for nodePortWatcherNFTables: %v", err)
 	}
 	return nil
 }
 
-func (npwipt *nodePortWatcherIptables) SyncServices(services []interface{}) error {
+func (npwnft *nodePortWatcherNFTables) SyncServices(services []interface{}) error {
 	var err error
 	var errors []error
-	keepIPTRules := []nodeipt.Rule{}
-	keepNFTElems := []*knftables.Element{}
+	var keepNFTObjects, nftContainers []knftables.Object
 	for _, serviceInterface := range services {
 		service, ok := serviceInterface.(*corev1.Service)
 		if !ok {
@@ -1701,7 +1666,7 @@ func (npwipt *nodePortWatcherIptables) SyncServices(services []interface{}) erro
 		if !util.ServiceTypeHasClusterIP(service) || !util.IsClusterIPSet(service) {
 			continue
 		}
-		netInfo, err := npwipt.networkManager.GetActiveNetworkForNamespace(service.GetNamespace())
+		netInfo, err := npwnft.networkManager.GetActiveNetworkForNamespace(service.GetNamespace())
 		if err != nil {
 			// During startup sync, avoid failing the entire processExisting loop for namespaces that
 			// require a UDN but have no primary NAD yet (or it has been deleted). Those services will
@@ -1716,23 +1681,14 @@ func (npwipt *nodePortWatcherIptables) SyncServices(services []interface{}) erro
 			// network not on our node
 			continue
 		}
-		// Add correct iptables rules.
+		// Add correct nftables rules.
 		// TODO: ETP and ITP is not implemented for smart NIC mode.
-		keepIPTRules = append(keepIPTRules, getGatewayIPTRules(service, nil, false)...)
-		keepNFTElems = append(keepNFTElems, getGatewayNFTRules(service, nil, false)...)
+		keepNFTObjects = append(keepNFTObjects, getGatewayNFTRules(service, nil, false)...)
 	}
 
-	// sync rules once
-	for _, chain := range []string{iptableNodePortChain, iptableExternalIPChain} {
-		if err = recreateIPTRules("nat", chain, keepIPTRules); err != nil {
-			errors = append(errors, err)
-		}
-	}
-
-	for _, set := range getGatewayNFTSets() {
-		if err = recreateNFTSet(set, keepNFTElems); err != nil {
-			errors = append(errors, err)
-		}
+	nftContainers = append(nftContainers, getGatewayNFTContainerObjects()...)
+	if err = nodenft.SyncObjects(nftContainers, keepNFTObjects); err != nil {
+		errors = append(errors, fmt.Errorf("failed to sync nftables rules for services: %w", err))
 	}
 
 	return utilerrors.Join(errors...)
@@ -1792,7 +1748,7 @@ func newGateway(
 	}
 
 	// OCP HACK -- block MCS ports https://github.com/openshift/ovn-kubernetes/pull/170
-	if err := insertMCSBlockIptRules(); err != nil {
+	if err := setupMCSBlockNFTRules(); err != nil {
 		return nil, err
 	}
 	// END OCP HACK
@@ -1905,17 +1861,11 @@ func newNodePortWatcher(
 	// In the shared gateway mode, the NodePort service is handled by the OpenFlow flows configured
 	// on the OVS bridge in the host. These flows act only on the packets coming in from outside
 	// of the node. If someone on the node is trying to access the NodePort service, those packets
-	// will not be processed by the OpenFlow flows, so we need to add iptable rules that DNATs the
-	// NodePortIP:NodePort to ClusterServiceIP:Port. We don't need to do this on DPU.
+	// will not be processed by the OpenFlow flows, so we need to add nftables rules that
+	// DNATs the NodePortIP:NodePort to ClusterServiceIP:Port. We don't need to do this on DPU.
 	if config.IsModeFull() {
-		if config.Gateway.Mode == config.GatewayModeLocal {
-			if err := initLocalGatewayIPTables(); err != nil {
-				return nil, err
-			}
-		} else if config.Gateway.Mode == config.GatewayModeShared {
-			if err := initSharedGatewayIPTables(); err != nil {
-				return nil, err
-			}
+		if err := initGatewayNFTables(); err != nil {
+			return nil, err
 		}
 		if util.IsNetworkSegmentationSupportEnabled() {
 			if err := configureUDNServicesNFTables(); err != nil {
@@ -2015,9 +1965,6 @@ func cleanupSharedGateway(ovsClient libovsdbclient.Client) error {
 		}
 	}
 
-	if config.IsModeDPUHost() || config.IsModeFull() {
-		cleanupSharedGatewayIPTChains()
-	}
 	return nil
 }
 

--- a/go-controller/pkg/node/gateway_shared_intf_test.go
+++ b/go-controller/pkg/node/gateway_shared_intf_test.go
@@ -7,6 +7,7 @@
 package node
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"strings"
@@ -20,6 +21,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes/fake"
+	"sigs.k8s.io/knftables"
 
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
 	adminpolicybasedrouteclient "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/adminpolicybasedroute/v1/apis/clientset/versioned/fake"
@@ -27,6 +29,7 @@ import (
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/kube"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/networkmanager"
+	nodenft "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/nftables"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/routemanager"
 	ovntest "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing"
 	netlink_mocks "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing/mocks/github.com/vishvananda/netlink"
@@ -196,13 +199,21 @@ func (m *mockNetworkManagerWithActiveUDN) GetActiveNetworkForNamespace(_ string)
 	return m.netInfo, nil
 }
 
-// verifyIPTablesRule checks if an iptables rule exists and asserts the expected state
-func verifyIPTablesRule(ipt util.IPTablesHelper, serviceIP string, servicePort, nodePort int32, shouldExist bool, message string) {
-	exists, err := ipt.Exists("nat", "OVN-KUBE-NODEPORT",
-		"-p", "TCP", "-m", "addrtype", "--dst-type", "LOCAL",
-		"--dport", fmt.Sprintf("%d", nodePort), "-j", "DNAT",
-		"--to-destination", fmt.Sprintf("%s:%d", serviceIP, servicePort))
+// verifyNFTablesRule checks if an nftables rule exists and asserts the expected state
+func verifyNFTablesRule(nft knftables.Interface, serviceIP string, servicePort, nodePort int32, shouldExist bool, message string) {
+	elements, err := nft.ListElements(context.Background(), "map", "nodeports-v4")
 	Expect(err).NotTo(HaveOccurred())
+
+	servicePortStr := fmt.Sprintf("%d", servicePort)
+	nodePortStr := fmt.Sprintf("%d", nodePort)
+
+	exists := false
+	for _, elem := range elements {
+		if elem.Key[0] == "tcp" && elem.Key[1] == nodePortStr && elem.Value[0] == serviceIP && elem.Value[1] == servicePortStr {
+			exists = true
+			break
+		}
+	}
 	if shouldExist {
 		Expect(exists).To(BeTrue(), message)
 	} else {
@@ -212,7 +223,7 @@ func verifyIPTablesRule(ipt util.IPTablesHelper, serviceIP string, servicePort, 
 
 // setupServiceAndEndpointSliceWithRules creates a service and endpoint slice, adds them to npw,
 // and verifies iptables rules are created. Returns the created endpoint slice.
-func setupServiceAndEndpointSliceWithRules(npw *nodePortWatcher, ipt util.IPTablesHelper, svcName, namespace, serviceIP, endpointIP string, servicePort, nodePort int32, annotations map[string]string) *discovery.EndpointSlice {
+func setupServiceAndEndpointSliceWithRules(npw *nodePortWatcher, nft knftables.Interface, svcName, namespace, serviceIP, endpointIP string, servicePort, nodePort int32, annotations map[string]string) *discovery.EndpointSlice {
 	// Create service
 	service := newService(svcName, namespace, serviceIP,
 		[]corev1.ServicePort{{
@@ -262,8 +273,8 @@ func setupServiceAndEndpointSliceWithRules(npw *nodePortWatcher, ipt util.IPTabl
 	err = npw.AddEndpointSlice(epSlice)
 	Expect(err).NotTo(HaveOccurred())
 
-	// Verify iptables rules were created
-	verifyIPTablesRule(ipt, serviceIP, servicePort, nodePort, true, "iptables rule should exist before deletion")
+	// Verify nftables rules were created
+	verifyNFTablesRule(nft, serviceIP, servicePort, nodePort, true, "nftables rule should exist before deletion")
 
 	return epSlice
 }
@@ -273,7 +284,7 @@ var _ = Describe("DeleteEndpointSlice", func() {
 		fakeClient *util.OVNNodeClientset
 		watcher    *factory.WatchFactory
 		npw        *nodePortWatcher
-		iptV4      util.IPTablesHelper
+		nft        knftables.Interface
 	)
 
 	const (
@@ -303,7 +314,7 @@ var _ = Describe("DeleteEndpointSlice", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		// Initialize nodePortWatcher with default network manager
-		iptV4, _ = util.SetFakeIPTablesHelpers()
+		nft = nodenft.SetFakeNFTablesHelper()
 		npw = initFakeNodePortWatcher()
 		npw.watchFactory = watcher
 		npw.networkManager = networkmanager.Default().Interface()
@@ -311,6 +322,11 @@ var _ = Describe("DeleteEndpointSlice", func() {
 		// Initialize nodeIPManager (required for GetLocalEligibleEndpointAddresses)
 		k := &kube.Kube{KClient: fakeClient.KubeClient}
 		npw.nodeIPManager = newAddressManagerInternal(nodeName, k, nil, watcher, nil, nil, false)
+
+		// Since the tests here never call startNodePortWatcher(), we have to call
+		// initGatewayNFTables() ourselves to set up the sets, maps, etc.
+		err = initGatewayNFTables()
+		Expect(err).NotTo(HaveOccurred())
 	})
 
 	AfterEach(func() {
@@ -319,9 +335,9 @@ var _ = Describe("DeleteEndpointSlice", func() {
 
 	Context("when UDN is deleted before processing endpoint slice", func() {
 		It("should execute delServiceRules and gracefully skip addServiceRules", func() {
-			// Setup service and endpoint slice with iptables rules
+			// Setup service and endpoint slice with nftables rules
 			// Add UDN annotation to simulate a mirrored UDN EndpointSlice
-			epSlice := setupServiceAndEndpointSliceWithRules(npw, iptV4, testService, testNamespace, "10.96.0.2", "10.244.0.2", 80, 30081,
+			epSlice := setupServiceAndEndpointSliceWithRules(npw, nft, testService, testNamespace, "10.96.0.2", "10.244.0.2", 80, 30081,
 				map[string]string{types.UserDefinedNetworkEndpointSliceAnnotation: "test-udn"})
 
 			// Replace network manager with one that returns InvalidPrimaryNetworkError
@@ -334,15 +350,15 @@ var _ = Describe("DeleteEndpointSlice", func() {
 			// Should gracefully handle UDN deletion (no error)
 			Expect(err).NotTo(HaveOccurred())
 
-			// iptables rules should be deleted even when UDN is deleted
-			verifyIPTablesRule(iptV4, "10.96.0.2", 80, 30081, false, "iptables rule should be deleted even when UDN is deleted")
+			// nftables rules should be deleted even when UDN is deleted
+			verifyNFTablesRule(nft, "10.96.0.2", 80, 30081, false, "nftables rule should be deleted even when UDN is deleted")
 		})
 	})
 
 	Context("when network lookup returns other errors", func() {
 		It("should execute delServiceRules but return error from network lookup", func() {
-			// Setup service and endpoint slice with iptables rules
-			epSlice := setupServiceAndEndpointSliceWithRules(npw, iptV4, testService, testNamespace, "10.96.0.3", "10.244.0.3", 80, 30082, nil)
+			// Setup service and endpoint slice with nftables rules
+			epSlice := setupServiceAndEndpointSliceWithRules(npw, nft, testService, testNamespace, "10.96.0.3", "10.244.0.3", 80, 30082, nil)
 
 			// Replace network manager with one that returns a generic error
 			npw.networkManager = &mockNetworkManagerWithError{}
@@ -356,8 +372,8 @@ var _ = Describe("DeleteEndpointSlice", func() {
 			Expect(err.Error()).To(ContainSubstring(testNamespace))
 			Expect(err.Error()).To(ContainSubstring(testService))
 
-			// iptables rules should still be deleted even when error is returned
-			verifyIPTablesRule(iptV4, "10.96.0.3", 80, 30082, false, "iptables rule should be deleted even when error occurs")
+			// nftables rules should still be deleted even when error is returned
+			verifyNFTablesRule(nft, "10.96.0.3", 80, 30082, false, "nftables rule should be deleted even when error occurs")
 		})
 	})
 
@@ -376,8 +392,8 @@ var _ = Describe("DeleteEndpointSlice", func() {
 
 	Context("when namespace is deleted before processing endpoint slice", func() {
 		It("should clean up old rules even when namespace is gone", func() {
-			// Setup service and endpoint slice with iptables rules
-			epSlice := setupServiceAndEndpointSliceWithRules(npw, iptV4, testService, testNamespace, "10.96.0.10", "10.244.0.5", 80, 30090, nil)
+			// Setup service and endpoint slice with nftables rules
+			epSlice := setupServiceAndEndpointSliceWithRules(npw, nft, testService, testNamespace, "10.96.0.10", "10.244.0.5", 80, 30090, nil)
 
 			// Simulate namespace not found error
 			npw.networkManager = &mockNetworkManagerWithNamespaceNotFoundError{}
@@ -385,8 +401,8 @@ var _ = Describe("DeleteEndpointSlice", func() {
 			// Verify no error (graceful handling)
 			Expect(err).NotTo(HaveOccurred())
 
-			// iptables rules should be deleted even though namespace lookup failed
-			verifyIPTablesRule(iptV4, "10.96.0.10", 80, 30090, false, "iptables rule should be deleted even when namespace lookup fails")
+			// nftables rules should be deleted even though namespace lookup failed
+			verifyNFTablesRule(nft, "10.96.0.10", 80, 30090, false, "nftables rule should be deleted even when namespace lookup fails")
 		})
 	})
 })
@@ -396,7 +412,7 @@ var _ = Describe("SyncServices", func() {
 		fakeClient *util.OVNNodeClientset
 		watcher    *factory.WatchFactory
 		npw        *nodePortWatcher
-		iptV4      util.IPTablesHelper
+		nft        knftables.Interface
 	)
 
 	const (
@@ -424,13 +440,18 @@ var _ = Describe("SyncServices", func() {
 		err = watcher.Start()
 		Expect(err).NotTo(HaveOccurred())
 
-		iptV4, _ = util.SetFakeIPTablesHelpers()
+		nft = nodenft.SetFakeNFTablesHelper()
 		npw = initFakeNodePortWatcher()
 		npw.watchFactory = watcher
 		npw.networkManager = networkmanager.Default().Interface()
 
 		k := &kube.Kube{KClient: fakeClient.KubeClient}
 		npw.nodeIPManager = newAddressManagerInternal(nodeName, k, nil, watcher, nil, nil, false)
+
+		// Since the tests here never call startNodePortWatcher(), we have to call
+		// initGatewayNFTables() ourselves to set up the sets, maps, etc.
+		err = initGatewayNFTables()
+		Expect(err).NotTo(HaveOccurred())
 	})
 
 	AfterEach(func() {
@@ -454,8 +475,8 @@ var _ = Describe("SyncServices", func() {
 			err := npw.SyncServices([]interface{}{service})
 			Expect(err).NotTo(HaveOccurred())
 
-			verifyIPTablesRule(iptV4, "10.96.0.20", 80, 30091, false,
-				"iptables rule should not be created when primary network is invalid")
+			verifyNFTablesRule(nft, "10.96.0.20", 80, 30091, false,
+				"nftables rule should not be created when primary network is invalid")
 		})
 	})
 
@@ -476,8 +497,8 @@ var _ = Describe("SyncServices", func() {
 			err := npw.SyncServices([]interface{}{service})
 			Expect(err).NotTo(HaveOccurred())
 
-			verifyIPTablesRule(iptV4, "10.96.0.30", 80, 30092, false,
-				"iptables rule should not be created when UDN is inactive on this node")
+			verifyNFTablesRule(nft, "10.96.0.30", 80, 30092, false,
+				"nftables rule should not be created when UDN is inactive on this node")
 		})
 	})
 
@@ -533,8 +554,8 @@ var _ = Describe("SyncServices", func() {
 			err = npw.SyncServices([]interface{}{service})
 			Expect(err).NotTo(HaveOccurred())
 
-			verifyIPTablesRule(iptV4, "10.96.0.40", 80, 30093, true,
-				"iptables rule should be created when UDN is active on this node")
+			verifyNFTablesRule(nft, "10.96.0.40", 80, 30093, true,
+				"nftables rule should be created when UDN is active on this node")
 		})
 	})
 })

--- a/go-controller/pkg/node/gateway_shared_intf_test.go
+++ b/go-controller/pkg/node/gateway_shared_intf_test.go
@@ -7,6 +7,7 @@
 package node
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"strings"
@@ -20,6 +21,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes/fake"
+	"sigs.k8s.io/knftables"
 
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
 	adminpolicybasedrouteclient "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/adminpolicybasedroute/v1/apis/clientset/versioned/fake"
@@ -27,6 +29,7 @@ import (
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/kube"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/networkmanager"
+	nodenft "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/nftables"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/routemanager"
 	ovntest "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing"
 	netlink_mocks "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing/mocks/github.com/vishvananda/netlink"
@@ -196,13 +199,21 @@ func (m *mockNetworkManagerWithActiveUDN) GetActiveNetworkForNamespace(_ string)
 	return m.netInfo, nil
 }
 
-// verifyIPTablesRule checks if an iptables rule exists and asserts the expected state
-func verifyIPTablesRule(ipt util.IPTablesHelper, serviceIP string, servicePort, nodePort int32, shouldExist bool, message string) {
-	exists, err := ipt.Exists("nat", "OVN-KUBE-NODEPORT",
-		"-p", "TCP", "-m", "addrtype", "--dst-type", "LOCAL",
-		"--dport", fmt.Sprintf("%d", nodePort), "-j", "DNAT",
-		"--to-destination", fmt.Sprintf("%s:%d", serviceIP, servicePort))
+// verifyNFTablesRule checks if an nftables rule exists and asserts the expected state
+func verifyNFTablesRule(nft knftables.Interface, serviceIP string, servicePort, nodePort int32, shouldExist bool, message string) {
+	elements, err := nft.ListElements(context.Background(), "map", "nodeports-v4")
 	Expect(err).NotTo(HaveOccurred())
+
+	servicePortStr := fmt.Sprintf("%d", servicePort)
+	nodePortStr := fmt.Sprintf("%d", nodePort)
+
+	exists := false
+	for _, elem := range elements {
+		if elem.Key[0] == "tcp" && elem.Key[1] == nodePortStr && elem.Value[0] == serviceIP && elem.Value[1] == servicePortStr {
+			exists = true
+			break
+		}
+	}
 	if shouldExist {
 		Expect(exists).To(BeTrue(), message)
 	} else {
@@ -211,8 +222,8 @@ func verifyIPTablesRule(ipt util.IPTablesHelper, serviceIP string, servicePort, 
 }
 
 // setupServiceAndEndpointSliceWithRules creates a service and endpoint slice, adds them to npw,
-// and verifies iptables rules are created. Returns the created endpoint slice.
-func setupServiceAndEndpointSliceWithRules(npw *nodePortWatcher, ipt util.IPTablesHelper, svcName, namespace, serviceIP, endpointIP string, servicePort, nodePort int32, annotations map[string]string) *discovery.EndpointSlice {
+// and verifies nftables rules are created. Returns the created endpoint slice.
+func setupServiceAndEndpointSliceWithRules(npw *nodePortWatcher, nft knftables.Interface, svcName, namespace, serviceIP, endpointIP string, servicePort, nodePort int32, annotations map[string]string) *discovery.EndpointSlice {
 	// Create service
 	service := newService(svcName, namespace, serviceIP,
 		[]corev1.ServicePort{{
@@ -262,8 +273,8 @@ func setupServiceAndEndpointSliceWithRules(npw *nodePortWatcher, ipt util.IPTabl
 	err = npw.AddEndpointSlice(epSlice)
 	Expect(err).NotTo(HaveOccurred())
 
-	// Verify iptables rules were created
-	verifyIPTablesRule(ipt, serviceIP, servicePort, nodePort, true, "iptables rule should exist before deletion")
+	// Verify nftables rules were created
+	verifyNFTablesRule(nft, serviceIP, servicePort, nodePort, true, "nftables rule should exist before deletion")
 
 	return epSlice
 }
@@ -273,7 +284,7 @@ var _ = Describe("DeleteEndpointSlice", func() {
 		fakeClient *util.OVNNodeClientset
 		watcher    *factory.WatchFactory
 		npw        *nodePortWatcher
-		iptV4      util.IPTablesHelper
+		nft        knftables.Interface
 	)
 
 	const (
@@ -303,7 +314,7 @@ var _ = Describe("DeleteEndpointSlice", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		// Initialize nodePortWatcher with default network manager
-		iptV4, _ = util.SetFakeIPTablesHelpers()
+		nft = nodenft.SetFakeNFTablesHelper()
 		npw = initFakeNodePortWatcher()
 		npw.watchFactory = watcher
 		npw.networkManager = networkmanager.Default().Interface()
@@ -311,6 +322,11 @@ var _ = Describe("DeleteEndpointSlice", func() {
 		// Initialize nodeIPManager (required for GetLocalEligibleEndpointAddresses)
 		k := &kube.Kube{KClient: fakeClient.KubeClient}
 		npw.nodeIPManager = newAddressManagerInternal(nodeName, k, nil, watcher, nil, nil, false)
+
+		// Since the tests here never call startNodePortWatcher(), we have to call
+		// initGatewayNFTables() ourselves to set up the sets, maps, etc.
+		err = initGatewayNFTables()
+		Expect(err).NotTo(HaveOccurred())
 	})
 
 	AfterEach(func() {
@@ -319,9 +335,9 @@ var _ = Describe("DeleteEndpointSlice", func() {
 
 	Context("when UDN is deleted before processing endpoint slice", func() {
 		It("should execute delServiceRules and gracefully skip addServiceRules", func() {
-			// Setup service and endpoint slice with iptables rules
+			// Setup service and endpoint slice with nftables rules
 			// Add UDN annotation to simulate a mirrored UDN EndpointSlice
-			epSlice := setupServiceAndEndpointSliceWithRules(npw, iptV4, testService, testNamespace, "10.96.0.2", "10.244.0.2", 80, 30081,
+			epSlice := setupServiceAndEndpointSliceWithRules(npw, nft, testService, testNamespace, "10.96.0.2", "10.244.0.2", 80, 30081,
 				map[string]string{types.UserDefinedNetworkEndpointSliceAnnotation: "test-udn"})
 
 			// Replace network manager with one that returns InvalidPrimaryNetworkError
@@ -334,15 +350,15 @@ var _ = Describe("DeleteEndpointSlice", func() {
 			// Should gracefully handle UDN deletion (no error)
 			Expect(err).NotTo(HaveOccurred())
 
-			// iptables rules should be deleted even when UDN is deleted
-			verifyIPTablesRule(iptV4, "10.96.0.2", 80, 30081, false, "iptables rule should be deleted even when UDN is deleted")
+			// nftables rules should be deleted even when UDN is deleted
+			verifyNFTablesRule(nft, "10.96.0.2", 80, 30081, false, "nftables rule should be deleted even when UDN is deleted")
 		})
 	})
 
 	Context("when network lookup returns other errors", func() {
 		It("should execute delServiceRules but return error from network lookup", func() {
-			// Setup service and endpoint slice with iptables rules
-			epSlice := setupServiceAndEndpointSliceWithRules(npw, iptV4, testService, testNamespace, "10.96.0.3", "10.244.0.3", 80, 30082, nil)
+			// Setup service and endpoint slice with nftables rules
+			epSlice := setupServiceAndEndpointSliceWithRules(npw, nft, testService, testNamespace, "10.96.0.3", "10.244.0.3", 80, 30082, nil)
 
 			// Replace network manager with one that returns a generic error
 			npw.networkManager = &mockNetworkManagerWithError{}
@@ -356,8 +372,8 @@ var _ = Describe("DeleteEndpointSlice", func() {
 			Expect(err.Error()).To(ContainSubstring(testNamespace))
 			Expect(err.Error()).To(ContainSubstring(testService))
 
-			// iptables rules should still be deleted even when error is returned
-			verifyIPTablesRule(iptV4, "10.96.0.3", 80, 30082, false, "iptables rule should be deleted even when error occurs")
+			// nftables rules should still be deleted even when error is returned
+			verifyNFTablesRule(nft, "10.96.0.3", 80, 30082, false, "nftables rule should be deleted even when error occurs")
 		})
 	})
 
@@ -376,8 +392,8 @@ var _ = Describe("DeleteEndpointSlice", func() {
 
 	Context("when namespace is deleted before processing endpoint slice", func() {
 		It("should clean up old rules even when namespace is gone", func() {
-			// Setup service and endpoint slice with iptables rules
-			epSlice := setupServiceAndEndpointSliceWithRules(npw, iptV4, testService, testNamespace, "10.96.0.10", "10.244.0.5", 80, 30090, nil)
+			// Setup service and endpoint slice with nftables rules
+			epSlice := setupServiceAndEndpointSliceWithRules(npw, nft, testService, testNamespace, "10.96.0.10", "10.244.0.5", 80, 30090, nil)
 
 			// Simulate namespace not found error
 			npw.networkManager = &mockNetworkManagerWithNamespaceNotFoundError{}
@@ -385,8 +401,8 @@ var _ = Describe("DeleteEndpointSlice", func() {
 			// Verify no error (graceful handling)
 			Expect(err).NotTo(HaveOccurred())
 
-			// iptables rules should be deleted even though namespace lookup failed
-			verifyIPTablesRule(iptV4, "10.96.0.10", 80, 30090, false, "iptables rule should be deleted even when namespace lookup fails")
+			// nftables rules should be deleted even though namespace lookup failed
+			verifyNFTablesRule(nft, "10.96.0.10", 80, 30090, false, "nftables rule should be deleted even when namespace lookup fails")
 		})
 	})
 })
@@ -396,7 +412,7 @@ var _ = Describe("SyncServices", func() {
 		fakeClient *util.OVNNodeClientset
 		watcher    *factory.WatchFactory
 		npw        *nodePortWatcher
-		iptV4      util.IPTablesHelper
+		nft        knftables.Interface
 	)
 
 	const (
@@ -424,13 +440,18 @@ var _ = Describe("SyncServices", func() {
 		err = watcher.Start()
 		Expect(err).NotTo(HaveOccurred())
 
-		iptV4, _ = util.SetFakeIPTablesHelpers()
+		nft = nodenft.SetFakeNFTablesHelper()
 		npw = initFakeNodePortWatcher()
 		npw.watchFactory = watcher
 		npw.networkManager = networkmanager.Default().Interface()
 
 		k := &kube.Kube{KClient: fakeClient.KubeClient}
 		npw.nodeIPManager = newAddressManagerInternal(nodeName, k, nil, watcher, nil, nil, false)
+
+		// Since the tests here never call startNodePortWatcher(), we have to call
+		// initGatewayNFTables() ourselves to set up the sets, maps, etc.
+		err = initGatewayNFTables()
+		Expect(err).NotTo(HaveOccurred())
 	})
 
 	AfterEach(func() {
@@ -454,8 +475,8 @@ var _ = Describe("SyncServices", func() {
 			err := npw.SyncServices([]interface{}{service})
 			Expect(err).NotTo(HaveOccurred())
 
-			verifyIPTablesRule(iptV4, "10.96.0.20", 80, 30091, false,
-				"iptables rule should not be created when primary network is invalid")
+			verifyNFTablesRule(nft, "10.96.0.20", 80, 30091, false,
+				"nftables rule should not be created when primary network is invalid")
 		})
 	})
 
@@ -476,8 +497,8 @@ var _ = Describe("SyncServices", func() {
 			err := npw.SyncServices([]interface{}{service})
 			Expect(err).NotTo(HaveOccurred())
 
-			verifyIPTablesRule(iptV4, "10.96.0.30", 80, 30092, false,
-				"iptables rule should not be created when UDN is inactive on this node")
+			verifyNFTablesRule(nft, "10.96.0.30", 80, 30092, false,
+				"nftables rule should not be created when UDN is inactive on this node")
 		})
 	})
 
@@ -533,8 +554,8 @@ var _ = Describe("SyncServices", func() {
 			err = npw.SyncServices([]interface{}{service})
 			Expect(err).NotTo(HaveOccurred())
 
-			verifyIPTablesRule(iptV4, "10.96.0.40", 80, 30093, true,
-				"iptables rule should be created when UDN is active on this node")
+			verifyNFTablesRule(nft, "10.96.0.40", 80, 30093, true,
+				"nftables rule should be created when UDN is active on this node")
 		})
 	})
 })

--- a/go-controller/pkg/node/gateway_shared_intf_test.go
+++ b/go-controller/pkg/node/gateway_shared_intf_test.go
@@ -222,7 +222,7 @@ func verifyNFTablesRule(nft knftables.Interface, serviceIP string, servicePort, 
 }
 
 // setupServiceAndEndpointSliceWithRules creates a service and endpoint slice, adds them to npw,
-// and verifies iptables rules are created. Returns the created endpoint slice.
+// and verifies nftables rules are created. Returns the created endpoint slice.
 func setupServiceAndEndpointSliceWithRules(npw *nodePortWatcher, nft knftables.Interface, svcName, namespace, serviceIP, endpointIP string, servicePort, nodePort int32, annotations map[string]string) *discovery.EndpointSlice {
 	// Create service
 	service := newService(svcName, namespace, serviceIP,

--- a/go-controller/pkg/node/gateway_udn_test.go
+++ b/go-controller/pkg/node/gateway_udn_test.go
@@ -974,8 +974,6 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 		getDeletionFakeOVSCommands(fexec, mgtPort)
 		nodeLister.On("Get", mock.AnythingOfType("string")).Return(node, nil)
 		factoryMock.On("GetNodeForWindows", "worker1").Return(node, nil)
-		cnode := node.DeepCopy()
-		kubeMock.On("UpdateNodeStatus", cnode).Return(nil) // check if network key gets deleted from annotation
 		err = testNS.Do(func(ns.NetNS) error {
 			defer GinkgoRecover()
 			ofm := getDummyOpenflowManager()
@@ -1065,8 +1063,6 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 		getDeletionFakeOVSCommands(fexec, mgtPort)
 		nodeLister.On("Get", mock.AnythingOfType("string")).Return(node, nil)
 		factoryMock.On("GetNodeForWindows", "worker1").Return(node, nil)
-		cnode := node.DeepCopy()
-		kubeMock.On("UpdateNodeStatus", cnode).Return(nil) // check if network key gets deleted from annotation
 		err = testNS.Do(func(ns.NetNS) error {
 			defer GinkgoRecover()
 			ofm := getDummyOpenflowManager()
@@ -1292,8 +1288,6 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 			removeOVSPatchPortInterface(ovsClient, "breth0", "patch-breth0_bluenet_worker1-to-br-int")
 			openflowManagerCheckPorts(udnGateway.openflowManager)
 
-			cnode := node.DeepCopy()
-			kubeMock.On("UpdateNodeStatus", cnode).Return(nil) // check if network key gets deleted from annotation
 			Expect(udnGateway.DelNetwork()).To(Succeed())
 			flowMap = udnGateway.gateway.openflowManager.defaultBridge.flowCache
 			Expect(flowMap["DEFAULT"]).To(HaveLen(baseFlowCount))
@@ -1719,8 +1713,6 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 			removeOVSPatchPortInterface(ovsClient, "breth0", "patch-breth0_bluenet_worker1-to-br-int")
 			openflowManagerCheckPorts(udnGateway.openflowManager)
 
-			cnode := node.DeepCopy()
-			kubeMock.On("UpdateNodeStatus", cnode).Return(nil) // check if network key gets deleted from annotation
 			Expect(udnGateway.DelNetwork()).To(Succeed())
 			flowMap = udnGateway.gateway.openflowManager.defaultBridge.flowCache
 			Expect(flowMap["DEFAULT"]).To(HaveLen(baseFlowCount))
@@ -1966,8 +1958,6 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 			removeOVSPatchPortInterface(ovsClient, "breth0", "patch-breth0_bluenet_worker1-to-br-int")
 			openflowManagerCheckPorts(udnGateway.openflowManager)
 
-			cnode := node.DeepCopy()
-			kubeMock.On("UpdateNodeStatus", cnode).Return(nil) // check if network key gets deleted from annotation
 			Expect(udnGateway.DelNetwork()).To(Succeed())
 			flowMap = udnGateway.gateway.openflowManager.defaultBridge.flowCache
 			Expect(flowMap["DEFAULT"]).To(HaveLen(baseFlowCount))

--- a/go-controller/pkg/node/managementport/port_dpu_linux.go
+++ b/go-controller/pkg/node/managementport/port_dpu_linux.go
@@ -171,7 +171,7 @@ func (mp *managementPortNetdev) create() error {
 		}
 	}
 
-	// configure management port: name, mac, MTU, iptables
+	// configure management port: name, mac, MTU, nftables
 	// mac addr, derived from the first entry in host subnets using the .2 address as mac with a fixed prefix.
 	klog.V(5).Infof("Setup netdevice management port: %s (deviceID: %s)", link.Attrs().Name, mp.deviceID)
 	mgmtPortMac := util.IPAddrToHWAddr(util.GetNodeManagementIfAddr(mp.cfg.hostSubnets[0]).IP)

--- a/go-controller/pkg/node/managementport/port_dpu_linux_test.go
+++ b/go-controller/pkg/node/managementport/port_dpu_linux_test.go
@@ -333,7 +333,7 @@ var _ = Describe("Mananagement port DPU tests", func() {
 			mockOVSListInterfaceMgmtPortNotExistCmd(execMock, types.K8sMgmtIntfName)
 
 			// mock createPlatformManagementPort, we fail it as it covers what we want to test without the
-			// need to mock the entire flow down to routes and iptable rules.
+			// need to mock the entire flow down to routes and nftables rules.
 			netlinkOpsMock.On("LinkByName", mock.Anything).Return(nil, fmt.Errorf(
 				"createPlatformManagementPort error"))
 
@@ -364,7 +364,7 @@ var _ = Describe("Mananagement port DPU tests", func() {
 			netlinkOpsMock.On("LinkSetUp", linkMock).Return(nil)
 
 			// mock createPlatformManagementPort, we fail it as it covers what we want to test without the
-			// need to mock the entire flow down to routes and iptable rules.
+			// need to mock the entire flow down to routes and nftables rules.
 			netlinkOpsMock.On("LinkByName", mock.Anything).Return(nil, fmt.Errorf(
 				"createPlatformManagementPort error"))
 

--- a/go-controller/pkg/node/nftables/util.go
+++ b/go-controller/pkg/node/nftables/util.go
@@ -38,14 +38,19 @@ func AddObjects(objects []knftables.Object) error {
 // correct value. Alternatively, you can leave Value unset, in which case DeleteObjects
 // will first "list" the map to find its current contents, and then only try to delete the
 // elements that are actually present.
+//
+// For knftables.Rule objects, if the Rule's Handle is not set, then it must have a
+// non-nil Comment. DeleteObjects will first "list" the Rule's Chain to find its current
+// contents, and then delete every rule in the chain with a matching comment.
 func DeleteObjects(objects []knftables.Object) error {
 	nft, err := GetNFTablesHelper()
 	if err != nil {
 		return err
 	}
 
-	// If there are any partial Map Elements, list their maps' existing contents
+	// List existing objects we need to list
 	existingMaps := make(map[string][]*knftables.Element)
+	existingChains := make(map[string][]*knftables.Rule)
 	for _, obj := range objects {
 		switch typed := obj.(type) {
 		case *knftables.Element:
@@ -56,6 +61,19 @@ func DeleteObjects(objects []knftables.Object) error {
 				}
 				existingMaps[typed.Map] = existingElements
 			}
+		case *knftables.Rule:
+			if typed.Handle != nil {
+				continue
+			} else if typed.Comment == nil {
+				return fmt.Errorf("rule passed to DeleteObject must have a Handle or Comment")
+			}
+			if existingChains[typed.Chain] == nil {
+				rules, err := nft.ListRules(context.TODO(), typed.Chain)
+				if err != nil {
+					return err
+				}
+				existingChains[typed.Chain] = rules
+			}
 		default:
 			return fmt.Errorf("unsupported object type %T passed to DeleteObjects", obj)
 		}
@@ -63,6 +81,7 @@ func DeleteObjects(objects []knftables.Object) error {
 
 	// Now build the actual transaction
 	tx := nft.NewTransaction()
+	deletedRules := sets.New[int]()
 	for _, obj := range objects {
 		switch typed := obj.(type) {
 		case *knftables.Element:
@@ -86,6 +105,20 @@ func DeleteObjects(objects []knftables.Object) error {
 			// not it previously existed.
 			tx.Add(typed)
 			tx.Delete(typed)
+		case *knftables.Rule:
+			if typed.Handle != nil {
+				if !deletedRules.Has(*typed.Handle) {
+					tx.Delete(typed)
+					deletedRules.Insert(*typed.Handle)
+				}
+			} else {
+				for _, rule := range findRulesByComment(existingChains[typed.Chain], *typed.Comment) {
+					if !deletedRules.Has(*rule.Handle) {
+						tx.Delete(rule)
+						deletedRules.Insert(*rule.Handle)
+					}
+				}
+			}
 		default:
 		}
 	}
@@ -93,8 +126,8 @@ func DeleteObjects(objects []knftables.Object) error {
 }
 
 // SyncObjects synchronizes the given nftables containers to contain only the elements in
-// contents. Currently containers must contain only Sets and Maps, while contents must
-// contain only Elements.
+// contents. containers can contain Sets, Maps, and Chains, and contents can contain
+// Elements and Rules.
 func SyncObjects(containers, contents []knftables.Object) error {
 	nft, err := GetNFTablesHelper()
 	if err != nil {
@@ -104,12 +137,15 @@ func SyncObjects(containers, contents []knftables.Object) error {
 	tx := nft.NewTransaction()
 
 	syncContainers := make(map[string]knftables.Object)
+	syncChains := make(map[string]*knftables.Chain)
 	for _, obj := range containers {
 		switch typed := obj.(type) {
 		case *knftables.Set:
 			syncContainers[typed.Name] = obj
 		case *knftables.Map:
 			syncContainers[typed.Name] = obj
+		case *knftables.Chain:
+			syncChains[typed.Name] = typed
 		default:
 			return fmt.Errorf("unsupported container type %T passed to SyncObjects", obj)
 		}
@@ -123,6 +159,10 @@ func SyncObjects(containers, contents []knftables.Object) error {
 				return fmt.Errorf("unexpected element from set %q which is not in containers", typed.Set)
 			} else if typed.Map != "" && syncContainers[typed.Map] == nil {
 				return fmt.Errorf("unexpected element from map %q which is not in containers", typed.Map)
+			}
+		case *knftables.Rule:
+			if syncChains[typed.Chain] == nil {
+				return fmt.Errorf("unexpected rule from chain %q which is not in containers", typed.Chain)
 			}
 		default:
 			return fmt.Errorf("unsupported contents type %T passed to SyncObjects", obj)
@@ -157,6 +197,26 @@ func SyncObjects(containers, contents []knftables.Object) error {
 			return err
 		}
 	}
+
+	for _, chainName := range sets.List(sets.KeySet(syncChains)) {
+		tx := nft.NewTransaction()
+		tx.Flush(syncChains[chainName])
+		keepRules := 0
+		for _, obj := range contents {
+			switch typed := obj.(type) {
+			case *knftables.Rule:
+				if typed.Chain == chainName {
+					tx.Add(obj)
+					keepRules++
+				}
+			}
+		}
+		err := nft.Run(context.TODO(), tx)
+		if err != nil && (!knftables.IsNotFound(err) || keepRules > 0) {
+			return err
+		}
+	}
+
 	return nil
 }
 
@@ -175,4 +235,14 @@ elemLoop:
 		return elem
 	}
 	return nil
+}
+
+func findRulesByComment(rules []*knftables.Rule, comment string) []*knftables.Rule {
+	matches := make([]*knftables.Rule, 0, 1)
+	for _, rule := range rules {
+		if rule.Comment != nil && *rule.Comment == comment {
+			matches = append(matches, rule)
+		}
+	}
+	return matches
 }

--- a/go-controller/pkg/node/nftables/util.go
+++ b/go-controller/pkg/node/nftables/util.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"fmt"
 
+	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/knftables"
 )
 
@@ -89,6 +90,74 @@ func DeleteObjects(objects []knftables.Object) error {
 		}
 	}
 	return nft.Run(context.TODO(), tx)
+}
+
+// SyncObjects synchronizes the given nftables containers to contain only the elements in
+// contents. Currently containers must contain only Sets and Maps, while contents must
+// contain only Elements.
+func SyncObjects(containers, contents []knftables.Object) error {
+	nft, err := GetNFTablesHelper()
+	if err != nil {
+		return err
+	}
+
+	tx := nft.NewTransaction()
+
+	syncContainers := make(map[string]knftables.Object)
+	for _, obj := range containers {
+		switch typed := obj.(type) {
+		case *knftables.Set:
+			syncContainers[typed.Name] = obj
+		case *knftables.Map:
+			syncContainers[typed.Name] = obj
+		default:
+			return fmt.Errorf("unsupported container type %T passed to SyncObjects", obj)
+		}
+		tx.Flush(obj)
+	}
+
+	for _, obj := range contents {
+		switch typed := obj.(type) {
+		case *knftables.Element:
+			if typed.Set != "" && syncContainers[typed.Set] == nil {
+				return fmt.Errorf("unexpected element from set %q which is not in containers", typed.Set)
+			} else if typed.Map != "" && syncContainers[typed.Map] == nil {
+				return fmt.Errorf("unexpected element from map %q which is not in containers", typed.Map)
+			}
+		default:
+			return fmt.Errorf("unsupported contents type %T passed to SyncObjects", obj)
+		}
+		tx.Add(obj)
+	}
+
+	err = nft.Run(context.TODO(), tx)
+	if err == nil || !knftables.IsNotFound(err) {
+		return err
+	}
+
+	// For compatibility with
+	// https://github.com/ovn-kubernetes/ovn-kubernetes/pull/5250, try again, doing
+	// each container separately, ignoring errors if we are asked to make a set/map
+	// empty when the set/map doesn't actually exist
+	for _, containerName := range sets.List(sets.KeySet(syncContainers)) {
+		tx := nft.NewTransaction()
+		tx.Flush(syncContainers[containerName])
+		keepElems := 0
+		for _, obj := range contents {
+			switch typed := obj.(type) {
+			case *knftables.Element:
+				if typed.Set == containerName || typed.Map == containerName {
+					tx.Add(obj)
+					keepElems++
+				}
+			}
+		}
+		err := nft.Run(context.TODO(), tx)
+		if err != nil && (!knftables.IsNotFound(err) || keepElems > 0) {
+			return err
+		}
+	}
+	return nil
 }
 
 func findElement(elements []*knftables.Element, key []string) *knftables.Element {

--- a/go-controller/pkg/node/nftables/util.go
+++ b/go-controller/pkg/node/nftables/util.go
@@ -8,77 +8,216 @@ package nftables
 
 import (
 	"context"
+	"fmt"
 
+	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/knftables"
 )
 
-// UpdateNFTElements adds/updates the given nftables set/map elements. The set or map must
-// already exist.
-func UpdateNFTElements(elements []*knftables.Element) error {
+// AddObjects adds each element of objects to nftables in a single transaction, using
+// tx.Add() for each object.
+func AddObjects(objects []knftables.Object) error {
 	nft, err := GetNFTablesHelper()
 	if err != nil {
 		return err
 	}
 
 	tx := nft.NewTransaction()
-	for _, elem := range elements {
-		tx.Add(elem)
+	for _, obj := range objects {
+		tx.Add(obj)
 	}
 	return nft.Run(context.TODO(), tx)
 }
 
-// DeleteNFTElements deletes the given nftables set/map elements. The set or map must
-// exist, but if the elements aren't already in the set/map, no error is returned.
+// DeleteObjects deletes each element of objects from nftables, if it exists; no errors
+// are returned for objects that don't exist.
 //
 // To avoid depending on `nft destroy` (which requires kernel 6.3+), this Add()s each
 // element before Delete()ing it, so you won't get an error if the element wasn't already
 // in the set/map, which means that for map elements, the Value field must be set to the
-// correct value. Alternatively, you can leave Value unset, in which case
-// DeleteNFTElements will first "list" the map to find its current contents, and then only
-// try to delete the elements that are actually present.
-func DeleteNFTElements(elements []*knftables.Element) error {
+// correct value. Alternatively, you can leave Value unset, in which case DeleteObjects
+// will first "list" the map to find its current contents, and then only try to delete the
+// elements that are actually present.
+//
+// For knftables.Rule objects, if the Rule's Handle is not set, then it must have a
+// non-nil Comment. DeleteObjects will first "list" the Rule's Chain to find its current
+// contents, and then delete every rule in the chain with a matching comment.
+func DeleteObjects(objects []knftables.Object) error {
 	nft, err := GetNFTablesHelper()
 	if err != nil {
 		return err
 	}
 
-	// If there are any partial Map Elements, list their maps' existing contents
+	// List existing objects we need to list
 	existingMaps := make(map[string][]*knftables.Element)
-	for _, elem := range elements {
-		if elem.Map != "" && len(elem.Value) == 0 && existingMaps[elem.Map] == nil {
-			existingElements, err := nft.ListElements(context.TODO(), "map", elem.Map)
-			if err != nil {
-				return err
+	existingChains := make(map[string][]*knftables.Rule)
+	for _, obj := range objects {
+		switch typed := obj.(type) {
+		case *knftables.Element:
+			if typed.Map != "" && len(typed.Value) == 0 && existingMaps[typed.Map] == nil {
+				existingElements, err := nft.ListElements(context.TODO(), "map", typed.Map)
+				if err != nil {
+					return err
+				}
+				existingMaps[typed.Map] = existingElements
 			}
-			existingMaps[elem.Map] = existingElements
+		case *knftables.Rule:
+			if typed.Handle != nil {
+				continue
+			} else if typed.Comment == nil {
+				return fmt.Errorf("rule passed to DeleteObject must have a Handle or Comment")
+			}
+			if existingChains[typed.Chain] == nil {
+				rules, err := nft.ListRules(context.TODO(), typed.Chain)
+				if err != nil {
+					return err
+				}
+				existingChains[typed.Chain] = rules
+			}
+		default:
+			return fmt.Errorf("unsupported object type %T passed to DeleteObjects", obj)
 		}
 	}
 
 	// Now build the actual transaction
 	tx := nft.NewTransaction()
-	for _, elem := range elements {
-		if elem.Map != "" && len(elem.Value) == 0 {
-			// We can't tx.Add() a Map Element with no Value, so try
-			// to find its existing value in the List output from
-			// above. If the element doesn't appear in that output
-			// then we just skip trying to delete it. Otherwise, we do
-			// the Add+Delete below just like in the normal case; the
-			// Add *should* be a no-op, but doing it anyway makes this
-			// work right even if another thread Deletes the element
-			// before we get to it (as long as they don't add it back
-			// with a different value).
-			elem = findElement(existingMaps[elem.Map], elem.Key)
-			if elem == nil {
-				continue
+	deletedRules := sets.New[int]()
+	for _, obj := range objects {
+		switch typed := obj.(type) {
+		case *knftables.Element:
+			if typed.Map != "" && len(typed.Value) == 0 {
+				// We can't tx.Add() a Map Element with no Value, so try
+				// to find its existing value in the List output from
+				// above. If the element doesn't appear in that output
+				// then we just skip trying to delete it. Otherwise, we do
+				// the Add+Delete below just like in the normal case; the
+				// Add *should* be a no-op, but doing it anyway makes this
+				// work right even if another thread Deletes the element
+				// before we get to it (as long as they don't add it back
+				// with a different value).
+				typed = findElement(existingMaps[typed.Map], typed.Key)
+				if typed == nil {
+					continue
+				}
 			}
-		}
 
-		// Do Add+Delete, which ensures the object is deleted whether or
-		// not it previously existed.
-		tx.Add(elem)
-		tx.Delete(elem)
+			// Do Add+Delete, which ensures the object is deleted whether or
+			// not it previously existed.
+			tx.Add(typed)
+			tx.Delete(typed)
+		case *knftables.Rule:
+			if typed.Handle != nil {
+				if !deletedRules.Has(*typed.Handle) {
+					tx.Delete(typed)
+					deletedRules.Insert(*typed.Handle)
+				}
+			} else {
+				for _, rule := range findRulesByComment(existingChains[typed.Chain], *typed.Comment) {
+					if !deletedRules.Has(*rule.Handle) {
+						tx.Delete(rule)
+						deletedRules.Insert(*rule.Handle)
+					}
+				}
+			}
+		default:
+		}
 	}
 	return nft.Run(context.TODO(), tx)
+}
+
+// SyncObjects synchronizes the given nftables containers to contain only the elements in
+// contents. containers can contain Sets, Maps, and Chains, and contents can contain
+// Elements and Rules.
+func SyncObjects(containers, contents []knftables.Object) error {
+	nft, err := GetNFTablesHelper()
+	if err != nil {
+		return err
+	}
+
+	tx := nft.NewTransaction()
+
+	syncContainers := make(map[string]knftables.Object)
+	syncChains := make(map[string]*knftables.Chain)
+	for _, obj := range containers {
+		switch typed := obj.(type) {
+		case *knftables.Set:
+			syncContainers[typed.Name] = obj
+		case *knftables.Map:
+			syncContainers[typed.Name] = obj
+		case *knftables.Chain:
+			syncChains[typed.Name] = typed
+		default:
+			return fmt.Errorf("unsupported container type %T passed to SyncObjects", obj)
+		}
+		tx.Flush(obj)
+	}
+
+	for _, obj := range contents {
+		switch typed := obj.(type) {
+		case *knftables.Element:
+			if typed.Set != "" && syncContainers[typed.Set] == nil {
+				return fmt.Errorf("unexpected element from set %q which is not in containers", typed.Set)
+			} else if typed.Map != "" && syncContainers[typed.Map] == nil {
+				return fmt.Errorf("unexpected element from map %q which is not in containers", typed.Map)
+			}
+		case *knftables.Rule:
+			if syncChains[typed.Chain] == nil {
+				return fmt.Errorf("unexpected rule from chain %q which is not in containers", typed.Chain)
+			}
+		default:
+			return fmt.Errorf("unsupported contents type %T passed to SyncObjects", obj)
+		}
+		tx.Add(obj)
+	}
+
+	err = nft.Run(context.TODO(), tx)
+	if err == nil || !knftables.IsNotFound(err) {
+		return err
+	}
+
+	// For compatibility with
+	// https://github.com/ovn-kubernetes/ovn-kubernetes/pull/5250, try again, doing
+	// each container separately, ignoring errors if we are asked to make a set/map
+	// empty when the set/map doesn't actually exist
+	for _, containerName := range sets.List(sets.KeySet(syncContainers)) {
+		tx := nft.NewTransaction()
+		tx.Flush(syncContainers[containerName])
+		keepElems := 0
+		for _, obj := range contents {
+			switch typed := obj.(type) {
+			case *knftables.Element:
+				if typed.Set == containerName || typed.Map == containerName {
+					tx.Add(obj)
+					keepElems++
+				}
+			}
+		}
+		err := nft.Run(context.TODO(), tx)
+		if err != nil && (!knftables.IsNotFound(err) || keepElems > 0) {
+			return err
+		}
+	}
+
+	for _, chainName := range sets.List(sets.KeySet(syncChains)) {
+		tx := nft.NewTransaction()
+		tx.Flush(syncChains[chainName])
+		keepRules := 0
+		for _, obj := range contents {
+			switch typed := obj.(type) {
+			case *knftables.Rule:
+				if typed.Chain == chainName {
+					tx.Add(obj)
+					keepRules++
+				}
+			}
+		}
+		err := nft.Run(context.TODO(), tx)
+		if err != nil && (!knftables.IsNotFound(err) || keepRules > 0) {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func findElement(elements []*knftables.Element, key []string) *knftables.Element {
@@ -96,4 +235,14 @@ elemLoop:
 		return elem
 	}
 	return nil
+}
+
+func findRulesByComment(rules []*knftables.Rule, comment string) []*knftables.Rule {
+	matches := make([]*knftables.Rule, 0, 1)
+	for _, rule := range rules {
+		if rule.Comment != nil && *rule.Comment == comment {
+			matches = append(matches, rule)
+		}
+	}
+	return matches
 }

--- a/go-controller/pkg/node/nftables/util.go
+++ b/go-controller/pkg/node/nftables/util.go
@@ -8,35 +8,36 @@ package nftables
 
 import (
 	"context"
+	"fmt"
 
 	"sigs.k8s.io/knftables"
 )
 
-// UpdateNFTElements adds/updates the given nftables set/map elements. The set or map must
-// already exist.
-func UpdateNFTElements(elements []*knftables.Element) error {
+// AddObjects adds each element of objects to nftables in a single transaction, using
+// tx.Add() for each object.
+func AddObjects(objects []knftables.Object) error {
 	nft, err := GetNFTablesHelper()
 	if err != nil {
 		return err
 	}
 
 	tx := nft.NewTransaction()
-	for _, elem := range elements {
-		tx.Add(elem)
+	for _, obj := range objects {
+		tx.Add(obj)
 	}
 	return nft.Run(context.TODO(), tx)
 }
 
-// DeleteNFTElements deletes the given nftables set/map elements. The set or map must
-// exist, but if the elements aren't already in the set/map, no error is returned.
+// DeleteObjects deletes each element of objects from nftables, if it exists; no errors
+// are returned for objects that don't exist.
 //
 // To avoid depending on `nft destroy` (which requires kernel 6.3+), this Add()s each
 // element before Delete()ing it, so you won't get an error if the element wasn't already
 // in the set/map, which means that for map elements, the Value field must be set to the
-// correct value. Alternatively, you can leave Value unset, in which case
-// DeleteNFTElements will first "list" the map to find its current contents, and then only
-// try to delete the elements that are actually present.
-func DeleteNFTElements(elements []*knftables.Element) error {
+// correct value. Alternatively, you can leave Value unset, in which case DeleteObjects
+// will first "list" the map to find its current contents, and then only try to delete the
+// elements that are actually present.
+func DeleteObjects(objects []knftables.Object) error {
 	nft, err := GetNFTablesHelper()
 	if err != nil {
 		return err
@@ -44,39 +45,48 @@ func DeleteNFTElements(elements []*knftables.Element) error {
 
 	// If there are any partial Map Elements, list their maps' existing contents
 	existingMaps := make(map[string][]*knftables.Element)
-	for _, elem := range elements {
-		if elem.Map != "" && len(elem.Value) == 0 && existingMaps[elem.Map] == nil {
-			existingElements, err := nft.ListElements(context.TODO(), "map", elem.Map)
-			if err != nil {
-				return err
+	for _, obj := range objects {
+		switch typed := obj.(type) {
+		case *knftables.Element:
+			if typed.Map != "" && len(typed.Value) == 0 && existingMaps[typed.Map] == nil {
+				existingElements, err := nft.ListElements(context.TODO(), "map", typed.Map)
+				if err != nil {
+					return err
+				}
+				existingMaps[typed.Map] = existingElements
 			}
-			existingMaps[elem.Map] = existingElements
+		default:
+			return fmt.Errorf("unsupported object type %T passed to DeleteObjects", obj)
 		}
 	}
 
 	// Now build the actual transaction
 	tx := nft.NewTransaction()
-	for _, elem := range elements {
-		if elem.Map != "" && len(elem.Value) == 0 {
-			// We can't tx.Add() a Map Element with no Value, so try
-			// to find its existing value in the List output from
-			// above. If the element doesn't appear in that output
-			// then we just skip trying to delete it. Otherwise, we do
-			// the Add+Delete below just like in the normal case; the
-			// Add *should* be a no-op, but doing it anyway makes this
-			// work right even if another thread Deletes the element
-			// before we get to it (as long as they don't add it back
-			// with a different value).
-			elem = findElement(existingMaps[elem.Map], elem.Key)
-			if elem == nil {
-				continue
+	for _, obj := range objects {
+		switch typed := obj.(type) {
+		case *knftables.Element:
+			if typed.Map != "" && len(typed.Value) == 0 {
+				// We can't tx.Add() a Map Element with no Value, so try
+				// to find its existing value in the List output from
+				// above. If the element doesn't appear in that output
+				// then we just skip trying to delete it. Otherwise, we do
+				// the Add+Delete below just like in the normal case; the
+				// Add *should* be a no-op, but doing it anyway makes this
+				// work right even if another thread Deletes the element
+				// before we get to it (as long as they don't add it back
+				// with a different value).
+				typed = findElement(existingMaps[typed.Map], typed.Key)
+				if typed == nil {
+					continue
+				}
 			}
-		}
 
-		// Do Add+Delete, which ensures the object is deleted whether or
-		// not it previously existed.
-		tx.Add(elem)
-		tx.Delete(elem)
+			// Do Add+Delete, which ensures the object is deleted whether or
+			// not it previously existed.
+			tx.Add(typed)
+			tx.Delete(typed)
+		default:
+		}
 	}
 	return nft.Run(context.TODO(), tx)
 }

--- a/go-controller/pkg/node/nftables/util_test.go
+++ b/go-controller/pkg/node/nftables/util_test.go
@@ -100,6 +100,30 @@ func TestAddObjects(t *testing.T) {
 				add element inet ovn-kubernetes testmap { 10.0.0.1 : 9.9.9.9 }
 			`,
 		},
+		{
+			name: "add rule",
+			initial: `
+				add chain inet ovn-kubernetes testchain
+				add rule inet ovn-kubernetes testchain ip saddr 1.2.3.4 drop
+			`,
+			objs: []knftables.Object{
+				&knftables.Rule{
+					Chain: "testchain",
+					Rule:  "ip saddr 5.6.7.8 drop",
+				},
+				&knftables.Rule{
+					Chain: "testchain",
+					Rule:  "ip saddr 1.2.3.4 drop",
+				},
+			},
+			final: `
+				add table inet ovn-kubernetes
+				add chain inet ovn-kubernetes testchain
+				add rule inet ovn-kubernetes testchain ip saddr 1.2.3.4 drop
+				add rule inet ovn-kubernetes testchain ip saddr 5.6.7.8 drop
+				add rule inet ovn-kubernetes testchain ip saddr 1.2.3.4 drop
+			`,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			fake := SetFakeNFTablesHelper()
@@ -235,6 +259,103 @@ func TestDeleteObjects(t *testing.T) {
 				add element inet ovn-kubernetes testmap { 10.0.0.4 : 6.6.6.6 }
 			`,
 		},
+		{
+			name: "delete with duplicate element",
+			initial: `
+				add set inet ovn-kubernetes testset { type ipv4_addr ; }
+				add element inet ovn-kubernetes testset { 1.2.3.4 }
+				add element inet ovn-kubernetes testset { 5.6.7.8 }
+			`,
+			objs: []knftables.Object{
+				&knftables.Element{
+					Set: "testset",
+					Key: []string{"1.2.3.4"},
+				},
+				&knftables.Element{
+					Set: "testset",
+					Key: []string{"1.2.3.4"},
+				},
+			},
+			final: `
+				add table inet ovn-kubernetes
+				add set inet ovn-kubernetes testset { type ipv4_addr ; }
+				add element inet ovn-kubernetes testset { 5.6.7.8 }
+			`,
+		},
+		{
+			name: "delete rules",
+			initial: `
+				add chain inet ovn-kubernetes testchain
+				add rule inet ovn-kubernetes testchain ip saddr 1.2.3.4 drop comment "one"
+				add rule inet ovn-kubernetes testchain bad-rule-with-no-comment
+				add rule inet ovn-kubernetes testchain ip saddr 5.6.7.8 drop comment "two"
+				add rule inet ovn-kubernetes testchain ip saddr 9.1.2.3 drop comment "two"
+				add rule inet ovn-kubernetes testchain ip saddr 4.5.6.7 drop comment "three"
+			`,
+			objs: []knftables.Object{
+				&knftables.Rule{
+					Chain:   "testchain",
+					Rule:    "ip saddr 5.6.7.8 drop",
+					Comment: knftables.PtrTo("two"),
+				},
+				&knftables.Rule{
+					Chain:   "testchain",
+					Rule:    "ip saddr 1.2.3.4 drop",
+					Comment: knftables.PtrTo("no match"),
+				},
+			},
+			final: `
+				add table inet ovn-kubernetes
+				add chain inet ovn-kubernetes testchain
+				add rule inet ovn-kubernetes testchain ip saddr 1.2.3.4 drop comment "one"
+				add rule inet ovn-kubernetes testchain bad-rule-with-no-comment
+				add rule inet ovn-kubernetes testchain ip saddr 4.5.6.7 drop comment "three"
+			`,
+		},
+		{
+			name: "delete with duplicate rule",
+			initial: `
+				add chain inet ovn-kubernetes testchain
+				add rule inet ovn-kubernetes testchain ip saddr 1.2.3.4 drop comment "one"
+				add rule inet ovn-kubernetes testchain ip saddr 5.6.7.8 drop comment "two"
+			`,
+			objs: []knftables.Object{
+				&knftables.Rule{
+					Chain:   "testchain",
+					Rule:    "ip saddr 5.6.7.8 drop",
+					Comment: knftables.PtrTo("two"),
+				},
+				&knftables.Rule{
+					Chain:   "testchain",
+					Rule:    "ip saddr 5.6.7.8 drop",
+					Comment: knftables.PtrTo("two"),
+				},
+			},
+			final: `
+				add table inet ovn-kubernetes
+				add chain inet ovn-kubernetes testchain
+				add rule inet ovn-kubernetes testchain ip saddr 1.2.3.4 drop comment "one"
+			`,
+		},
+		{
+			name: "delete with rule comment only",
+			initial: `
+				add chain inet ovn-kubernetes testchain
+				add rule inet ovn-kubernetes testchain ip saddr 1.2.3.4 drop comment "one"
+				add rule inet ovn-kubernetes testchain ip saddr 5.6.7.8 drop comment "two"
+			`,
+			objs: []knftables.Object{
+				&knftables.Rule{
+					Chain:   "testchain",
+					Comment: knftables.PtrTo("two"),
+				},
+			},
+			final: `
+				add table inet ovn-kubernetes
+				add chain inet ovn-kubernetes testchain
+				add rule inet ovn-kubernetes testchain ip saddr 1.2.3.4 drop comment "one"
+			`,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			fake := SetFakeNFTablesHelper()
@@ -326,6 +447,40 @@ func TestSyncObjects(t *testing.T) {
 			`,
 		},
 		{
+			name: "sync rules",
+			initial: `
+				add chain inet ovn-kubernetes testchain
+				add rule inet ovn-kubernetes testchain ip saddr 1.2.3.4 drop comment "one"
+				add rule inet ovn-kubernetes testchain bad-rule-with-no-comment
+				add rule inet ovn-kubernetes testchain ip saddr 5.6.7.8 drop comment "two"
+				add rule inet ovn-kubernetes testchain ip saddr 9.1.2.3 drop comment "two"
+				add rule inet ovn-kubernetes testchain ip saddr 4.5.6.7 drop comment "three"
+			`,
+			containers: []knftables.Object{
+				&knftables.Chain{
+					Name: "testchain",
+				},
+			},
+			contents: []knftables.Object{
+				&knftables.Rule{
+					Chain:   "testchain",
+					Rule:    "ip saddr 1.2.3.4 drop",
+					Comment: knftables.PtrTo("one"),
+				},
+				&knftables.Rule{
+					Chain:   "testchain",
+					Rule:    "ip saddr 9.1.2.3 drop",
+					Comment: knftables.PtrTo("two"),
+				},
+			},
+			final: `
+				add table inet ovn-kubernetes
+				add chain inet ovn-kubernetes testchain
+				add rule inet ovn-kubernetes testchain ip saddr 1.2.3.4 drop comment "one"
+				add rule inet ovn-kubernetes testchain ip saddr 9.1.2.3 drop comment "two"
+			`,
+		},
+		{
 			name: "bad container type",
 			containers: []knftables.Object{
 				&knftables.Table{},
@@ -350,6 +505,21 @@ func TestSyncObjects(t *testing.T) {
 				&knftables.Element{
 					Set: "wrong-set",
 					Key: []string{"1.2.3.4"},
+				},
+			},
+			err: true,
+		},
+		{
+			name: "rule not in containers",
+			containers: []knftables.Object{
+				&knftables.Chain{
+					Name: "chain",
+				},
+			},
+			contents: []knftables.Object{
+				&knftables.Rule{
+					Chain: "wrong-chain",
+					Rule:  "drop",
 				},
 			},
 			err: true,

--- a/go-controller/pkg/node/nftables/util_test.go
+++ b/go-controller/pkg/node/nftables/util_test.go
@@ -12,17 +12,17 @@ import (
 	"sigs.k8s.io/knftables"
 )
 
-func TestUpdateNFTElements(t *testing.T) {
+func TestAddObjects(t *testing.T) {
 	for _, tc := range []struct {
 		name    string
 		initial string
-		elems   []*knftables.Element
+		objs    []knftables.Object
 		final   string
 	}{
 		{
 			name:    "empty transaction",
 			initial: "",
-			elems:   []*knftables.Element{},
+			objs:    []knftables.Object{},
 			final:   "add table inet ovn-kubernetes",
 		},
 		{
@@ -30,12 +30,12 @@ func TestUpdateNFTElements(t *testing.T) {
 			initial: `
 				add set inet ovn-kubernetes testset { type ipv4_addr ; }
 			`,
-			elems: []*knftables.Element{
-				{
+			objs: []knftables.Object{
+				&knftables.Element{
 					Set: "testset",
 					Key: []string{"1.2.3.4"},
 				},
-				{
+				&knftables.Element{
 					Set: "testset",
 					Key: []string{"5.6.7.8"},
 				},
@@ -53,12 +53,12 @@ func TestUpdateNFTElements(t *testing.T) {
 				add set inet ovn-kubernetes testset { type ipv4_addr ; }
 				add element inet ovn-kubernetes testset { 1.2.3.4 }
 			`,
-			elems: []*knftables.Element{
-				{
+			objs: []knftables.Object{
+				&knftables.Element{
 					Set: "testset",
 					Key: []string{"1.2.3.4"},
 				},
-				{
+				&knftables.Element{
 					Set: "testset",
 					Key: []string{"5.6.7.8"},
 				},
@@ -76,17 +76,17 @@ func TestUpdateNFTElements(t *testing.T) {
 				add set inet ovn-kubernetes testset { type ipv4_addr ; }
 				add map inet ovn-kubernetes testmap { type ipv4_addr : ipv4_addr ; }
 			`,
-			elems: []*knftables.Element{
-				{
+			objs: []knftables.Object{
+				&knftables.Element{
 					Set: "testset",
 					Key: []string{"1.2.3.4"},
 				},
-				{
+				&knftables.Element{
 					Map:   "testmap",
 					Key:   []string{"10.0.0.1"},
 					Value: []string{"9.9.9.9"},
 				},
-				{
+				&knftables.Element{
 					Set: "testset",
 					Key: []string{"5.6.7.8"},
 				},
@@ -107,9 +107,9 @@ func TestUpdateNFTElements(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error parsing initial state: %v", err)
 			}
-			err = UpdateNFTElements(tc.elems)
+			err = AddObjects(tc.objs)
 			if err != nil {
-				t.Fatalf("unexpected error updating elements: %v", err)
+				t.Fatalf("unexpected error adding objects: %v", err)
 			}
 			err = MatchNFTRules(tc.final, fake.Dump())
 			if err != nil {
@@ -119,17 +119,17 @@ func TestUpdateNFTElements(t *testing.T) {
 	}
 }
 
-func TestDeleteNFTElements(t *testing.T) {
+func TestDeleteObjects(t *testing.T) {
 	for _, tc := range []struct {
 		name    string
 		initial string
-		elems   []*knftables.Element
+		objs    []knftables.Object
 		final   string
 	}{
 		{
 			name:    "empty transaction",
 			initial: "",
-			elems:   []*knftables.Element{},
+			objs:    []knftables.Object{},
 			final:   "add table inet ovn-kubernetes",
 		},
 		{
@@ -139,12 +139,12 @@ func TestDeleteNFTElements(t *testing.T) {
 				add element inet ovn-kubernetes testset { 1.2.3.4 }
 				add element inet ovn-kubernetes testset { 5.6.7.8 }
 			`,
-			elems: []*knftables.Element{
-				{
+			objs: []knftables.Object{
+				&knftables.Element{
 					Set: "testset",
 					Key: []string{"1.2.3.4"},
 				},
-				{
+				&knftables.Element{
 					Set: "testset",
 					Key: []string{"5.6.7.8"},
 				},
@@ -160,12 +160,12 @@ func TestDeleteNFTElements(t *testing.T) {
 				add set inet ovn-kubernetes testset { type ipv4_addr ; }
 				add element inet ovn-kubernetes testset { 1.2.3.4 }
 			`,
-			elems: []*knftables.Element{
-				{
+			objs: []knftables.Object{
+				&knftables.Element{
 					Set: "testset",
 					Key: []string{"1.2.3.4"},
 				},
-				{
+				&knftables.Element{
 					Set: "testset",
 					Key: []string{"5.6.7.8"},
 				},
@@ -184,17 +184,17 @@ func TestDeleteNFTElements(t *testing.T) {
 				add element inet ovn-kubernetes testset { 5.6.7.8 }
 				add element inet ovn-kubernetes testmap { 10.0.0.1 : 9.9.9.9 }
 			`,
-			elems: []*knftables.Element{
-				{
+			objs: []knftables.Object{
+				&knftables.Element{
 					Set: "testset",
 					Key: []string{"1.2.3.4"},
 				},
-				{
+				&knftables.Element{
 					Map:   "testmap",
 					Key:   []string{"10.0.0.1"},
 					Value: []string{"9.9.9.9"},
 				},
-				{
+				&knftables.Element{
 					Set: "testset",
 					Key: []string{"5.6.7.8"},
 				},
@@ -214,16 +214,16 @@ func TestDeleteNFTElements(t *testing.T) {
 				add element inet ovn-kubernetes testmap { 10.0.0.3 : 7.7.7.7 }
 				add element inet ovn-kubernetes testmap { 10.0.0.4 : 6.6.6.6 }
 			`,
-			elems: []*knftables.Element{
-				{
+			objs: []knftables.Object{
+				&knftables.Element{
 					Map: "testmap",
 					Key: []string{"10.0.0.1"},
 				},
-				{
+				&knftables.Element{
 					Map: "testmap",
 					Key: []string{"10.0.0.3"},
 				},
-				{
+				&knftables.Element{
 					Map: "testmap",
 					Key: []string{"10.0.0.5"},
 				},
@@ -242,7 +242,7 @@ func TestDeleteNFTElements(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error parsing initial state: %v", err)
 			}
-			err = DeleteNFTElements(tc.elems)
+			err = DeleteObjects(tc.objs)
 			if err != nil {
 				t.Fatalf("unexpected error deleting objects: %v", err)
 			}

--- a/go-controller/pkg/node/nftables/util_test.go
+++ b/go-controller/pkg/node/nftables/util_test.go
@@ -253,3 +253,128 @@ func TestDeleteObjects(t *testing.T) {
 		})
 	}
 }
+
+func TestSyncObjects(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		initial    string
+		containers []knftables.Object
+		contents   []knftables.Object
+		final      string
+		err        bool
+	}{
+		{
+			name:       "empty transaction",
+			initial:    "",
+			containers: []knftables.Object{},
+			contents:   []knftables.Object{},
+			final:      "add table inet ovn-kubernetes",
+		},
+		{
+			name: "start empty / end empty",
+			initial: `
+				add set inet ovn-kubernetes starts-empty { type ipv4_addr ; }
+				add set inet ovn-kubernetes becomes-empty { type ipv4_addr ; }
+				add element inet ovn-kubernetes becomes-empty { 1.1.1.1 }
+				add element inet ovn-kubernetes becomes-empty { 2.2.2.2 }
+				add element inet ovn-kubernetes becomes-empty { 3.3.3.3 }
+			`,
+			containers: []knftables.Object{
+				&knftables.Set{
+					Name: "starts-empty",
+				},
+				&knftables.Set{
+					Name: "becomes-empty",
+				},
+			},
+			contents: []knftables.Object{
+				&knftables.Element{
+					Set: "starts-empty",
+					Key: []string{"1.2.3.4"},
+				},
+				&knftables.Element{
+					Set: "starts-empty",
+					Key: []string{"5.6.7.8"},
+				},
+			},
+			final: `
+				add table inet ovn-kubernetes
+				add set inet ovn-kubernetes becomes-empty { type ipv4_addr ; }
+				add set inet ovn-kubernetes starts-empty { type ipv4_addr ; }
+				add element inet ovn-kubernetes starts-empty { 1.2.3.4 }
+				add element inet ovn-kubernetes starts-empty { 5.6.7.8 }
+			`,
+		},
+		{
+			name: "no changed sets",
+			initial: `
+				add set inet ovn-kubernetes starts-empty { type ipv4_addr ; }
+				add set inet ovn-kubernetes becomes-empty { type ipv4_addr ; }
+				add element inet ovn-kubernetes becomes-empty { 1.1.1.1 }
+				add element inet ovn-kubernetes becomes-empty { 2.2.2.2 }
+				add element inet ovn-kubernetes becomes-empty { 3.3.3.3 }
+			`,
+			containers: []knftables.Object{},
+			contents:   []knftables.Object{},
+			final: `
+				add table inet ovn-kubernetes
+				add set inet ovn-kubernetes becomes-empty { type ipv4_addr ; }
+				add set inet ovn-kubernetes starts-empty { type ipv4_addr ; }
+				add element inet ovn-kubernetes becomes-empty { 1.1.1.1 }
+				add element inet ovn-kubernetes becomes-empty { 2.2.2.2 }
+				add element inet ovn-kubernetes becomes-empty { 3.3.3.3 }
+			`,
+		},
+		{
+			name: "bad container type",
+			containers: []knftables.Object{
+				&knftables.Table{},
+			},
+			err: true,
+		},
+		{
+			name: "bad contents type",
+			contents: []knftables.Object{
+				&knftables.Table{},
+			},
+			err: true,
+		},
+		{
+			name: "element not in containers",
+			containers: []knftables.Object{
+				&knftables.Set{
+					Name: "set",
+				},
+			},
+			contents: []knftables.Object{
+				&knftables.Element{
+					Set: "wrong-set",
+					Key: []string{"1.2.3.4"},
+				},
+			},
+			err: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fake := SetFakeNFTablesHelper()
+			err := fake.ParseDump(tc.initial)
+			if err != nil {
+				t.Fatalf("unexpected error parsing initial state: %v", err)
+			}
+			err = SyncObjects(tc.containers, tc.contents)
+			if tc.err {
+				if err == nil {
+					t.Fatalf("expected an error but got none")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error syncing objects: %v", err)
+			}
+			err = MatchNFTRules(tc.final, fake.Dump())
+			if err != nil {
+				t.Fatalf("unexpected final result: %v", err)
+			}
+		})
+	}
+}

--- a/go-controller/pkg/node/nftables/util_test.go
+++ b/go-controller/pkg/node/nftables/util_test.go
@@ -12,17 +12,17 @@ import (
 	"sigs.k8s.io/knftables"
 )
 
-func TestUpdateNFTElements(t *testing.T) {
+func TestAddObjects(t *testing.T) {
 	for _, tc := range []struct {
 		name    string
 		initial string
-		elems   []*knftables.Element
+		objs    []knftables.Object
 		final   string
 	}{
 		{
 			name:    "empty transaction",
 			initial: "",
-			elems:   []*knftables.Element{},
+			objs:    []knftables.Object{},
 			final:   "add table inet ovn-kubernetes",
 		},
 		{
@@ -30,12 +30,12 @@ func TestUpdateNFTElements(t *testing.T) {
 			initial: `
 				add set inet ovn-kubernetes testset { type ipv4_addr ; }
 			`,
-			elems: []*knftables.Element{
-				{
+			objs: []knftables.Object{
+				&knftables.Element{
 					Set: "testset",
 					Key: []string{"1.2.3.4"},
 				},
-				{
+				&knftables.Element{
 					Set: "testset",
 					Key: []string{"5.6.7.8"},
 				},
@@ -53,12 +53,12 @@ func TestUpdateNFTElements(t *testing.T) {
 				add set inet ovn-kubernetes testset { type ipv4_addr ; }
 				add element inet ovn-kubernetes testset { 1.2.3.4 }
 			`,
-			elems: []*knftables.Element{
-				{
+			objs: []knftables.Object{
+				&knftables.Element{
 					Set: "testset",
 					Key: []string{"1.2.3.4"},
 				},
-				{
+				&knftables.Element{
 					Set: "testset",
 					Key: []string{"5.6.7.8"},
 				},
@@ -76,17 +76,17 @@ func TestUpdateNFTElements(t *testing.T) {
 				add set inet ovn-kubernetes testset { type ipv4_addr ; }
 				add map inet ovn-kubernetes testmap { type ipv4_addr : ipv4_addr ; }
 			`,
-			elems: []*knftables.Element{
-				{
+			objs: []knftables.Object{
+				&knftables.Element{
 					Set: "testset",
 					Key: []string{"1.2.3.4"},
 				},
-				{
+				&knftables.Element{
 					Map:   "testmap",
 					Key:   []string{"10.0.0.1"},
 					Value: []string{"9.9.9.9"},
 				},
-				{
+				&knftables.Element{
 					Set: "testset",
 					Key: []string{"5.6.7.8"},
 				},
@@ -100,6 +100,30 @@ func TestUpdateNFTElements(t *testing.T) {
 				add element inet ovn-kubernetes testmap { 10.0.0.1 : 9.9.9.9 }
 			`,
 		},
+		{
+			name: "add rule",
+			initial: `
+				add chain inet ovn-kubernetes testchain
+				add rule inet ovn-kubernetes testchain ip saddr 1.2.3.4 drop
+			`,
+			objs: []knftables.Object{
+				&knftables.Rule{
+					Chain: "testchain",
+					Rule:  "ip saddr 5.6.7.8 drop",
+				},
+				&knftables.Rule{
+					Chain: "testchain",
+					Rule:  "ip saddr 1.2.3.4 drop",
+				},
+			},
+			final: `
+				add table inet ovn-kubernetes
+				add chain inet ovn-kubernetes testchain
+				add rule inet ovn-kubernetes testchain ip saddr 1.2.3.4 drop
+				add rule inet ovn-kubernetes testchain ip saddr 5.6.7.8 drop
+				add rule inet ovn-kubernetes testchain ip saddr 1.2.3.4 drop
+			`,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			fake := SetFakeNFTablesHelper()
@@ -107,9 +131,9 @@ func TestUpdateNFTElements(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error parsing initial state: %v", err)
 			}
-			err = UpdateNFTElements(tc.elems)
+			err = AddObjects(tc.objs)
 			if err != nil {
-				t.Fatalf("unexpected error updating elements: %v", err)
+				t.Fatalf("unexpected error adding objects: %v", err)
 			}
 			err = MatchNFTRules(tc.final, fake.Dump())
 			if err != nil {
@@ -119,17 +143,17 @@ func TestUpdateNFTElements(t *testing.T) {
 	}
 }
 
-func TestDeleteNFTElements(t *testing.T) {
+func TestDeleteObjects(t *testing.T) {
 	for _, tc := range []struct {
 		name    string
 		initial string
-		elems   []*knftables.Element
+		objs    []knftables.Object
 		final   string
 	}{
 		{
 			name:    "empty transaction",
 			initial: "",
-			elems:   []*knftables.Element{},
+			objs:    []knftables.Object{},
 			final:   "add table inet ovn-kubernetes",
 		},
 		{
@@ -139,12 +163,12 @@ func TestDeleteNFTElements(t *testing.T) {
 				add element inet ovn-kubernetes testset { 1.2.3.4 }
 				add element inet ovn-kubernetes testset { 5.6.7.8 }
 			`,
-			elems: []*knftables.Element{
-				{
+			objs: []knftables.Object{
+				&knftables.Element{
 					Set: "testset",
 					Key: []string{"1.2.3.4"},
 				},
-				{
+				&knftables.Element{
 					Set: "testset",
 					Key: []string{"5.6.7.8"},
 				},
@@ -160,12 +184,12 @@ func TestDeleteNFTElements(t *testing.T) {
 				add set inet ovn-kubernetes testset { type ipv4_addr ; }
 				add element inet ovn-kubernetes testset { 1.2.3.4 }
 			`,
-			elems: []*knftables.Element{
-				{
+			objs: []knftables.Object{
+				&knftables.Element{
 					Set: "testset",
 					Key: []string{"1.2.3.4"},
 				},
-				{
+				&knftables.Element{
 					Set: "testset",
 					Key: []string{"5.6.7.8"},
 				},
@@ -184,17 +208,17 @@ func TestDeleteNFTElements(t *testing.T) {
 				add element inet ovn-kubernetes testset { 5.6.7.8 }
 				add element inet ovn-kubernetes testmap { 10.0.0.1 : 9.9.9.9 }
 			`,
-			elems: []*knftables.Element{
-				{
+			objs: []knftables.Object{
+				&knftables.Element{
 					Set: "testset",
 					Key: []string{"1.2.3.4"},
 				},
-				{
+				&knftables.Element{
 					Map:   "testmap",
 					Key:   []string{"10.0.0.1"},
 					Value: []string{"9.9.9.9"},
 				},
-				{
+				&knftables.Element{
 					Set: "testset",
 					Key: []string{"5.6.7.8"},
 				},
@@ -214,16 +238,16 @@ func TestDeleteNFTElements(t *testing.T) {
 				add element inet ovn-kubernetes testmap { 10.0.0.3 : 7.7.7.7 }
 				add element inet ovn-kubernetes testmap { 10.0.0.4 : 6.6.6.6 }
 			`,
-			elems: []*knftables.Element{
-				{
+			objs: []knftables.Object{
+				&knftables.Element{
 					Map: "testmap",
 					Key: []string{"10.0.0.1"},
 				},
-				{
+				&knftables.Element{
 					Map: "testmap",
 					Key: []string{"10.0.0.3"},
 				},
-				{
+				&knftables.Element{
 					Map: "testmap",
 					Key: []string{"10.0.0.5"},
 				},
@@ -235,6 +259,103 @@ func TestDeleteNFTElements(t *testing.T) {
 				add element inet ovn-kubernetes testmap { 10.0.0.4 : 6.6.6.6 }
 			`,
 		},
+		{
+			name: "delete with duplicate element",
+			initial: `
+				add set inet ovn-kubernetes testset { type ipv4_addr ; }
+				add element inet ovn-kubernetes testset { 1.2.3.4 }
+				add element inet ovn-kubernetes testset { 5.6.7.8 }
+			`,
+			objs: []knftables.Object{
+				&knftables.Element{
+					Set: "testset",
+					Key: []string{"1.2.3.4"},
+				},
+				&knftables.Element{
+					Set: "testset",
+					Key: []string{"1.2.3.4"},
+				},
+			},
+			final: `
+				add table inet ovn-kubernetes
+				add set inet ovn-kubernetes testset { type ipv4_addr ; }
+				add element inet ovn-kubernetes testset { 5.6.7.8 }
+			`,
+		},
+		{
+			name: "delete rules",
+			initial: `
+				add chain inet ovn-kubernetes testchain
+				add rule inet ovn-kubernetes testchain ip saddr 1.2.3.4 drop comment "one"
+				add rule inet ovn-kubernetes testchain bad-rule-with-no-comment
+				add rule inet ovn-kubernetes testchain ip saddr 5.6.7.8 drop comment "two"
+				add rule inet ovn-kubernetes testchain ip saddr 9.1.2.3 drop comment "two"
+				add rule inet ovn-kubernetes testchain ip saddr 4.5.6.7 drop comment "three"
+			`,
+			objs: []knftables.Object{
+				&knftables.Rule{
+					Chain:   "testchain",
+					Rule:    "ip saddr 5.6.7.8 drop",
+					Comment: knftables.PtrTo("two"),
+				},
+				&knftables.Rule{
+					Chain:   "testchain",
+					Rule:    "ip saddr 1.2.3.4 drop",
+					Comment: knftables.PtrTo("no match"),
+				},
+			},
+			final: `
+				add table inet ovn-kubernetes
+				add chain inet ovn-kubernetes testchain
+				add rule inet ovn-kubernetes testchain ip saddr 1.2.3.4 drop comment "one"
+				add rule inet ovn-kubernetes testchain bad-rule-with-no-comment
+				add rule inet ovn-kubernetes testchain ip saddr 4.5.6.7 drop comment "three"
+			`,
+		},
+		{
+			name: "delete with duplicate rule",
+			initial: `
+				add chain inet ovn-kubernetes testchain
+				add rule inet ovn-kubernetes testchain ip saddr 1.2.3.4 drop comment "one"
+				add rule inet ovn-kubernetes testchain ip saddr 5.6.7.8 drop comment "two"
+			`,
+			objs: []knftables.Object{
+				&knftables.Rule{
+					Chain:   "testchain",
+					Rule:    "ip saddr 5.6.7.8 drop",
+					Comment: knftables.PtrTo("two"),
+				},
+				&knftables.Rule{
+					Chain:   "testchain",
+					Rule:    "ip saddr 5.6.7.8 drop",
+					Comment: knftables.PtrTo("two"),
+				},
+			},
+			final: `
+				add table inet ovn-kubernetes
+				add chain inet ovn-kubernetes testchain
+				add rule inet ovn-kubernetes testchain ip saddr 1.2.3.4 drop comment "one"
+			`,
+		},
+		{
+			name: "delete with rule comment only",
+			initial: `
+				add chain inet ovn-kubernetes testchain
+				add rule inet ovn-kubernetes testchain ip saddr 1.2.3.4 drop comment "one"
+				add rule inet ovn-kubernetes testchain ip saddr 5.6.7.8 drop comment "two"
+			`,
+			objs: []knftables.Object{
+				&knftables.Rule{
+					Chain:   "testchain",
+					Comment: knftables.PtrTo("two"),
+				},
+			},
+			final: `
+				add table inet ovn-kubernetes
+				add chain inet ovn-kubernetes testchain
+				add rule inet ovn-kubernetes testchain ip saddr 1.2.3.4 drop comment "one"
+			`,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			fake := SetFakeNFTablesHelper()
@@ -242,9 +363,183 @@ func TestDeleteNFTElements(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error parsing initial state: %v", err)
 			}
-			err = DeleteNFTElements(tc.elems)
+			err = DeleteObjects(tc.objs)
 			if err != nil {
 				t.Fatalf("unexpected error deleting objects: %v", err)
+			}
+			err = MatchNFTRules(tc.final, fake.Dump())
+			if err != nil {
+				t.Fatalf("unexpected final result: %v", err)
+			}
+		})
+	}
+}
+
+func TestSyncObjects(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		initial    string
+		containers []knftables.Object
+		contents   []knftables.Object
+		final      string
+		err        bool
+	}{
+		{
+			name:       "empty transaction",
+			initial:    "",
+			containers: []knftables.Object{},
+			contents:   []knftables.Object{},
+			final:      "add table inet ovn-kubernetes",
+		},
+		{
+			name: "start empty / end empty",
+			initial: `
+				add set inet ovn-kubernetes starts-empty { type ipv4_addr ; }
+				add set inet ovn-kubernetes becomes-empty { type ipv4_addr ; }
+				add element inet ovn-kubernetes becomes-empty { 1.1.1.1 }
+				add element inet ovn-kubernetes becomes-empty { 2.2.2.2 }
+				add element inet ovn-kubernetes becomes-empty { 3.3.3.3 }
+			`,
+			containers: []knftables.Object{
+				&knftables.Set{
+					Name: "starts-empty",
+				},
+				&knftables.Set{
+					Name: "becomes-empty",
+				},
+			},
+			contents: []knftables.Object{
+				&knftables.Element{
+					Set: "starts-empty",
+					Key: []string{"1.2.3.4"},
+				},
+				&knftables.Element{
+					Set: "starts-empty",
+					Key: []string{"5.6.7.8"},
+				},
+			},
+			final: `
+				add table inet ovn-kubernetes
+				add set inet ovn-kubernetes becomes-empty { type ipv4_addr ; }
+				add set inet ovn-kubernetes starts-empty { type ipv4_addr ; }
+				add element inet ovn-kubernetes starts-empty { 1.2.3.4 }
+				add element inet ovn-kubernetes starts-empty { 5.6.7.8 }
+			`,
+		},
+		{
+			name: "no changed sets",
+			initial: `
+				add set inet ovn-kubernetes starts-empty { type ipv4_addr ; }
+				add set inet ovn-kubernetes becomes-empty { type ipv4_addr ; }
+				add element inet ovn-kubernetes becomes-empty { 1.1.1.1 }
+				add element inet ovn-kubernetes becomes-empty { 2.2.2.2 }
+				add element inet ovn-kubernetes becomes-empty { 3.3.3.3 }
+			`,
+			containers: []knftables.Object{},
+			contents:   []knftables.Object{},
+			final: `
+				add table inet ovn-kubernetes
+				add set inet ovn-kubernetes becomes-empty { type ipv4_addr ; }
+				add set inet ovn-kubernetes starts-empty { type ipv4_addr ; }
+				add element inet ovn-kubernetes becomes-empty { 1.1.1.1 }
+				add element inet ovn-kubernetes becomes-empty { 2.2.2.2 }
+				add element inet ovn-kubernetes becomes-empty { 3.3.3.3 }
+			`,
+		},
+		{
+			name: "sync rules",
+			initial: `
+				add chain inet ovn-kubernetes testchain
+				add rule inet ovn-kubernetes testchain ip saddr 1.2.3.4 drop comment "one"
+				add rule inet ovn-kubernetes testchain bad-rule-with-no-comment
+				add rule inet ovn-kubernetes testchain ip saddr 5.6.7.8 drop comment "two"
+				add rule inet ovn-kubernetes testchain ip saddr 9.1.2.3 drop comment "two"
+				add rule inet ovn-kubernetes testchain ip saddr 4.5.6.7 drop comment "three"
+			`,
+			containers: []knftables.Object{
+				&knftables.Chain{
+					Name: "testchain",
+				},
+			},
+			contents: []knftables.Object{
+				&knftables.Rule{
+					Chain:   "testchain",
+					Rule:    "ip saddr 1.2.3.4 drop",
+					Comment: knftables.PtrTo("one"),
+				},
+				&knftables.Rule{
+					Chain:   "testchain",
+					Rule:    "ip saddr 9.1.2.3 drop",
+					Comment: knftables.PtrTo("two"),
+				},
+			},
+			final: `
+				add table inet ovn-kubernetes
+				add chain inet ovn-kubernetes testchain
+				add rule inet ovn-kubernetes testchain ip saddr 1.2.3.4 drop comment "one"
+				add rule inet ovn-kubernetes testchain ip saddr 9.1.2.3 drop comment "two"
+			`,
+		},
+		{
+			name: "bad container type",
+			containers: []knftables.Object{
+				&knftables.Table{},
+			},
+			err: true,
+		},
+		{
+			name: "bad contents type",
+			contents: []knftables.Object{
+				&knftables.Table{},
+			},
+			err: true,
+		},
+		{
+			name: "element not in containers",
+			containers: []knftables.Object{
+				&knftables.Set{
+					Name: "set",
+				},
+			},
+			contents: []knftables.Object{
+				&knftables.Element{
+					Set: "wrong-set",
+					Key: []string{"1.2.3.4"},
+				},
+			},
+			err: true,
+		},
+		{
+			name: "rule not in containers",
+			containers: []knftables.Object{
+				&knftables.Chain{
+					Name: "chain",
+				},
+			},
+			contents: []knftables.Object{
+				&knftables.Rule{
+					Chain: "wrong-chain",
+					Rule:  "drop",
+				},
+			},
+			err: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fake := SetFakeNFTablesHelper()
+			err := fake.ParseDump(tc.initial)
+			if err != nil {
+				t.Fatalf("unexpected error parsing initial state: %v", err)
+			}
+			err = SyncObjects(tc.containers, tc.contents)
+			if tc.err {
+				if err == nil {
+					t.Fatalf("expected an error but got none")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error syncing objects: %v", err)
 			}
 			err = MatchNFTRules(tc.final, fake.Dump())
 			if err != nil {

--- a/go-controller/pkg/node/obj_retry_test_helper.go
+++ b/go-controller/pkg/node/obj_retry_test_helper.go
@@ -27,7 +27,7 @@ func (h *nodePortWatcherEventHandler) FilterOutResource(_ interface{}) bool {
 	return false
 }
 
-// used only in unit tests to narrow the scope to just the nodeport iptables changes and not all the other parts that
+// used only in unit tests to narrow the scope to just the nodeport nftables changes and not all the other parts that
 // go along with the gateway type (port claim, openflow, healthchecker)
 func (n *nodePortWatcher) newRetryFrameworkForTests(objectType reflect.Type, stopChan <-chan struct{}, wg *sync.WaitGroup) *retry.RetryFramework {
 	resourceHandler := &retry.ResourceHandler{

--- a/go-controller/pkg/node/user_defined_node_network_controller_test.go
+++ b/go-controller/pkg/node/user_defined_node_network_controller_test.go
@@ -541,8 +541,6 @@ var _ = Describe("UserDefinedNodeNetworkController: UserDefinedPrimaryNetwork Ga
 			Expect(v6MasqIPRule).To(BeTrue())
 
 			By("delete the network and ensure its associated VRF device is also deleted")
-			cnode := node.DeepCopy()
-			kubeMock.On("UpdateNodeStatus", cnode).Return(nil)
 			err = controller.Cleanup()
 			Expect(err).NotTo(HaveOccurred())
 			Eventually(func() error {

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -128,15 +128,9 @@ func (oc *DefaultNetworkController) nodeGatewayConfig(node *corev1.Node) (*Gatew
 
 	gwLRPIPs, err := udn.GetGWRouterIPs(node, oc.GetNetInfo())
 	if err != nil {
-		if util.IsAnnotationNotSetError(err) {
-			// FIXME(tssurya): This is present for backwards compatibility
-			// Remove me a few months from now
-			var err1 error
-			gwLRPIPs, err1 = util.ParseNodeGatewayRouterLRPAddrs(node)
-			if err1 != nil {
-				return nil, fmt.Errorf("failed to get join switch port IP address for node %s: %v/%v", node.Name, err, err1)
-			}
-		}
+		// The join address has to be derived from the node id alone so that
+		// the local and the remote view of it agree.
+		return nil, fmt.Errorf("failed to get join switch port IP address for node %s: %w", node.Name, err)
 	}
 
 	return &GatewayConfig{

--- a/go-controller/pkg/ovn/master_gateway_config_test.go
+++ b/go-controller/pkg/ovn/master_gateway_config_test.go
@@ -1,0 +1,101 @@
+// SPDX-FileCopyrightText: Copyright The OVN-Kubernetes Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package ovn
+
+import (
+	"fmt"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	"github.com/urfave/cli/v2"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
+)
+
+var _ = ginkgo.Describe("nodeGatewayConfig join address contract", func() {
+	const (
+		clusterCIDR = "10.1.0.0/16"
+	)
+
+	var app *cli.App
+
+	ginkgo.BeforeEach(func() {
+		gomega.Expect(config.PrepareTestConfig()).To(gomega.Succeed())
+		app = cli.NewApp()
+		app.Name = "test"
+		app.Flags = config.Flags
+	})
+
+	ginkgo.It("derives join addresses from node-id", func() {
+		app.Action = func(ctx *cli.Context) error {
+			_, err := config.InitConfig(ctx, nil, nil)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "worker-1",
+					Annotations: map[string]string{
+						"k8s.ovn.org/l3-gateway-config": `{"default":{"mode":"local","mac-address":"7e:57:f8:f0:3c:49", "ip-address":"169.255.33.2/24", "next-hop":"169.255.33.1"}}`,
+						"k8s.ovn.org/node-chassis-id":   "79fdcfc4-6fe6-4cd3-8242-c0f85a4668ec",
+						"k8s.ovn.org/node-subnets":      `{"default":["10.244.1.0/24"]}`,
+						util.OvnNodeID:                  "2",
+					},
+				},
+			}
+
+			oc := getFakeController("default-network-controller")
+			gwConfig, err := oc.nodeGatewayConfig(node)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(gwConfig.gwRouterJoinCIDRs).To(gomega.HaveLen(1))
+			gomega.Expect(gwConfig.gwRouterJoinCIDRs[0].IP.String()).To(gomega.Equal("100.64.0.2"))
+			return nil
+		}
+
+		err := app.Run([]string{
+			app.Name,
+			"-cluster-subnets=" + clusterCIDR,
+		})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+
+	ginkgo.It("fails when node-id is missing", func() {
+		app.Action = func(ctx *cli.Context) error {
+			_, err := config.InitConfig(ctx, nil, nil)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "worker-1",
+					Annotations: map[string]string{
+						"k8s.ovn.org/l3-gateway-config": `{"default":{"mode":"local","mac-address":"7e:57:f8:f0:3c:49", "ip-address":"169.255.33.2/24", "next-hop":"169.255.33.1"}}`,
+						"k8s.ovn.org/node-chassis-id":   "79fdcfc4-6fe6-4cd3-8242-c0f85a4668ec",
+						"k8s.ovn.org/node-subnets":      `{"default":["10.244.1.0/24"]}`,
+						// Retired annotation with a valid value: if the deprecated
+						// node-id fallback is ever restored, this test would stop
+						// failing and thus catch the regression.
+						"k8s.ovn.org/node-gateway-router-lrp-ifaddr": `{"ipv4":"100.64.0.99/16"}`,
+					},
+				},
+			}
+
+			oc := getFakeController("default-network-controller")
+			_, err = oc.nodeGatewayConfig(node)
+			gomega.Expect(err).To(gomega.MatchError(gomega.ContainSubstring(
+				fmt.Sprintf("failed to get join switch port IP address for node %s", node.Name))))
+			gomega.Expect(err).To(gomega.MatchError(gomega.ContainSubstring(
+				fmt.Sprintf("%s annotation not found", util.OvnNodeID))))
+			return nil
+		}
+
+		err := app.Run([]string{
+			app.Name,
+			"-cluster-subnets=" + clusterCIDR,
+		})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+})

--- a/go-controller/pkg/ovn/zone_interconnect/zone_ic_handler.go
+++ b/go-controller/pkg/ovn/zone_interconnect/zone_ic_handler.go
@@ -257,19 +257,7 @@ func (zic *ZoneInterconnectHandler) AddRemoteZoneNode(node *corev1.Node) error {
 	if !zic.IsUserDefinedNetwork() || (util.IsNetworkSegmentationSupportEnabled() && zic.IsPrimaryNetwork()) {
 		nodeGRPIPs, err = udn.GetGWRouterIPs(node, zic.GetNetInfo())
 		if err != nil {
-			if util.IsAnnotationNotSetError(err) {
-				// FIXME(tssurya): This is present for backwards compatibility
-				// Remove me a few months from now
-				var err1 error
-				nodeGRPIPs, err1 = util.ParseNodeGatewayRouterLRPAddrs(node)
-				if err1 != nil {
-					err1 = fmt.Errorf("failed to parse node %s Gateway router LRP Addrs annotation %w", node.Name, err1)
-					if util.IsAnnotationNotSetError(err1) {
-						return types.NewSuppressedError(err1)
-					}
-					return err1
-				}
-			}
+			return fmt.Errorf("failed to get the gateway router port IP addresses for node %s: %w", node.Name, err)
 		}
 	}
 
@@ -733,15 +721,14 @@ func (zic *ZoneInterconnectHandler) deleteLocalNodeStaticRoutes(node *corev1.Nod
 	// Clear the routes connecting to the GW Router for the default network
 	nodeGRPIPs, err := udn.GetGWRouterIPs(node, zic.GetNetInfo())
 	if err != nil {
-		if util.IsAnnotationNotSetError(err) {
-			// FIXME(tssurya): This is present for backwards compatibility
-			// Remove me a few months from now
-			var err1 error
-			nodeGRPIPs, err1 = util.ParseNodeGatewayRouterLRPAddrs(node)
-			if err1 != nil {
-				return fmt.Errorf("failed to parse node %s Gateway router LRP Addrs annotation %w", node.Name, err1)
-			}
+		// Without node-id we can't reconstruct the GR join IPs; delete by owner.
+		p := func(lrsr *nbdb.LogicalRouterStaticRoute) bool {
+			return lrsr.ExternalIDs["ic-node"] == node.Name
 		}
+		if opserr := libovsdbops.DeleteLogicalRouterStaticRoutesWithPredicate(zic.nbClient, zic.networkClusterRouterName, p); opserr != nil {
+			return fmt.Errorf("failed to delete gateway router static routes for node %s: %w", node.Name, opserr)
+		}
+		return fmt.Errorf("failed to get the gateway router port IP addresses for node %s: %w", node.Name, err)
 	}
 
 	nodenodeGRPIPStaticRoutes := zic.getStaticRoutes(nodeGRPIPs, nodeTransitSwitchPortIPs, true)

--- a/go-controller/pkg/ovn/zone_interconnect/zone_ic_handler_test.go
+++ b/go-controller/pkg/ovn/zone_interconnect/zone_ic_handler_test.go
@@ -903,6 +903,129 @@ var _ = ginkgo.Describe("Zone Interconnect Operations", func() {
 			})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		})
+
+		ginkgo.It("AddRemoteZoneNode rejects missing node-id even when the legacy join annotation is present", func() {
+			app.Action = func(ctx *cli.Context) error {
+				dbSetup := libovsdbtest.TestSetup{
+					NBData: initialNBDB,
+					SBData: initialSBDB,
+				}
+
+				_, err := config.InitConfig(ctx, nil, nil)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				var libovsdbOvnNBClient, libovsdbOvnSBClient libovsdbclient.Client
+				libovsdbOvnNBClient, libovsdbOvnSBClient, libovsdbCleanup, err = libovsdbtest.NewNBSBTestHarness(dbSetup)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				err = createTransitSwitchPortBindings(libovsdbOvnSBClient, types.DefaultNetworkName, &testNode1, &testNode2, &testNode3)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				zoneICHandler := NewZoneInterconnectHandler(&util.DefaultNetInfo{}, libovsdbOvnNBClient, libovsdbOvnSBClient, nil)
+				err = zoneICHandler.createOrUpdateTransitSwitch(0)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				err = invokeICHandlerAddNodeFunction("global", zoneICHandler, &testNode1, &testNode2, &testNode3)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				clusterRouter, err := libovsdbops.GetLogicalRouter(libovsdbOvnNBClient, &nbdb.LogicalRouter{Name: types.OVNClusterRouter})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				routesBefore := len(clusterRouter.StaticRoutes)
+
+				remoteNodeWithoutNodeID := corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "remote-without-node-id",
+						Annotations: map[string]string{
+							ovnNodeChassisIDAnnotation:         "cb9ec8fa-b409-4ef3-9f42-d9283c47aac9",
+							ovnNodeZoneNameAnnotation:          "foo",
+							ovnNodeSubnetsAnnotation:           "{\"default\":[\"10.244.5.0/24\"]}",
+							ovnTransitSwitchPortAddrAnnotation: "{\"ipv4\":\"100.88.0.5/16\"}",
+							// Retired annotation with a valid value: if the deprecated
+							// node-id fallback is ever restored, this add would stop
+							// failing and thus catch the regression.
+							"k8s.ovn.org/node-gateway-router-lrp-ifaddr": "{\"ipv4\":\"100.64.0.5/16\"}",
+						},
+					},
+				}
+
+				err = zoneICHandler.AddRemoteZoneNode(&remoteNodeWithoutNodeID)
+				gomega.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("failed to get node id for node - remote-without-node-id")))
+
+				clusterRouter, err = libovsdbops.GetLogicalRouter(libovsdbOvnNBClient, &nbdb.LogicalRouter{Name: types.OVNClusterRouter})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Expect(clusterRouter.StaticRoutes).To(gomega.HaveLen(routesBefore))
+
+				remotePortName := getNetworkScopedName(types.DefaultNetworkName, types.TransitSwitchToRouterPrefix+remoteNodeWithoutNodeID.Name)
+				_, err = libovsdbops.GetLogicalSwitchPort(libovsdbOvnNBClient, &nbdb.LogicalSwitchPort{Name: remotePortName})
+				gomega.Expect(err).To(gomega.HaveOccurred())
+
+				return nil
+			}
+
+			err := app.Run([]string{
+				app.Name,
+				"-cluster-subnets=" + clusterCIDR,
+				"-init-cluster-manager",
+				"-zone-join-switch-subnets=" + joinSubnetCIDR,
+			})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+
+		ginkgo.It("deleteLocalNodeStaticRoutes cleans up gateway-router routes when node-id lookup fails", func() {
+			app.Action = func(ctx *cli.Context) error {
+				dbSetup := libovsdbtest.TestSetup{
+					NBData: initialNBDB,
+					SBData: initialSBDB,
+				}
+
+				_, err := config.InitConfig(ctx, nil, nil)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				var libovsdbOvnNBClient, libovsdbOvnSBClient libovsdbclient.Client
+				libovsdbOvnNBClient, libovsdbOvnSBClient, libovsdbCleanup, err = libovsdbtest.NewNBSBTestHarness(dbSetup)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				err = createTransitSwitchPortBindings(libovsdbOvnSBClient, types.DefaultNetworkName, &testNode1, &testNode2, &testNode3)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				zoneICHandler := NewZoneInterconnectHandler(&util.DefaultNetInfo{}, libovsdbOvnNBClient, libovsdbOvnSBClient, nil)
+				err = zoneICHandler.createOrUpdateTransitSwitch(0)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				err = invokeICHandlerAddNodeFunction("global", zoneICHandler, &testNode1, &testNode2, &testNode3)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				nodeWithoutNodeID := testNode3.DeepCopy()
+				delete(nodeWithoutNodeID.Annotations, ovnNodeIDAnnotaton)
+				// Retired annotation with a valid value: if the deprecated node-id
+				// fallback is ever restored, this delete would stop failing and thus
+				// catch the regression.
+				nodeWithoutNodeID.Annotations["k8s.ovn.org/node-gateway-router-lrp-ifaddr"] = "{\"ipv4\":\"100.64.0.4/16\"}"
+
+				nodeTransitSwitchPortIPs, err := util.ParseNodeTransitSwitchPortAddrs(nodeWithoutNodeID)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				err = zoneICHandler.deleteLocalNodeStaticRoutes(nodeWithoutNodeID, nodeTransitSwitchPortIPs)
+				gomega.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("failed to get the gateway router port IP addresses for node node3")))
+
+				clusterRouter, err := libovsdbops.GetLogicalRouter(libovsdbOvnNBClient, &nbdb.LogicalRouter{Name: types.OVNClusterRouter})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				nodeRoutesPredicate := func(route *nbdb.LogicalRouterStaticRoute) bool {
+					return route.ExternalIDs != nil && route.ExternalIDs["ic-node"] == testNode3.Name
+				}
+				nodeRoutes, err := libovsdbops.GetRouterLogicalRouterStaticRoutesWithPredicate(libovsdbOvnNBClient, clusterRouter, nodeRoutesPredicate)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Expect(nodeRoutes).To(gomega.BeEmpty())
+
+				return nil
+			}
+
+			err := app.Run([]string{
+				app.Name,
+				"-cluster-subnets=" + clusterCIDR,
+				"-init-cluster-manager",
+				"-zone-join-switch-subnets=" + joinSubnetCIDR,
+			})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
 	})
 
 	ginkgo.Context("Secondary networks", func() {

--- a/go-controller/pkg/types/const.go
+++ b/go-controller/pkg/types/const.go
@@ -363,7 +363,7 @@ const (
 	// OVNKubeITPMark is the fwmark used for host->ITP=local svc traffic. Note
 	// that the fwmark is not a part of the packet, but just stored by kernel in
 	// its memory to track/filter packet. Hence fwmark is lost as soon as packet
-	// exits the host. The mark is set with an iptables rule by gateway and used
+	// exits the host. The mark is set with an nftables rule by gateway and used
 	// to route to management port.
 	OVNKubeITPMark = "0x1745ec" // constant itp(174)-service(5ec)
 

--- a/go-controller/pkg/util/node_annotations.go
+++ b/go-controller/pkg/util/node_annotations.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gaissmai/cidrtree"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/util/retry"
 
@@ -21,6 +22,15 @@ import (
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/kube"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
 )
+
+// IsNodeAnnotationPatchRetryable returns true for errors that should trigger a
+// relist-and-retry when patching node annotations via JSON Patch.
+//
+// JSON Patch "test" failures from the apiserver are surfaced as Invalid rather
+// than Conflict, so this retry path needs to handle both.
+func IsNodeAnnotationPatchRetryable(err error) bool {
+	return apierrors.IsConflict(err) || apierrors.IsInvalid(err)
+}
 
 // This handles the annotations used by the node to pass information about its local
 // network configuration to the ovnkube controller:

--- a/go-controller/pkg/util/node_annotations.go
+++ b/go-controller/pkg/util/node_annotations.go
@@ -76,12 +76,6 @@ const (
 	// OvnNodeIfAddr is the CIDR form representation of primary network interface's attached IP address (i.e: 192.168.126.31/24 or 0:0:0:0:0:feff:c0a8:8e0c/64)
 	OvnNodeIfAddr = "k8s.ovn.org/node-primary-ifaddr"
 
-	// ovnNodeGRLRPAddr is the CIDR form representation of Gate Router LRP IP address to join switch (i.e: 100.64.0.5/24)
-	// DEPRECATED; use ovnNodeGRLRPAddrs moving forward
-	// FIXME(tssurya): Remove this a few months from now; needed for backwards
-	// compatbility during upgrades while updating to use the new annotation "ovnNodeGRLRPAddrs"
-	ovnNodeGRLRPAddr = "k8s.ovn.org/node-gateway-router-lrp-ifaddr"
-
 	// ovnNodeGRLRPAddrs is the CIDR form representation of Gate Router LRP IP address to join switch (i.e: 100.64.0.4/16)
 	// for all the networks keyed by the network-name and ipFamily.
 	// "k8s.ovn.org/node-gateway-router-lrp-ifaddrs": "{
@@ -125,6 +119,9 @@ const (
 	OvnTransitSwitchPortAddr = "k8s.ovn.org/node-transit-switch-port-ifaddr"
 
 	// OvnNodeID is the id (of type integer) of a node. It is set by cluster-manager.
+	// Controllers derive the gateway router join switch port address from this value
+	// so that the local and remote views of the address agree. The deprecated
+	// k8s.ovn.org/node-gateway-router-lrp-ifaddr annotation is not used as a fallback.
 	OvnNodeID = "k8s.ovn.org/node-id"
 
 	// InvalidNodeID indicates an invalid node id
@@ -696,27 +693,6 @@ func ParseNodePrimaryIfAddr(node *corev1.Node) (*ParsedNodeEgressIPConfiguration
 	return parsedEgressIPConfig, nil
 }
 
-// ParseNodeGatewayRouterLRPAddr returns the IPv4 / IPv6 values for the node's gateway router
-// DEPRECATED; kept for backwards compatibility
-func ParseNodeGatewayRouterLRPAddr(node *corev1.Node) (net.IP, error) {
-	nodeIfAddrAnnotation, ok := node.Annotations[ovnNodeGRLRPAddr]
-	if !ok {
-		return nil, newAnnotationNotSetError("%s annotation not found for node %q", ovnNodeGRLRPAddr, node.Name)
-	}
-	nodeIfAddr := PrimaryIfAddrAnnotation{}
-	if err := json.Unmarshal([]byte(nodeIfAddrAnnotation), &nodeIfAddr); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal annotation: %s for node %q, err: %v", ovnNodeGRLRPAddr, node.Name, err)
-	}
-	if nodeIfAddr.IPv4 == "" && nodeIfAddr.IPv6 == "" {
-		return nil, fmt.Errorf("node: %q does not have any IP information set", node.Name)
-	}
-	ip, _, err := net.ParseCIDR(nodeIfAddr.IPv4)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse annotation: %s for node %q, err: %v", ovnNodeGRLRPAddr, node.Name, err)
-	}
-	return ip, nil
-}
-
 // parsePrimaryIfAddrAnnotation unmarshals the IPv4 / IPv6 values in the
 // primaryIfAddrAnnotation format from the nodeAnnotation map with the
 // provided 'annotationName' as key and returns the addresses.
@@ -757,12 +733,6 @@ func convertPrimaryIfAddrAnnotationToIPNet(ifAddr PrimaryIfAddrAnnotation) ([]*n
 		ipAddrs = append(ipAddrs, &net.IPNet{IP: ip, Mask: ipNet.Mask})
 	}
 	return ipAddrs, nil
-}
-
-// ParseNodeGatewayRouterLRPAddrs returns the IPv4 and/or IPv6 addresses for the node's gateway router port
-// stored in the 'ovnNodeGRLRPAddr' annotation
-func ParseNodeGatewayRouterLRPAddrs(node *corev1.Node) ([]*net.IPNet, error) {
-	return parsePrimaryIfAddrAnnotation(node, ovnNodeGRLRPAddr)
 }
 
 // ParseNodeTransitSwitchPortAddrs returns the IPv4 and/or IPv6 addresses for the node's transit switch port

--- a/go-controller/pkg/util/node_annotations.go
+++ b/go-controller/pkg/util/node_annotations.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gaissmai/cidrtree"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/util/retry"
 
@@ -21,6 +22,15 @@ import (
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/kube"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
 )
+
+// IsNodeAnnotationPatchRetryable returns true for errors that should trigger a
+// relist-and-retry when patching node annotations via JSON Patch.
+//
+// JSON Patch "test" failures from the apiserver are surfaced as Invalid rather
+// than Conflict, so this retry path needs to handle both.
+func IsNodeAnnotationPatchRetryable(err error) bool {
+	return apierrors.IsConflict(err) || apierrors.IsInvalid(err)
+}
 
 // This handles the annotations used by the node to pass information about its local
 // network configuration to the ovnkube controller:
@@ -76,12 +86,6 @@ const (
 	// OvnNodeIfAddr is the CIDR form representation of primary network interface's attached IP address (i.e: 192.168.126.31/24 or 0:0:0:0:0:feff:c0a8:8e0c/64)
 	OvnNodeIfAddr = "k8s.ovn.org/node-primary-ifaddr"
 
-	// ovnNodeGRLRPAddr is the CIDR form representation of Gate Router LRP IP address to join switch (i.e: 100.64.0.5/24)
-	// DEPRECATED; use ovnNodeGRLRPAddrs moving forward
-	// FIXME(tssurya): Remove this a few months from now; needed for backwards
-	// compatbility during upgrades while updating to use the new annotation "ovnNodeGRLRPAddrs"
-	ovnNodeGRLRPAddr = "k8s.ovn.org/node-gateway-router-lrp-ifaddr"
-
 	// ovnNodeGRLRPAddrs is the CIDR form representation of Gate Router LRP IP address to join switch (i.e: 100.64.0.4/16)
 	// for all the networks keyed by the network-name and ipFamily.
 	// "k8s.ovn.org/node-gateway-router-lrp-ifaddrs": "{
@@ -125,6 +129,9 @@ const (
 	OvnTransitSwitchPortAddr = "k8s.ovn.org/node-transit-switch-port-ifaddr"
 
 	// OvnNodeID is the id (of type integer) of a node. It is set by cluster-manager.
+	// Controllers derive the gateway router join switch port address from this value
+	// so that the local and remote views of the address agree. The deprecated
+	// k8s.ovn.org/node-gateway-router-lrp-ifaddr annotation is not used as a fallback.
 	OvnNodeID = "k8s.ovn.org/node-id"
 
 	// InvalidNodeID indicates an invalid node id
@@ -696,27 +703,6 @@ func ParseNodePrimaryIfAddr(node *corev1.Node) (*ParsedNodeEgressIPConfiguration
 	return parsedEgressIPConfig, nil
 }
 
-// ParseNodeGatewayRouterLRPAddr returns the IPv4 / IPv6 values for the node's gateway router
-// DEPRECATED; kept for backwards compatibility
-func ParseNodeGatewayRouterLRPAddr(node *corev1.Node) (net.IP, error) {
-	nodeIfAddrAnnotation, ok := node.Annotations[ovnNodeGRLRPAddr]
-	if !ok {
-		return nil, newAnnotationNotSetError("%s annotation not found for node %q", ovnNodeGRLRPAddr, node.Name)
-	}
-	nodeIfAddr := PrimaryIfAddrAnnotation{}
-	if err := json.Unmarshal([]byte(nodeIfAddrAnnotation), &nodeIfAddr); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal annotation: %s for node %q, err: %v", ovnNodeGRLRPAddr, node.Name, err)
-	}
-	if nodeIfAddr.IPv4 == "" && nodeIfAddr.IPv6 == "" {
-		return nil, fmt.Errorf("node: %q does not have any IP information set", node.Name)
-	}
-	ip, _, err := net.ParseCIDR(nodeIfAddr.IPv4)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse annotation: %s for node %q, err: %v", ovnNodeGRLRPAddr, node.Name, err)
-	}
-	return ip, nil
-}
-
 // parsePrimaryIfAddrAnnotation unmarshals the IPv4 / IPv6 values in the
 // primaryIfAddrAnnotation format from the nodeAnnotation map with the
 // provided 'annotationName' as key and returns the addresses.
@@ -757,12 +743,6 @@ func convertPrimaryIfAddrAnnotationToIPNet(ifAddr PrimaryIfAddrAnnotation) ([]*n
 		ipAddrs = append(ipAddrs, &net.IPNet{IP: ip, Mask: ipNet.Mask})
 	}
 	return ipAddrs, nil
-}
-
-// ParseNodeGatewayRouterLRPAddrs returns the IPv4 and/or IPv6 addresses for the node's gateway router port
-// stored in the 'ovnNodeGRLRPAddr' annotation
-func ParseNodeGatewayRouterLRPAddrs(node *corev1.Node) ([]*net.IPNet, error) {
-	return parsePrimaryIfAddrAnnotation(node, ovnNodeGRLRPAddr)
 }
 
 // ParseNodeTransitSwitchPortAddrs returns the IPv4 and/or IPv6 addresses for the node's transit switch port

--- a/go-controller/pkg/util/node_annotations_unit_test.go
+++ b/go-controller/pkg/util/node_annotations_unit_test.go
@@ -488,62 +488,6 @@ func TestParseNodeManagementPortMACAddresses(t *testing.T) {
 	}
 }
 
-func TestParseNodeGatewayRouterLRPAddr(t *testing.T) {
-	tests := []struct {
-		desc        string
-		inpNode     corev1.Node
-		errExpected bool
-		expOutput   bool
-	}{
-		{
-			desc:      "Gateway router LPR IP address annotation not found for node, however, does not return error",
-			inpNode:   corev1.Node{},
-			expOutput: false,
-		},
-		{
-			desc: "success: Gateway router parse LPR IP address",
-			inpNode: corev1.Node{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{"k8s.ovn.org/node-gateway-router-lrp-ifaddr": `{"ipv4":"100.64.0.5/16"}`},
-				},
-			},
-			expOutput: true,
-		},
-		{
-			desc: "success: Gateway router parse LPR IP address dual stack",
-			inpNode: corev1.Node{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{"k8s.ovn.org/node-gateway-router-lrp-ifaddr": `{"ipv4":"100.64.0.5/16", "ipv6":"fd:98::/64"}`},
-				},
-			},
-			expOutput: true,
-		},
-		{
-			desc: "error: Gateway router parse LPR IP address error",
-			inpNode: corev1.Node{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{"k8s.ovn.org/node-gateway-router-lrp-ifaddr": `{"ipv4":"100.64.0.5"}`},
-				},
-			},
-			errExpected: true,
-		},
-	}
-
-	for i, tc := range tests {
-		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
-			cfg, e := ParseNodeGatewayRouterLRPAddr(&tc.inpNode)
-			if tc.errExpected {
-				t.Log(e)
-				require.Error(t, e)
-				assert.Nil(t, cfg)
-			}
-			if tc.expOutput {
-				assert.NotNil(t, cfg)
-			}
-		})
-	}
-}
-
 func TestSetGatewayMTUSupport(t *testing.T) {
 	mockAnnotator := new(annotatorMock.Annotator)
 

--- a/go-controller/pkg/util/node_annotations_unit_test.go
+++ b/go-controller/pkg/util/node_annotations_unit_test.go
@@ -14,7 +14,10 @@ import (
 	"github.com/stretchr/testify/require"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/kube"
@@ -971,6 +974,36 @@ func TestParseNodeManagementPortAnnotation(t *testing.T) {
 				require.NoError(t, err)
 				assert.True(t, reflect.DeepEqual(mpDetails, tc.expectedOutput))
 			}
+		})
+	}
+}
+
+func TestIsNodeAnnotationPatchRetryable(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "conflict error is retryable",
+			err:      apierrors.NewConflict(schema.GroupResource{Resource: "nodes"}, "node1", fmt.Errorf("conflict")),
+			expected: true,
+		},
+		{
+			name:     "invalid error is retryable (JSON Patch test failure)",
+			err:      apierrors.NewInvalid(schema.GroupKind{Group: "", Kind: "Node"}, "node1", field.ErrorList{field.Invalid(field.NewPath("metadata"), nil, "test failed")}),
+			expected: true,
+		},
+		{
+			name:     "plain error is not retryable",
+			err:      fmt.Errorf("plain error"),
+			expected: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, IsNodeAnnotationPatchRetryable(tc.err))
 		})
 	}
 }

--- a/go-controller/pkg/util/node_annotations_unit_test.go
+++ b/go-controller/pkg/util/node_annotations_unit_test.go
@@ -14,7 +14,10 @@ import (
 	"github.com/stretchr/testify/require"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/kube"
@@ -476,62 +479,6 @@ func TestParseNodeManagementPortMACAddresses(t *testing.T) {
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
 			cfg, e := ParseNodeManagementPortMACAddresses(&tc.inpNode, tc.netName)
-			if tc.errExpected {
-				t.Log(e)
-				require.Error(t, e)
-				assert.Nil(t, cfg)
-			}
-			if tc.expOutput {
-				assert.NotNil(t, cfg)
-			}
-		})
-	}
-}
-
-func TestParseNodeGatewayRouterLRPAddr(t *testing.T) {
-	tests := []struct {
-		desc        string
-		inpNode     corev1.Node
-		errExpected bool
-		expOutput   bool
-	}{
-		{
-			desc:      "Gateway router LPR IP address annotation not found for node, however, does not return error",
-			inpNode:   corev1.Node{},
-			expOutput: false,
-		},
-		{
-			desc: "success: Gateway router parse LPR IP address",
-			inpNode: corev1.Node{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{"k8s.ovn.org/node-gateway-router-lrp-ifaddr": `{"ipv4":"100.64.0.5/16"}`},
-				},
-			},
-			expOutput: true,
-		},
-		{
-			desc: "success: Gateway router parse LPR IP address dual stack",
-			inpNode: corev1.Node{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{"k8s.ovn.org/node-gateway-router-lrp-ifaddr": `{"ipv4":"100.64.0.5/16", "ipv6":"fd:98::/64"}`},
-				},
-			},
-			expOutput: true,
-		},
-		{
-			desc: "error: Gateway router parse LPR IP address error",
-			inpNode: corev1.Node{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{"k8s.ovn.org/node-gateway-router-lrp-ifaddr": `{"ipv4":"100.64.0.5"}`},
-				},
-			},
-			errExpected: true,
-		},
-	}
-
-	for i, tc := range tests {
-		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
-			cfg, e := ParseNodeGatewayRouterLRPAddr(&tc.inpNode)
 			if tc.errExpected {
 				t.Log(e)
 				require.Error(t, e)
@@ -1027,6 +974,36 @@ func TestParseNodeManagementPortAnnotation(t *testing.T) {
 				require.NoError(t, err)
 				assert.True(t, reflect.DeepEqual(mpDetails, tc.expectedOutput))
 			}
+		})
+	}
+}
+
+func TestIsNodeAnnotationPatchRetryable(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "conflict error is retryable",
+			err:      apierrors.NewConflict(schema.GroupResource{Resource: "nodes"}, "node1", fmt.Errorf("conflict")),
+			expected: true,
+		},
+		{
+			name:     "invalid error is retryable (JSON Patch test failure)",
+			err:      apierrors.NewInvalid(schema.GroupKind{Group: "", Kind: "Node"}, "node1", field.ErrorList{field.Invalid(field.NewPath("metadata"), nil, "test failed")}),
+			expected: true,
+		},
+		{
+			name:     "plain error is not retryable",
+			err:      fmt.Errorf("plain error"),
+			expected: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, IsNodeAnnotationPatchRetryable(tc.err))
 		})
 	}
 }

--- a/go-controller/pkg/util/util.go
+++ b/go-controller/pkg/util/util.go
@@ -843,7 +843,7 @@ func GetEndpointsForService(endpointSlices []*discoveryv1.EndpointSlice, service
 	targetEndpoints := newTargetEndpoints(endpointSlices)
 
 	// Build list of valid service port keys, if a non-nil service was provided. Otherwise, if service is nil, this
-	// is a deletion (at least for the iptables / nftables logic) and thus accept all endpoints.
+	// is a deletion (at least for the nftables logic) and thus accept all endpoints.
 	validServicePortKeys := map[string]bool{}
 	if service != nil {
 		for _, servicePort := range service.Spec.Ports {

--- a/test/e2e/route_advertisements.go
+++ b/test/e2e/route_advertisements.go
@@ -1430,14 +1430,21 @@ var _ = ginkgo.Describe("BGP: When an advertised CUDN network is dynamically all
 
 var _ = ginkgo.Describe("BGP: isolation", feature.RouteAdvertisements, func() {
 	ginkgo.DescribeTableSubtree("between advertised networks", func(cudnATemplate, cudnBTemplate *udnv1.ClusterUserDefinedNetwork) {
-		const curlConnectionTimeoutCode = "28"
-		// match the whole phrase: a bare "7" is always contained in the curl
-		// error output, if only in the target address
-		const curlConnectionRefusedCode = "exit code 7"
 		const nodePortBackendLabel = "nodeport-backend"
 		const clientNodeBackend = "client-node"
 		const remoteNodeBackend = "remote-node"
 		const nodePortNodeBackend = "nodeport-node"
+
+		// The pod-to-X tests use e2epodoutput.RunHostCmdWithFullOutput(), which
+		// returns output like "exit code 28" on error, while the host-to-X tests
+		// use infraprovider.Get().ExecK8NodeCommand()), which returns output like
+		// "exit status 28" ("status" rather than "code"). We just look for just
+		// "28" (and hope there are no false positives).
+		const curlConnectionTimeoutCode = "28"
+
+		// Currently only pod-to-X tests ever expect "connection refused", so we
+		// can match the longer error string.
+		const curlConnectionRefusedCode = "exit code 7"
 
 		f := wrappedTestFramework("bgp-network-isolation")
 		f.SkipNamespaceCreation = true
@@ -2122,7 +2129,7 @@ var _ = ginkgo.Describe("BGP: isolation", feature.RouteAdvertisements, func() {
 						return clientPod.Name, clientPod.Namespace, net.JoinHostPort(nodeIP, fmt.Sprint(hostNetworkPort)) + "/clientip", clientNodeIP, false
 					}),
 				ginkgo.Entry("[ETP=Cluster] UDN pod to the same node nodeport service in default network should not work",
-					// FIXME: https://github.com/ovn-kubernetes/ovn-kubernetes/issues/5410
+					// FIXME: https://github.com/ovn-kubernetes/ovn-kubernetes/issues/5419
 					func(ipFamily utilnet.IPFamily) (clientName string, clientNamespace string, dst string, expectedOutput string, expectErr bool) {
 						clientPod := podsNetA[0]
 						// podsNetA[0] is on nodes[0]. We need the same node. Let's hit the nodeport on nodes[0].
@@ -2135,7 +2142,16 @@ var _ = ginkgo.Describe("BGP: isolation", feature.RouteAdvertisements, func() {
 						}
 						nodePort := svcNodePortNetDefault.Spec.Ports[0].NodePort
 
-						return clientPod.Name, clientPod.Namespace, net.JoinHostPort(nodeIP, fmt.Sprint(nodePort)) + "/hostname", curlConnectionTimeoutCode, true
+						// Because of the difference in IPv4 vs IPv6 "fib daddr type local" (see #5419, above),
+						// forbidden IPv4 NodePort connections do not match the nftables rule, don't get DNATted,
+						// and then get rejected by the host, while forbidden IPv6 NodePort connections do get
+						// DNATted but then get dropped by OVN ACLs.
+						expectedOutput = curlConnectionRefusedCode
+						if ipFamily == utilnet.IPv6 {
+							expectedOutput = curlConnectionTimeoutCode
+						}
+
+						return clientPod.Name, clientPod.Namespace, net.JoinHostPort(nodeIP, fmt.Sprint(nodePort)) + "/hostname", expectedOutput, true
 					}),
 				ginkgo.Entry("[ETP=Cluster] UDN pod to a different node nodeport service in default network should work",
 					func(ipFamily utilnet.IPFamily) (clientName string, clientNamespace string, dst string, expectedOutput string, expectErr bool) {
@@ -2231,9 +2247,9 @@ var _ = ginkgo.Describe("BGP: isolation", feature.RouteAdvertisements, func() {
 							// network B is not active on the client's node: the
 							// nodeport is unreachable for both families
 							expectErr = true
+						}
+						if expectErr {
 							expectedOutput = curlConnectionRefusedCode
-						} else if expectErr {
-							expectedOutput = curlConnectionTimeoutCode
 						}
 						return clientPod.Name, clientPod.Namespace, net.JoinHostPort(nodeIP, fmt.Sprint(nodePort)) + "/hostname", expectedOutput, expectErr
 					}),
@@ -2337,7 +2353,14 @@ var _ = ginkgo.Describe("BGP: isolation", feature.RouteAdvertisements, func() {
 						nodePortA := svcNodePortETPLocalNetA.Spec.Ports[0].NodePort
 						expectErr = ipFamily == utilnet.IPv4 || IsGatewayModeLocal(f.ClientSet)
 						if expectErr {
-							expectedOutput = curlConnectionTimeoutCode
+							// Because of the difference in IPv4 vs IPv6 "fib daddr type local" (see #5419, above),
+							// forbidden IPv4 NodePort connections do not match the nftables rule, don't get DNATted,
+							// and then get rejected by the host, while forbidden IPv6 NodePort connections do get
+							// DNATted but then get dropped by OVN ACLs.
+							expectedOutput = curlConnectionRefusedCode
+							if ipFamily == utilnet.IPv6 {
+								expectedOutput = curlConnectionTimeoutCode
+							}
 						}
 						return clientPod.Name, clientPod.Namespace, net.JoinHostPort(nodeIP, fmt.Sprint(nodePortA)) + "/hostname", expectedOutput, expectErr
 					}),
@@ -2366,7 +2389,16 @@ var _ = ginkgo.Describe("BGP: isolation", feature.RouteAdvertisements, func() {
 							nodeIP = nodeIPv6
 						}
 						nodePortB := svcNodePortETPLocalDefault.Spec.Ports[0].NodePort
-						return clientPod.Name, clientPod.Namespace, net.JoinHostPort(nodeIP, fmt.Sprint(nodePortB)) + "/hostname", curlConnectionTimeoutCode, true
+						// Because of the difference in IPv4 vs IPv6 "fib daddr type local" (see #5419, above),
+						// forbidden IPv4 NodePort connections do not match the nftables rule, don't get DNATted,
+						// and then get rejected by the host, while forbidden IPv6 NodePort connections do get
+						// DNATted but then get dropped by OVN ACLs.
+						expectedOutput = curlConnectionRefusedCode
+						if ipFamily == utilnet.IPv6 {
+							expectedOutput = curlConnectionTimeoutCode
+						}
+
+						return clientPod.Name, clientPod.Namespace, net.JoinHostPort(nodeIP, fmt.Sprint(nodePortB)) + "/hostname", expectedOutput, true
 					}),
 				ginkgo.Entry("[ETP=LOCAL] UDN pod to a different node nodeport service in default network should work",
 					func(ipFamily utilnet.IPFamily) (clientName string, clientNamespace string, dst string, expectedOutput string, expectErr bool) {

--- a/test/e2e/service.go
+++ b/test/e2e/service.go
@@ -416,7 +416,7 @@ var _ = ginkgo.Describe("Services", feature.Service, func() {
 							if isLocalGWModeEnabled() && hostNetwork {
 								// if local gateway mode the intermediary node will attempt to fragment the packet, if the DF
 								// bit is not set. However, the decision on setting DF bit is left up to the kernel, and
-								// is unpredictable. If the DF bit is set, the iptables rule that DNATs nodeport -> cluster IP
+								// is unpredictable. If the DF bit is set, the nftables rule that DNATs nodeport -> cluster IP
 								// will then attempt to route the packet, and hit our 1400 byte MTU route. This will cause:
 								// 172.18.0.2:37755->10.96.141.254:9881(udp) sk_skb_reason_drop(SKB_DROP_REASON_PKT_TOO_BIG)
 								packetSizes = []string{"small"}
@@ -1439,10 +1439,10 @@ spec:
 					// send ingress traffic from external container to egressNode where the pod lives
 					// On secondary bridges CI lane we will also created eth1 interface on each node
 					// in the cluster. In that case:
-					// (1) SGW: npclient's eth1 -> node's eth1-> node's breth1 -> iptables -> DNAT to CIP ->
+					// (1) SGW: npclient's eth1 -> node's eth1-> node's breth1 -> nftables -> DNAT to CIP ->
 					//          route to breth0 -> send to OVN -> hit GR; ETP=local will not be respected
 					//          in this case and its broken at the moment. (FIXME)
-					// (2) LGW: npclient's eth1 -> node's eth1-> node's breth1 -> iptables -> DNAT to .3 masquerade ->
+					// (2) LGW: npclient's eth1 -> node's eth1-> node's breth1 -> nftables -> DNAT to .3 masquerade ->
 					//          route to mp0 -> send to OVN -> hit switch; ETP=local will be respected
 					//          in this case and its delivered to the pod. (test works for this case)
 					if !isLocalGWModeEnabled() || serviceSpec.Name != etpLocalServiceName {


### PR DESCRIPTION
Manual d/s merge to resolve conflict in gateway_init_linux_test.go file. Following are the conflict resolution details:

- Resolve gateway_init_linux_test.go merge conflict for MCS nftables migration
  - Resolve conflict between downstream MCS iptables expectations and
    upstream nftables gateway-service expectations.
  - Keep upstream's expectedNFT path (nftablesRulesBase +
    nftablesRulesGatewayServices, plus local-gateway rules where needed).
  - Drop the conflicting OCP HACK iptables MatchState checks for MCS
    REJECT rules on filter/FORWARD and filter/OUTPUT.
  - Add nftablesRulesMCS and append it to expectedNFT in shared-gateway and
    local-gateway tests so MCS blocking is asserted via nftables instead.