### PR TITLE
[Testing] DS ocpbugs-85540 EgressIP: Fix cache desync causing stale allocations and cloud retry storms - Split Changes

### DIFF
--- a/go-controller/pkg/clustermanager/egressip_controller.go
+++ b/go-controller/pkg/clustermanager/egressip_controller.go
@@ -1046,6 +1046,18 @@ func (eIPC *egressIPClusterController) reconcileEgressIP(old, new *egressipv1.Eg
 	statusToAdd := make([]egressipv1.EgressIPStatusItem, 0, len(ipsToAssign))
 	statusToKeep := make([]egressipv1.EgressIPStatusItem, 0, len(validStatus))
 	for status := range validStatus {
+		// Check if node is still available before keeping assignment
+		node, err := eIPC.watchFactory.GetNode(status.Node)
+		if err != nil || (!util.PlatformTypeIsEgressIPCloudProvider() && !eIPC.isEgressNodeReady(node)) {
+			klog.Infof("EgressIP %s has assignment to unavailable node %s for IP %s, "+
+				"cleaning cache before reassignment",
+				name, status.Node, status.EgressIP)
+
+			// Clean cache to prevent reusing failed node
+			eIPC.deleteAllAllocatorEgressIPAssignments(name, status.EgressIP)
+			ipsToRemove.Insert(status.EgressIP)
+			continue
+		}
 		statusToKeep = append(statusToKeep, status)
 		ipsToAssign.Delete(status.EgressIP)
 	}

--- a/go-controller/pkg/clustermanager/egressip_controller.go
+++ b/go-controller/pkg/clustermanager/egressip_controller.go
@@ -814,15 +814,34 @@ func (eIPC *egressIPClusterController) addEgressNode(nodeName string) error {
 	return nil
 }
 
+// cleanAllocationsForNodeLocked removes all EgressIP allocations for a node without
+// removing the node from the cache. Used when a node loses the egress-assignable label
+// but may gain it again (graceful cleanup). Must be called with nodeAllocator.Lock held.
+func (eIPC *egressIPClusterController) cleanAllocationsForNodeLocked(nodeName string) {
+	if eNode, exists := eIPC.nodeAllocator.cache[nodeName]; exists {
+		// Clear all allocations for this node
+		eNode.allocations = make(map[string]string)
+	}
+}
+
+// deleteNodeForEgressLocked removes a node from the allocator cache and disconnects
+// its health client. Performs complete cleanup including allocations. Must be called
+// with nodeAllocator.Lock held to ensure atomicity with cache modifications.
+func (eIPC *egressIPClusterController) deleteNodeForEgressLocked(nodeName string) {
+	if eNode, exists := eIPC.nodeAllocator.cache[nodeName]; exists {
+		// Disconnect health client
+		eNode.healthClient.Disconnect()
+		// Remove node from cache (implicit cleanup of allocations)
+	}
+	delete(eIPC.nodeAllocator.cache, nodeName)
+}
+
 // deleteNodeForEgress remove the default allow logical router policies for the
 // node and removes the node from the allocator cache.
 func (eIPC *egressIPClusterController) deleteNodeForEgress(node *corev1.Node) {
 	eIPC.nodeAllocator.Lock()
-	if eNode, exists := eIPC.nodeAllocator.cache[node.Name]; exists {
-		eNode.healthClient.Disconnect()
-	}
-	delete(eIPC.nodeAllocator.cache, node.Name)
-	eIPC.nodeAllocator.Unlock()
+	defer eIPC.nodeAllocator.Unlock()
+	eIPC.deleteNodeForEgressLocked(node.Name)
 }
 
 func (eIPC *egressIPClusterController) deleteEgressNode(nodeName string) error {
@@ -830,7 +849,10 @@ func (eIPC *egressIPClusterController) deleteEgressNode(nodeName string) error {
 	klog.V(5).Infof("Egress node: %s about to be removed", nodeName)
 	// Since the node has been labelled as "not usable" for egress IP
 	// assignments we need to find all egress IPs which have an assignment to
-	// it, and move them elsewhere.
+	// it, and move them elsewhere. First, clean all allocations from the cache.
+	eIPC.nodeAllocator.Lock()
+	eIPC.cleanAllocationsForNodeLocked(nodeName)
+	eIPC.nodeAllocator.Unlock()
 	egressIPs, err := eIPC.kube.GetEgressIPs()
 	if err != nil {
 		return fmt.Errorf("unable to list EgressIPs, err: %v", err)

--- a/go-controller/pkg/clustermanager/egressip_controller.go
+++ b/go-controller/pkg/clustermanager/egressip_controller.go
@@ -915,6 +915,19 @@ func (eIPC *egressIPClusterController) deleteAllocatorEgressIPAssignmentIfExists
 	return ""
 }
 
+// deleteAllAllocatorEgressIPAssignments performs defensive cleanup of all allocations for an EgressIP
+// by iterating through all nodes in the cache and removing any allocation that matches the given
+// EgressIP name and IP address. This ensures stale cache entries are cleaned up completely.
+func (eIPC *egressIPClusterController) deleteAllAllocatorEgressIPAssignments(name, egressIP string) {
+	eIPC.nodeAllocator.Lock()
+	defer eIPC.nodeAllocator.Unlock()
+	for _, eNode := range eIPC.nodeAllocator.cache {
+		if egressIPName, exists := eNode.allocations[egressIP]; exists && egressIPName == name {
+			delete(eNode.allocations, egressIP)
+		}
+	}
+}
+
 // addAllocatorEgressIPAssignments adds the allocation to the cache, so that
 // they are tracked during the life-cycle of the cluster-manager controller.
 func (eIPC *egressIPClusterController) addAllocatorEgressIPAssignments(name string, statusAssignments []egressipv1.EgressIPStatusItem) {
@@ -967,6 +980,13 @@ func (eIPC *egressIPClusterController) reconcileEgressIP(old, new *egressipv1.Eg
 		}
 	} else {
 		eIPC.deallocMark(name)
+		// When processing deletion (new == nil), ensure complete cache cleanup
+		// to prevent stale entries from blocking EgressIP reassignments.
+		if old != nil {
+			for _, egressIP := range old.Spec.EgressIPs {
+				eIPC.deleteAllAllocatorEgressIPAssignments(name, egressIP)
+			}
+		}
 	}
 
 	// Validate the spec and use only the valid egress IPs when performing any

--- a/go-controller/pkg/clustermanager/egressip_controller.go
+++ b/go-controller/pkg/clustermanager/egressip_controller.go
@@ -821,10 +821,37 @@ func (eIPC *egressIPClusterController) addEgressNode(nodeName string) error {
 // cleanAllocationsForNodeLocked removes all EgressIP allocations for a node without
 // removing the node from the cache. Used when a node loses the egress-assignable label
 // but may gain it again (graceful cleanup). Must be called with nodeAllocator.Lock held.
+// This performs defensive cleanup by scanning ALL nodes and removing entries that match
+// IPs that were allocated to the target node, handling race conditions where allocations
+// may have been moved to other nodes before the lock was acquired.
 func (eIPC *egressIPClusterController) cleanAllocationsForNodeLocked(nodeName string) {
 	if eNode, exists := eIPC.nodeAllocator.cache[nodeName]; exists {
+		// Collect all IPs currently allocated to this node before clearing
+		// This allows us to defensively clean entries from other nodes that may
+		// reference the same IPs (handling race conditions)
+		ipsToClean := make([]string, 0)
+		for ip := range eNode.allocations {
+			ipsToClean = append(ipsToClean, ip)
+		}
+
 		// Clear all allocations for this node
 		eNode.allocations = make(map[string]string)
+
+		// Defensive cleanup: scan ALL nodes and remove entries that match the IPs
+		// that were on this node. This handles cases where allocations may have been
+		// moved to other nodes before the lock was acquired (race conditions).
+		for currentNodeName, currentNode := range eIPC.nodeAllocator.cache {
+			if currentNodeName == nodeName {
+				continue // Skip the target node, we already cleared it
+			}
+			for _, ipToClean := range ipsToClean {
+				if _, exists := currentNode.allocations[ipToClean]; exists {
+					klog.V(5).Infof("Defensive cleanup: removing allocation for IP %s from node %s (was also on %s)",
+						ipToClean, currentNodeName, nodeName)
+					delete(currentNode.allocations, ipToClean)
+				}
+			}
+		}
 	}
 }
 

--- a/go-controller/pkg/clustermanager/egressip_controller.go
+++ b/go-controller/pkg/clustermanager/egressip_controller.go
@@ -546,12 +546,16 @@ func (eIPC *egressIPClusterController) initEgressNodeReachability(objs []interfa
 	// with existing assignments from EgressIP statuses. This prevents duplicate IP
 	// assignments when two EgressIPs have the same IP in their specs but only one has
 	// it assigned in status (e.g., after control-plane restart or during initial sync).
+	// However, validate each assignment before adding to cache to prevent stale entries
+	// from causing errors after controller restart.
 	egressIPs, err := eIPC.kube.GetEgressIPs()
 	if err != nil {
 		return fmt.Errorf("unable to list EgressIPs, err: %v", err)
 	}
 	for _, egressIP := range egressIPs {
-		eIPC.ensureAllocatorEgressIPAssignments(egressIP)
+		if err := eIPC.ensureAllocatorEgressIPAssignments(egressIP); err != nil {
+			klog.Errorf("Failed to ensure EgressIP %s assignments during init: %v", egressIP.Name, err)
+		}
 	}
 
 	go eIPC.checkEgressNodesReachability()
@@ -1898,11 +1902,49 @@ func generateStatusPatchOp(statusItems []egressipv1.EgressIPStatusItem) jsonPatc
 
 // ensureAllocatorEgressIPAssignments adds EgressIP assignments to the allocator cache
 // if the EgressIP has status items. This is critical to prevent duplicate IP assignments
-// during restart when EgressIPs are processed in arbitrary order.
-func (eIPC *egressIPClusterController) ensureAllocatorEgressIPAssignments(egressIP *egressipv1.EgressIP) {
-	if len(egressIP.Status.Items) > 0 {
-		eIPC.addAllocatorEgressIPAssignments(egressIP.Name, egressIP.Status.Items)
+// during restart when EgressIPs are processed in arbitrary order. Validates that assigned
+// nodes exist and are ready before adding to cache, preventing stale entries from blocking
+// future allocations after controller restart.
+func (eIPC *egressIPClusterController) ensureAllocatorEgressIPAssignments(egressIP *egressipv1.EgressIP) error {
+	if len(egressIP.Status.Items) == 0 {
+		return nil
 	}
+
+	// Validate each status item before adding to cache
+	validAssignments := make([]egressipv1.EgressIPStatusItem, 0, len(egressIP.Status.Items))
+	for _, status := range egressIP.Status.Items {
+		// Verify node exists
+		node, err := eIPC.watchFactory.GetNode(status.Node)
+		if err != nil {
+			klog.Warningf("EgressIP %s has assignment to non-existent node %s for IP %s, skipping",
+				egressIP.Name, status.Node, status.EgressIP)
+			continue
+		}
+
+		// Verify node is ready (on non-cloud platforms)
+		if !util.PlatformTypeIsEgressIPCloudProvider() && !eIPC.isEgressNodeReady(node) {
+			klog.Warningf("EgressIP %s has assignment to unready node %s for IP %s, skipping",
+				egressIP.Name, status.Node, status.EgressIP)
+			continue
+		}
+
+		// Node is valid, keep this assignment
+		validAssignments = append(validAssignments, status)
+	}
+
+	// Add only valid assignments to cache
+	if len(validAssignments) > 0 {
+		eIPC.addAllocatorEgressIPAssignments(egressIP.Name, validAssignments)
+	}
+
+	// Log if we filtered out any invalid assignments
+	if len(validAssignments) < len(egressIP.Status.Items) {
+		klog.Infof("EgressIP %s: filtered %d invalid assignments (total: %d), added %d valid",
+			egressIP.Name, len(egressIP.Status.Items)-len(validAssignments),
+			len(egressIP.Status.Items), len(validAssignments))
+	}
+
+	return nil
 }
 
 // syncEgressIPMarkAllocator iterates over all existing EgressIPs. It builds a mark cache of existing marks stored on each

--- a/go-controller/pkg/clustermanager/egressip_controller.go
+++ b/go-controller/pkg/clustermanager/egressip_controller.go
@@ -947,8 +947,10 @@ func (eIPC *egressIPClusterController) deleteAllocatorEgressIPAssignmentIfExists
 func (eIPC *egressIPClusterController) deleteAllAllocatorEgressIPAssignments(name, egressIP string) {
 	eIPC.nodeAllocator.Lock()
 	defer eIPC.nodeAllocator.Unlock()
-	for _, eNode := range eIPC.nodeAllocator.cache {
+	for nodeName, eNode := range eIPC.nodeAllocator.cache {
 		if egressIPName, exists := eNode.allocations[egressIP]; exists && egressIPName == name {
+			klog.V(5).Infof("Deleting egress IP allocation from cache - node: %s, EIP name: %s, IP: %s",
+				nodeName, name, egressIP)
 			delete(eNode.allocations, egressIP)
 		}
 	}
@@ -1345,17 +1347,61 @@ func (eIPC *egressIPClusterController) assignEgressIPs(name string, egressIPs []
 				})
 				continue
 			} else {
-				eIPC.recorder.Eventf(
-					&corev1.ObjectReference{
-						Kind: "EgressIP",
-						Name: name,
-					},
-					corev1.EventTypeWarning,
-					"UnsupportedRequest",
-					"IP: %q for EgressIP: %s is already allocated for EgressIP: %s on %s", egressIP, name, status.Name, status.Node,
-				)
-				klog.Errorf("IP: %q for EgressIP: %s is already allocated for EgressIP: %s on %s", egressIP, name, status.Name, status.Node)
-				continue
+				// IP is allocated to a DIFFERENT EgressIP - could be stale if that
+				// EgressIP was deleted but cleanup raced with this assignment.
+				// Verify if the old EgressIP still exists before failing.
+				klog.V(5).Infof("IP: %q for EgressIP: %s appears allocated to EgressIP: %s on %s, verifying",
+					egressIP, name, status.Name, status.Node)
+
+				_, err := eIPC.kube.GetEgressIP(status.Name)
+				isDeleted := apierrors.IsNotFound(err)
+
+				if isDeleted {
+					// Old EgressIP doesn't exist - stale cache entry!
+					// This can happen during rapid delete+create cycles (e.g., during upgrade)
+					// when deletion cleanup hasn't completed before new EgressIP is assigned.
+					klog.Warningf("Detected stale cache entry: IP %q allocated to non-existent "+
+						"EgressIP %s, cleaning and retrying assignment for EgressIP %s",
+						egressIP, status.Name, name)
+
+					// Clean stale entry immediately (we already hold lock)
+					for nodeName, eNode := range eIPC.nodeAllocator.cache {
+						if egressIPName, exists := eNode.allocations[egressIP]; exists && egressIPName == status.Name {
+							klog.V(5).Infof("Deleting stale allocation - node: %s, IP: %s", nodeName, egressIP)
+							delete(eNode.allocations, egressIP)
+						}
+					}
+
+					// Refresh existingAllocations after cleanup
+					_, existingAllocations = eIPC.getSortedEgressData()
+
+					// Check if cleanup succeeded
+					if _, stillExists := existingAllocations[eIP.String()]; !stillExists {
+						klog.Infof("Successfully cleaned stale entry for IP %q, proceeding with assignment", egressIP)
+						// Fall through to normal assignment logic below
+					} else {
+						klog.Errorf("Failed to clean stale entry for IP %q, skipping assignment", egressIP)
+						continue
+					}
+				} else if err != nil {
+					// Unexpected error checking old EgressIP
+					klog.Errorf("Error verifying old EgressIP %s for IP %q: %v, skipping assignment",
+						status.Name, egressIP, err)
+					continue
+				} else {
+					// Old EgressIP still exists - genuine conflict!
+					eIPC.recorder.Eventf(
+						&corev1.ObjectReference{
+							Kind: "EgressIP",
+							Name: name,
+						},
+						corev1.EventTypeWarning,
+						"UnsupportedRequest",
+						"IP: %q for EgressIP: %s is already allocated for EgressIP: %s on %s", egressIP, name, status.Name, status.Node,
+					)
+					klog.Errorf("IP: %q for EgressIP: %s is already allocated for EgressIP: %s on %s", egressIP, name, status.Name, status.Node)
+					continue
+				}
 			}
 		}
 		// Egress IP for secondary host networks is only available on baremetal environments
@@ -1599,6 +1645,100 @@ func (eIPC *egressIPClusterController) reconcileCloudPrivateIPConfig(old, new *o
 	}
 	if new != nil {
 		newCloudPrivateIPConfig = new
+		// We should only proceed to setting things up for objects where the new
+		// object has the same .spec.node and .status.node, and assignment
+		// condition being true. However, if assignment FAILED, we must clean
+		// the cache to prevent retry storms.
+		if len(newCloudPrivateIPConfig.Status.Conditions) > 0 {
+			cond := newCloudPrivateIPConfig.Status.Conditions[0]
+
+			// Check for assignment failure (e.g., PrivateIpAddressLimitExceeded)
+			if ocpcloudnetworkapi.CloudPrivateIPConfigConditionType(cond.Type) == ocpcloudnetworkapi.Assigned &&
+				corev1.ConditionStatus(cond.Status) == corev1.ConditionFalse {
+
+				// Extract EgressIP name from owner annotation
+				egressIPName, exists := newCloudPrivateIPConfig.Annotations[util.OVNEgressIPOwnerRefLabel]
+				if exists {
+					klog.Warningf("CloudPrivateIPConfig %s failed assignment on node %s: %s (reason: %s), "+
+						"cleaning cache to prevent retry storm for EgressIP %s",
+						newCloudPrivateIPConfig.Name, newCloudPrivateIPConfig.Spec.Node,
+						cond.Message, cond.Reason, egressIPName)
+
+					egressIPString := cloudPrivateIPConfigNameToIPString(newCloudPrivateIPConfig.Name)
+					// Clean stale cache entry to prevent retrying same failed node
+					eIPC.deleteAllAllocatorEgressIPAssignments(egressIPName, egressIPString)
+
+					// Trigger reallocation to a different node
+					egressIP, err := eIPC.kube.GetEgressIP(egressIPName)
+					if err != nil {
+						return fmt.Errorf("failed to get EgressIP %s for reallocation: %w", egressIPName, err)
+					}
+					if err := eIPC.reconcileEgressIP(nil, egressIP); err != nil {
+						return fmt.Errorf("failed to reconcile EgressIP %s after CPIC failure: %w", egressIPName, err)
+					}
+				} else {
+					klog.Warningf("CloudPrivateIPConfig %s failed but missing EgressIP owner annotation", newCloudPrivateIPConfig.Name)
+				}
+				return nil
+			}
+
+			// Handle spec/status node mismatch that can occur during upgrade.
+			// Mismatch happens when an EgressIP is deleted and recreated with the same IP
+			// while CloudPrivateIPConfig persists in cloud with stale node assignment.
+			// The cloud provider shows successful assignment (status=True) on a different
+			// node than requested (spec.node != status.node).
+			// Resolution: Accept cloud reality (status.node) and sync cache accordingly.
+			if ocpcloudnetworkapi.CloudPrivateIPConfigConditionType(cond.Type) == ocpcloudnetworkapi.Assigned &&
+				corev1.ConditionStatus(cond.Status) == corev1.ConditionTrue &&
+				newCloudPrivateIPConfig.Spec.Node != "" &&
+				newCloudPrivateIPConfig.Status.Node != "" &&
+				newCloudPrivateIPConfig.Spec.Node != newCloudPrivateIPConfig.Status.Node {
+
+				egressIPName, exists := newCloudPrivateIPConfig.Annotations[util.OVNEgressIPOwnerRefLabel]
+				if !exists {
+					// No owner annotation - log warning but don't retry
+					klog.Warningf("CloudPrivateIPConfig %s has spec/status node mismatch "+
+						"(spec=%s, status=%s) but missing EgressIP owner annotation",
+						newCloudPrivateIPConfig.Name,
+						newCloudPrivateIPConfig.Spec.Node,
+						newCloudPrivateIPConfig.Status.Node)
+					return nil
+				}
+
+				klog.Warningf("CloudPrivateIPConfig %s spec/status node mismatch detected: "+
+					"spec.node=%s but status.node=%s (status=True) for EgressIP %s. "+
+					"Accepting cloud reality and syncing cache to status.node.",
+					newCloudPrivateIPConfig.Name,
+					newCloudPrivateIPConfig.Spec.Node,
+					newCloudPrivateIPConfig.Status.Node,
+					egressIPName)
+
+				egressIPString := cloudPrivateIPConfigNameToIPString(newCloudPrivateIPConfig.Name)
+				// Strategy: Accept cloud reality (status.node) to minimize disruption
+				// Clean cache entry on spec.node (where we THOUGHT it should be)
+				eIPC.deleteAllAllocatorEgressIPAssignments(egressIPName, egressIPString)
+
+				// Trigger reconciliation to sync cache to actual cloud state (status.node)
+				egressIP, err := eIPC.kube.GetEgressIP(egressIPName)
+				if err != nil {
+					if apierrors.IsNotFound(err) {
+						// EgressIP was deleted - this is expected during cleanup
+						klog.Infof("EgressIP %s not found during spec/status mismatch reconciliation, likely deleted", egressIPName)
+						return nil
+					}
+					return fmt.Errorf("failed to get EgressIP %s for spec/status mismatch reconciliation: %w", egressIPName, err)
+				}
+
+				// Reconcile to update cache to match reality
+				if err := eIPC.reconcileEgressIP(nil, egressIP); err != nil {
+					return fmt.Errorf("failed to reconcile EgressIP %s after spec/status node mismatch: %w", egressIPName, err)
+				}
+
+				// Return nil to skip normal processing (we've handled it)
+				return nil
+			}
+		}
+
 		// We should only proceed to setting things up for objects where the new
 		// object has the same .spec.node and .status.node, and assignment
 		// condition being true. This is how the cloud-network-config-controller

--- a/go-controller/pkg/clustermanager/egressip_controller_test.go
+++ b/go-controller/pkg/clustermanager/egressip_controller_test.go
@@ -2559,7 +2559,7 @@ var _ = ginkgo.Describe("OVN cluster-manager EgressIP Operations", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		})
 
-		ginkgo.It("should not be able to allocate conflicting compressed IP", func() {
+		ginkgo.It("should clean stale compressed IP allocation and assign successfully", func() {
 			app.Action = func(*cli.Context) error {
 				egressIP := "::feff:c0a8:8e32"
 				node1IPv4 := ""
@@ -2622,6 +2622,7 @@ var _ = ginkgo.Describe("OVN cluster-manager EgressIP Operations", func() {
 					&egressipv1.EgressIPList{Items: []egressipv1.EgressIP{eIP}},
 				)
 
+				// Pre-populate cache with stale entries (bogus1/2/3 don't exist as EgressIP objects)
 				egressNode1 := setupNode(node1Name, []string{"0:0:0:0:0:feff:c0a8:8e0c/64"}, map[string]string{"0:0:0:0:0:feff:c0a8:8e32": "bogus1", "0:0:0:0:0:feff:c0a8:8e1e": "bogus2"})
 				egressNode2 := setupNode(node2Name, []string{"0:0:0:0:0:fedf:c0a8:8e0c/64"}, map[string]string{"0:0:0:0:0:feff:c0a8:8e23": "bogus3"})
 
@@ -2629,7 +2630,11 @@ var _ = ginkgo.Describe("OVN cluster-manager EgressIP Operations", func() {
 				fakeClusterManagerOVN.eIPC.nodeAllocator.cache[egressNode2.name] = &egressNode2
 
 				assignedStatuses := fakeClusterManagerOVN.eIPC.assignEgressIPs(eIP.Name, eIP.Spec.EgressIPs)
-				gomega.Expect(assignedStatuses).To(gomega.BeEmpty())
+
+				gomega.Expect(assignedStatuses).To(gomega.HaveLen(1))
+				gomega.Expect(assignedStatuses[0].Node).To(gomega.Equal(node2Name))
+				gomega.Expect(assignedStatuses[0].EgressIP).To(gomega.Equal(egressIP))
+
 				return nil
 			}
 
@@ -3467,6 +3472,127 @@ var _ = ginkgo.Describe("OVN cluster-manager EgressIP Operations", func() {
 				}).Should(gomega.Succeed())
 				return nil
 			}
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+
+		// Disabled: fake CNCC always overwrites CPIC status to match spec,
+		// so we cannot simulate a persistent spec/status node mismatch.
+		ginkgo.XIt("ensure egressIP is assigned when cloud private ip config has spec/status node mismatch", func() {
+			app.Action = func(*cli.Context) error {
+				config.Kubernetes.PlatformType = string(ocpconfigapi.AWSPlatformType)
+				node1IPv4 := "192.168.126.12/24"
+				node2IPv4 := "192.168.126.51/24"
+				egressIP := "192.168.126.101"
+
+				node1 := corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: node1Name,
+						Annotations: map[string]string{
+							"k8s.ovn.org/node-primary-ifaddr": fmt.Sprintf("{\"ipv4\": \"%s\", \"ipv6\": \"%s\"}", node1IPv4, ""),
+							"k8s.ovn.org/node-subnets":        fmt.Sprintf("{\"default\":[\"%s\", \"%s\"]}", v4NodeSubnet, v6NodeSubnet),
+							util.OVNNodeHostCIDRs:             fmt.Sprintf("[\"%s\"]", node1IPv4),
+						},
+						Labels: map[string]string{
+							"k8s.ovn.org/egress-assignable": "",
+						},
+					},
+					Status: corev1.NodeStatus{
+						Conditions: []corev1.NodeCondition{
+							{
+								Type:   corev1.NodeReady,
+								Status: corev1.ConditionTrue,
+							},
+						},
+					},
+				}
+
+				node2 := corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: node2Name,
+						Annotations: map[string]string{
+							"k8s.ovn.org/node-primary-ifaddr": fmt.Sprintf("{\"ipv4\": \"%s\", \"ipv6\": \"%s\"}", node2IPv4, ""),
+							"k8s.ovn.org/node-subnets":        fmt.Sprintf("{\"default\": [\"%s\",\"%s\"]}", v4NodeSubnet, v6NodeSubnet),
+							util.OVNNodeHostCIDRs:             fmt.Sprintf("[\"%s\"]", node2IPv4),
+						},
+						Labels: map[string]string{
+							"k8s.ovn.org/egress-assignable": "",
+						},
+					},
+					Status: corev1.NodeStatus{
+						Conditions: []corev1.NodeCondition{
+							{
+								Type:   corev1.NodeReady,
+								Status: corev1.ConditionTrue,
+							},
+						},
+					},
+				}
+
+				egressNode1 := setupNode(node1Name, []string{node1IPv4}, map[string]string{})
+				egressNode2 := setupNode(node2Name, []string{node2IPv4}, map[string]string{})
+
+				eIP := egressipv1.EgressIP{
+					ObjectMeta: newEgressIPMeta(egressIPName),
+					Spec: egressipv1.EgressIPSpec{
+						EgressIPs: []string{egressIP},
+					},
+				}
+
+				// CPIC with spec/status node mismatch: controller wants node2, cloud has it on node1
+				cloudPrivateIPConfig := ocpcloudnetworkapi.CloudPrivateIPConfig{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: egressIP,
+						Annotations: map[string]string{
+							util.OVNEgressIPOwnerRefLabel: egressIPName,
+						},
+					},
+					Spec: ocpcloudnetworkapi.CloudPrivateIPConfigSpec{
+						Node: node2Name, // Controller wants this node
+					},
+					Status: ocpcloudnetworkapi.CloudPrivateIPConfigStatus{
+						Node: node1Name, // Cloud has it on this node (MISMATCH!)
+						Conditions: []metav1.Condition{
+							{
+								Status: metav1.ConditionTrue,
+								Type:   string(ocpcloudnetworkapi.Assigned),
+							},
+						},
+					},
+				}
+
+				fakeClusterManagerOVN.start(
+					&egressipv1.EgressIPList{
+						Items: []egressipv1.EgressIP{eIP},
+					},
+					&ocpcloudnetworkapi.CloudPrivateIPConfigList{
+						Items: []ocpcloudnetworkapi.CloudPrivateIPConfig{cloudPrivateIPConfig},
+					},
+					&corev1.NodeList{
+						Items: []corev1.Node{node1, node2},
+					},
+				)
+
+				fakeClusterManagerOVN.eIPC.nodeAllocator.cache[egressNode1.name] = &egressNode1
+				fakeClusterManagerOVN.eIPC.nodeAllocator.cache[egressNode2.name] = &egressNode2
+
+				_, err := fakeClusterManagerOVN.eIPC.WatchEgressIP()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				_, err = fakeClusterManagerOVN.eIPC.WatchCloudPrivateIPConfig()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				gomega.Eventually(getEgressIPStatusLen(egressIPName)).Should(gomega.Equal(1))
+				egressIPs, nodes := getEgressIPStatus(egressIPName)
+				gomega.Expect(nodes[0]).To(gomega.Equal(node1Name))
+				gomega.Expect(egressIPs[0]).To(gomega.Equal(egressIP))
+
+				gomega.Expect(egressNode1.allocations).To(gomega.HaveKey(egressIP))
+				gomega.Expect(egressNode1.allocations[egressIP]).To(gomega.Equal(egressIPName))
+				gomega.Expect(egressNode2.allocations).NotTo(gomega.HaveKey(egressIP))
+
+				return nil
+			}
+
 			err := app.Run([]string{app.Name})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		})
@@ -4463,16 +4589,18 @@ var _ = ginkgo.Describe("OVN cluster-manager EgressIP Operations", func() {
 				_, err = fakeClusterManagerOVN.eIPC.WatchEgressIP()
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-				// eIP1 should keep its assignment (the IP was already assigned)
-				gomega.Eventually(getEgressIPStatusLen("egressip-1")).Should(gomega.Equal(1))
+				// eIP1 should keep its assignment (the IP was already assigned in status)
+				gomega.Eventually(getEgressIPStatusLen("egressip-1"), "2s").Should(gomega.Equal(1))
 				egressIPs1, nodes1 := getEgressIPStatus("egressip-1")
 				gomega.Expect(nodes1[0]).To(gomega.Equal(node1Name))
 				gomega.Expect(egressIPs1[0]).To(gomega.Equal(duplicateIP))
 
-				// eIP2 should NOT get the duplicate IP assigned (not even to node2) -
-				// it should remain unassigned because initEgressNodeReachability pre-populated the
-				// cache with eIP1's assignment
-				gomega.Eventually(getEgressIPStatusLen("egressip-2")).Should(gomega.Equal(0))
+				// eIP2 must NOT get the IP: eIP1 exists and legitimately owns it (not stale)
+				gomega.Consistently(getEgressIPStatusLen("egressip-2"), "2s").Should(gomega.Equal(0))
+
+				egressIPs1, nodes1 = getEgressIPStatus("egressip-1")
+				gomega.Expect(nodes1[0]).To(gomega.Equal(node1Name))
+				gomega.Expect(egressIPs1[0]).To(gomega.Equal(duplicateIP))
 
 				return nil
 			}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
US PR: https://github.com/ovn-kubernetes/ovn-kubernetes/pull/6896

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code does not require changes to the documentation
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] My code does not require tests
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
