### PR TITLE
Prevent duplicate MAC responses during egress IP failover with nftables

### DIFF
--- a/go-controller/pkg/controllermanager/node_controller_manager.go
+++ b/go-controller/pkg/controllermanager/node_controller_manager.go
@@ -515,7 +515,11 @@ waitForControllerSyncLoop:
 
 	// Cleanup stale nftables from previous shutdown. Critical for container restarts where
 	// nftables state persists and would block ARP responses for reassigned egress IPs.
+<<<<<<< HEAD
 	if err := node.CleanupEgressIPARPBlockNFT(ctx); err != nil {
+=======
+	if err := node.CleanupEgressIPARPBlockNFTTable(ctx); err != nil {
+>>>>>>> 693a5f612 (Prevent duplicate MAC responses during egress IP failover with nftables)
 		return fmt.Errorf("failed to cleanup egress IP ARP/NDP block table: %v", err)
 	}
 
@@ -643,8 +647,12 @@ func (ncm *NodeControllerManager) getAssignedEgressIPs() ([]string, error) {
 				} else {
 					klog.Warningf("Invalid Egress IP format in status: %s", status.EgressIP)
 				}
+<<<<<<< HEAD
 				// one object can only have one IP assigned to a given node at a time, so its safe to break here
 				break
+=======
+				break // Move to next EgressIP resource
+>>>>>>> 693a5f612 (Prevent duplicate MAC responses during egress IP failover with nftables)
 			}
 		}
 	}
