### PR TITLE
OCPBUGS-113693: retry secondary-host EgressIP SNAT promptly

### DIFF
--- a/go-controller/pkg/node/controllers/egressip/egressip.go
+++ b/go-controller/pkg/node/controllers/egressip/egressip.go
@@ -362,13 +362,19 @@ func (c *Controller) onEIPUpdate(oldObj, newObj interface{}) {
 		utilruntime.HandleError(errors.New("invalid Egress IP policy to onEIPUpdate()"))
 		return
 	}
-	if oldEIP.Generation == newEIP.Generation ||
-		!newEIP.GetDeletionTimestamp().IsZero() {
+	if !newEIP.GetDeletionTimestamp().IsZero() {
+		return
+	}
+	// Generation is unchanged for status-only patches (node assignment). Skipping
+	// those delayed SNAT programming until an unrelated pod/namespace event
+	// (OCPBUGS-113693). Spec changes still bump Generation and are handled here.
+	if oldEIP.Generation == newEIP.Generation && reflect.DeepEqual(oldEIP.Status.Items, newEIP.Status.Items) {
 		return
 	}
 	key, err := cache.MetaNamespaceKeyFunc(newObj)
 	if err != nil {
 		utilruntime.HandleError(fmt.Errorf("couldn't get key for object %+v: %v", newObj, err))
+		return
 	}
 	c.eIPQueue.Add(key)
 }
@@ -524,7 +530,13 @@ func (c *Controller) processEIP(eip *eipv1.EgressIP) (*eIPConfig, sets.Set[strin
 				fmt.Errorf("failed to find a network to host EgressIP %s IP %s: %v", eip.Name, status.EgressIP, err)
 		}
 		if !found {
-			continue
+			// Do not treat a missing host network as success: the EIP is already
+			// assigned to this node. Returning nil previously dropped the work
+			// item with no retry, so SNAT waited for an unrelated event or the
+			// 6-minute nftables/iptables safety-net sync (OCPBUGS-113693).
+			return nil, selectedNamespaces, selectedPods, selectedNamespacesPodIPs,
+				fmt.Errorf("no host network found to host EgressIP %s IP %s on node %s; will retry",
+					eip.Name, status.EgressIP, c.nodeName)
 		}
 		// namespace selector is mandatory for EIP
 		namespaces, err := c.listNamespacesBySelector(&eip.Spec.NamespaceSelector)

--- a/go-controller/pkg/node/controllers/egressip/egressip_test.go
+++ b/go-controller/pkg/node/controllers/egressip/egressip_test.go
@@ -29,10 +29,12 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
 	utilnet "k8s.io/utils/net"
 	"sigs.k8s.io/knftables"
 
 	ovnconfig "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
+	ovncontroller "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/controller"
 	egressipv1 "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/egressip/v1"
 	egressipfake "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/egressip/v1/apis/clientset/versioned/fake"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/factory"
@@ -1925,5 +1927,78 @@ var _ = ginkgo.Describe("isEgressIPOnLink", func() {
 			return nil
 		})
 		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+	})
