### PR TITLE
OCPBUGS-104393: address CVE-2026-33814 HTTP/2 SETTINGS_MAX_FRAME_SIZE…

### DIFF
--- a/openshift/go.mod
+++ b/openshift/go.mod
@@ -2,6 +2,8 @@ module github.com/ovn-kubernetes/ovn-kubernetes/openshift
 
 go 1.26.0
 
+toolchain go1.26.3
+
 require (
 	github.com/onsi/ginkgo/v2 v2.28.1
 	github.com/onsi/gomega v1.39.1

--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -2,6 +2,8 @@ module github.com/ovn-kubernetes/ovn-kubernetes/test/e2e
 
 go 1.26.0
 
+toolchain go1.26.3
+
 require (
 	github.com/google/go-cmp v0.7.0
 	github.com/k8snetworkplumbingwg/ipamclaims v0.5.1-alpha


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

Address CVE-2026-33814 (High, CVSS 7.5) — denial of service in Go’s HTTP/2 client when a malicious server sends `SETTINGS_MAX_FRAME_SIZE = 0`, causing the transport to loop on CONTINUATION frames.
Pin `toolchain go1.26.3` in `openshift/go.mod` and `test/e2e/go.mod` so all modules in this repo build with the patched Go stdlib. `go-controller` and `test/conformance` already pin this toolchain.

Fixes OCPBUGS-104393

## Additional Information for reviewers
**CVE:** [CVE-2026-33814](https://www.cve.org/CVERecord?id=CVE-2026-33814)  
**Go vuln:** [GO-2026-4918](https://pkg.go.dev/vuln/GO-2026-4918)  
**Go issue:** https://go.dev/issue/78476  
**Bugzilla:** bz#2467815
**Fix requirements:**
- Go toolchain ≥ 1.25.10 or ≥ 1.26.3 (stdlib `net/http/internal/http2`)
- `golang.org/x/net` ≥ v0.53.0 (vendor http2)

**Versions after this change:**
| Module | `toolchain` | `golang.org/x/net` |
|--------|-------------|-------------------|
| `go-controller` | `go1.26.3` (existing) | `v0.55.0` (existing) |
| `openshift` | `go1.26.3` (this PR) | `v0.55.1-0.20260602153038-...` (indirect, existing) |
| `test/e2e` | `go1.26.3` (this PR) | `v0.55.0` (indirect, existing) |
| `test/conformance` | `go1.26.3` (existing) | `v0.55.0` (indirect, existing) |
The core networking binaries (`ovnkube`, CNI, etc.) are built from `go-controller`, which already had the fix via prior dependency bumps (`6a73851ed`, `cdc5c2113`). This PR aligns the remaining `go.mod` files so the `ovn-kubernetes-tests-ext` binary and e2e tests also compile with the patched toolchain.
**Component:** `openshift5/ose-ovn-kubernetes-rhel9`  
**Target:** OpenShift 5.0


## ✅ Checks
- [ ] My code does not require changes to the documentation
- [ ] My code does not require tests
- [ ] All the tests have passed in the CI

## How to verify it
1. Confirm toolchain pin across all modules:
   ```bash
   find . -name go.mod -exec grep -H "toolchain\|golang.org/x/net" {} +
All four modules should show toolchain go1.26.3; golang.org/x/net should be ≥ v0.53.0.

2. Run vulnerability scan (CVE should not appear):

cd go-controller && govulncheck ./...


3..Confirm vendor http2 validation rejects invalid SETTINGS_MAX_FRAME_SIZE:

grep -A2 'SettingMaxFrameSize' go-controller/vendor/golang.org/x/net/http2/http2.go
Values < 16384 should return ConnectionError(ErrCodeProtocol).

4. Build sanity check:

cd go-controller && make build
cd ../openshift && ./hack/build-tests-ext.sh
