### PR TITLE
OCPBUGS-113964: skip NetworkSegmentation UDN LB service test where external containers are unavailable

### DIFF
--- a/openshift/test/infraprovider/openshift.go
+++ b/openshift/test/infraprovider/openshift.go
@@ -151,7 +151,7 @@ func isLocalGatewayMode(network *operv1.Network) bool {
 
 func (o *OpenshiftInfraProvider) GetExternalContainerNetworkInterface(container api.ExternalContainer, network api.Network) (api.NetworkInterface, error) {
 	if o.clusterInfra == nil {
-		panic("not implemented")
+		return api.NetworkInterface{}, fmt.Errorf("cannot get network interface for external container %q: external container infrastructure is not available on this platform", container.Name)
 	}
 	return o.clusterInfra.GetExternalContainerNetworkInterface(container, network)
 }
@@ -223,7 +223,7 @@ func (o *OpenshiftInfraProvider) ExecK8NodeCommand(nodeName string, cmd []string
 
 func (o *OpenshiftInfraProvider) ExecExternalContainerCommand(container api.ExternalContainer, cmd []string) (string, error) {
 	if o.clusterInfra == nil {
-		panic("not implemented")
+		return "", fmt.Errorf("cannot exec into external container %q: external container infrastructure is not available on this platform", container.Name)
 	}
 	return o.clusterInfra.ExecExternalContainerCommand(container, cmd)
 }
@@ -237,7 +237,7 @@ func (o *OpenshiftInfraProvider) ExternalContainerPrimaryInterfaceName() string 
 
 func (o *OpenshiftInfraProvider) GetExternalContainerLogs(container api.ExternalContainer) (string, error) {
 	if o.clusterInfra == nil {
-		panic("not implemented")
+		return "", fmt.Errorf("cannot get logs for external container %q: external container infrastructure is not available on this platform", container.Name)
 	}
 	return o.clusterInfra.GetExternalContainerLogs(container)
 }
@@ -251,9 +251,17 @@ func (o *OpenshiftInfraProvider) GetExternalContainerPort() uint16 {
 
 func (o *OpenshiftInfraProvider) ListNetworks() ([]string, error) {
 	if o.clusterInfra == nil {
-		panic("not implemented")
+		return nil, fmt.Errorf("cannot list external container networks: external container infrastructure is not available on this platform")
 	}
 	return o.clusterInfra.ListNetworks()
+}
+
+// IsExternalContainerAvailable reports whether external container infrastructure
+// (e.g. the FRR container used by BGP/EVPN scenarios) is available. It is only
+// populated on bare-metal clusters; cloud platforms (Azure, AWS, GCP) have none,
+// so tests must skip external container connectivity checks when this returns false.
+func (o *OpenshiftInfraProvider) IsExternalContainerAvailable() bool {
+	return o.clusterInfra != nil
 }
 
 func (o *OpenshiftInfraProvider) NewTestContext() api.Context {

--- a/openshift/test/infraprovider/openshift_test.go
+++ b/openshift/test/infraprovider/openshift_test.go
@@ -1,0 +1,40 @@
+package infraprovider
+
+import (
+	"testing"
+
+	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/infraprovider/api"
+)
+
+// A nil clusterInfra models a cloud platform (e.g. Azure) where no external
+// container infrastructure exists. Historically these methods panicked with
+// "not implemented", which crashed the test binary instead of failing
+// gracefully. They must now return an error (OCPBUGS-113964).
+func TestExternalContainerMethodsReturnErrorWhenUnavailable(t *testing.T) {
+	o := &OpenshiftInfraProvider{} // clusterInfra is nil
+
+	if _, err := o.ExecExternalContainerCommand(api.ExternalContainer{Name: "frr"}, []string{"true"}); err == nil {
+		t.Error("ExecExternalContainerCommand: expected error when clusterInfra is nil, got nil")
+	}
+	if _, err := o.GetExternalContainerNetworkInterface(api.ExternalContainer{Name: "frr"}, nil); err == nil {
+		t.Error("GetExternalContainerNetworkInterface: expected error when clusterInfra is nil, got nil")
+	}
+	if _, err := o.GetExternalContainerLogs(api.ExternalContainer{Name: "frr"}); err == nil {
+		t.Error("GetExternalContainerLogs: expected error when clusterInfra is nil, got nil")
+	}
+	if _, err := o.ListNetworks(); err == nil {
+		t.Error("ListNetworks: expected error when clusterInfra is nil, got nil")
+	}
+}
+
+// IsExternalContainerAvailable gates external container connectivity checks in
+// the e2e tests. It must report false on platforms without external container
+// infrastructure (clusterInfra nil) and true otherwise.
+func TestIsExternalContainerAvailable(t *testing.T) {
+	if (&OpenshiftInfraProvider{}).IsExternalContainerAvailable() {
+		t.Error("expected IsExternalContainerAvailable to be false when clusterInfra is nil")
+	}
+	if !(&OpenshiftInfraProvider{clusterInfra: &baremetalInfra{}}).IsExternalContainerAvailable() {
+		t.Error("expected IsExternalContainerAvailable to be true when clusterInfra is set")
+	}
+}

--- a/test/e2e/network_segmentation_services.go
+++ b/test/e2e/network_segmentation_services.go
@@ -30,6 +30,7 @@ import (
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	e2eservice "k8s.io/kubernetes/test/e2e/framework/service"
+	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 	utilnet "k8s.io/utils/net"
 )
 
@@ -98,6 +99,16 @@ var _ = Describe("Network Segmentation: services", feature.NetworkSegmentation, 
 			func(
 				netConfigParams networkAttachmentConfigParams,
 			) {
+				// This test validates connectivity to a UDN LoadBalancer service from an
+				// external container (the "frr" container). That infrastructure only
+				// exists on providers such as kind and bare-metal; cloud platforms
+				// (Azure, AWS, GCP) have none. Skip the whole test there rather than
+				// running a partial variant, which would still exercise default-network
+				// pods that violate restricted PodSecurity and trip cluster monitors.
+				if !externalContainerConnectivitySupported() {
+					e2eskipper.Skipf("test requires external container infrastructure, which is not available on this platform")
+				}
+
 				namespace := f.Namespace.Name
 				jig := e2eservice.NewTestJig(cs, namespace, "udn-service")
 
@@ -495,6 +506,23 @@ func checkConnectionOrNoConnectionToLoadBalancers(f *framework.Framework, client
 		}
 		framework.ExpectNoError(err, fmt.Sprintf("Failed to verify that %s", msg))
 	}
+}
+
+// externalContainerConnectivitySupported reports whether the active infrastructure
+// provider can reach pre-provisioned external containers (e.g. the "frr" container).
+// It uses an optional capability interface so providers that do not implement it
+// (such as kind, which always has external containers) default to supported, while
+// providers that do (e.g. the OpenShift provider on cloud platforms without external
+// container infrastructure) can advertise the lack of support so callers skip the
+// external container connectivity checks instead of failing.
+func externalContainerConnectivitySupported() bool {
+	type externalContainerCapabilityChecker interface {
+		IsExternalContainerAvailable() bool
+	}
+	if checker, ok := infraprovider.Get().(externalContainerCapabilityChecker); ok {
+		return checker.IsExternalContainerAvailable()
+	}
+	return true
 }
 
 func checkConnectionToNodePortFromExternalContainer(externalContainer infraapi.ExternalContainer, service *v1.Service, node *v1.Node, nodeRoleMsg, expectedOutput string) {


### PR DESCRIPTION
## 📑 Description

On cloud platforms (e.g. Azure, GCP) the OTE `[Feature:NetworkSegmentation]` UDN
load balancer / node port service test panicked with `Test Panicked: not
implemented` instead of failing gracefully.

`OpenshiftInfraProvider` only populates `clusterInfra` on bare-metal clusters, so
on cloud it is `nil` and the external-container methods panicked. The UDN service
test reaches a pre-provisioned `frr` external container unconditionally,
triggering the panic inside a gomega `Eventually` poll.

This PR:

1. **infraprovider** (`openshift/test/infraprovider/openshift.go`): the
   external-container methods (`ExecExternalContainerCommand`,
   `GetExternalContainerNetworkInterface`, `GetExternalContainerLogs`,
   `ListNetworks`) return a descriptive error instead of `panic("not implemented")`
   when `clusterInfra == nil`; adds `IsExternalContainerAvailable()`.
2. **network segmentation e2e** (`test/e2e/network_segmentation_services.go`):
   skips the entire UDN LB service test when the provider reports no external
   container infrastructure.

### Why skip the whole test (not just the external-container checks)

An earlier revision skipped only the external-container assertions and kept the
rest of the test. CI (`e2e-gcp-ovn-techpreview`) proved that is not viable: with
the panic gone, the test proceeds to its default-network section, which creates
`default-net-pod` in a plain namespace. That pod violates restricted
PodSecurity, which trips blocking cluster monitors
(`[Monitor:audit-log-analyzer] ... PodSecurityViolation` and the
`PodSecurityViolation` alert) and fails the job. Skipping the whole test on
platforms that lack external-container infra avoids both the panic and the
PodSecurity violation.

### Known limitations / follow-up

This is a targeted fix to stop the test from breaking cloud CI. It does **not**
make the test cloud-capable — on cloud it is now skipped, so there is no UDN LB
service coverage there. Making it run on cloud requires (at least) external
container support on cloud providers and PodSecurity-compliant default-network
pods. Tracked for follow-up in OCPBUGS-113964.

JIRA: https://redhat.atlassian.net/browse/OCPBUGS-113964

## Additional Information for reviewers

- `vendor/` is git-ignored in the `openshift/` module and generated at build time
  (`hack/build-tests-ext.sh`), so this PR touches only 3 files.
- Capability is exposed via an optional interface consumed by the e2e test, so the
  upstream `kind` provider needs no change (it defaults to supported).
- Regression: `e2e-metal-ipi-ovn-dualstack-bgp` (external containers present,
  `clusterInfra != nil`) passed — the external-container path still runs.

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [x] My code does not require changes to the documentation
- [x] My code requires tests
- [x] if so, I have added and/or updated the tests as required
- [ ] My code does not require tests
- [ ] All the tests have passed in the CI

## How to verify it

Unit (offline):

```
cd openshift && go test ./test/infraprovider/...
```

proves the external-container methods return an error (no panic) when
`clusterInfra` is nil and that `IsExternalContainerAvailable()` reports the
capability. On cloud, the UDN LB service test is now reported as `skipped`
(no panic, no PodSecurity violation); on kind/bare-metal it runs unchanged.

Build/lint performed locally: `gofmt`, `go vet` (test/e2e + openshift), and
`hack/build-tests-ext.sh` all pass.

## Special notes for reviewers (AI disclosure)

AI tooling (OpenCode, model claude-opus-4-8) was used to investigate the CI panics
and to draft this change and its tests. The author has reviewed and tested all
changes. Commits carry an `Assisted-by` trailer per CONTRIBUTING.md.