+})
+
+func newTestEIPQueue() workqueue.TypedRateLimitingInterface[string] {
+	return workqueue.NewTypedRateLimitingQueueWithConfig(
+		ovncontroller.DefaultRateLimiter[string](),
+		workqueue.TypedRateLimitingQueueConfig[string]{Name: "test-eipeip"},
+	)
+}
+
+var _ = ginkgo.Describe("EgressIP handler event filtering", func() {
+	ginkgo.It("queues on status-only updates with unchanged Generation", func() {
+		c := &Controller{eIPQueue: newTestEIPQueue(), nodeName: node1Name}
+		oldEIP := newEgressIP(egressIP1Name, egressIP1IPV4, "", namespace1Label, egressPodLabel)
+		oldEIP.Generation = 1
+		newEIP := oldEIP.DeepCopy()
+		newEIP.Generation = 1
+		newEIP.Status.Items = []egressipv1.EgressIPStatusItem{{
+			Node:     node1Name,
+			EgressIP: egressIP1IPV4,
+		}}
+		c.onEIPUpdate(oldEIP, newEIP)
+		gomega.Expect(c.eIPQueue.Len()).To(gomega.Equal(1))
+	})
+
+	ginkgo.It("does not queue when Generation and status are unchanged", func() {
+		c := &Controller{eIPQueue: newTestEIPQueue(), nodeName: node1Name}
+		oldEIP := newEgressIP(egressIP1Name, egressIP1IPV4, node1Name, namespace1Label, egressPodLabel)
+		oldEIP.Generation = 1
+		newEIP := oldEIP.DeepCopy()
+		newEIP.Generation = 1
+		c.onEIPUpdate(oldEIP, newEIP)
+		gomega.Expect(c.eIPQueue.Len()).To(gomega.Equal(0))
+	})
+})
+
+var _ = ginkgo.Describe("processEIP host-network retry", func() {
+	ginkgo.It("returns a retriable error when assigned EIP has no matching host interface", func() {
+		defer ginkgo.GinkgoRecover()
+		if ovntest.NoRoot() {
+			ginkgo.Skip("Test requires root privileges")
+		}
+		runtime.LockOSThread()
+		defer runtime.UnlockOSThread()
+
+		nodeCfg := nodeConfig{
+			linkConfigs: []linkConfig{
+				{dummyLink1Name, []address{{dummy1IPv4CIDR, false}}},
+			},
+		}
+		testNS, cleanupFn, err := setupFakeTestNode(nodeCfg)
+		if err != nil {
+			ginkgo.Skip(fmt.Sprintf("unable to create test netns: %v", err))
+		}
+		defer func() {
+			gomega.Expect(cleanupFn()).Should(gomega.Succeed())
+		}()
+
+		eIP := newEgressIP(egressIP1Name, egressIP3IP, node1Name, namespace1Label, egressPodLabel)
+		c, _, err := initController(
+			[]corev1.Namespace{newNamespaceWithLabels(namespace1, namespace1Label)},
+			[]corev1.Pod{newPodWithLabels(namespace1, pod1Name, node1Name, pod1IPv4, egressPodLabel)},
+			[]egressipv1.EgressIP{*eIP},
+			nodeCfg, true, false, false,
+		)
+		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+
+		err = testNS.Do(func(ns.NetNS) error {
+			_, _, _, _, procErr := c.processEIP(eIP)
+			return procErr
+		})
+		gomega.Expect(err).To(gomega.HaveOccurred())
+		gomega.Expect(err.Error()).To(gomega.ContainSubstring("no host network found"))
 	})
 })

--- a/go-controller/pkg/node/nftelementmanager/nft_element_manager.go
+++ b/go-controller/pkg/node/nftelementmanager/nft_element_manager.go
@@ -28,22 +28,38 @@ type Controller struct {
 	// failedRetryPeriod is how long to wait after a failed reconcile before
 	// retrying. Zero uses nftFailedReconcileRetry. Tests may override.
 	failedRetryPeriod time.Duration
+	// retryCh is signaled when Add/Delete/OwnMaps reconcile fails so Run
+	// retries soon instead of waiting for the next full sync period.
+	retryCh chan struct{}
 }
 
 const nftFailedReconcileRetry = time.Second
+
+// getNFTablesHelper is overridden in tests to inject reconcile failures.
+var getNFTablesHelper = nodenft.GetNFTablesHelper
 
 func NewController() *Controller {
 	return &Controller{
 		elements:  make([]element, 0),
 		ownedMaps: sets.New[string](),
+		retryCh:   make(chan struct{}, 1),
+	}
+}
+
+func (c *Controller) scheduleRetry() {
+	if c.retryCh == nil {
+		return
+	}
+	select {
+	case c.retryCh <- struct{}{}:
+	default:
 	}
 }
 
 // Run periodically reconciles nftables elements, including owned-map cleanup.
 // Immediate Add/Delete already reconcile; this loop is a safety net. If a
