### PR TITLE
[release-4.18] OCPBUGS-114016: Disable IGMP/MLD querier unless multicast is used

### DIFF
--- a/docs/features/multicast.md
+++ b/docs/features/multicast.md
@@ -129,15 +129,22 @@ lists is the switch that is configured to act as an IGMP querier - on OVN-K's
 case, the node's logical switches.
 
 For these membership requests to be allowed in the network, each node's logical
-switch's must declare themselves "multicast queriers", by using the
-`other_config:mcast_querier=true` option.
+switch must declare itself a "multicast querier" with
+`other_config:mcast_querier=true`.
 
-The `other_config:mcast_snoop=true` is also used so the logical switches can
-passively snoop IGMP query / report / leave packets transferred between the
-multicast hosts and switches to compute group membership.
+Snooping and the querier are separate knobs. `mcast_snoop=true` is what lets
+the switch watch IGMP query / report / leave packets and build group
+membership. The querier is the thing that *injects* those queries. We only
+set `mcast_querier=true` while at least one namespace has
+`k8s.ovn.org/multicast-enabled=true`. OpenShift always enables multicast
+support in ovn-kubernetes, so if we also leave the querier on all the time,
+ovn-controller keeps sending unused IGMP/MLD queries. Those get flooded to
+every local port on `br-int` and can exceed the OVS 4096 resubmit limit.
 
-Without these two options, multicast traffic would be treated as broadcast
-traffic, which forwards packets to all ports on the network.
+Without snooping, multicast is treated as broadcast and forwarded to every
+port. The snippets below are from a cluster that is actually using multicast
+(`mcast_querier=true`). If multicast support is on but no namespace has the
+annotation, you should see `mcast_querier=false`.
 
 Please refer to the following snippet featuring the node's logical swithes
 of a cluster with one control plane node, and two workers, to see these

--- a/go-controller/pkg/ovn/base_network_controller.go
+++ b/go-controller/pkg/ovn/base_network_controller.go
@@ -530,20 +530,27 @@ func (bnc *BaseNetworkController) createNodeLogicalSwitch(nodeName string, hostS
 		logicalSwitch.LoadBalancerGroup = []string{clusterLoadBalancerGroupUUID, switchLoadBalancerGroupUUID}
 	}
 
