### PR TITLE
CORENET-7495: node: move MCS-blocking nftables to openshift-ovn-kubernetes table

### DIFF
--- a/go-controller/pkg/node/OCP_HACKS.go
+++ b/go-controller/pkg/node/OCP_HACKS.go
@@ -23,7 +23,7 @@ const (
 )
 
 // cleanupLegacyMCSBlockIptRules best-effort deletes leftover host iptables MCS REJECT
-// rules from before the nftables migration (both --syn and legacy non--syn variants).
+// rules from before the nftables migration.
 func cleanupLegacyMCSBlockIptRules() {
 	var delRules []nodeipt.Rule
 	for _, protocol := range []iptables.Protocol{iptables.ProtocolIPv4, iptables.ProtocolIPv6} {
@@ -40,12 +40,6 @@ func cleanupLegacyMCSBlockIptRules() {
 						Table:    "filter",
 						Chain:    chain,
 						Args:     []string{"-p", "tcp", "-m", "tcp", "--dport", port, "--syn", "-j", "REJECT"},
-						Protocol: protocol,
-					},
-					nodeipt.Rule{
-						Table:    "filter",
-						Chain:    chain,
-						Args:     []string{"-p", "tcp", "-m", "tcp", "--dport", port, "-j", "REJECT"},
 						Protocol: protocol,
 					},
 				)

--- a/go-controller/pkg/node/OCP_HACKS.go
+++ b/go-controller/pkg/node/OCP_HACKS.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/coreos/go-iptables/iptables"
 
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/knftables"
 
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
@@ -49,10 +50,35 @@ func cleanupLegacyMCSBlockIptRules() {
 	_ = nodeipt.DelRules(delRules)
 }
 
+// cleanupLegacyMCSBlockNFTRulesFromSharedTable best-effort deletes leftover MCS-blocking
+// chains from the shared ovn-kubernetes nftables table after they were moved to the
+// openshift-ovn-kubernetes table.
+func cleanupLegacyMCSBlockNFTRulesFromSharedTable() {
+	nft, err := nodenft.GetNFTablesHelper()
+	if err != nil {
+		return
+	}
+
+	tx := nft.NewTransaction()
+	// Delete hooked chains first, then the shared chain they jump to.
+	for _, chain := range []string{mcsBlockingForwardChain, mcsBlockingOutputChain, mcsBlockingChain} {
+		tx.Add(&knftables.Chain{Name: chain})
+		tx.Flush(&knftables.Chain{Name: chain})
+		tx.Delete(&knftables.Chain{Name: chain})
+	}
+	if err := nft.Run(context.TODO(), tx); err != nil && !knftables.IsNotFound(err) {
+		klog.Warningf("Failed to clean up legacy MCS nftables chains from ovn-kubernetes table: %v", err)
+	}
+}
+
 // setupMCSBlockNFTRules inserts nftables rules to block local Machine Config Service
 // ports. See https://github.com/openshift/ovn-kubernetes/pull/170
 func setupMCSBlockNFTRules() error {
-	nft, err := nodenft.GetNFTablesHelper()
+	cleanupLegacyMCSBlockNFTRulesFromSharedTable()
+
+	// Use a separate OpenShift-specific table so these downstream-only rules don't end
+	// up in the shared "ovn-kubernetes" table (and thus in upstream unit test dumps).
+	nft, err := nodenft.GetOpenShiftNFTablesHelper()
 	if err != nil {
 		return fmt.Errorf("failed to setup MCS-blocking rules: %w", err)
 	}

--- a/go-controller/pkg/node/OCP_HACKS_test.go
+++ b/go-controller/pkg/node/OCP_HACKS_test.go
@@ -1,0 +1,81 @@
+//go:build linux
+// +build linux
+
+package node
+
+import (
+	"sigs.k8s.io/knftables"
+
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
+	nodenft "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/nftables"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// OCP HACK: expected MCS-blocking rules in the dedicated OpenShift nftables table.
+const nftablesRulesMCSOpenShift = `
+add table inet openshift-ovn-kubernetes
+add chain inet openshift-ovn-kubernetes mcs-blocking
+add rule inet openshift-ovn-kubernetes mcs-blocking tcp dport { 22623, 22624 } tcp flags syn / fin,syn,rst,ack reject
+add chain inet openshift-ovn-kubernetes mcs-blocking-output { type filter hook output priority 0 ; }
+add rule inet openshift-ovn-kubernetes mcs-blocking-output jump mcs-blocking
+add chain inet openshift-ovn-kubernetes mcs-blocking-forward { type filter hook forward priority 0 ; }
+add rule inet openshift-ovn-kubernetes mcs-blocking-forward jump mcs-blocking
+`
+
+var _ = Describe("OCP MCS-blocking nftables", func() {
+	assertMCSBlockNFTRules := func() {
+		GinkgoHelper()
+
+		err := setupMCSBlockNFTRules()
+		Expect(err).NotTo(HaveOccurred())
+
+		ocpNFT, err := nodenft.GetOpenShiftNFTablesHelper()
+		Expect(err).NotTo(HaveOccurred())
+
+		ocpFake, ok := ocpNFT.(*knftables.Fake)
+		Expect(ok).To(BeTrue(), "expected OpenShift nftables helper to be faked in unit tests")
+		err = nodenft.MatchNFTRules(nftablesRulesMCSOpenShift, ocpFake.Dump())
+		Expect(err).NotTo(HaveOccurred())
+
+		mainNFT, err := nodenft.GetNFTablesHelper()
+		Expect(err).NotTo(HaveOccurred())
+		mainFake, ok := mainNFT.(*knftables.Fake)
+		Expect(ok).To(BeTrue())
+		Expect(mainFake.Dump()).NotTo(ContainSubstring("mcs-blocking"),
+			"MCS rules must not appear in the shared ovn-kubernetes table")
+	}
+
+	It("installs MCS-blocking rules in the openshift-ovn-kubernetes table (IPv4-only)", func() {
+		oldIPv4Mode := config.IPv4Mode
+		oldIPv6Mode := config.IPv6Mode
+		defer func() {
+			config.IPv4Mode = oldIPv4Mode
+			config.IPv6Mode = oldIPv6Mode
+		}()
+
+		config.IPv4Mode = true
+		config.IPv6Mode = false
+		nodenft.SetFakeNFTablesHelper()
+
+		assertMCSBlockNFTRules()
+	})
+
+	It("installs MCS-blocking rules in the openshift-ovn-kubernetes table (dual-stack)", func() {
+		oldIPv4Mode := config.IPv4Mode
+		oldIPv6Mode := config.IPv6Mode
+		defer func() {
+			config.IPv4Mode = oldIPv4Mode
+			config.IPv6Mode = oldIPv6Mode
+		}()
+
+		config.IPv4Mode = true
+		config.IPv6Mode = true
+		nodenft.SetFakeNFTablesHelper()
+
+		assertMCSBlockNFTRules()
+	})
+})
+
+// END OCP HACK

--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -141,18 +141,6 @@ add rule inet ovn-kubernetes services-prerouting jump services-etp-no-nodeport
 add rule inet ovn-kubernetes services-prerouting jump services
 `
 
-// OCP HACK: Block MCS Access. https://github.com/openshift/ovn-kubernetes/pull/170
-const nftablesRulesMCS = `
-add chain inet ovn-kubernetes mcs-blocking
-add rule inet ovn-kubernetes mcs-blocking tcp dport { 22623, 22624 } tcp flags syn / fin,syn,rst,ack reject
-add chain inet ovn-kubernetes mcs-blocking-output { type filter hook output priority 0 ; }
-add rule inet ovn-kubernetes mcs-blocking-output jump mcs-blocking
-add chain inet ovn-kubernetes mcs-blocking-forward { type filter hook forward priority 0 ; }
-add rule inet ovn-kubernetes mcs-blocking-forward jump mcs-blocking
-`
-
-// END OCP HACK
-
 func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 	eth0Name, eth0MAC, eth0GWIP, eth0CIDR string, gatewayVLANID uint, l netlink.Link, hwOffload, setNodeIP bool) {
 	const mtu string = "1234"
@@ -552,7 +540,7 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 				"'k8s.ovn.org/gateway-mtu-support' with value == \"false\"")
 		}
 
-		expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices + nftablesRulesMCS
+		expectedNFT := nftablesRulesBase + nftablesRulesGatewayServices
 		err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 		Expect(err).NotTo(HaveOccurred())
 
@@ -1378,7 +1366,7 @@ OFPT_GET_CONFIG_REPLY (xid=0x4): frags=normal miss_send_len=0`
 		Expect(err).NotTo(HaveOccurred())
 		Eventually(fexec.CalledMatchesExpected, 5).Should(BeTrue(), fexec.ErrorDesc)
 
-		expectedNFT := nftablesRulesBase + nftablesRulesLocalGateway + nftablesRulesGatewayServices + nftablesRulesMCS
+		expectedNFT := nftablesRulesBase + nftablesRulesLocalGateway + nftablesRulesGatewayServices
 		if util.IsNetworkSegmentationSupportEnabled() {
 			expectedNFT += nftablesRulesUDN
 		}

--- a/go-controller/pkg/node/nftables/OCP_HACKS.go
+++ b/go-controller/pkg/node/nftables/OCP_HACKS.go
@@ -1,0 +1,58 @@
+//go:build linux
+// +build linux
+
+package nftables
+
+import (
+	"context"
+	"fmt"
+
+	"sigs.k8s.io/knftables"
+)
+
+// OCP HACK: OpenShift-specific (downstream-only) nftables rules — eg the MCS-blocking
+// rules set up by pkg/node/OCP_HACKS.go — live in their own "openshift-ovn-kubernetes"
+// table rather than the shared "ovn-kubernetes" table. Keeping them separate means they
+// don't show up in the table dumps checked by upstream unit tests, so we don't have to
+// carry downstream patches to those tests (which would otherwise cause repeated merge
+// conflicts on every downstream merge). See the review discussion on
+// https://github.com/openshift/ovn-kubernetes/pull/3383
+
+// OpenShiftNFTablesName is the name of the nftables table used for OpenShift-specific
+// (downstream-only) rules.
+const OpenShiftNFTablesName = "openshift-ovn-kubernetes"
+
+var ocpNFTHelper knftables.Interface
+
+// GetOpenShiftNFTablesHelper returns a knftables.Interface for the OpenShift-specific
+// "openshift-ovn-kubernetes" table. In unit tests, when GetNFTablesHelper has been faked,
+// this returns a matching fake interface; otherwise it creates a real one.
+func GetOpenShiftNFTablesHelper() (knftables.Interface, error) {
+	if ocpNFTHelper == nil {
+		base, err := GetNFTablesHelper()
+		if err != nil {
+			return nil, err
+		}
+
+		var nft knftables.Interface
+		if _, ok := base.(*knftables.Fake); ok {
+			nft = knftables.NewFake(knftables.InetFamily, OpenShiftNFTablesName)
+		} else {
+			nft, err = knftables.New(knftables.InetFamily, OpenShiftNFTablesName)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create OpenShift nftables helper: %w", err)
+			}
+		}
+
+		tx := nft.NewTransaction()
+		tx.Add(&knftables.Table{})
+		if err := nft.Run(context.TODO(), tx); err != nil {
+			return nil, fmt.Errorf("failed to initialize OpenShift nftables table: %w", err)
+		}
+
+		ocpNFTHelper = nft
+	}
+	return ocpNFTHelper, nil
+}
+
+// END OCP HACK


### PR DESCRIPTION
## Summary

Addresses review feedback from Dan Winship on https://github.com/openshift/ovn-kubernetes/pull/3383 (downstream-only OCP hacks).

- Drop the legacy non-`--syn` MCS iptables cleanup variant from `cleanupLegacyMCSBlockIptRules()`; only the `--syn` variant is still relevant for upgrades.
- Move MCS-blocking nftables rules into a separate `openshift-ovn-kubernetes` table via `SetFakeOpenShiftNFTablesHelper()` / `GetOpenShiftNFTablesHelper()`, mirroring the existing `helpers.go` pattern.
- Remove the downstream carry patch to `gateway_init_linux_test.go` (`nftablesRulesMCS`), eliminating a recurring downstream-merge conflict.

The new OpenShift table is intentionally not torn down by upstream `CleanupNFTables()` (per review: "nothing else should need to change").

Jira: https://redhat.atlassian.net/browse/CORENET-7495

## Test plan

- [x] `cd go-controller && go build ./pkg/node/...`
- [x] `go vet ./pkg/node/nftables/`
- [x] `gofmt -l` on touched files (clean)
- [x] `go test ./pkg/node/nftables/... -count=1`
- [x] `sudo go test ./pkg/node/ -run TestNodeSuite -count=1 -ginkgo.focus="sets up a (shared interface|local) gateway"` — 13/13 passed