-// reconcile fails, retry quickly instead of waiting for the next full period
-// (which is 6 minutes for EgressIP SNAT and caused multi-minute gaps in
-// OCPBUGS-113693).
+// reconcile fails (including Add/OwnMaps while the link or nftables is not
+// ready), retry quickly instead of waiting for the next full period.
 func (c *Controller) Run(stopCh <-chan struct{}, syncPeriod time.Duration) {
 	ticker := time.NewTicker(syncPeriod)
 	defer ticker.Stop()
@@ -55,6 +71,15 @@ func (c *Controller) Run(stopCh <-chan struct{}, syncPeriod time.Duration) {
 	retryTimer.Stop()
 	defer retryTimer.Stop()
 
+	stopRetryTimer := func() {
+		if !retryTimer.Stop() {
+			select {
+			case <-retryTimer.C:
+			default:
+			}
+		}
+	}
+
 	tryReconcile := func() {
 		c.mu.Lock()
 		err := c.fullReconcile()
@@ -64,11 +89,10 @@ func (c *Controller) Run(stopCh <-chan struct{}, syncPeriod time.Duration) {
 			retryTimer.Reset(retryAfter)
 			return
 		}
-		if !retryTimer.Stop() {
-			select {
-			case <-retryTimer.C:
-			default:
-			}
+		stopRetryTimer()
+		select {
+		case <-c.retryCh:
+		default:
 		}
 	}
 
@@ -80,6 +104,8 @@ func (c *Controller) Run(stopCh <-chan struct{}, syncPeriod time.Duration) {
 			tryReconcile()
 		case <-retryTimer.C:
 			tryReconcile()
+		case <-c.retryCh:
+			retryTimer.Reset(retryAfter)
 		}
 	}
 }
@@ -164,8 +190,9 @@ func (c *Controller) doReconcile(pruneOwnedMaps bool) error {
 		klog.V(5).Infof("Reconciling NFT elements took %v", time.Since(start))
 	}()
 
-	nft, err := nodenft.GetNFTablesHelper()
+	nft, err := getNFTablesHelper()
 	if err != nil {
+		c.scheduleRetry()
 		return err
 	}
 
@@ -189,6 +216,7 @@ func (c *Controller) doReconcile(pruneOwnedMaps bool) error {
 				if knftables.IsNotFound(err) {
 					continue
 				}
+				c.scheduleRetry()
 				return err
 			}
 			for _, existingElem := range existing {
@@ -202,6 +230,7 @@ func (c *Controller) doReconcile(pruneOwnedMaps bool) error {
 	}
 
 	if err := nft.Run(context.TODO(), tx); err != nil {
+		c.scheduleRetry()
 		return err
 	}
 	c.elements = elementsToKeep

--- a/go-controller/pkg/node/nftelementmanager/nft_element_manager.go
+++ b/go-controller/pkg/node/nftelementmanager/nft_element_manager.go
@@ -25,7 +25,12 @@ type Controller struct {
 	mu        sync.Mutex
 	elements  []element
 	ownedMaps sets.Set[string]
+	// failedRetryPeriod is how long to wait after a failed reconcile before
+	// retrying. Zero uses nftFailedReconcileRetry. Tests may override.
+	failedRetryPeriod time.Duration
 }
+
+const nftFailedReconcileRetry = time.Second
 
 func NewController() *Controller {
 	return &Controller{
@@ -34,21 +39,47 @@ func NewController() *Controller {
 	}
 }
 
-// Run periodically reconciles nftables elements, including owned-map cleanup
+// Run periodically reconciles nftables elements, including owned-map cleanup.
+// Immediate Add/Delete already reconcile; this loop is a safety net. If a
+// reconcile fails, retry quickly instead of waiting for the next full period
+// (which is 6 minutes for EgressIP SNAT and caused multi-minute gaps in
+// OCPBUGS-113693).
 func (c *Controller) Run(stopCh <-chan struct{}, syncPeriod time.Duration) {
 	ticker := time.NewTicker(syncPeriod)
 	defer ticker.Stop()
+	retryAfter := c.failedRetryPeriod
+	if retryAfter <= 0 {
+		retryAfter = nftFailedReconcileRetry
+	}
+	retryTimer := time.NewTimer(time.Hour)
+	retryTimer.Stop()
+	defer retryTimer.Stop()
+
+	tryReconcile := func() {
+		c.mu.Lock()
+		err := c.fullReconcile()
+		c.mu.Unlock()
+		if err != nil {
+			klog.Errorf("NFT element manager: failed to reconcile (retry in %s): %v", retryAfter, err)
+			retryTimer.Reset(retryAfter)
+			return
+		}
+		if !retryTimer.Stop() {
+			select {
+			case <-retryTimer.C:
+			default:
+			}
+		}
+	}
 
 	for {
 		select {
 		case <-stopCh:
 			return
 		case <-ticker.C:
-			c.mu.Lock()
-			if err := c.fullReconcile(); err != nil {
-				klog.Errorf("NFT element manager: failed to reconcile (retry in %s): %v", syncPeriod.String(), err)
-			}
-			c.mu.Unlock()
+			tryReconcile()
+		case <-retryTimer.C:
+			tryReconcile()
 		}
 	}
 }

--- a/go-controller/pkg/node/nftelementmanager/nft_element_manager_test.go
+++ b/go-controller/pkg/node/nftelementmanager/nft_element_manager_test.go
@@ -8,6 +8,7 @@ package nftelementmanager
 
 import (
 	"context"
+	"time"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
@@ -266,6 +267,13 @@ var _ = ginkgo.Describe("NFT Element Manager", func() {
 
 			elems := listElements(fake, testMapV4)
 			gomega.Expect(elems).To(gomega.HaveLen(1))
+		})
+	})
+
+	ginkgo.Context("Run retry", func() {
+		ginkgo.It("uses a short retry period after reconcile failure instead of the full sync period", func() {
+			gomega.Expect(nftFailedReconcileRetry).To(gomega.BeNumerically("<", 6*time.Minute))
+			gomega.Expect(nftFailedReconcileRetry).To(gomega.Equal(time.Second))
 		})
 	})
 

--- a/go-controller/pkg/node/nftelementmanager/nft_element_manager_test.go
+++ b/go-controller/pkg/node/nftelementmanager/nft_element_manager_test.go
@@ -8,6 +8,8 @@ package nftelementmanager
 
 import (
 	"context"
+	"fmt"
+	"sync/atomic"
 	"time"
 
 	"github.com/onsi/ginkgo/v2"
@@ -274,6 +276,38 @@ var _ = ginkgo.Describe("NFT Element Manager", func() {
 		ginkgo.It("uses a short retry period after reconcile failure instead of the full sync period", func() {
 			gomega.Expect(nftFailedReconcileRetry).To(gomega.BeNumerically("<", 6*time.Minute))
 			gomega.Expect(nftFailedReconcileRetry).To(gomega.Equal(time.Second))
+		})
+
+		ginkgo.It("retries a failed Add from Run without waiting for the full sync period", func() {
+			orig := getNFTablesHelper
+			defer func() { getNFTablesHelper = orig }()
+
+			var fail atomic.Bool
+			fail.Store(true)
+			getNFTablesHelper = func() (knftables.Interface, error) {
+				if fail.Load() {
+					return nil, fmt.Errorf("nft temporarily unavailable")
+				}
+				return orig()
+			}
+
+			ctrl.failedRetryPeriod = 20 * time.Millisecond
+			stop := make(chan struct{})
+			defer close(stop)
+			go ctrl.Run(stop, time.Hour)
+
+			elem := &knftables.Element{
+				Map:   testMapV4,
+				Key:   []string{"10.0.0.1", "eth0"},
+				Value: []string{"192.168.1.1"},
+			}
+			gomega.Expect(ctrl.Add(elem)).To(gomega.HaveOccurred())
+			gomega.Expect(listElements(fake, testMapV4)).To(gomega.BeEmpty())
+
+			fail.Store(false)
+			gomega.Eventually(func() bool {
+				return hasElement(listElements(fake, testMapV4), testMapV4, []string{"10.0.0.1", "eth0"}, []string{"192.168.1.1"})
+			}, 2*time.Second, 20*time.Millisecond).Should(gomega.BeTrue())
 		})
 	})
 


### PR DESCRIPTION
## 📑 Description

Node-side SNAT for EgressIP on a secondary host interface can take about 1–8 minutes after assignment. Logical assignment is instant; the SNAT rule is not.

This patch makes ovnkube-node program that SNAT as soon as assignment is visible, and retry when the host link or nftables apply is not ready yet.

Fixes: OCPBUGS-113693

## Additional Information for reviewers

Three stacked node-side gaps produced the delay:

1. `onEIPUpdate` skipped status-only patches because `Generation` does not bump on assignment. SNAT waited for an unrelated pod/namespace event.
2. `processEIP` treated a missing secondary host link as success (`if !found { continue }`), so the workqueue did not retry while the VLAN/NMState link was still coming up.
3. A failed nftables reconcile waited for the 6-minute `Run()` safety-net ticker. After 15 workqueue retries (backoff cap 1 minute) the item was dropped, which matches the ~1m10s and 7–8 minute customer timestamps.

This is against `main` (nftables maps). 4.18 still uses iptables `EnsureRule` with the same 6-minute ticker, so the backport needs the status + missing-link retries plus the equivalent iptables retry.

OCPBUGS-112810 (drop leaking packets until SNAT exists) is complementary and does not make SNAT fast. Scale programming of 100+ EIPs remains [RFE-9532](https://redhat.atlassian.net/browse/RFE-9532) / OCPBUGS-89326.

## ✅ Checks

- [x] My code does not require changes to the documentation
- [x] My code requires tests
- [x] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI

## How to verify it

Unit tests (passed locally):

```
cd go-controller
go test -mod=vendor -count=1 -timeout 180s ./pkg/node/nftelementmanager ./pkg/node/controllers/egressip \
  -ginkgo.focus="EgressIP handler event filtering|NFT Element Manager|processEIP host-network retry"
```

- Handler queues on status-only updates and skips no-op Generation+status updates.
- `processEIP` returns a retriable error when the assigned EIP has no matching host interface.
- nft element manager failed-reconcile retry is 1s, not 6 minutes.

Manual / E2E: assign EgressIP on a secondary host VLAN (NMState). SNAT should appear on the egress node within 1–2 seconds of status assignment, including when the VLAN is not up at the first reconcile.

## Special notes for your reviewer

AI (Cursor) was used to implement the retry/status-update changes and unit tests. Root cause was matched against the 4.18 timestamps in OCPBUGS-113693 (assignment at 05:51:26, SNAT at 05:52:36 / 05:52:43).

Made with [Cursor](https://cursor.com)