-	// If supported, enable IGMP/MLD snooping and querier on the node.
+	// If supported, enable IGMP/MLD snooping on the node. The querier is only
+	// enabled while at least one namespace has multicast enabled; otherwise
+	// ovn-controller injects unused IGMP/MLD queries that flood every local
+	// port and can exceed the OVS 4096 resubmit limit.
 	if bnc.multicastSupport {
 		logicalSwitch.OtherConfig["mcast_snoop"] = "true"
 
-		// Configure IGMP/MLD querier if the gateway IP address is known.
-		// Otherwise disable it.
+		// Configure IGMP/MLD querier source addresses if the gateway IP is known.
+		// Leave the querier disabled until a namespace actually uses multicast.
 		if v4Gateway != nil || v6Gateway != nil {
-			logicalSwitch.OtherConfig["mcast_querier"] = "true"
 			logicalSwitch.OtherConfig["mcast_eth_src"] = nodeLRPMAC.String()
 			if v4Gateway != nil {
 				logicalSwitch.OtherConfig["mcast_ip4_src"] = v4Gateway.String()
 			}
 			if v6Gateway != nil {
 				logicalSwitch.OtherConfig["mcast_ip6_src"] = util.HWAddrToIPv6LLA(nodeLRPMAC).String()
+			}
+			if bnc.hasMulticastEnabledNamespace() {
+				logicalSwitch.OtherConfig["mcast_querier"] = "true"
+			} else {
+				logicalSwitch.OtherConfig["mcast_querier"] = "false"
 			}
 		} else {
 			logicalSwitch.OtherConfig["mcast_querier"] = "false"

--- a/go-controller/pkg/ovn/base_network_controller_multicast.go
+++ b/go-controller/pkg/ovn/base_network_controller_multicast.go
@@ -1,10 +1,13 @@
 package ovn
 
 import (
+	"errors"
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
+
+	libovsdbclient "github.com/ovn-kubernetes/libovsdb/client"
 
 	libovsdbops "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdb/ops"
 	libovsdbutil "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdb/util"
@@ -269,6 +272,87 @@ func (bnc *BaseNetworkController) disableMulticast() error {
 	err = bnc.syncNsMulticast(map[string]bool{})
 	if err != nil {
 		return fmt.Errorf("unable to delete namespaced multicast objects: %v", err)
+	}
+	if err = bnc.syncNodeLogicalSwitchQueriers(false); err != nil {
+		return fmt.Errorf("unable to disable IGMP/MLD querier: %v", err)
+	}
+	return nil
+}
+
+// hasMulticastEnabledNamespace reports whether any namespace currently has
+// k8s.ovn.org/multicast-enabled=true. The cluster-wide multicast flag enables
+// snooping on every node switch; the querier should only run while a namespace
+// actually uses multicast.
+func (bnc *BaseNetworkController) hasMulticastEnabledNamespace() bool {
+	if bnc.watchFactory == nil {
+		return false
+	}
+	namespaces, err := bnc.watchFactory.GetNamespaces()
+	if err != nil {
+		klog.Warningf("Failed to list namespaces while checking multicast querier state: %v", err)
+		return false
+	}
+	for _, ns := range namespaces {
+		if isNamespaceMulticastEnabled(ns.Annotations) {
+			return true
+		}
+	}
+	return false
+}
+
+// syncNodeLogicalSwitchQueriers enables or disables the IGMP/MLD querier on
+// node logical switches that already have multicast snooping configured.
+// Switches without mcast_snoop are left unchanged (for example test fixtures
+// and switches that were never configured for multicast).
+func (bnc *BaseNetworkController) syncNodeLogicalSwitchQueriers(enableQuerier bool) error {
+	if bnc.watchFactory == nil {
+		return nil
+	}
+	want := "false"
+	if enableQuerier {
+		want = "true"
+	}
+
+	nodes, err := bnc.watchFactory.GetNodes()
+	if err != nil {
+		return fmt.Errorf("failed to list nodes while syncing IGMP/MLD querier: %w", err)
+	}
+
+	seen := sets.New[string]()
+	for _, node := range nodes {
+		switchName := bnc.GetNetworkScopedSwitchName(node.Name)
+		if seen.Has(switchName) {
+			continue
+		}
+		seen.Insert(switchName)
+
+		sw, err := libovsdbops.GetLogicalSwitch(bnc.nbClient, &nbdb.LogicalSwitch{Name: switchName})
+		if err != nil {
+			if errors.Is(err, libovsdbclient.ErrNotFound) {
+				continue
+			}
+			return fmt.Errorf("failed to get logical switch %s while syncing IGMP/MLD querier: %w", switchName, err)
+		}
+		if sw.OtherConfig["mcast_snoop"] != "true" {
+			continue
+		}
+		if sw.OtherConfig["mcast_querier"] == want {
+			continue
+		}
+		if enableQuerier && sw.OtherConfig["mcast_eth_src"] == "" {
+			klog.Warningf("Skipping IGMP/MLD querier enable on switch %s: querier source addresses are not configured", switchName)
+			continue
+		}
+		patch := &nbdb.LogicalSwitch{
+			Name: switchName,
+			OtherConfig: map[string]string{
+				"mcast_querier": want,
+			},
+		}
+		if err := libovsdbops.UpdateLogicalSwitchSetOtherConfig(bnc.nbClient, patch); err != nil {
+			return fmt.Errorf("failed to set mcast_querier=%s on switch %s: %w", want, switchName, err)
+		}
+		klog.Infof("Set mcast_querier=%s on logical switch %s", want, switchName)
 	}
 	return nil
 }

--- a/go-controller/pkg/ovn/base_network_controller_namespace.go
+++ b/go-controller/pkg/ovn/base_network_controller_namespace.go
@@ -202,6 +202,9 @@ func (bnc *BaseNetworkController) syncNamespaces(namespaces []interface{}) error
 		if err = bnc.syncNsMulticast(nsWithMulticast); err != nil {
 			return fmt.Errorf("error in syncing multicast for namespaces: %v", err)
 		}
+		if err = bnc.syncNodeLogicalSwitchQueriers(len(nsWithMulticast) > 0); err != nil {
+			return fmt.Errorf("error in syncing IGMP/MLD querier state: %v", err)
+		}
 	}
 	return nil
 }
@@ -230,7 +233,8 @@ func (bnc *BaseNetworkController) multicastUpdateNamespace(ns *corev1.Namespace,
 	if err != nil {
 		return err
 	}
-	return nil
+	// Enable the node IGMP/MLD querier only while multicast is in use.
+	return bnc.syncNodeLogicalSwitchQueriers(enabled || bnc.hasMulticastEnabledNamespace())
 }
 
 // Cleans up the multicast policy for this namespace if multicast was
@@ -241,6 +245,7 @@ func (bnc *BaseNetworkController) multicastDeleteNamespace(ns *corev1.Namespace,
 		if err := bnc.deleteMulticastAllowPolicy(ns.Name); err != nil {
 			return err
 		}
+		return bnc.syncNodeLogicalSwitchQueriers(bnc.hasMulticastEnabledNamespace())
 	}
 	return nil
 }

