### PR TITLE
[release-5.0] OCPBUGS-122282: egressip: set IFA_PROTO on EgressIP addresses to prevent nmstate persistence

### DIFF
--- a/go-controller/pkg/types/const.go
+++ b/go-controller/pkg/types/const.go
@@ -155,6 +155,13 @@ const (
 	// LabelUserDefinedServiceName label key used in mirrored EndpointSlices that contains the service name matching the EndpointSlice
 	LabelUserDefinedServiceName = "k8s.ovn.org/service-name"
 
+	// IFAProtOVNK is the IFA_PROTO value used to mark addresses as
+	// OVN-Kubernetes-managed. Value 85 is used instead of RTPROT_OVN (84)
+	// so we do not reuse a protocol identifier already owned by OVN.
+	// IFA_PROTO requires Linux kernel 5.18+; on older kernels the
+	// attribute is silently ignored.
+	IFAProtOVNK = 85
+
 	// Packet marking
 	EgressIPNodeConnectionMark         = "1008"
 	EgressIPReplyTrafficConnectionMark = 42

--- a/go-controller/pkg/util/egressip/net.go
+++ b/go-controller/pkg/util/egressip/net.go
@@ -10,11 +10,17 @@ import (
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
 
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
 )
 
 // GetNetlinkAddress returns a netlink address configured with specific
-// egress ip parameters
+// egress ip parameters. The address is marked with IFA_PROTO=85 (OVN-K)
+// to indicate it is managed by OVN-Kubernetes. This allows external tools
+// to identify and filter out OVN-Kubernetes-managed addresses when
+// capturing interface state.
+// Note: IFA_PROTO requires Linux kernel 5.18+; on older kernels, the
+// attribute is silently ignored.
 func GetNetlinkAddress(ip net.IP, ifindex int) *netlink.Addr {
 	return &netlink.Addr{
 		IPNet:     &net.IPNet{IP: ip, Mask: util.GetIPFullMask(ip)},
@@ -22,6 +28,7 @@ func GetNetlinkAddress(ip net.IP, ifindex int) *netlink.Addr {
 		Scope:     int(netlink.SCOPE_UNIVERSE),
 		ValidLft:  getNetlinkAddressValidLft(ip),
 		LinkIndex: ifindex,
+		Protocol:  types.IFAProtOVNK, // Mark as OVN-Kubernetes-managed for external tooling
 	}
 }
 

--- a/go-controller/pkg/util/egressip/net_test.go
+++ b/go-controller/pkg/util/egressip/net_test.go
@@ -1,0 +1,91 @@
+// SPDX-FileCopyrightText: Copyright The OVN-Kubernetes Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package egressip
+
+import (
+	"math"
+	"net"
+	"testing"
+
+	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
+
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
+)
+
+func TestGetNetlinkAddress(t *testing.T) {
+	tests := []struct {
+		name             string
+		ip               net.IP
+		ifindex          int
+		expectedProto    int
+		expectedScope    int
+		expectedMask     int
+		expectedFlags    int
+		expectedValidLft int
+	}{
+		{
+			name:             "IPv4 address",
+			ip:               net.ParseIP("192.168.1.100"),
+			ifindex:          5,
+			expectedProto:    types.IFAProtOVNK,
+			expectedScope:    int(netlink.SCOPE_UNIVERSE),
+			expectedMask:     32,
+			expectedFlags:    0,
+			expectedValidLft: 0,
+		},
+		{
+			name:             "IPv6 address",
+			ip:               net.ParseIP("2001:db8::1"),
+			ifindex:          10,
+			expectedProto:    types.IFAProtOVNK,
+			expectedScope:    int(netlink.SCOPE_UNIVERSE),
+			expectedMask:     128,
+			expectedFlags:    unix.IFA_F_NODAD,
+			expectedValidLft: math.MaxUint32,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			addr := GetNetlinkAddress(tt.ip, tt.ifindex)
+
+			// Verify Protocol is set to OVN-K (85)
+			if addr.Protocol != tt.expectedProto {
+				t.Errorf("Protocol = %d, want %d", addr.Protocol, tt.expectedProto)
+			}
+
+			// Verify Scope
+			if addr.Scope != tt.expectedScope {
+				t.Errorf("Scope = %d, want %d", addr.Scope, tt.expectedScope)
+			}
+
+			// Verify LinkIndex
+			if addr.LinkIndex != tt.ifindex {
+				t.Errorf("LinkIndex = %d, want %d", addr.LinkIndex, tt.ifindex)
+			}
+
+			// Verify IP
+			if !addr.IP.Equal(tt.ip) {
+				t.Errorf("IP = %v, want %v", addr.IP, tt.ip)
+			}
+
+			// Verify mask (should be full mask for EgressIP)
+			ones, _ := addr.Mask.Size()
+			if ones != tt.expectedMask {
+				t.Errorf("Mask prefix length = %d, want %d", ones, tt.expectedMask)
+			}
+
+			// Verify Flags
+			if addr.Flags != tt.expectedFlags {
+				t.Errorf("Flags = %d, want %d", addr.Flags, tt.expectedFlags)
+			}
+
+			// Verify ValidLft
+			if addr.ValidLft != tt.expectedValidLft {
+				t.Errorf("ValidLft = %d, want %d", addr.ValidLft, tt.expectedValidLft)
+			}
+		})
+	}
+}

--- a/test/e2e/egressip.go
+++ b/test/e2e/egressip.go
@@ -606,16 +606,12 @@ var _ = ginkgo.Describe("e2e egress IP validation", feature.EgressIP, func() {
 		// rt_addrprotos. IFA_PROTO requires Linux kernel 5.18+; on older kernels
 		// the attribute is silently ignored by the kernel and the ip CLI will not
 		// report a protocol field, so the check is skipped.
-		// EgressIP addresses are only assigned to node interfaces when both
-		// interconnect and network segmentation are enabled (see canHandleBridgeEgressIP
-		// in gateway.go); otherwise EgressIP is handled entirely through OVN logical
-		// flows and no Linux address is present on the node.
+		//
+		// Callers must only invoke this when a Linux address is expected:
+		// - secondary-host EIPs always assign the address on a host NIC
+		// - OVN-network EIPs assign the address on the gateway bridge only when
+		//   network segmentation is enabled (see canHandleBridgeEgressIP)
 		verifyEgressIPAddrProto := func(nodeName, eipAddr string) {
-			if !isInterconnectEnabled() || !isNetworkSegmentationEnabled() {
-				framework.Logf("Skipping IFA_PROTO check for EgressIP %s on node %s: EgressIP addresses are only assigned to node interfaces when interconnect and network segmentation are enabled", eipAddr, nodeName)
-				return
-			}
-
 			type ipAddrInfo struct {
 				Local    string `json:"local"`
 				Protocol string `json:"protocol"`
@@ -1067,8 +1063,12 @@ spec:
 					framework.ExpectNoError(err, "Step 4. Check connectivity from second to an external \"node\" and verify that the IPs are both of the above, failed: %v", err)
 
 					ginkgo.By("4a. Check that the EgressIP addresses have IFA_PROTO set to OVN-K (85)")
-					for _, status := range statuses {
-						verifyEgressIPAddrProto(status.Node, status.EgressIP)
+					// OVN-network EIPs are assigned on the gateway bridge only when
+					// network segmentation is enabled (canHandleBridgeEgressIP).
+					if isNetworkSegmentationEnabled() {
+						for _, status := range statuses {
+							verifyEgressIPAddrProto(status.Node, status.EgressIP)
+						}
 					}
 
 					ginkgo.By("5. Check connectivity from one pod to the other and verify that the connection is achieved")
@@ -1286,7 +1286,11 @@ spec:
 			framework.ExpectNoError(err, "Step 6. Check connectivity from pod to an external node and verify that the srcIP is the expected egressIP, failed: %v", err)
 
 			ginkgo.By("6a. Check that the EgressIP address has IFA_PROTO set to OVN-K (85)")
-			verifyEgressIPAddrProto(statuses[0].Node, statuses[0].EgressIP)
+			// OVN-network EIPs are assigned on the gateway bridge only when
+			// network segmentation is enabled (canHandleBridgeEgressIP).
+			if isNetworkSegmentationEnabled() {
+				verifyEgressIPAddrProto(statuses[0].Node, statuses[0].EgressIP)
+			}
 
 			ginkgo.By("7. Check connectivity from pod to another node primary IP and verify that the srcIP is the expected nodeIP")
 			err = wait.PollImmediate(retryInterval, retryTimeout, targetHostNetworkContainerAndTest(hostNetPod, podNamespace.Name, pod1Name, true, []string{egress1Node.nodeIP}))

--- a/test/e2e/egressip.go
+++ b/test/e2e/egressip.go
@@ -598,6 +598,61 @@ var _ = ginkgo.Describe("e2e egress IP validation", feature.EgressIP, func() {
 			return reflect.DeepEqual(eIPsFound, ips)
 		}
 
+		// verifyEgressIPAddrProto checks that the EgressIP address assigned on the
+		// node has IFA_PROTO set to 85 (OVN-K). Value 85 is used instead of
+		// RTPROT_OVN (84) so we do not reuse a protocol identifier owned by OVN.
+		// iproute2 renders unknown protocol numbers in hex, so protocol
+		// 85 appears as "0x55" in JSON output unless a name mapping exists in
+		// rt_addrprotos. IFA_PROTO requires Linux kernel 5.18+; on older kernels
+		// the attribute is silently ignored by the kernel and the ip CLI will not
+		// report a protocol field, so the check is skipped.
+		// EgressIP addresses are only assigned to node interfaces when both
+		// interconnect and network segmentation are enabled (see canHandleBridgeEgressIP
+		// in gateway.go); otherwise EgressIP is handled entirely through OVN logical
+		// flows and no Linux address is present on the node.
+		verifyEgressIPAddrProto := func(nodeName, eipAddr string) {
+			if !isInterconnectEnabled() || !isNetworkSegmentationEnabled() {
+				framework.Logf("Skipping IFA_PROTO check for EgressIP %s on node %s: EgressIP addresses are only assigned to node interfaces when interconnect and network segmentation are enabled", eipAddr, nodeName)
+				return
+			}
+
+			type ipAddrInfo struct {
+				Local    string `json:"local"`
+				Protocol string `json:"protocol"`
+			}
+			type ipAddrEntry struct {
+				AddrInfo []ipAddrInfo `json:"addr_info"`
+			}
+
+			// iproute2 renders unknown protocol numbers in hex (e.g. 85 -> "0x55").
+			expectedProtoHex := fmt.Sprintf("0x%x", types.IFAProtOVNK)
+
+			gomega.Eventually(func(g gomega.Gomega) {
+				output, err := infraprovider.Get().ExecK8NodeCommand(nodeName,
+					[]string{"ip", "-d", "-j", "addr", "show", "to", eipAddr})
+				g.Expect(err).NotTo(gomega.HaveOccurred(), "failed to get address info on node %s", nodeName)
+
+				var entries []ipAddrEntry
+				g.Expect(json.Unmarshal([]byte(output), &entries)).To(gomega.Succeed(), "failed to parse ip addr JSON")
+				g.Expect(entries).To(gomega.HaveLen(1), "expected a single interface entry for EgressIP %s on node %s", eipAddr, nodeName)
+
+				var ai *ipAddrInfo
+				for i, info := range entries[0].AddrInfo {
+					if info.Local == eipAddr {
+						ai = &entries[0].AddrInfo[i]
+						break
+					}
+				}
+				g.Expect(ai).NotTo(gomega.BeNil(), "EgressIP %s not found on node %s", eipAddr, nodeName)
+				if ai.Protocol == "" {
+					framework.Logf("IFA_PROTO not reported for EgressIP %s on node %s; kernel may not support IFA_PROTO (requires 5.18+), skipping check", eipAddr, nodeName)
+					return
+				}
+				g.Expect(ai.Protocol).To(gomega.Equal(expectedProtoHex),
+					"EgressIP %s on node %s should have IFA_PROTO 85/0x55 (OVN-K), got %q", eipAddr, nodeName, ai.Protocol)
+			}, 30*time.Second, 2*time.Second).Should(gomega.Succeed())
+		}
+
 		getIPVersions := func(ips ...string) (bool, bool) {
 			var v4, v6 bool
 			for _, ip := range ips {
@@ -1011,6 +1066,11 @@ spec:
 						podNamespace.Name, pod2Name, true, []string{egressIP1.String(), egressIP2.String()}))
 					framework.ExpectNoError(err, "Step 4. Check connectivity from second to an external \"node\" and verify that the IPs are both of the above, failed: %v", err)
 
+					ginkgo.By("4a. Check that the EgressIP addresses have IFA_PROTO set to OVN-K (85)")
+					for _, status := range statuses {
+						verifyEgressIPAddrProto(status.Node, status.EgressIP)
+					}
+
 					ginkgo.By("5. Check connectivity from one pod to the other and verify that the connection is achieved")
 					err = wait.PollImmediate(retryInterval, retryTimeout, targetPodAndTest(f.Namespace.Name, pod1Name, pod2Name, pod2IP, clusterNetworkHTTPPort))
 					framework.ExpectNoError(err, "Step 5. Check connectivity from one pod to the other and verify that the connection is achieved, failed, err: %v", err)
@@ -1224,6 +1284,9 @@ spec:
 			ginkgo.By("6. Check connectivity from pod to an external node and verify that the srcIP is the expected egressIP")
 			err = wait.PollImmediate(retryInterval, retryTimeout, targetExternalContainerAndTest(primaryTargetExternalContainer, podNamespace.Name, pod1Name, true, []string{egressIP1.String()}))
 			framework.ExpectNoError(err, "Step 6. Check connectivity from pod to an external node and verify that the srcIP is the expected egressIP, failed: %v", err)
+
+			ginkgo.By("6a. Check that the EgressIP address has IFA_PROTO set to OVN-K (85)")
+			verifyEgressIPAddrProto(statuses[0].Node, statuses[0].EgressIP)
 
 			ginkgo.By("7. Check connectivity from pod to another node primary IP and verify that the srcIP is the expected nodeIP")
 			err = wait.PollImmediate(retryInterval, retryTimeout, targetHostNetworkContainerAndTest(hostNetPod, podNamespace.Name, pod1Name, true, []string{egress1Node.nodeIP}))
@@ -2318,6 +2381,11 @@ spec:
 			framework.ExpectNoError(err, "Step 5. Check connectivity from pod (%s/%s) to an external container attached to "+
 				"a network that is a secondary host network and verify that the src IP is the expected egressIP, failed: %v", podNamespace.Name, pod2Name, err)
 
+			ginkgo.By("5a. Check that the EgressIP addresses have IFA_PROTO set to OVN-K (85)")
+			for _, status := range statuses {
+				verifyEgressIPAddrProto(status.Node, status.EgressIP)
+			}
+
 			ginkgo.By("6. Check connectivity from one pod to the other and verify that the connection is achieved")
 			pod2IP, err := getPodIPWithRetry(f.ClientSet, isIPv6TestRun, f.Namespace.Name, pod2Name)
 			framework.ExpectNoError(err, "Step 6. Check connectivity from one pod to the other and verify that the connection "+
@@ -3037,6 +3105,9 @@ spec:
 			status := verifyEgressIPStatusLengthEquals(1, nil)
 			inf, err = infraprovider.Get().GetK8NodeNetworkInterface(status[0].Node, secondaryNetwork)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "should have network interface for network %s on instance %s", secondaryNetwork.Name(), egress1Node.name)
+
+			ginkgo.By("Verifying EgressIP address has IFA_PROTO set to OVN-K (85)")
+			verifyEgressIPAddrProto(status[0].Node, status[0].EgressIP)
 
 			ginkgo.By("Verifying neighbor table")
 			var neighborMAC string


### PR DESCRIPTION
* main/5.1: https://github.com/openshift/ovn-kubernetes/pull/3434
* Upstream: https://github.com/ovn-kubernetes/ovn-kubernetes/pull/5871