@@ -656,11 +664,24 @@ func (ncm *NodeControllerManager) getAssignedEgressIPs() ([]string, error) {
 // addEgressIPARPBlockRules adds nftables rules to block ARP/NDP requests for egress IPs
 // during graceful shutdown. This prevents duplicate MAC responses during migration.
 func (ncm *NodeControllerManager) addEgressIPARPBlockRules(egressIPs []string) error {
+<<<<<<< HEAD
 	klog.Infof("Adding nftables ARP/NDP block rules for %d egress IPs during shutdown", len(egressIPs))
 
 	uplinkName := ncm.defaultNodeNetworkController.Gateway.GetUplinkName()
 	if err := node.SetupEgressIPARPBlockNFT(egressIPs, uplinkName); err != nil {
 		return fmt.Errorf("failed to setup egress IP ARP block nftables %s: %w", nodenft.OVNKubernetesEgressIPNFTablesName, err)
+=======
+	if len(egressIPs) == 0 {
+		klog.V(5).Info("No egress IPs to add ARP block rules for")
+		return nil
+	}
+
+	klog.Infof("Adding nftables ARP/NDP block rules for %d egress IPs during shutdown", len(egressIPs))
+
+	uplinkName := ncm.defaultNodeNetworkController.Gateway.GetUplinkName()
+	if err := node.SetupEgressIPARPBlockNFTables(egressIPs, uplinkName); err != nil {
+		return fmt.Errorf("failed to setup egress IP ARP block nftables: %w", err)
+>>>>>>> 693a5f612 (Prevent duplicate MAC responses during egress IP failover with nftables)
 	}
 
 	klog.Infof("Successfully added nftables ARP/NDP block rules for %d egress IPs", len(egressIPs))

--- a/go-controller/pkg/node/nftables/helpers.go
+++ b/go-controller/pkg/node/nftables/helpers.go
@@ -13,6 +13,7 @@ import (
 )
 
 const OVNKubernetesNFTablesName = "ovn-kubernetes"
+const OVNKubernetesEgressIPNFTablesName = "ovn-kubernetes-egressip"
 
 // OVNKubernetesEgressIPNFTablesName is a netdev table required for dropping
 // incoming ARP requests for an EgressIP during node or ovnkube-controller restart.

--- a/go-controller/pkg/node/node_nftables.go
+++ b/go-controller/pkg/node/node_nftables.go
@@ -207,10 +207,22 @@ func setupPMTUDNFTChain() error {
 	return nil
 }
 
+<<<<<<< HEAD
 // SetupEgressIPARPBlockNFT sets up nftables for blocking ARP/NDP responses for egress IPs during
 // graceful shutdown. Uses netdev family with ingress hook on the physical uplink interface to intercept
 // packets before they reach the OVS bridge, preventing OVN from responding to ARP/NDP requests.
 func SetupEgressIPARPBlockNFT(egressIPs []string, uplinkName string) error {
+=======
+// SetupEgressIPARPBlockNFTables sets up nftables for blocking ARP/NDP responses for egress IPs during
+// graceful shutdown. Uses netdev family with ingress hook on the physical uplink interface to intercept
+// packets before they reach the OVS bridge, preventing OVN from responding to ARP/NDP requests.
+func SetupEgressIPARPBlockNFTables(egressIPs []string, uplinkName string) error {
+	if len(egressIPs) == 0 {
+		klog.V(5).Info("No egress IPs to setup ARP block rules for")
+		return nil
+	}
+
+>>>>>>> 693a5f612 (Prevent duplicate MAC responses during egress IP failover with nftables)
 	if uplinkName == "" {
 		return fmt.Errorf("uplink interface name is required for netdev nftables rules")
 	}
@@ -301,10 +313,17 @@ func SetupEgressIPARPBlockNFT(egressIPs []string, uplinkName string) error {
 	return nil
 }
 
+<<<<<<< HEAD
 // CleanupEgressIPARPBlockNFT deletes the dedicated nftable "ovn-kubernetes-egressip"  for egress IP ARP/NDP blocking.
 // Called during startup to remove stale rules from previous container shutdown.
 // On full node reboot, nftables state is cleared automatically, so this primarily handles container restarts.
 func CleanupEgressIPARPBlockNFT(ctx context.Context) error {
+=======
+// CleanupEgressIPARPBlockNFTTable deletes the dedicated nftables table for egress IP ARP/NDP blocking.
+// Called during startup to remove stale rules from previous container shutdown.
+// On full node reboot, nftables state is cleared automatically, so this primarily handles container restarts.
+func CleanupEgressIPARPBlockNFTTable(ctx context.Context) error {
+>>>>>>> 693a5f612 (Prevent duplicate MAC responses during egress IP failover with nftables)
 	nft, err := nodenft.GetEgressIPNFTablesHelper()
 	if err != nil {
 		return fmt.Errorf("failed to get egress IP nftables helper: %w", err)
@@ -314,9 +333,16 @@ func CleanupEgressIPARPBlockNFT(ctx context.Context) error {
 	tx.Delete(&knftables.Table{})
 
 	if err = nft.Run(ctx, tx); err != nil && !knftables.IsNotFound(err) {
+<<<<<<< HEAD
 		return fmt.Errorf("could not delete egress IP nftables table %s: %v", nodenft.OVNKubernetesEgressIPNFTablesName, err)
 	}
 
 	klog.Infof("Cleaned up egress IP nftables table from previous shutdown : %s", nodenft.OVNKubernetesEgressIPNFTablesName)
+=======
+		return fmt.Errorf("could not delete egress IP nftables table: %v", err)
+	}
+
+	klog.Infof("Cleaned up egress IP nftables table from previous shutdown")
+>>>>>>> 693a5f612 (Prevent duplicate MAC responses during egress IP failover with nftables)
 	return nil
 }

--- a/go-controller/pkg/node/node_nftables_test.go
+++ b/go-controller/pkg/node/node_nftables_test.go
@@ -19,7 +19,11 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+<<<<<<< HEAD
 func TestSetupEgressIPARPBlockNFT(t *testing.T) {
+=======
+func TestSetupEgressIPARPBlockNFTables(t *testing.T) {
+>>>>>>> 693a5f612 (Prevent duplicate MAC responses during egress IP failover with nftables)
 	const testUplinkName = "eth0"
 
 	tests := []struct {
@@ -143,7 +147,11 @@ func TestSetupEgressIPARPBlockNFT(t *testing.T) {
 
 			nft := nodenft.SetFakeEgressIPNFTablesHelper()
 
+<<<<<<< HEAD
 			err := SetupEgressIPARPBlockNFT(tt.egressIPs, tt.uplinkName)
+=======
+			err := SetupEgressIPARPBlockNFTables(tt.egressIPs, tt.uplinkName)
+>>>>>>> 693a5f612 (Prevent duplicate MAC responses during egress IP failover with nftables)
 
 			if tt.expectError != "" {
 				g.Expect(err).To(HaveOccurred())
@@ -186,7 +194,11 @@ func TestSetupEgressIPARPBlockNFT(t *testing.T) {
 	}
 }
 
+<<<<<<< HEAD
 func TestCleanupEgressIPARPBlockNFT(t *testing.T) {
+=======
+func TestCleanupEgressIPARPBlockNFTTable(t *testing.T) {
+>>>>>>> 693a5f612 (Prevent duplicate MAC responses during egress IP failover with nftables)
 	const testUplinkName = "eth0"
 
 	tests := []struct {
@@ -244,8 +256,13 @@ func TestCleanupEgressIPARPBlockNFT(t *testing.T) {
 			nft := nodenft.SetFakeEgressIPNFTablesHelper()
 
 			if tt.setupTable {
+<<<<<<< HEAD
 				// Create the table first by calling SetupEgressIPARPBlockNFT
 				err := SetupEgressIPARPBlockNFT(tt.egressIPs, tt.uplinkName)
+=======
+				// Create the table first by calling SetupEgressIPARPBlockNFTables
+				err := SetupEgressIPARPBlockNFTables(tt.egressIPs, tt.uplinkName)
+>>>>>>> 693a5f612 (Prevent duplicate MAC responses during egress IP failover with nftables)
 				g.Expect(err).NotTo(HaveOccurred())
 				rules, err := nft.ListRules(context.TODO(), nftEgressIPDropChain)
 				g.Expect(err).NotTo(HaveOccurred())
@@ -253,7 +270,11 @@ func TestCleanupEgressIPARPBlockNFT(t *testing.T) {
 			}
 
 			// Call the cleanup function
+<<<<<<< HEAD
 			err := CleanupEgressIPARPBlockNFT(context.TODO())
+=======
+			err := CleanupEgressIPARPBlockNFTTable(context.TODO())
+>>>>>>> 693a5f612 (Prevent duplicate MAC responses during egress IP failover with nftables)
 
 			if tt.expectError != "" {
 				g.Expect(err).To(HaveOccurred())

--- a/test/e2e/egressip.go
+++ b/test/e2e/egressip.go
@@ -433,9 +433,15 @@ func checkForDuplicateMAC(externalContainer infraapi.ExternalContainer, interfac
 		if err != nil {
 			framework.Logf("Check %d/%d: %s command returned error: %v; output: %s", i+1, maxChecks, toolName, err, output)
 		}
+<<<<<<< HEAD
 		matches := macRegex.FindAllStringSubmatch(output, -1)
 		for _, match := range matches {
 			respondingMAC := strings.ToLower(strings.TrimSpace(match[1]))
+=======
+		matches := macRegex.FindStringSubmatch(output)
+		if len(matches) >= 2 {
+			respondingMAC := strings.ToLower(strings.TrimSpace(matches[1]))
+>>>>>>> 693a5f612 (Prevent duplicate MAC responses during egress IP failover with nftables)
 			if respondingMAC == oldMAC {
 				return fmt.Errorf("DUPLICATE MAC DETECTED on check %d: Old node MAC %s responded to %s for egress IP %s after migration. "+
 					"The nftables drop rules should have prevented this response", i+1, oldMAC, toolName, egressIP)
@@ -3931,6 +3937,7 @@ spec:
 			gomega.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("The \"k8s.ovn.org/egressip-mark\" annotation cannot be modified or removed once set. This annotation is managed by the system.")))
 		})
 
+<<<<<<< HEAD
 		ginkgo.It("Should skip orphaned nodes and assign EgressIPs to valid nodes", func() {
 			if isUserDefinedNetwork(netConfigParams) {
 				ginkgo.Skip("Unsupported for UDNs")
@@ -4101,6 +4108,8 @@ spec:
 				"EgressIPs must not be assigned to node %s while its host-cidrs annotation is missing", nodeToOrphan)
 		})
 
+=======
+>>>>>>> 693a5f612 (Prevent duplicate MAC responses during egress IP failover with nftables)
 		ginkgo.It("should prevent duplicate MAC responses when egress node is rebooted", func() {
 			if !isNetworkSegmentationEnabled() {
 				ginkgo.Skip("network segmentation is disabled")


### PR DESCRIPTION
Issue:
When an egress IP node is rebooted, the egress IP moves to another egress assignable node after health check failure. However the old egress IP node keep on responding to ARP request for the egress IP. This happens due to following reasons:

- EgressIP stays attached to primary interface of the old EgressIP node until the primary interface is brought down as per node reboot workflow.
- SNAT rules at GR creates logical flows which can respond with unicast ARP in response of broadcast GARPs from newly assigned egressIP node. This can happen till ovs-vswitchd is running.

In baremetal environment node reboot takes longer time(~10-20 second) and as a result we get multiple MAC for an egress IP during that interval.

This commit Implement dedicated nftables rules to prevent duplicate MAC/IP conflicts during egress IP failover scenarios.

Changes:
- Create dedicated nftables tables for egress IP ARP/NDP blocking:
  - ovn-kubernetes-egressip (netdev family) for both IPv4 and IPv6 egress IPs
- Implement cleanup on startup to remove stale nftables rules
- Add e2e test to validate no duplicate MAC responses during node reboot

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Release Notes
<!--
REQUIRED. Add a short, user-facing release note in the block below describing any
user-visible change (new/changed/removed flags or APIs, behavior changes,
deprecations, etc.).
Write `NONE` if this PR has no user-facing impact (tests, refactors, CI,
internal-only changes) — `NONE` is a valid entry.
-->
```release-note
NONE
```

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code does not require changes to the documentation
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] My code does not require tests
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