--- a/go-controller/pkg/ovn/multicast_test.go
+++ b/go-controller/pkg/ovn/multicast_test.go
@@ -258,6 +258,32 @@ func getNodeData(netInfo util.NetInfo, nodeName string) []libovsdb.TestData {
 	}
 }
 
+func getNodeDataWithQuerier(netInfo util.NetInfo, nodeName, querier string) []libovsdb.TestData {
+	switchName := netInfo.GetNetworkScopedSwitchName(nodeName)
+	return []libovsdb.TestData{
+		&nbdb.LogicalSwitch{
+			UUID: switchName + "_UUID",
+			Name: switchName,
+			OtherConfig: map[string]string{
+				"mcast_snoop":   "true",
+				"mcast_querier": querier,
+				"mcast_eth_src": "0a:58:0a:80:00:01",
+				"mcast_ip4_src": "10.128.0.1",
+			},
+		},
+	}
+}
+
+func expectNodeSwitchQuerier(fakeOvn *FakeOVN, netInfo util.NetInfo, nodeName, want string) {
+	Eventually(func() string {
+		sw, err := libovsdbops.GetLogicalSwitch(fakeOvn.nbClient, &nbdb.LogicalSwitch{Name: netInfo.GetNetworkScopedSwitchName(nodeName)})
+		if err != nil {
+			return ""
+		}
+		return sw.OtherConfig["mcast_querier"]
+	}).Should(Equal(want))
+}
+
 func newNodeWithNad(nad *nadapi.NetworkAttachmentDefinition, networkName, networkID string) *corev1.Node {
 	n := newNode(nodeName, "192.168.126.202/24")
 	if nad != nil {
@@ -951,6 +977,98 @@ var _ = Describe("OVN Multicast with IP Address Family", func() {
 			Entry("IPv6", false, true, nil),
 			Entry("[Network Segmentation] IPv4", true, false, nadFromIPMode(namespaceName1, true, false)),
 			Entry("[Network Segmentation] IPv6", false, true, nadFromIPMode(namespaceName1, false, true)),
+		)
+	})
+
+	Context("IGMP querier", func() {
+		DescribeTable("disables the querier on existing node switches when no namespace uses multicast", func(useIPv4, useIPv6 bool, nad *nadapi.NetworkAttachmentDefinition) {
+			app.Action = func(*cli.Context) error {
+				config.IPv4Mode = useIPv4
+				config.IPv6Mode = useIPv6
+
+				netInfo := getNetInfoFromNAD(nad)
+				node := newNodeWithNad(nad, networkName, networkID)
+				namespace1 := *newNamespace(namespaceName1)
+				if nad != nil {
+					namespace1 = *newUDNNamespace(namespaceName1)
+				}
+
+				objs := []runtime.Object{
+					&corev1.NamespaceList{Items: []corev1.Namespace{namespace1}},
+					&corev1.NodeList{Items: []corev1.Node{*node}},
+				}
+				if nad != nil {
+					objs = append(objs, &nadapi.NetworkAttachmentDefinitionList{
+						Items: []nadapi.NetworkAttachmentDefinition{*nad},
+					})
+				}
+
+				fakeOvn.startWithDBSetup(libovsdb.TestSetup{NBData: getNodeDataWithQuerier(netInfo, nodeName, "true")}, objs...)
+				if nad != nil {
+					Expect(fakeOvn.networkManager.Start()).To(Succeed())
+					defer fakeOvn.networkManager.Stop()
+				}
+				bnc, _ := startBaseNetworkController(fakeOvn, nad)
+				Expect(bnc.WatchNamespaces()).To(Succeed())
+				expectNodeSwitchQuerier(fakeOvn, netInfo, nodeName, "false")
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			Expect(err).NotTo(HaveOccurred())
+		},
+			Entry("IPv4", true, false, nil),
+			Entry("[Network Segmentation] IPv4", true, false, nadFromIPMode(namespaceName1, true, false)),
+		)
+
+		DescribeTable("enables and disables the querier with the namespace annotation", func(useIPv4, useIPv6 bool, nad *nadapi.NetworkAttachmentDefinition) {
+			app.Action = func(*cli.Context) error {
+				config.IPv4Mode = useIPv4
+				config.IPv6Mode = useIPv6
+
+				netInfo := getNetInfoFromNAD(nad)
+				node := newNodeWithNad(nad, networkName, networkID)
+				namespace1 := *newNamespace(namespaceName1)
+				if nad != nil {
+					namespace1 = *newUDNNamespace(namespaceName1)
+				}
+
+				objs := []runtime.Object{
+					&corev1.NamespaceList{Items: []corev1.Namespace{namespace1}},
+					&corev1.NodeList{Items: []corev1.Node{*node}},
+				}
+				if nad != nil {
+					objs = append(objs, &nadapi.NetworkAttachmentDefinitionList{
+						Items: []nadapi.NetworkAttachmentDefinition{*nad},
+					})
+				}
+
+				fakeOvn.startWithDBSetup(libovsdb.TestSetup{NBData: getNodeDataWithQuerier(netInfo, nodeName, "false")}, objs...)
+				if nad != nil {
+					Expect(fakeOvn.networkManager.Start()).To(Succeed())
+					defer fakeOvn.networkManager.Stop()
+				}
+				bnc, _ := startBaseNetworkController(fakeOvn, nad)
+				Expect(bnc.WatchNamespaces()).To(Succeed())
+				expectNodeSwitchQuerier(fakeOvn, netInfo, nodeName, "false")
+
+				ns, err := fakeOvn.fakeClient.KubeClient.CoreV1().Namespaces().Get(context.TODO(), namespace1.Name, metav1.GetOptions{})
+				Expect(err).To(Succeed())
+				updateMulticast(fakeOvn, ns, true)
+				expectNodeSwitchQuerier(fakeOvn, netInfo, nodeName, "true")
+
+				ns, err = fakeOvn.fakeClient.KubeClient.CoreV1().Namespaces().Get(context.TODO(), namespace1.Name, metav1.GetOptions{})
+				Expect(err).To(Succeed())
+				updateMulticast(fakeOvn, ns, false)
+				expectNodeSwitchQuerier(fakeOvn, netInfo, nodeName, "false")
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			Expect(err).NotTo(HaveOccurred())
+		},
+			Entry("IPv4", true, false, nil),
+			Entry("[Network Segmentation] IPv4", true, false, nadFromIPMode(namespaceName1, true, false)),
 		)
 	})
 })


### PR DESCRIPTION
OCPBUGS-114016

This is the leftover of the ARP/GARP 4096 work (OCPBUGS-85627). After 4.18.53 the unicast ARP/GARP warnings on `br-int` are gone. IGMP Membership Queries still hit the same OVS hard limit and get dropped.

On a dense cluster (the report had ~321 namespaces and a lot of pods) ovn-controller periodically injects IGMPv3 general queries. The ofproto log looks like:

```
over 4096 resubmit actions on bridge br-int while processing
ip,in_port=CONTROLLER,dl_dst=01:00:5e:00:00:01,nw_src=10.131.72.1,nw_dst=224.0.0.1,nw_proto=2,...
sending OFPFMFC_UNKNOWN error reply to OFPT_PACKET_OUT message
```

`in_port=CONTROLLER` is the important part: this is not a pod packet. OVN pinctrl is acting as the local IGMP/MLD querier. `nw_src` is the node logical-router port (`mcast_ip4_src`). Destination is `224.0.0.1` / `01:00:5e:00:00:01`. Those packet-outs are flooded to every local port on `br-int`. Nested resubmits go over 4096 and OVS replies `OFPFMFC_UNKNOWN` to the `OFPT_PACKET_OUT`.

OpenShift hits this even on clusters that never use multicast. ovn-kubernetes has a cluster-wide multicast-support flag; upstream that can be off, but OpenShift always turns it on. `createNodeLogicalSwitch` was therefore setting both `mcast_snoop=true` and `mcast_querier=true` on every node switch as soon as the gateway IP was known.

Snooping is cheap and we want it. The querier is the expensive part: it is what injects the queries. It was running even when no namespace had `k8s.ovn.org/multicast-enabled=true`. Most OpenShift clusters never opt into multicast, so every node was generating unused queries all the time.

This patch keeps snooping as-is when multicast support is enabled. It only sets `other_config:mcast_querier=true` while at least one namespace currently has the multicast annotation.

That is wired in three places:

- new node switches (`createNodeLogicalSwitch`)
- namespace multicast enable / disable / delete
- namespace sync, so existing switches get corrected without waiting for a node recreate

`syncNodeLogicalSwitchQueriers` only touches switches that already have `mcast_snoop=true`. If querier source addresses are missing we log and skip rather than turning the querier on half-configured.

If someone actually annotates a namespace for multicast, the querier comes back on. In that case the same flood path can still hit 4096. The datapath fix belongs in OVN (inject local queries with `MC_FLOOD_L2` instead of `MC_FLOOD`) and has to go through FDP, not this repo. This PR does not turn multicast support off; it only gates the querier.

How to test
Unit tests:

```
go test ./pkg/ovn -ginkgo.focus "IGMP querier"
```

That covers an existing node switch with the querier already on and no annotated namespace (should go `mcast_querier=false`), and annotate / unannotate a namespace (querier should flip true then false). Default network and UDN/network-segmentation IPv4 are both in the table.

On a 4.18 cluster with multicast support on and no `k8s.ovn.org/multicast-enabled` namespaces:

```
ovn-nbctl get logical_switch <node> other_config:mcast_snoop
ovn-nbctl get logical_switch <node> other_config:mcast_querier
```

Snoop should still be true. Querier should be false. The IGMP `in_port=CONTROLLER` 4096 warnings should stop.

Then annotate one namespace with `k8s.ovn.org/multicast-enabled=true`, confirm querier goes true and multicast still works, and remove the last annotation to confirm the querier goes false again.